### PR TITLE
Enable barrier check for TarjanSCC

### DIFF
--- a/algorithms/tiny_components.hpp
+++ b/algorithms/tiny_components.hpp
@@ -150,7 +150,7 @@ template <typename GraphT> class TarjanSCC
                         // Traverse outgoing edges
                         if (barrier_node_set.find(v) != barrier_node_set.end() && u != vprime)
                         {
-                            // continue;
+                            continue;
                         }
 
                         if (to_node_of_only_restriction != std::numeric_limits<unsigned>::max() &&


### PR DESCRIPTION
Re-enabling turn restrictions as well requires some further work to
extend the algorithm.

This is split from https://github.com/Project-OSRM/osrm-backend/pull/1493 to get a partial fix.