### PR TITLE
Fix assertion in debug version

### DIFF
--- a/Contractor/TemporaryStorage.cpp
+++ b/Contractor/TemporaryStorage.cpp
@@ -38,7 +38,6 @@ TemporaryStorage & TemporaryStorage::GetInstance(){
 
 TemporaryStorage::~TemporaryStorage() {
     RemoveAll();
-    mutex.unlock();
 }
 
 void TemporaryStorage::RemoveAll() {


### PR DESCRIPTION
When running tests on FreeBSD 10 on debug verion I got boost assertion errors in mutex.hpp:79 . 

It seems that mutex unlock is not needed (it is already unlocked and behavior of this line is undefined).
