### PR TITLE
perform a sanity check on which ways are used during routability tests

### DIFF
--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -56,7 +56,7 @@ def build_ways_from_table table
     tags = row.dup
     tags.delete 'forw'
     tags.delete 'backw'
-    tags['name'] = "abcd#{ri}"
+    tags['name'] = "w#{ri}"
     tags.reject! { |k,v| v=='' }
     way << tags
     osm_db << way


### PR DESCRIPTION
you might get conflicts in features/step_definitions/routing.rb when merging. you can avoid it my merging manually using the 'theirs' option:

make sure your have a clean working dir before you start, so you can undo failed merge attempts. 

if you get conflicts using a normal merge, use "git reset --hard HEAD" (but please be sure your got a clean git status before you start, or you might loose changes) to undo the merge attempt, and then do:

  git merge emiltin/cuke_way_check -X theirs 

the 'theirs' option will prefer the version in the pull request. you might need to adjust  the 'emltin' part depending on how you've set up your remotes.
