### PR TITLE
CMake: add missing optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ endif(CMAKE_BUILD_TYPE MATCHES Release)
 # set compile switches
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # not using Visual Studio C++
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC -O0")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC -O3")
 endif()
 
 # Configuring compilers


### PR DESCRIPTION
I noticed that CMake appears to not automatically add optimization flags. So these were missing for me:

``` sh
$ cmake --version
cmake version 2.8.11.2
```
