### PR TITLE
testing of barrier nodes

### DIFF
--- a/features/barrier.feature
+++ b/features/barrier.feature
@@ -1,0 +1,50 @@
+@routing @barrier
+Feature: Barriers
+
+	Scenario: Barriers and cars
+	 	Given the speedprofile "car"
+		Then routability should be
+		 | highway | node/barrier   | node/access   | forw | backw |
+		 | primary |                |               | x    | x     |
+		 | primary | bollard        |               |      |       |
+		 | primary | gate           |               |      |       |
+		 | primary | cattle_grid    |               |      |       |
+		 | primary | border_control |               |      |       |
+		 | primary | toll_booth     |               |      |       |
+		 | primary | sally_port     |               |      |       |
+		 | primary | bollard        | yes           | x    | x     |
+		 | primary | gate           | yes           | x    | x     |
+		 | primary | cattle_grid    | yes           | x    | x     |
+		 | primary | border_control | yes           | x    | x     |
+		 | primary | toll_booth     | yes           | x    | x     |
+		 | primary | sally_port     | yes           | x    | x     |
+		 | primary | bollard        | motorcar      | x    | x     |
+		 | primary | bollard        | motor_vehicle | x    | x     |
+		 | primary | bollard        | vehicle       | x    | x     |
+		 | primary | bollard        | motorcar      | x    | x     |
+		 | primary | bollard        | permissive    | x    | x     |
+		 | primary | bollard        | designated    | x    | x     |
+	
+	Scenario: Barriers and bicycles
+	 	Given the speedprofile "bicycle"
+		Then routability should be
+		 | highway | node/barrier   | node/access   | forw | backw |
+		 | primary |                |               | x    | x     |
+		 | primary | bollard        |               | x    | x     |
+		 | primary | gate           |               |      |       |
+		 | primary | cattle_grid    |               |      |       |
+		 | primary | border_control |               |      |       |
+		 | primary | toll_booth     |               |      |       |
+		 | primary | sally_port     |               |      |       |
+		 | primary | bollard        | yes           | x    | x     |
+		 | primary | gate           | yes           | x    | x     |
+		 | primary | cattle_grid    | yes           | x    | x     |
+		 | primary | border_control | yes           | x    | x     |
+		 | primary | toll_booth     | yes           | x    | x     |
+		 | primary | sally_port     | yes           | x    | x     |
+		 | primary | bollard        | motorcar      |      |       |
+		 | primary | bollard        | motor_vehicle |      |       |
+		 | primary | bollard        | vehicle       | x    | x     |
+		 | primary | bollard        | motorcar      |      |       |
+		 | primary | bollard        | permissive    | x    | x     |
+		 | primary | bollard        | designated    | x    | x     |

--- a/features/step_definitions/routing.rb
+++ b/features/step_definitions/routing.rb
@@ -160,9 +160,9 @@ Then /^routability should be$/ do |table|
       ['forw','backw'].each do |direction|
         if table.headers.include? direction
           if direction == 'forw'
-            response = request_route("#{ORIGIN[1]},#{ORIGIN[0]+(1+WAY_SPACING*i)*@zoom}","#{ORIGIN[1]},#{ORIGIN[0]+(2+WAY_SPACING*i)*@zoom}")
+            response = request_route("#{ORIGIN[1]},#{ORIGIN[0]+(1+WAY_SPACING*i)*@zoom}","#{ORIGIN[1]},#{ORIGIN[0]+(3+WAY_SPACING*i)*@zoom}")
           elsif direction == 'backw'
-            response = request_route("#{ORIGIN[1]},#{ORIGIN[0]+(2+WAY_SPACING*i)*@zoom}","#{ORIGIN[1]},#{ORIGIN[0]+(1+WAY_SPACING*i)*@zoom}")
+            response = request_route("#{ORIGIN[1]},#{ORIGIN[0]+(3+WAY_SPACING*i)*@zoom}","#{ORIGIN[1]},#{ORIGIN[0]+(1+WAY_SPACING*i)*@zoom}")
           end
           got[direction] = route_status response
           json = JSON.parse(response.body)

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -43,19 +43,23 @@ def build_ways_from_table table
     node2 = OSM::Node.new make_osm_id, OSM_USER, OSM_TIMESTAMP, ORIGIN[0]+(1+WAY_SPACING*ri)*@zoom, ORIGIN[1] 
     node3 = OSM::Node.new make_osm_id, OSM_USER, OSM_TIMESTAMP, ORIGIN[0]+(2+WAY_SPACING*ri)*@zoom, ORIGIN[1] 
     node4 = OSM::Node.new make_osm_id, OSM_USER, OSM_TIMESTAMP, ORIGIN[0]+(3+WAY_SPACING*ri)*@zoom, ORIGIN[1] 
+    node5 = OSM::Node.new make_osm_id, OSM_USER, OSM_TIMESTAMP, ORIGIN[0]+(4+WAY_SPACING*ri)*@zoom, ORIGIN[1] 
     node1.uid = OSM_UID
     node2.uid = OSM_UID
     node3.uid = OSM_UID
     node4.uid = OSM_UID
+    node5.uid = OSM_UID
     node1 << { :name => "a#{ri}" }
     node2 << { :name => "b#{ri}" }
     node3 << { :name => "c#{ri}" }
     node4 << { :name => "d#{ri}" }
+    node5 << { :name => "e#{ri}" }
 
     osm_db << node1
     osm_db << node2
     osm_db << node3
     osm_db << node4
+    osm_db << node5
     
     #...with a way between them
     way = OSM::Way.new make_osm_id, OSM_USER, OSM_TIMESTAMP
@@ -64,12 +68,28 @@ def build_ways_from_table table
     way << node2
     way << node3
     way << node4
+    way << node5
+    
     tags = row.dup
     tags.delete 'forw'
     tags.delete 'backw'
-    tags['name'] = "w#{ri}"
     tags.reject! { |k,v| v=='' }
-    way << tags
+    
+    # sort tag keys in the form of 'node/....'
+    way_tags = {}
+    node_tags = {}
+    tags.each_pair do |k,v|
+      if k =~ /node\/(.*)/
+        node_tags[$1] = v
+      else
+        way_tags[k] = v
+      end
+    end
+    
+    way_tags['name'] = "w#{ri}"
+    way << way_tags
+    node3 << node_tags
+    
     osm_db << way
   end
 end


### PR DESCRIPTION
enable testing of barrier nodes, by extending the 'routeability should be' cucumber definition.

for each row, a way is constructed with 5 nodes: a-b-c-d-e. tags on the center node c can be set using columns with titles in the form of 'node/...'. routing is testing between b and d.
