### PR TITLE
fix appveyor packaging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build_script:
   - cmake .. -G "Visual Studio 12 Win64" -DCMAKE_BUILD_TYPE=%Configuration% -DBZIP2_INCLUDE_DIR=%P%/libs/include -DBZIP2_LIBRARIES=%P%/libs/lib/libbz2.lib -DCMAKE_INSTALL_PREFIX=%P%/libs -DBOOST_ROOT=%P%/boost_min -DBoost_USE_STATIC_LIBS=ON -T CTP_Nov2013
   - msbuild /clp:Verbosity=minimal /nologo OSRM.sln
   - msbuild /clp:Verbosity=minimal /nologo tests.vcxproj
-  - if "%APPVEYOR_REPO_BRANCH%"=="develop" (7z a %P%/osrm_%Configuration%.zip *.exe *.pdb %P%/libs/bin/*.dll -tzip)
+  - if "%APPVEYOR_REPO_BRANCH%"=="develop" (7z a %P%/osrm_%Configuration%.zip %Configuration%/*.exe %Configuration%/*.pdb %P%/libs/bin/*.dll -tzip)
   - set PATH=%PATH%;c:/projects/osrm/libs/bin
   - cd c:/projects/osrm/build/%Configuration%
   - datastructure-tests.exe


### PR DESCRIPTION
After switching to msbuild the .exe were missing in built archives (they moved to Debug or Release folder).

Hope this will work... (see Appveyor log and artifacts https://ci.appveyor.com/project/DennisOSRM/osrm-backend )
