### PR TITLE
Mingw support update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
 
     # Since gcc 4.9 the LTO format is non-standart ('slim'), so we need to use the build-in tools
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
-        NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9.0")
+        NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9.0" AND NOT MINGW)
       message(STATUS "Using gcc specific binutils for LTO.")
       set(CMAKE_AR     "/usr/bin/gcc-ar")
       set(CMAKE_RANLIB "/usr/bin/gcc-ranlib")


### PR DESCRIPTION
When trying to build OSRM under MSYS2 with its package Archlinux-ported package system, I have noticed new MinGW incompatibilities. Currently M_1_PI and so on are used in the code but only M_PI defined by CMake, so _USE_MATH_DEFINES could help.  
gcc-ar is also unavailable in gcc 4.9.1 from MSYS2 , hope it will  be ok to disable that fragment.

openmp problem still remained (only manual adding `gomp` to osrm-extract helped), but this is to be fixed in stxxl, I guess (compiled with USE_GNU_PARALLEL but still uses OpenMP too).
