### PR TITLE
Routing currently stops at cattle_grids, leading to large detours.

### DIFF
--- a/DataStructures/PBFParser.h
+++ b/DataStructures/PBFParser.h
@@ -224,7 +224,7 @@ private:
                 denseTagIndex += 2;
             }
             std::string barrierValue = keyVals.Find("barrier");
-            if(0 < barrierValue.length() && "border_control" != barrierValue && "toll_booth" != barrierValue && "no" != barrierValue)
+            if(0 < barrierValue.length() && "cattle_grid" != barrierValue && "border_control" != barrierValue && "toll_booth" != barrierValue && "no" != barrierValue)
                 n.bollard = true;
 
             if("traffic_signals" == keyVals.Find("highway"))


### PR DESCRIPTION
Added exception for "barrier=cattle_grid".  A cattle grid is not a barrier for
cars and/or bicycles.   Quite commonly used in rural
Scandinavia.
