### PR TITLE
Treat `restriction:*` tags specifically based on profiles

### DIFF
--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -226,6 +226,54 @@ Feature: Car - Turn restrictions
             | s    | n  | sj,nj |
             | s    | e  |       |
 
+    @specific
+    Scenario: Car - :hgv-qualified on a standard turn restriction
+        Given the node map
+            |   | n |   |
+            | w | j | e |
+            |   | s |   |
+
+        And the ways
+            | nodes | oneway |
+            | sj    | yes    |
+            | nj    | -1     |
+            | wj    | -1     |
+            | ej    | -1     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction:hgv |
+            | restriction | sj       | nj     | j        | no_straight_on  |
+
+        When I route I should get
+            | from | to | route |
+            | s    | w  | sj,wj |
+            | s    | n  | sj,nj |
+            | s    | e  | sj,ej |
+
+    @specific
+    Scenario: Car - :motorcar-qualified on a standard turn restriction
+        Given the node map
+            |   | n |   |
+            | w | j | e |
+            |   | s |   |
+
+        And the ways
+            | nodes | oneway |
+            | sj    | yes    |
+            | nj    | -1     |
+            | wj    | -1     |
+            | ej    | -1     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction:motorcar |
+            | restriction | sj       | nj     | j        | no_straight_on       |
+
+        When I route I should get
+            | from | to | route |
+            | s    | w  | sj,wj |
+            | s    | n  |       |
+            | s    | e  | sj,ej |
+
     @except
     Scenario: Car - Except tag and on no_ restrictions
         Given the node map

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -115,8 +115,8 @@ Given /^the relations$/ do |table|
           raise "*** unknown relation way member '#{way_name}'" unless way
           relation << OSM::Member.new( 'way', way.id, $1 )
         end
-      elsif key =~ /^(.*):(.*)/
-        raise "*** unknown relation member type '#{$1}', must be either 'node' or 'way'"
+      elsif key =~ /^(.*):(.*)/ && "#{$1}" != 'restriction'
+        raise "*** unknown relation member type '#{$1}:#{$2}', must be either 'node' or 'way'"
       else
         relation << { key => value }
       end


### PR DESCRIPTION
Fixes https://github.com/Project-OSRM/osrm-backend/issues/1606.

This treats any keys in [`restriction_exception_tags`](https://github.com/Project-OSRM/osrm-backend/blob/master/profiles/car.lua#L14) as candidates for specific restriction keys (so the only `restriction:*` tags applied in the car profile would be `restriction:motorcar`, `restriction:motor_vehicle`, `restriction:vehicle`).

@daniel-j-h or @TheMarex would love a second set of eyes on the way I approached this. Also, I think I changed the line endings on lines I added in restriction_parser.cpp — what should I do about that?