### PR TITLE
[not ready] Fix Point Reyer

### DIFF
--- a/contractor/edge_based_graph_factory.cpp
+++ b/contractor/edge_based_graph_factory.cpp
@@ -172,6 +172,8 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u,
                          node_v != m_edge_based_node_list.back().u);
         }
 
+        std::cout << forward_data.edge_id << " / " << reverse_data.edge_id << ": compressed" << std::endl;
+
         BOOST_ASSERT(current_edge_source_coordinate_id == node_v);
         BOOST_ASSERT(m_edge_based_node_list.back().IsCompressed());
     }
@@ -199,6 +201,8 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u,
 
         BOOST_ASSERT(forward_data.edge_id != SPECIAL_NODEID ||
                      reverse_data.edge_id != SPECIAL_NODEID);
+
+        std::cout << forward_data.edge_id << " / " << reverse_data.edge_id << ": not compressed" << std::endl;
 
         m_edge_based_node_list.emplace_back(
             forward_data.edge_id, reverse_data.edge_id, node_u, node_v,
@@ -282,7 +286,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedNodes()
     {
         BOOST_ASSERT(node_u != SPECIAL_NODEID);
         BOOST_ASSERT(node_u < m_node_based_graph->GetNumberOfNodes());
-        progress.printStatus(node_u);
+        //progress.printStatus(node_u);
         for (EdgeID e1 : m_node_based_graph->GetAdjacentEdgeRange(node_u))
         {
             const EdgeData &edge_data = m_node_based_graph->GetEdgeData(e1);
@@ -344,7 +348,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
     for (const auto node_u : osrm::irange(0u, m_node_based_graph->GetNumberOfNodes()))
     {
-        progress.printStatus(node_u);
+        //progress.printStatus(node_u);
         for (const EdgeID e1 : m_node_based_graph->GetAdjacentEdgeRange(node_u))
         {
             if (m_node_based_graph->GetEdgeData(e1).reversed)
@@ -461,6 +465,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
                 BOOST_ASSERT(SPECIAL_NODEID != edge_data1.edge_id);
                 BOOST_ASSERT(SPECIAL_NODEID != edge_data2.edge_id);
+
+                std::cout << edge_data1.edge_id << " -> " << edge_data2.edge_id << ": " << edge_is_compressed << std::endl;
 
                 m_edge_based_edge_list.emplace_back(edge_data1.edge_id, edge_data2.edge_id,
                                   m_edge_based_edge_list.size(), distance, true, false);

--- a/data_structures/internal_route_result.hpp
+++ b/data_structures/internal_route_result.hpp
@@ -46,15 +46,17 @@ struct PathData
     }
 
     PathData(NodeID node,
+             FixedPointCoordinate location,
              unsigned name_id,
              TurnInstruction turn_instruction,
              EdgeWeight segment_duration,
              TravelMode travel_mode)
-        : node(node), name_id(name_id), segment_duration(segment_duration),
+        : node(node), location(location), name_id(name_id), segment_duration(segment_duration),
           turn_instruction(turn_instruction), travel_mode(travel_mode)
     {
     }
     NodeID node;
+    FixedPointCoordinate location;
     unsigned name_id;
     EdgeWeight segment_duration;
     TurnInstruction turn_instruction;
@@ -63,8 +65,8 @@ struct PathData
 
 struct InternalRouteResult
 {
-    std::vector<PathData> unpacked_route;
-    std::vector<PathData> unpacked_alternative;
+    std::vector<PathData> uncompressed_route;
+    std::vector<PathData> uncompressed_alternative;
     std::vector<std::size_t> segment_end_indices;
     std::vector<PhantomNodes> segment_end_coordinates;
     std::vector<bool> source_traversed_in_reverse;

--- a/data_structures/internal_route_result.hpp
+++ b/data_structures/internal_route_result.hpp
@@ -63,8 +63,9 @@ struct PathData
 
 struct InternalRouteResult
 {
-    std::vector<std::vector<PathData>> unpacked_path_segments;
+    std::vector<PathData> unpacked_route;
     std::vector<PathData> unpacked_alternative;
+    std::vector<std::size_t> segment_end_indices;
     std::vector<PhantomNodes> segment_end_coordinates;
     std::vector<bool> source_traversed_in_reverse;
     std::vector<bool> target_traversed_in_reverse;
@@ -72,11 +73,6 @@ struct InternalRouteResult
     std::vector<bool> alt_target_traversed_in_reverse;
     int shortest_path_length;
     int alternative_path_length;
-
-    bool is_via_leg(const std::size_t leg) const
-    {
-        return (leg != unpacked_path_segments.size() - 1);
-    }
 
     InternalRouteResult()
         : shortest_path_length(INVALID_EDGE_WEIGHT), alternative_path_length(INVALID_EDGE_WEIGHT)

--- a/descriptors/description_factory.cpp
+++ b/descriptors/description_factory.cpp
@@ -39,40 +39,11 @@ DescriptionFactory::DescriptionFactory() : entire_length(0) { via_indices.push_b
 
 std::vector<unsigned> const &DescriptionFactory::GetViaIndices() const { return via_indices; }
 
-void DescriptionFactory::SetStartSegment(const PhantomNode &source, const bool traversed_in_reverse)
-{
-    start_phantom = source;
-    const EdgeWeight segment_duration =
-        (traversed_in_reverse ? source.reverse_weight : source.forward_weight);
-    const TravelMode travel_mode =
-        (traversed_in_reverse ? source.backward_travel_mode : source.forward_travel_mode);
-    AppendSegment(source.location, PathData(0, source.name_id, TurnInstruction::HeadOn,
-                                            segment_duration, travel_mode));
-    BOOST_ASSERT(path_description.back().duration == segment_duration);
-}
-
-void DescriptionFactory::SetEndSegment(const PhantomNode &target,
-                                       const bool traversed_in_reverse,
-                                       const bool is_via_location)
-{
-    target_phantom = target;
-    const EdgeWeight segment_duration =
-        (traversed_in_reverse ? target.reverse_weight : target.forward_weight);
-    const TravelMode travel_mode =
-        (traversed_in_reverse ? target.backward_travel_mode : target.forward_travel_mode);
-    path_description.emplace_back(target.location, target.name_id, segment_duration, 0.f,
-                                  is_via_location ? TurnInstruction::ReachViaLocation
-                                                  : TurnInstruction::NoTurn,
-                                  true, true, travel_mode);
-    BOOST_ASSERT(path_description.back().duration == segment_duration);
-}
-
-void DescriptionFactory::AppendSegment(const FixedPointCoordinate &coordinate,
-                                       const PathData &path_point)
+void DescriptionFactory::AppendSegment(const PathData &path_point)
 {
     // if the start location is on top of a node, the first movement might be zero-length,
     // in which case we dont' add a new description, but instead update the existing one
-    if ((1 == path_description.size()) && (path_description.front().location == coordinate))
+    if ((1 == path_description.size()) && (path_description.front().location == path_point.location))
     {
         if (path_point.segment_duration > 0)
         {
@@ -94,7 +65,7 @@ void DescriptionFactory::AppendSegment(const FixedPointCoordinate &coordinate,
         return path_point.turn_instruction;
     }();
 
-    path_description.emplace_back(coordinate, path_point.name_id, path_point.segment_duration, 0.f,
+    path_description.emplace_back(path_point.location, path_point.name_id, path_point.segment_duration, 0.f,
                                   turn, path_point.travel_mode);
 }
 

--- a/descriptors/description_factory.cpp
+++ b/descriptors/description_factory.cpp
@@ -57,7 +57,7 @@ void DescriptionFactory::AppendSegment(const PathData &path_point)
     const TurnInstruction turn = [&]() -> TurnInstruction
     {
         if (TurnInstruction::NoTurn == path_point.turn_instruction &&
-            path_description.front().travel_mode != path_point.travel_mode &&
+            path_description.size() > 0 && path_description.front().travel_mode != path_point.travel_mode &&
             path_point.segment_duration > 0)
         {
             return TurnInstruction::GoStraight;

--- a/descriptors/description_factory.hpp
+++ b/descriptors/description_factory.hpp
@@ -79,12 +79,8 @@ class DescriptionFactory
     // I know, declaring this public is considered bad. I'm lazy
     std::vector<SegmentInformation> path_description;
     DescriptionFactory();
-    void AppendSegment(const FixedPointCoordinate &coordinate, const PathData &data);
+    void AppendSegment(const PathData &data);
     void BuildRouteSummary(const double distance, const unsigned time);
-    void SetStartSegment(const PhantomNode &start_phantom, const bool traversed_in_reverse);
-    void SetEndSegment(const PhantomNode &start_phantom,
-                       const bool traversed_in_reverse,
-                       const bool is_via_location = false);
     osrm::json::Value AppendGeometryString(const bool return_encoded);
     std::vector<unsigned> const &GetViaIndices() const;
 

--- a/descriptors/gpx_descriptor.hpp
+++ b/descriptors/gpx_descriptor.hpp
@@ -75,14 +75,11 @@ template <class DataFacadeT> class GPXDescriptor final : public BaseDescriptor<D
             AddRoutePoint(raw_route.segment_end_coordinates.front().source_phantom.location,
                           json_route);
 
-            for (const std::vector<PathData> &path_data_vector : raw_route.unpacked_path_segments)
+            for (const PathData &path_data : raw_route.unpacked_route)
             {
-                for (const PathData &path_data : path_data_vector)
-                {
-                    const FixedPointCoordinate current_coordinate =
-                        facade->GetCoordinateOfNode(path_data.node);
-                    AddRoutePoint(current_coordinate, json_route);
-                }
+                const FixedPointCoordinate current_coordinate =
+                    facade->GetCoordinateOfNode(path_data.node);
+                AddRoutePoint(current_coordinate, json_route);
             }
             AddRoutePoint(raw_route.segment_end_coordinates.back().target_phantom.location,
                           json_route);

--- a/descriptors/gpx_descriptor.hpp
+++ b/descriptors/gpx_descriptor.hpp
@@ -72,17 +72,10 @@ template <class DataFacadeT> class GPXDescriptor final : public BaseDescriptor<D
         osrm::json::Array json_route;
         if (raw_route.shortest_path_length != INVALID_EDGE_WEIGHT)
         {
-            AddRoutePoint(raw_route.segment_end_coordinates.front().source_phantom.location,
-                          json_route);
-
-            for (const PathData &path_data : raw_route.unpacked_route)
+            for (const PathData &path_data : raw_route.uncompressed_route)
             {
-                const FixedPointCoordinate current_coordinate =
-                    facade->GetCoordinateOfNode(path_data.node);
-                AddRoutePoint(current_coordinate, json_route);
+                AddRoutePoint(path_data.location, json_route);
             }
-            AddRoutePoint(raw_route.segment_end_coordinates.back().target_phantom.location,
-                          json_route);
         }
         // osrm::json::gpx_render(reply.content, json_route);
         json_result.values["route"] = json_route;

--- a/descriptors/json_descriptor.hpp
+++ b/descriptors/json_descriptor.hpp
@@ -79,7 +79,8 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
 
     virtual void SetConfig(const DescriptorConfig &c) override final { config = c; }
 
-    unsigned DescribeLeg(const std::vector<PathData> &route_leg,
+    template<typename ForwardIter>
+    unsigned DescribeLeg(ForwardIter leg_begin, ForwardIter leg_end,
                          const PhantomNodes &leg_phantoms,
                          const bool target_traversed_in_reverse,
                          const bool is_via_leg)
@@ -87,16 +88,15 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
         unsigned added_element_count = 0;
         // Get all the coordinates for the computed route
         FixedPointCoordinate current_coordinate;
-        for (const PathData &path_data : route_leg)
+        for (auto iter = leg_begin; iter != leg_end; ++iter)
         {
-            current_coordinate = facade->GetCoordinateOfNode(path_data.node);
-            description_factory.AppendSegment(current_coordinate, path_data);
+            current_coordinate = facade->GetCoordinateOfNode(iter->node);
+            description_factory.AppendSegment(current_coordinate, *iter);
             ++added_element_count;
         }
         description_factory.SetEndSegment(leg_phantoms.target_phantom, target_traversed_in_reverse,
                                           is_via_leg);
         ++added_element_count;
-        BOOST_ASSERT((route_leg.size() + 1) == added_element_count);
         return added_element_count;
     }
 
@@ -112,25 +112,30 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
             return;
         }
 
-        // check if first segment is non-zero
-        BOOST_ASSERT(raw_route.unpacked_path_segments.size() ==
-                     raw_route.segment_end_coordinates.size());
-
         description_factory.SetStartSegment(
             raw_route.segment_end_coordinates.front().source_phantom,
             raw_route.source_traversed_in_reverse.front());
+
         json_result.values["status"] = 0;
         json_result.values["status_message"] = "Found route between points";
 
+        BOOST_ASSERT(raw_route.segment_end_indices.size() ==
+                     raw_route.segment_end_coordinates.size());
+
+        BOOST_ASSERT(raw_route.segment_end_indices.back() == raw_route.unpacked_route.size());
+
+        std::size_t start_idx = 0;
         // for each unpacked segment add the leg to the description
-        for (const auto i : osrm::irange<std::size_t>(0, raw_route.unpacked_path_segments.size()))
+        for (const auto i : osrm::irange<std::size_t>(0, raw_route.segment_end_coordinates.size()))
         {
-#ifndef NDEBUG
+            auto end_idx = raw_route.segment_end_indices[i];
             const int added_segments =
-#endif
-                DescribeLeg(raw_route.unpacked_path_segments[i],
+                DescribeLeg(raw_route.unpacked_route.begin() + start_idx,
+                            raw_route.unpacked_route.begin() + end_idx,
                             raw_route.segment_end_coordinates[i],
-                            raw_route.target_traversed_in_reverse[i], raw_route.is_via_leg(i));
+                            raw_route.target_traversed_in_reverse[i],
+                            i < raw_route.segment_end_coordinates.size() - 1);
+            start_idx = end_idx;
             BOOST_ASSERT(0 < added_segments);
         }
         description_factory.Run(config.zoom_level);

--- a/descriptors/json_descriptor.hpp
+++ b/descriptors/json_descriptor.hpp
@@ -355,7 +355,7 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
                     const double bearing_value = (segment.bearing / 10.);
                     json_instruction_row.values.push_back(bearing::get(bearing_value));
                     json_instruction_row.values.push_back(
-                        static_cast<unsigned>(round(bearing_value)));
+                        static_cast<unsigned>(std::round(bearing_value)));
                     json_instruction_row.values.push_back(segment.travel_mode);
 
                     route_segments_list.emplace_back(
@@ -385,6 +385,7 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
         json_last_instruction_row.values.push_back("0m");
         json_last_instruction_row.values.push_back(bearing::get(0.0));
         json_last_instruction_row.values.push_back(0.);
+        json_last_instruction_row.values.push_back(TRAVEL_MODE_DEFAULT);
         json_instruction_array.values.push_back(json_last_instruction_row);
     }
 };

--- a/descriptors/json_descriptor.hpp
+++ b/descriptors/json_descriptor.hpp
@@ -129,7 +129,9 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
         for (const auto i : osrm::irange<std::size_t>(0, raw_route.segment_end_coordinates.size()))
         {
             auto end_idx = raw_route.segment_end_indices[i];
+#ifndef NDEBUG
             const int added_segments =
+#endif
                 DescribeLeg(raw_route.unpacked_route.begin() + start_idx,
                             raw_route.unpacked_route.begin() + end_idx,
                             raw_route.segment_end_coordinates[i],

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -172,27 +172,10 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         if (route_parameters.geometry)
         {
             DescriptionFactory factory;
-            FixedPointCoordinate current_coordinate;
-            factory.SetStartSegment(raw_route.segment_end_coordinates.front().source_phantom,
-                                    raw_route.source_traversed_in_reverse.front());
 
-            std::size_t start_idx = 0;
-            for (const auto i :
-                 osrm::irange<std::size_t>(0, raw_route.segment_end_coordinates.size()))
-            {
-                auto end_idx = raw_route.segment_end_indices[i];
-                auto begin_leg = raw_route.unpacked_route.begin() + start_idx;
-                auto end_leg = raw_route.unpacked_route.begin() + end_idx;
-                for (auto iter = begin_leg; iter != end_leg; ++iter)
-                {
-                    current_coordinate = facade->GetCoordinateOfNode(iter->node);
-                    factory.AppendSegment(current_coordinate, *iter);
-                }
-                factory.SetEndSegment(raw_route.segment_end_coordinates[i].target_phantom,
-                                      raw_route.target_traversed_in_reverse[i],
-                                      i < raw_route.segment_end_coordinates.size() - 1);
-                start_idx = end_idx;
-            }
+            std::for_each(raw_route.uncompressed_route.begin(), raw_route.uncompressed_route.end(),
+                          [&](const PathData& data) { factory.AppendSegment(data); });
+
             // we need this because we don't run DP
             for (auto &segment : factory.path_description)
             {

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -175,17 +175,23 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
             FixedPointCoordinate current_coordinate;
             factory.SetStartSegment(raw_route.segment_end_coordinates.front().source_phantom,
                                     raw_route.source_traversed_in_reverse.front());
+
+            std::size_t start_idx = 0;
             for (const auto i :
-                 osrm::irange<std::size_t>(0, raw_route.unpacked_path_segments.size()))
+                 osrm::irange<std::size_t>(0, raw_route.segment_end_coordinates.size()))
             {
-                for (const PathData &path_data : raw_route.unpacked_path_segments[i])
+                auto end_idx = raw_route.segment_end_indices[i];
+                auto begin_leg = raw_route.unpacked_route.begin() + start_idx;
+                auto end_leg = raw_route.unpacked_route.begin() + end_idx;
+                for (auto iter = begin_leg; iter != end_leg; ++iter)
                 {
-                    current_coordinate = facade->GetCoordinateOfNode(path_data.node);
-                    factory.AppendSegment(current_coordinate, path_data);
+                    current_coordinate = facade->GetCoordinateOfNode(iter->node);
+                    factory.AppendSegment(current_coordinate, *iter);
                 }
                 factory.SetEndSegment(raw_route.segment_end_coordinates[i].target_phantom,
                                       raw_route.target_traversed_in_reverse[i],
-                                      raw_route.is_via_leg(i));
+                                      i < raw_route.segment_end_coordinates.size() - 1);
+                start_idx = end_idx;
             }
             // we need this because we don't run DP
             for (auto &segment : factory.path_description)

--- a/plugins/viaroute.hpp
+++ b/plugins/viaroute.hpp
@@ -163,8 +163,7 @@ template <class DataFacadeT> class ViaRoutePlugin final : public BasePlugin
             }
             else
             {
-                search_engine_ptr->direct_shortest_path(raw_route.segment_end_coordinates,
-                                                        route_parameters.uturns, raw_route);
+                search_engine_ptr->direct_shortest_path(raw_route.segment_end_coordinates, raw_route);
             }
         }
         else

--- a/routing_algorithms/alternative_path.hpp
+++ b/routing_algorithms/alternative_path.hpp
@@ -314,10 +314,12 @@ class AlternativeRouting final
             raw_route_data.target_traversed_in_reverse.push_back(
                 (packed_shortest_path.back() != phantom_node_pair.target_phantom.forward_node_id));
 
-            super::UnpackPath(packed_shortest_path.begin(), packed_shortest_path.end(),
-                              phantom_node_pair, raw_route_data.unpacked_route);
+            std::vector<NodeID> unpacked_route;
+            super::UnpackPath(packed_shortest_path.begin(), packed_shortest_path.end(), unpacked_route);
+            super::UncompressPath(unpacked_route.begin(), unpacked_route.end(),
+                                  phantom_node_pair, raw_route_data.uncompressed_route);
             raw_route_data.shortest_path_length = upper_bound_to_shortest_path_distance;
-            raw_route_data.segment_end_indices.push_back(raw_route_data.unpacked_route.size());
+            raw_route_data.segment_end_indices.push_back(raw_route_data.uncompressed_route.size());
         }
 
         if (SPECIAL_NODEID != selected_via_node)
@@ -333,8 +335,10 @@ class AlternativeRouting final
                 (packed_alternate_path.back() != phantom_node_pair.target_phantom.forward_node_id));
 
             // unpack the alternate path
-            super::UnpackPath(packed_alternate_path.begin(), packed_alternate_path.end(),
-                              phantom_node_pair, raw_route_data.unpacked_alternative);
+            std::vector<NodeID> unpacked_route;
+            super::UnpackPath(packed_alternate_path.begin(), packed_alternate_path.end(), unpacked_route);
+            super::UncompressPath(unpacked_route.begin(), unpacked_route.end(),
+                                  phantom_node_pair, raw_route_data.uncompressed_alternative);
 
             raw_route_data.alternative_path_length = length_of_via_path;
         }

--- a/routing_algorithms/alternative_path.hpp
+++ b/routing_algorithms/alternative_path.hpp
@@ -309,15 +309,18 @@ class AlternativeRouting final
         if (INVALID_EDGE_WEIGHT != upper_bound_to_shortest_path_distance)
         {
             BOOST_ASSERT(!packed_shortest_path.empty());
-            raw_route_data.source_traversed_in_reverse.push_back(
-                (packed_shortest_path.front() != phantom_node_pair.source_phantom.forward_node_id));
-            raw_route_data.target_traversed_in_reverse.push_back(
-                (packed_shortest_path.back() != phantom_node_pair.target_phantom.forward_node_id));
+            auto source_traversed_in_reverse =
+                packed_shortest_path.front() != phantom_node_pair.source_phantom.forward_node_id;
+            auto target_traversed_in_reverse =
+                packed_shortest_path.back() != phantom_node_pair.target_phantom.forward_node_id;
+            raw_route_data.source_traversed_in_reverse.push_back(source_traversed_in_reverse);
+            raw_route_data.target_traversed_in_reverse.push_back(target_traversed_in_reverse);
 
             std::vector<NodeID> unpacked_route;
             super::UnpackPath(packed_shortest_path.begin(), packed_shortest_path.end(), unpacked_route);
             super::UncompressPath(unpacked_route.begin(), unpacked_route.end(),
-                                  phantom_node_pair, raw_route_data.uncompressed_route);
+                                  phantom_node_pair, source_traversed_in_reverse, target_traversed_in_reverse,
+                                  raw_route_data.uncompressed_route);
             raw_route_data.shortest_path_length = upper_bound_to_shortest_path_distance;
             raw_route_data.segment_end_indices.push_back(raw_route_data.uncompressed_route.size());
         }
@@ -328,17 +331,20 @@ class AlternativeRouting final
             // retrieve alternate path
             RetrievePackedAlternatePath(forward_heap1, reverse_heap1, forward_heap2, reverse_heap2,
                                         s_v_middle, v_t_middle, packed_alternate_path);
+            auto source_traversed_in_reverse =
+                packed_alternate_path.front() != phantom_node_pair.source_phantom.forward_node_id;
+            auto target_traversed_in_reverse =
+                packed_alternate_path.back() != phantom_node_pair.target_phantom.forward_node_id;
 
-            raw_route_data.alt_source_traversed_in_reverse.push_back((
-                packed_alternate_path.front() != phantom_node_pair.source_phantom.forward_node_id));
-            raw_route_data.alt_target_traversed_in_reverse.push_back(
-                (packed_alternate_path.back() != phantom_node_pair.target_phantom.forward_node_id));
+            raw_route_data.alt_source_traversed_in_reverse.push_back(source_traversed_in_reverse);
+            raw_route_data.alt_target_traversed_in_reverse.push_back(target_traversed_in_reverse);
 
             // unpack the alternate path
             std::vector<NodeID> unpacked_route;
             super::UnpackPath(packed_alternate_path.begin(), packed_alternate_path.end(), unpacked_route);
             super::UncompressPath(unpacked_route.begin(), unpacked_route.end(),
-                                  phantom_node_pair, raw_route_data.uncompressed_alternative);
+                                  phantom_node_pair, source_traversed_in_reverse, target_traversed_in_reverse,
+                                  raw_route_data.uncompressed_alternative);
 
             raw_route_data.alternative_path_length = length_of_via_path;
         }

--- a/routing_algorithms/alternative_path.hpp
+++ b/routing_algorithms/alternative_path.hpp
@@ -309,20 +309,15 @@ class AlternativeRouting final
         if (INVALID_EDGE_WEIGHT != upper_bound_to_shortest_path_distance)
         {
             BOOST_ASSERT(!packed_shortest_path.empty());
-            raw_route_data.unpacked_path_segments.resize(1);
             raw_route_data.source_traversed_in_reverse.push_back(
                 (packed_shortest_path.front() != phantom_node_pair.source_phantom.forward_node_id));
             raw_route_data.target_traversed_in_reverse.push_back(
                 (packed_shortest_path.back() != phantom_node_pair.target_phantom.forward_node_id));
 
-            super::UnpackPath(
-                // -- packed input
-                packed_shortest_path,
-                // -- start of route
-                phantom_node_pair,
-                // -- unpacked output
-                raw_route_data.unpacked_path_segments.front());
+            super::UnpackPath(packed_shortest_path.begin(), packed_shortest_path.end(),
+                              phantom_node_pair, raw_route_data.unpacked_route);
             raw_route_data.shortest_path_length = upper_bound_to_shortest_path_distance;
+            raw_route_data.segment_end_indices.push_back(raw_route_data.unpacked_route.size());
         }
 
         if (SPECIAL_NODEID != selected_via_node)
@@ -338,8 +333,8 @@ class AlternativeRouting final
                 (packed_alternate_path.back() != phantom_node_pair.target_phantom.forward_node_id));
 
             // unpack the alternate path
-            super::UnpackPath(packed_alternate_path, phantom_node_pair,
-                              raw_route_data.unpacked_alternative);
+            super::UnpackPath(packed_alternate_path.begin(), packed_alternate_path.end(),
+                              phantom_node_pair, raw_route_data.unpacked_alternative);
 
             raw_route_data.alternative_path_length = length_of_via_path;
         }

--- a/routing_algorithms/direct_shortest_path.hpp
+++ b/routing_algorithms/direct_shortest_path.hpp
@@ -234,9 +234,11 @@ class DirectShortestPathRouting final
         raw_route_data.target_traversed_in_reverse.push_back(
             (packed_leg.back() != phantom_node_pair.target_phantom.forward_node_id));
 
-        super::UnpackPath(packed_leg.begin(), packed_leg.end(),
-                          phantom_node_pair, raw_route_data.unpacked_route);
-        raw_route_data.segment_end_indices.push_back(raw_route_data.unpacked_route.size());
+        std::vector<NodeID> unpacked_route;
+        super::UnpackPath(packed_leg.begin(), packed_leg.end(), unpacked_route);
+        super::UncompressPath(unpacked_route.begin(), unpacked_route.end(),
+                              phantom_node_pair, raw_route_data.uncompressed_route);
+        raw_route_data.segment_end_indices.push_back(raw_route_data.uncompressed_route.size());
 
         raw_route_data.shortest_path_length = distance;
     }

