### PR TITLE
Core termination criterion

### DIFF
--- a/contractor/contractor.hpp
+++ b/contractor/contractor.hpp
@@ -549,11 +549,18 @@ class Contractor
 
         if (remaining_nodes.size() > 2)
         {
+            // TODO: for small cores a sorted array of core ids might also work good
             for (const auto& node : remaining_nodes)
             {
                 auto orig_id = orig_node_id_from_new_node_id_map[node.id];
                 is_core_node[orig_id] = true;
             }
+        }
+        else
+        {
+            // in this case we don't need core markers since we fully contracted
+            // the graph
+            is_core_node.clear();
         }
 
         SimpleLogger().Write() << "[core] " << remaining_nodes.size() << " nodes " << contractor_graph->GetNumberOfEdges() << " edges." << std::endl;

--- a/contractor/contractor_options.cpp
+++ b/contractor/contractor_options.cpp
@@ -131,6 +131,7 @@ ContractorOptions::ParseArguments(int argc, char *argv[], ContractorConfig &cont
 void ContractorOptions::GenerateOutputFilesNames(ContractorConfig &contractor_config)
 {
     contractor_config.node_output_path = contractor_config.osrm_input_path.string() + ".nodes";
+    contractor_config.core_output_path = contractor_config.osrm_input_path.string() + ".core";
     contractor_config.edge_output_path = contractor_config.osrm_input_path.string() + ".edges";
     contractor_config.geometry_output_path = contractor_config.osrm_input_path.string() + ".geometry";
     contractor_config.graph_output_path = contractor_config.osrm_input_path.string() + ".hsgr";

--- a/contractor/contractor_options.hpp
+++ b/contractor/contractor_options.hpp
@@ -49,6 +49,7 @@ struct ContractorConfig
     boost::filesystem::path profile_path;
 
     std::string node_output_path;
+    std::string core_output_path;
     std::string edge_output_path;
     std::string geometry_output_path;
     std::string graph_output_path;

--- a/contractor/processing_chain.cpp
+++ b/contractor/processing_chain.cpp
@@ -214,6 +214,8 @@ void Prepare::WriteCoreNodeMarker(std::vector<bool>&& in_is_core_node) const
     }
 
     boost::filesystem::ofstream core_marker_output_stream(config.core_output_path, std::ios::binary);
+    unsigned size = unpacked_bool_flags.size();
+    core_marker_output_stream.write((char *)&size, sizeof(unsigned));
     core_marker_output_stream.write((char *)unpacked_bool_flags.data(), sizeof(char)*unpacked_bool_flags.size());
 }
 

--- a/contractor/processing_chain.hpp
+++ b/contractor/processing_chain.hpp
@@ -63,7 +63,9 @@ class Prepare
     unsigned CalculateEdgeChecksum(std::unique_ptr<std::vector<EdgeBasedNode>> node_based_edge_list);
     void ContractGraph(const unsigned max_edge_id,
                        DeallocatingVector<EdgeBasedEdge>& edge_based_edge_list,
-                       DeallocatingVector<QueryEdge>& contracted_edge_list);
+                       DeallocatingVector<QueryEdge>& contracted_edge_list,
+                       std::vector<bool>& is_core_node);
+    void WriteCoreNodeMarker(std::vector<bool>&& is_core_node) const;
     std::size_t WriteContractedGraph(unsigned number_of_edge_based_nodes,
                                      std::unique_ptr<std::vector<EdgeBasedNode>> node_based_edge_list,
                                      std::unique_ptr<DeallocatingVector<QueryEdge>> contracted_edge_list);

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -296,7 +296,7 @@ def prepare_data
       raise PrepareError.new $?.exitstatus, "osrm-prepare exited with code #{$?.exitstatus}."
     end
     begin
