### PR TITLE
Strip user's via points from output geometry

### DIFF
--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -183,10 +183,11 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
                     current_coordinate = facade->GetCoordinateOfNode(path_data.node);
                     factory.AppendSegment(current_coordinate, path_data);
                 }
-                factory.SetEndSegment(raw_route.segment_end_coordinates[i].target_phantom,
-                                      raw_route.target_traversed_in_reverse[i],
-                                      raw_route.is_via_leg(i));
             }
+            auto last = raw_route.unpacked_path_segments.size() - 1;
+            factory.SetEndSegment(raw_route.segment_end_coordinates[last].target_phantom,
+                                  raw_route.target_traversed_in_reverse[last],
+                                  raw_route.is_via_leg(last));
             // we need this because we don't run DP
             for (auto &segment : factory.path_description)
             {


### PR DESCRIPTION
For map matching of a complete GPS trace, we want a pristine geometry based on
official data. This change makes sure that only the first and last points may
be via points; all other points are in the road network.

I am not sure why the code is the way it was -- perhaps because we need those intermediate points for actual routing? I'm also not certain that my changes aren't a bad idea, but it seems to work well for me.