### PR TITLE
Obtain char* from boost::filesystem::path on all systems

### DIFF
--- a/datastore.cpp
+++ b/datastore.cpp
@@ -310,7 +310,7 @@ int main(const int argc, const char *argv[])
         shared_layout_ptr->coordinate_list_size = coordinate_list_size;
 
         // load geometries sizes
-        std::ifstream geometry_input_stream(geometries_data_path.c_str(), std::ios::binary);
+        std::ifstream geometry_input_stream(geometries_data_path.string().c_str(), std::ios::binary);
         unsigned number_of_geometries_indices = 0;
         unsigned number_of_compressed_geometries = 0;
 

--- a/extractor.cpp
+++ b/extractor.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
         tbb::task_scheduler_init init(real_num_threads);
 
         /*** Setup Scripting Environment ***/
-        ScriptingEnvironment scripting_environment(profile_path.c_str());
+        ScriptingEnvironment scripting_environment(profile_path.string().c_str());
 
         bool file_has_pbf_format(false);
         std::string output_file_name = input_path.string();
@@ -229,11 +229,11 @@ int main(int argc, char *argv[])
         BaseParser *parser;
         if (file_has_pbf_format)
         {
-            parser = new PBFParser(input_path.c_str(), extractor_callbacks, scripting_environment);
+            parser = new PBFParser(input_path.string().c_str(), extractor_callbacks, scripting_environment);
         }
         else
         {
-            parser = new XMLParser(input_path.c_str(), extractor_callbacks, scripting_environment);
+            parser = new XMLParser(input_path.string().c_str(), extractor_callbacks, scripting_environment);
         }
 
         if (!parser->ReadHeader())

--- a/prepare.cpp
+++ b/prepare.cpp
@@ -229,10 +229,10 @@ int main(int argc, char *argv[])
         luaL_openlibs(lua_state);
 
         // adjust lua load path
-        luaAddScriptFolderToLoadPath(lua_state, profile_path.c_str());
+        luaAddScriptFolderToLoadPath(lua_state, profile_path.string().c_str());
 
         // Now call our function in a lua script
-        if (0 != luaL_dofile(lua_state, profile_path.c_str()))
+        if (0 != luaL_dofile(lua_state, profile_path.string().c_str()))
         {
             std::cerr << lua_tostring(lua_state, -1) << " occured in scripting block" << std::endl;
             return 1;


### PR DESCRIPTION
The definition of c_str function in boost is
`const value_type*   c_str() const`
and on some compilers and runtimes in can be not char\* (wchar_t\* on Windows, for example), To guarantee getting char*, it is recommended to use `.string().c_str()`
http://stackoverflow.com/questions/11352641/boostfilesystempath-and-fopen
patch from 
https://github.com/DennisOSRM/Project-OSRM/pull/998
