### PR TITLE
load LUA standard library earlier

### DIFF
--- a/createHierarchy.cpp
+++ b/createHierarchy.cpp
@@ -129,7 +129,7 @@ int main (int argc, char *argv[]) {
 
     // Connect LuaBind to this lua state
     luabind::open(myLuaState);
-
+    luaL_openlibs(myLuaState);
 
     // Now call our function in a lua script
 	INFO("Parsing speedprofile from " << (argc > 3 ? argv[3] : "profile.lua") );

--- a/extractor.cpp
+++ b/extractor.cpp
@@ -87,10 +87,10 @@ int main (int argc, char *argv[]) {
 
     // Connect LuaBind to this lua state
     luabind::open(myLuaState);
+    luaL_openlibs(myLuaState);
 
     // Add our function to the state's global scope
     luabind::module(myLuaState) [
-      luabind::def("print", LUA_print<std::string>),
       luabind::def("parseMaxspeed", parseMaxspeed),
       luabind::def("durationIsValid", durationIsValid),
       luabind::def("parseDuration", parseDuration)
@@ -146,9 +146,6 @@ int main (int argc, char *argv[]) {
     if(0 != luaL_dofile(myLuaState, (argc > 2 ? argv[2] : "profile.lua") )) {
         ERR(lua_tostring(myLuaState,-1)<< " occured in scripting block");
     }
-
-    //open utility libraries string library;
-    luaL_openlibs(myLuaState);
 
     /*** End of Scripting Environment Setup; ***/
 


### PR DESCRIPTION
Load LUA standard library right after initializing LUA for both, extractor and createHierarchy. 

Currently, the library is loaded too late, so that the package library is not available when the profile script is loaded. Consequently, 'require' does not work as expected.