--- a/routing_algorithms/direct_shortest_path.hpp
+++ b/routing_algorithms/direct_shortest_path.hpp
@@ -229,15 +229,19 @@ class DirectShortestPathRouting final
             super::RetrievePackedPathFromHeap(forward_heap, reverse_heap, middle, packed_leg);
         }
 
-        raw_route_data.source_traversed_in_reverse.push_back(
-            (packed_leg.front() != phantom_node_pair.source_phantom.forward_node_id));
-        raw_route_data.target_traversed_in_reverse.push_back(
-            (packed_leg.back() != phantom_node_pair.target_phantom.forward_node_id));
+        auto source_traversed_in_reverse =
+          packed_leg.front() != phantom_node_pair.source_phantom.forward_node_id;
+        auto target_traversed_in_reverse =
+          packed_leg.back() != phantom_node_pair.target_phantom.forward_node_id;
+
+        raw_route_data.source_traversed_in_reverse.push_back(source_traversed_in_reverse);
+        raw_route_data.target_traversed_in_reverse.push_back(target_traversed_in_reverse);
 
         std::vector<NodeID> unpacked_route;
         super::UnpackPath(packed_leg.begin(), packed_leg.end(), unpacked_route);
         super::UncompressPath(unpacked_route.begin(), unpacked_route.end(),
-                              phantom_node_pair, raw_route_data.uncompressed_route);
+                              phantom_node_pair, source_traversed_in_reverse, target_traversed_in_reverse,
+                              raw_route_data.uncompressed_route);
         raw_route_data.segment_end_indices.push_back(raw_route_data.uncompressed_route.size());
 
         raw_route_data.shortest_path_length = distance;

