### PR TITLE
simplified distance formula. more precise values for distance testing

### DIFF
--- a/DataStructures/ExtractorStructs.h
+++ b/DataStructures/ExtractorStructs.h
@@ -367,17 +367,10 @@ inline double ApproximateDistance( const int lat1, const int lon1, const int lat
     assert(lat2 != INT_MIN);
     assert(lon2 != INT_MIN);
     static const double DEG_TO_RAD = 0.017453292519943295769236907684886;
-    //Earth's quatratic mean radius for WGS-84
-    static const double EARTH_RADIUS_IN_METERS = 6372797.560856;
-    double latitudeArc  = ( lat1/100000. - lat2/100000. ) * DEG_TO_RAD;
-    double longitudeArc = ( lon1/100000. - lon2/100000. ) * DEG_TO_RAD;
-    double latitudeH = sin( latitudeArc * 0.5 );
-    latitudeH *= latitudeH;
-    double lontitudeH = sin( longitudeArc * 0.5 );
-    lontitudeH *= lontitudeH;
-    double tmp = cos( lat1/100000. * DEG_TO_RAD ) * cos( lat2/100000. * DEG_TO_RAD );
-    double distanceArc =  2.0 * asin( sqrt( latitudeH + tmp * lontitudeH ) );
-    return EARTH_RADIUS_IN_METERS * distanceArc;
+    static const double EARTH_RADIUS_IN_METERS = 6372797.560856;    //Earth's quatratic mean radius for WGS-84
+    double latArc = lat2-lat1;
+    double lonArc = lon2-lon1;
+    return EARTH_RADIUS_IN_METERS * DEG_TO_RAD * sqrt( latArc*latArc + lonArc*lonArc ) / 100000.0;
 }
 
 inline double ApproximateDistance(const _Coordinate &c1, const _Coordinate &c2) {

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -16,8 +16,10 @@ DEFAULT_GRID_SIZE = 100   #meters
 
 ORIGIN = [1,1]
 
-def set_grid_size meters    
-  @zoom = 0.001*(meters.to_f/111.21)
+def set_grid_size meters 
+  #the constant is calculated (with BigDecimal as: 1.0/(DEG_TO_RAD*EARTH_RADIUS_IN_METERS
+  #see ApproximateDistance() in ExtractorStructs.h
+  @zoom = meters.to_f*0.8990679362704610899694577444566908445396483347536032203503E-5
 end
 
 def build_ways_from_table table


### PR DESCRIPTION
i was working on calculating a more precise scaling constant for use in the distance tests, when i discovered that the distance formula can be greatly simplified.

the formula provides the same mathematical result. but should be more numerically stable and less prone to rounding errors, since it much simpler, and doesn't involve trigonometric functions.

the original formula boils down to pythogoras' good old formula c=sqrt(a*a+b+b). this suprises me, since the earth is of course not flat. also the original formula did involve some trig stuff, so i'm wondering what's going on.

this pull request also provides an accurate distance scaling in the cucumber tests. test on 10000km scale now return accurate results (try cucumber features/distance.feature:262)
