### PR TITLE
FIX:

### DIFF
--- a/contractor/geometry_compressor.cpp
+++ b/contractor/geometry_compressor.cpp
@@ -35,8 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <limits>
 #include <string>
 
-int free_list_maximum = 0;
-int UniqueNumber() { return ++free_list_maximum; }
+//int UniqueNumber() { return ++free_list_maximum; }
 
 GeometryCompressor::GeometryCompressor()
 {

--- a/contractor/geometry_compressor.hpp
+++ b/contractor/geometry_compressor.hpp
@@ -58,6 +58,8 @@ class GeometryCompressor
     NodeID GetLastNodeIDOfBucket(const EdgeID edge_id) const;
 
   private:
+    int free_list_maximum = 0;
+    
     void IncreaseFreeList();
     std::vector<std::vector<CompressedNode>> m_compressed_geometries;
     std::vector<unsigned> m_free_list;


### PR DESCRIPTION
Moved the GeometryCompressor's free_list_maximum into a member variable of the class.
(+UniqueNumber() commented out since it is not being used anywhere in all of OSRM)

There was absolutely no need for free_list_maximum to be a static variable and it caused major issues in my code.
Short description:
- I ran osrm-prepare's Prepare().Process(..) function in my own code multiple times for multiple files
	=> After the first file is done, free_list_maximum is still on the same size, but a new GeometryCompressor will start at a size of 100 again.
	=> Indices broken.