### PR TITLE
Abstracted OSRM intermediate file writer spec for edges and nodes.

### DIFF
--- a/data_structures/hilbert_value.cpp
+++ b/data_structures/hilbert_value.cpp
@@ -57,7 +57,7 @@ uint64_t HilbertCode::BitInterleaving(const uint32_t latitude, const uint32_t lo
 
 void HilbertCode::TransposeCoordinate(uint32_t *X) const
 {
-    uint32_t M = 1 << (32 - 1), P, Q, t;
+    uint32_t M = 1u << (32 - 1), P, Q, t;
     int i;
     // Inverse undo
     for (Q = M; Q > 1; Q >>= 1)

--- a/extractor/extraction_containers.cpp
+++ b/extractor/extraction_containers.cpp
@@ -84,7 +84,6 @@ void ExtractionContainers::PrepareData(const std::string &output_file_name,
         std::ofstream file_out_stream{output_file_name, std::ios::binary};
 
         HeaderWriter out{file_out_stream, fingerprint};
-        //out.Write();
 
         PrepareNodes();
         WriteNodes(file_out_stream);
@@ -414,7 +413,7 @@ void ExtractionContainers::WriteEdges(std::ofstream& file_out_stream) const
     std::cout << "[extractor] setting number of edges   ... " << std::flush;
     std::cout << "ok" << std::endl;
 
-    //SimpleLogger().Write() << "Processed " << number_of_used_edges << " edges";
+    SimpleLogger().Write() << "Processed " << out.Count() << " edges";
 }
 
 void ExtractionContainers::WriteNodes(std::ofstream& file_out_stream) const

--- a/extractor/extraction_containers.cpp
+++ b/extractor/extraction_containers.cpp
@@ -32,6 +32,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../data_structures/node_id.hpp"
 #include "../data_structures/range_table.hpp"
 
+#include "../io/osrm_writer.hpp"
+
 #include "../util/osrm_exception.hpp"
 #include "../util/simple_logger.hpp"
 #include "../util/timing_util.hpp"
@@ -79,16 +81,15 @@ void ExtractionContainers::PrepareData(const std::string &output_file_name,
 {
     try
     {
-        std::ofstream file_out_stream;
-        file_out_stream.open(output_file_name.c_str(), std::ios::binary);
-        file_out_stream.write((char *)&fingerprint, sizeof(FingerPrint));
+        std::ofstream file_out_stream{output_file_name, std::ios::binary};
+
+        HeaderWriter out{file_out_stream, fingerprint};
+        //out.Write();
 
         PrepareNodes();
         WriteNodes(file_out_stream);
         PrepareEdges();
         WriteEdges(file_out_stream);
-
-        file_out_stream.close();
 
         PrepareRestrictions();
         WriteRestrictions(restrictions_file_name);
@@ -393,13 +394,10 @@ void ExtractionContainers::PrepareEdges()
 
 void ExtractionContainers::WriteEdges(std::ofstream& file_out_stream) const
 {
+    EdgeWriter out{file_out_stream, fingerprint};
+
     std::cout << "[extractor] Writing used egdes       ... " << std::flush;
     TIMER_START(write_edges);
-    // Traverse list of edges and nodes in parallel and set target coord
-    unsigned number_of_used_edges = 0;
-
-    auto start_position = file_out_stream.tellp();
-    file_out_stream.write((char *)&number_of_used_edges, sizeof(unsigned));
 
     for (const auto& edge : all_edges_list)
     {
@@ -408,25 +406,21 @@ void ExtractionContainers::WriteEdges(std::ofstream& file_out_stream) const
             continue;
         }
 
-        file_out_stream.write((char*) &edge.result, sizeof(NodeBasedEdge));
-        number_of_used_edges++;
+        out.Write(edge.result);
     }
     TIMER_STOP(write_edges);
     std::cout << "ok, after " << TIMER_SEC(write_edges) << "s" << std::endl;
 
     std::cout << "[extractor] setting number of edges   ... " << std::flush;
-    file_out_stream.seekp(start_position);
-    file_out_stream.write((char *)&number_of_used_edges, sizeof(unsigned));
     std::cout << "ok" << std::endl;
 
-    SimpleLogger().Write() << "Processed " << number_of_used_edges << " edges";
+    //SimpleLogger().Write() << "Processed " << number_of_used_edges << " edges";
 }
 
 void ExtractionContainers::WriteNodes(std::ofstream& file_out_stream) const
 {
-    unsigned number_of_used_nodes = 0;
-    // write dummy value, will be overwritten later
-    file_out_stream.write((char *)&number_of_used_nodes, sizeof(unsigned));
+    NodeWriter out{file_out_stream, fingerprint};
+
     std::cout << "[extractor] Confirming/Writing used nodes     ... " << std::flush;
     TIMER_START(write_nodes);
     // identify all used nodes by a merging step of two sorted lists
@@ -446,9 +440,8 @@ void ExtractionContainers::WriteNodes(std::ofstream& file_out_stream) const
         }
         BOOST_ASSERT(*node_id_iterator == node_iterator->node_id);
 
-        file_out_stream.write((char *)&(*node_iterator), sizeof(ExternalMemoryNode));
+        out.Write(*node_iterator);
 
-        ++number_of_used_nodes;
         ++node_id_iterator;
         ++node_iterator;
     }
@@ -456,13 +449,9 @@ void ExtractionContainers::WriteNodes(std::ofstream& file_out_stream) const
     std::cout << "ok, after " << TIMER_SEC(write_nodes) << "s" << std::endl;
 
     std::cout << "[extractor] setting number of nodes   ... " << std::flush;
-    std::ios::pos_type previous_file_position = file_out_stream.tellp();
-    file_out_stream.seekp(std::ios::beg + sizeof(FingerPrint));
-    file_out_stream.write((char *)&number_of_used_nodes, sizeof(unsigned));
-    file_out_stream.seekp(previous_file_position);
     std::cout << "ok" << std::endl;
 
-    SimpleLogger().Write() << "Processed " << number_of_used_nodes << " nodes";
+    //SimpleLogger().Write() << "Processed " << number_of_used_nodes << " nodes";
 }
 
 void ExtractionContainers::WriteRestrictions(const std::string& path) const

--- a/io/osrm_writer.hpp
+++ b/io/osrm_writer.hpp
@@ -1,0 +1,132 @@
+#ifndef OSRM_WRITER_HPP
+#define OSRM_WRITER_HPP
+
+#include "../data_structures/import_edge.hpp"
+#include "../data_structures/external_memory_node.hpp"
+
+#include "../util/fingerprint.hpp"
+
+#include <ostream>
+#include <cstddef>
+#include <type_traits>
+
+// The OSRMWriter is fully customizable by providing policies for
+//  - a header, written once at the beginning
+//  - each item or no item at all
+//  - a finalizer, run once after writing is done
+
+template <typename HeaderPolicy, typename TypeWritePolicy, typename FinalizePolicy>
+class OSRMWriter final
+{
+  public:
+    template <typename Header>
+    OSRMWriter(std::ostream &stream, const Header &header)
+        : stream_{stream}, segment_start_(stream_.tellp()), count_{0}
+    {
+        header_offset_ = HeaderPolicy::Write(header, stream_, segment_start_, count_);
+
+        unsigned reserve_prefix = 0;
+        const auto written =
+            TypeWritePolicy::Write(reserve_prefix, stream_, segment_start_, header_offset_, count_);
+        (void)written; // unused, as this is reserved space
+    }
+
+    ~OSRMWriter()
+    {
+        const auto len = FinalizePolicy::Write(stream_, segment_start_, header_offset_, count_);
+        (void)len; // unused
+    }
+
+    template <typename T> void Write(const T &item)
+    {
+        const auto written =
+            TypeWritePolicy::Write(item, stream_, segment_start_, header_offset_, count_);
+        count_ += written;
+    }
+
+  private:
+    std::ostream &stream_;
+    std::size_t segment_start_;
+    std::size_t header_offset_; // should be compile time constant
+    std::size_t count_;
+};
+
+// Silent Policies
+struct NoHeaderPolicy final
+{
+    template <typename T>
+    static std::size_t Write(const T &, std::ostream &, std::size_t, std::size_t)
+    {
+        return 0;
+    }
+};
+
+struct NoTypeWritePolicy final
+{
+    template <typename T>
+    static std::size_t Write(const T &, std::ostream &, std::size_t, std::size_t, std::size_t)
+    {
+        return 0;
+    }
+};
+
+struct NoFinalizePolicy final
+{
+    static std::size_t Write(std::ostream &, std::size_t, std::size_t, std::size_t) { return 0; }
+};
+
+// TODO: Debug Policies, i.e. diagnostics to stderr
+
+// Concrete Policies
+struct TrivialHeaderPolicy final
+{
+    template <typename T>
+    static std::size_t
+    Write(const T &header, std::ostream &stream, std::size_t segment_start, std::size_t count)
+    {
+        // TODO: strictly speaking we need a trivial type, but most are not; check this on callside
+        // static_assert(std::is_trivial<T>::value, "T is not a trivial type");
+        const auto offset = sizeof(T);
+        stream.write(reinterpret_cast<const char *>(&header), offset);
+        return offset;
+    }
+};
+
+struct TrivialTypeWritePolicy final
+{
+    template <typename T>
+    static std::size_t Write(const T &item,
+                             std::ostream &stream,
+                             std::size_t segment_start,
+                             std::size_t header_off,
+                             std::size_t count)
+    {
+        // TODO: strictly speaking we need a trivial type, but most are not; check this on callside
+        // static_assert(std::is_trivial<T>::value, "T is not a trivial type");
+        stream.write(reinterpret_cast<const char *>(&item), sizeof(decltype(item)));
+        return 1u;
+    }
+};
+
+struct LengthPrefixFinalizePolicy final
+{
+    static std::size_t Write(std::ostream &stream,
+                             std::size_t segment_start,
+                             std::size_t header_offset,
+                             std::size_t count)
+    {
+        const auto here = stream.tellp();
+        stream.seekp(segment_start + header_offset);
+        // XXX: why do we write unsigned; what about overflow?
+        unsigned len = static_cast<unsigned>(count);
+        stream.write(reinterpret_cast<const char *>(&len), sizeof(decltype(len)));
+        stream.seekp(here);
+        return 1u;
+    }
+};
+
+using HeaderWriter = OSRMWriter<TrivialHeaderPolicy, NoTypeWritePolicy, NoFinalizePolicy>;
+using EdgeWriter = OSRMWriter<NoHeaderPolicy, TrivialTypeWritePolicy, LengthPrefixFinalizePolicy>;
+using NodeWriter = OSRMWriter<NoHeaderPolicy, TrivialTypeWritePolicy, LengthPrefixFinalizePolicy>;
+
+#endif

--- a/io/osrm_writer.hpp
+++ b/io/osrm_writer.hpp
@@ -44,6 +44,8 @@ class OSRMWriter final
         count_ += written;
     }
 
+    std::size_t Count() const { return count_; }
+
   private:
     std::ostream &stream_;
     std::size_t segment_start_;

--- a/io/osrm_writer.hpp
+++ b/io/osrm_writer.hpp
@@ -18,6 +18,8 @@
 //
 //  As of now the policies as stateless; this may change though
 //  in order to support e.g. profiling policies that hold timers.
+//
+//  Note: see end of file for HeaderWriter, EdgeWriter, NodeWriter.
 
 template <typename HeaderWritePolicy, typename TypeWritePolicy, typename FinalizeWritePolicy>
 class OSRMWriter final
@@ -28,16 +30,12 @@ class OSRMWriter final
         : stream_{stream}, segment_start_(stream_.tellp()), count_{0}
     {
         header_offset_ = HeaderWritePolicy::Write(header, stream_, segment_start_, count_);
-
-        unsigned reserve_prefix = 0;
-        const auto written =
-            TypeWritePolicy::Write(reserve_prefix, stream_, segment_start_, header_offset_, count_);
-        (void)written; // unused, as this is reserved space
     }
 
     ~OSRMWriter()
     {
-        const auto len = FinalizeWritePolicy::Write(stream_, segment_start_, header_offset_, count_);
+        const auto len =
+            FinalizeWritePolicy::Write(stream_, segment_start_, header_offset_, count_);
         (void)len; // unused
     }
 
@@ -61,7 +59,7 @@ class OSRMWriter final
 struct NoHeaderWritePolicy final
 {
     template <typename T>
-    static std::size_t Write(const T &, std::ostream &, std::size_t, std::size_t)
+    static inline std::size_t Write(const T &, std::ostream &, std::size_t, std::size_t)
     {
         return 0;
     }
@@ -70,7 +68,8 @@ struct NoHeaderWritePolicy final
 struct NoTypeWritePolicy final
 {
     template <typename T>
-    static std::size_t Write(const T &, std::ostream &, std::size_t, std::size_t, std::size_t)
+    static inline std::size_t
+    Write(const T &, std::ostream &, std::size_t, std::size_t, std::size_t)
     {
         return 0;
     }
@@ -78,7 +77,10 @@ struct NoTypeWritePolicy final
 
 struct NoFinalizeWritePolicy final
 {
-    static std::size_t Write(std::ostream &, std::size_t, std::size_t, std::size_t) { return 0; }
+    static inline std::size_t Write(std::ostream &, std::size_t, std::size_t, std::size_t)
+    {
+        return 0;
+    }
 };
 
 // TODO: Debug Policies, i.e. diagnostics to stderr
@@ -87,12 +89,11 @@ struct NoFinalizeWritePolicy final
 struct TrivialHeaderWritePolicy final
 {
     template <typename T>
-    static std::size_t
-    Write(const T &header, std::ostream &stream, std::size_t segment_start, std::size_t count)
+    static inline std::size_t Write(const T &header, std::ostream &stream, std::size_t, std::size_t)
     {
         // TODO: strictly speaking we need a trivial type, but most are not; check this on callside
         // static_assert(std::is_trivial<T>::value, "T is not a trivial type");
-        const auto offset = sizeof(T);
+        const constexpr auto offset = sizeof(T);
         stream.write(reinterpret_cast<const char *>(&header), offset);
         return offset;
     }
@@ -101,38 +102,55 @@ struct TrivialHeaderWritePolicy final
 struct TrivialTypeWritePolicy final
 {
     template <typename T>
-    static std::size_t Write(const T &item,
-                             std::ostream &stream,
-                             std::size_t segment_start,
-                             std::size_t header_off,
-                             std::size_t count)
+    static inline std::size_t
+    Write(const T &item, std::ostream &stream, std::size_t, std::size_t, std::size_t)
     {
         // TODO: strictly speaking we need a trivial type, but most are not; check this on callside
         // static_assert(std::is_trivial<T>::value, "T is not a trivial type");
         stream.write(reinterpret_cast<const char *>(&item), sizeof(decltype(item)));
-        return 1u;
+        return 1;
+    }
+};
+
+struct LengthPrefixHeaderWritePolicy final
+{
+    template <typename T>
+    static inline std::size_t Write(const T &, std::ostream &stream, std::size_t, std::size_t)
+    {
+        // XXX: why do we write unsigned; what about overflow?
+        const unsigned reserved = 0;
+        stream.write(reinterpret_cast<const char *>(&reserved), sizeof(decltype(reserved)));
+        return 0; // do not offset the reserved space as finalizer writes into it
     }
 };
 
 struct LengthPrefixFinalizeWritePolicy final
 {
-    static std::size_t Write(std::ostream &stream,
-                             std::size_t segment_start,
-                             std::size_t header_offset,
-                             std::size_t count)
+    static inline std::size_t Write(std::ostream &stream,
+                                    std::size_t segment_start,
+                                    std::size_t header_offset,
+                                    std::size_t count)
     {
         const auto here = stream.tellp();
         stream.seekp(segment_start + header_offset);
         // XXX: why do we write unsigned; what about overflow?
-        unsigned len = static_cast<unsigned>(count);
+        const auto len = static_cast<unsigned>(count);
         stream.write(reinterpret_cast<const char *>(&len), sizeof(decltype(len)));
         stream.seekp(here);
-        return 1u;
+        return 1;
     }
 };
 
-using HeaderWriter = OSRMWriter<TrivialHeaderWritePolicy, NoTypeWritePolicy, NoFinalizeWritePolicy>;
-using EdgeWriter = OSRMWriter<NoHeaderWritePolicy, TrivialTypeWritePolicy, LengthPrefixFinalizeWritePolicy>;
-using NodeWriter = OSRMWriter<NoHeaderWritePolicy, TrivialTypeWritePolicy, LengthPrefixFinalizeWritePolicy>;
+using HeaderWriter = OSRMWriter<TrivialHeaderWritePolicy, // Write headers of trivial type
+                                NoTypeWritePolicy,        // No elements to write
+                                NoFinalizeWritePolicy>;   // No finalizer
+
+using EdgeWriter = OSRMWriter<LengthPrefixHeaderWritePolicy,    // Reserve for length
+                              TrivialTypeWritePolicy,           // Write items of trivial type
+                              LengthPrefixFinalizeWritePolicy>; // Write length into reserved
+
+using NodeWriter = OSRMWriter<LengthPrefixHeaderWritePolicy,    // Reserve for length
+                              TrivialTypeWritePolicy,           // Write items of trivial type
+                              LengthPrefixFinalizeWritePolicy>; // Write length into reserved
 
 #endif

--- a/util/graph_loader.hpp
+++ b/util/graph_loader.hpp
@@ -51,6 +51,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iomanip>
 #include <unordered_map>
 #include <vector>
+#include <iterator>
 
 /**
  * Reads the .restrictions file and loads it to a vector.
@@ -107,20 +108,18 @@ NodeID loadNodesFromFile(std::istream &input_stream,
     input_stream.read(reinterpret_cast<char *>(&n), sizeof(NodeID));
     SimpleLogger().Write() << "Importing n = " << n << " nodes ";
 
-    ExternalMemoryNode current_node;
+    std::vector<ExternalMemoryNode> nodes(n);
+    input_stream.read(reinterpret_cast<char *>(nodes.data()), sizeof(ExternalMemoryNode) * n);
+
     for (NodeID i = 0; i < n; ++i)
     {
-        input_stream.read(reinterpret_cast<char *>(&current_node), sizeof(ExternalMemoryNode));
-        node_array.emplace_back(current_node.lat, current_node.lon, current_node.node_id);
-        if (current_node.barrier)
-        {
+        if (nodes[i].barrier)
             barrier_node_list.emplace_back(i);
-        }
-        if (current_node.traffic_lights)
-        {
+        if (nodes[i].traffic_lights)
             traffic_light_node_list.emplace_back(i);
-        }
     }
+
+    std::move(begin(nodes), end(nodes), std::back_inserter(node_array));
 
     // tighten vector sizes
     barrier_node_list.shrink_to_fit();

--- a/util/graph_loader.hpp
+++ b/util/graph_loader.hpp
@@ -79,6 +79,8 @@ unsigned loadRestrictionsFromFile(std::istream &input_stream,
                           number_of_usable_restrictions * sizeof(TurnRestriction));
     }
 
+    restriction_list.shrink_to_fit();
+
     return number_of_usable_restrictions;
 }
 
@@ -123,6 +125,7 @@ NodeID loadNodesFromFile(std::istream &input_stream,
     // tighten vector sizes
     barrier_node_list.shrink_to_fit();
     traffic_light_node_list.shrink_to_fit();
+    node_array.shrink_to_fit();
 
     return n;
 }
@@ -165,6 +168,8 @@ NodeID loadEdgesFromFile(std::istream &input_stream, std::vector<NodeBasedEdge> 
 #endif
 
     SimpleLogger().Write() << "Graph loaded ok and has " << edge_list.size() << " edges";
+
+    edge_list.shrink_to_fit();
 
     return m;
 }
@@ -216,6 +221,9 @@ unsigned readHSGRFromStream(const boost::filesystem::path &hsgr_file,
                                number_of_edges * sizeof(EdgeT));
     }
     hsgr_input_stream.close();
+
+    node_list.shrink_to_fit();
+    edge_list.shrink_to_fit();
 
     return number_of_nodes;
 }

--- a/util/graph_loader.hpp
+++ b/util/graph_loader.hpp
@@ -58,8 +58,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The since the restrictions reference nodes using their external node id,
  * we need to renumber it to the new internal id.
 */
-unsigned loadRestrictionsFromFile(std::istream& input_stream,
-                                  std::vector<TurnRestriction>& restriction_list)
+unsigned loadRestrictionsFromFile(std::istream &input_stream,
+                                  std::vector<TurnRestriction> &restriction_list)
 {
     const FingerPrint fingerprint_orig;
     FingerPrint fingerprint_loaded;
@@ -75,13 +75,12 @@ unsigned loadRestrictionsFromFile(std::istream& input_stream,
     restriction_list.resize(number_of_usable_restrictions);
     if (number_of_usable_restrictions > 0)
     {
-        input_stream.read((char *) restriction_list.data(),
-                                number_of_usable_restrictions * sizeof(TurnRestriction));
+        input_stream.read((char *)restriction_list.data(),
+                          number_of_usable_restrictions * sizeof(TurnRestriction));
     }
 
     return number_of_usable_restrictions;
 }
-
 
 /**
  * Reads the beginning of an .osrm file and produces:
@@ -131,36 +130,37 @@ NodeID loadNodesFromFile(std::istream &input_stream,
 /**
  * Reads a .osrm file and produces the edges.
  */
-NodeID loadEdgesFromFile(std::istream &input_stream,
-                         std::vector<NodeBasedEdge> &edge_list)
+NodeID loadEdgesFromFile(std::istream &input_stream, std::vector<NodeBasedEdge> &edge_list)
 {
     EdgeID m;
     input_stream.read(reinterpret_cast<char *>(&m), sizeof(unsigned));
     edge_list.resize(m);
     SimpleLogger().Write() << " and " << m << " edges ";
 
-    input_stream.read((char *) edge_list.data(), m * sizeof(NodeBasedEdge));
+    input_stream.read((char *)edge_list.data(), m * sizeof(NodeBasedEdge));
 
     BOOST_ASSERT(edge_list.size() > 0);
 
 #ifndef NDEBUG
     SimpleLogger().Write() << "Validating loaded edges...";
-    std::sort(edge_list.begin(), edge_list.end(),
-            [](const NodeBasedEdge& lhs, const NodeBasedEdge& rhs)
-            {
-                return (lhs.source < rhs.source) || (lhs.source == rhs.source && lhs.target < rhs.target);
-            });
+    std::sort(edge_list.begin(),
+              edge_list.end(),
+              [](const NodeBasedEdge &lhs, const NodeBasedEdge &rhs)
+              {
+        return (lhs.source < rhs.source) || (lhs.source == rhs.source && lhs.target < rhs.target);
+    });
     for (auto i = 1u; i < edge_list.size(); ++i)
     {
-        const auto& edge = edge_list[i];
-        const auto& prev_edge = edge_list[i-1];
+        const auto &edge = edge_list[i];
+        const auto &prev_edge = edge_list[i - 1];
 
         BOOST_ASSERT_MSG(edge.weight > 0, "loaded null weight");
         BOOST_ASSERT_MSG(edge.forward, "edge must be oriented in forward direction");
         BOOST_ASSERT_MSG(edge.travel_mode != TRAVEL_MODE_INACCESSIBLE, "loaded non-accessible");
 
         BOOST_ASSERT_MSG(edge.source != edge.target, "loaded edges contain a loop");
-        BOOST_ASSERT_MSG(edge.source != prev_edge.source || edge.target != prev_edge.target, "loaded edges contain a multi edge");
+        BOOST_ASSERT_MSG(edge.source != prev_edge.source || edge.target != prev_edge.target,
+                         "loaded edges contain a multi edge");
     }
 #endif
 


### PR DESCRIPTION
The OSRM intermediate file spec is currently implicitly written down in form of source code, copy and pasted throughout the source base. This pull request starts to abstract the writing process, in order to e.g. later easily be able to change to format to using something like protobuf instead of the hand-crafted byte-wise writing.

The main idea is this: writing can be split into three concepts:

* The file header
* a number of item and
* a finalization step which prefix-length encodes the file by reserving a location for the size and in the end jumping back writing it