--- a/routing_algorithms/direct_shortest_path.hpp
+++ b/routing_algorithms/direct_shortest_path.hpp
@@ -59,7 +59,6 @@ class DirectShortestPathRouting final
     ~DirectShortestPathRouting() {}
 
     void operator()(const std::vector<PhantomNodes> &phantom_nodes_vector,
-                    const std::vector<bool> &uturn_indicators,
                     InternalRouteResult &raw_route_data) const
     {
         engine_working_data.InitializeOrClearFirstThreadLocalStorage(
@@ -230,16 +229,14 @@ class DirectShortestPathRouting final
             super::RetrievePackedPathFromHeap(forward_heap, reverse_heap, middle, packed_leg);
         }
 
-
-        BOOST_ASSERT_MSG(!packed_leg.empty(), "packed path empty");
-
-        raw_route_data.unpacked_path_segments.resize(1);
         raw_route_data.source_traversed_in_reverse.push_back(
             (packed_leg.front() != phantom_node_pair.source_phantom.forward_node_id));
         raw_route_data.target_traversed_in_reverse.push_back(
             (packed_leg.back() != phantom_node_pair.target_phantom.forward_node_id));
 
-        super::UnpackPath(packed_leg, phantom_node_pair, raw_route_data.unpacked_path_segments.front());
+        super::UnpackPath(packed_leg.begin(), packed_leg.end(),
+                          phantom_node_pair, raw_route_data.unpacked_route);
+        raw_route_data.segment_end_indices.push_back(raw_route_data.unpacked_route.size());
 
         raw_route_data.shortest_path_length = distance;
     }

