### PR TITLE
Fix std::list splice usage error

### DIFF
--- a/DataStructures/Coordinate.cpp
+++ b/DataStructures/Coordinate.cpp
@@ -284,14 +284,14 @@ float FixedPointCoordinate::ComputePerpendicularDistance(const FixedPointCoordin
     bool inverse_ratio = false;
 
     // straight line segment on equator
-    if (std::abs(c) < std::numeric_limits<float>::epsilon() &&
-        std::abs(a) < std::numeric_limits<float>::epsilon())
+    if (std::abs(c) < std::numeric_limits<double>::epsilon() &&
+        std::abs(a) < std::numeric_limits<double>::epsilon())
     {
         ratio = (q - b) / (d - b);
     }
     else
     {
-        if (std::abs(c) < std::numeric_limits<float>::epsilon())
+        if (std::abs(c) < std::numeric_limits<double>::epsilon())
         {
             // swap start/end
             std::swap(a, c);

--- a/DataStructures/LRUCache.h
+++ b/DataStructures/LRUCache.h
@@ -86,7 +86,7 @@ template <typename KeyT, typename ValueT> class LRUCache
             result = e.value;
 
             // move to front
-            itemsInCache.splice(positionMap.find(key)->second, itemsInCache, itemsInCache.begin());
+            itemsInCache.splice(itemsInCache.begin(), itemsInCache, positionMap.find(key)->second);
             positionMap.find(key)->second = itemsInCache.begin();
             return true;
         }


### PR DESCRIPTION
to move an latest accessed item to the front of the list, one should use
mylist.splice(mylist.begin(), mylist, iterator_to_the_to_be_moved_element 