### PR TITLE
Basic CORS support.

### DIFF
--- a/Server/Connection.h
+++ b/Server/Connection.h
@@ -71,6 +71,11 @@ private:
 			    request.endpoint = TCPsocket.remote_endpoint().address();
 				requestHandler.handle_request(request, reply);
 
+				Header CorsHeader;
+				CorsHeader.name = "Access-Control-Allow-Origin";
+				CorsHeader.value = "*";
+				reply.headers.push_back(CorsHeader);
+				
 				Header compressionHeader;
 				std::vector<unsigned char> compressed;
 				std::vector<boost::asio::const_buffer> outputBuffer;


### PR DESCRIPTION
This patch adds an HTTP header of the form "Access-Control-Allow-Origin: *" to all responses in order to allow use in a cross-origin AJAX situation.

Note that this change allows the service to be used by everyone. I don't consider this a security issue as the current version already enables this behaviour by supporting JSONP.
