### PR TITLE
 Add rising bollard exception to barriers for car profile.

### DIFF
--- a/features/car/barrier.feature
+++ b/features/car/barrier.feature
@@ -37,3 +37,10 @@ Feature: Car - Barriers
             | wall         | no            |       |
             | wall         | private       |       |
             | wall         | agricultural  |       |
+
+    Scenario: Car - Rising bollard exception for barriers
+        Then routability should be
+            | node/barrier | node/bollard  | bothw |
+            | bollard      |               |       |
+            | bollard      | rising        | x     |
+            | bollard      | removable     |       |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -94,7 +94,6 @@ traffic_signal_penalty          = 2
 use_turn_restrictions           = false
 
 local obey_oneway               = true
-local obey_bollards             = false
 local ignore_areas              = true
 local u_turn_penalty            = 20
 local turn_penalty              = 60

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -132,7 +132,6 @@ traffic_signal_penalty          = 2
 use_turn_restrictions           = true
 
 local obey_oneway               = true
-local obey_bollards             = true
 local ignore_areas              = true
 local u_turn_penalty            = 20
 

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -195,7 +195,11 @@ function node_function (node, result)
   else
     local barrier = node:get_value_by_key("barrier")
     if barrier and "" ~= barrier then
-      if not barrier_whitelist[barrier] then
+      --  make an exception for rising bollard barriers
+      local bollard = node:get_value_by_key("bollard")
+      local rising_bollard = bollard and "rising" == bollard
+
+      if not barrier_whitelist[barrier] and not rising_bollard then
         result.barrier = true
       end
     end

--- a/profiles/examples/postgis.lua
+++ b/profiles/examples/postgis.lua
@@ -33,7 +33,6 @@ print("PostGIS connection opened")
 -- these settings are read directly by osrm
 take_minimum_of_speeds   = true
 obey_oneway             = true
-obey_bollards           = true
 use_restrictions         = true
 ignore_areas             = true  -- future feature
 traffic_signal_penalty   = 7      -- seconds


### PR DESCRIPTION
This handles `barrier=bollard` with `bollard=rising`, by making an
exception to the barrier whitelist. Barriers tagged as such do no longer
require an explicit access tag.

This also adds corresponding tests, check this out:

    cucumber --tags @barrier

References:

- http://wiki.openstreetmap.org/wiki/Tag:barrier%3Dbollard
- http://wiki.openstreetmap.org/wiki/Key:bollard
- #1616