### PR TITLE
SConstruct: find Libzip on Darwin

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -90,6 +90,7 @@ if sys.platform == 'darwin':	#Mac OS X
 	boost_prefix = subprocess.check_output(["brew", "--prefix", "boost"]).strip()
 	env.Append(CPPPATH = [boost_prefix+"/include"] )
 	env.Append(LIBPATH = [boost_prefix+"/lib"] )	
+	env.ParseConfig('pkg-config --cflags --libs libzip')
 elif sys.platform.startswith("freebsd"):
 	env.ParseConfig('pkg-config --cflags --libs protobuf')
 	env.Append(CPPPATH = ['/usr/local/include', '/usr/local/include/libxml2'])


### PR DESCRIPTION
Add a `pkg-config` statement for Darwin in SConstruct to help
scons find the Libzip includes.  Patch from Homebrew.  Fixes
compile error with llvm-gcc.

Fixes #274
