### PR TITLE
Polyline string as parameter

### DIFF
--- a/algorithms/polyline_compressor.cpp
+++ b/algorithms/polyline_compressor.cpp
@@ -119,8 +119,8 @@ std::vector<FixedPointCoordinate> PolylineCompressor::decode_string(const std::s
         lng += dlng;
 
         FixedPointCoordinate p;
-        p.lat = COORDINATE_PRECISION * (((double) lat / 1E5));
-        p.lon = COORDINATE_PRECISION * (((double) lng / 1E5));
+        p.lat = COORDINATE_PRECISION * (((double) lat / 1E6));
+        p.lon = COORDINATE_PRECISION * (((double) lng / 1E6));
         new_coordinates.push_back(p);
     }
 

--- a/algorithms/polyline_compressor.cpp
+++ b/algorithms/polyline_compressor.cpp
@@ -89,7 +89,7 @@ PolylineCompressor::get_encoded_string(const std::vector<SegmentInformation> &po
     return encode_vector(delta_numbers);
 }
 
-std::vector<FixedPointCoordinate> PolylineCompressor::decode_string(const std::string geometry_string) const
+std::vector<FixedPointCoordinate> PolylineCompressor::decode_string(const std::string &geometry_string) const
 {
     std::vector<FixedPointCoordinate> new_coordinates;
     int index = 0, len = geometry_string.size();

--- a/algorithms/polyline_compressor.hpp
+++ b/algorithms/polyline_compressor.hpp
@@ -30,6 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct SegmentInformation;
 
+#include <osrm/coordinate.hpp>
+
 #include <string>
 #include <vector>
 
@@ -42,6 +44,8 @@ class PolylineCompressor
 
   public:
     std::string get_encoded_string(const std::vector<SegmentInformation> &polyline) const;
+    
+    std::vector<FixedPointCoordinate> decode_string(const std::string geometry_string) const;
 };
 
 #endif /* POLYLINECOMPRESSOR_H_ */

--- a/algorithms/polyline_compressor.hpp
+++ b/algorithms/polyline_compressor.hpp
@@ -45,7 +45,7 @@ class PolylineCompressor
   public:
     std::string get_encoded_string(const std::vector<SegmentInformation> &polyline) const;
     
-    std::vector<FixedPointCoordinate> decode_string(const std::string geometry_string) const;
+    std::vector<FixedPointCoordinate> decode_string(const std::string &geometry_string) const;
 };
 
 #endif /* POLYLINECOMPRESSOR_H_ */

--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <osrm/route_parameters.hpp>
 
+#include "../algorithms/polyline_compressor.hpp"
+
 RouteParameters::RouteParameters()
     : zoom_level(18), print_instructions(false), alternate_route(true), geometry(true),
       compression(true), deprecatedAPI(false), uturn_default(false), classify(false),
@@ -130,4 +132,10 @@ void RouteParameters::addCoordinate(
     coordinates.emplace_back(
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<0>(received_coordinates)),
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
+}
+
+void RouteParameters::getCoordinatesFromGeometry(const std::string geometry_string)
+{
+    PolylineCompressor pc;
+    coordinates = pc.decode_string(geometry_string);
 }

--- a/include/osrm/route_parameters.hpp
+++ b/include/osrm/route_parameters.hpp
@@ -78,6 +78,8 @@ struct RouteParameters
     void setCompressionFlag(const bool flag);
 
     void addCoordinate(const boost::fusion::vector<double, double> &received_coordinates);
+    
+    void getCoordinatesFromGeometry(const std::string geometry_string);
 
     short zoom_level;
     bool print_instructions;

--- a/server/api_grammar.hpp
+++ b/server/api_grammar.hpp
@@ -42,7 +42,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                    *(query) >> -(uturns);
         query = ('?') >> (+(zoom | output | jsonp | checksum | location | hint | timestamp | u | cmp |
                             language | instruction | geometry | alt_route | old_API | num_results |
-                            matching_beta | gps_precision | classify));
+                            matching_beta | gps_precision | classify | geometry_string));
 
         zoom = (-qi::lit('&')) >> qi::lit('z') >> '=' >>
                qi::short_[boost::bind(&HandlerT::setZoomLevel, handler, ::_1)];
@@ -83,17 +83,20 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                qi::short_[boost::bind(&HandlerT::setGPSPrecision, handler, ::_1)];
         classify = (-qi::lit('&')) >> qi::lit("classify") >> '=' >>
             qi::bool_[boost::bind(&HandlerT::setClassify, handler, ::_1)];
+        geometry_string = (-qi::lit('&')) >> qi::lit("geometry_string") >> '=' >>
+            stringforPolyline[boost::bind(&HandlerT::getCoordinatesFromGeometry, handler, ::_1)];
 
         string = +(qi::char_("a-zA-Z"));
         stringwithDot = +(qi::char_("a-zA-Z0-9_.-"));
         stringwithPercent = +(qi::char_("a-zA-Z0-9_.-") | qi::char_('[') | qi::char_(']') |
                               (qi::char_('%') >> qi::char_("0-9A-Z") >> qi::char_("0-9A-Z")));
+        stringforPolyline = +(qi::char_("a-zA-Z0-9_.-[]{}@?|\\%~`^"));
     }
 
     qi::rule<Iterator> api_call, query;
     qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location,
         hint, timestamp, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
-        uturns, old_API, num_results, matching_beta, gps_precision, classify;
+        uturns, old_API, num_results, matching_beta, gps_precision, classify, geometry_string, stringforPolyline;
 
     HandlerT *handler;
 };