--- a/routing_algorithms/routing_base.hpp
+++ b/routing_algorithms/routing_base.hpp
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/assert.hpp>
 
 #include <stack>
+#include <iterator>
 
 SearchEngineData::SearchEngineHeapPtr SearchEngineData::forward_heap_1;
 SearchEngineData::SearchEngineHeapPtr SearchEngineData::reverse_heap_1;
@@ -149,121 +150,171 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         }
     }
 
-    /// This function decompresses routes given as list of _edge based_ node ids.
+    /// This function decompresses routes given as list of _edge based_ edge ids.
     ///
-    /// (0,1,2) and (1,2,3) form an edge based edge each and the node list we are going
-    /// to get will represent (0,1)(1,2)(2,3).
-    /// If all edges are uncompressedwe want to extract is (1, 2).
+    /// (a,b,c) and (b,c,d) form an edge based edge. We will get the edge based
+    /// edge ids 0 and 1 as input and the phantom nodes s and t.
     ///           s
-    ///       1-----0
+    ///       b-----a
     ///       |
     ///       |
-    /// 3-----2
+    /// d-----c
     ///     t
+    /// -> s, b, c, t
     ///
-    /// If (0, 1), (1,2) and (2,3) are actually compressed that means we need to
-    /// add all the segments inbetween:
+    /// An edge based edge is compressed if the start edge based node is compressed.
+    /// e.g. (a,b,c) is marked as compressed if (a,b) is compressed. As such we only
+    /// decompress (a,b) and add it to the result path, (b,c) is covered by the next edge.
     ///            s
