### PR TITLE
Integration scripts for Clang's Modernize and Tidy tool.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          '-clang-analyzer-*,google-*,llvm-*,misc-*,readability-*,-google-build-explicit-make-pair,-google-explicit-constructor,-google-readability-braces-around-statements,-google-readability-casting,-google-readability-namespace-comments,-google-readability-function,-google-readability-todo,-google-runtime-int,-llvm-namespace-comment,-llvm-header-guard,-llvm-twine-local,-misc-argument-comment,-readability-braces-around-statements,-readability-identifier-naming'
+...
+

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Runs the Static Analyzer on the code base.
+# This is a wrapper intended to be used with like this:
+# 1/ analyze cmake ..
+# 2/ analyze cmake --build .
+
+exec scan-build -analyze-headers -no-failure-reports --keep-going --status-bugs \
+  -enable-checker alpha.core.BoolAssignment \
+  -enable-checker alpha.core.IdenticalExpr \
+  -enable-checker alpha.core.TestAfterDivZero \
+  -enable-checker alpha.deadcode.UnreachableCode \
+  -enable-checker alpha.security.ArrayBoundV2 \
+  -enable-checker alpha.security.MallocOverflow \
+  -enable-checker alpha.security.ReturnPtrRange \
+  -enable-checker security.FloatLoopCounter \
+  -enable-checker security.insecureAPI.rand \
+  -enable-checker security.insecureAPI.strcpy \
+  "${@}"

--- a/scripts/modernize.sh
+++ b/scripts/modernize.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Runs the Clang Modernizer in parallel on the code base.
+# Requires a compilation database in the build directory.
+
+git ls-files '*.cpp' | xargs -I{} -P $(nproc) clang-modernize -p build -final-syntax-check -format -style=file -summary -for-compilers=clang-3.4,gcc-4.8 -include . -exclude third_party {}

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Runs the Clang Tidy Tool in parallel on the code base.
+# Requires a compilation database in the build directory.
+
+git ls-files '*.cpp' | grep -v third_party | xargs -I{} -P $(nproc) clang-tidy -p build -header-filter='.*' {}

--- a/scripts/update_depdendencies.sh
+++ b/scripts/update_depdendencies.sh
@@ -3,7 +3,7 @@
 OSMIUM_REPO=https://github.com/osmcode/libosmium.git
 OSMIUM_TAG=v2.3.0
 
-VARIANT_REPO=https://github.com/mapbox/variant.git 
+VARIANT_REPO=https://github.com/mapbox/variant.git
 VARIANT_TAG=v1.0
 
 VARIANT_LATEST=$(curl https://api.github.com/repos/mapbox/variant/releases/latest | jq ".tag_name")


### PR DESCRIPTION
New directory: `scripts/`, in which small scripts for developers reside.

- `modernize`: runs all cpp files through `clang-modernize`, respecting
  out targeted compiler versions, applying C++11 transformations, doing
  syntax checks and formatting --- in parallel.

- `tidy`: runs all cpp files through `clang-tidy`, with selected
  warnings only, since we do not want to warn on every small detail.

Please check the talk slides for `clang-tidy` linked in the references!

Note: there might be a static analyzer script coming! :)

References:

- http://clang.llvm.org/extra/clang-tidy/
- http://llvm.org/devmtg/2014-04/PDFs/Talks/clang-tidy%20LLVM%20Euro%202014.pdf
- http://clang.llvm.org/extra/clang-tidy/checks/list.html
- https://github.com/Project-OSRM/osrm-backend/pull/1603