### PR TITLE
Remove extra mutex unlocking in ConcurrentQueue.h

### DIFF
--- a/DataStructures/ConcurrentQueue.h
+++ b/DataStructures/ConcurrentQueue.h
@@ -46,7 +46,6 @@ template <typename Data> class ConcurrentQueue
                         [this]
                         { return m_internal_queue.size() < m_internal_queue.capacity(); });
         m_internal_queue.push_back(data);
-        m_mutex.unlock();
         m_not_empty.notify_one();
     }
 
@@ -60,7 +59,6 @@ template <typename Data> class ConcurrentQueue
                          { return !m_internal_queue.empty(); });
         popped_value = m_internal_queue.front();
         m_internal_queue.pop_front();
-        m_mutex.unlock();
         m_not_full.notify_one();
     }
 
@@ -73,7 +71,6 @@ template <typename Data> class ConcurrentQueue
         }
         popped_value = m_internal_queue.front();
         m_internal_queue.pop_front();
-        m_mutex.unlock();
         m_not_full.notify_one();
         return true;
     }


### PR DESCRIPTION
As discussed in https://github.com/DennisOSRM/Project-OSRM/pull/998 , unlocking the mutex is performed on destruction. Second unlocking gives an assertion (for debug version) for Windows and FreeBSD 10.
