### PR TITLE
Make map matching more robust

### DIFF
--- a/data_structures/hidden_markov_model.hpp
+++ b/data_structures/hidden_markov_model.hpp
@@ -96,6 +96,7 @@ template <class CandidateLists> struct HiddenMarkovModel
         path_lengths.resize(candidates_list.size());
         suspicious.resize(candidates_list.size());
         pruned.resize(candidates_list.size());
+        breakage.resize(candidates_list.size());
         for (const auto i : osrm::irange<std::size_t>(0u, candidates_list.size()))
         {
             const auto& num_candidates = candidates_list[i].size();

--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 RouteParameters::RouteParameters()
     : zoom_level(18), print_instructions(false), alternate_route(true), geometry(true),
       compression(true), deprecatedAPI(false), uturn_default(false), classify(false),
-      matching_beta(-1.0), gps_precision(-1.0), check_sum(-1), num_results(1)
+      matching_beta(5), gps_precision(5), check_sum(-1), num_results(1)
 {
 }
 

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -40,6 +40,7 @@ Feature: Basic Map Matching
             | afcde  | abcde     |
 
     Scenario: Testbot - Map matching with oneways
+        Given a grid size of 10 meters
         Given the node map
             | a | b | c | d |
             | e | f | g | h |

--- a/features/testbot/post.feature
+++ b/features/testbot/post.feature
@@ -30,6 +30,7 @@ Feature: POST request
             | z    | x  | yz,xy | head,left,destination  |
 
     Scenario: Testbot - match POST request
+        Given a grid size of 10 meters
         Given the node map
             | a | b | c | d |
             | e | f | g | h |

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -216,6 +216,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         // check number of parameters
         if (!check_all_coordinates(route_parameters.coordinates))
         {
+            json_result.values["status"] = "Invalid coordinates.";
             return 400;
         }
 
@@ -225,6 +226,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         const auto &input_timestamps = route_parameters.timestamps;
         if (input_timestamps.size() > 0 && input_coords.size() != input_timestamps.size())
         {
+            json_result.values["status"] = "Number of timestamps does not match number of coordinates .";
             return 400;
         }
 
@@ -232,6 +234,14 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         if (max_locations_map_matching > 0 &&
             static_cast<int>(input_coords.size()) < max_locations_map_matching)
         {
+            json_result.values["status"] = "Too many coodindates.";
+            return 400;
+        }
+
+        // enforce maximum number of locations for performance reasons
+        if (static_cast<int>(input_coords.size()) < 2)
+        {
+            json_result.values["status"] = "At least two coordinates needed.";
             return 400;
         }
 
@@ -239,6 +249,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
             getCandiates(input_coords, sub_trace_lengths, candidates_lists);
         if (!found_candidates)
         {
+            json_result.values["status"] = "No suitable matching candidates found.";
             return 400;
         }
 
@@ -254,6 +265,7 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
 
         if (sub_matchings.empty())
         {
+            json_result.values["status"] = "No matchings found.";
             return 400;
         }
 

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -324,6 +324,8 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
                 raw_route.segment_end_coordinates,
                 std::vector<bool>(raw_route.segment_end_coordinates.size(), true), raw_route);
 
+            BOOST_ASSERT(raw_route.shortest_path_length != INVALID_EDGE_WEIGHT);
+
             matchings.values.emplace_back(submatchingToJSON(sub, route_parameters, raw_route));
         }
 

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -63,9 +63,6 @@ constexpr static const unsigned MAX_BROKEN_STATES = 10;
 
 constexpr static const double MAX_SPEED = 180 / 3.6; // 150km -> m/s
 constexpr static const unsigned SUSPICIOUS_DISTANCE_DELTA = 100;
-
-constexpr static const double default_beta = 5.0;
-constexpr static const double default_sigma_z = 4.07;
 }
 }
 
@@ -128,10 +125,8 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
         }();
 
         // TODO replace default values with table lookup based on sampling frequency
-        EmissionLogProbability emission_log_probability(
-            gps_precision > 0. ? gps_precision : osrm::matching::default_sigma_z);
-        TransitionLogProbability transition_log_probability(
-            matching_beta > 0. ? matching_beta : osrm::matching::default_beta);
+        EmissionLogProbability emission_log_probability(gps_precision);
+        TransitionLogProbability transition_log_probability(matching_beta);
 
         osrm::matching::HMM model(candidates_list, emission_log_probability);
 

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -61,7 +61,7 @@ using SubMatchingList = std::vector<SubMatching>;
 
 constexpr static const unsigned MAX_BROKEN_STATES = 10;
 
-constexpr static const double MAX_SPEED = 180 / 3.6; // 150km -> m/s
+constexpr static const double MAX_SPEED = 180 / 3.6; // 180km -> m/s
 constexpr static const unsigned SUSPICIOUS_DISTANCE_DELTA = 100;
 }
 }

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -139,6 +139,12 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
         MatchingDebugInfo matching_debug(osrm::json::Logger::get());
         matching_debug.initialize(candidates_list);
 
+        engine_working_data.InitializeOrClearFirstThreadLocalStorage(
+            super::facade->GetNumberOfNodes());
+
+        QueryHeap &forward_heap = *(engine_working_data.forward_heap_1);
+        QueryHeap &reverse_heap = *(engine_working_data.reverse_heap_1);
+
         std::size_t breakage_begin = osrm::matching::INVALID_STATE;
         std::vector<std::size_t> split_points;
         std::vector<std::size_t> prev_unbroken_timestamps;
@@ -205,12 +211,6 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
             auto &current_lengths = model.path_lengths[t];
             const auto &current_timestamps_list = candidates_list[t];
             const auto &current_coordinate = trace_coordinates[t];
