### PR TITLE
fix travel speeds for cars

### DIFF
--- a/features/car/maxspeed.feature
+++ b/features/car/maxspeed.feature
@@ -1,5 +1,6 @@
 @routing @maxspeed @car
 Feature: Car - Max speed restrictions
+When a max speed is set, osrm will use 2/3 of that as the actual speed.
 
     Background: Use specific speeds
         Given the profile "car"
@@ -12,12 +13,12 @@ Feature: Car - Max speed restrictions
         And the ways
             | nodes | highway | maxspeed |
             | ab    | trunk   |          |
-            | bc    | trunk   | 10       |
+            | bc    | trunk   | 60       |
 
         When I route I should get
-            | from | to | route | time      |
-            | a    | b  | ab    | 64s  ~10% |
-            | b    | c  | bc    | 545s ~10% |
+            | from | to | route | speed   |
+            | a    | b  | ab    | 85 km/h |
+            | b    | c  | bc    | 40 km/h |
 
     Scenario: Car - Do not ignore maxspeed when higher than way speed
         Given the node map
@@ -26,32 +27,25 @@ Feature: Car - Max speed restrictions
         And the ways
             | nodes | highway     | maxspeed |
             | ab    | residential |          |
-            | bc    | residential | 85       |
+            | bc    | residential | 90       |
 
         When I route I should get
-            | from | to | route | time      |
-            | a    | b  | ab    | 216s ~10% |
-            | b    | c  | bc    | 64s  ~10% |
+            | from | to | route | speed   |
+            | a    | b  | ab    | 25 km/h |
+            | b    | c  | bc    | 60 km/h |
 
     Scenario: Car - Forward/backward maxspeed
-        Given the shortcuts
-            | key   | value      |
-            | car   | 17s   ~10% |
-            | run   | 109s  ~10% |
-            | walk  | 219s  ~10% |
-            | snail | 1080s ~10% |
-
-        And a grid size of 100 meters
+        Given a grid size of 100 meters
 
         Then routability should be
-            | maxspeed | maxspeed:forward | maxspeed:backward | forw  | backw |
-            |          |                  |                   | car   | car   |
-            | 10       |                  |                   | run   | run   |
-            |          | 10               |                   | run   | car   |
-            |          |                  | 10                | car   | run   |
-            | 1        | 10               |                   | run   | snail |
-            | 1        |                  | 10                | snail | run   |
-            | 1        | 5                | 10                | walk  | run   |
+            | highway | maxspeed | maxspeed:forward | maxspeed:backward | forw    | backw   |
+            | primary |          |                  |                   | 65 km/h | 65 km/h |
+            | primary | 60       |                  |                   | 40 km/h | 40 km/h |
+            | primary |          | 60               |                   | 40 km/h | 65 km/h |
+            | primary |          |                  | 60                | 65 km/h | 40 km/h |
+            | primary | 15       | 60               |                   | 40 km/h | 10 km/h |
+            | primary | 15       |                  | 60                | 10 km/h | 40 km/h |
+            | primary | 15       | 30               | 60                | 20 km/h | 40 km/h |
 
     Scenario: Car - Maxspeed should not allow routing on unroutable ways
         Then routability should be

--- a/features/car/speed.feature
+++ b/features/car/speed.feature
@@ -5,7 +5,6 @@ Feature: Car - speeds
         Given the profile "car"
         And a grid size of 1000 meters
     
-    @bug
     Scenario: Car - speed of various way types
         Then routability should be
             | highway        | oneway | bothw   |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -44,6 +44,8 @@ local abs = math.abs
 local min = math.min
 local max = math.max
 
+local maxspeed_reduction = 0.66
+
 -- End of globals
 local function find_access_tag(source,access_tags_hierachy)
   for i,v in ipairs(access_tags_hierachy) do
@@ -161,7 +163,7 @@ function way_function (way)
 
   if way.speed == -1 then
     local highway_speed = speed_profile[highway]
-    local max_speed = parse_maxspeed( way.tags:Find("maxspeed") )
+    local max_speed = parse_maxspeed( way.tags:Find("maxspeed") )*maxspeed_reduction
     -- Set the avg speed on the way if it is accessible by road class
     if highway_speed then
       if max_speed > highway_speed then
@@ -234,8 +236,8 @@ function way_function (way)
   end
 
   -- Override speed settings if explicit forward/backward maxspeeds are given
-  local maxspeed_forward = parse_maxspeed(way.tags:Find( "maxspeed:forward"))
-  local maxspeed_backward = parse_maxspeed(way.tags:Find( "maxspeed:backward"))
+  local maxspeed_forward = parse_maxspeed(way.tags:Find( "maxspeed:forward"))*maxspeed_reduction
+  local maxspeed_backward = parse_maxspeed(way.tags:Find( "maxspeed:backward"))*maxspeed_reduction
   if maxspeed_forward > 0 then
     if Way.bidirectional == way.direction then
       way.backward_speed = way.speed
@@ -251,10 +253,6 @@ function way_function (way)
 		way.ignore_in_grid = true
 	end
 	way.type = 1
-  way.speed = abs(way.speed*0.66) -- scaling of travel times.
-  if(way.backward_speed > 0) then
-    way.backward_speed = abs(way.backward_speed*0.66) -- scaling of travel times.
-  end
   return
 end
 


### PR DESCRIPTION
It seems the car profile is scaling speeds by 2/3, even when no maxspeed isset. In other words, motorways which have 90 km/h specified in the speed profile end up with 60 km/h.

This commit fixes this, and activates some speed tests. It also rewrites a few relevant tests so they test for speed directly, rather that test for travel time. This makes it easiser to see what's going on.

Btw, I think that scaling by 0.66 might be a bit too conservative. maybe 0.8 would be more realistic?
