### PR TITLE
Fix multiple vias with same coordinate

### DIFF
--- a/descriptors/description_factory.cpp
+++ b/descriptors/description_factory.cpp
@@ -173,6 +173,7 @@ void DescriptionFactory::Run(const unsigned zoom_level)
     //        }
     //        string0 = string1;
     //    }
+    //
 
     float segment_length = 0.;
     EdgeWeight segment_duration = 0;
@@ -197,7 +198,8 @@ void DescriptionFactory::Run(const unsigned zoom_level)
 
     // Post-processing to remove empty or nearly empty path segments
     if (path_description.size() > 2 &&
-        std::numeric_limits<float>::epsilon() > path_description.back().length)
+        std::numeric_limits<float>::epsilon() > path_description.back().length &&
+        !(path_description.end() - 2)->is_via_location)
     {
         path_description.pop_back();
         path_description.back().necessary = true;
@@ -206,7 +208,8 @@ void DescriptionFactory::Run(const unsigned zoom_level)
     }
 
     if (path_description.size() > 2 &&
-        std::numeric_limits<float>::epsilon() > path_description.front().length)
+        std::numeric_limits<float>::epsilon() > path_description.front().length &&
+        !(path_description.begin() + 1)->is_via_location)
     {
         path_description.erase(path_description.begin());
         path_description.front().turn_instruction = TurnInstruction::HeadOn;

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -52,6 +52,21 @@ Feature: Via points
             | a,c,f     | ab,bcd,bcd,de,efg        |
             | a,c,f,h   | ab,bcd,bcd,de,efg,efg,gh |
 
+    Scenario: Duplicate via point
+        Given the node map
+            | x |   |   |   |   |   |
+            | a | 1 | 2 | 3 | 4 | b |
+            |   |   |   |   |   |   |
+
+        And the ways
+            | nodes |
+            | xa    |
+            | ab    |
+
+        When I route I should get
+            | waypoints | route | turns                |
+            | 1,1,4     | ab,ab | head,via,destination |
+
     Scenario: Via points on ring of oneways
     # xa it to avoid only having a single ring, which cna trigger edge cases
         Given the node map


### PR DESCRIPTION
This fixes adding multiple vias with the same coordinate. It is an edge case, but should not produce invalid data.