### PR TITLE
Fix #1260 (crash on Windows/debug, memory error in sending compressed answer with boost::asio)

### DIFF
--- a/Server/Connection.h
+++ b/Server/Connection.h
@@ -85,8 +85,8 @@ class Connection : public std::enable_shared_from_this<Connection>
     void handle_read(const boost::system::error_code &e, std::size_t bytes_transferred);
 
     /// Handle completion of a write operation.
-    void handle_write(const boost::system::error_code &e);
-
+    void handle_write(const boost::system::error_code &e, boost::shared_ptr<std::vector<char>> buffer);
+    void handle_write2(std::unique_ptr<int> a);
     void CompressBufferCollection(std::vector<char> uncompressed_data,
                                   CompressionType compression_type,
                                   std::vector<char> &compressed_data);


### PR DESCRIPTION
I tried to make a patch for https://github.com/Project-OSRM/osrm-backend/issues/1260
(based on mentioned stackoverflow ideas)

Checked with Visual Leak Detector - no memory leaks (there were many of them before adding buffer delete call).

Feel free to replace this patch with some shared_ptr solution if needed, I am just afraid of it (know only new/delete well enough) :)