### PR TITLE
update turn restrictions tests to use oneway streets, to avoid u-turns

### DIFF
--- a/features/distance.feature
+++ b/features/distance.feature
@@ -278,7 +278,6 @@ Feature: Distance calculation
 		 | a    | c  | abc   | 2000000  |
 		 | c    | a  | abc   | 2000000  |
 		
-	@a
 	Scenario: Angles at 1000km scale
 		Given a grid size of 1000 meters
 		Given the nodes

--- a/features/oneway.feature
+++ b/features/oneway.feature
@@ -31,23 +31,6 @@ Feature: Oneway streets
 		 | a    | b  | ab       |
 		 | b    | a  | bc,cd,da |
 	
-	Scenario: Avoid oneway traps
-		Given the nodes
-		 |   | x |   |		
-		 | a | b | c |
-		 |   | y |   |		
-
-		And the ways
-		 | nodes | oneway |
-		 | abc   |        |
-		 | bx    | yes    |
-		 | yb    | -1     |
-
-		When I route I should get
-		 | from | to | route |
-		 | b    | x  |       |
-		 | b    | y  |       |
-	
 	Scenario: Handle various oneway tag values
  		Given the speedprofile "bicycle"
 	 	Then routability should be

--- a/features/restrictions.feature
+++ b/features/restrictions.feature
@@ -2,41 +2,23 @@
 Feature: Turn restrictions
 	Handle turn restrictions as defined by http://wiki.openstreetmap.org/wiki/Relation:restriction
 	Note that if u-turns are allowed, turn restrictions can lead to suprising, but correct, routes.
-
-	#left side	
-	@restriction_left @no_left_turn @no_turn
-	Scenario: No left turn, no way to reach destination
-		Given the nodes
-		 | w | j |
-		 |   | s |
-
-		And the ways
-		 | nodes |
-		 | sj    |
-		 | wj    |
-
-		And the relations
-		 | from | to | via | restriction  |
-		 | sj   | wj | j   | no_left_turn |
-
-		When I route I should get
-		 | from | to | route |
-		 | s    | w  |       |
-		 | w    | s  | wj,sj |
-
-	@restriction_left  @no_left_turn @no_turn
-	Scenario: No left turn, don't use u-turns to reach destination
+	
+	Background: Use car routing
+		Given the speedprofile "car"
+	
+	@no_turning
+	Scenario: No left turn
 		Given the nodes
 		 |   | n |   |
 		 | w | j | e |
 		 |   | s |   |
 
 		And the ways
-		 | nodes |
-		 | nj    |
-		 | ej    |
-		 | sj    |
-		 | wj    |
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
 
 		And the relations
 		 | from | to | via | restriction  |
@@ -47,117 +29,20 @@ Feature: Turn restrictions
 		 | s    | w  |       |
 		 | s    | n  | sj,nj |
 		 | s    | e  | sj,ej |
-		 | w    | n  | wj,nj |
-		 | w    | e  | wj,ej |
-		 | w    | s  | wj,sj |
-		 | n    | e  | nj,ej |
-		 | n    | s  | nj,sj |
-		 | n    | w  | nj,wj |
-		 | e    | s  | ej,sj |
-		 | e    | w  | ej,wj |
-		 | e    | n  | ej,nj |
 
