### PR TITLE
LTO fix for gcc 4.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,16 @@ endif()
 # Check if LTO is available
 set(LTO_FLAGS "")
 CHECK_CXX_COMPILER_FLAG("-flto" HAS_LTO_FLAG)
-if    (HAS_LTO_FLAG)
+if (HAS_LTO_FLAG)
   set(LTO_FLAGS "${LTO_FLAGS} -flto")
+
+  # Since gcc 4.9 the LTO format is non-standart ('slim'), so we need to use the build-in tools
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+      NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9.0")
+    message(STATUS "Using gcc specific binutils for LTO.")
+    set(CMAKE_AR     "/usr/bin/gcc-ar")
+    set(CMAKE_RANLIB "/usr/bin/gcc-ranlib")
+  endif()
 endif (HAS_LTO_FLAG)
 
 # disable partitioning of LTO process when possible (fixes Debian issues)


### PR DESCRIPTION
GCC 4.9 changed the (default) format for object files when compiled with -flto, which make it incompatible with vanilla ar / ranlib.
