### PR TITLE
Partially fix via-routing when vias are on the same way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ file(GLOB DatastructureGlob data_structures/search_engine_data.cpp data_structur
 list(REMOVE_ITEM DatastructureGlob data_structures/Coordinate.cpp)
 file(GLOB CoordinateGlob data_structures/coordinate*.cpp)
 file(GLOB AlgorithmGlob algorithms/*.cpp)
+file(GLOB RoutingAlgorithmGlob routing_algorithms/*.hpp)
 file(GLOB HttpGlob server/http/*.cpp)
 file(GLOB LibOSRMGlob library/*.cpp)
 file(GLOB DataStructureTestsGlob unit_tests/data_structures/*.cpp data_structures/hilbert_value.cpp)
@@ -85,6 +86,7 @@ set(
   ${DescriptorGlob}
   ${DatastructureGlob}
   ${AlgorithmGlob}
+  ${RoutingAlgorithmGlob}
   ${HttpGlob}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ file(GLOB DatastructureGlob data_structures/search_engine_data.cpp data_structur
 list(REMOVE_ITEM DatastructureGlob data_structures/Coordinate.cpp)
 file(GLOB CoordinateGlob data_structures/coordinate*.cpp)
 file(GLOB AlgorithmGlob algorithms/*.cpp)
-file(GLOB RoutingAlgorithmGlob routing_algorithms/*.hpp)
 file(GLOB HttpGlob server/http/*.cpp)
 file(GLOB LibOSRMGlob library/*.cpp)
 file(GLOB DataStructureTestsGlob unit_tests/data_structures/*.cpp data_structures/hilbert_value.cpp)
@@ -86,7 +85,6 @@ set(
   ${DescriptorGlob}
   ${DatastructureGlob}
   ${AlgorithmGlob}
-  ${RoutingAlgorithmGlob}
   ${HttpGlob}
 )
 

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -97,6 +97,6 @@ Feature: Via points
             | waypoints | route                      | distance  | turns                                                            |
             | 1,3       | ab                         | 200m +-1  | head,destination                                                 |
             | 3,1       | ab,bc,cd,da,ab             | 800m +-1  | head,right,right,right,right,destination                         |
-            | 1,2,3     | ab                         | 200m +-1  | head,destination                                                 |
+            | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
             | 1,3,2     | ab,bc,cd,da,ab             | 1100m +-1 | head,right,right,right,right,destination                         |
             | 3,2,1     | ab,bc,cd,da,ab,bc,cd,da,ab | 1600m +-1 | head,right,right,right,right,right,right,right,right,destination |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -97,28 +97,5 @@ Feature: Via points
             | 1,3       | ab                         | 200m +-1  | head,destination                                                 |
             | 3,1       | ab,bc,cd,da,ab             | 800m +-1  | head,right,right,right,right,destination                         |
             | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
-            | 1,3,2     | ab,bc,cd,da,ab             | 1100m +-1 | head,right,right,right,right,destination                         |
-            | 3,2,1     | ab,bc,cd,da,ab,bc,cd,da,ab | 1600m +-1 | head,right,right,right,right,right,right,right,right,destination |
-
-    Scenario: Via points on ring on the same oneway
-    # xa it to avoid only having a single ring, which cna trigger edge cases
-        Given the node map
-            | x |   |   |   |   |
-            | a | 1 | 2 | 3 | b |
-            | d |   |   |   | c |
-
-        And the ways
-            | nodes | oneway |
-            | xa    |        |
-            | ab    | yes    |
-            | bc    | yes    |
-            | cd    | yes    |
-            | da    | yes    |
-
-        When I route I should get
-            | waypoints | route                      | distance  | turns                                                            |
-            | 1,3       | ab                         | 200m +-1  | head,destination                                                 |
-            | 3,1       | ab,bc,cd,da,ab             | 800m +-1  | head,right,right,right,right,destination                         |
-            | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
             | 1,3,2     | ab,ab,bc,cd,da,ab          | 1100m +-1 | head,via,right,right,right,right,destination                     |
             | 3,2,1     | ab,bc,cd,da,ab,ab,bc,cd,da,ab | 1800m     | head,right,right,right,right,via,right,right,right,right,destination |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -120,5 +120,5 @@ Feature: Via points
             | 1,3       | ab                         | 200m +-1  | head,destination                                                 |
             | 3,1       | ab,bc,cd,da,ab             | 800m +-1  | head,right,right,right,right,destination                         |
             | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
-            | 1,3,2     | ab,ab,bc,cd,da,ab          | 1100m +-1 | (+) head,via,right,right,right,right,destination                 |
-            | 3,2,1     | ab,bc,cd,da,ab,ab,bc,cd,da,ab | 1800m     | (+) head,right,right,right,right,via,right,right,right,right,destination |
+            | 1,3,2     | ab,ab,bc,cd,da,ab          | 1100m +-1 | head,via,right,right,right,right,destination                     |
+            | 3,2,1     | ab,bc,cd,da,ab,ab,bc,cd,da,ab | 1800m     | head,right,right,right,right,via,right,right,right,right,destination |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -77,7 +77,6 @@ Feature: Via points
             | 1,3,2     | ab,bc,cd,cd,de,ef,fa,ab,bc | 1600m +-1 | head,straight,straight,via,right,right,right,right,straight,destination |
             | 3,2,1     | cd,de,ef,fa,ab,bc,bc,cd,de,ef,fa,ab | 2400m +-1 | head,right,right,right,right,straight,via,straight,right,right,right,right,destination |
 
-    @bug
     Scenario: Via points on ring on the same oneway
     # xa it to avoid only having a single ring, which cna trigger edge cases
         Given the node map

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -99,3 +99,26 @@ Feature: Via points
             | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
             | 1,3,2     | ab,bc,cd,da,ab             | 1100m +-1 | head,right,right,right,right,destination                         |
             | 3,2,1     | ab,bc,cd,da,ab,bc,cd,da,ab | 1600m +-1 | head,right,right,right,right,right,right,right,right,destination |
+
+    Scenario: Via points on ring on the same oneway
+    # xa it to avoid only having a single ring, which cna trigger edge cases
+        Given the node map
+            | x |   |   |   |   |
+            | a | 1 | 2 | 3 | b |
+            | d |   |   |   | c |
+
+        And the ways
+            | nodes | oneway |
+            | xa    |        |
+            | ab    | yes    |
+            | bc    | yes    |
+            | cd    | yes    |
+            | da    | yes    |
+
+        When I route I should get
+            | waypoints | route                      | distance  | turns                                                            |
+            | 1,3       | ab                         | 200m +-1  | head,destination                                                 |
+            | 3,1       | ab,bc,cd,da,ab             | 800m +-1  | head,right,right,right,right,destination                         |
+            | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
+            | 1,3,2     | ab,ab,bc,cd,da,ab          | 1100m +-1 | (+) head,via,right,right,right,right,destination                 |
+            | 3,2,1     | ab,bc,cd,da,ab,ab,bc,cd,da,ab | 1800m     | (+) head,right,right,right,right,via,right,right,right,right,destination |

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -272,11 +272,13 @@ class ShortestPathRouting final
                     if (start_id_of_leg1 != last_id_of_packed_legs1)
                     {
                         packed_legs1 = packed_legs2;
+                        distance1 = distance2;
                         BOOST_ASSERT(start_id_of_leg1 == temporary_packed_leg1.front());
                     }
                     else if (start_id_of_leg2 != last_id_of_packed_legs2)
                     {
                         packed_legs2 = packed_legs1;
+                        distance2 = distance1;
                         BOOST_ASSERT(start_id_of_leg2 == temporary_packed_leg2.front());
                     }
                 }

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -92,6 +92,9 @@ class ShortestPathRouting final
 
             const bool allow_u_turn = current_leg > 0 && uturn_indicators.size() > current_leg &&
                                       uturn_indicators[current_leg - 1];
+
+            const bool same_node = phantom_node_pair.source_phantom.forward_node_id == phantom_node_pair.target_phantom.forward_node_id;
+             
             EdgeWeight min_edge_offset = 0;
 
             // insert new starting nodes into forward heap, adjusted by previous distances.
@@ -100,24 +103,24 @@ class ShortestPathRouting final
             {
                 forward_heap1.Insert(
                     phantom_node_pair.source_phantom.forward_node_id,
-                    (allow_u_turn ? 0 : distance1) -
+                    (allow_u_turn || same_node ? 0 : distance1) -
                         phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
                     phantom_node_pair.source_phantom.forward_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance1) -
+                             (allow_u_turn || same_node ? 0 : distance1) -
                                  phantom_node_pair.source_phantom.GetForwardWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-a2 insert: " <<
                 // phantom_node_pair.source_phantom.forward_node_id << ", w: " << (allow_u_turn ? 0
                 // : distance1) - phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
                 forward_heap2.Insert(
                     phantom_node_pair.source_phantom.forward_node_id,
-                    (allow_u_turn ? 0 : distance1) -
+                    (allow_u_turn || same_node ? 0 : distance1) -
                         phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
                     phantom_node_pair.source_phantom.forward_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance1) -
+                             (allow_u_turn || same_node ? 0 : distance1) -
                                  phantom_node_pair.source_phantom.GetForwardWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-b2 insert: " <<
                 // phantom_node_pair.source_phantom.forward_node_id << ", w: " << (allow_u_turn ? 0
@@ -128,12 +131,12 @@ class ShortestPathRouting final
             {
                 forward_heap1.Insert(
                     phantom_node_pair.source_phantom.reverse_node_id,
-                    (allow_u_turn ? 0 : distance2) -
+                    (allow_u_turn || same_node ? 0 : distance2) -
                         phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
                     phantom_node_pair.source_phantom.reverse_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance2) -
+                             (allow_u_turn || same_node ? 0 : distance2) -
                                  phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-a2 insert: " <<
                 // phantom_node_pair.source_phantom.reverse_node_id <<
@@ -141,12 +144,12 @@ class ShortestPathRouting final
                 //                     phantom_node_pair.source_phantom.GetReverseWeightPlusOffset();
                 forward_heap2.Insert(
                     phantom_node_pair.source_phantom.reverse_node_id,
-                    (allow_u_turn ? 0 : distance2) -
+                    (allow_u_turn || same_node ? 0 : distance2) -
                         phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
                     phantom_node_pair.source_phantom.reverse_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance2) -
+                             (allow_u_turn || same_node ? 0 : distance2) -
                                  phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-b2 insert: " <<
                 // phantom_node_pair.source_phantom.reverse_node_id <<

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -92,7 +92,9 @@ class ShortestPathRouting final
 
             const bool allow_u_turn = current_leg > 0 && uturn_indicators.size() > current_leg &&
                                       uturn_indicators[current_leg - 1];
-            EdgeWeight min_edge_offset = 0;
+            const EdgeWeight min_edge_offset =
+                std::min(phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
+                         phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
 
             // insert new starting nodes into forward heap, adjusted by previous distances.
             if ((allow_u_turn || search_from_1st_node) &&
@@ -100,58 +102,32 @@ class ShortestPathRouting final
             {
                 forward_heap1.Insert(
                     phantom_node_pair.source_phantom.forward_node_id,
-                    (allow_u_turn ? 0 : distance1) -
-                        phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
+                    -phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
                     phantom_node_pair.source_phantom.forward_node_id);
-                min_edge_offset =
-                    std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance1) -
-                                 phantom_node_pair.source_phantom.GetForwardWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-a2 insert: " <<
-                // phantom_node_pair.source_phantom.forward_node_id << ", w: " << (allow_u_turn ? 0
-                // : distance1) - phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
+                // phantom_node_pair.source_phantom.forward_node_id << ", w: " << -phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
                 forward_heap2.Insert(
                     phantom_node_pair.source_phantom.forward_node_id,
-                    (allow_u_turn ? 0 : distance1) -
-                        phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
+                    -phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
                     phantom_node_pair.source_phantom.forward_node_id);
-                min_edge_offset =
-                    std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance1) -
-                                 phantom_node_pair.source_phantom.GetForwardWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-b2 insert: " <<
-                // phantom_node_pair.source_phantom.forward_node_id << ", w: " << (allow_u_turn ? 0
-                // : distance1) - phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
+                // phantom_node_pair.source_phantom.forward_node_id << ", w: " << -phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
             }
             if ((allow_u_turn || search_from_2nd_node) &&
                 phantom_node_pair.source_phantom.reverse_node_id != SPECIAL_NODEID)
             {
                 forward_heap1.Insert(
                     phantom_node_pair.source_phantom.reverse_node_id,
-                    (allow_u_turn ? 0 : distance2) -
-                        phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
+                    -phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
                     phantom_node_pair.source_phantom.reverse_node_id);
-                min_edge_offset =
-                    std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance2) -
-                                 phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-a2 insert: " <<
-                // phantom_node_pair.source_phantom.reverse_node_id <<
-                //                     ", w: " << (allow_u_turn ? 0 : distance2) -
-                //                     phantom_node_pair.source_phantom.GetReverseWeightPlusOffset();
+                // phantom_node_pair.source_phantom.reverse_node_id << ", w: " << -phantom_node_pair.source_phantom.GetReverseWeightPlusOffset();
                 forward_heap2.Insert(
                     phantom_node_pair.source_phantom.reverse_node_id,
-                    (allow_u_turn ? 0 : distance2) -
-                        phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
+                    -phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
                     phantom_node_pair.source_phantom.reverse_node_id);
-                min_edge_offset =
-                    std::min(min_edge_offset,
-                             (allow_u_turn ? 0 : distance2) -
-                                 phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-b2 insert: " <<
-                // phantom_node_pair.source_phantom.reverse_node_id <<
-                //                     ", w: " << (allow_u_turn ? 0 : distance2) -
-                //                     phantom_node_pair.source_phantom.GetReverseWeightPlusOffset();
+                // phantom_node_pair.source_phantom.reverse_node_id << ", w: " << -phantom_node_pair.source_phantom.GetReverseWeightPlusOffset();
             }
 
             // insert new backward nodes into backward heap, unadjusted.
@@ -161,9 +137,7 @@ class ShortestPathRouting final
                                      phantom_node_pair.target_phantom.GetForwardWeightPlusOffset(),
                                      phantom_node_pair.target_phantom.forward_node_id);
                 // SimpleLogger().Write(logDEBUG) << "rev-a insert: " <<
-                // phantom_node_pair.target_phantom.forward_node_id <<
-                //                     ", w: " <<
-                //                     phantom_node_pair.target_phantom.GetForwardWeightPlusOffset();
+                // phantom_node_pair.target_phantom.forward_node_id << ", w: " << phantom_node_pair.target_phantom.GetForwardWeightPlusOffset();
             }
 
             if (phantom_node_pair.target_phantom.reverse_node_id != SPECIAL_NODEID)
@@ -172,9 +146,7 @@ class ShortestPathRouting final
                                      phantom_node_pair.target_phantom.GetReverseWeightPlusOffset(),
                                      phantom_node_pair.target_phantom.reverse_node_id);
                 // SimpleLogger().Write(logDEBUG) << "rev-a insert: " <<
-                // phantom_node_pair.target_phantom.reverse_node_id <<
-                //                     ", w: " <<
-                //                     phantom_node_pair.target_phantom.GetReverseWeightPlusOffset();
+                // phantom_node_pair.target_phantom.reverse_node_id << ", w: " << phantom_node_pair.target_phantom.GetReverseWeightPlusOffset();
             }
 
             // run two-Target Dijkstra routing step.
@@ -332,8 +304,8 @@ class ShortestPathRouting final
                 BOOST_ASSERT(search_from_1st_node != search_from_2nd_node);
             }
 
-            distance1 = local_upper_bound1;
-            distance2 = local_upper_bound2;
+            distance1 += local_upper_bound1;
+            distance2 += local_upper_bound2;
             ++current_leg;
         }
 

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -92,9 +92,6 @@ class ShortestPathRouting final
 
             const bool allow_u_turn = current_leg > 0 && uturn_indicators.size() > current_leg &&
                                       uturn_indicators[current_leg - 1];
-
-            const bool same_node = phantom_node_pair.source_phantom.forward_node_id == phantom_node_pair.target_phantom.forward_node_id;
-             
             EdgeWeight min_edge_offset = 0;
 
             // insert new starting nodes into forward heap, adjusted by previous distances.
@@ -103,24 +100,24 @@ class ShortestPathRouting final
             {
                 forward_heap1.Insert(
                     phantom_node_pair.source_phantom.forward_node_id,
-                    (allow_u_turn || same_node ? 0 : distance1) -
+                    (allow_u_turn ? 0 : distance1) -
                         phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
                     phantom_node_pair.source_phantom.forward_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn || same_node ? 0 : distance1) -
+                             (allow_u_turn ? 0 : distance1) -
                                  phantom_node_pair.source_phantom.GetForwardWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-a2 insert: " <<
                 // phantom_node_pair.source_phantom.forward_node_id << ", w: " << (allow_u_turn ? 0
                 // : distance1) - phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
                 forward_heap2.Insert(
                     phantom_node_pair.source_phantom.forward_node_id,
-                    (allow_u_turn || same_node ? 0 : distance1) -
+                    (allow_u_turn ? 0 : distance1) -
                         phantom_node_pair.source_phantom.GetForwardWeightPlusOffset(),
                     phantom_node_pair.source_phantom.forward_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn || same_node ? 0 : distance1) -
+                             (allow_u_turn ? 0 : distance1) -
                                  phantom_node_pair.source_phantom.GetForwardWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-b2 insert: " <<
                 // phantom_node_pair.source_phantom.forward_node_id << ", w: " << (allow_u_turn ? 0
@@ -131,12 +128,12 @@ class ShortestPathRouting final
             {
                 forward_heap1.Insert(
                     phantom_node_pair.source_phantom.reverse_node_id,
-                    (allow_u_turn || same_node ? 0 : distance2) -
+                    (allow_u_turn ? 0 : distance2) -
                         phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
                     phantom_node_pair.source_phantom.reverse_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn || same_node ? 0 : distance2) -
+                             (allow_u_turn ? 0 : distance2) -
                                  phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-a2 insert: " <<
                 // phantom_node_pair.source_phantom.reverse_node_id <<
@@ -144,12 +141,12 @@ class ShortestPathRouting final
                 //                     phantom_node_pair.source_phantom.GetReverseWeightPlusOffset();
                 forward_heap2.Insert(
                     phantom_node_pair.source_phantom.reverse_node_id,
-                    (allow_u_turn || same_node ? 0 : distance2) -
+                    (allow_u_turn ? 0 : distance2) -
                         phantom_node_pair.source_phantom.GetReverseWeightPlusOffset(),
                     phantom_node_pair.source_phantom.reverse_node_id);
                 min_edge_offset =
                     std::min(min_edge_offset,
-                             (allow_u_turn || same_node ? 0 : distance2) -
+                             (allow_u_turn ? 0 : distance2) -
                                  phantom_node_pair.source_phantom.GetReverseWeightPlusOffset());
                 // SimpleLogger().Write(logDEBUG) << "fwd-b2 insert: " <<
                 // phantom_node_pair.source_phantom.reverse_node_id <<


### PR DESCRIPTION
This small change partly addresses #1424, and does not seem to re-introduce #1429.

When two vias are placed on the same way (NodeID), it causes the reverse heap test (`WasInserted`) to return true in the first round call to `RoutingStep`.  When a previous leg has a distance offset in place, the loop thinks the two ends of the bi-directional Dijkstra search have met and no further edges are visited, the two vias are routed directly, even if the way is marked as one-way, and the vias are not visitable in their placed order.

This change adds an explicit test for vias on the same way.  When detected, the distance offset is not applied to the nodes inserted into the search heaps.  This leads to proper traversal of the edge graph.

One point of note:  the `raw_route_data.shortest_path_length` value is not correct, further changes are needed to make that bit work too.

Additionally, while the tests in `features/testbot/via.feature` address this bug specifically, I could not get them all to work.   Only two of the tests in the `Via points on ring on the same oneway` scenario work, the other three are returning no results to the test suite, although manual testing of these scenarios seems to work OK.  I'm not familiar enough with cucumber to dig all the way into it at this stage.