-	@restriction_left @no_left_turn @no_turn
-	Scenario: No left turn, go around the block instead
-		Given the nodes
-		 | y | n |   |
-		 | w | j | e |
-		 |   | s |   |
-
-		And the ways
-		 | nodes |
-		 | nj    |
-		 | ej    |
-		 | sj    |
-		 | wj    |
-		 | wyn   |
-
-		And the relations
-		 | from | to | via | restriction  |
-		 | sj   | wj | j   | no_left_turn |
-
-		When I route I should get
-		 | from | to | route     |
-		 | s    | w  | sj,nj,wyn |
-		 | s    | n  | sj,nj     |
-		 | s    | e  | sj,ej     |
-		 | w    | n  | wj,nj     |
-		 | w    | e  | wj,ej     |
-		 | w    | s  | wj,sj     |
-		 | n    | e  | nj,ej     |
-		 | n    | s  | nj,sj     |
-		 | n    | w  | nj,wj     |
-		 | e    | s  | ej,sj     |
-		 | e    | w  | ej,wj     |
-		 | e    | n  | ej,nj     |
-	
-	@restriction_left @only_left_turn @must_turn
-	Scenario: Only left turn, don't use u-turns to reach destination
+	@no_turning
+	Scenario: No right turn
 		Given the nodes
 		 |   | n |   |
 		 | w | j | e |
 		 |   | s |   |
 
 		And the ways
-		 | nodes |
-		 | nj    |
-		 | ej    |
-		 | sj    |
-		 | wj    |
-
-		And the relations
-		 | from | to | via | restriction    |
-		 | sj   | wj | j   | only_restriction_left |
-
-		When I route I should get
-		 | from | to | route |
-		 | s | w | sj,wj |
-		 | s | n |       |
-		 | s | e |       |
-		 | w | n | wj,nj |
-		 | w | e | wj,ej |
-		 | w | s | wj,sj |
-		 | n | e | nj,ej |
-		 | n | s | nj,sj |
-		 | n | w | nj,wj |
-		 | e | s | ej,sj |
-		 | e | w | ej,wj |
-		 | e | n | ej,nj |
-
-	#right side
-	@restriction_right @no_right_turn @no_turn
-	Scenario: No right turn, no way to reach destination
-		Given the nodes
-		 | j | e |
-		 | s |   |
-
-		And the ways
-		 | nodes |
-		 | ej    |
-		 | sj    |
-		 
-		And the relations
-		 | from | to | via | restriction   |
-		 | sj   | ej | j   | no_right_turn |
-
-		When I route I should get
-		 | from | to | route |
-		 | s    | e  |       |
-		 | e    | s  | ej,sj |
-		 
-	@restriction_right @no_right_turn @no_turn
-	Scenario: No right turn, don't use u-turns to reach destination
-		Given the nodes
-		 |   | n |   |
-		 | w | j | e |
-		 |   | s |   |
-
-		And the ways
-		 | nodes |
-		 | nj    |
-		 | ej    |
-		 | sj    |
-		 | wj    |
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
 
 		And the relations
 		 | from | to | via | restriction   |
@@ -168,66 +53,95 @@ Feature: Turn restrictions
 		 | s    | w  | sj,wj |
 		 | s    | n  | sj,nj |
 		 | s    | e  |       |
-		 | w    | n  | wj,nj |
-		 | w    | e  | wj,ej |
-		 | w    | s  | wj,sj |
-		 | n    | e  | nj,ej |
-		 | n    | s  | nj,sj |
-		 | n    | w  | nj,wj |
-		 | e    | s  | ej,sj |
-		 | e    | w  | ej,wj |
-		 | e    | n  | ej,nj |
 
-	@restriction_right @no_right_turn @no_turn
-	Scenario: No right turn, go around the block instead
-		Given the nodes
-		 |   | n | y |
-		 | w | j | e |
-		 |   | s |   |
-
-		And the ways
-		 | nodes |
-		 | nj    |
-		 | ej    |
-		 | sj    |
-		 | wj    |
-		 | nye   |
-
-		And the relations
-		 | from | to | via | restriction  |
-		 | sj   | ej | j   | no_right_turn |
-
-		When I route I should get
-		 | from | to | route     |
-		 | s    | w  | sj,wj     |
-		 | s    | n  | sj,nj     |
-		 | s    | e  | sj,nj,nye |
-		 | w    | n  | wj,nj     |
-		 | w    | e  | wj,ej     |
-		 | w    | s  | wj,sj     |
-		 | n    | e  | nj,ej     |
-		 | n    | s  | nj,sj     |
-		 | n    | w  | nj,wj     |
-		 | e    | s  | ej,sj     |
-		 | e    | w  | ej,wj     |
-		 | e    | n  | ej,nj     |
-
-	@restriction_right @only_right_turn @must_turn
-	Scenario: Right turn only, don't use u-turns to reach destination
+	@no_turning
+	Scenario: No u-turn
 		Given the nodes
 		 |   | n |   |
 		 | w | j | e |
 		 |   | s |   |
 
 		And the ways