-    ///       1-b-a-0
+    ///       b-*-*-a
     ///       |
-    ///       c
+    ///       *
     ///       |
-    /// 3-e-d-2
+    /// d-*-*-c
     ///    t
-    /// -> (a, b, 1, c, 2, d)
+    /// (0, 1) -> (s, *, *, b, *, c, *, t)
     template<typename ForwardIter>
     void UncompressPath(ForwardIter unpacked_path_begin, ForwardIter unpacked_path_end,
                         const PhantomNodes &phantom_node_pair,
+                        const bool source_traversed_in_reverse,
+                        const bool target_traversed_in_reverse,
                         std::vector<PathData> &uncompressed_path) const
     {
-        BOOST_ASSERT(std::distance(unpacked_path_begin, unpacked_path_end) > 0);
-
-        const bool source_traversed_in_reverse =
-            (*unpacked_path_begin != phantom_node_pair.source_phantom.forward_node_id);
-        const bool target_traversed_in_reverse =
-            (*std::prev(unpacked_path_end) != phantom_node_pair.target_phantom.forward_node_id);
-
-        BOOST_ASSERT(*unpacked_path_begin == phantom_node_pair.source_phantom.forward_node_id ||
-                     *unpacked_path_begin == phantom_node_pair.source_phantom.reverse_node_id);
-        BOOST_ASSERT(std::prev(unpacked_path_end) == phantom_node_pair.target_phantom.forward_node_id ||
-                     std::prev(unpacked_path_end) == phantom_node_pair.target_phantom.reverse_node_id);
-
+        std::cout << "source: " << phantom_node_pair.source_phantom.forward_node_id << " / " << phantom_node_pair.source_phantom.reverse_node_id << std::endl;
+        std::cout << "target: " << phantom_node_pair.target_phantom.forward_node_id << " / " << phantom_node_pair.target_phantom.reverse_node_id << std::endl;
         bool same_edge = phantom_node_pair.source_phantom.forward_node_id == phantom_node_pair.target_phantom.forward_node_id;
         BOOST_ASSERT(!same_edge || phantom_node_pair.source_phantom.reverse_node_id == phantom_node_pair.target_phantom.reverse_node_id);
+
+        // outputs either [first_id, last_id) or in reverse [last_id, first_id)
+        // depening on which is bigger.
+        // 3, 6 -> 3, 4, 5
+        // 3, 0 -> 0, 1, 2
+        auto add_node_id_range = [this](unsigned first_id, unsigned last_id, unsigned name_index,
+                                        TravelMode travel_mode, std::vector<PathData>& uncompressed_path)
+            {
+                if (first_id < last_id)
+                {
+                    for (unsigned node_id = first_id; node_id < last_id; node_id++)
+                    {
+                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
+                            name_index, TurnInstruction::NoTurn, 0, travel_mode);
+                    }
+                }
+                else if (first_id > last_id)
+                {
+                    BOOST_ASSERT(first_id > 0);
+                    for (unsigned node_id = first_id-1; node_id > last_id; node_id--)
+                    {
+                        BOOST_ASSERT(node_id > 0);
+                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
+                            name_index, TurnInstruction::NoTurn, 0, travel_mode);
+                    }
+                    // we need this because of possible node_id underflows if last_id = 0
+                    uncompressed_path.emplace_back(last_id, facade->GetCoordinateOfNode(last_id),
+                        name_index, TurnInstruction::NoTurn, 0, travel_mode);
+                }
+            };
+
+        // this return SPECIAL_NODEID if the phantom node is on
+        // a uncompressed edge
+        auto get_phantom_id = [this](const PhantomNode& node)
+        {
+            const auto geometry_index = node.packed_geometry_id;
+            if (geometry_index != SPECIAL_NODEID)
+            {
+                return facade->BeginGeometry(geometry_index) +
+                       node.fwd_segment_position;
+            }
+            else
+            {
+                return geometry_index;
+            }
+        };
+
+        const auto source_id = get_phantom_id(phantom_node_pair.source_phantom);
+        const auto target_id = get_phantom_id(phantom_node_pair.target_phantom);
+        const unsigned source_name_index = phantom_node_pair.source_phantom.name_id;
+        const unsigned target_name_index = phantom_node_pair.target_phantom.name_id;
+        const TravelMode source_travel_mode = source_traversed_in_reverse ?
+            phantom_node_pair.source_phantom.backward_travel_mode :
+            phantom_node_pair.source_phantom.forward_travel_mode;
+        const TravelMode target_travel_mode = target_traversed_in_reverse ?
+            phantom_node_pair.target_phantom.backward_travel_mode :
+            phantom_node_pair.target_phantom.forward_travel_mode;
+        const auto source_duration = source_traversed_in_reverse ?
+            phantom_node_pair.source_phantom.GetReverseWeightPlusOffset() :
+            phantom_node_pair.source_phantom.GetForwardWeightPlusOffset();
+        const auto target_duration = target_traversed_in_reverse ?
+            phantom_node_pair.target_phantom.GetReverseWeightPlusOffset() :
+            phantom_node_pair.target_phantom.GetForwardWeightPlusOffset();
 
         // source and target are on the same compressed edge
         if (same_edge)
         {
-            const auto edge_id = *unpacked_path_begin;
+            BOOST_ASSERT(std::distance(unpacked_path_begin, unpacked_path_end) == 0);
 
-            unsigned name_index = phantom_node_pair.source_phantom.name_id;
-            const TravelMode travel_mode = source_traversed_in_reverse ? phantom_node_pair.source_phantom.backward_travel_mode :
-                                            phantom_node_pair.source_phantom.forward_travel_mode;
-            const EdgeWeight duration = [&]() {
-                if (source_traversed_in_reverse)
-                {
-                  BOOST_ASSERT(target_traversed_in_reverse);
-                  return phantom_node_pair.source_phantom.GetForwardWeightPlusOffset() - phantom_node_pair.target_phantom.GetForwardWeightPlusOffset();
-                }
-                else
-                {
-                  BOOST_ASSERT(!target_traversed_in_reverse);
-                  return phantom_node_pair.source_phantom.GetReverseWeightPlusOffset() - phantom_node_pair.target_phantom.GetReverseWeightPlusOffset();
-                }
-            }();
+            std::cout << "same egde!" << std::endl;
 
-            if (facade->EdgeIsCompressed(edge_id))
+            const EdgeWeight duration = source_duration - target_duration;
+            uncompressed_path.emplace_back(source_id, phantom_node_pair.source_phantom.location,
+                                           source_name_index, TurnInstruction::HeadOn, duration, source_travel_mode);
+
+            // single compressed edge (start x is not encoded in the geometry bucket)
+            // x---->0--->1--->2--->3--->4
+            //   t                    s
+            // -> 3, 2, 1, 0
+            //
+            // x---->0--->1--->2--->3--->4
+            //    s                    t
+            // -> 0, 1, 2, 3
+            if (source_id != SPECIAL_NODEID)
             {
-                std::vector<unsigned> uncompressed_node_ids;
-                facade->GetUncompressedGeometry(facade->GetGeometryIndexForEdgeID(edge_id), uncompressed_node_ids);
+                BOOST_ASSERT(source_id >= facade->BeginGeometry(phantom_node_pair.source_phantom.packed_geometry_id));
+                BOOST_ASSERT(source_id <  facade->EndGeometry(phantom_node_pair.source_phantom.packed_geometry_id));
+                BOOST_ASSERT(target_id >= facade->BeginGeometry(phantom_node_pair.source_phantom.packed_geometry_id));
+                BOOST_ASSERT(target_id <  facade->EndGeometry(phantom_node_pair.source_phantom.packed_geometry_id));
+                add_node_id_range(source_id, target_id, source_name_index, source_travel_mode, uncompressed_path);
 
-                auto source_node_id = uncompressed_node_ids[phantom_node_pair.source_phantom.fwd_segment_position];
-                uncompressed_path.emplace_back(source_node_id, phantom_node_pair.source_phantom.location,
-                                               name_index, TurnInstruction::HeadOn, 0, travel_mode);
-                if (source_traversed_in_reverse)
-                {
-                    // single compressed edge
-                    // 0--->1--->2--->3--->4
-                    //   t              s
-                    // -> 3, 2, 1
-                    for (int idx = phantom_node_pair.source_phantom.fwd_segment_position+1;
-                         idx > phantom_node_pair.target_phantom.fwd_segment_position; idx--)
-                    {
-                        auto node_id = uncompressed_node_ids[idx];
-                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
-                                                       name_index, TurnInstruction::NoTurn, 0, travel_mode);
-                    }
-                }
-                else
-                {
-                    // single compressed edge
-                    // 0--->1--->2--->3--->4
-                    //   s              t
-                    // -> 1, 2, 3
-                    for (int idx = phantom_node_pair.source_phantom.fwd_segment_position+1;
-                         idx <= phantom_node_pair.target_phantom.fwd_segment_position; idx++)
-                    {
-                        auto node_id = uncompressed_node_ids[idx];
-                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
-                                                       name_index, TurnInstruction::NoTurn, 0, travel_mode);
-                    }
-                }
+            }
 
