### PR TITLE
Make pedestrian roads marked as destination routable with car profile.

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -125,13 +125,15 @@ Feature: Car - Restricted access
 
     Scenario: Car - Access combinations
         Then routability should be
-            | highway     | accesss      | vehicle    | motor_vehicle | motorcar   | bothw |
-            | runway      | private      |            |               | permissive | x     |
-            | primary     | forestry     |            | yes           |            | x     |
-            | cycleway    |              |            | designated    |            | x     |
-            | residential |              | yes        | no            |            |       |
-            | motorway    | yes          | permissive |               | private    |       |
-            | trunk       | agricultural | designated | permissive    | no         |       |
+            | highway     | accesss      | vehicle    | motor_vehicle | motorcar    | bothw |
+            | runway      | private      |            |               | permissive  | x     |
+            | primary     | forestry     |            | yes           |             | x     |
+            | cycleway    |              |            | designated    |             | x     |
+            | residential |              | yes        | no            |             |       |
+            | motorway    | yes          | permissive |               | private     |       |
+            | trunk       | agricultural | designated | permissive    | no          |       |
+            | pedestrian  |              |            |               |             |       |
+            | pedestrian  |              |            |               | destination | x     |
 
     Scenario: Car - Ignore access tags for other modes
         Then routability should be

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -4,7 +4,7 @@ local find_access_tag = require("lib/access").find_access_tag
 
 -- Begin of globals
 barrier_whitelist = { ["cattle_grid"] = true, ["border_control"] = true, ["checkpoint"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["lift_gate"] = true, ["no"] = true, ["entrance"] = true }
-access_tag_whitelist = { ["yes"] = true, ["motorcar"] = true, ["motor_vehicle"] = true, ["vehicle"] = true, ["permissive"] = true, ["designated"] = true }
+access_tag_whitelist = { ["yes"] = true, ["motorcar"] = true, ["motor_vehicle"] = true, ["vehicle"] = true, ["permissive"] = true, ["designated"] = true, ["destination"] = true }
 access_tag_blacklist = { ["no"] = true, ["private"] = true, ["agricultural"] = true, ["forestry"] = true, ["emergency"] = true, ["psv"] = true }
 access_tag_restricted = { ["destination"] = true, ["delivery"] = true }
 access_tags = { "motorcar", "motor_vehicle", "vehicle" }
@@ -297,12 +297,8 @@ function way_function (way, result)
         result.backward_speed = highway_speed
       end
     else
-      -- make an exception for restricted highway=pedestrian with motorcar=destination
-      local motorcar = way:get_value_by_key("motorcar")
-      local pedestrian_road = motorcar and "destination" == motorcar and "pedestrian" == highway
-
       -- Set the avg speed on ways that are marked accessible
-      if access_tag_whitelist[access] or pedestrian_road then
+      if access_tag_whitelist[access] then
         result.forward_speed = speed_profile["default"]
         result.backward_speed = speed_profile["default"]
       end

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -297,8 +297,12 @@ function way_function (way, result)
         result.backward_speed = highway_speed
       end
     else
+      -- make an exception for restricted highway=pedestrian with motorcar=destination
+      local motorcar = way:get_value_by_key("motorcar")
+      local pedestrian_road = motorcar and "destination" == motorcar and "pedestrian" == highway
+
       -- Set the avg speed on ways that are marked accessible
-      if access_tag_whitelist[access] then
+      if access_tag_whitelist[access] or pedestrian_road then
         result.forward_speed = speed_profile["default"]
         result.backward_speed = speed_profile["default"]
       end


### PR DESCRIPTION
Discussion: it seems like the `@destination` tests are not executed by default, seeing as they are also marked `@todo`? --- I would love to get some eyes on this before merging.

From what I can tell, [access_tag_whitelist](https://github.com/Project-OSRM/osrm-backend/blob/f6a90e9b429b4e2fdfa231580ae404d7c0696b14/profiles/car.lua#L301) is used only once to determine speed values for the way. I started out adding `destination` to the white list (which works), with the idea that I could add an exception [here](https://github.com/Project-OSRM/osrm-backend/blob/f6a90e9b429b4e2fdfa231580ae404d7c0696b14/profiles/car.lua#L362). But I'm not totally sure yet how the "restriction flag" influences routing?

The solution right now adds speed values for pedestrian destination roads, which seems to make them routable, at least that's what the tests are telling. But I have a strange feeling that this may not be a correct solution..

/cc @TheMarex 

---------------------------------------------------

Check provided tests with:

    cucumber --tags @access -p verify

References:

- https://github.com/Project-OSRM/osrm-backend/issues/1617
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dpedestrian
- http://wiki.openstreetmap.org/wiki/Key:motorcar
- http://wiki.openstreetmap.org/wiki/Key:access