-		 | nodes |
-		 | nj    |
-		 | ej    |
-		 | sj    |
-		 | wj    |
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
 
 		And the relations
-		 | from | to | via | restriction   |
+		 | from | to | via | restriction |
+		 | sj   | wj | j   | no_u_turn   |
+
+		When I route I should get
+		 | from | to | route |
+		 | s    | w  |       |
+		 | s    | n  | sj,nj |
+		 | s    | e  | sj,ej |
+
+	@no_turning
+	Scenario: Handle any no_* relation
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
+
+		And the relations
+		 | from | to | via | restriction      |
+		 | sj   | wj | j   | no_weird_zigzags |
+
+		When I route I should get
+		 | from | to | route |
+		 | s    | w  |       |
+		 | s    | n  | sj,nj |
+		 | s    | e  | sj,ej |
+
+	@only_turning
+	Scenario: Only left turn
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
+
+		And the relations
+		 | from | to | via | restriction    |
+		 | sj   | wj | j   | only_left_turn |
+
+		When I route I should get
+		 | from | to | route |
+		 | s | w | sj,wj |
+		 | s | n |       |
+		 | s | e |       |
+
+	@only_turning
+	Scenario: Only right turn
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
+
+		And the relations
+		 | from | to | via | restriction     |
 		 | sj   | ej | j   | only_right_turn |
 
 		When I route I should get
@@ -235,33 +149,51 @@ Feature: Turn restrictions
 		 | s    | w  |       |
 		 | s    | n  |       |
 		 | s    | e  | sj,ej |
-		 | w    | n  | wj,nj |
-		 | w    | e  | wj,ej |
-		 | w    | s  | wj,sj |
-		 | n    | e  | nj,ej |
-		 | n    | s  | nj,sj |
-		 | n    | w  | nj,wj |
-		 | e    | s  | ej,sj |
-		 | e    | w  | ej,wj |
-		 | e    | n  | ej,nj |
-
-	@no_u_turn
-	Scenario: No U-turn
+	
+	@only_turning
+	Scenario: Only straight on
 		Given the nodes
-		 |   | b |   |
-		 |   |   |   |
-		 | c |   | a |
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
 
 		And the ways
-		 | nodes |
-		 | ab    |
-		 | bc    |
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
 
 		And the relations
-		 | from | to | via | restriction |
-		 | ab   | bc | b   | no_u_turn   |
+		 | from | to | via | restriction      |
+		 | sj   | nj | j   | only_straight_on |
 
 		When I route I should get
 		 | from | to | route |
-		 | a    | c  |       |
-		 | c    | a  | bc,ab |
+		 | s    | w  |       |
+		 | s    | n  | sj,nj |
+		 | s    | e  |       |
+
+	@no_turning
+	Scenario: Handle any only_* restriction
+		Given the nodes
+		 |   | n |   |
+		 | w | j | e |
+		 |   | s |   |
+
+		And the ways
+		 | nodes | oneway  |
+		 | sj    | yes     |
+		 | nj    | -1      |
+		 | wj    | -1      |
+		 | ej    | -1      |
+
+		And the relations
+		 | from | to | via | restriction        |
+		 | sj   | nj | j   | only_weird_zigzags |
+
+		When I route I should get
+		 | from | to | route |
+		 | s    | w  |       |
+		 | s    | n  | sj,nj |
+		 | s    | e  |       |


### PR DESCRIPTION
all restrictions tests now pass, except one: for some reason, osrm-routed seems to hangs in the "only right turn" scenario.