-                auto target_node_id = uncompressed_node_ids[phantom_node_pair.target_phantom.fwd_segment_position];
-                uncompressed_path.emplace_back(target_node_id, phantom_node_pair.target_phantom.location,
-                                               name_index, TurnInstruction::ReachedYourDestination, duration, travel_mode);
-            }
-            else
-            {
-                uncompressed_path.emplace_back(facade->GetGeometryIndexForEdgeID(edge_id), phantom_node_pair.source_phantom.location,
-                                               name_index, TurnInstruction::HeadOn, 0, travel_mode);
-                uncompressed_path.emplace_back(facade->GetGeometryIndexForEdgeID(edge_id), phantom_node_pair.target_phantom.location,
-                                               name_index, TurnInstruction::ReachedYourDestination, duration, travel_mode);
-            }
+            uncompressed_path.emplace_back(target_id, phantom_node_pair.target_phantom.location,
+                                           target_name_index, TurnInstruction::ReachedYourDestination, 0, target_travel_mode);
         }
         else
         {
-            for (auto iter = unpacked_path_begin; iter != unpacked_path_end; ++iter)
+            BOOST_ASSERT(std::distance(unpacked_path_begin, unpacked_path_end) > 0);
+
+            uncompressed_path.emplace_back(source_id, phantom_node_pair.source_phantom.location,
+                                           phantom_node_pair.source_phantom.name_id,
+                                           TurnInstruction::HeadOn,
+                                           0,
+                                           source_travel_mode);
+
+            if (phantom_node_pair.source_phantom.packed_geometry_id != SPECIAL_NODEID)
+            {
+                const auto geometry_index = phantom_node_pair.source_phantom.packed_geometry_id;
+                const auto end_id = source_traversed_in_reverse ?
+                                    facade->BeginGeometry(geometry_index) :
+                                    facade->EndGeometry(geometry_index);
+                BOOST_ASSERT(source_id >= facade->BeginGeometry(geometry_index));
+                BOOST_ASSERT(source_id <  facade->EndGeometry(geometry_index));
+                add_node_id_range(source_id, end_id, source_name_index, source_travel_mode, uncompressed_path);
+            }
+            else
+            {
+                const auto source_edge_id = *unpacked_path_begin;
+                BOOST_ASSERT(!facade->EdgeIsCompressed(source_edge_id));
+                const auto geometry_index = facade->GetGeometryIndexForEdgeID(source_edge_id);
+                uncompressed_path.emplace_back(geometry_index, facade->GetCoordinateOfNode(geometry_index), source_name_index,
+                                           TurnInstruction::NoTurn, 0, source_travel_mode);
+            }
+
+            // fix last node on source edge: needs the turn instruction and correct distance to source
+            // phantom node
+            uncompressed_path.back().turn_instruction = facade->GetTurnInstructionForEdgeID(*unpacked_path_begin);
+            uncompressed_path.back().segment_duration = source_duration;
+
+            for (auto iter = std::next(unpacked_path_begin); iter != unpacked_path_end; ++iter)
             {
                 const auto edge_id = *iter;
                 const auto data = facade->GetEdgeData(edge_id);
@@ -275,33 +326,13 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
 
                 if (facade->EdgeIsCompressed(edge_id))
                 {
-                    std::vector<unsigned> uncompressed_node_ids;
-                    facade->GetUncompressedGeometry(facade->GetGeometryIndexForEdgeID(edge_id),
-                                                    uncompressed_node_ids);
+                    const auto geometry_index = facade->GetGeometryIndexForEdgeID(edge_id);
+                    const auto begin_id = facade->BeginGeometry(geometry_index);
+                    const auto end_id = facade->EndGeometry(geometry_index);
 
-                    const auto end_index = uncompressed_node_ids.size();
-                    const auto begin_index = [&]() {
-                        if (uncompressed_path.size() > 0)
-                            return 0UL;
+                    // these points all have 0 duration, we only need the geometry
+                    add_node_id_range(begin_id, end_id, name_index, travel_mode, uncompressed_path);
 
-                        if (source_traversed_in_reverse)
-                        {
-                            return end_index - phantom_node_pair.source_phantom.fwd_segment_position - 1;
-                        }
-                        else
-                        {
-                            return static_cast<unsigned long>(phantom_node_pair.source_phantom.fwd_segment_position);
-                        }
-                    }();
-
-                    BOOST_ASSERT(begin_index >= 0);
-                    BOOST_ASSERT(begin_index <= end_index);
-                    for (auto idx = begin_index; idx < end_index; ++idx)
-                    {
-                        auto node_id = uncompressed_node_ids[idx];
-                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
-                                                       name_index, TurnInstruction::NoTurn, 0, travel_mode);
-                    }
                     uncompressed_path.back().turn_instruction = turn_instruction;
                     uncompressed_path.back().segment_duration = duration;
                 }
@@ -313,59 +344,30 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 }
             }
 
