### PR TITLE
updated turn restriction tests

### DIFF
--- a/features/restrictions.feature
+++ b/features/restrictions.feature
@@ -1,95 +1,267 @@
 @routing @restrictions
 Feature: Turn restrictions
 	Handle turn restrictions as defined by http://wiki.openstreetmap.org/wiki/Relation:restriction
-	How this plays with u-turns can be tricky.
-	
-	Scenario: No left turn
+	Note that if u-turns are allowed, turn restrictions can lead to suprising, but correct, routes.
+
+	#left side	
+	@restriction_left @no_left_turn @no_turn
+	Scenario: No left turn, no way to reach destination
 		Given the nodes
-		 |   | t |   |
-		 | a | j | b |
-		 |   | s |   |
+		 | w | j |
+		 |   | s |
 
 		And the ways
 		 | nodes |
-		 | bj    |
-		 | aj    |
 		 | sj    |
-		 | tj    |
+		 | wj    |
 
 		And the relations
 		 | from | to | via | restriction  |
-		 | sj   | aj | j   | no_left_turn |
+		 | sj   | wj | j   | no_left_turn |
 
 		When I route I should get
 		 | from | to | route |
-		 | s    | a  |       |
-		 | s    | b  | sj,jb |
-		 | s    | t  | sj,tj |
-		 | a    | b  | aj,bj |
-		 | a    | a  | aj,sj |
-		 | a    | t  | aj,tj |
-		 | b    | b  | jb,aj |
-		 | b    | s  | bj,sj |
-		 | b    | t  | bj,tj |
+		 | s    | w  |       |
+		 | w    | s  | wj,sj |
 
-	Scenario: No left turn, go counter-clockwise around the block instead
+	@restriction_left  @no_left_turn @no_turn
+	Scenario: No left turn, don't use u-turns to reach destination
 		Given the nodes
-		 | x | t |   |
-		 | a | j | b |
+		 |   | n |   |
+		 | w | j | e |
 		 |   | s |   |
 
 		And the ways
 		 | nodes |
-		 | bj    |
-		 | aj    |
+		 | nj    |
+		 | ej    |
 		 | sj    |
-		 | tj    |
-		 | axt   |
+		 | wj    |
 
 		And the relations
 		 | from | to | via | restriction  |
-		 | sj   | aj | j   | no_left_turn |
+		 | sj   | wj | j   | no_left_turn |
 
 		When I route I should get
-		 | from | to | route     |
-		 | s    | a  | sj,tj,axt |
-		 | s    | b  | sj,jb     |
-		 | s    | t  | sj,tj     |
-		 | a    | b  | aj,bj     |
-		 | a    | a  | aj,sj     |
-		 | a    | t  | aj,tj     |
-		 | b    | b  | jb,aj     |
-		 | b    | s  | bj,sj     |
-		 | b    | t  | bj,tj     |
-		
-	Scenario: No left turn, go clockwise around the block instead
+		 | from | to | route |
+		 | s    | w  |       |
+		 | s    | n  | sj,nj |
+		 | s    | e  | sj,ej |
+		 | w    | n  | wj,nj |
+		 | w    | e  | wj,ej |
+		 | w    | s  | wj,sj |
+		 | n    | e  | nj,ej |
+		 | n    | s  | nj,sj |
+		 | n    | w  | nj,wj |
+		 | e    | s  | ej,sj |
+		 | e    | w  | ej,wj |
+		 | e    | n  | ej,nj |
+
+	@restriction_left @no_left_turn @no_turn
+	Scenario: No left turn, go around the block instead
 		Given the nodes
-		 |   |   | t |   |
-		 | z | a | j | b |
-		 | x |   | s |   |
+		 | y | n |   |
+		 | w | j | e |
+		 |   | s |   |
 
 		And the ways
 		 | nodes |
-		 | bj    |
-		 | aj    |
+		 | nj    |
+		 | ej    |
 		 | sj    |
