### PR TITLE
Script for fully automated test bisecting.

### DIFF
--- a/scripts/bisect_cucumber.sh
+++ b/scripts/bisect_cucumber.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Automates bisecting cucumber tests in a portable way; usage:
+#
+#     git bisect start GOODGITSHA BADGITSHA
+#     git bisect run /path/to/bisect_cucumber.sh
+#
+# XXX: store this file outside source control first, e.g. by copying it over
+#      to /tmp, otherwise jumping through commits will change this script, too.
+
+
+# e: exit on first error, x: print commands
+set -ex
+
+BUILD_DIR=build
+
+cmake -E remove_directory $BUILD_DIR
+cmake -E make_directory $BUILD_DIR
+cmake -E chdir $BUILD_DIR cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake -E chdir $BUILD_DIR cmake --build .
+cucumber -p verify
+
+
+# notes on the return codes git bisect understands:
+# - exit code 0 means okay
+# - exit code 125 means skip this commit and try a commit nearby
+# - every other exit code means bad


### PR DESCRIPTION
Automate cucumber tests bisecting by providing a `git bisect` script.

Because it is stored in source control, but bisecting changes the HEAD,
it is advised to first copy over the script to a place outside source
control, e.g. `/tmp`.

Usage:

    git bisect start HEAD HEAD~10
    git bisect run /tmp/bisect_cucumber.sh

    # wait till it gives you the fault-introducing commit

    git bisect reset

This automatically configures and builds OSRM, spawns the cucumber tests
and communicates with `git bisect` based on its return code.

Note: uses the same `scripts` directory as proposed in https://github.com/Project-OSRM/osrm-backend/pull/1677, but does not depend on pull request.

Reference:

- man git-bisect