### PR TITLE
CMake: Respect CXXFLAGS set in environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,14 +80,14 @@ endif()
 # Configuring compilers
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	# using Clang
-	set(CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -Wno-unneeded-internal-declaration")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unknown-pragmas -Wno-unneeded-internal-declaration")
 	message(STATUS "OpenMP parallelization not available using clang++")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	# using GCC
-	set(CMAKE_CXX_FLAGS "-Wall -fopenmp -pedantic")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fopenmp -pedantic")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
 	# using Intel C++
-	set(CMAKE_CXX_FLAGS "-static-intel -wd10237 -Wall -openmp -ipo")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-intel -wd10237 -Wall -openmp -ipo")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# using Visual Studio C++
 endif()


### PR DESCRIPTION
Without this change the `CXXFLAGS` environment setting is not respected (tested on OS X 10.8/clang++)
