### PR TITLE
Extend compressed output lifetime till the async write function finishes.

### DIFF
--- a/server/connection.cpp
+++ b/server/connection.cpp
@@ -78,7 +78,6 @@ void Connection::handle_read(const boost::system::error_code &error, std::size_t
         request_handler.handle_request(current_request, current_reply);
 
         // Header compression_header;
-        std::vector<char> compressed_output;
         std::vector<boost::asio::const_buffer> output_buffer;
 
         // compress the result w/ gzip/deflate if requested

--- a/server/connection.hpp
+++ b/server/connection.hpp
@@ -87,6 +87,7 @@ class Connection : public std::enable_shared_from_this<Connection>
     boost::array<char, 8192> incoming_data_buffer;
     request current_request;
     reply current_reply;
+    std::vector<char> compressed_output;
 };
 
 } // namespace http


### PR DESCRIPTION
This extends the compressed output vector's lifetime, as we issue an
asynchronous write operation that only receives a non-owning buffer to
the compressed data.

When the compressed output vector then goes out of scope, its destructor
is called and the data gets (potentially) destroyed. If the asynchronous
write happens afterwards, it's accessing data that is no longer there.

This is the reason for race conditions --- well, for undefined behavior
in general, but it manifests in the routed _sometimes_ not responding at
all.

The fix works like this: keep the compressed output associated with a
connection. Connections inherit from `std::enable_shared_from_this` and
issues a `shared_from_this()` call, passing a `std::shared_ptr` to the
asynchronous write function, thus extending their lifetime.

Connecitons thus manage their lifetime by themselves, extending it when
needed (and of course via the `std::shared_pointers` pointing to it).

Buffer's non owning property, from the `async_write` documentation:

> One or more buffers containing the data to be written. Although
> the buffers object may be copied as necessary, ownership of the
> underlying memory blocks is retained by the caller, which must
> guarantee that they remain valid until the handler is called.

Reference:

- http://www.boost.org/doc/libs/1_59_0/doc/html/boost_asio/reference/async_write/overload1.html