### PR TITLE
Refactor alternative route test

### DIFF
--- a/features/step_definitions/routing.rb
+++ b/features/step_definitions/routing.rb
@@ -83,8 +83,12 @@ When /^I route I should get$/ do |table|
         if table.headers.include? 'route'
           got['route'] = (instructions || '').strip
           if table.headers.include?('alternative')
-            raise "*** No alternative found ***" unless json['found_alternative']
-            got['alternative'] = way_list json['alternative_instructions'].first
+            got['alternative'] =
+              if json['found_alternative']
+                way_list json['alternative_instructions'].first
+              else
+                ""
+              end
           end
           if table.headers.include?('distance')
             if row['distance']!=''

--- a/features/testbot/alternative.feature
+++ b/features/testbot/alternative.feature
@@ -1,0 +1,38 @@
+@routing @testbot @alternative
+Feature: Alternative route
+
+    Background:
+        Given the profile "testbot"
+
+        And the node map
+            |   | b | c | d |   |   |
+            | a |   |   |   |   | z |
+            |   | g | h | i | j |   |
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | cd    |
+            | dz    |
+            | ag    |
+            | gh    |
+            | hi    |
+            | ij    |
+            | jz    |
+
+    Scenario: Enabled alternative
+        Given the query options
+            | alt | true |
+
+        When I route I should get
+            | from | to | route       | alternative    |
+            | a    | z  | ab,bc,cd,dz | ag,gh,hi,ij,jz |
+
+    Scenario: Disabled alternative
+        Given the query options
+            | alt | false |
+
+        When I route I should get
+            | from | to | route       | alternative |
+            | a    | z  | ab,bc,cd,dz |             |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -52,30 +52,6 @@ Feature: Via points
             | a,c,f     | ab,bcd,bcd,de,efg        |
             | a,c,f,h   | ab,bcd,bcd,de,efg,efg,gh |
 
-    Scenario: Alternative via points
-        Given the node map
-            |   | b | c | d |   |   |
-            | a |   |   |   |   | z |
-            |   | g | h | i | j |   |
-
-        And the ways
-            | nodes |
-            | ab    |
-            | bc    |
-            | cd    |
-            | dz    |
-            | ag    |
-            | gh    |
-            | hi    |
-            | ij    |
-            | jz    |
-
-        And the query options
-            | alt | true |
-
-        When I route I should get
-            | waypoints | route       | alternative    |
-            | a,z       | ab,bc,cd,dz | ag,gh,hi,ij,jz |
 
     Scenario: Duplicate via point
         Given the node map


### PR DESCRIPTION
Re-rolling https://github.com/Project-OSRM/osrm-backend/pull/1701 because was PRed against wrong branch

Picking up comments by @emiltin from https://github.com/Project-OSRM/osrm-backend/pull/1695

I've added another test for the alt flag set to false. @emiltin other tests you can think of? @TheMarex are there more cases where we want to test for that an alternative exists?