-      ["osrm.hsgr","osrm.fileIndex","osrm.geometry","osrm.nodes","osrm.ramIndex"].each do |file|
+      ["osrm.hsgr","osrm.fileIndex","osrm.geometry","osrm.nodes","osrm.ramIndex","osrm.core"].each do |file|
         File.rename "#{extracted_file}.#{file}", "#{prepared_file}.#{file}"
       end
     rescue Exception => e

--- a/routing_algorithms/direct_shortest_path.hpp
+++ b/routing_algorithms/direct_shortest_path.hpp
@@ -186,7 +186,8 @@ class DirectShortestPathRouting final
         }
 
         // run two-target Dijkstra routing step on core with termination criterion
-        while (distance > (forward_core_heap.MinKey() + reverse_core_heap.MinKey()) )
+        while (0 < (forward_core_heap.Size() + reverse_core_heap.Size()) &&
+               distance > (forward_core_heap.MinKey() + reverse_core_heap.MinKey()))
         {
             if (!forward_core_heap.Empty())
             {

--- a/server/data_structures/datafacade_base.hpp
+++ b/server/data_structures/datafacade_base.hpp
@@ -113,6 +113,8 @@ template <class EdgeDataT> class BaseDataFacade
 
     virtual unsigned GetCheckSum() const = 0;
 
+    virtual bool IsCoreNode(const NodeID id) const = 0;
+
     virtual unsigned GetNameIndexFromEdgeID(const unsigned id) const = 0;
 
     virtual std::string get_name_for_id(const unsigned name_id) const = 0;

--- a/server/data_structures/internal_datafacade.hpp
+++ b/server/data_structures/internal_datafacade.hpp
@@ -181,6 +181,12 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
         std::vector<char> unpacked_core_markers(number_of_markers);
         core_stream.read((char *)unpacked_core_markers.data(), sizeof(char)*number_of_markers);
 
+        // in this case we have nothing to do
+        if (number_of_markers <= 0)
+        {
+            return;
+        }
+
         m_is_core_node.resize(number_of_markers);
         for (auto i = 0u; i < number_of_markers; ++i)
         {
@@ -494,7 +500,14 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
 
     virtual bool IsCoreNode(const NodeID id) const override final
     {
-        return m_is_core_node[id];
+        if (m_is_core_node.size() > 0)
+        {
+            return m_is_core_node[id];
+        }
+        else
+        {
+            return false;
+        }
     }
 
     virtual void GetUncompressedGeometry(const unsigned id,

--- a/server/data_structures/shared_datafacade.hpp
+++ b/server/data_structures/shared_datafacade.hpp
@@ -194,6 +194,21 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         m_names_char_list.swap(names_char_list);
     }
 
+    void LoadCoreInformation()
+    {
+        if (data_layout->num_entries[SharedDataLayout::CORE_MARKER] <= 0)
+        {
+            return;
+        }
+
+        unsigned *core_marker_ptr = data_layout->GetBlockPtr<unsigned>(
+            shared_memory, SharedDataLayout::CORE_MARKER);
+        typename ShM<bool, true>::vector is_core_node(
+            core_marker_ptr,
+            data_layout->num_entries[SharedDataLayout::CORE_MARKER]);
+        m_is_core_node.swap(is_core_node);
+    }
+
     void LoadGeometries()
     {
         unsigned *geometries_compressed_ptr = data_layout->GetBlockPtr<unsigned>(
@@ -269,6 +284,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
             LoadTimestamp();
             LoadViaNodeList();
             LoadNames();
+            LoadCoreInformation();
 
             data_layout->PrintInformation();
 
@@ -450,7 +466,11 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
 
     bool IsCoreNode(const NodeID id) const override final
     {
-        //return m_is_core_node[id];
+        if (m_is_core_node.size() > 0)
+        {
+            return m_is_core_node.at(id);
+        }
+
         return false;
     }
 

--- a/server/data_structures/shared_datafacade.hpp
+++ b/server/data_structures/shared_datafacade.hpp
@@ -84,6 +84,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
     ShM<bool, true>::vector m_edge_is_compressed;
     ShM<unsigned, true>::vector m_geometry_indices;
     ShM<unsigned, true>::vector m_geometry_list;
+    ShM<bool, true>::vector m_is_core_node;
 
     boost::thread_specific_ptr<std::pair<unsigned, std::shared_ptr<SharedRTree>>> m_static_rtree;
     boost::filesystem::path file_index_path;
@@ -445,6 +446,12 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
                       m_names_char_list.begin() + range.back() + 1, result.begin());
         }
         return result;
+    }
+
+    bool IsCoreNode(const NodeID id) const override final
+    {
+        //return m_is_core_node[id];
+        return false;
     }
 
     std::string GetTimestamp() const override final { return m_timestamp; }

--- a/server/data_structures/shared_datatype.hpp
+++ b/server/data_structures/shared_datatype.hpp
@@ -62,6 +62,7 @@ struct SharedDataLayout
         HSGR_CHECKSUM,
         TIMESTAMP,
         FILE_INDEX_PATH,
+        CORE_MARKER,
         NUM_BLOCKS
     };
 
@@ -72,40 +73,6 @@ struct SharedDataLayout
 
     void PrintInformation() const
     {
-        SimpleLogger().Write(logDEBUG) << "-";
-        SimpleLogger().Write(logDEBUG)
-            << "name_offsets_size:          " << num_entries[NAME_OFFSETS];
-        SimpleLogger().Write(logDEBUG)
-            << "name_blocks_size:           " << num_entries[NAME_BLOCKS];
-        SimpleLogger().Write(logDEBUG)
-            << "name_char_list_size:        " << num_entries[NAME_CHAR_LIST];
-        SimpleLogger().Write(logDEBUG)
-            << "name_id_list_size:          " << num_entries[NAME_ID_LIST];
-        SimpleLogger().Write(logDEBUG)
-            << "via_node_list_size:         " << num_entries[VIA_NODE_LIST];
-        SimpleLogger().Write(logDEBUG)
-            << "graph_node_list_size:       " << num_entries[GRAPH_NODE_LIST];
-        SimpleLogger().Write(logDEBUG)
-            << "graph_edge_list_size:       " << num_entries[GRAPH_EDGE_LIST];
-        SimpleLogger().Write(logDEBUG) << "timestamp_length:           " << num_entries[TIMESTAMP];
-        SimpleLogger().Write(logDEBUG)
-            << "coordinate_list_size:       " << num_entries[COORDINATE_LIST];
-        SimpleLogger().Write(logDEBUG)
-            << "turn_instruction_list_size: " << num_entries[TURN_INSTRUCTION];
-        SimpleLogger().Write(logDEBUG)
-            << "travel_mode_list_size:      " << num_entries[TRAVEL_MODE];
-        SimpleLogger().Write(logDEBUG)
-            << "r_search_tree_size:         " << num_entries[R_SEARCH_TREE];
-        SimpleLogger().Write(logDEBUG)
-            << "geometries_indicators:      " << num_entries[GEOMETRIES_INDICATORS] << "/"
-            << ((num_entries[GEOMETRIES_INDICATORS] / 8) + 1);
-        SimpleLogger().Write(logDEBUG)
-            << "geometries_index_list_size: " << num_entries[GEOMETRIES_INDEX];
-        SimpleLogger().Write(logDEBUG)
-            << "geometries_list_size:       " << num_entries[GEOMETRIES_LIST];
-        SimpleLogger().Write(logDEBUG)
-            << "sizeof(checksum):           " << entry_size[HSGR_CHECKSUM];
-
         SimpleLogger().Write(logDEBUG) << "NAME_OFFSETS         "
                                        << ": " << GetBlockSize(NAME_OFFSETS);
         SimpleLogger().Write(logDEBUG) << "NAME_BLOCKS          "
@@ -140,6 +107,8 @@ struct SharedDataLayout
                                        << ": " << GetBlockSize(TIMESTAMP);
         SimpleLogger().Write(logDEBUG) << "FILE_INDEX_PATH      "
                                        << ": " << GetBlockSize(FILE_INDEX_PATH);
+        SimpleLogger().Write(logDEBUG) << "CORE_MARKER          "
+                                       << ": " << GetBlockSize(CORE_MARKER);
     }
 
     template <typename T> inline void SetBlockSize(BlockID bid, uint64_t entries)
@@ -150,11 +119,11 @@ struct SharedDataLayout
 
     inline uint64_t GetBlockSize(BlockID bid) const
     {
-        // special encoding
-        if (bid == GEOMETRIES_INDICATORS)
+        // special bit encoding
+        if (bid == GEOMETRIES_INDICATORS || bid == CORE_MARKER)
         {
-            return (num_entries[GEOMETRIES_INDICATORS] / 32 + 1) *
-                   entry_size[GEOMETRIES_INDICATORS];
+            return (num_entries[bid] / 32 + 1) *
+                   entry_size[bid];
         }
 
         return num_entries[bid] * entry_size[bid];

--- a/util/datastore_options.hpp
+++ b/util/datastore_options.hpp
@@ -69,6 +69,8 @@ bool GenerateDataStoreOptions(const int argc, const char *argv[], ServerPaths &p
         ".ramIndex file")(
         "fileindex", boost::program_options::value<boost::filesystem::path>(&paths["fileindex"]),
         ".fileIndex file")(
+        "core", boost::program_options::value<boost::filesystem::path>(&paths["core"]),
+        ".core file")(
         "namesdata", boost::program_options::value<boost::filesystem::path>(&paths["namesdata"]),
         ".names file")("timestamp",
                        boost::program_options::value<boost::filesystem::path>(&paths["timestamp"]),
@@ -130,6 +132,8 @@ bool GenerateDataStoreOptions(const int argc, const char *argv[], ServerPaths &p
                                     !paths.find("ramindex")->second.string().empty()) ||
                                    (paths.find("fileindex") != paths.end() &&
                                     !paths.find("fileindex")->second.string().empty()) ||
+                                   (paths.find("core") != paths.end() &&
+                                    !paths.find("core")->second.string().empty()) ||
                                    (paths.find("timestamp") != paths.end() &&
                                     !paths.find("timestamp")->second.string().empty());
 
@@ -197,6 +201,12 @@ bool GenerateDataStoreOptions(const int argc, const char *argv[], ServerPaths &p
         if (path_iterator != paths.end())
         {
             path_iterator->second = base_string + ".fileIndex";
+        }
+
+        path_iterator = paths.find("core");
+        if (path_iterator != paths.end())
+        {
+            path_iterator->second = base_string + ".core";
         }
 
         path_iterator = paths.find("namesdata");

--- a/util/routed_options.hpp
+++ b/util/routed_options.hpp
@@ -59,6 +59,8 @@ inline void populate_base_path(ServerPaths &server_paths)
         BOOST_ASSERT(server_paths.find("hsgrdata") != server_paths.end());
         server_paths["nodesdata"] = base_string + ".nodes";
         BOOST_ASSERT(server_paths.find("nodesdata") != server_paths.end());
+        server_paths["coredata"] = base_string + ".core";
+        BOOST_ASSERT(server_paths.find("coredata") != server_paths.end());
         server_paths["edgesdata"] = base_string + ".edges";
         BOOST_ASSERT(server_paths.find("edgesdata") != server_paths.end());
         server_paths["geometries"] = base_string + ".geometry";


### PR DESCRIPTION
This PR adds a speedup to graphs that are not fully contracted. When searching on the core the stricter Dijkstra termination criterion of `tentative_distance < forward.MinKey() + reverse.MinKey()` can be used.

- [x] Mark core nodes (`.core` file)
- [x] Load in `InternalDataFacade`
- [x] Load in `SharedDataFacade`
- [x] Implement strict termination criterion on core nodes