### PR TITLE
Generating matching instructions

### DIFF
--- a/descriptors/description_factory.cpp
+++ b/descriptors/description_factory.cpp
@@ -39,14 +39,16 @@ DescriptionFactory::DescriptionFactory() : entire_length(0) { via_indices.push_b
 
 std::vector<unsigned> const &DescriptionFactory::GetViaIndices() const { return via_indices; }
 
-void DescriptionFactory::SetStartSegment(const PhantomNode &source, const bool traversed_in_reverse)
+void DescriptionFactory::SetStartSegment(const PhantomNode &source, const bool traversed_in_reverse,
+                                         const bool is_first_segment)
 {
     start_phantom = source;
     const EdgeWeight segment_duration =
         (traversed_in_reverse ? source.reverse_weight : source.forward_weight);
     const TravelMode travel_mode =
         (traversed_in_reverse ? source.backward_travel_mode : source.forward_travel_mode);
-    AppendSegment(source.location, PathData(0, source.name_id, TurnInstruction::HeadOn,
+    AppendSegment(source.location, PathData(0, source.name_id, 
+                                            (is_first_segment ? TurnInstruction::HeadOn : TurnInstruction::ReachViaLocation),
                                             segment_duration, travel_mode));
     BOOST_ASSERT(path_description.back().duration == segment_duration);
 }

--- a/descriptors/description_factory.hpp
+++ b/descriptors/description_factory.hpp
@@ -81,7 +81,9 @@ class DescriptionFactory
     DescriptionFactory();
     void AppendSegment(const FixedPointCoordinate &coordinate, const PathData &data);
     void BuildRouteSummary(const double distance, const unsigned time);
-    void SetStartSegment(const PhantomNode &start_phantom, const bool traversed_in_reverse);
+    void SetStartSegment(const PhantomNode &start_phantom, 
+                         const bool traversed_in_reverse,
+                         const bool is_first_segment = true);
     void SetEndSegment(const PhantomNode &start_phantom,
                        const bool traversed_in_reverse,
                        const bool is_via_location = false);

--- a/features/step_definitions/matching.rb
+++ b/features/step_definitions/matching.rb
@@ -94,3 +94,170 @@ When /^I match I should get$/ do |table|
   table.diff! actual
 end
 
+When /^I match with turns I should get$/ do |table|
+  reprocess
+  actual = []
+  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+    table.hashes.each_with_index do |row,ri|
+      if row['request']
+        got = {'request' => row['request'] }
+        response = request_url row['request']
+      else
+        params = @query_params
+        trace = []
+        timestamps = []
+        if row['from'] and row['to']
+          node = find_node_by_name(row['from'])
+          raise "*** unknown from-node '#{row['from']}" unless node
+          trace << node
+
+          node = find_node_by_name(row['to'])
+          raise "*** unknown to-node '#{row['to']}" unless node
+          trace << node
+
+          got = {'from' => row['from'], 'to' => row['to'] }
+          response = request_matching trace, timestamps, params
+        elsif row['trace']
+          row['trace'].each_char do |n|
+            node = find_node_by_name(n.strip)
+            raise "*** unknown waypoint node '#{n.strip}" unless node
+            trace << node
+          end
+          if row['timestamps']
+              timestamps = row['timestamps'].split(" ").compact.map { |t| t.to_i}
+          end
+          got = {'trace' => row['trace'] }
+          response = request_matching trace, timestamps, params
+        else
+          raise "*** no trace"
+        end
+      end
+
+      row.each_pair do |k,v|
+        if k =~ /param:(.*)/
+          if v=='(nil)'
+            params[$1]=nil
+          elsif v!=nil
+            params[$1]=v
+          end
+          got[k]=v
+        end
+      end
+
+      if response.body.empty? == false
+        json = JSON.parse response.body
+      end
+      if response.body.empty? == false
+        if response.code == "200"
+          instructions = way_list json['matchings'][0]['instructions']
+          bearings = bearing_list json['matchings'][0]['instructions']
+          compasses = compass_list json['matchings'][0]['instructions']
+          turns = turn_list json['matchings'][0]['instructions']
+          modes = mode_list json['matchings'][0]['instructions']
+          times = time_list json['matchings'][0]['instructions']
+          distances = distance_list json['matchings'][0]['instructions']
+        end
+      end
+      
+      if table.headers.include? 'status'
+        got['status'] = json['status'].to_s
+      end
+      if table.headers.include? 'message'
+        got['message'] = json['status_message']
+      end
+      if table.headers.include? '#'   # comment column
+        got['#'] = row['#']           # copy value so it always match
+      end
+
+      sub_matchings = []
+      if response.code == "200"
+        if table.headers.include? 'matchings'
+          sub_matchings = json['matchings'].compact.map { |sub| sub['matched_points']}
+
+          got['route'] = (instructions || '').strip
+          if table.headers.include?('distance')
+            if row['distance']!=''
+              raise "*** Distance must be specied in meters. (ex: 250m)" unless row['distance'] =~ /\d+m/
+            end
+            got['distance'] = instructions ? "#{json['route_summary']['total_distance'].to_s}m" : ''
+          end
+          if table.headers.include?('time')
+            raise "*** Time must be specied in seconds. (ex: 60s)" unless row['time'] =~ /\d+s/
+            got['time'] = instructions ? "#{json['route_summary']['total_time'].to_s}s" : ''
+          end
+          if table.headers.include?('speed')
+            if row['speed'] != '' && instructions
+              raise "*** Speed must be specied in km/h. (ex: 50 km/h)" unless row['speed'] =~ /\d+ km\/h/
+                time = json['route_summary']['total_time']
+                distance = json['route_summary']['total_distance']
+                speed = time>0 ? (3.6*distance/time).to_i : nil
+                got['speed'] =  "#{speed} km/h"
+            else
+              got['speed'] = ''
+            end
+          end
+          if table.headers.include? 'bearing'
+            got['bearing'] = instructions ? bearings : ''
+          end
+          if table.headers.include? 'compass'
+            got['compass'] = instructions ? compasses : ''
+          end
+          if table.headers.include? 'turns'
+            got['turns'] = instructions ? turns : ''
+          end
+          if table.headers.include? 'modes'
+            got['modes'] = instructions ? modes : ''
+          end
+          if table.headers.include? 'times'
+            got['times'] = instructions ? times : ''
+          end
+          if table.headers.include? 'distances'
+            got['distances'] = instructions ? distances : ''
+          end
+        end
+        if table.headers.include? 'start'
+          got['start'] = instructions ? json['route_summary']['start_point'] : nil
+        end
+        if table.headers.include? 'end'
+          got['end'] = instructions ? json['route_summary']['end_point'] : nil
+        end
+        if table.headers.include? 'geometry'
+            got['geometry'] = json['route_geometry']
+        end
+      end
+
+      ok = true
+      encoded_result = ""
+      extended_target = ""
+      row['matchings'].split(',').each_with_index do |sub, sub_idx|
+        if sub_idx >= sub_matchings.length
+          ok = false
+          break
+        end
+        sub.length.times do |node_idx|
+          node = find_node_by_name(sub[node_idx])
+          out_node = sub_matchings[sub_idx][node_idx]
+          if FuzzyMatch.match_location out_node, node
+            encoded_result += sub[node_idx]
+            extended_target += sub[node_idx]
+          else
+            encoded_result += "? [#{out_node[0]},#{out_node[1]}]"
+            extended_target += "#{sub[node_idx]} [#{node.lat},#{node.lon}]"
+            ok = false
+          end
+        end
+      end
+      if ok
+        got['matchings'] = row['matchings']
+        got['timestamps'] = row['timestamps']
+      else
+        got['matchings'] = encoded_result
+        row['matchings'] = extended_target
+        log_fail row,got, { 'matching' => {:query => @query, :response => response} }
+      end
+
+      actual << got
+    end
+  end
+  table.diff! actual
+end

--- a/features/step_definitions/matching.rb
+++ b/features/step_definitions/matching.rb
@@ -149,13 +149,13 @@ When /^I match with turns I should get$/ do |table|
       end
       if response.body.empty? == false
         if response.code == "200"
-          instructions = way_list json['matchings'][0]['instructions']
-          bearings = bearing_list json['matchings'][0]['instructions']
-          compasses = compass_list json['matchings'][0]['instructions']
-          turns = turn_list json['matchings'][0]['instructions']
-          modes = mode_list json['matchings'][0]['instructions']
-          times = time_list json['matchings'][0]['instructions']
-          distances = distance_list json['matchings'][0]['instructions']
+          instructions = way_list json['route_instructions']
+          bearings = bearing_list json['route_instructions']
+          compasses = compass_list json['route_instructions']
+          turns = turn_list json['route_instructions']
+          modes = mode_list json['route_instructions']
+          times = time_list json['route_instructions']
+          distances = distance_list json['route_instructions']
         end
       end
       

--- a/features/support/match.rb
+++ b/features/support/match.rb
@@ -3,7 +3,7 @@ require 'net/http'
 HOST = "http://127.0.0.1:#{OSRM_PORT}"
 
 def request_matching trace=[], timestamps=[], options={}
-  defaults = { 'output' => 'json' }
+  defaults = { 'output' => 'json', 'instructions' => 'true' }
   locs = trace.compact.map { |w| "loc=#{w.lat},#{w.lon}" }
   ts = timestamps.compact.map { |t| "t=#{t}" }
   if ts.length > 0

--- a/features/testbot/matching_turns.feature
+++ b/features/testbot/matching_turns.feature
@@ -1,0 +1,82 @@
+@routing @turns @testbot
+Feature: Turn directions/codes
+
+    Background:
+        Given the profile "testbot"
+
+    Scenario: Turn directions
+        Given the node map
+            | o | p | a | b | c |
+            | n |   |   |   | d |
+            | m |   | x |   | e |
+            | l |   |   |   | f |
+            | k | j | i | h | g |
+
+        And the ways
+            | nodes |
+            | xa    |
+            | xb    |
+            | xc    |
+            | xd    |
+            | xe    |
+            | xf    |
+            | xg    |
+            | xh    |
+            | xi    |
+            | xj    |
+            | xk    |
+            | xl    |
+            | xm    |
+            | xn    |
+            | xo    |
+            | xp    |
+
+        When I match with turns I should get
+            | trace | route | turns                         | matchings |
+            | im    | xi,xm | head,left,destination         | im        |
+            | io    | xi,xo | head,slight_left,destination  | io        |
+            | ia    | xi,xa | head,straight,destination     | ia        |
+            | ic    | xi,xc | head,slight_right,destination | ic        |
+            | ie    | xi,xe | head,right,destination        | ie        |
+            
+            | ko    | xk,xo | head,left,destination         | ko        |
+            | ka    | xk,xa | head,slight_left,destination  | ka        |
+            | kc    | xk,xc | head,straight,destination     | kc        |
+            | ke    | xk,xe | head,slight_right,destination | ke        |
+            | kg    | xk,xg | head,right,destination        | kg        |
+
+            | ma    | xm,xa | head,left,destination         | ma        |
+            | mc    | xm,xc | head,slight_left,destination  | mc        |
+            | me    | xm,xe | head,straight,destination     | me        |
+            | mg    | xm,xg | head,slight_right,destination | mg        |
+            | mi    | xm,xi | head,right,destination        | mi        |
+
+            | oc    | xo,xc | head,left,destination         | oc        |
+            | oe    | xo,xe | head,slight_left,destination  | oe        |
+            | og    | xo,xg | head,straight,destination     | og        |
+            | oi    | xo,xi | head,slight_right,destination | oi        |
+            | ok    | xo,xk | head,right,destination        | ok        |
+
+            | ae    | xa,xe | head,left,destination         | ae        |
+            | ag    | xa,xg | head,slight_left,destination  | ag        |
+            | ai    | xa,xi | head,straight,destination     | ai        |
+            | ak    | xa,xk | head,slight_right,destination | ak        |
+            | am    | xa,xm | head,right,destination        | am        |
+
+            | cg    | xc,xg | head,left,destination         | cg        |
+            | ci    | xc,xi | head,slight_left,destination  | ci        |
+            | ck    | xc,xk | head,straight,destination     | ck        |
+            | cm    | xc,xm | head,slight_right,destination | cm        |
+            | co    | xc,xo | head,right,destination        | co        |
+
+            | ei    | xe,xi | head,left,destination         | ei        |
+            | ek    | xe,xk | head,slight_left,destination  | ek        |
+            | em    | xe,xm | head,straight,destination     | em        |
+            | eo    | xe,xo | head,slight_right,destination | eo        |
+            | ea    | xe,xa | head,right,destination        | ea        |
+
+            | gk    | xg,xk | head,left,destination         | gk        |
+            | gm    | xg,xm | head,slight_left,destination  | gm        |
+            | go    | xg,xo | head,straight,destination     | go        |
+            | ga    | xg,xa | head,slight_right,destination | ga        |
+            | gc    | xg,xc | head,right,destination        | gc        |

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -299,9 +299,12 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
                     current_coordinate = facade->GetCoordinateOfNode(path_data.node);
                     factory.AppendSegment(current_coordinate, path_data);
                 }
+                // in some cases the map matching alogrithm creates lots of ViaPoints
+                // these points aren't very user-friendly, so instead of checking the is_via_leg function
+                // we always set it to false
                 factory.SetEndSegment(raw_route.segment_end_coordinates[i].target_phantom,
                                       raw_route.target_traversed_in_reverse[i],
-                                      raw_route.is_via_leg(i));
+                                      false);
             }
             // we run this to get the instructions
             factory.Run(route_parameters.zoom_level);
