### PR TITLE
std::pair's to structures

### DIFF
--- a/DataStructures/RestrictionMap.cpp
+++ b/DataStructures/RestrictionMap.cpp
@@ -46,7 +46,7 @@ RestrictionMap::RestrictionMap(const std::shared_ptr<NodeBasedDynamicGraph> &gra
         m_restriction_start_nodes.insert(restriction.fromNode);
         m_no_turn_via_node_set.insert(restriction.viaNode);
 
-        RestrictionSource restriction_source{restriction.fromNode, restriction.viaNode};
+        RestrictionSource restriction_source = {restriction.fromNode, restriction.viaNode};
 
         unsigned index;
         auto restriction_iter = m_restriction_map.find(restriction_source);
@@ -106,7 +106,7 @@ void RestrictionMap::FixupArrivingTurnRestriction(const NodeID node_u,
 
     for (const NodeID node_x : predecessors)
     {
-        const auto restriction_iterator = m_restriction_map.find(RestrictionSource{node_x, node_u});
+        const auto restriction_iterator = m_restriction_map.find({node_x, node_u});
         if (restriction_iterator == m_restriction_map.end())
         {
             continue;
@@ -138,7 +138,7 @@ void RestrictionMap::FixupStartingTurnRestriction(const NodeID node_u,
         return;
     }
 
-    const auto restriction_iterator = m_restriction_map.find(RestrictionSource{node_v, node_w});
+    const auto restriction_iterator = m_restriction_map.find({node_v, node_w});
     if (restriction_iterator != m_restriction_map.end())
     {
         const unsigned index = restriction_iterator->second;
@@ -146,7 +146,7 @@ void RestrictionMap::FixupStartingTurnRestriction(const NodeID node_u,
         m_restriction_map.erase(restriction_iterator);
         m_restriction_start_nodes.emplace(node_u);
         // insert new restriction start (u,w) (pointing to index)
-        RestrictionSource new_source{node_u, node_w};
+        RestrictionSource new_source = {node_u, node_w};
         m_restriction_map.emplace(new_source, index);
     }
 }
@@ -164,7 +164,7 @@ NodeID RestrictionMap::CheckForEmanatingIsOnlyTurn(const NodeID node_u,
         return SPECIAL_NODEID;
     }
 
-    auto restriction_iter = m_restriction_map.find(RestrictionSource{node_u, node_v});
+    auto restriction_iter = m_restriction_map.find({node_u, node_v});
     if (restriction_iter != m_restriction_map.end())
     {
         const unsigned index = restriction_iter->second;
@@ -196,7 +196,7 @@ bool RestrictionMap::CheckIfTurnIsRestricted(const NodeID node_u,
         return false;
     }
 
-    auto restriction_iter = m_restriction_map.find(RestrictionSource{node_u, node_v});
+    auto restriction_iter = m_restriction_map.find({node_u, node_v});
     if (restriction_iter != m_restriction_map.end())
     {
         const unsigned index = restriction_iter->second;

--- a/DataStructures/RestrictionMap.h
+++ b/DataStructures/RestrictionMap.h
@@ -45,7 +45,7 @@ struct RestrictionSource
     NodeID start_node;
     NodeID via_node;
 
-    explicit RestrictionSource(NodeID start, NodeID via)
+    RestrictionSource(NodeID start, NodeID via)
         : start_node(start), via_node(via) {}
 
     friend inline bool operator==(const RestrictionSource& lhs, const RestrictionSource& rhs)
@@ -74,7 +74,7 @@ namespace std
     {
         size_t operator()(const RestrictionSource &r_source) const
         {
-            return std::hash<int>()(r_source.start_node) ^ std::hash<int>()(r_source.via_node);
+            return hash_val(r_source.start_node, r_source.via_node);
         }
     };
 
@@ -82,7 +82,7 @@ namespace std
     {
         size_t operator()(const RestrictionTarget &r_target) const
         {
-            return std::hash<int>()(r_target.target_node) ^ std::hash<bool>()(r_target.is_only);
+            return hash_val(r_target.target_node, r_target.is_only);
         }
     };
 }


### PR DESCRIPTION
I've replaced std::pair&lt;NodeID, NodeID&gt; and std::pair&lt;NodeID, bool&gt; with structs RestrictionSource and RestrictionTarget. I think now it's more readable and easier to understand.
Also replaced wrong type in CheckForEmanatingIsOnlyTurn method (in 'for' was RestrictionSource instead of RestrictionTarget).
