### PR TITLE
link -lrt to osrm-prepare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ if(APPLE)
 endif()
 
 if(UNIX AND NOT APPLE)
+  target_link_libraries(osrm-prepare rt)
   target_link_libraries(osrm-datastore rt)
   target_link_libraries(OSRM rt)
 endif()


### PR DESCRIPTION
Avoids linking error for me on Ubuntu precise:

``` sh
Linking CXX executable osrm-prepare
/usr/bin/cmake -E cmake_link_script CMakeFiles/osrm-prepare.dir/link.txt --verbose=1
/usr/bin/g++-4.8   -std=c++11 -DBOOST_SPIRIT_USE_PHOENIX_V3=1 -I/home/ubuntu/mapnik-packaging/osx/out/build-cpp11-libstdcpp-gcc-x86_64-linux/include  -DNDEBUG -O3  -D_FILE_OFFSET_BITS=64 -fPIC  -Wall -pedantic -fPIC            -flto -O3 -DNDEBUG  -lrt -fopenmp  -L/home/ubuntu/mapnik-packaging/osx/out/build-cpp11-libstdcpp-gcc-x86_64-linux/lib -O3  -Wl,-rpath=\$$ORIGIN     -flto  -flto-partition=none CMakeFiles/osrm-prepare.dir/prepare.cpp.o CMakeFiles/osrm-prepare.dir/Contractor/TemporaryStorage.cpp.o CMakeFiles/osrm-prepare.dir/Contractor/GeometryCompressor.cpp.o CMakeFiles/osrm-prepare.dir/Contractor/EdgeBasedGraphFactory.cpp.o CMakeFiles/osrm-prepare.dir/DataStructures/HilbertValue.cpp.o CMakeFiles/osrm-prepare.dir/DataStructures/RestrictionMap.cpp.o  -o osrm-prepare -rdynamic -Wl,-Bstatic -lboost_date_time -lboost_filesystem -lboost_iostreams -lboost_program_options -lboost_regex -lboost_system -lboost_thread -Wl,-Bdynamic -lpthread libUUID.a libGITDESCRIPTION.a libCOORDLIB.a -ltbb -ltbbmalloc -Wl,-Bstatic -llua -lluabind -lstxxl -losmpbf -lprotobuf -Wl,-Bdynamic 
linux/lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_for(timespec const&)':
thread.cpp:(.text+0x132e): undefined reference to `clock_gettime'
/home/ubuntu/mapnik-packaging/osx/out/build-cpp11-libstdcpp-gcc-x86_64-linux/lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_until(timespec const&)':
thread.cpp:(.text+0x1495): undefined reference to `clock_gettime'
thread.cpp:(.text+0x1518): undefined reference to `clock_gettime'
collect2: error: ld returned 1 exit status
make[2]: *** [osrm-prepare] Error 1
make[2]: Leaving directory `/home/ubuntu/mapnik-packaging/osx/out/packages/Project-OSRM/build'
make[1]: *** [CMakeFiles/osrm-prepare.dir/all] Error 2
```