@@ -444,11 +447,9 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         }
         if(route_parameters.print_instructions)
         {
-            osrm::json::Object json_summary_object;
-
             setDestinationPoint(json_instruction_array);
             json_result.values["route_instructions"] = json_instruction_array;
-            buildRouteSummary(json_summary_object, route_summary);
+            buildRouteSummary(json_result, route_summary);
         }
 
         if (osrm::json::Logger::get())

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -287,10 +287,21 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
 
         if (route_parameters.geometry)
         {
+            // prevent multiple start points - set ViaPoints instead
+            bool is_first_segment;
+            if(route_parameters.print_instructions)
+            {
+                is_first_segment = (route_summary.distance != 0 ? false : true);
+            }
+            else
+            {
+                is_first_segment = true;
+            }
+
             DescriptionFactory factory;
             FixedPointCoordinate current_coordinate;
             factory.SetStartSegment(raw_route.segment_end_coordinates.front().source_phantom,
-                                    raw_route.source_traversed_in_reverse.front());
+                                    raw_route.source_traversed_in_reverse.front(), is_first_segment);
             for (const auto i :
                  osrm::irange<std::size_t>(0, raw_route.unpacked_path_segments.size()))
             {
@@ -306,7 +317,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
                                       raw_route.target_traversed_in_reverse[i],
                                       false);
             }
-            // we run this to get the instructions
+            // we run this to get the distance for the instructions
             factory.Run(route_parameters.zoom_level);
 
             necessary_segments_running_index = 0;

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -449,7 +449,6 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
             setDestinationPoint(json_instruction_array);
             json_result.values["route_instructions"] = json_instruction_array;
             buildRouteSummary(json_summary_object, route_summary);
-            json_result.values["route_summary"] = json_summary_object;
         }
 
         if (osrm::json::Logger::get())


### PR DESCRIPTION
This is based on the pull request #1512.
This allows to generate via ```match?{locs}&instructions=true``` routing instructions for the matched route.

The instructions are now generated in the ```plugin/match.hpp```. Instead of getting the instructions for every submatching, the instructions are in an array ```route_instructions``` for the whole route, just like the viaroute service provides it. So it is possible to match and then getting routing instructions for this route.

This service is kinda wanted for companies who wants routing instructions for recorded (or generated) routes (this is also a reason why I reopened this PR, because there seems to be an interest in this feature).