### PR TITLE
Made the request parser a member of the Connection

### DIFF
--- a/server/connection.cpp
+++ b/server/connection.cpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "connection.hpp"
 #include "request_handler.hpp"
 #include "request_parser.hpp"
+//#include "../util/simple_logger.hpp"
 
 #include <boost/assert.hpp>
 #include <boost/bind.hpp>
@@ -68,7 +69,7 @@ void Connection::handle_read(const boost::system::error_code &error, std::size_t
     compression_type compression_type(no_compression);
     osrm::tribool result;
     std::tie(result, compression_type) =
-        RequestParser().parse(current_request, incoming_data_buffer.data(),
+        request_parser.parse(current_request, incoming_data_buffer.data(),
                               incoming_data_buffer.data() + bytes_transferred);
 
     // the request has been parsed
@@ -126,6 +127,7 @@ void Connection::handle_read(const boost::system::error_code &error, std::size_t
     else
     {
         // we don't have a result yet, so continue reading
+        //SimpleLogger().Write(logDEBUG) << "Continue reading...";
         TCP_socket.async_read_some(
             boost::asio::buffer(incoming_data_buffer),
             strand.wrap(boost::bind(&Connection::handle_read, this->shared_from_this(),

--- a/server/connection.cpp
+++ b/server/connection.cpp
@@ -28,7 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "connection.hpp"
 #include "request_handler.hpp"
 #include "request_parser.hpp"
-//#include "../util/simple_logger.hpp"
 
 #include <boost/assert.hpp>
 #include <boost/bind.hpp>
@@ -127,7 +126,6 @@ void Connection::handle_read(const boost::system::error_code &error, std::size_t
     else
     {
         // we don't have a result yet, so continue reading
-        //SimpleLogger().Write(logDEBUG) << "Continue reading...";
         TCP_socket.async_read_some(
             boost::asio::buffer(incoming_data_buffer),
             strand.wrap(boost::bind(&Connection::handle_read, this->shared_from_this(),

--- a/server/connection.hpp
+++ b/server/connection.hpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "http/compression_type.hpp"
 #include "http/reply.hpp"
 #include "http/request.hpp"
+#include "request_parser.hpp"
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
@@ -82,6 +83,7 @@ class Connection : public std::enable_shared_from_this<Connection>
     boost::asio::io_service::strand strand;
     boost::asio::ip::tcp::socket TCP_socket;
     RequestHandler &request_handler;
+    RequestParser request_parser;
     boost::array<char, 8192> incoming_data_buffer;
     request current_request;
     reply current_reply;


### PR DESCRIPTION
As discussed in issue #1379 - a simple (and quite probably naive) change to allow long strings to be parsed.

Previously, the request parser was created on demand...but this could
cause requests to be flagged as bad requests if the string length was
large enough to cause the string to be split up into chunks by boost's
read_some method.

(Apologies for creating a second pull request!)