### PR TITLE
Allow configure to work with clang and openmp disabled

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -150,8 +150,9 @@ if GetOption('buildconfiguration') != 'debug' and sys.platform != 'darwin' and G
 	env.Append(CCFLAGS = ['-march=native'])
 
 if not conf.CheckHeader('omp.h'):
-	print "Compiler does not support OpenMP. Exiting"
-	Exit(-1)
+	if "clang" not in env["CXX"]:
+		print "OpenMP not found, Exiting"
+		Exit(-1)
 if not conf.CheckLibWithHeader('bz2', 'bzlib.h', 'CXX'):
 	print "bz2 library not found. Exiting"
 	Exit(-1)


### PR DESCRIPTION
The `scons` script has a [check](https://github.com/DennisOSRM/Project-OSRM/blob/master/SConstruct#L85) for clang and properly disables openmp support by avoiding trying to link the library.

But later on `omp.h` is still checked for and the configure script exits, preventing the build from continuing. This fixes this logical bug by allowing the build to continue with `clang`.
