### PR TITLE
Make an exception for block barriers in bicycle and foot profile.

### DIFF
--- a/features/bicycle/barrier.feature
+++ b/features/bicycle/barrier.feature
@@ -19,6 +19,7 @@ Feature: Barriers
             | wall           |       |
             | fence          |       |
             | some_tag       |       |
+            | block          | x     |
 
     Scenario: Bike - Access tag trumphs barriers
         Then routability should be

--- a/features/car/barrier.feature
+++ b/features/car/barrier.feature
@@ -19,6 +19,7 @@ Feature: Car - Barriers
             | wall           |       |
             | fence          |       |
             | some_tag       |       |
+            | block          |       |
 
     Scenario: Car - Access tag trumphs barriers
         Then routability should be

--- a/features/foot/barrier.feature
+++ b/features/foot/barrier.feature
@@ -19,6 +19,7 @@ Feature: Barriers
             | wall           |       |
             | fence          |       |
             | some_tag       |       |
+            | block          | x     |
 
     Scenario: Foot - Access tag trumphs barriers
         Then routability should be

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -4,7 +4,7 @@ local find_access_tag = require("lib/access").find_access_tag
 local limit = require("lib/maxspeed").limit
 
 -- Begin of globals
-barrier_whitelist = { [""] = true, ["cycle_barrier"] = true, ["bollard"] = true, ["entrance"] = true, ["cattle_grid"] = true, ["border_control"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["no"] = true }
+barrier_whitelist = { [""] = true, ["cycle_barrier"] = true, ["bollard"] = true, ["entrance"] = true, ["cattle_grid"] = true, ["border_control"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["no"] = true, ["block"] = true }
 access_tag_whitelist = { ["yes"] = true, ["permissive"] = true, ["designated"] = true }
 access_tag_blacklist = { ["no"] = true, ["private"] = true, ["agricultural"] = true, ["forestry"] = true }
 access_tag_restricted = { ["destination"] = true, ["delivery"] = true }

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -3,7 +3,7 @@
 local find_access_tag = require("lib/access").find_access_tag
 
 -- Begin of globals
-barrier_whitelist = { [""] = true, ["cycle_barrier"] = true, ["bollard"] = true, ["entrance"] = true, ["cattle_grid"] = true, ["border_control"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["no"] = true}
+barrier_whitelist = { [""] = true, ["cycle_barrier"] = true, ["bollard"] = true, ["entrance"] = true, ["cattle_grid"] = true, ["border_control"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["no"] = true, ["block"] = true}
 access_tag_whitelist = { ["yes"] = true, ["foot"] = true, ["permissive"] = true, ["designated"] = true  }
 access_tag_blacklist = { ["no"] = true, ["private"] = true, ["agricultural"] = true, ["forestry"] = true }
 access_tag_restricted = { ["destination"] = true, ["delivery"] = true }


### PR DESCRIPTION
This adds `barrier=block` exceptions to the respective white lists.

In addition this adds tests to check for the exception in bicycle and
foot profiles and makes sure cars are still not able to cross them.

Checked with:

    cucumber --tags @barrier -p verify

References:

- https://github.com/Project-OSRM/osrm-backend/issues/1643
- http://wiki.openstreetmap.org/wiki/Tag:barrier%3Dblock