### PR TITLE
update rspec matchers to use expect()

### DIFF
--- a/features/step_definitions/options.rb
+++ b/features/step_definitions/options.rb
@@ -15,35 +15,35 @@ When(/^I run "osrm\-prepare\s?(.*?)"$/) do |options|
 end
 
 Then /^it should exit with code (\d+)$/ do |code|
-  @exit_code.should == code.to_i
+  expect(@exit_code).to eq( code.to_i )
 end
 
 Then /^stdout should contain "(.*?)"$/ do |str|
-  @stdout.should include(str)
+  expect(@stdout).to include(str)
 end
 
 Then /^stderr should contain "(.*?)"$/ do |str|
-  @stderr.should include(str)
+  expect(@stderr).to include(str)
 end
 
 Then(/^stdout should contain \/(.*)\/$/) do |regex_str|
   regex = Regexp.new regex_str
-  @stdout.should =~ regex
+  expect(@stdout).to match( regex )
 end
 
 Then(/^stderr should contain \/(.*)\/$/) do |regex_str|
   regex = Regexp.new regex_str
-  @stderr.should =~ regex
+  expect(@stderr).to match( regex )
 end
 
 Then /^stdout should be empty$/ do
-  @stdout.should == ""
+  expect(@stdout).to eq("")
 end
 
 Then /^stderr should be empty$/ do
-  @stderr.should == ""
+  expect(@stderr).to eq("")
 end
 
 Then /^stdout should contain (\d+) lines?$/ do |lines|
-  @stdout.lines.count.should == lines.to_i
+  expect(@stdout.lines.count).to eq( lines.to_i )
 end

--- a/features/step_definitions/requests.rb
+++ b/features/step_definitions/requests.rb
@@ -6,9 +6,9 @@ When /^I request \/(.*)$/ do |path|
 end
 
 Then /^I should get a response/ do
-  @response.code.should == "200"
-  @response.body.should_not == nil
-  @response.body.should_not == ''
+  expect(@response.code).to eq("200")
+  expect(@response.body).not_to eq(nil)
+  expect(@response.body).not_to eq('')
 end
 
 Then /^response should be valid JSON$/ do
@@ -16,31 +16,31 @@ Then /^response should be valid JSON$/ do
 end
 
 Then /^response should be well-formed$/ do
-  @json['status'].class.should == Fixnum
+  expect(@json['status'].class).to eq(Fixnum)
 end
 
 Then /^status code should be (\d+)$/ do |code|
   @json = JSON.parse @response.body
-  @json['status'].should == code.to_i
+  expect(@json['status']).to eq(code.to_i)
 end
 
 Then /^status message should be "(.*?)"$/ do |message|
   @json = JSON.parse @response.body
-  @json['status_message'].should == message
+  expect(@json['status_message']).to eq(message)
 end
 
 Then /^response should be a well-formed route$/ do
   step "response should be well-formed"
-  @json['status_message'].class.should == String
-  @json['route_summary'].class.should == Hash
-  @json['route_geometry'].class.should == String
-  @json['route_instructions'].class.should == Array
-  @json['via_points'].class.should == Array
-  @json['via_indices'].class.should == Array
+  expect(@json['status_message'].class).to eq(String)
+  expect(@json['route_summary'].class).to eq(Hash)
+  expect(@json['route_geometry'].class).to eq(String)
+  expect(@json['route_instructions'].class).to eq(Array)
+  expect(@json['via_points'].class).to eq(Array)
+  expect(@json['via_indices'].class).to eq(Array)
 end
 
 Then /^"([^"]*)" should return code (\d+)$/ do |binary, code|
-  @process_error.is_a?(OSRMError).should == true
-  @process_error.process.should == binary
-  @process_error.code.to_i.should == code.to_i
+  expect(@process_error.is_a?(OSRMError)).to eq(true)
+  expect(@process_error.process).to eq(binary)
+  expect(@process_error.code.to_i).to eq(code.to_i)
 end

--- a/features/step_definitions/timestamp.rb
+++ b/features/step_definitions/timestamp.rb
@@ -2,6 +2,6 @@ Then /^I should get a valid timestamp/ do
   step "I should get a response"
   step "response should be valid JSON"
   step "response should be well-formed"
-  @json['timestamp'].class.should == String
-  @json['timestamp'].should == OSM_TIMESTAMP
+  expect(@json['timestamp'].class).to eq(String)
+  expect(@json['timestamp']).to eq(OSM_TIMESTAMP)
 end


### PR DESCRIPTION
updates cucumber to use rspec expect() style: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax

avoids warnings with new versions of rspec.
