### PR TITLE
Refactored the EdgeBasedNode class.

### DIFF
--- a/DataStructures/EdgeBasedNode.h
+++ b/DataStructures/EdgeBasedNode.h
@@ -39,7 +39,7 @@ struct EdgeBasedNode {
         ) const {
         BOOST_ASSERT( query_location.isValid() );
 
-        const double epsilon = 1.0/COORDINATE_PRECISION;
+        const double epsilon = 1.0/precision;
 
         if( ignoreInGrid ) {
             return std::numeric_limits<double>::max();


### PR DESCRIPTION
The ComputePerpendicularDistance method of the EdgeBaseNode class exhibits some numerical problems that can occur during the computation of the perpendicular foot point. This patch remedies those problems. Also, the method's implementation has been refactored and now uses several smaller, single-purpose methods. I have also added comments.
