### PR TITLE
Fix:Correct number of nodes in connected component.

### DIFF
--- a/Algorithms/StronglyConnectedComponents.h
+++ b/Algorithms/StronglyConnectedComponents.h
@@ -242,9 +242,9 @@ class TarjanSCC
         std::vector<TarjanNode> tarjan_node_list(m_node_based_graph->GetNumberOfNodes());
         unsigned component_index = 0, size_of_current_component = 0;
         int index = 0;
-        NodeID last_node = m_node_based_graph->GetNumberOfNodes();
+        const NodeID last_node = m_node_based_graph->GetNumberOfNodes();
         std::vector<bool> processing_node_before_recursion(m_node_based_graph->GetNumberOfNodes(), true);
-        for (NodeID node = 0; node < last_node; ++node)
+        for(const NodeID node : boost::irange(0u, last_node))
         {
             if (UINT_MAX == components_index[node])
             {
@@ -259,7 +259,9 @@ class TarjanSCC
                 const bool before_recursion = processing_node_before_recursion[v];
 
                 if (before_recursion && tarjan_node_list[v].index != UINT_MAX)
+                {
                     continue;
+                }
 
                 if (before_recursion)
                 {


### PR DESCRIPTION
Previous algorithm, assume we have full graph size of 3. We start from node 0 and add it to stack. Output node 0, put it back to stack with false flag(and add it to tarjan stack) and put to stack nodes 1, 2. Output 2, put it back with false flag(and add it to tarjan stack), also we put into stack 1, because we haven't processed it yet. Current stack 0, false -> 1, true -> 2, false -> 1, true.
As you see from that stack we will put 1 into tarjan stack twice. And current algorithm will output that the size of component is 3.