-            if (SPECIAL_EDGEID != phantom_node_pair.target_phantom.packed_geometry_id)
+            // we don't have an edge based egde that covers the path to the target node,
+            // so we need to check if its compressed this way
+            if (phantom_node_pair.target_phantom.packed_geometry_id != SPECIAL_NODEID)
             {
-                std::vector<unsigned> uncompressed_node_ids;
-                facade->GetUncompressedGeometry(phantom_node_pair.target_phantom.packed_geometry_id,
-                                                uncompressed_node_ids);
-
-                const auto end_index = phantom_node_pair.target_phantom.fwd_segment_position;
-                unsigned name_index = phantom_node_pair.target_phantom.name_id;
-                auto target_node_id = uncompressed_node_ids[phantom_node_pair.target_phantom.fwd_segment_position];
-
-                //         t
-                //         <<<<<<<<
-                // u--->x--->x--->v
-                if (target_traversed_in_reverse)
-                {
-                    TravelMode travel_mode = phantom_node_pair.target_phantom.backward_travel_mode;
-                    EdgeWeight duration = phantom_node_pair.target_phantom.reverse_offset;
-
-                    BOOST_ASSERT(begin_index >= end_index);
-                    for (auto idx = uncompressed_node_ids.size()-1; idx > end_index; --idx)
-                    {
-                        auto node_id = uncompressed_node_ids[idx];
-                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
-                                                       name_index, TurnInstruction::NoTurn, 0, travel_mode);
-                    }
-                    uncompressed_path.emplace_back(target_node_id, phantom_node_pair.target_phantom.location,
-                                                   name_index, TurnInstruction::ReachedYourDestination, duration, travel_mode);
-                }
-                //         t
-                // >>>>>>>>>
-                // u--->x--->x--->v
-                else
-                {
-                    TravelMode travel_mode = phantom_node_pair.target_phantom.forward_travel_mode;
-                    EdgeWeight duration = phantom_node_pair.target_phantom.forward_weight;
-
-                    BOOST_ASSERT(begin_index >= end_index);
-                    for (auto idx = 0; idx < end_index; ++idx)
-                    {
-                        auto node_id = uncompressed_node_ids[idx];
-                        uncompressed_path.emplace_back(node_id, facade->GetCoordinateOfNode(node_id),
-                                                       name_index, TurnInstruction::NoTurn, 0, travel_mode);
-                    }
-                    uncompressed_path.emplace_back(target_node_id, phantom_node_pair.target_phantom.location,
-                                                   name_index, TurnInstruction::ReachedYourDestination, duration, travel_mode);
-                }
+                const auto geometry_index = phantom_node_pair.target_phantom.packed_geometry_id;
+                const auto end_id = target_traversed_in_reverse ?
+                                    facade->EndGeometry(geometry_index) :
+                                    facade->BeginGeometry(geometry_index);
+                BOOST_ASSERT(target_id >= facade->BeginGeometry(geometry_index));
+                BOOST_ASSERT(target_id <  facade->EndGeometry(geometry_index));
+                add_node_id_range(target_id, end_id, target_name_index, target_travel_mode, uncompressed_path);
             }
+
+            uncompressed_path.emplace_back(target_id, phantom_node_pair.target_phantom.location,
+                                           target_name_index, TurnInstruction::ReachedYourDestination,
+                                           target_duration, target_travel_mode);
+
+            std::cout << "Unpacked size: " << uncompressed_path.size() << std::endl;
         }
     }
 
-    /// Gets a list of node ids that potentially cover shortcuts. This recursively
-    /// unpacks shortcuts until only simple edges are left.
-    /// Returns a list of edge-based node ids.
+    /// Gets a list of edge based node ids that potentially cover shortcuts.
+    /// This recursively unpacks shortcuts until only simple edges are left.
+    /// Returns a list of edge-based _edge_ ids.
     template<typename ForwardIter>
     void UnpackPath(ForwardIter packed_path_begin, ForwardIter packed_path_end,
                     std::vector<NodeID> &unpacked_path) const
@@ -375,7 +377,6 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         // handle local path on same edge, they are always unpacked
         if (std::distance(packed_path_begin, packed_path_end) < 2)
         {
-            unpacked_path.emplace_back(*packed_path_begin);
             return;
         }
 
@@ -395,17 +396,37 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
 
             // facade->FindEdge does not suffice here in case of shortcuts.
             // The above explanation unclear? Think!
-            EdgeID smaller_edge_id = facade->FindSmallestEdge(edge.first, edge.second);
+            EdgeID smaller_edge_id = SPECIAL_EDGEID;
+            int edge_weight = std::numeric_limits<EdgeWeight>::max();
+            for (const auto edge_id : facade->GetAdjacentEdgeRange(edge.first))
+            {
+                const int weight = facade->GetEdgeData(edge_id).distance;
+                if ((facade->GetTarget(edge_id) == edge.second) && (weight < edge_weight) &&
+                    facade->GetEdgeData(edge_id).forward)
+                {
+                    smaller_edge_id = edge_id;
+                    edge_weight = weight;
+                }
+            }
 
             if (SPECIAL_EDGEID == smaller_edge_id)
             {
-                smaller_edge_id = facade->FindSmallestEdge(edge.second, edge.first);
+                for (const auto edge_id : facade->GetAdjacentEdgeRange(edge.second))
+                {
+                    const int weight = facade->GetEdgeData(edge_id).distance;
+                    if ((facade->GetTarget(edge_id) == edge.first) && (weight < edge_weight) &&
+                        facade->GetEdgeData(edge_id).backward)
+                    {
+                        smaller_edge_id = edge_id;
+                        edge_weight = weight;
+                    }
+                }
             }
-            BOOST_ASSERT_MSG(smaller_edge_id != SPECIAL_EDGEID, "edge id invalid");
 
             const EdgeData &data = facade->GetEdgeData(smaller_edge_id);
             if (data.shortcut)
             {
+                std::cout << "Shortcut!" << std::endl;
                 const NodeID middle_node_id = data.id;
                 // again, we need to this in reversed order
                 recursion_stack.emplace(middle_node_id, edge.second);
@@ -413,11 +434,23 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
             }
             else
             {
+                std::cout << "Added " << data.id << std::endl;
+                // add edge based egde id to result vector
                 unpacked_path.emplace_back(data.id);
             }
         }
+
+        std::cout << "packed: ";
+        std::copy(packed_path_begin, packed_path_end, std::ostream_iterator<unsigned>(std::cout, ","));
+        std::cout << std::endl;
+        std::cout << "unpacked: ";
+        std::copy(unpacked_path.begin(), unpacked_path.end(), std::ostream_iterator<unsigned>(std::cout, ","));
+        std::cout << std::endl;
     }
 
