### PR TITLE
dont quantize distance to 10m, use double for summation

### DIFF
--- a/DataStructures/SegmentInformation.h
+++ b/DataStructures/SegmentInformation.h
@@ -26,14 +26,14 @@ or see http://www.gnu.org/licenses/agpl.txt.
 struct SegmentInformation {
     _Coordinate location;
     NodeID nameID;
-    unsigned length;
+    double length;
     unsigned duration;
     double bearing;
     short turnInstruction;
     bool necessary;
-    SegmentInformation(const _Coordinate & loc, const NodeID nam, const unsigned len, const unsigned dur, const short tInstr, const bool nec) :
+    SegmentInformation(const _Coordinate & loc, const NodeID nam, const double len, const unsigned dur, const short tInstr, const bool nec) :
             location(loc), nameID(nam), length(len), duration(dur), bearing(0.), turnInstruction(tInstr), necessary(nec) {}
-    SegmentInformation(const _Coordinate & loc, const NodeID nam, const unsigned len, const unsigned dur, const short tInstr) :
+    SegmentInformation(const _Coordinate & loc, const NodeID nam, const double len, const unsigned dur, const short tInstr) :
         location(loc), nameID(nam), length(len), duration(dur), bearing(0.), turnInstruction(tInstr), necessary(tInstr != 0) {}
 };
 

--- a/Descriptors/DescriptionFactory.cpp
+++ b/Descriptors/DescriptionFactory.cpp
@@ -90,7 +90,7 @@ void DescriptionFactory::Run(const SearchEngineT &sEngine, const unsigned zoomLe
         pathDescription[i].length = ApproximateDistance(pathDescription[i-1].location, pathDescription[i].location);
     }
 
-    unsigned lengthOfSegment = 0;
+    double lengthOfSegment = 0;
     unsigned durationOfSegment = 0;
     unsigned indexOfSegmentBegin = 0;
 
@@ -193,7 +193,7 @@ void DescriptionFactory::Run(const SearchEngineT &sEngine, const unsigned zoomLe
     return;
 }
 
-void DescriptionFactory::BuildRouteSummary(const unsigned distance, const unsigned time) {
+void DescriptionFactory::BuildRouteSummary(const double distance, const unsigned time) {
     summary.startName = startPhantom.nodeBasedEdgeNameID;
     summary.destName = targetPhantom.nodeBasedEdgeNameID;
     summary.BuildDurationAndLengthStrings(distance, time);

--- a/Descriptors/DescriptionFactory.h
+++ b/Descriptors/DescriptionFactory.h
@@ -51,10 +51,10 @@ public:
         unsigned startName;
         unsigned destName;
         _RouteSummary() : lengthString("0"), durationString("0"), startName(0), destName(0) {}
-        void BuildDurationAndLengthStrings(unsigned distance, unsigned time) {
+        void BuildDurationAndLengthStrings(double distance, unsigned time) {
             //compute distance/duration for route summary
             std::ostringstream s;
-            s << 10*(round(distance/10.));
+            s << round(distance);
             lengthString = s.str();
             int travelTime = time/10 + 1;
             s.str("");
@@ -63,7 +63,7 @@ public:
         }
     } summary;
 
-    unsigned entireLength;
+    double entireLength;
 
     //I know, declaring this public is considered bad. I'm lazy
     std::vector <SegmentInformation> pathDescription;
@@ -73,7 +73,7 @@ public:
     void AppendEncodedPolylineString(std::string &output);
     void AppendUnencodedPolylineString(std::string &output);
     void AppendSegment(const _Coordinate & coordinate, const _PathData & data);
-    void BuildRouteSummary(const unsigned distance, const unsigned time);
+    void BuildRouteSummary(const double distance, const unsigned time);
     void SetStartSegment(const PhantomNode & startPhantom);
     void SetEndSegment(const PhantomNode & startPhantom);
     void AppendEncodedPolylineString(std::string & output, bool isEncoded);


### PR DESCRIPTION
a proposed fix for #383

-don't quantizate total distance in route results to nearest 10m. instead rounds to nearest meter.
-use doubles instead of unsigned for internal route segment distances
-use a double for summing the total. current way of summing unsigned ints involves a potential error of 1m for each segment.

as far as i understand, SegmentInformation is used only for returning route results, not for the entire network. if this is correct, the fix should not affect memory use or performance.
