### PR TITLE
remove unused variable in Windows code

### DIFF
--- a/DataStructures/SharedMemoryFactory.h
+++ b/DataStructures/SharedMemoryFactory.h
@@ -286,7 +286,6 @@ class SharedMemory : boost::noncopyable
   private:
     static void build_key(int id, char *key)
     {
-        OSRMLockFile lock_file;
         sprintf(key, "%s.%d", "osrm.lock", id);
     }
 


### PR DESCRIPTION
Just removed one variable and multiple warnings.
(osrm.lock is hardcoded in all Windows code anyway)