+    /// Unpacks the edge starting at s and ending at t.
+    /// Returns the list of unpacked edge based _node_ ids.
+    /// Important: This is in contrast to UnpackPath which returns _edge_ ids.
     void UnpackEdge(const NodeID s, const NodeID t, std::vector<NodeID> &unpacked_path) const
     {
         std::stack<std::pair<NodeID, NodeID>> recursion_stack;
@@ -557,10 +590,17 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
             PhantomNodes nodes;
             nodes.source_phantom = source_phantom;
             nodes.target_phantom = target_phantom;
+
             std::vector<NodeID> unpacked_path;
             UnpackPath(packed_leg.begin(), packed_leg.end(), unpacked_path);
+
+
+            auto source_traversed_in_reverse = packed_leg.front() != nodes.source_phantom.forward_node_id;
+            auto target_traversed_in_reverse = packed_leg.back() != nodes.target_phantom.forward_node_id;
             std::vector<PathData> uncompressed_path;
-            UncompressPath(unpacked_path.begin(), unpacked_path.end(), nodes, uncompressed_path);
+            UncompressPath(unpacked_path.begin(), unpacked_path.end(),
+                           nodes, source_traversed_in_reverse, target_traversed_in_reverse,
+                           uncompressed_path);
 
             FixedPointCoordinate previous_coordinate = source_phantom.location;
             FixedPointCoordinate current_coordinate;

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -249,7 +249,9 @@ class ShortestPathRouting final
             if (!allow_u_turn && 0 < current_leg)
             {
                 const NodeID previous_forward_id = packed_route1.back();
+#ifndef NDEBUG
                 const NodeID previous_reverse_id = packed_route2.back();
+#endif
 
                 BOOST_ASSERT(!packed_sub_path1.empty() && !packed_sub_path2.empty());
 

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -316,22 +316,25 @@ class ShortestPathRouting final
         std::size_t start_index = 0;
         for (const std::size_t index : osrm::irange<std::size_t>(0, phantom_nodes_vector.size()))
         {
-
             std::size_t end_index = packed_leg_ends1[index];
             std::vector<NodeID> unpacked_leg;
             super::UnpackPath(packed_route1.begin() + start_index,
                               packed_route1.begin() + end_index,
                               unpacked_leg);
 
+            auto source_traversed_in_reverse =
+                packed_route1[start_index] != phantom_nodes_vector[index].source_phantom.forward_node_id;
+            auto target_traversed_in_reverse =
+                packed_route1[end_index-1] != phantom_nodes_vector[index].target_phantom.forward_node_id;
+
             PhantomNodes unpack_phantom_node_pair = phantom_nodes_vector[index];
             super::UncompressPath(unpacked_leg.begin(), unpacked_leg.end(),
-                                  unpack_phantom_node_pair, raw_route_data.uncompressed_route);
+                                  unpack_phantom_node_pair, source_traversed_in_reverse, target_traversed_in_reverse,
+                                  raw_route_data.uncompressed_route);
 
             raw_route_data.segment_end_indices.push_back(raw_route_data.uncompressed_route.size());
-            raw_route_data.source_traversed_in_reverse.push_back(
-                (packed_route1[start_index] != phantom_nodes_vector[index].source_phantom.forward_node_id));
-            raw_route_data.target_traversed_in_reverse.push_back(
-                (packed_route1[end_index-1] != phantom_nodes_vector[index].target_phantom.forward_node_id));
+            raw_route_data.source_traversed_in_reverse.push_back(source_traversed_in_reverse);
+            raw_route_data.target_traversed_in_reverse.push_back(target_traversed_in_reverse);
 
             BOOST_ASSERT(end_index > 0);
             start_index = end_index;

--- a/routing_algorithms/shortest_path.hpp
+++ b/routing_algorithms/shortest_path.hpp
@@ -317,24 +317,17 @@ class ShortestPathRouting final
         for (const std::size_t index : osrm::irange<std::size_t>(0, phantom_nodes_vector.size()))
         {
 
-            PhantomNodes unpack_phantom_node_pair = phantom_nodes_vector[index];
             std::size_t end_index = packed_leg_ends1[index];
-            std::vector<PathData> unpacked_leg;
+            std::vector<NodeID> unpacked_leg;
             super::UnpackPath(packed_route1.begin() + start_index,
                               packed_route1.begin() + end_index,
-                              unpack_phantom_node_pair,
                               unpacked_leg);
 
-            //This would only be correct if we source and target phantom
-            //are always included
-            //BOOST_ASSERT(unpacked_leg.size() > 0);
+            PhantomNodes unpack_phantom_node_pair = phantom_nodes_vector[index];
+            super::UncompressPath(unpacked_leg.begin(), unpacked_leg.end(),
+                                  unpack_phantom_node_pair, raw_route_data.uncompressed_route);
 
-            raw_route_data.unpacked_route.insert(raw_route_data.unpacked_route.end(),
-                                                 // skip first path entry, as vias would be included twice
-                                                 unpacked_leg.begin(),
-                                                 unpacked_leg.end());
-
-            raw_route_data.segment_end_indices.push_back(raw_route_data.unpacked_route.size());
+            raw_route_data.segment_end_indices.push_back(raw_route_data.uncompressed_route.size());
             raw_route_data.source_traversed_in_reverse.push_back(
                 (packed_route1[start_index] != phantom_nodes_vector[index].source_phantom.forward_node_id));
             raw_route_data.target_traversed_in_reverse.push_back(

--- a/server/data_structures/datafacade_base.hpp
+++ b/server/data_structures/datafacade_base.hpp
@@ -73,6 +73,9 @@ template <class EdgeDataT> class BaseDataFacade
     // searches for a specific edge
     virtual EdgeID FindEdge(const NodeID from, const NodeID to) const = 0;
 
+    /// Find the edge with the smallest edge weight
+    virtual EdgeID FindSmallestEdge(const NodeID from, const NodeID to) const = 0;
+
     virtual EdgeID FindEdgeInEitherDirection(const NodeID from, const NodeID to) const = 0;
 
     virtual EdgeID

--- a/server/data_structures/datafacade_base.hpp
+++ b/server/data_structures/datafacade_base.hpp
@@ -88,8 +88,9 @@ template <class EdgeDataT> class BaseDataFacade
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const = 0;
 
-    virtual void GetUncompressedGeometry(const unsigned id,
-                                         std::vector<unsigned> &result_nodes) const = 0;
+    virtual unsigned BeginGeometry(const unsigned id) const = 0;
+
+    virtual unsigned EndGeometry(const unsigned id) const = 0;
 
     virtual TurnInstruction GetTurnInstructionForEdgeID(const unsigned id) const = 0;
 

--- a/server/data_structures/internal_datafacade.hpp
+++ b/server/data_structures/internal_datafacade.hpp
@@ -376,6 +376,11 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
         return m_query_graph->FindEdge(from, to);
     }
 
+    EdgeID FindSmallestEdge(const NodeID from, const NodeID to) const override final
+    {
+        return m_query_graph->FindSmallestEdge(from, to);
+    }
+
     EdgeID FindEdgeInEitherDirection(const NodeID from, const NodeID to) const override final
     {
         return m_query_graph->FindEdgeInEitherDirection(from, to);

--- a/server/data_structures/internal_datafacade.hpp
+++ b/server/data_structures/internal_datafacade.hpp
@@ -500,6 +500,7 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const override final
     {
+      std::cout << "Max geometry id: " << m_via_node_list.size() << std::endl;
         return m_via_node_list.at(id);
     }
 
@@ -515,15 +516,14 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
         }
     }
 
-    virtual void GetUncompressedGeometry(const unsigned id,
-                                         std::vector<unsigned> &result_nodes) const override final
+    virtual unsigned BeginGeometry(const unsigned id) const override final
     {
-        const unsigned begin = m_geometry_indices.at(id);
-        const unsigned end = m_geometry_indices.at(id + 1);
+        return m_geometry_indices.at(id);
+    }
 
-        result_nodes.clear();
-        result_nodes.insert(result_nodes.begin(), m_geometry_list.begin() + begin,
-                            m_geometry_list.begin() + end);
+    virtual unsigned EndGeometry(const unsigned id) const override final
+    {
+        return m_geometry_indices.at(id+1);
     }
 
     std::string GetTimestamp() const override final { return m_timestamp; }

--- a/server/data_structures/shared_datafacade.hpp
+++ b/server/data_structures/shared_datafacade.hpp
@@ -358,15 +358,14 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         return m_edge_is_compressed.at(id);
     }
 
-    virtual void GetUncompressedGeometry(const unsigned id,
-                                         std::vector<unsigned> &result_nodes) const override final
+    virtual unsigned BeginGeometry(const unsigned id) const override final
     {
-        const unsigned begin = m_geometry_indices.at(id);
-        const unsigned end = m_geometry_indices.at(id + 1);
+        return m_geometry_indices.at(id);
+    }
 
-        result_nodes.clear();
-        result_nodes.insert(result_nodes.begin(), m_geometry_list.begin() + begin,
-                            m_geometry_list.begin() + end);
+    virtual unsigned EndGeometry(const unsigned id) const override final
+    {
+        return m_geometry_indices.at(id+1);
     }
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const override final

--- a/server/data_structures/shared_datafacade.hpp
+++ b/server/data_structures/shared_datafacade.hpp
@@ -331,6 +331,11 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         return m_query_graph->FindEdge(from, to);
     }
 
+    EdgeID FindSmallestEdge(const NodeID from, const NodeID to) const override final
+    {
+        return m_query_graph->FindSmallestEdge(from, to);
+    }
+
     EdgeID FindEdgeInEitherDirection(const NodeID from, const NodeID to) const override final
     {
         return m_query_graph->FindEdgeInEitherDirection(from, to);


### PR DESCRIPTION
This PR aims to address #1575.

- [x] Change `InternalDataStructre.unpacked_route_segments` to be a continuous array
- [ ] Change `UnpackPath()` to only generate a list of edge-based-nodes (currently it also does decompression + handles phantom nodes)
- [ ] Create  `UncompressPath()` that takes a list of edge-based nodes and de-compresses the corresponding edges into `PathData` (needs access to phantom nodes)