### PR TITLE
cucumber test with specific lat/lon coordinates

### DIFF
--- a/features/bug.feature
+++ b/features/bug.feature
@@ -1,35 +1,65 @@
 @bug
 Feature: Things that causes crashes or hangs
 
-@nohang
-Scenario: OK
-#this works as expected
-	Given the node map
-	 | a |   |
-	 | b | c |
+	@nohang
+	Scenario: OK
+	#this works as expected
+		Given the node map
+		 | a |   |
+		 | b | c |
 	
-	And the ways
-	 | nodes |
-	 | ab    |
-	 | cb    |
+		And the ways
+		 | nodes |
+		 | ab    |
+		 | cb    |
 
-	When I route I should get
-	 | from | to | route |
-	 | c    | b  | cb    |
+		When I route I should get
+		 | from | to | route |
+		 | c    | b  | cb    |
 
-@hang
-Scenario: Routed hangs on simple ways
-#this causes osrm-routed to hang (at least on mac 10.8)
-#note that this is very similar to the example above, exept that the node map is mirrored
-	Given the node map
-	|   | a |
-	| c | b |
+	@hang
+	Scenario: Routed hangs on simple ways
+	#this causes osrm-routed to hang (at least on mac 10.8)
+	#note that this is very similar to the example above, except that the node map is mirrored
+		Given the node map
+		|   | a |
+		| c | b |
 	
-	And the ways
-	 | nodes |
-	 | ab    |
-	 | cb    |
+		And the ways
+		 | nodes |
+		 | ab    |
+		 | cb    |
 
-	When I route I should get
-	 | from | to | route |
-	 | c    | b  | cb    |
+		When I route I should get
+		 | from | to | route |
+		 | c    | b  | cb    |
+
+	@crash
+	Scenario: Quarter way around the equator
+		Given the node locations
+		 | node | lat | lon |
+		 | a    | 0   | 0   |
+		 | b    | 0   | 90  |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+
+		When I route I should get
+		 | from | to | route |
+		 | a    | b  | ab    |
+
+	@crash
+	Scenario: From the equator to the north pole
+		Given the node locations
+		 | node | lat | lon |
+		 | a    | 0   | 0   |
+		 | b    | 90  | 0   |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+
+		When I route I should get
+		 | from | to | route |
+		 | a    | b  | ab    |

--- a/features/planetary.feature
+++ b/features/planetary.feature
@@ -1,0 +1,87 @@
+@routing @planetary
+Feature: Distance calculation
+#reference distances have been calculated usign http://seismo.cqu.edu.au/CQSRG/VDistance/
+ 
+	Scenario: Longitudinal distances at equator
+		Given the node locations
+		 | node | lat | lon |
+		 | a    | 0   | 80  |
+		 | b    | 0   | 0   |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+
+		When I route I should get
+		 | from | to | route | distance      |
+		 | a    | b  | ab    | 8905559 ~0.1% |
+
+	Scenario: Longitudinal distances at latitude 45
+		Given the node locations
+		 | node | lat | lon |
+		 | c    | 45   | 80 |
+		 | d    | 45   | 0  |
+
+		And the ways
+		 | nodes |
+		 | cd    |
+
+		When I route I should get
+		 | from | to | route | distance      |
+		 | c    | d  | cd    | 6028844 ~0.5% |
+
+	Scenario: Longitudinal distances at latitude 80
+		Given the node locations
+		 | node | lat | lon |
+		 | c    | 80   | 80 |
+		 | d    | 80   | 0  |
+
+		And the ways
+		 | nodes |
+		 | cd    |
+
+		When I route I should get
+		 | from | to | route | distance      |
+		 | c    | d  | cd    | 1431469 ~0.5% |
+
+	Scenario: Latitudinal distances at longitude 0
+		Given the node locations
+		 | node | lat | lon |
+		 | a    | 80  | 0   |
+		 | b    | 0   | 0   |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+
+		When I route I should get
+		 | from | to | route | distance      |
+		 | a    | b  | ab    | 8905559 ~0.1% |
+
+	Scenario: Latitudinal distances at longitude 45
+		Given the node locations
+		 | node | lat | lon |
+		 | a    | 80  | 45   |
+		 | b    | 0   | 45   |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+
+		When I route I should get
+		 | from | to | route | distance      |
+		 | a    | b  | ab    | 8905559 ~0.1% |
+
+	Scenario: Latitudinal distances at longitude 80
+		Given the node locations
+		 | node | lat | lon |
+		 | a    | 80  | 80   |
+		 | b    | 0   | 80   |
+
+		And the ways
+		 | nodes |
+		 | ab    |
+
+		When I route I should get
+		 | from | to | route | distance      |
+		 | a    | b  | ab    | 8905559 ~0.1% |

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -29,6 +29,20 @@ Given /^the node map$/ do |table|
   end
 end
 
+Given /^the node locations$/ do |table|
+  table.hashes.each do |row|
+    name = row['node']
+    raise "*** node invalid name '#{name}', must be single characters" unless name.size == 1
+    raise "*** invalid node name '#{name}', must me alphanumeric" unless name.match /[a-z0-9]/
+    raise "*** duplicate node '#{name}'" if name_node_hash[name]
+    node = OSM::Node.new make_osm_id, OSM_USER, OSM_TIMESTAMP, row['lon'].to_f, row['lat'].to_f 
+    node << { :name => name }
+    node.uid = OSM_UID
+    osm_db << node
+    name_node_hash[name] = node
+  end
+end
+
 Given /^the nodes$/ do |table|
   table.hashes.each do |row|
     name = row.delete 'node'


### PR DESCRIPTION
adds the ability to specify nodes in cucumber tests using absolute lat/lon coordinates. example:

```
        Given the node locations
         | node | lat | lon |
         | a    | 0   | 0   |
         | b    | 0   | 12  |

```

also adds tests for huge distances (all passing).
