### PR TITLE
Add script to update subtree-ed third party dependencies more easily.

### DIFF
--- a/update_depdendencies.sh
+++ b/update_depdendencies.sh
@@ -16,6 +16,6 @@ read -p "Looks good? (Y/n) " ok
 
 if [[ $ok =~ [yY] ]]
 then
-  echo git subtree pull -P third_party/libosmium/ $OSMIUM_REPO $OSMIUM_TAG --squash
-  echo git subtree pull -P third_party/variant/ $VARIANT_REPO $VARIANT_TAG --squash
+  git subtree pull -P third_party/libosmium/ $OSMIUM_REPO $OSMIUM_TAG --squash
+  git subtree pull -P third_party/variant/ $VARIANT_REPO $VARIANT_TAG --squash
 fi

--- a/update_depdendencies.sh
+++ b/update_depdendencies.sh
@@ -6,6 +6,16 @@ OSMIUM_TAG=v2.3.0
 VARIANT_REPO=https://github.com/mapbox/variant.git 
 VARIANT_TAG=v1.0
 
+VARIANT_LATEST=$(http --body https://api.github.com/repos/mapbox/variant/releases/latest | jq ".tag_name")
+OSMIUM_LATEST=$(http --body https://api.github.com/repos/osmcode/libosmium/releases/latest | jq ".tag_name")
 
-git subtree pull -P third_party/libosmium/ $OSMIUM_REPO $OSMIUM_TAG --squash
-git subtree pull -P third_party/variant/ $VARIANT_REPO $VARIANT_TAG --squash
+echo "Latest osmium release is $OSMIUM_LATEST, pulling in \"$OSMIUM_TAG\""
+echo "Latest variant release is $VARIANT_LATEST, pulling in \"$VARIANT_TAG\""
+
+read -p "Looks good? (Y/n) " ok
+
+if [[ $ok =~ [yY] ]]
+then
+  echo git subtree pull -P third_party/libosmium/ $OSMIUM_REPO $OSMIUM_TAG --squash
+  echo git subtree pull -P third_party/variant/ $VARIANT_REPO $VARIANT_TAG --squash
+fi

--- a/update_depdendencies.sh
+++ b/update_depdendencies.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+OSMIUM_REPO=https://github.com/osmcode/libosmium.git
+OSMIUM_TAG=v2.3.0
+
+VARIANT_REPO=https://github.com/mapbox/variant.git 
+VARIANT_TAG=v1.0
+
+
+git subtree pull -P third_party/libosmium/ $OSMIUM_REPO $OSMIUM_TAG --squash
+git subtree pull -P third_party/variant/ $VARIANT_REPO $VARIANT_TAG --squash


### PR DESCRIPTION
Note: this updates the subtrees immediately.

Discussion: would it make sense to do something along the lines of:

```bash
$ http --body https://api.github.com/repos/mapbox/variant/releases/latest | jq ".tag_name"
"v1.0"
```

And warn the user if the latest release tag is not the tag the update
script was called with. Or at least ask for confirmation?