### PR TITLE
Ownership: vector already owns, no need for wrapping in unique_ptr.

### DIFF
--- a/contractor/processing_chain.cpp
+++ b/contractor/processing_chain.cpp
@@ -230,7 +230,7 @@ std::size_t Prepare::WriteContractedGraph(unsigned max_node_id,
     const unsigned crc32_value = CalculateEdgeChecksum(node_based_edge_list);
 
     // Sorting contracted edges in a way that the static query graph can read some in in-place.
-    tbb::parallel_sort(contracted_edge_list);
+    tbb::parallel_sort(contracted_edge_list.begin(), contracted_edge_list.end());
     const unsigned contracted_edge_count = contracted_edge_list.size();
     SimpleLogger().Write() << "Serializing compacted graph of " << contracted_edge_count
                            << " edges";

--- a/contractor/processing_chain.hpp
+++ b/contractor/processing_chain.hpp
@@ -58,30 +58,32 @@ class Prepare
     int Run();
 
   protected:
-    void SetupScriptingEnvironment(lua_State *myLuaState,
-                                   SpeedProfileProperties &speed_profile);
-    unsigned CalculateEdgeChecksum(std::unique_ptr<std::vector<EdgeBasedNode>> node_based_edge_list);
+    void SetupScriptingEnvironment(lua_State *myLuaState, SpeedProfileProperties &speed_profile);
+    unsigned CalculateEdgeChecksum(const std::vector<EdgeBasedNode> &node_based_edge_list);
     void ContractGraph(const unsigned max_edge_id,
-                       DeallocatingVector<EdgeBasedEdge>& edge_based_edge_list,
-                       DeallocatingVector<QueryEdge>& contracted_edge_list,
-                       std::vector<bool>& is_core_node);
-    void WriteCoreNodeMarker(std::vector<bool>&& is_core_node) const;
+                       DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list,
+                       DeallocatingVector<QueryEdge> &contracted_edge_list,
+                       std::vector<bool> &is_core_node);
+    void WriteCoreNodeMarker(std::vector<bool> &&is_core_node) const;
     std::size_t WriteContractedGraph(unsigned number_of_edge_based_nodes,
-                                     std::unique_ptr<std::vector<EdgeBasedNode>> node_based_edge_list,
-                                     std::unique_ptr<DeallocatingVector<QueryEdge>> contracted_edge_list);
+                                     const std::vector<EdgeBasedNode> &node_based_edge_list,
+                                     const DeallocatingVector<QueryEdge> &contracted_edge_list);
     std::shared_ptr<RestrictionMap> LoadRestrictionMap();
     std::shared_ptr<NodeBasedDynamicGraph>
     LoadNodeBasedGraph(std::unordered_set<NodeID> &barrier_nodes,
                        std::unordered_set<NodeID> &traffic_lights,
-                       std::vector<QueryNode>& internal_to_external_node_map);
+                       std::vector<QueryNode> &internal_to_external_node_map);
     std::pair<std::size_t, std::size_t>
     BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_node_map,
-                                       std::vector<EdgeBasedNode> &node_based_edge_list,
-                                       DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list);
-    void WriteNodeMapping(std::unique_ptr<std::vector<QueryNode>> internal_to_external_node_map);
-    void FindComponents(unsigned max_edge_id, const DeallocatingVector<EdgeBasedEdge>& edges, std::vector<EdgeBasedNode>& nodes) const;
+                           std::vector<EdgeBasedNode> &node_based_edge_list,
+                           DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list);
+    void WriteNodeMapping(const std::vector<QueryNode> &internal_to_external_node_map);
+    void FindComponents(unsigned max_edge_id,
+                        const DeallocatingVector<EdgeBasedEdge> &edges,
+                        std::vector<EdgeBasedNode> &nodes) const;
     void BuildRTree(const std::vector<EdgeBasedNode> &node_based_edge_list,
                     const std::vector<QueryNode> &internal_to_external_node_map);
+
   private:
     ContractorConfig config;
 };


### PR DESCRIPTION
Removes the pointless `std::unique_ptr<std::vector<T>>` usage,
as a `std::vector` already owns its resources and manages them.

Results in one indirection less (hint: good).


Sidenote: I also don't get things like [this here](https://github.com/Project-OSRM/osrm-backend/blob/db092c828e09e55570e5f1ac15dd63a8735f2012/contractor/processing_chain.cpp#L207-L209). This is introducing an additional move, even though taking by rvalue reference `&&` means we have it exclusively for us. If at all the function should accept the argument by-value and then the call site can decide ito transfer ownership with a move or to create a copy.

(And sorry for the clang-format noise)