### PR TITLE
add two scenarios to check row-type test mechanism

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -132,5 +132,28 @@ Feature: Basic Routing
 		 | c    | a  | abc     |
 		 | c    | e  | cde     |
 		 | e    | c  | cde     |
+	
+	@rows
+	Scenario: Basic routability using row test
+	 	Then routability should be
+		 | highway       | forw | backw |
+		 | cycleway      | x    | x     |
+		 | cycleway      | x    | x     |
+		
+	@rows
+	Scenario: Basic routability using node map
+	This test mimics what the row test above acutally does: construct a map with isolated ways, then route on each.
+		Given the node map
+		 | a | b | c | d |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | e | f | g | h |
 
+		And the ways
+		 | nodes |
+		 | abcd  |
+		 | efgh  |
 
+		When I route I should get
+		 | from | to | route |
+		 | b    | c  | abcd  |
+		 | c    | b  | abcd  |
+		 | f    | g  | efgh  |
+		 | g    | f  | efgh  |


### PR DESCRIPTION
i've looked into the "testing w1, but got w1,w1!?" cucumber errors. what happens is that osrm-routed adds a spurious u-turn to the instructions. suppose you have this way:

a-b-c-d

if you route from b to c, you get instructions to head on abcd, then do a u-turn on abcd.

however, this error depends on what other (unconnected) ways are on the map.

this pull request adds two tests that demonstrate the problem. the first first uses the row-type test with "Then routability should be", the other does the same thing, but constructs the map manually using "Given the node map" etc. both show the same result.
