### PR TITLE
Generate a more direct geometry for match service

### DIFF
--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -131,3 +131,5 @@ void RouteParameters::addCoordinate(
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<0>(received_coordinates)),
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
 }
+
+void RouteParameters::setCutFlag(const bool flag) { cut = flag; }

--- a/include/osrm/route_parameters.hpp
+++ b/include/osrm/route_parameters.hpp
@@ -78,6 +78,8 @@ struct RouteParameters
     void setCompressionFlag(const bool flag);
 
     void addCoordinate(const boost::fusion::vector<double, double> &received_coordinates);
+    
+    void setCutFlag(const bool flag);
 
     short zoom_level;
     bool print_instructions;
@@ -87,6 +89,7 @@ struct RouteParameters
     bool deprecatedAPI;
     bool uturn_default;
     bool classify;
+    bool cut;
     double matching_beta;
     double gps_precision;
     unsigned check_sum;

--- a/server/api_grammar.hpp
+++ b/server/api_grammar.hpp
@@ -42,7 +42,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                    *(query) >> -(uturns);
         query = ('?') >> (+(zoom | output | jsonp | checksum | location | hint | timestamp | u | cmp |
                             language | instruction | geometry | alt_route | old_API | num_results |
-                            matching_beta | gps_precision | classify));
+                            matching_beta | gps_precision | classify | cut));
 
         zoom = (-qi::lit('&')) >> qi::lit('z') >> '=' >>
                qi::short_[boost::bind(&HandlerT::setZoomLevel, handler, ::_1)];
@@ -83,6 +83,8 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                qi::short_[boost::bind(&HandlerT::setGPSPrecision, handler, ::_1)];
         classify = (-qi::lit('&')) >> qi::lit("classify") >> '=' >>
             qi::bool_[boost::bind(&HandlerT::setClassify, handler, ::_1)];
+        cut = (-qi::lit('&')) >> qi::lit("cut") >> '=' >>
+            qi::bool_[boost::bind(&HandlerT::setCutFlag, handler, ::_1)];
 
         string = +(qi::char_("a-zA-Z"));
         stringwithDot = +(qi::char_("a-zA-Z0-9_.-"));
@@ -93,7 +95,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     qi::rule<Iterator> api_call, query;
     qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location,
         hint, timestamp, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
-        uturns, old_API, num_results, matching_beta, gps_precision, classify;
+        uturns, old_API, num_results, matching_beta, gps_precision, classify, cut;
 
     HandlerT *handler;
 };


### PR DESCRIPTION
This is an editing for the geometry of the matching service. You can turn it on via ```match?{locs}&cut=true```.

The actual problem is that some recorded routes may be very inaccurate:
![matching_bad_ex_1](https://cloud.githubusercontent.com/assets/12281156/8182261/09b65dfa-142e-11e5-9062-81231e54d684.png)
![matching_bad_ex_2](https://cloud.githubusercontent.com/assets/12281156/8182264/0f80484a-142e-11e5-85b7-276f311ed540.png)

The green line is the recorded route, the blue line is the actual result of the matching service. The bicycle profile was used for this.
The gps_precision and matching_beta parameter can get rid of some of these segments, but not all of them.

So the actual geometry is not good enough for e.g. navigation purpose, because it leads to dead ends where the actual recorded route didn't go (see the pictures above; the first picture you start at the bottom and should just turn left; the second picture you start also from the bottom and should just go straight and not turn left).
This solution generates a new geometry for the matching service, a geometry which is more direct:
![matching_cut_1](https://cloud.githubusercontent.com/assets/12281156/8182320/86893974-142e-11e5-9f42-cef3bde075ee.png)

It cuts the geometry when the result does these dead ends. Furthermore, dead ends which are quite big (>= 200m) are excluded, since it is very unlikely that these paths are the results of inaccurate coordiantes.

A real recorded route is linked for an example (the track is from Germany, North Rhine-Westphalia):
[Click here](http://www.file-upload.net/download-10694597/weg3.gpx.html)