### PR TITLE
implementation of use_restrictions switch

### DIFF
--- a/Extractor/PBFParser.h
+++ b/Extractor/PBFParser.h
@@ -266,6 +266,14 @@ private:
 
     void parseRelation(_ThreadData * threadData) {
         const OSMPBF::PrimitiveGroup& group = threadData->PBFprimitiveBlock.primitivegroup( threadData->currentGroupID );
+
+        if(0 != luaL_dostring( myLuaState, "return use_restrictions\n")) {
+            ERR(lua_tostring(myLuaState,-1)<< " occured in scripting block");
+        }
+        if (!lua_toboolean(myLuaState, -1)) {
+            return;
+        }
+
         for(int i = 0; i < group.relations_size(); i++ ) {
             const OSMPBF::Relation& inputRelation = threadData->PBFprimitiveBlock.primitivegroup( threadData->currentGroupID ).relations(i);
             bool isRestriction = false;

--- a/Extractor/XMLParser.h
+++ b/Extractor/XMLParser.h
@@ -53,6 +53,11 @@ public:
         return (xmlTextReaderRead( inputReader ) == 1);
     }
     bool Parse() {
+        if(0 != luaL_dostring( myLuaState, "return use_restrictions\n")) {
+            ERR(lua_tostring(myLuaState,-1)<< " occured in scripting block");
+        }
+        bool useRestrictions = lua_toboolean(myLuaState, -1) != 0;
+
         while ( xmlTextReaderRead( inputReader ) == 1 ) {
             const int type = xmlTextReaderNodeType( inputReader );
 
@@ -113,7 +118,7 @@ public:
             }
             if ( xmlStrEqual( currentName, ( const xmlChar* ) "relation" ) == 1 ) {
                 _RawRestrictionContainer r = _ReadXMLRestriction();
-                if(r.fromWay != UINT_MAX) {
+                if(useRestrictions && r.fromWay != UINT_MAX) {
                     if(!(*restrictionCallback)(r)) {
                         std::cerr << "[XMLParser] restriction not parsed" << std::endl;
                     }


### PR DESCRIPTION
I needed the use_restrictions setting for pedestrian routing, so I had a go at implementing it.

The setting of the use_restrictions variable in the lua profile script is checked during relation parsing and turn restriction relations are skipped if it is set to false. Works for both, XML and PBF parsing.

Currently, the variable defaults to false if not set at all. Not sure, if that breaks some unwritten assumptions. I did run the test suite and there are no additional errors.
