### PR TITLE
Fix compilation without OpenMP on Mac

### DIFF
--- a/Util/OpenMPReplacement.h
+++ b/Util/OpenMPReplacement.h
@@ -19,11 +19,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 
 */
 
-#ifdef _OPENMP
-#include <omp.h>
-#else
 const int omp_get_num_procs() { return 1; }
 const int omp_get_max_threads() { return 1; }
 const int omp_get_thread_num() { return 0; }
 const int omp_set_num_threads(int i) {}
-#endif

--- a/createHierarchy.cpp
+++ b/createHierarchy.cpp
@@ -36,7 +36,12 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <string>
 #include <vector>
 
-#include "openmp.h"
+#ifdef _OPENMP
+#include <omp.h>  	
+#else
+#include "Util/OpenMPReplacement.h"
+#endif
+
 #include "typedefs.h"
 #include "Contractor/Contractor.h"
 #include "Contractor/ContractionCleanup.h"

--- a/extractor.cpp
+++ b/extractor.cpp
@@ -43,7 +43,12 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <unistd.h>
 #include <stxxl.h>
 
-#include "openmp.h"
+#ifdef _OPENMP
+#include <omp.h>  	
+#else
+#include "Util/OpenMPReplacement.h"
+#endif
+
 #include "typedefs.h"
 #include "DataStructures/InputReaderFactory.h"
 #include "DataStructures/ExtractorCallBacks.h"

--- a/routed.cpp
+++ b/routed.cpp
@@ -24,7 +24,11 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 
-#include "openmp.h"
+#ifdef _OPENMP
+#include <omp.h>  	
+#else
+#include "Util/OpenMPReplacement.h"
+#endif
 
 #include "Server/ServerConfiguration.h"
 #include "Server/ServerFactory.h"


### PR DESCRIPTION
Copied empty methods from createHierachies.cpp and copied to extractor.cpp to make things compile without OpenMP on Mac.
