### PR TITLE
[cucumber] Use rounding for speed

### DIFF
--- a/features/bicycle/bridge.feature
+++ b/features/bicycle/bridge.feature
@@ -42,6 +42,6 @@ Feature: Bicycle - Handle movable bridge
         When I route I should get
             | from | to | route       | modes | speed   |
             | a    | g  | abc,cde,efg | 1,5,1 | 5 km/h |
-            | b    | f  | abc,cde,efg | 1,5,1 | 3 km/h |
+            | b    | f  | abc,cde,efg | 1,5,1 | 4 km/h |
             | c    | e  | cde         | 5     | 2 km/h |
             | e    | c  | cde         | 5     | 2 km/h |

--- a/features/car/bridge.feature
+++ b/features/car/bridge.feature
@@ -41,7 +41,7 @@ Feature: Car - Handle movable bridge
 
         When I route I should get
             | from | to | route       | modes | speed   |
-            | a    | g  | abc,cde,efg | 1,3,1 | 6 km/h |
-            | b    | f  | abc,cde,efg | 1,3,1 | 4 km/h |
+            | a    | g  | abc,cde,efg | 1,3,1 | 7 km/h |
+            | b    | f  | abc,cde,efg | 1,3,1 | 5 km/h |
             | c    | e  | cde         | 3     | 2 km/h |
             | e    | c  | cde         | 3     | 2 km/h |

--- a/features/car/maxspeed.feature
+++ b/features/car/maxspeed.feature
@@ -23,10 +23,10 @@ OSRM will use 4/5 of the projected free-flow speed.
             | from | to | route | speed         |
             | a    | b  | ab    |  78 km/h      |
             | b    | c  | bc    |  59 km/h +- 1 |
-            | c    | d  | cd    |  50 km/h      |
+            | c    | d  | cd    |  51 km/h      |
             | d    | e  | de    |  75 km/h      |
             | e    | f  | ef    |  90 km/h      |
-            | f    | g  | fg    | 105 km/h      |
+            | f    | g  | fg    | 106 km/h      |
 
     Scenario: Car - Do not ignore maxspeed when higher than way speed
         Given the node map
@@ -42,7 +42,7 @@ OSRM will use 4/5 of the projected free-flow speed.
             | from | to | route | speed        |
             | a    | b  | ab    | 31 km/h      |
             | b    | c  | bc    | 83 km/h +- 1 |
-            | c    | d  | cd    | 50 km/h      |
+            | c    | d  | cd    | 51 km/h      |
 
     Scenario: Car - Forward/backward maxspeed
         Given a grid size of 100 meters
@@ -119,4 +119,3 @@ OSRM will use 4/5 of the projected free-flow speed.
             | primary |   30     |   1    | -1     |         | 34 km/h |
             | primary |   30     |   1    |        | 15 km/h | 15 km/h |
             | primary |   30     |   2    |        | 34 km/h | 34 km/h |
-

--- a/features/step_definitions/routing.rb
+++ b/features/step_definitions/routing.rb
@@ -97,7 +97,7 @@ When /^I route I should get$/ do |table|
               raise "*** Speed must be specied in km/h. (ex: 50 km/h)" unless row['speed'] =~ /\d+ km\/h/
                 time = json['route_summary']['total_time']
                 distance = json['route_summary']['total_distance']
-                speed = time>0 ? (3.6*distance/time).to_i : nil
+                speed = time>0 ? (3.6*distance/time).round : nil
                 got['speed'] =  "#{speed} km/h"
             else
               got['speed'] = ''

--- a/features/testbot/compression.feature
+++ b/features/testbot/compression.feature
@@ -18,5 +18,5 @@ Feature: Geometry Compression
 
         When I route I should get
             | from | to | route   | distance | speed   |
-            | b    | e  | abcdef  | 589m     | 35 km/h |
-            | e    | b  | abcdef  | 589m     | 35 km/h |
+            | b    | e  | abcdef  | 589m     | 36 km/h |
+            | e    | b  | abcdef  | 589m     | 36 km/h |


### PR DESCRIPTION
In writing [cucumber tests for raster sources](https://github.com/Project-OSRM/osrm-backend/blob/07a28c18a95e57cb4f31ecad4908e7cf80da6353/features/raster/weights.feature#L40-L50) I noticed something weird was happening with speeds; namely, edges marked `highway=primary` and evaluated with `testbot` heuristics (primary = 36mph) were sometimes resulting in `speed=36 km/h` and sometimes `speed=35 km/h`. In investigating it seems this is the result of `35.999.to_i` — ruby truncates decimals to the nearest int rather than rounding. This PR changes from `to_i` to `round` and also modifies any tests that subsequently failed. (This change to routing.rb fixes the failing cucumber tests in the raster source branch as well.)

@emiltin — at quick glance I imagine these test fixtures were written based on the results of the speed conversion in routing.rb, so I assume it's okay to change them based on switching from `to_i` to `round`. Is this okay?

cc @TheMarex 