### PR TITLE
Use absolute path for .fileindex in osrm-datastore

### DIFF
--- a/datastore.cpp
+++ b/datastore.cpp
@@ -124,7 +124,8 @@ int main( const int argc, const char * argv[] ) {
         paths_iterator = server_paths.find("fileindex");
         BOOST_ASSERT(server_paths.end() != paths_iterator);
         BOOST_ASSERT(!paths_iterator->second.empty());
-        const std::string & file_index_file_name = paths_iterator->second.string();
+        const boost::filesystem::path index_file_path_absolute = boost::filesystem::absolute(paths_iterator->second);
+        const std::string & file_index_file_name = index_file_path_absolute.string();
         paths_iterator = server_paths.find("nodesdata");
         BOOST_ASSERT(server_paths.end() != paths_iterator);
         BOOST_ASSERT(!paths_iterator->second.empty());


### PR DESCRIPTION
[patch revision 2]

Currently the following procedure leads to error:
 1) build/osrm-datastore test/cache/sample1.orsm
 2) cd some_other_dir
 3) orsm-routed --sharedmemory=yes

osrm-routed does not fine the sample.fileindex file because it tries to use given relative path.
If the file name will be stored in memory as absolute path, user can run osrm-datastore and osrm-routed from arbitrary folder without giving the full path to .osrm.
