### PR TITLE
Return error message when lua error occurs.

### DIFF
--- a/extractor/restriction_parser.cpp
+++ b/extractor/restriction_parser.cpp
@@ -44,7 +44,7 @@ namespace
 {
 int lua_error_callback(lua_State *lua_state)
 {
-    luabind::object error_msg(luabind::from_stack(lua_state, -1));
+    std::string error_msg = lua_tostring(lua_state, -1);
     std::ostringstream error_stream;
     error_stream << error_msg;
     throw osrm::exception("ERROR occured in profile script:\n" + error_stream.str());

--- a/extractor/scripting_environment.cpp
+++ b/extractor/scripting_environment.cpp
@@ -53,7 +53,7 @@ auto get_value_by_key(T const &object, const char *key) -> decltype(object.get_v
 int lua_error_callback(lua_State *L) // This is so I can use my own function as an
 // exception handler, pcall_log()
 {
-    luabind::object error_msg(luabind::from_stack(L, -1));
+    std::string error_msg = lua_tostring(L, -1);
     std::ostringstream error_stream;
     error_stream << error_msg;
     throw osrm::exception("ERROR occured in profile script:\n" + error_stream.str());


### PR DESCRIPTION
This change gets Lua error messages visible on the console again.  When inside the `lua_error_callback()`, the error message may not be the first item on the stack.

This fixes #1467.