### PR TITLE
add test case for overruled implied oneways

### DIFF
--- a/features/car/oneway.feature
+++ b/features/car/oneway.feature
@@ -15,7 +15,7 @@ Handle oneways streets, as defined at http://wiki.openstreetmap.org/wiki/OSM_tag
 		 | highway | oneway | forw | backw |
 		 | primary | -1     |      | x     |
 
-	Scenario: Car - Implied onewatys
+	Scenario: Car - Implied oneways
 		Then routability should be
 		 | highway       | junction   | forw | backw |
 		 | motorway      |            | x    |       |
@@ -24,6 +24,12 @@ Handle oneways streets, as defined at http://wiki.openstreetmap.org/wiki/OSM_tag
 		 | motorway      | roundabout | x    |       |
 		 | motorway_link | roundabout | x    |       |
 		 | primary       | roundabout | x    |       |
+
+	Scenario: Car - Overrule implied oneway
+		Then routability should be
+		 | highway       | oneway | forw | backw | 
+		 | motorway      | no     | x    | x     | 
+		 | motorway_link | no     | x    | x     |
 
 	Scenario: Car - Around the Block
 		Given the node map


### PR DESCRIPTION
On a motorway `oneway=no` should overrule the implied oneway rule.

Here is a real-life failing example: http://osrm.at/434
