### PR TITLE
Remove lexical cast

### DIFF
--- a/Contractor/EdgeBasedGraphFactory.h
+++ b/Contractor/EdgeBasedGraphFactory.h
@@ -32,7 +32,6 @@
 #include <cstdlib>
 
 #include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>

--- a/SConstruct
+++ b/SConstruct
@@ -239,9 +239,6 @@ if not conf.CheckCXXHeader('boost/enable_shared_from_this.hpp'):
 if not conf.CheckCXXHeader('boost/foreach.hpp'):
 	print "boost/foreach.hpp not found. Exiting"
 	Exit(-1)
-if not conf.CheckCXXHeader('boost/lexical_cast.hpp'):
-	print "boost/foreach.hpp not found. Exiting"
-	Exit(-1)
 if not conf.CheckCXXHeader('boost/logic/tribool.hpp'):
 	print "boost/foreach.hpp not found. Exiting"
 	Exit(-1)

--- a/Server/BasicDatastructures.h
+++ b/Server/BasicDatastructures.h
@@ -21,8 +21,8 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #ifndef BASIC_DATASTRUCTURES_H
 #define BASIC_DATASTRUCTURES_H
 #include <string>
+#include <sstream>
 #include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include "../Util/StringUtil.h"
 
@@ -143,7 +143,9 @@ Reply Reply::stockReply(Reply::status_type status) {
 	rep.headers[0].name = "Access-Control-Allow-Origin";
 	rep.headers[0].value = "*";
 	rep.headers[1].name = "Content-Length";
-	rep.headers[1].value = boost::lexical_cast<std::string>(rep.content.size());
+	std::ostringstream s;
+	s << rep.content.size();
+	rep.headers[1].value = s.str();
 	rep.headers[2].name = "Content-Type";
 	rep.headers[2].value = "text/html";
 	return rep;

--- a/Server/RequestHandler.h
+++ b/Server/RequestHandler.h
@@ -25,7 +25,6 @@ or see http://www.gnu.org/licenses/agpl.txt.
 #include <cctype> // std::tolower
 #include <string>
 #include <iostream>
-#include <boost/lexical_cast.hpp>
 #include <boost/noncopyable.hpp>
 
 #include "APIGrammar.h"


### PR DESCRIPTION
There seems to be no pressing reason to depend on lexical_cast, a part of boost which is notoriously slow. This removes the dependency.
