### PR TITLE
Enable turn penalties on car profile

### DIFF
--- a/features/car/ferry.feature
+++ b/features/car/ferry.feature
@@ -41,7 +41,7 @@ Feature: Car - Handle ferry routes
 
         When I route I should get
             | from | to | route       | modes | speed   |
-            | a    | g  | abc,cde,efg | 1,2,1 | 26 km/h |
+            | a    | g  | abc,cde,efg | 1,2,1 | 25 km/h |
             | b    | f  | abc,cde,efg | 1,2,1 | 20 km/h |
             | c    | e  | cde         | 2     | 12 km/h |
             | e    | c  | cde         | 2     | 12 km/h |
@@ -60,7 +60,7 @@ Feature: Car - Handle ferry routes
 
         When I route I should get
             | from | to | route       | modes | speed   |
-            | a    | g  | abc,cde,efg | 1,2,1 | 26 km/h |
+            | a    | g  | abc,cde,efg | 1,2,1 | 25 km/h |
             | b    | f  | abc,cde,efg | 1,2,1 | 20 km/h |
             | c    | e  | cde         | 2     | 12 km/h |
             | e    | c  | cde         | 2     | 12 km/h |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -131,6 +131,11 @@ maxspeed_table = {
 traffic_signal_penalty          = 2
 use_turn_restrictions           = true
 
+local turn_penalty              = 10
+-- Note: this biases right-side driving.  Should be
+-- inverted for left-driving countries.
+local turn_bias                 = 1.2
+
 local obey_oneway               = true
 local ignore_areas              = true
 local u_turn_penalty            = 20
@@ -431,3 +436,12 @@ function way_function (way, result)
   end
 end
 
+function turn_function (angle)
+  ---- compute turn penalty as angle^2, with a left/right bias
+  k = turn_penalty/(90.0*90.0)
+  if angle>=0 then
+    return angle*angle*k/turn_bias
+  else
+    return angle*angle*k*turn_bias
+  end
+end


### PR DESCRIPTION
These values were derived by comparing several thousand real-world driving routes, and comparing ETA estimates from OSRM with the real-world travel times.  Enabling turn penalties narrows the variance between OSRM estimates and real-world values, which implies better edge weighting, and thus, more realistic selection of routes.

For now, this has a right-side driving bias.  Further work is needed to bias properly in left-side-driving locations.