### PR TITLE
sort vectors before using std::set_difference

### DIFF
--- a/Algorithms/ExtractRouteNames.h
+++ b/Algorithms/ExtractRouteNames.h
@@ -75,6 +75,8 @@ template <class DataFacadeT, class SegmentT> struct ExtractRouteNames
         }
         std::vector<SegmentT> shortest_path_set_difference(shortest_path_segments.size());
         std::vector<SegmentT> alternative_path_set_difference(alternative_path_segments.size());
+        std::sort(shortest_path_segments.begin(), shortest_path_segments.end(), name_id_comperator);
+        std::sort(alternative_path_segments.begin(), alternative_path_segments.end(), name_id_comperator);
         std::set_difference(shortest_path_segments.begin(),
                             shortest_path_segments.end(),
                             alternative_path_segments.begin(),


### PR DESCRIPTION
discussed in https://github.com/DennisOSRM/Project-OSRM/pull/998#issuecomment-45238338
The vectors are better to be sorted up to `name_id_comperator` before running std::set_difference. Elsewhere we get debug checked iterator assertions on Windows and theoretically possible incorrect results.
