### PR TITLE
lint corrections

### DIFF
--- a/plugins/map_matching.hpp
+++ b/plugins/map_matching.hpp
@@ -1,39 +1,46 @@
-    /*
-        open source routing machine
-    Copyright (C) Dennis Luxen, others 2010
+/*
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU AFFERO General Public License as published by
-the Free Software Foundation; either version 3 of the License, or
-any later version.
+Copyright (c) 2015, Project OSRM contributors
+All rights reserved.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-You should have received a copy of the GNU Affero General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-or see http://www.gnu.org/licenses/agpl.txt.
- */
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
 
-#ifndef MAP_MATCHING_PLUGIN_H
-#define MAP_MATCHING_PLUGIN_H
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef MAP_MATCHING_HPP
+#define MAP_MATCHING_HPP
 
 #include "plugin_base.hpp"
 
 #include "../algorithms/bayes_classifier.hpp"
 #include "../algorithms/object_encoder.hpp"
-#include "../util/integer_range.hpp"
 #include "../data_structures/search_engine.hpp"
-#include "../routing_algorithms/map_matching.hpp"
-#include "../util/compute_angle.hpp"
-#include "../util/simple_logger.hpp"
-#include "../util/string_util.hpp"
 #include "../descriptors/descriptor_base.hpp"
 #include "../descriptors/gpx_descriptor.hpp"
 #include "../descriptors/json_descriptor.hpp"
+#include "../routing_algorithms/map_matching.hpp"
+#include "../util/compute_angle.hpp"
+#include "../util/integer_range.hpp"
+#include "../util/simple_logger.hpp"
+#include "../util/string_util.hpp"
 
 #include <cstdlib>
 
@@ -65,7 +72,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         search_engine_ptr = std::make_shared<SearchEngine<DataFacadeT>>(facade);
     }
 
-    virtual ~MapMatchingPlugin() { search_engine_ptr.reset(); }
+    virtual ~MapMatchingPlugin() { }
 
     const std::string GetDescriptor() const final { return descriptor_string; }
 
@@ -287,4 +294,4 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
     ClassifierT classifier;
 };
 
-#endif /* MAP_MATCHING_PLUGIN_H */
+#endif /* MAP_MATCHING_HPP */

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -1,39 +1,46 @@
 /*
-    open source routing machine
-    Copyright (C) Dennis Luxen, others 2010
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU AFFERO General Public License as published by
-the Free Software Foundation; either version 3 of the License, or
-any later version.
+Copyright (c) 2015, Project OSRM contributors
+All rights reserved.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-You should have received a copy of the GNU Affero General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-or see http://www.gnu.org/licenses/agpl.txt.
- */
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
 
-#ifndef MAP_MATCHING_H
-#define MAP_MATCHING_H
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef MAP_MATCHING_HPP
+#define MAP_MATCHING_HPP
 
 #include "routing_base.hpp"
 
 #include "../data_structures/coordinate_calculation.hpp"
 #include "../util/simple_logger.hpp"
 
-#include <variant/variant.hpp>
 #include <osrm/json_container.hpp>
+#include <variant/variant.hpp>
+
+#include <fstream>
 
 #include <algorithm>
 #include <iomanip>
 #include <numeric>
-
-#include <fstream>
 
 using JSONVariantArray = mapbox::util::recursive_wrapper<osrm::json::Array>;
 using JSONVariantObject = mapbox::util::recursive_wrapper<osrm::json::Object>;
@@ -591,4 +598,4 @@ template <class DataFacadeT> class MapMatching final : public BasicRoutingInterf
 
 //[1] "Hidden Markov Map Matching Through Noise and Sparseness"; P. Newson and J. Krumm; 2009; ACM GIS
 
-#endif /* MAP_MATCHING_H */
+#endif /* MAP_MATCHING_HPP */


### PR DESCRIPTION
    lint corrections
    
    - fix license header
    - let shared_ptr autodestruct as it's shared
    - rename fences to resemble file names
    - reorder includes into lexicographic order

@TheMarex 