### PR TITLE
move cuke origin to 1,1, add origin tests

### DIFF
--- a/features/origin.feature
+++ b/features/origin.feature
@@ -1,0 +1,73 @@
+@routing @origin
+Feature: Routing close to the [0,0] origin
+Reference distances have been calculated usign http://seismo.cqu.edu.au/CQSRG/VDistance/
+ 	
+	Scenario: East-west oneways close to the origin
+		Given the node locations
+		 | node | lat                   | lon |
+		 | a    | 0                     | 0   |
+		 | b    | 0.0008990679362704611 | 0   |
+		 | c    | 0.0017981358725409223 | 0   |
+		 | d    | 0.0026972038088113833 | 0   |
+
+		And the ways
+		 | nodes | oneway |
+		 | abcd  | yes    |
+
+		When I route I should get
+		 | from | to | route | distance |
+		 | b    | c  | abcd  | 100 +-1  |
+		 | c    | b  |       |          |
+
+	Scenario: North-south oneways close to the origin
+		Given the node locations
+		 | node | lat | lon                   |
+		 | a    | 0   | 0                     |
+		 | b    | 0   | 0.0008990679362704611 |
+		 | c    | 0   | 0.0017981358725409223 |
+		 | d    | 0   | 0.0026972038088113833 |
+
+		And the ways
+		 | nodes | oneway |
+		 | abcd  | yes    |
+
+		When I route I should get
+		 | from | to | route | distance |
+		 | b    | c  | abcd  | 100 +-1  |
+		 | c    | b  |       |          |
+		
+	Scenario: East-west oneways crossing the origin
+		Given the node locations
+		 | node | lat                    | lon |
+		 | a    | -0.0017981358725409223 | 0   |
+		 | b    | -0.0008990679362704611 | 0   |
+		 | c    | 0                      | 0   |
+		 | d    | 0.0008990679362704611  | 0   |
+		 | e    | 0.0017981358725409223  | 0   |
+
+		And the ways
+		 | nodes | oneway |
+		 | abcde | yes    |
+
+		When I route I should get
+		 | from | to | route | distance |
+		 | b    | d  | abcde | 200 +-1  |
+		 | d    | b  |       |          |
+	
+	Scenario: North-south oneways crossing the origin
+		Given the node locations
+		 | node | lat | lon                    |
+		 | a    | 0   | -0.0017981358725409223 |
+		 | b    | 0   | -0.0008990679362704611 |
+		 | c    | 0   | 0                      |
+		 | d    | 0   | 0.0008990679362704611  |
+		 | e    | 0   | 0.0017981358725409223  |
+
+		And the ways
+		 | nodes | oneway |
+		 | abcde | yes    |
+
+		When I route I should get
+		 | from | to | route | distance |
+		 | b    | d  | abcde | 200 +-1  |
+		 | d    | b  |       |          |

--- a/features/step_definitions/routing.rb
+++ b/features/step_definitions/routing.rb
@@ -217,11 +217,11 @@ When /^I route I should get$/ do |table|
       if table.headers.include? 'route'
         got['route'] = (instructions || '').strip
         if table.headers.include? 'distance'
-          got['distance'] = instructions ? json['route_summary']['total_distance'].to_s : nil
+          got['distance'] = instructions ? json['route_summary']['total_distance'].to_s : ''
         end
         if table.headers.include? 'time'
           raise "*** time must be specied in seconds. (ex: 60s)" unless row['time'] =~ /\d+s/
-          got['time'] = instructions ? "#{json['route_summary']['total_time'].to_s}s" : nil
+          got['time'] = instructions ? "#{json['route_summary']['total_time'].to_s}s" : ''
         end
         if table.headers.include? 'bearing'
           got['bearing'] = bearings

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -14,7 +14,8 @@ DEFAULT_SPEEDPROFILE = 'bicycle'
 WAY_SPACING = 100
 DEFAULT_GRID_SIZE = 100   #meters
 
-ORIGIN = [0,0]
+
+ORIGIN = [1,1]
 
 def set_grid_size meters
   #the constant is calculated (with BigDecimal as: 1.0/(DEG_TO_RAD*EARTH_RADIUS_IN_METERS


### PR DESCRIPTION
once again moving origin for cuke test away from 0,0, and instead placing them at 1,1, since the origin is really an edge case.

there seems to be edge bases related to ways close to the origin, these are now handled by a set of separate tests.

1,1 will incur a minor distance distortion but this will have to handles in some other way.
