### PR TITLE
[not ready] Integrate RangeTable into StaticGraph

### DIFF
--- a/DataStructures/RangeTable.h
+++ b/DataStructures/RangeTable.h
@@ -133,7 +133,7 @@ public:
         sum_lengths = lengths_prefix_sum;
     }
 
-    inline void swap(typename RangeT<BLOCK_SIZE, USE_SHARED_MEMORY>& other)
+    inline void swap(RangeTable<BLOCK_SIZE, USE_SHARED_MEMORY>& other)
     {
         block_offsets.swap(other.block_offsets);
         diff_blocks.swap(other.diff_blocks);

--- a/DataStructures/RangeTable.h
+++ b/DataStructures/RangeTable.h
@@ -133,6 +133,17 @@ public:
         sum_lengths = lengths_prefix_sum;
     }
 
+    inline void swap(typename RangeT<BLOCK_SIZE, USE_SHARED_MEMORY>& other)
+    {
+        block_offsets.swap(other.block_offsets);
+        diff_blocks.swap(other.diff_blocks);
+    }
+
+    inline unsigned GetSum() const
+    {
+        return sum_lengths;
+    }
+
     inline RangeT GetRange(const unsigned id) const
     {
         BOOST_ASSERT(id < block_offsets.size() + diff_blocks.size() * BLOCK_SIZE);

--- a/Server/DataStructures/InternalDataFacade.h
+++ b/Server/DataStructures/InternalDataFacade.h
@@ -58,7 +58,6 @@ template <class EdgeDataT> class InternalDataFacade : public BaseDataFacade<Edge
     InternalDataFacade() {}
 
     unsigned m_check_sum;
-    unsigned m_number_of_nodes;
     QueryGraph *m_query_graph;
     std::string m_timestamp;
 
@@ -103,20 +102,20 @@ template <class EdgeDataT> class InternalDataFacade : public BaseDataFacade<Edge
 
     void LoadGraph(const boost::filesystem::path &hsgr_path)
     {
-        typename RangeTable<16, false> node_idx;
+        typename QueryGraph::NodeTable node_table;
         typename ShM<typename QueryGraph::EdgeArrayEntry, false>::vector edge_list;
 
         SimpleLogger().Write() << "loading graph from " << hsgr_path.string();
 
-        m_number_of_nodes = readHSGRFromStream(hsgr_path, node_list, edge_list, &m_check_sum);
+        readHSGRFromStream(hsgr_path, node_table, edge_list, &m_check_sum);
 
         BOOST_ASSERT_MSG(0 != node_list.size(), "node list empty");
         // BOOST_ASSERT_MSG(0 != edge_list.size(), "edge list empty");
-        SimpleLogger().Write() << "loaded " << node_list.size() << " nodes and " << edge_list.size()
-                               << " edges";
-        m_query_graph = new QueryGraph(node_list, edge_list);
+        //SimpleLogger().Write() << "loaded " << node_list.size() << " nodes and " << edge_list.size()
+        //                       << " edges";
+        m_query_graph = new QueryGraph(node_table, edge_list);
 
-        BOOST_ASSERT_MSG(0 == node_list.size(), "node list not flushed");
+        //BOOST_ASSERT_MSG(0 == node_list.size(), "node list not flushed");
         BOOST_ASSERT_MSG(0 == edge_list.size(), "edge list not flushed");
         SimpleLogger().Write() << "Data checksum is " << m_check_sum;
     }

--- a/Server/DataStructures/InternalDataFacade.h
+++ b/Server/DataStructures/InternalDataFacade.h
@@ -103,7 +103,7 @@ template <class EdgeDataT> class InternalDataFacade : public BaseDataFacade<Edge
 
     void LoadGraph(const boost::filesystem::path &hsgr_path)
     {
-        typename ShM<typename QueryGraph::NodeArrayEntry, false>::vector node_list;
+        typename RangeTable<16, false> node_idx;
         typename ShM<typename QueryGraph::EdgeArrayEntry, false>::vector edge_list;
 
         SimpleLogger().Write() << "loading graph from " << hsgr_path.string();

--- a/Server/DataStructures/SharedDataType.h
+++ b/Server/DataStructures/SharedDataType.h
@@ -46,7 +46,9 @@ struct SharedDataLayout
         NAME_CHAR_LIST,
         NAME_ID_LIST,
         VIA_NODE_LIST,
-        GRAPH_NODE_LIST,
+        GRAPH_NODE_OFFSETS,
+        GRAPH_NODE_BLOCKS,
+        GRAPH_NODE_NUM,
         GRAPH_EDGE_LIST,
         COORDINATE_LIST,
         TURN_INSTRUCTION,
@@ -78,7 +80,6 @@ struct SharedDataLayout
         SimpleLogger().Write(logDEBUG) << "name_char_list_size:        " << num_entries[NAME_CHAR_LIST];
         SimpleLogger().Write(logDEBUG) << "name_id_list_size:          " << num_entries[NAME_ID_LIST];
         SimpleLogger().Write(logDEBUG) << "via_node_list_size:         " << num_entries[VIA_NODE_LIST];
-        SimpleLogger().Write(logDEBUG) << "graph_node_list_size:       " << num_entries[GRAPH_NODE_LIST];
         SimpleLogger().Write(logDEBUG) << "graph_edge_list_size:       " << num_entries[GRAPH_EDGE_LIST];
         SimpleLogger().Write(logDEBUG) << "timestamp_length:           " << num_entries[TIMESTAMP];
         SimpleLogger().Write(logDEBUG) << "coordinate_list_size:       " << num_entries[COORDINATE_LIST];
@@ -96,7 +97,8 @@ struct SharedDataLayout
         SimpleLogger().Write(logDEBUG) << "NAME_CHAR_LIST       " << ": " << GetBlockSize(NAME_CHAR_LIST       );
         SimpleLogger().Write(logDEBUG) << "NAME_ID_LIST         " << ": " << GetBlockSize(NAME_ID_LIST         );
         SimpleLogger().Write(logDEBUG) << "VIA_NODE_LIST        " << ": " << GetBlockSize(VIA_NODE_LIST        );
-        SimpleLogger().Write(logDEBUG) << "GRAPH_NODE_LIST      " << ": " << GetBlockSize(GRAPH_NODE_LIST      );
+        SimpleLogger().Write(logDEBUG) << "GRAPH_NODE_OFFSETS   " << ": " << GetBlockSize(GRAPH_NODE_OFFSETS   );
+        SimpleLogger().Write(logDEBUG) << "GRAPH_NODE_BLOCKS    " << ": " << GetBlockSize(GRAPH_NODE_BLOCKS    );
         SimpleLogger().Write(logDEBUG) << "GRAPH_EDGE_LIST      " << ": " << GetBlockSize(GRAPH_EDGE_LIST      );
         SimpleLogger().Write(logDEBUG) << "COORDINATE_LIST      " << ": " << GetBlockSize(COORDINATE_LIST      );
         SimpleLogger().Write(logDEBUG) << "TURN_INSTRUCTION     " << ": " << GetBlockSize(TURN_INSTRUCTION     );

--- a/Util/GraphLoader.h
+++ b/Util/GraphLoader.h
@@ -373,11 +373,11 @@ NodeID readBinaryOSRMGraphFromStream(std::istream &input_stream,
 }
 
 
-template <typename NodeT, typename EdgeT>
-unsigned readHSGRFromStream(const boost::filesystem::path &hsgr_file,
-                            std::vector<NodeT> &node_list,
-                            std::vector<EdgeT> &edge_list,
-                            unsigned *check_sum)
+template <typename EdgeT>
+void readHSGRFromStream(const boost::filesystem::path &hsgr_file,
+                        typename StaticGraph<EdgeT>::NodeTable &node_table,
+                        std::vector<EdgeT> &edge_list,
+                        unsigned *check_sum)
 {
     if (!boost::filesystem::exists(hsgr_file))
     {
@@ -398,19 +398,14 @@ unsigned readHSGRFromStream(const boost::filesystem::path &hsgr_file,
                                             "Reprocess to get rid of this warning.";
     }
 
-    unsigned number_of_nodes = 0;
     unsigned number_of_edges = 0;
     hsgr_input_stream.read((char *)check_sum, sizeof(unsigned));
-    hsgr_input_stream.read((char *)&number_of_nodes, sizeof(unsigned));
-    BOOST_ASSERT_MSG(0 != number_of_nodes, "number of nodes is zero");
     hsgr_input_stream.read((char *)&number_of_edges, sizeof(unsigned));
 
-    SimpleLogger().Write() << "number_of_nodes: " << number_of_nodes
-                           << ", number_of_edges: " << number_of_edges;
-
     // BOOST_ASSERT_MSG( 0 != number_of_edges, "number of edges is zero");
-    node_list.resize(number_of_nodes);
-    hsgr_input_stream.read((char *)&(node_list[0]), number_of_nodes * sizeof(NodeT));
+    hsgr_input_stream >> node_table;
+
+    SimpleLogger().Write() << "number_of_edges: " << number_of_edges;
 
     edge_list.resize(number_of_edges);
     if (number_of_edges > 0)
@@ -418,8 +413,6 @@ unsigned readHSGRFromStream(const boost::filesystem::path &hsgr_file,
         hsgr_input_stream.read((char *)&(edge_list[0]), number_of_edges * sizeof(EdgeT));
     }
     hsgr_input_stream.close();
-
-    return number_of_nodes;
 }
 
 #endif // GRAPHLOADER_H


### PR DESCRIPTION
StaticGraph uses an adjacency array data structure that can easily be mapped to RangeTable. The idea is so save some memory here.

Preliminary tests have shown no big improvement: For Brandenburg we only saved 2MB (about 5%).

TODO:
- [ ] Fix SharedDatafacade and datastore
- [ ] Fix StaticGraph test
- [ ] Write a benchmark for StaticGraph to test performance
- [x] Actually calculate the amount of memory that could be theoretically saved

Just did a small estimate the potential memory that could be saved is about 400MB for the whole planet, so sadly not that much.