### PR TITLE
Uppercase street names compare.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/Util/FingerPrint.cpp FingerPrint.c
 
 add_custom_target(FingerPrintConfigure DEPENDS ${CMAKE_SOURCE_DIR}/Util/FingerPrint.cpp)
 
-set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread)
+set(BOOST_COMPONENTS locale date_time filesystem iostreams program_options regex system thread)
 
 configure_file(
   ${CMAKE_SOURCE_DIR}/Util/GitDescription.cpp.in

--- a/Extractor/ExtractorCallbacks.cpp
+++ b/Extractor/ExtractorCallbacks.cpp
@@ -43,6 +43,11 @@ ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containe
                                        std::unordered_map<std::string, NodeID> &string_map)
     : string_map(string_map), external_memory(extraction_containers)
 {
+    // Create system default locale
+    boost::locale::generator gen;
+    global_loc = gen("");
+    std::locale::global(global_loc);
+    std::wcout.imbue(global_loc);
 }
 
 /** warning: caller needs to take care of synchronization! */
@@ -94,12 +99,13 @@ void ExtractorCallbacks::ProcessWay(ExtractionWay &parsed_way)
     }
 
     // Get the unique identifier for the street name
-    const auto &string_map_iterator = string_map.find(parsed_way.name);
+    const std::string& upper_way_name = to_upper(parsed_way.name);
+    const auto &string_map_iterator = string_map.find(upper_way_name);
     if (string_map.end() == string_map_iterator)
     {
         parsed_way.nameID = external_memory.name_list.size();
         external_memory.name_list.push_back(parsed_way.name);
-        string_map.insert(std::make_pair(parsed_way.name, parsed_way.nameID));
+        string_map.insert(std::make_pair(upper_way_name, parsed_way.nameID));
     }
     else
     {

--- a/Extractor/ExtractorCallbacks.h
+++ b/Extractor/ExtractorCallbacks.h
@@ -31,6 +31,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../typedefs.h"
 
 #include <unordered_map>
+
+#include <boost/locale.hpp>
+
 #include <string>
 
 struct ExternalMemoryNode;
@@ -43,6 +46,7 @@ class ExtractorCallbacks
   private:
     std::unordered_map<std::string, NodeID> &string_map;
     ExtractionContainers &external_memory;
+    std::locale global_loc;
 
   public:
     ExtractorCallbacks() = delete;
@@ -58,6 +62,12 @@ class ExtractorCallbacks
 
     // warning: caller needs to take care of synchronization!
     void ProcessWay(ExtractionWay &way);
+
+private:
+    inline std::string to_upper(const std::string& str) const
+    {
+        return boost::locale::to_upper(str, global_loc);
+    }
 };
 
 #endif /* EXTRACTOR_CALLBACKS_H */


### PR DESCRIPTION
In some rare cases parts of one street are named similar but with lowercase and uppercase characters. So in instructions we have two or even more rows for same street. For example "Some Name" and "Some name". I think it's better to compare in uppercase to fix this issue.
uses boost.locale
