### PR TITLE
make sure oneway:<class> overrides standard oneway tag

### DIFF
--- a/DataStructures/ExtractorCallBacks.h
+++ b/DataStructures/ExtractorCallBacks.h
@@ -173,12 +173,19 @@ public:
             }
 
             if( settings.obeyOneways ) {
-                if( oneway == "no" || oneway == "0" || oneway == "false" || onewayClass == "no" || onewayClass == "0" || onewayClass == "false" || ((settings.accessTag == "bicycle") && (cycleway == "opposite" || cycleway == "opposite_track" || cycleway == "opposite_lane")) ) {
+				if( onewayClass == "yes" || onewayClass == "1" || onewayClass == "true" ) {
+                    w.direction = _Way::oneway;
+				} else if( onewayClass == "no" || onewayClass == "0" || onewayClass == "false" ) {
+	            	w.direction = _Way::bidirectional;
+				} else if( onewayClass == "-1" ) {
+	            	w.direction = _Way::opposite;
+				} else if( oneway == "no" || oneway == "0" || oneway == "false" ) {
+                    w.direction = _Way::bidirectional;
+				} else if( settings.accessTag == "bicycle" && (cycleway == "opposite" || cycleway == "opposite_track" || cycleway == "opposite_lane") ) {
                     w.direction = _Way::bidirectional;
                 } else if( oneway == "-1") {
                     w.direction  = _Way::opposite;
-                }
-                else if( oneway == "yes" || oneway == "1" || oneway == "true" || onewayClass == "yes" || onewayClass == "1" || onewayClass == "true" || junction == "roundabout" || highway == "motorway_link" || highway == "motorway" ) {
+                } else if( oneway == "yes" || oneway == "1" || oneway == "true" || junction == "roundabout" || highway == "motorway_link" || highway == "motorway" ) {
                     w.direction = _Way::oneway;
                 } else {
                     w.direction = _Way::bidirectional;

--- a/features/oneway.feature
+++ b/features/oneway.feature
@@ -97,22 +97,22 @@ Feature: Oneway streets
 	Scenario: Oneway:bicycle should override normal oneways tags
  		Given the speedprofile "bicycle"
 	 	Then routability should be
-		 | highway       | junction   | oneway | oneway:bicycle | forw | backw |
-		 | primary       |            |        | yes            | x    |       |
-		 | primary       |            | yes    | yes            | x    |       |
-		 | primary       |            | no     | yes            | x    |       |
-		 | primary       |            | -1     | yes            | x    |       |
-		 | primary       | roundabout |        | yes            | x    |       |
-		 | primary       |            |        | no             | x    | x     |
-		 | primary       |            | yes    | no             | x    | x     |
-		 | primary       |            | no     | no             | x    | x     |
-		 | primary       |            | -1     | no             | x    | x     |
-		 | primary       | roundabout |        | no             | x    | x     |
-		 | primary       |            |        | -1             |      | x     |
-		 | primary       |            | yes    | -1             |      | x     |
-		 | primary       |            | no     | -1             |      | x     |
-		 | primary       |            | -1     | -1             |      | x     |
-		 | primary       | roundabout |        | -1             |      | x     |
+		 | highway | oneway:bicycle | oneway | junction   | forw | backw |
+		 | primary | yes            |        |            | x    |       |
+		 | primary | yes            | yes    |            | x    |       |
+		 | primary | yes            | no     |            | x    |       |
+		 | primary | yes            | -1     |            | x    |       |
+		 | primary | yes            |        | roundabout | x    |       |
+		 | primary | no             |        |            | x    | x     |
+		 | primary | no             | yes    |            | x    | x     |
+		 | primary | no             | no     |            | x    | x     |
+		 | primary | no             | -1     |            | x    | x     |
+		 | primary | no             |        | roundabout | x    | x     |
+		 | primary | -1             |        |            |      | x     |
+		 | primary | -1             | yes    |            |      | x     |
+		 | primary | -1             | no     |            |      | x     |
+		 | primary | -1             | -1     |            |      | x     |
+		 | primary | -1             |        | roundabout |      | x     |
 	
 	@bicycle
 	Scenario: Bicycles and contra flow


### PR DESCRIPTION
this commit makes the oneway tests pass.
it just reorganized the tests in the extractor, so that oneway:bicycle tag is checked before the normal oneway tag.
