### PR TITLE
Use shared memory if no server paths are provided.

### DIFF
--- a/include/osrm/libosrm_config.hpp
+++ b/include/osrm/libosrm_config.hpp
@@ -35,7 +35,7 @@ struct libosrm_config
     libosrm_config(const libosrm_config &) = delete;
     libosrm_config()
         : max_locations_distance_table(100), max_locations_map_matching(-1),
-          use_shared_memory(false)
+          use_shared_memory(true)
     {
     }
 

--- a/include/osrm/libosrm_config.hpp
+++ b/include/osrm/libosrm_config.hpp
@@ -39,9 +39,9 @@ struct libosrm_config
     {
     }
 
-    libosrm_config(const ServerPaths &paths, const bool flag, const int max_table, const int max_matching)
+    libosrm_config(const ServerPaths &paths, const bool sharedmemory_flag, const int max_table, const int max_matching)
         : server_paths(paths), max_locations_distance_table(max_table),
-          max_locations_map_matching(max_matching), use_shared_memory(flag)
+          max_locations_map_matching(max_matching), use_shared_memory(sharedmemory_flag)
     {
     }
 

--- a/routed.cpp
+++ b/routed.cpp
@@ -74,6 +74,8 @@ int main(int argc, const char *argv[])
         int ip_port, requested_thread_num;
 
         libosrm_config lib_config;
+        // make the behaviour of routed backward compatible
+        lib_config.use_shared_memory = false;
 
         const unsigned init_result = GenerateServerProgramOptions(
             argc, argv, lib_config.server_paths, ip_address, ip_port, requested_thread_num,


### PR DESCRIPTION
This caused a bug in the node bindings that would invoke the constructor
without parameters.