### PR TITLE
turn penalties

### DIFF
--- a/Contractor/EdgeBasedGraphFactory.h
+++ b/Contractor/EdgeBasedGraphFactory.h
@@ -117,6 +117,8 @@ private:
     unsigned numberOfTurnRestrictions;
     unsigned trafficSignalPenalty;
     unsigned uturnPenalty;
+    unsigned turnPenalty;
+    double turnBias;
     bool takeMinimumOfSpeeds;
 
 public:
@@ -127,8 +129,9 @@ public:
     template< class ImportEdgeT >
     void GetEdgeBasedEdges( std::vector< ImportEdgeT >& edges );
     void GetEdgeBasedNodes( std::vector< EdgeBasedNode> & nodes);
-    short AnalyzeTurn(const NodeID u, const NodeID v, const NodeID w) const;
-    unsigned GetNumberOfNodes() const;
+    short AnalyzeTurn(const NodeID u, const NodeID v, const NodeID w, unsigned& penalty) const;
+	unsigned ComputeTurnPenalty(const float angle) const;
+   unsigned GetNumberOfNodes() const;
 };
 
 #endif /* EDGEBASEDGRAPHFACTORY_H_ */

--- a/DataStructures/TurnInstructions.h
+++ b/DataStructures/TurnInstructions.h
@@ -80,7 +80,7 @@ struct TurnInstructionsClass {
     };
 
     static inline double GetTurnDirectionOfInstruction( const double angle ) {
-        if(angle >= 23 && angle < 67) {
+		if(angle >= 23 && angle < 67) {
             return TurnSharpRight;
         }
         if (angle >= 67 && angle < 113) {

--- a/speedprofiles/bicycle.ini
+++ b/speedprofiles/bicycle.ini
@@ -1,28 +1,34 @@
 [bicycle]
-	accessTag		= bicycle
-	defaultSpeed	= 17
-	obeyOneways		= yes
-	useRestrictions = yes
-	obeyBollards	= no
+	accessTag				= bicycle
+	obeyOneways				= yes
+	useRestrictions 		= yes
+	obeyBollards			= no
+	takeMinimumOfSpeeds 	= yes
+	excludeFromGrid 		= ferry
+	
+	defaultSpeed			= 17
+	trafficSignalPenalty 	= 10
+	turnPenalty				= 50
+	turnBias				= 1.4
+	
+	cycleway				= 19
+	primary         		= 19
+	primary_link    		= 19
+	secondary       		= 18
+	secondary_link  		= 18
+	tertiary        		= 17
+	residential     		= 16
+	unclassified    		= 16
+	road		    		= 16
+	living_street   		= 15
+	service         		= 15
+	track					= 13
+	path					= 13
+	footway					= 5
+	pedestrian				= 5
+	pier					= 5
+	platform				= 5
+	steps					= 3
+	
+	ferry					= 5
 
-	cycleway		= 19
-	primary         = 19
-	primary_link    = 19
-	secondary       = 17
-	secondary_link  = 17
-	tertiary        = 15
-	residential     = 15
-	unclassified    = 15
-	living_street   = 13
-	road		    = 13
-	service         = 12
-	track			= 12
-	path			= 12
-	footway			= 10
-	pedestrian		= 5
-	pier			= 5
-	steps			= 3
-	ferry			= 5
-
-	excludeFromGrid = ferry
-	trafficSignalPenalty = 10


### PR DESCRIPTION
this commit implements a simple turn penalty formula that squares the turn angle (where straight ahead is 0, uturn is 180), scales it and multiplies it with the "turnPenalty" speedprofile setting. in addition you can set "turnBias" to make left turns more expensive than right turns (or the other way around). 1 (or leaving it out) means no bias.

this seems to work quite well. it really helps to smooth out routes a bit - you avoid overly wriggly routes with a minimal increase in length.

"turnPenalty" or "turnBias" can be left out in the speedprofile in case you don't want to incur turn penalties.
