### PR TITLE
Include (road) name of matched nodes in addition to coordinate.

### DIFF
--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -244,6 +244,13 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         }
         subtrace.values["matched_points"] = points;
 
+        osrm::json::Array names;
+        for (const auto &node : sub.nodes)
+        {
+            names.values.emplace_back( facade->get_name_for_id(node.name_id) );
+        }
+        subtrace.values["matched_names"] = names;
+
         return subtrace;
     }
 


### PR DESCRIPTION
This came up as part of customer project.  They wanted to know the names of the roads the matched points were on.  We discussed using the matched-points to call `/nearest` which returns the name, but even though we know the matched coordinate is on a real geometry, we can't guarantee that `/nearest` will select the correct edge direction.

This PR is to discuss the approach, and whether we want to include this feature upstream.