### PR TITLE
Modernize the code base to C++11 standards and beyond.

### DIFF
--- a/algorithms/bayes_classifier.hpp
+++ b/algorithms/bayes_classifier.hpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 
 #include <vector>
+#include <utility>
 
 struct NormalDistribution
 {
@@ -80,11 +81,11 @@ class BayesClassifier
     };
     using ClassificationT = std::pair<ClassLabel, double>;
 
-    BayesClassifier(const PositiveDistributionT &positive_distribution,
-                    const NegativeDistributionT &negative_distribution,
+    BayesClassifier(PositiveDistributionT positive_distribution,
+                    NegativeDistributionT negative_distribution,
                     const double positive_apriori_probability)
-        : positive_distribution(positive_distribution),
-          negative_distribution(negative_distribution),
+        : positive_distribution(std::move(positive_distribution)),
+          negative_distribution(std::move(negative_distribution)),
           positive_apriori_probability(positive_apriori_probability),
           negative_apriori_probability(1. - positive_apriori_probability)
     {

--- a/algorithms/douglas_peucker.cpp
+++ b/algorithms/douglas_peucker.cpp
@@ -99,8 +99,8 @@ void DouglasPeucker::Run(RandomAccessIt begin, RandomAccessIt end, const unsigne
 
     {
         BOOST_ASSERT_MSG(zoom_level < DOUGLAS_PEUCKER_THRESHOLDS.size(), "unsupported zoom level");
-        RandomAccessIt left_border = begin;
-        RandomAccessIt right_border = std::next(begin);
+        auto left_border = begin;
+        auto right_border = std::next(begin);
         // Sweep over array and identify those ranges that need to be checked
         do
         {

--- a/algorithms/graph_compressor.cpp
+++ b/algorithms/graph_compressor.cpp
@@ -8,8 +8,8 @@
 
 #include "../util/simple_logger.hpp"
 
-GraphCompressor::GraphCompressor(const SpeedProfileProperties& speed_profile)
-    : speed_profile(speed_profile)
+GraphCompressor::GraphCompressor(SpeedProfileProperties speed_profile)
+    : speed_profile(std::move(speed_profile))
 {
 }
 

--- a/algorithms/graph_compressor.hpp
+++ b/algorithms/graph_compressor.hpp
@@ -43,7 +43,7 @@ class GraphCompressor
     using EdgeData = NodeBasedDynamicGraph::EdgeData;
 
 public:
-    GraphCompressor(const SpeedProfileProperties& speed_profile);
+  GraphCompressor(SpeedProfileProperties speed_profile);
 
     void Compress(const std::unordered_set<NodeID>& barrier_nodes,
                   const std::unordered_set<NodeID>& traffic_lights,

--- a/contractor/edge_based_graph_factory.cpp
+++ b/contractor/edge_based_graph_factory.cpp
@@ -39,20 +39,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iomanip>
 #include <limits>
 
-EdgeBasedGraphFactory::EdgeBasedGraphFactory(std::shared_ptr<NodeBasedDynamicGraph> node_based_graph,
-                                             const CompressedEdgeContainer& compressed_edge_container,
-                                             const std::unordered_set<NodeID>& barrier_nodes,
-                                             const std::unordered_set<NodeID>& traffic_lights,
-                                             std::shared_ptr<const RestrictionMap> restriction_map,
-                                             const std::vector<QueryNode> &node_info_list,
-                                             const SpeedProfileProperties &speed_profile)
-    : m_node_info_list(node_info_list),
-      m_node_based_graph(node_based_graph),
-      m_restriction_map(restriction_map),
-      m_barrier_nodes(barrier_nodes),
-      m_traffic_lights(traffic_lights),
-      m_compressed_edge_container(compressed_edge_container),
-      speed_profile(speed_profile)
+EdgeBasedGraphFactory::EdgeBasedGraphFactory(
+    std::shared_ptr<NodeBasedDynamicGraph> node_based_graph,
+    const CompressedEdgeContainer &compressed_edge_container,
+    const std::unordered_set<NodeID> &barrier_nodes,
+    const std::unordered_set<NodeID> &traffic_lights,
+    std::shared_ptr<const RestrictionMap> restriction_map,
+    const std::vector<QueryNode> &node_info_list,
+    SpeedProfileProperties speed_profile)
+    : m_node_info_list(node_info_list), m_node_based_graph(std::move(node_based_graph)),
+      m_restriction_map(std::move(restriction_map)), m_barrier_nodes(barrier_nodes),
+      m_traffic_lights(traffic_lights), m_compressed_edge_container(compressed_edge_container),
+      speed_profile(std::move(speed_profile))
 {
 }
 

--- a/contractor/edge_based_graph_factory.hpp
+++ b/contractor/edge_based_graph_factory.hpp
@@ -58,14 +58,13 @@ class EdgeBasedGraphFactory
     EdgeBasedGraphFactory() = delete;
     EdgeBasedGraphFactory(const EdgeBasedGraphFactory &) = delete;
 
-
     explicit EdgeBasedGraphFactory(std::shared_ptr<NodeBasedDynamicGraph> node_based_graph,
-                                   const CompressedEdgeContainer& compressed_edge_container,
-                                   const std::unordered_set<NodeID>& barrier_nodes,
-                                   const std::unordered_set<NodeID>& traffic_lights,
+                                   const CompressedEdgeContainer &compressed_edge_container,
+                                   const std::unordered_set<NodeID> &barrier_nodes,
+                                   const std::unordered_set<NodeID> &traffic_lights,
                                    std::shared_ptr<const RestrictionMap> restriction_map,
                                    const std::vector<QueryNode> &node_info_list,
-                                   const SpeedProfileProperties &speed_profile);
+                                   SpeedProfileProperties speed_profile);
 
     void Run(const std::string &original_edge_data_filename,
              lua_State *lua_state);

--- a/contractor/processing_chain.hpp
+++ b/contractor/processing_chain.hpp
@@ -51,8 +51,7 @@ class Prepare
     using InputEdge = DynamicGraph<EdgeData>::InputEdge;
     using StaticEdge = StaticGraph<EdgeData>::InputEdge;
 
-    explicit Prepare(const ContractorConfig& contractor_config)
-        : config(contractor_config) {}
+    explicit Prepare(ContractorConfig contractor_config) : config(std::move(contractor_config)) {}
     Prepare(const Prepare &) = delete;
     ~Prepare();
 

--- a/data_structures/binary_heap.hpp
+++ b/data_structures/binary_heap.hpp
@@ -212,7 +212,7 @@ class BinaryHeap
     void DeleteAll()
     {
         auto iend = heap.end();
-        for (typename std::vector<HeapElement>::iterator i = heap.begin() + 1; i != iend; ++i)
+        for (auto i = heap.begin() + 1; i != iend; ++i)
         {
             inserted_nodes[i->index].key = 0;
         }
@@ -237,7 +237,9 @@ class BinaryHeap
     class HeapNode
     {
       public:
-        HeapNode(NodeID n, Key k, Weight w, Data d) : node(n), key(k), weight(w), data(d) {}
+        HeapNode(NodeID n, Key k, Weight w, Data d) : node(n), key(k), weight(w), data(std::move(d))
+        {
+        }
 
         NodeID node;
         Key key;

--- a/data_structures/query_edge.hpp
+++ b/data_structures/query_edge.hpp
@@ -58,7 +58,7 @@ struct QueryEdge
     QueryEdge() : source(SPECIAL_NODEID), target(SPECIAL_NODEID) {}
 
     QueryEdge(NodeID source, NodeID target, EdgeData data)
-        : source(source), target(target), data(data)
+        : source(source), target(target), data(std::move(data))
     {
     }
 

--- a/data_structures/segment_information.hpp
+++ b/data_structures/segment_information.hpp
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../typedefs.h"
 
 #include <osrm/coordinate.hpp>
+#include <utility>
 
 // Struct fits everything in one cache line
 struct SegmentInformation
@@ -48,7 +49,7 @@ struct SegmentInformation
     bool necessary;
     bool is_via_location;
 
-    explicit SegmentInformation(const FixedPointCoordinate &location,
+    explicit SegmentInformation(FixedPointCoordinate location,
                                 const NodeID name_id,
                                 const EdgeWeight duration,
                                 const float length,
@@ -56,20 +57,20 @@ struct SegmentInformation
                                 const bool necessary,
                                 const bool is_via_location,
                                 const TravelMode travel_mode)
-        : location(location), name_id(name_id), duration(duration), length(length), bearing(0),
-          turn_instruction(turn_instruction), travel_mode(travel_mode), necessary(necessary),
-          is_via_location(is_via_location)
+        : location(std::move(location)), name_id(name_id), duration(duration), length(length),
+          bearing(0), turn_instruction(turn_instruction), travel_mode(travel_mode),
+          necessary(necessary), is_via_location(is_via_location)
     {
     }
 
-    explicit SegmentInformation(const FixedPointCoordinate &location,
+    explicit SegmentInformation(FixedPointCoordinate location,
                                 const NodeID name_id,
                                 const EdgeWeight duration,
                                 const float length,
                                 const TurnInstruction turn_instruction,
                                 const TravelMode travel_mode)
-        : location(location), name_id(name_id), duration(duration), length(length), bearing(0),
-          turn_instruction(turn_instruction), travel_mode(travel_mode),
+        : location(std::move(location)), name_id(name_id), duration(duration), length(length),
+          bearing(0), turn_instruction(turn_instruction), travel_mode(travel_mode),
           necessary(turn_instruction != TurnInstruction::NoTurn), is_via_location(false)
     {
     }

--- a/data_structures/shared_memory_factory.hpp
+++ b/data_structures/shared_memory_factory.hpp
@@ -126,7 +126,7 @@ class SharedMemory
             shm = boost::interprocess::xsi_shared_memory(boost::interprocess::open_or_create, key,
                                                          size);
 #ifdef __linux__
-            if (-1 == shmctl(shm.get_shmid(), SHM_LOCK, 0))
+            if (-1 == shmctl(shm.get_shmid(), SHM_LOCK, nullptr))
             {
                 if (ENOMEM == errno)
                 {

--- a/data_structures/static_rtree.hpp
+++ b/data_structures/static_rtree.hpp
@@ -316,8 +316,8 @@ class StaticRTree
     using IncrementalQueryNodeType = mapbox::util::variant<TreeNode, EdgeDataT>;
     struct IncrementalQueryCandidate
     {
-        explicit IncrementalQueryCandidate(const float dist, const IncrementalQueryNodeType &node)
-            : min_dist(dist), node(node)
+        explicit IncrementalQueryCandidate(const float dist, IncrementalQueryNodeType node)
+            : min_dist(dist), node(std::move(node))
         {
         }
 
@@ -553,7 +553,7 @@ class StaticRTree
                          const boost::filesystem::path &leaf_file,
                          std::shared_ptr<CoordinateListT> coordinate_list)
         : m_search_tree(tree_node_ptr, number_of_nodes), m_leaf_node_filename(leaf_file.string()),
-          m_coordinate_list(coordinate_list)
+          m_coordinate_list(std::move(coordinate_list))
     {
         // open leaf node file and store thread specific pointer
         if (!boost::filesystem::exists(leaf_file))

--- a/extractor/extractor.hpp
+++ b/extractor/extractor.hpp
@@ -33,8 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class extractor
 {
 public:
-    extractor(const ExtractorConfig &extractor_config)
-        : config(extractor_config) {}
+  extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
     int run();
 private:
    ExtractorConfig config;

--- a/extractor/internal_extractor_edge.hpp
+++ b/extractor/internal_extractor_edge.hpp
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/assert.hpp>
 
 #include <osrm/coordinate.hpp>
+#include <utility>
 
 struct InternalExtractorEdge
 {
@@ -68,18 +69,26 @@ struct InternalExtractorEdge
     }
 
     explicit InternalExtractorEdge(NodeID source,
-                           NodeID target,
-                           NodeID name_id,
-                           const WeightData& weight_data,
-                           bool forward,
-                           bool backward,
-                           bool roundabout,
-                           bool access_restricted,
-                           TravelMode travel_mode,
-                           bool is_split)
-        : result(source, target, name_id, 0, forward, backward, roundabout,
-                 access_restricted, travel_mode, is_split),
-          weight_data(weight_data)
+                                   NodeID target,
+                                   NodeID name_id,
+                                   WeightData weight_data,
+                                   bool forward,
+                                   bool backward,
+                                   bool roundabout,
+                                   bool access_restricted,
+                                   TravelMode travel_mode,
+                                   bool is_split)
+        : result(source,
+                 target,
+                 name_id,
+                 0,
+                 forward,
+                 backward,
+                 roundabout,
+                 access_restricted,
+                 travel_mode,
+                 is_split),
+          weight_data(std::move(weight_data))
     {
     }
 

--- a/include/osrm/json_container.hpp
+++ b/include/osrm/json_container.hpp
@@ -50,7 +50,7 @@ struct String
 {
     String() {}
     String(const char *value) : value(value) {}
-    String(const std::string &value) : value(value) {}
+    String(std::string value) : value(std::move(value)) {}
     std::string value;
 };
 

--- a/include/osrm/libosrm_config.hpp
+++ b/include/osrm/libosrm_config.hpp
@@ -39,8 +39,11 @@ struct libosrm_config
     {
     }
 
-    libosrm_config(const ServerPaths &paths, const bool sharedmemory_flag, const int max_table, const int max_matching)
-        : server_paths(paths), max_locations_distance_table(max_table),
+    libosrm_config(ServerPaths paths,
+                   const bool sharedmemory_flag,
+                   const int max_table,
+                   const int max_matching)
+        : server_paths(std::move(paths)), max_locations_distance_table(max_table),
           max_locations_map_matching(max_matching), use_shared_memory(sharedmemory_flag)
     {
     }

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -73,7 +73,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
 
     virtual ~MapMatchingPlugin() {}
 
-    const std::string GetDescriptor() const final { return descriptor_string; }
+    const std::string GetDescriptor() const final override { return descriptor_string; }
 
     TraceClassification
     classify(const float trace_length, const float matched_length, const int removed_points) const
@@ -211,7 +211,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
     }
 
     int HandleRequest(const RouteParameters &route_parameters,
-                      osrm::json::Object &json_result) final
+                      osrm::json::Object &json_result) final override
     {
         // check number of parameters
         if (!check_all_coordinates(route_parameters.coordinates))

--- a/routed.cpp
+++ b/routed.cpp
@@ -136,12 +136,12 @@ int main(int argc, const char *argv[])
 
 #ifndef _WIN32
             sigset_t wait_mask;
-            pthread_sigmask(SIG_SETMASK, &old_mask, 0);
+            pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
             sigemptyset(&wait_mask);
             sigaddset(&wait_mask, SIGINT);
             sigaddset(&wait_mask, SIGQUIT);
             sigaddset(&wait_mask, SIGTERM);
-            pthread_sigmask(SIG_BLOCK, &wait_mask, 0);
+            pthread_sigmask(SIG_BLOCK, &wait_mask, nullptr);
             SimpleLogger().Write() << "running and waiting for requests";
             sigwait(&wait_mask, &sig);
 #else

--- a/server/data_structures/internal_datafacade.hpp
+++ b/server/data_structures/internal_datafacade.hpp
@@ -264,7 +264,7 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
             throw osrm::exception("no names file given in ini file");
         }
 
-        ServerPaths::const_iterator paths_iterator = server_paths.find("hsgrdata");
+        auto paths_iterator = server_paths.find("hsgrdata");
         BOOST_ASSERT(server_paths.end() != paths_iterator);
         const boost::filesystem::path &hsgr_path = paths_iterator->second;
         paths_iterator = server_paths.find("timestamp");

--- a/server/http/header.hpp
+++ b/server/http/header.hpp
@@ -37,7 +37,7 @@ struct header
 {
     // explicitly use default copy c'tor as adding move c'tor
     header &operator=(const header &other) = default;
-    header(const std::string &name, const std::string &value) : name(name), value(value) {}
+    header(std::string name, std::string value) : name(std::move(name)), value(std::move(value)) {}
     header(header &&other) : name(std::move(other.name)), value(std::move(other.value)) {}
 
     void clear()

--- a/util/datastore_options.hpp
+++ b/util/datastore_options.hpp
@@ -146,7 +146,7 @@ bool GenerateDataStoreOptions(const int argc, const char *argv[], ServerPaths &p
     }
 
     // parse config file
-    ServerPaths::iterator path_iterator = paths.find("config");
+    auto path_iterator = paths.find("config");
     if (path_iterator != paths.end() && boost::filesystem::is_regular_file(path_iterator->second) &&
         !option_variables.count("base"))
     {

--- a/util/matching_debug_info.hpp
+++ b/util/matching_debug_info.hpp
@@ -54,16 +54,16 @@ struct MatchingDebugInfo
         }
 
         osrm::json::Array states;
-        for (unsigned t = 0; t < candidates_list.size(); t++)
+        for (auto &elem : candidates_list)
         {
             osrm::json::Array timestamps;
-            for (unsigned s = 0; s < candidates_list[t].size(); s++)
+            for (unsigned s = 0; s < elem.size(); s++)
             {
                 osrm::json::Object state;
                 state.values["transitions"] = osrm::json::Array();
-                state.values["coordinate"] = osrm::json::make_array(
-                    candidates_list[t][s].first.location.lat / COORDINATE_PRECISION,
-                    candidates_list[t][s].first.location.lon / COORDINATE_PRECISION);
+                state.values["coordinate"] =
+                    osrm::json::make_array(elem[s].first.location.lat / COORDINATE_PRECISION,
+                                           elem[s].first.location.lon / COORDINATE_PRECISION);
                 state.values["viterbi"] =
                     osrm::json::clamp_float(osrm::matching::IMPOSSIBLE_LOG_PROB);
                 state.values["pruned"] = 0u;

--- a/util/osrm_exception.hpp
+++ b/util/osrm_exception.hpp
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <exception>
 #include <string>
+#include <utility>
 
 namespace osrm
 {
@@ -37,14 +38,14 @@ class exception final : public std::exception
 {
   public:
     explicit exception(const char *message) : message(message) {}
-    explicit exception(const std::string &message) : message(message) {}
+    explicit exception(std::string message) : message(std::move(message)) {}
 
   private:
     // This function exists to 'anchor' the class, and stop the compiler from
     // copying vtable and RTTI info into every object file that includes
     // this header. (Caught by -Wweak-vtables under Clang.)
     virtual void anchor() const;
-    const char *what() const noexcept { return message.c_str(); }
+    const char *what() const noexcept override { return message.c_str(); }
     const std::string message;
 };
 }

--- a/util/routed_options.hpp
+++ b/util/routed_options.hpp
@@ -243,7 +243,7 @@ inline unsigned GenerateServerProgramOptions(const int argc,
     boost::program_options::notify(option_variables);
 
     // parse config file
-    ServerPaths::iterator path_iterator = paths.find("config");
+    auto path_iterator = paths.find("config");
     if (path_iterator != paths.end() && boost::filesystem::is_regular_file(path_iterator->second) &&
         !option_variables.count("base"))
     {


### PR DESCRIPTION
Apply `clang-modernize` (based on Clang 3.6) transformations to the
codebase while making sure to support Clang>=3.4 and GCC>=4.8.

We apply the transformations in parallel to speed up the quite
time consuming process, and use our `clang-format` style file
to automatically format the code respecting our coding conventions.

We use the following self-explanatory transformations:

* AddOverride
* LoopConvert
* PassByValue
* ReplaceAutoPtr
* UseAuto
* UseNullptr

This required a `compile_commands.json` compilation database, e.g.

    ccmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1

for CMake or check Bear for a Makefile based solution (or even Ninja).

    git ls-files -x '*.cpp|*.h' | \
      xargs -I{} -P $(nproc) clang-modernize -p build -final-syntax-check -format -style=file -summary -for-compilers=clang-3.4,gcc-4.8 -include . -exclude third_party {}

Boom!

References:

* http://clang.llvm.org/extra/clang-modernize.html
* http://clang.llvm.org/extra/ModernizerUsage.html