### PR TITLE
Mini roundabouts and traffic calming penalties

### DIFF
--- a/Algorithms/StronglyConnectedComponents.h
+++ b/Algorithms/StronglyConnectedComponents.h
@@ -76,6 +76,8 @@ private:
     boost::shared_ptr<_NodeBasedDynamicGraph>   _nodeBasedGraph;
     boost::unordered_map<NodeID, bool>          _barrierNodes;
     boost::unordered_map<NodeID, bool>          _trafficLights;
+    boost::unordered_map<NodeID, bool>          _miniRoundabouts;
+    boost::unordered_map<NodeID, bool>          _trafficCalmingNodes;
 
     typedef std::pair<NodeID, NodeID> RestrictionSource;
     typedef std::pair<NodeID, bool>   RestrictionTarget;
@@ -120,7 +122,7 @@ private:
         NodeID parent;
     };
 public:
-    TarjanSCC(int nodes, std::vector<NodeBasedEdge> & inputEdges, std::vector<NodeID> & bn, std::vector<NodeID> & tl, std::vector<_Restriction> & irs, std::vector<NodeInfo> & nI) : inputNodeInfoList(nI), numberOfTurnRestrictions(irs.size()) {
+    TarjanSCC(int nodes, std::vector<NodeBasedEdge> & inputEdges, std::vector<NodeID> & bn, std::vector<NodeID> & tl, std::vector<NodeID> & mrl, std::vector<NodeID> & tcl, std::vector<_Restriction> & irs, std::vector<NodeInfo> & nI) : inputNodeInfoList(nI), numberOfTurnRestrictions(irs.size()) {
         BOOST_FOREACH(_Restriction & restriction, irs) {
             std::pair<NodeID, NodeID> restrictionSource = std::make_pair(restriction.fromNode, restriction.viaNode);
             unsigned index;
@@ -149,6 +151,12 @@ public:
         BOOST_FOREACH(NodeID id, tl) {
             _trafficLights[id] = true;
         }
+        BOOST_FOREACH(NodeID id, mrl) {
+			_miniRoundabouts[id] = true;
+		}
+		BOOST_FOREACH(NodeID id, tcl) {
+			_trafficCalmingNodes[id] = true;
+		}
 
         DeallocatingVector< _NodeBasedEdge > edges;
         for ( std::vector< NodeBasedEdge >::const_iterator i = inputEdges.begin(); i != inputEdges.end(); ++i ) {

--- a/Contractor/EdgeBasedGraphFactory.cpp
+++ b/Contractor/EdgeBasedGraphFactory.cpp
@@ -1,5 +1,5 @@
 /*
- open source routing machine
+/// open source routing machine
  Copyright (C) Dennis Luxen, others 2010
 
  This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@
 #include "EdgeBasedGraphFactory.h"
 
 template<>
-EdgeBasedGraphFactory::EdgeBasedGraphFactory(int nodes, std::vector<NodeBasedEdge> & inputEdges, std::vector<NodeID> & bn, std::vector<NodeID> & tl, std::vector<_Restriction> & irs, std::vector<NodeInfo> & nI, SpeedProfileProperties sp) : inputNodeInfoList(nI), numberOfTurnRestrictions(irs.size()), speedProfile(sp) {
+EdgeBasedGraphFactory::EdgeBasedGraphFactory(int nodes, std::vector<NodeBasedEdge> & inputEdges, std::vector<NodeID> & bn, std::vector<NodeID> & tl, std::vector<NodeID> & mrl, std::vector<NodeID> & tcl, std::vector<_Restriction> & irs, std::vector<NodeInfo> & nI, SpeedProfileProperties sp) : inputNodeInfoList(nI), numberOfTurnRestrictions(irs.size()), speedProfile(sp) {
 	BOOST_FOREACH(_Restriction & restriction, irs) {
         std::pair<NodeID, NodeID> restrictionSource = std::make_pair(restriction.fromNode, restriction.viaNode);
         unsigned index;
@@ -50,6 +50,12 @@ EdgeBasedGraphFactory::EdgeBasedGraphFactory(int nodes, std::vector<NodeBasedEdg
     BOOST_FOREACH(NodeID id, tl) {
         _trafficLights[id] = true;
     }
+    BOOST_FOREACH(NodeID id, mrl) {
+		_miniRoundabouts[id] = true;
+	}
+    BOOST_FOREACH(NodeID id, tcl) {
+		_trafficCalmingNodes[id] = true;
+	}
 
     DeallocatingVector< _NodeBasedEdge > edges;
     //    edges.reserve( 2 * inputEdges.size() );
@@ -280,6 +286,12 @@ void EdgeBasedGraphFactory::Run(const char * originalEdgeDataFilename) {
                         if(_trafficLights.find(v) != _trafficLights.end()) {
                             distance += speedProfile.trafficSignalPenalty;
                         }
+                        if(_miniRoundabouts.find(v) != _miniRoundabouts.end()) {
+							distance += speedProfile.miniRoundaboutPenalty;
+						}
+                        if(_trafficCalmingNodes.find(v) != _trafficCalmingNodes.end()) {
+							distance += speedProfile.trafficCalmingPenalty;
+						}
                         short turnInstruction = AnalyzeTurn(u, v, w);
                         if(turnInstruction == TurnInstructions.UTurn)
                             distance += speedProfile.uTurnPenalty;

--- a/Contractor/EdgeBasedGraphFactory.h
+++ b/Contractor/EdgeBasedGraphFactory.h
@@ -97,14 +97,18 @@ public:
 
 
     struct SpeedProfileProperties{
-        SpeedProfileProperties()  : trafficSignalPenalty(0), uTurnPenalty(0) {}
+        SpeedProfileProperties()  : trafficSignalPenalty(0), uTurnPenalty(0), miniRoundaboutPenalty(0), trafficCalmingPenalty(0) {}
         int trafficSignalPenalty;
         int uTurnPenalty;
+        int miniRoundaboutPenalty;
+        int trafficCalmingPenalty;
     } speedProfile;
 private:
     boost::shared_ptr<_NodeBasedDynamicGraph>   _nodeBasedGraph;
     boost::unordered_map<NodeID, bool>          _barrierNodes;
     boost::unordered_map<NodeID, bool>          _trafficLights;
+    boost::unordered_map<NodeID, bool>          _miniRoundabouts;
+    boost::unordered_map<NodeID, bool>          _trafficCalmingNodes;
 
     typedef std::pair<NodeID, NodeID> RestrictionSource;
     typedef std::pair<NodeID, bool>   RestrictionTarget;
@@ -132,7 +136,7 @@ private:
 
 public:
     template< class InputEdgeT >
-    explicit EdgeBasedGraphFactory(int nodes, std::vector<InputEdgeT> & inputEdges, std::vector<NodeID> & _bollardNodes, std::vector<NodeID> & trafficLights, std::vector<_Restriction> & inputRestrictions, std::vector<NodeInfo> & nI, SpeedProfileProperties speedProfile);
+    explicit EdgeBasedGraphFactory(int nodes, std::vector<InputEdgeT> & inputEdges, std::vector<NodeID> & _bollardNodes, std::vector<NodeID> & trafficLights, std::vector<NodeID> & miniRoundabouts, std::vector<NodeID> & trafficCalmingNodes, std::vector<_Restriction> & inputRestrictions, std::vector<NodeInfo> & nI, SpeedProfileProperties speedProfile);
 
     void Run(const char * originalEdgeDataFilename);
     void GetEdgeBasedEdges( DeallocatingVector< EdgeBasedEdge >& edges );

--- a/DataStructures/ImportNode.h
+++ b/DataStructures/ImportNode.h
@@ -26,20 +26,22 @@ or see http://www.gnu.org/licenses/agpl.txt.
 
 
 struct _Node : NodeInfo{
-    _Node(int _lat, int _lon, unsigned int _id, bool _bollard, bool _trafficLight) : NodeInfo(_lat, _lon,  _id), bollard(_bollard), trafficLight(_trafficLight) {}
-    _Node() : bollard(false), trafficLight(false) {}
+    _Node(int _lat, int _lon, unsigned int _id, bool _bollard, bool _trafficLight, bool _miniRoundabout, bool _trafficCalming) : NodeInfo(_lat, _lon,  _id), bollard(_bollard), trafficLight(_trafficLight), miniRoundabout(_miniRoundabout), trafficCalming(_trafficCalming) {}
+    _Node() : bollard(false), trafficLight(false), miniRoundabout(false), trafficCalming(false) {}
 
     static _Node min_value() {
-        return _Node(0,0,0, false, false);
+        return _Node(0,0,0, false, false, false, false);
     }
     static _Node max_value() {
-        return _Node((std::numeric_limits<int>::max)(), (std::numeric_limits<int>::max)(), (std::numeric_limits<unsigned int>::max)(), false, false);
+        return _Node((std::numeric_limits<int>::max)(), (std::numeric_limits<int>::max)(), (std::numeric_limits<unsigned int>::max)(), false, false, false, false);
     }
     NodeID key() const {
         return id;
     }
     bool bollard;
     bool trafficLight;
+    bool miniRoundabout;
+    bool trafficCalming;
 };
 
 struct ImportNode : public _Node {
@@ -47,7 +49,7 @@ struct ImportNode : public _Node {
 	
 	inline void Clear() {
 		keyVals.EraseAll();
-		lat = 0; lon = 0; id = 0; bollard = false; trafficLight = false;
+		lat = 0; lon = 0; id = 0; bollard = false; trafficLight = false, miniRoundabout = false, trafficCalming = false;
 	}
 };
 

--- a/Extractor/ScriptingEnvironment.cpp
+++ b/Extractor/ScriptingEnvironment.cpp
@@ -77,6 +77,8 @@ ScriptingEnvironment::ScriptingEnvironment(const char * fileName) {
                                      .def_readwrite("id", &ImportNode::id)
                                      .def_readwrite("bollard", &ImportNode::bollard)
                                      .def_readwrite("traffic_light", &ImportNode::trafficLight)
+                                     .def_readwrite("mini_roundabout", &ImportNode::miniRoundabout)
+                                     .def_readwrite("traffic_calming", &ImportNode::trafficCalming)
                                      .def_readwrite("tags", &ImportNode::keyVals)
                                      ];
 

--- a/Tools/componentAnalysis.cpp
+++ b/Tools/componentAnalysis.cpp
@@ -55,6 +55,8 @@ std::vector<NodeInfo> internalToExternalNodeMapping;
 std::vector<_Restriction> inputRestrictions;
 std::vector<NodeID> bollardNodes;
 std::vector<NodeID> trafficLightNodes;
+std::vector<NodeID> miniRoundaboutNodes;
+std::vector<NodeID> trafficCalmingNodes;
 
 int main (int argc, char *argv[]) {
     if(argc < 3) {
@@ -81,21 +83,23 @@ int main (int argc, char *argv[]) {
     }
 
     std::vector<ImportEdge> edgeList;
-    NodeID nodeBasedNodeNumber = readBinaryOSRMGraphFromStream(in, edgeList, bollardNodes, trafficLightNodes, &internalToExternalNodeMapping, inputRestrictions);
+    NodeID nodeBasedNodeNumber = readBinaryOSRMGraphFromStream(in, edgeList, bollardNodes, trafficLightNodes, miniRoundaboutNodes, trafficCalmingNodes, &internalToExternalNodeMapping, inputRestrictions);
     in.close();
-    INFO(inputRestrictions.size() << " restrictions, " << bollardNodes.size() << " bollard nodes, " << trafficLightNodes.size() << " traffic lights");
+    INFO(inputRestrictions.size() << " restrictions, " << bollardNodes.size() << " bollard nodes, " << trafficLightNodes.size() << " traffic lights, " << miniRoundaboutNodes.size() << " mini roundabouts, " << trafficCalmingNodes.size() << " traffic calming nodes");
 
     /***
      * Building an edge-expanded graph from node-based input an turn restrictions
      */
 
     INFO("Starting SCC graph traversal");
-    TarjanSCC * tarjan = new TarjanSCC (nodeBasedNodeNumber, edgeList, bollardNodes, trafficLightNodes, inputRestrictions, internalToExternalNodeMapping);
+    TarjanSCC * tarjan = new TarjanSCC (nodeBasedNodeNumber, edgeList, bollardNodes, trafficLightNodes, miniRoundaboutNodes, trafficCalmingNodes, inputRestrictions, internalToExternalNodeMapping);
     std::vector<ImportEdge>().swap(edgeList);
     tarjan->Run();
     std::vector<_Restriction>().swap(inputRestrictions);
     std::vector<NodeID>().swap(bollardNodes);
     std::vector<NodeID>().swap(trafficLightNodes);
+    std::vector<NodeID>().swap(miniRoundaboutNodes);
+    std::vector<NodeID>().swap(trafficCalmingNodes);
     INFO("finished component analysis");
     return 0;
 }

--- a/Util/GraphLoader.h
+++ b/Util/GraphLoader.h
@@ -48,7 +48,7 @@ struct _ExcessRemover {
 };
 
 template<typename EdgeT>
-NodeID readBinaryOSRMGraphFromStream(std::istream &in, std::vector<EdgeT>& edgeList, std::vector<NodeID> &bollardNodes, std::vector<NodeID> &trafficLightNodes, std::vector<NodeInfo> * int2ExtNodeMap, std::vector<_Restriction> & inputRestrictions) {
+NodeID readBinaryOSRMGraphFromStream(std::istream &in, std::vector<EdgeT>& edgeList, std::vector<NodeID> &bollardNodes, std::vector<NodeID> &trafficLightNodes, std::vector<NodeID> &miniRoundaboutNodes, std::vector<NodeID> &trafficCalmingNodes, std::vector<NodeInfo> * int2ExtNodeMap, std::vector<_Restriction> & inputRestrictions) {
     NodeID n, source, target;
     EdgeID m;
     short dir;// direction (0 = open, 1 = forward, 2+ = open)
@@ -64,11 +64,17 @@ NodeID readBinaryOSRMGraphFromStream(std::istream &in, std::vector<EdgeT>& edgeL
         	bollardNodes.push_back(i);
         if(node.trafficLight)
         	trafficLightNodes.push_back(i);
+        if(node.miniRoundabout)
+            miniRoundaboutNodes.push_back(i);
+        if(node.trafficCalming)
+            trafficCalmingNodes.push_back(i);
     }
 
     //tighten vector sizes
     std::vector<NodeID>(bollardNodes).swap(bollardNodes);
     std::vector<NodeID>(trafficLightNodes).swap(trafficLightNodes);
+    std::vector<NodeID>(miniRoundaboutNodes).swap(miniRoundaboutNodes);
+    std::vector<NodeID>(trafficCalmingNodes).swap(trafficCalmingNodes);
 
     in.read((char*)&m, sizeof(unsigned));
     DEBUG(" and " << m << " edges ");

--- a/profile.lua
+++ b/profile.lua
@@ -34,7 +34,9 @@ obey_oneway 			= true
 obey_bollards 			= true
 use_restrictions 		= true
 ignore_areas 			= true -- future feature
-traffic_signal_penalty 	= 2
+traffic_signal_penalty 	= 20
+mini_roundabout_penalty = 5
+traffic_calming_penalty = 5
 u_turn_penalty 			= 20
 
 -- End of globals

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -65,6 +65,8 @@ obey_bollards 			= false
 use_restrictions 		= true
 ignore_areas 			= true -- future feature
 traffic_signal_penalty 	= 2
+mini_roundabout_penalty = 2
+traffic_calming_penalty = 0
 u_turn_penalty 			= 20
 
 -- End of globals

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -34,7 +34,9 @@ obey_oneway 			= true
 obey_bollards 			= true
 use_restrictions 		= true
 ignore_areas 			= true -- future feature
-traffic_signal_penalty 	= 2
+traffic_signal_penalty 	= 10
+mini_roundabout_penalty = 5
+traffic_calming_penalty = 5
 u_turn_penalty 			= 20
 
 -- End of globals

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -38,7 +38,9 @@ obey_oneway 			= true
 obey_bollards 			= false
 use_restrictions 		= false
 ignore_areas 			= true -- future feature
-traffic_signal_penalty 	= 2
+traffic_signal_penalty 	= 0
+mini_roundabout_penalty = 0
+traffic_calming_penalty = 0
 u_turn_penalty 			= 2
 
 -- End of globals

--- a/profiles/testbot.lua
+++ b/profiles/testbot.lua
@@ -21,6 +21,8 @@ obey_bollards 			= true
 use_restrictions 		= true
 ignore_areas 			= true	-- future feature
 traffic_signal_penalty 	= 7		-- seconds
+mini_roundabout_penalty = 0
+traffic_calming_penalty = 0
 u_turn_penalty 			= 20
 
 


### PR DESCRIPTION
I have been trying to get an accurate travel duration output from OSRM. I have noticed that various road items such as mini roundabouts and speed bumps don't get considered. These nodes can often affect the speed at which a vehicle travels and frequently influences a route. For example, a lot of people are deterred from using certain roads with speed bumps.

This branch makes the system consider mini roundabouts and traffic calming nodes when calculating a duration for a route. Each of the respective nodes have penalty scores added to the lua script. The code change is a very straightforward extension of the traffic light code.

What do you think? In my evaluation, it certainly seems to improve the accuracy of the route times.

Phil