-		 | tj    |
-		 | sxza  |
+		 | wj    |
+		 | wyn   |
 
 		And the relations
 		 | from | to | via | restriction  |
-		 | sj   | aj | j   | no_left_turn |
+		 | sj   | wj | j   | no_left_turn |
 
 		When I route I should get
 		 | from | to | route     |
-		 | s    | a  | sxza      |
-		 | s    | b  | sj,jb     |
-		 | s    | t  | sj,tj     |
-		 | a    | b  | aj,bj     |
-		 | a    | a  | aj,sj     |
-		 | a    | t  | aj,tj     |
-		 | b    | b  | jb,aj     |
-		 | b    | s  | bj,sj     |
-		 | b    | t  | bj,tj     |
+		 | s    | w  | sj,nj,wyn |
+		 | s    | n  | sj,nj     |
+		 | s    | e  | sj,ej     |
+		 | w    | n  | wj,nj     |
+		 | w    | e  | wj,ej     |
+		 | w    | s  | wj,sj     |
+		 | n    | e  | nj,ej     |
+		 | n    | s  | nj,sj     |
+		 | n    | w  | nj,wj     |
+		 | e    | s  | ej,sj     |
+		 | e    | w  | ej,wj     |
+		 | e    | n  | ej,nj     |
+	
+	@restriction_left @only_left_turn @must_turn
+	Scenario: Only left turn, don't use u-turns to reach destination
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
 
+		And the ways
+		 | nodes |
+		 | nj    |
+		 | ej    |
+		 | sj    |
+		 | wj    |
 
+		And the relations
+		 | from | to | via | restriction    |
+		 | sj   | wj | j   | only_restriction_left |
+
+		When I route I should get
+		 | from | to | route |
+		 | s | w | sj,wj |
+		 | s | n |       |
+		 | s | e |       |
+		 | w | n | wj,nj |
+		 | w | e | wj,ej |
+		 | w | s | wj,sj |
+		 | n | e | nj,ej |
+		 | n | s | nj,sj |
+		 | n | w | nj,wj |
+		 | e | s | ej,sj |
+		 | e | w | ej,wj |
+		 | e | n | ej,nj |
+
+	#right side
+	@restriction_right @no_right_turn @no_turn
+	Scenario: No right turn, no way to reach destination
+		Given the nodes
+		 | j | e |
+		 | s |   |
+
+		And the ways
+		 | nodes |
+		 | ej    |
+		 | sj    |
+		 
+		And the relations
+		 | from | to | via | restriction   |
+		 | sj   | ej | j   | no_right_turn |
+
+		When I route I should get
+		 | from | to | route |
+		 | s    | e  |       |
+		 | e    | s  | ej,sj |
+		 
+	@restriction_right @no_right_turn @no_turn
+	Scenario: No right turn, don't use u-turns to reach destination
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes |
+		 | nj    |
+		 | ej    |
+		 | sj    |
+		 | wj    |
+
+		And the relations
+		 | from | to | via | restriction   |
+		 | sj   | ej | j   | no_right_turn |
+
+		When I route I should get
+		 | from | to | route |
+		 | s    | w  | sj,wj |
+		 | s    | n  | sj,nj |
+		 | s    | e  |       |
+		 | w    | n  | wj,nj |
+		 | w    | e  | wj,ej |
+		 | w    | s  | wj,sj |
+		 | n    | e  | nj,ej |
+		 | n    | s  | nj,sj |
+		 | n    | w  | nj,wj |
+		 | e    | s  | ej,sj |
+		 | e    | w  | ej,wj |
+		 | e    | n  | ej,nj |
+
+	@restriction_right @no_right_turn @no_turn
+	Scenario: No right turn, go around the block instead
+		Given the nodes
+		 |   | n | y |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes |
+		 | nj    |
+		 | ej    |
+		 | sj    |
+		 | wj    |
+		 | nye   |
+
+		And the relations
+		 | from | to | via | restriction  |
+		 | sj   | ej | j   | no_right_turn |
+
+		When I route I should get
+		 | from | to | route     |
+		 | s    | w  | sj,wj     |
+		 | s    | n  | sj,nj     |
+		 | s    | e  | sj,nj,nye |
+		 | w    | n  | wj,nj     |
+		 | w    | e  | wj,ej     |
+		 | w    | s  | wj,sj     |
+		 | n    | e  | nj,ej     |
+		 | n    | s  | nj,sj     |
+		 | n    | w  | nj,wj     |
+		 | e    | s  | ej,sj     |
+		 | e    | w  | ej,wj     |
+		 | e    | n  | ej,nj     |
+
+	@restriction_right @only_right_turn @must_turn
+	Scenario: Right turn only, don't use u-turns to reach destination
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes |
+		 | nj    |
+		 | ej    |
+		 | sj    |
+		 | wj    |
+
+		And the relations
+		 | from | to | via | restriction   |
+		 | sj   | ej | j   | only_right_turn |
+
+		When I route I should get
+		 | from | to | route |
+		 | s    | w  |       |
+		 | s    | n  |       |
+		 | s    | e  | sj,ej |
+		 | w    | n  | wj,nj |
+		 | w    | e  | wj,ej |
+		 | w    | s  | wj,sj |
+		 | n    | e  | nj,ej |
+		 | n    | s  | nj,sj |
+		 | n    | w  | nj,wj |
+		 | e    | s  | ej,sj |
+		 | e    | w  | ej,wj |
+		 | e    | n  | ej,nj |
+
+	@no_u_turn
+	Scenario: No U-turn
+		Given the nodes
+		 |   | b |   |
+		 |   |   |   |
+		 | c |   | a |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+		 | bc    |
+
+		And the relations
+		 | from | to | via | restriction |
+		 | ab   | bc | b   | no_u_turn   |
+
+		When I route I should get
+		 | from | to | route |
+		 | a    | c  |       |
+		 | c    | a  | bc,ab |

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -66,7 +66,7 @@ end
 Given /^the relations$/ do |table|
   table.hashes.each do |row|
     relation = OSM::Relation.new make_osm_id, OSM_USER, OSM_TIMESTAMP
