### PR TITLE
Modify profiles to use Lua 5.2+ without needing compatibility flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
  - sudo add-apt-repository -y ppa:boost-latest/ppa
  - sudo apt-get update >/dev/null
- - sudo apt-get -q install protobuf-compiler libprotoc-dev libprotobuf7 libprotobuf-dev libbz2-dev libstxxl-dev libstxxl1 libxml2-dev libzip-dev lua5.1 liblua5.1-0-dev rubygems libtbb-dev
+ - sudo apt-get -q install protobuf-compiler libprotoc-dev libprotobuf7 libprotobuf-dev libbz2-dev libstxxl-dev libstxxl1 libxml2-dev libzip-dev lua5.2 liblua5.2-dev rubygems libtbb-dev
  - sudo apt-get -q install g++-4.8
  - sudo apt-get install libboost1.54-all-dev
  - sudo apt-get install libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
  - sudo add-apt-repository -y ppa:boost-latest/ppa
  - sudo apt-get update >/dev/null
- - sudo apt-get -q install protobuf-compiler libprotoc-dev libprotobuf7 libprotobuf-dev libbz2-dev libstxxl-dev libstxxl1 libxml2-dev libzip-dev lua5.2 liblua5.2-dev rubygems libtbb-dev
+ - sudo apt-get -q install protobuf-compiler libprotoc-dev libprotobuf7 libprotobuf-dev libbz2-dev libstxxl-dev libstxxl1 libxml2-dev libzip-dev lua5.1 liblua5.1-0-dev rubygems libtbb-dev
  - sudo apt-get -q install g++-4.8
  - sudo apt-get install libboost1.54-all-dev
  - sudo apt-get install libgdal-dev

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -1,5 +1,7 @@
-require("lib/access")
-require("lib/maxspeed")
+-- Bicycle profile
+
+local find_access_tag = require("lib/access").find_access_tag
+local limit = require("lib/maxspeed").limit
 
 -- Begin of globals
 barrier_whitelist = { [""] = true, ["cycle_barrier"] = true, ["bollard"] = true, ["entrance"] = true, ["cattle_grid"] = true, ["border_control"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["no"] = true }
@@ -122,7 +124,6 @@ local function parse_maxspeed(source)
     return n
 end
 
-
 function get_exceptions(vector)
   for i,v in ipairs(restriction_exception_tags) do
     vector:Add(v)
@@ -131,7 +132,7 @@ end
 
 function node_function (node, result)
   local barrier = node:get_value_by_key("barrier")
-  local access = Access.find_access_tag(node, access_tags_hierachy)
+  local access = find_access_tag(node, access_tags_hierachy)
   local traffic_signal = node:get_value_by_key("highway")
 
 	-- flag node if it carries a traffic light
@@ -181,7 +182,7 @@ function way_function (way, result)
   end
 
   -- access
-  local access = Access.find_access_tag(way, access_tags_hierachy)
+  local access = find_access_tag(way, access_tags_hierachy)
   if access and access_tag_blacklist[access] then
     return
   end
@@ -391,7 +392,7 @@ function way_function (way, result)
   end
 
   -- maxspeed
-  MaxSpeed.limit( result, maxspeed, maxspeed_forward, maxspeed_backward )
+  limit( result, maxspeed, maxspeed_forward, maxspeed_backward )
 end
 
 function turn_function (angle)

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -1,6 +1,8 @@
--- Begin of globals
---require("lib/access") --function temporarily inlined
+-- Car profile
 
+local find_access_tag = require("lib/access").find_access_tag
+
+-- Begin of globals
 barrier_whitelist = { ["cattle_grid"] = true, ["border_control"] = true, ["checkpoint"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["lift_gate"] = true, ["no"] = true, ["entrance"] = true }
 access_tag_whitelist = { ["yes"] = true, ["motorcar"] = true, ["motor_vehicle"] = true, ["vehicle"] = true, ["permissive"] = true, ["designated"] = true }
 access_tag_blacklist = { ["no"] = true, ["private"] = true, ["agricultural"] = true, ["forestry"] = true, ["emergency"] = true, ["psv"] = true }
@@ -146,16 +148,6 @@ local speed_reduction = 0.8
 local mode_normal = 1
 local mode_ferry = 2
 local mode_movable_bridge = 3
-
-local function find_access_tag(source, access_tags_hierachy)
-  for i,v in ipairs(access_tags_hierachy) do
-    local access_tag = source:get_value_by_key(v)
-    if access_tag and "" ~= access_tag then
-      return access_tag
-    end
-  end
-  return ""
-end
 
 function get_exceptions(vector)
   for i,v in ipairs(restriction_exception_tags) do

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -1,7 +1,8 @@
 -- Foot profile
 
-require("lib/access")
+local find_access_tag = require("lib/access").find_access_tag
 
+-- Begin of globals
 barrier_whitelist = { [""] = true, ["cycle_barrier"] = true, ["bollard"] = true, ["entrance"] = true, ["cattle_grid"] = true, ["border_control"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["no"] = true}
 access_tag_whitelist = { ["yes"] = true, ["foot"] = true, ["permissive"] = true, ["designated"] = true  }
 access_tag_blacklist = { ["no"] = true, ["private"] = true, ["agricultural"] = true, ["forestery"] = true }
@@ -75,7 +76,7 @@ end
 
 function node_function (node, result)
 	local barrier = node:get_value_by_key("barrier")
-	local access = Access.find_access_tag(node, access_tags_hierachy)
+	local access = find_access_tag(node, access_tags_hierachy)
 	local traffic_signal = node:get_value_by_key("highway")
 
 	-- flag node if it carries a traffic light
@@ -125,7 +126,7 @@ function way_function (way, result)
     end
 
 	-- access
-    local access = Access.find_access_tag(way, access_tags_hierachy)
+    local access = find_access_tag(way, access_tags_hierachy)
     if access_tag_blacklist[access] then
 		return
     end

--- a/profiles/lib/access.lua
+++ b/profiles/lib/access.lua
@@ -1,13 +1,15 @@
 local ipairs = ipairs
 
-module "Access"
+local Access = {}
 
-function find_access_tag(source,access_tags_hierachy)
+function Access.find_access_tag(source,access_tags_hierachy)
     for i,v in ipairs(access_tags_hierachy) do
         local tag = source:get_value_by_key(v)
         if tag and tag ~= '' then
             return tag
         end
     end
-    return nil
+    return ""
 end
+
+return Access

--- a/profiles/lib/maxspeed.lua
+++ b/profiles/lib/maxspeed.lua
@@ -1,8 +1,8 @@
 local math = math
 
-module "MaxSpeed"
+local MaxSpeed = {}
 
-function limit(way,max,maxf,maxb)
+function MaxSpeed.limit(way,max,maxf,maxb)
   if maxf and maxf>0 then
     way.forward_speed = math.min(way.forward_speed, maxf)
   elseif max and max>0 then
@@ -15,3 +15,5 @@ function limit(way,max,maxf,maxb)
     way.backward_speed = math.min(way.backward_speed, max)
   end
 end
+
+return MaxSpeed

--- a/util/lua_util.hpp
+++ b/util/lua_util.hpp
@@ -59,7 +59,7 @@ inline void luaAddScriptFolderToLoadPath(lua_State *lua_state, const char *file_
     std::string folder = profile_path.parent_path().string();
     // TODO: This code is most probably not Windows safe since it uses UNIX'ish path delimiters
     const std::string lua_code =
-        "package.path = \"" + folder + "/?.lua;profiles/?.lua;\" .. package.path";
+        "package.path = \"" + folder + "/?.lua;" + folder + "/profiles/?.lua;profiles/?.lua;\" .. package.path";
     luaL_dostring(lua_state, lua_code.c_str());
 }
 

--- a/util/lua_util.hpp
+++ b/util/lua_util.hpp
@@ -55,11 +55,10 @@ inline bool lua_function_exists(lua_State *lua_state, const char *name)
 // See http://lua-users.org/wiki/PackagePath for details on the package.path syntax.
 inline void luaAddScriptFolderToLoadPath(lua_State *lua_state, const char *file_name)
 {
-    const boost::filesystem::path profile_path(file_name);
+    boost::filesystem::path profile_path = boost::filesystem::canonical(file_name);
     std::string folder = profile_path.parent_path().string();
     // TODO: This code is most probably not Windows safe since it uses UNIX'ish path delimiters
-    const std::string lua_code =
-        "package.path = \"" + folder + "/?.lua;" + folder + "/profiles/?.lua;profiles/?.lua;\" .. package.path";
+    const std::string lua_code = "package.path = \"" + folder + "/?.lua;\" .. package.path";
     luaL_dostring(lua_state, lua_code.c_str());
 }
 


### PR DESCRIPTION
Since the deprecation of `module` in Lua 5.2+, the current approach only works in 5.2 with compatibility flags, and doesn't work in Lua 5.3 at all. This alternate approach allows us to use Lua 5.2 with or without compatibility flags and fixes issues raised in https://github.com/Project-OSRM/osrm-backend/issues/1454.

Note: the [change](https://github.com/Project-OSRM/osrm-backend/blob/f6cc4a652060be504e4fbce79936aee3a7989d44/profiles/lib/access.lua#L12) I introduce here to `lib/access.lua`'s nil return reflects the way it [had been inlined in car.lua](https://github.com/Project-OSRM/osrm-backend/blob/11bdfba37e3e1e2b4e3490ccec492d59b4b42397/profiles/car.lua#L157) — before changing the `lib/access.lua` value, two car barrier tests (features/car/barrier.feature) were failing; after the change all cucumber tests pass. I'm not entirely confident as to why this is as I am by no means a lua expert… @emiltin would you mind taking a look?

I'm curious to see how upgrading affects travis (especially wrt questions about using LuaJIT, https://github.com/Project-OSRM/osrm-backend/issues/1442) (I'm developing on OSX locally).
cc @TheMarex @springmeyer @willwhite 