### PR TITLE
Bugfix: allow POST request without POST data

### DIFF
--- a/server/request_parser.cpp
+++ b/server/request_parser.cpp
@@ -328,11 +328,14 @@ osrm::tribool RequestParser::consume(request &current_request, const char input)
         }
         return osrm::tribool::no;
     case internal_state::expecting_newline_3:
-        if(input == '\n')
+        if (input == '\n')
         {
-            if(is_post_header)
+            if (is_post_header)
             {
-                current_request.uri.push_back('?');
+		if (content_length > 0)
+		{
+		    current_request.uri.push_back('?');
+		}
                 state = internal_state::post_request;
                 return osrm::tribool::indeterminate;
             }


### PR DESCRIPTION
Since commit a87d89302fb412f4b64a1e77a91fa8cecc70fbfd OSRM returns errors like

*{"status_message":"Query string malformed close to position 6","status":400}*

if you send a POST request without POST data. For example: 

*curl -X POST http://OSRM_SERVER/hello*

With this change the question mark will only be added if there is any POST data.