-    relation << { :type => :restriction, :restriction => 'no_left_turn' }
+    relation << { :type => :restriction, :restriction => row['restriction'] }
     from_way = find_way_by_name(row['from'])
     raise "*** unknown way '#{row['from']}'" unless from_way
     to_way = find_way_by_name(row['to'])

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -179,7 +179,7 @@ def reprocess
     unless prepared?
       log_preprocess_info
       log "== Preparing #{@osm_file}.osm...", :preprocess
-      unless system "../osrm-prepare #{@osm_file}.osrm #{@osm_file}.restrictions 1>>#{PREPROCESS_LOG_FILE} 2>>#{PREPROCESS_LOG_FILE}"
+      unless system "../osrm-prepare #{@osm_file}.osrm #{@osm_file}.osrm.restrictions 1>>#{PREPROCESS_LOG_FILE} 2>>#{PREPROCESS_LOG_FILE}"
         log "*** Exited with code #{$?.exitstatus}.", :preprocess
         raise "*** osrm-prepare exited with code #{$?.exitstatus}. The file preprocess.log might contain more info." 
       end 


### PR DESCRIPTION
cucumber tests now loads the correct .osrm.restrictions file.

i also updated all the restrictions tests (there were a few bugs in the previous markup), and added tests for no_right_turn, no_u_turn, only_left_turn and only_right_turn.

most test now pass (yay!), but i did find a few things:
1. osrm will make use of u-turns inside dead-ends to try to reach the destination. i'm not sure this behaviour is desirable, or if osrm should rather not find a route? at the moment the tests assume osrm should not find a route.
2. it seems like osrm doesn't handle the only_xxx_turn type of restriction?
