### PR TITLE
fix spelling error and lacking boost header includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 if(APPLE)
 	SET(CMAKE_OSX_ARCHITECTURES "x86_64")
-	message("Set Archtitecture to x64 on OS X")
+	message("Set Architecture to x64 on OS X")
 endif()
 
 #Check Boost
@@ -54,6 +54,7 @@ find_package( Boost ${BOOST_MIN_VERSION} COMPONENTS ${BOOST_COMPONENTS} REQUIRED
 if (NOT Boost_FOUND)
       message(FATAL_ERROR "Fatal error: Boost (version >= 1.44.0) required.\n")
 endif (NOT Boost_FOUND)
+include_directories(${Boost_INCLUDE_DIRS})
 target_link_libraries( osrm-extract ${Boost_LIBRARIES} )
 target_link_libraries( osrm-prepare ${Boost_LIBRARIES} )
 target_link_libraries( osrm-routed ${Boost_LIBRARIES} )


### PR DESCRIPTION
I have boost in `/opt/boost-53` and after doing

``` sh
mkdir build && cd build
cmake ../ -DBOOST_ROOT=/opt/boost-53/
```

I hit:

``` sh
[  7%] Building CXX object CMakeFiles/osrm-extract.dir/extractor.cpp.o
In file included from /Users/dane/projects/Project-OSRM/extractor.cpp:26:
/Users/dane/projects/Project-OSRM/typedefs.h:29:10: fatal error: 'boost/integer.hpp' file not found
#include <boost/integer.hpp>
```

This pull fixes this problem of lacking includes being passed to the compiler.
