### PR TITLE
Make compilation work on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@
 
 # OS generated files #
 ######################
-.DS_Store?
+.DS_Store
 ehthumbs.db
 Icon?
 Thumbs.db

--- a/Contractor/ContractionCleanup.h
+++ b/Contractor/ContractionCleanup.h
@@ -31,10 +31,6 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #endif
 #include "Contractor.h"
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 class ContractionCleanup {
 private:
 

--- a/Contractor/Contractor.h
+++ b/Contractor/Contractor.h
@@ -30,15 +30,13 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include "../DataStructures/DynamicGraph.h"
 #include "../DataStructures/Percent.h"
 #include "../DataStructures/BinaryHeap.h"
+#include "../Util/OpenMPReplacement.h"
 #include <ctime>
 #include <vector>
 #include <queue>
 #include <set>
 #include <stack>
 #include <limits>
-#ifdef _OPEMP
-#include <omp.h>
-#endif
 
 class Contractor {
 
@@ -190,7 +188,7 @@ public:
     }
 
     ~Contractor() { }
-
+	
     void Run() {
         const NodeID numberOfNodes = _graph->GetNumberOfNodes();
         Percent p (numberOfNodes);

--- a/Contractor/EdgeBasedGraphFactory.cpp
+++ b/Contractor/EdgeBasedGraphFactory.cpp
@@ -25,6 +25,7 @@
 #endif
 #include <boost/foreach.hpp>
 
+#include "../Util/OpenMPReplacement.h"
 #include "EdgeBasedGraphFactory.h"
 
 template<>
@@ -39,7 +40,7 @@ EdgeBasedGraphFactory::EdgeBasedGraphFactory(int nodes, std::vector<NodeBasedEdg
 
     std::vector< _NodeBasedEdge > edges;
     edges.reserve( 2 * inputEdges.size() );
-    for ( typename std::vector< NodeBasedEdge >::const_iterator i = inputEdges.begin(), e = inputEdges.end(); i != e; ++i ) {
+    for ( std::vector< NodeBasedEdge >::const_iterator i = inputEdges.begin(), e = inputEdges.end(); i != e; ++i ) {
         _NodeBasedEdge edge;
         edge.source = i->source();
         edge.target = i->target();

--- a/DataStructures/Percent.h
+++ b/DataStructures/Percent.h
@@ -22,9 +22,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #define PERCENT_H
 
 #include <iostream>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+
 
 class Percent
 {

--- a/Server/ServerFactory.h
+++ b/Server/ServerFactory.h
@@ -27,10 +27,6 @@ or see http://www.gnu.org/licenses/agpl.txt.
 
 #include <cstdlib>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 #include "Server.h"
 #include "ServerConfiguration.h"
 

--- a/Util/OpenMPReplacement.h
+++ b/Util/OpenMPReplacement.h
@@ -19,7 +19,16 @@ or see http://www.gnu.org/licenses/agpl.txt.
 
 */
 
-const int omp_get_num_procs() { return 1; }
-const int omp_get_max_threads() { return 1; }
-const int omp_get_thread_num() { return 0; }
-const int omp_set_num_threads(int i) {}
+#ifndef _OPENMPREPLACEMENTY_H
+#define _OPENMPREPLACEMENTY_H
+
+#ifdef _OPENMP
+#include <omp.h>  	
+#else
+inline const int omp_get_num_procs() { return 1; }
+inline const int omp_get_max_threads() { return 1; }
+inline const int omp_get_thread_num() { return 0; }
+inline const int omp_set_num_threads(int i) {}
+#endif
+
+#endif

--- a/createHierarchy.cpp
+++ b/createHierarchy.cpp
@@ -36,12 +36,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <string>
 #include <vector>
 
-#ifdef _OPENMP
-#include <omp.h>  	
-#else
 #include "Util/OpenMPReplacement.h"
-#endif
-
 #include "typedefs.h"
 #include "Contractor/Contractor.h"
 #include "Contractor/ContractionCleanup.h"
@@ -52,6 +47,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include "Util/BaseConfiguration.h"
 #include "Util/InputFileUtil.h"
 #include "Util/GraphLoader.h"
+#include "Util/OpenMPReplacement.h"
 
 using namespace std;
 

--- a/extractor.cpp
+++ b/extractor.cpp
@@ -43,12 +43,6 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <unistd.h>
 #include <stxxl.h>
 
-#ifdef _OPENMP
-#include <omp.h>  	
-#else
-#include "Util/OpenMPReplacement.h"
-#endif
-
 #include "typedefs.h"
 #include "DataStructures/InputReaderFactory.h"
 #include "DataStructures/ExtractorCallBacks.h"

--- a/routed.cpp
+++ b/routed.cpp
@@ -24,12 +24,6 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 
-#ifdef _OPENMP
-#include <omp.h>  	
-#else
-#include "Util/OpenMPReplacement.h"
-#endif
-
 #include "Server/ServerConfiguration.h"
 #include "Server/ServerFactory.h"
 
@@ -39,6 +33,7 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include "Plugins/ObjectForPluginStruct.h"
 #include "Plugins/ViaRoutePlugin.h"
 #include "Util/InputFileUtil.h"
+#include "Util/OpenMPReplacement.h"
 
 #ifndef _WIN32
 #include "Util/LinuxStackTrace.h"


### PR DESCRIPTION
Fix more compilations problems on Mac. The OpenMP stubs had to be made inline, otherwise I got duplicated symbols when linking. I moved the conditional inclusion to the header file.

Also had to remove a 'typename' that wasn't needed.
