### PR TITLE
gitignore the sandbox/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ win/bin-debug/
 /osrm-routed
 /osrm-prepare
 /nohup.out
+
+# Sandbox folder #
+###################
+sandbox/


### PR DESCRIPTION
when you use the rake tasks for downloading and processing osm data, it's stored in the sandbox folder. you can also play with the speedprofile there without git wanting to commit it to the repo.