-
-            engine_working_data.InitializeOrClearFirstThreadLocalStorage(
-                super::facade->GetNumberOfNodes());
-
-            QueryHeap &forward_heap = *(engine_working_data.forward_heap_1);
-            QueryHeap &reverse_heap = *(engine_working_data.reverse_heap_1);
 
             // compute d_t for this timestamp and the next one
             for (const auto s : osrm::irange<std::size_t>(0u, prev_viterbi.size()))

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -248,7 +248,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                     const auto d_t = std::abs(network_distance - great_circle_distance);
 
                     // very low probability transition -> prune
-                    if (d_t > max_distance_delta)
+                    if (d_t >= max_distance_delta)
                     {
                         continue;
                     }

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -214,6 +214,8 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
             const auto &current_timestamps_list = candidates_list[t];
             const auto &current_coordinate = trace_coordinates[t];
 
+            const auto great_circle_distance = coordinate_calculation::great_circle_distance(prev_coordinate, current_coordinate);
+
             // compute d_t for this timestamp and the next one
             for (const auto s : osrm::irange<std::size_t>(0u, prev_viterbi.size()))
             {
@@ -241,9 +243,6 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                     const auto network_distance = super::get_network_distance(
                         forward_heap, reverse_heap, prev_unbroken_timestamps_list[s].first,
                         current_timestamps_list[s_prime].first);
-                    const auto great_circle_distance =
-                        coordinate_calculation::great_circle_distance(prev_coordinate,
-                                                                      current_coordinate);
 
                     const auto d_t = std::abs(network_distance - great_circle_distance);
 

--- a/routing_algorithms/map_matching.hpp
+++ b/routing_algorithms/map_matching.hpp
@@ -301,13 +301,16 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
         {
             osrm::matching::SubMatching matching;
 
-            // find real end of trace
-            // not sure if this is really needed
             std::size_t parent_timestamp_index = sub_matching_end - 1;
             while (parent_timestamp_index >= sub_matching_begin &&
                    model.breakage[parent_timestamp_index])
             {
                 --parent_timestamp_index;
+            }
+            while (sub_matching_begin < sub_matching_end &&
+                   model.breakage[sub_matching_begin])
+            {
+                ++sub_matching_begin;
             }
 
             // matchings that only consist of one candidate are invalid
@@ -335,6 +338,11 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
 
                 reconstructed_indices.emplace_front(parent_timestamp_index, parent_candidate_index);
                 const auto &next = model.parents[parent_timestamp_index][parent_candidate_index];
+                // make sure we can never get stuck in this loop
+                if (parent_timestamp_index == next.first)
+                {
+                    break;
+                }
                 parent_timestamp_index = next.first;
                 parent_candidate_index = next.second;
             }

--- a/server/data_structures/datafacade_base.hpp
+++ b/server/data_structures/datafacade_base.hpp
@@ -107,9 +107,7 @@ template <class EdgeDataT> class BaseDataFacade
     virtual bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &resulting_phantom_node_vector,
-        const double max_distance,
-        const unsigned min_number_of_phantom_nodes,
-        const unsigned max_number_of_phantom_nodes) = 0;
+        const double max_distance) = 0;
 
     virtual unsigned GetCheckSum() const = 0;
 

--- a/server/data_structures/internal_datafacade.hpp
+++ b/server/data_structures/internal_datafacade.hpp
@@ -453,9 +453,7 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
     bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &resulting_phantom_node_vector,
-        const double max_distance,
-        const unsigned min_number_of_phantom_nodes,
-        const unsigned max_number_of_phantom_nodes) override final
+        const double max_distance) override final
     {
         if (!m_static_rtree.get())
         {
@@ -463,8 +461,7 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
         }
 
         return m_static_rtree->IncrementalFindPhantomNodeForCoordinateWithDistance(
-            input_coordinate, resulting_phantom_node_vector, max_distance,
-            min_number_of_phantom_nodes, max_number_of_phantom_nodes);
+            input_coordinate, resulting_phantom_node_vector, max_distance);
     }
 
     unsigned GetCheckSum() const override final { return m_check_sum; }

--- a/server/data_structures/shared_datafacade.hpp
+++ b/server/data_structures/shared_datafacade.hpp
@@ -424,9 +424,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
     bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &resulting_phantom_node_vector,
-        const double max_distance,
-        const unsigned min_number_of_phantom_nodes,
-        const unsigned max_number_of_phantom_nodes) override final
+        const double max_distance) override final
     {
         if (!m_static_rtree.get() || CURRENT_TIMESTAMP != m_static_rtree->first)
         {
@@ -434,8 +432,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         }
 
         return m_static_rtree->second->IncrementalFindPhantomNodeForCoordinateWithDistance(
-            input_coordinate, resulting_phantom_node_vector, max_distance,
-            min_number_of_phantom_nodes, max_number_of_phantom_nodes);
+            input_coordinate, resulting_phantom_node_vector, max_distance);
     }
 
     unsigned GetCheckSum() const override final { return m_check_sum; }


### PR DESCRIPTION
Main problem with map matching is that the algorithm currently assumes your sample rate is around 5-10s. This is because a few thresholds where hard-coded and optimized for that.

Still TODO is the re-calibration of the `confidence` classifier - most traces will have a very low confidence if the same rate is very low.

- [x] Make trace splitting threshold sample rate dependent
- [x] Make transition pruning sample rate dependent
- [x] Re-measure `matching_beta` for low sample rate (100sec -> ~200)
- [x] Calculate candidate query radius based on `gps_accuracy`
- [x] Filter candidates by compressed edge id
- [x] Fix broken splitting test case