### PR TITLE
Fixes alternative route end-point (http://imgur.com/ZQhwTZi)

### DIFF
--- a/Descriptors/JSONDescriptor.h
+++ b/Descriptors/JSONDescriptor.h
@@ -201,6 +201,7 @@ template <class DataFacadeT> class JSONDescriptor : public BaseDescriptor<DataFa
                 current = facade->GetCoordinateOfNode(path_data.node);
                 alternate_description_factory.AppendSegment(current, path_data);
             }
+            alternate_description_factory.SetEndSegment(raw_route.segment_end_coordinates.back().target_phantom, raw_route.alt_source_traversed_in_reverse.back());
             alternate_description_factory.Run(facade, config.zoom_level);
 
             if (config.geometry)


### PR DESCRIPTION
Bug can be seen on foot profile by request:
viaroute?loc=55.891659,37.594341&loc=55.89254494309415,37.59550452232361&alt=true&instructions=true
![alter-route-bug](https://cloud.githubusercontent.com/assets/6870069/3766046/2a0a3694-18c1-11e4-9811-0371c985f34e.png)

How it should be when fixed:
![alter-route-fixed](https://cloud.githubusercontent.com/assets/6870069/3766038/1bc7a076-18c1-11e4-82ac-09c850aef0eb.png)

I have no proper links, because I don't know open servers with foot profile routes in Moscow. 
