### PR TITLE
update tests for handling of invalid oneway mapping

### DIFF
--- a/features/bad.feature
+++ b/features/bad.feature
@@ -53,3 +53,77 @@ Feature: Handle bad data in a graceful manner
 		 | 3    | 1  |       |
 		 | 3    | 2  |       |
 
+	@bad_oneway
+	Scenario: Invalid oneway dead-ends
+		Given the nodes
+		 | a | x | b |
+
+		And the ways
+		 | nodes | oneway |
+		 | ax    | -1     |
+		 | xb    | yes    |
+
+		When I route I should get
+		 | from | to | route |
+		 | x    | a  | ax    |
+		 | x    | b  | xb    |
+
+	@bad_oneway
+	Scenario: Impossible-to-leave oneway dead-ends
+		Given the nodes
+		 |   | t |   |
+		 | a | x | b |
+		 |   | s |   |
+
+		And the ways
+		 | nodes | oneway |
+		 | ax    | -1     |
+		 | xb    | yes    |
+		 | sxt   |        |
+
+		When I route I should get
+		 | from | to | route |
+		 | x    | a  | ax    |
+		 | x    | b  | xb    |
+		 | a    | x  |       |
+		 | b    | x  |       |
+	
+	@bad_oneway
+	Scenario: Impossible-to-reach oneway dead-ends
+		Given the nodes
+		 |   | t |   |
+		 | a | x | b |
+		 |   | s |   |
+
+		And the ways
+		 | nodes | oneway |
+		 | ax    | yes    |
+		 | xb    | -1     |
+		 | sxt   |        |
+
+		When I route I should get
+		 | from | to | route |
+		 | a    | x  | ax    |
+		 | b    | b  | xb    |
+		 | x    | a  |       |
+		 | x    | b  |       |
+
+	@bad_oneway
+	Scenario: Impossible-to-leave oneway junctions
+		Given the nodes
+		 | t |   |   |
+		 | a | x | b |
+		 | s |   |   |
+
+		And the ways
+		 | nodes | oneway |
+		 | ax    | yes    |
+		 | bx    | yes    |
+		 | sat   |        |
+
+		When I route I should get
+		 | from | to | route |
+		 | a    | x  | ax    |
+		 | b    | x  | xb    |
+		 | x    | a  |       |
+		 | x    | b  |       |

--- a/features/oneway.feature
+++ b/features/oneway.feature
@@ -31,23 +31,6 @@ Feature: Oneway streets
 		 | a    | b  | ab       |
 		 | b    | a  | bc,cd,da |
 	
-	Scenario: Avoid oneway traps
-		Given the nodes
-		 |   | x |   |		
-		 | a | b | c |
-		 |   | y |   |		
-
-		And the ways
-		 | nodes | oneway |
-		 | abc   |        |
-		 | bx    | yes    |
-		 | yb    | -1     |
-
-		When I route I should get
-		 | from | to | route |
-		 | b    | x  |       |
-		 | b    | y  |       |
-	
 	Scenario: Handle various oneway tag values
  		Given the speedprofile "bicycle"
 	 	Then routability should be


### PR DESCRIPTION
i've updated cuke tests to reflect the expected handling of impossible oneways: osrm should always start/stop where requested, even if it would be impossible to reach or leave that point according to the oneway tags.

several of the tests currently fail, perhaps due to bugs not directly related to oneways.