--- a/server/api_grammar.hpp
+++ b/server/api_grammar.hpp
@@ -42,7 +42,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                    *(query) >> -(uturns);
         query = ('?') >> (+(zoom | output | jsonp | checksum | location | hint | timestamp | u | cmp |
                             language | instruction | geometry | alt_route | old_API | num_results |
-                            matching_beta | gps_precision | classify | geometry_string));
+                            matching_beta | gps_precision | classify | locs));
 
         zoom = (-qi::lit('&')) >> qi::lit('z') >> '=' >>
                qi::short_[boost::bind(&HandlerT::setZoomLevel, handler, ::_1)];
@@ -83,7 +83,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                qi::short_[boost::bind(&HandlerT::setGPSPrecision, handler, ::_1)];
         classify = (-qi::lit('&')) >> qi::lit("classify") >> '=' >>
             qi::bool_[boost::bind(&HandlerT::setClassify, handler, ::_1)];
-        geometry_string = (-qi::lit('&')) >> qi::lit("geometry_string") >> '=' >>
+        locs = (-qi::lit('&')) >> qi::lit("locs") >> '=' >>
             stringforPolyline[boost::bind(&HandlerT::getCoordinatesFromGeometry, handler, ::_1)];
 
         string = +(qi::char_("a-zA-Z"));
@@ -96,7 +96,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     qi::rule<Iterator> api_call, query;
     qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location,
         hint, timestamp, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
-        uturns, old_API, num_results, matching_beta, gps_precision, classify, geometry_string, stringforPolyline;
+        uturns, old_API, num_results, matching_beta, gps_precision, classify, locs, stringforPolyline;
 
     HandlerT *handler;
 };

--- a/unit_tests/algorithms/geometry_string.cpp
+++ b/unit_tests/algorithms/geometry_string.cpp
@@ -63,7 +63,12 @@ BOOST_AUTO_TEST_CASE(geometry_string)
 
     for(unsigned i = 0; i < cmp_coords.size(); ++i)
     {
-        BOOST_CHECK_CLOSE(cmp_coords.at(i).lat, coords.at(i).lat, 0.0001);
-        BOOST_CHECK_CLOSE(cmp_coords.at(i).lon, coords.at(i).lon, 0.0001);
+	const double cmp1_lat = coords.at(i).lat;
+	const double cmp2_lat = cmp_coords.at(i).lat;
+        BOOST_CHECK_CLOSE(cmp1_lat, cmp2_lat, 0.0001);
+	
+	const double cmp1_lon = coords.at(i).lon;
+	const double cmp2_lon = cmp_coords.at(i).lon;
+        BOOST_CHECK_CLOSE(cmp1_lon, cmp2_lon, 0.0001);
     }
 }

--- a/unit_tests/algorithms/geometry_string.cpp
+++ b/unit_tests/algorithms/geometry_string.cpp
@@ -1,0 +1,69 @@
+/*
+
+Copyright (c) 2015, Project OSRM contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "../../algorithms/polyline_compressor.hpp"
+#include "../../data_structures/coordinate_calculation.hpp"
+
+#include <osrm/coordinate.hpp>
+
+#include <cmath>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(geometry_string)
+{
+    // Polyline string for the 5 coordinates
+    const std::string polyline = "_c`|@_c`|@o}@_pRo}@}oRm}@apRo}@_pR";
+    PolylineCompressor pc;
+    std::vector<FixedPointCoordinate> coords = pc.decode_string(polyline);
+
+    // Test coordinates; these would be the coordinates we give the loc parameter,
+    // e.g. loc=10.00,10.0&loc=10.01,10.1...
+    FixedPointCoordinate coord1(10.00 * COORDINATE_PRECISION, 10.0 * COORDINATE_PRECISION);
+    FixedPointCoordinate coord2(10.01 * COORDINATE_PRECISION, 10.1 * COORDINATE_PRECISION);
+    FixedPointCoordinate coord3(10.02 * COORDINATE_PRECISION, 10.2 * COORDINATE_PRECISION);
+    FixedPointCoordinate coord4(10.03 * COORDINATE_PRECISION, 10.3 * COORDINATE_PRECISION);
+    FixedPointCoordinate coord5(10.04 * COORDINATE_PRECISION, 10.4 * COORDINATE_PRECISION);
+    
+    // Put the test coordinates into the vector for comparison
+    std::vector<FixedPointCoordinate> cmp_coords;
+    cmp_coords.emplace_back(coord1);
+    cmp_coords.emplace_back(coord2);
+    cmp_coords.emplace_back(coord3);
+    cmp_coords.emplace_back(coord4);
+    cmp_coords.emplace_back(coord5);
+
+    BOOST_CHECK_EQUAL(cmp_coords.size(), coords.size());
+
+    for(unsigned i = 0; i < cmp_coords.size(); ++i)
+    {
+        BOOST_CHECK_CLOSE(cmp_coords.at(i).lat, coords.at(i).lat, 0.0001);
+        BOOST_CHECK_CLOSE(cmp_coords.at(i).lon, coords.at(i).lon, 0.0001);
+    }
+}

--- a/unit_tests/algorithms/geometry_string.cpp
+++ b/unit_tests/algorithms/geometry_string.cpp
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 BOOST_AUTO_TEST_CASE(geometry_string)
 {
     // Polyline string for the 5 coordinates
-    const std::string polyline = "_c`|@_c`|@o}@_pRo}@}oRm}@apRo}@_pR";
+    const std::string polyline = "_gjaR_gjaR_pR_ibE_pR_ibE_pR_ibE_pR_ibE";
     PolylineCompressor pc;
     std::vector<FixedPointCoordinate> coords = pc.decode_string(polyline);
 


### PR DESCRIPTION
Instead of sending lots of loc-values (e.g. for match or viaroute service) you can use geometry_string={polyline_string} which decodes the given polyline to coordinates.