### PR TITLE
Use TimingUtil.h for all time measurement

### DIFF
--- a/Contractor/EdgeBasedGraphFactory.cpp
+++ b/Contractor/EdgeBasedGraphFactory.cpp
@@ -273,10 +273,10 @@ void EdgeBasedGraphFactory::Run(const std::string &original_edge_data_filename,
     m_geometry_compressor.SerializeInternalVector(geometry_filename);
 
     SimpleLogger().Write() << "Timing statistics for edge-expanded graph:";
-    SimpleLogger().Write() << "Geometry compression: " << TIMER_MSEC(geometry)*0.001 << "s";
-    SimpleLogger().Write() << "Renumbering edges: " << TIMER_MSEC(renumber)*0.001 << "s";
-    SimpleLogger().Write() << "Generating nodes: " << TIMER_MSEC(generate_nodes)*0.001 << "s";
-    SimpleLogger().Write() << "Generating edges: " << TIMER_MSEC(generate_edges)*0.001 << "s";
+    SimpleLogger().Write() << "Geometry compression: " << TIMER_SEC(geometry) << "s";
+    SimpleLogger().Write() << "Renumbering edges: " << TIMER_SEC(renumber) << "s";
+    SimpleLogger().Write() << "Generating nodes: " << TIMER_SEC(generate_nodes) << "s";
+    SimpleLogger().Write() << "Generating edges: " << TIMER_SEC(generate_edges) << "s";
 }
 
 void EdgeBasedGraphFactory::CompressGeometry()

--- a/DataStructures/StaticRTree.h
+++ b/DataStructures/StaticRTree.h
@@ -424,7 +424,7 @@ class StaticRTree
         tree_node_file.close();
 
         TIMER_STOP(construction);
-        SimpleLogger().Write() << "finished r-tree construction in " << TIMER_MSEC(construction)/1000. << " seconds";
+        SimpleLogger().Write() << "finished r-tree construction in " << TIMER_SEC(construction) << " seconds";
     }
 
     // Read-only operation for queries

--- a/Util/TimingUtil.h
+++ b/Util/TimingUtil.h
@@ -30,10 +30,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <chrono>
 
-#define TIMER_START(_X) std::chrono::time_point<std::chrono::steady_clock> _X##_start, _X##_stop; _X##_start = std::chrono::steady_clock::now()
+#define TIMER_START(_X) auto _X##_start = std::chrono::steady_clock::now(), _X##_stop = _X##_start
 #define TIMER_STOP(_X) _X##_stop = std::chrono::steady_clock::now()
 #define TIMER_MSEC(_X) std::chrono::duration_cast<std::chrono::milliseconds>(_X##_stop - _X##_start).count()
-#define TIMER_SEC(_X) std::chrono::duration_cast<std::chrono::seconds>(_X##_stop - _X##_start).count()
+#define TIMER_SEC(_X) (0.001*std::chrono::duration_cast<std::chrono::milliseconds>(_X##_stop - _X##_start).count())
 #define TIMER_MIN(_X) std::chrono::duration_cast<std::chrono::minutes>(_X##_stop - _X##_start).count()
 
 #endif // TIMINGUTIL_H

--- a/extractor.cpp
+++ b/extractor.cpp
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Util/ProgramOptions.h"
 #include "Util/SimpleLogger.h"
 #include "Util/StringUtil.h"
+#include "Util/TimingUtil.h"
 #include "Util/UUID.h"
 #include "typedefs.h"
 
@@ -58,8 +59,8 @@ int main(int argc, char *argv[])
     try
     {
         LogPolicy::GetInstance().Unmute();
-        std::chrono::time_point<std::chrono::steady_clock> startup_time =
-            std::chrono::steady_clock::now();
+
+        TIMER_START(extracting);
 
         boost::filesystem::path config_file_path, input_path, profile_path;
         unsigned requested_num_threads;
@@ -240,16 +241,14 @@ int main(int argc, char *argv[])
             throw OSRMException("Parser not initialized!");
         }
         SimpleLogger().Write() << "Parsing in progress..";
-        std::chrono::time_point<std::chrono::steady_clock> parsing_start_time =
-            std::chrono::steady_clock::now();
+        TIMER_START(parsing);
 
         parser->Parse();
         delete parser;
         delete extractor_callbacks;
 
-        std::chrono::duration<double> parsing_duration =
-            std::chrono::steady_clock::now() - parsing_start_time;
-        SimpleLogger().Write() << "Parsing finished after " << parsing_duration.count()
+        TIMER_STOP(parsing);
+        SimpleLogger().Write() << "Parsing finished after " << TIMER_SEC(parsing)
                                << " seconds";
 
         if (extraction_containers.all_edges_list.empty())
@@ -260,9 +259,8 @@ int main(int argc, char *argv[])
 
         extraction_containers.PrepareData(output_file_name, restriction_fileName);
 
-        std::chrono::duration<double> extraction_duration =
-            std::chrono::steady_clock::now() - startup_time;
-        SimpleLogger().Write() << "extraction finished after " << extraction_duration.count()
+        TIMER_STOP(extracting);
+        SimpleLogger().Write() << "extraction finished after " << TIMER_SEC(extracting)
                                << "s";
         SimpleLogger().Write() << "To prepare the data for routing, run: "
                                << "./osrm-prepare " << output_file_name << std::endl;


### PR DESCRIPTION
As discussed in https://github.com/DennisOSRM/Project-OSRM/pull/998 , I have repalced all time measurement with TIMER_\* macros from TimingUtil.h (making it Windows-compatible). There is one more change: TIMER_SEC( ) now returns double value, not integer (used for almost all measurements).
