### PR TITLE
Don't pass by const-value for a read-only view.

### DIFF
--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -134,7 +134,7 @@ void RouteParameters::addCoordinate(
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
 }
 
-void RouteParameters::getCoordinatesFromGeometry(const std::string geometry_string)
+void RouteParameters::getCoordinatesFromGeometry(const std::string &geometry_string)
 {
     PolylineCompressor pc;
     coordinates = pc.decode_string(geometry_string);

--- a/data_structures/static_rtree.hpp
+++ b/data_structures/static_rtree.hpp
@@ -345,8 +345,8 @@ class StaticRTree
 
     // Construct a packed Hilbert-R-Tree with Kamel-Faloutsos algorithm [1]
     explicit StaticRTree(const std::vector<EdgeDataT> &input_data_vector,
-                         const std::string tree_node_filename,
-                         const std::string leaf_node_filename,
+                         const std::string &tree_node_filename,
+                         const std::string &leaf_node_filename,
                          const std::vector<QueryNode> &coordinate_list)
         : m_element_count(input_data_vector.size()), m_leaf_node_filename(leaf_node_filename)
     {

--- a/include/osrm/route_parameters.hpp
+++ b/include/osrm/route_parameters.hpp
@@ -79,7 +79,7 @@ struct RouteParameters
 
     void addCoordinate(const boost::fusion::vector<double, double> &received_coordinates);
 
-    void getCoordinatesFromGeometry(const std::string geometry_string);
+    void getCoordinatesFromGeometry(const std::string &geometry_string);
 
     short zoom_level;
     bool print_instructions;


### PR DESCRIPTION
I can't see a reason why we pass by const-value here.

Note: strictly speaking this changes the API because of the `route_parameters` publicly facing header.