### PR TITLE
Feature/bearing selection

### DIFF
--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/fusion/container/vector.hpp>
 #include <boost/fusion/sequence/intrinsic.hpp>
 #include <boost/fusion/include/at_c.hpp>
+#include <boost/spirit/include/qi.hpp>
 
 #include <osrm/route_parameters.hpp>
 
@@ -114,6 +115,18 @@ void RouteParameters::addTimestamp(const unsigned timestamp)
     if (!timestamps.empty())
     {
         timestamps.back() = timestamp;
+    }
+}
+
+void RouteParameters::addBearing(const int bearing, boost::spirit::qi::unused_type unused, bool& pass)
+{
+    bearings.resize(coordinates.size());
+    pass = false;
+    if (bearing < 0 || bearing > 359) return;
+    if (!bearings.empty())
+    {
+        bearings.back() = bearing;
+        pass = true;
     }
 }
 

--- a/data_structures/static_rtree.hpp
+++ b/data_structures/static_rtree.hpp
@@ -642,10 +642,55 @@ class StaticRTree
         return result_coordinate.is_valid();
     }
 
+    /**
+     * Checks whether A is between B-range and B+range, all modulo 360
+     * e.g. A = 5, B = 5, range = 10 == true
+     *      A = -6, B = 5, range = 10 == false
+     *      A = -2, B = 355, range = 10 == true
+     *      A = 6, B = 355, range = 10 == false
+     *      A = 355, B = -2, range = 10 == true
+     *
+     * @param A the bearing to check, in degrees, 0-359, 0=north
+     * @param B the bearing to check against, in degrees, 0-359, 0=north
+     * @param range the number of degrees either side of B that A will still match
+     * @return true if B-range <= A <= B+range, modulo 360
+     * */
+    static bool IsBearingWithinBounds(const int A,
+                                      const int B,
+                                      const int range)
+    {
+
+        if (range >= 180) return true;
+        if (range <= 0) return false;
+
+        // Map both bearings into positive modulo 360 space
+        const int normalized_B = (B < 0)?(B % 360)+360:(B % 360);
+        const int normalized_A = (A < 0)?(A % 360)+360:(A % 360);
+
+        if (normalized_B - range < 0)
+        {
+            return (normalized_B - range + 360 <= normalized_A && normalized_A < 360) ||
+                   (0 <= normalized_A && normalized_A <= normalized_B + range);
+        }
+        else if (normalized_B + range > 360)
+        {
+            return (normalized_B - range <= normalized_A && normalized_A < 360) ||
+                   (0 <= normalized_A && normalized_A <= normalized_B + range - 360);
+        }
+        else
+        {
+            return normalized_B - range <= normalized_A && normalized_A <= normalized_B + range;
+        }
+    }
+
+
+
     bool IncrementalFindPhantomNodeForCoordinate(
         const FixedPointCoordinate &input_coordinate,
         std::vector<PhantomNode> &result_phantom_node_vector,
         const unsigned max_number_of_phantom_nodes,
+        const int filter_bearing = 0,
+        const int filter_bearing_range = 180,
         const float max_distance = 1100,
         const unsigned max_checked_elements = 4 * LEAF_NODE_SIZE)
     {
@@ -737,9 +782,34 @@ class StaticRTree
                     m_coordinate_list->at(current_segment.v), input_coordinate,
                     projected_coordinate, foot_point_coordinate_on_segment, current_ratio);
 
+                const float forward_edge_bearing = coordinate_calculation::bearing(
+                                m_coordinate_list->at(current_segment.u),
+                                m_coordinate_list->at(current_segment.v));
+
+                const float backward_edge_bearing = (forward_edge_bearing + 180) > 360 
+                                                      ? (forward_edge_bearing - 180) 
+                                                      : (forward_edge_bearing + 180);
+
+                const bool forward_bearing_valid = IsBearingWithinBounds(forward_edge_bearing, filter_bearing, filter_bearing_range);
+                const bool backward_bearing_valid = IsBearingWithinBounds(backward_edge_bearing, filter_bearing, filter_bearing_range);
+
+                if (!forward_bearing_valid && !backward_bearing_valid)
+                {
+                    continue;
+                }
+
                 // store phantom node in result vector
                 result_phantom_node_vector.emplace_back(current_segment,
                                                         foot_point_coordinate_on_segment);
+
+                if (!forward_bearing_valid)
+                {
+                    result_phantom_node_vector.back().forward_node_id = SPECIAL_NODEID;
+                } 
+                else if (!backward_bearing_valid)
+                {
+                    result_phantom_node_vector.back().reverse_node_id = SPECIAL_NODEID;
+                }
 
                 // Hack to fix rounding errors and wandering via nodes.
                 FixUpRoundingIssue(input_coordinate, result_phantom_node_vector.back());
@@ -788,6 +858,8 @@ class StaticRTree
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &result_phantom_node_vector,
         const double max_distance,
+        const int filter_bearing = 0,
+        const int filter_bearing_range = 180,
         const unsigned max_checked_elements = 4 * LEAF_NODE_SIZE)
     {
         unsigned inspected_elements = 0;
@@ -881,6 +953,23 @@ class StaticRTree
                     continue;
                 }
 
+                const float forward_edge_bearing = coordinate_calculation::bearing(
+                                m_coordinate_list->at(current_segment.u),
+                                m_coordinate_list->at(current_segment.v));
+
+                const float backward_edge_bearing = (forward_edge_bearing + 180) > 360 
+                                                      ? (forward_edge_bearing - 180) 
+                                                      : (forward_edge_bearing + 180);
+
+                const bool forward_bearing_valid = IsBearingWithinBounds(forward_edge_bearing, filter_bearing, filter_bearing_range);
+                const bool backward_bearing_valid = IsBearingWithinBounds(backward_edge_bearing, filter_bearing, filter_bearing_range);
+
+                if (!forward_bearing_valid && !backward_bearing_valid)
+                {
+                    // This edge doesn't fall within our bearing filter
+                    continue;
+                }
+
                 // store phantom node in result vector
                 result_phantom_node_vector.emplace_back(
                     PhantomNode(
@@ -892,6 +981,15 @@ class StaticRTree
                         foot_point_coordinate_on_segment, current_segment.fwd_segment_position,
                         current_segment.forward_travel_mode, current_segment.backward_travel_mode),
                     current_perpendicular_distance);
+
+                if (!forward_bearing_valid)
+                {
+                    result_phantom_node_vector.back().first.forward_node_id = SPECIAL_NODEID;
+                }
+                if (!backward_bearing_valid)
+                {
+                    result_phantom_node_vector.back().first.reverse_node_id = SPECIAL_NODEID;
+                }
 
                 // Hack to fix rounding errors and wandering via nodes.
                 FixUpRoundingIssue(input_coordinate, result_phantom_node_vector.back().first);

--- a/include/osrm/route_parameters.hpp
+++ b/include/osrm/route_parameters.hpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <osrm/coordinate.hpp>
 
 #include <boost/fusion/container/vector/vector_fwd.hpp>
+#include <boost/spirit/include/qi.hpp>
 
 #include <string>
 #include <vector>
@@ -71,6 +72,8 @@ struct RouteParameters
 
     void addTimestamp(const unsigned timestamp);
 
+    void addBearing(const int timestamp, boost::spirit::qi::unused_type unused, bool& pass);
+
     void setLanguage(const std::string &language);
 
     void setGeometryFlag(const bool flag);
@@ -99,6 +102,7 @@ struct RouteParameters
     std::string language;
     std::vector<std::string> hints;
     std::vector<unsigned> timestamps;
+    std::vector<int> bearings;
     std::vector<bool> uturns;
     std::vector<FixedPointCoordinate> coordinates;
 };

--- a/plugins/viaroute.hpp
+++ b/plugins/viaroute.hpp
@@ -80,6 +80,13 @@ template <class DataFacadeT> class ViaRoutePlugin final : public BasePlugin
             return 400;
         }
 
+        const auto &input_bearings = route_parameters.bearings;
+        if (input_bearings.size() > 0 && route_parameters.coordinates.size() != input_bearings.size())
+        {
+            json_result.values["status"] = "Number of bearings does not match number of coordinates .";
+            return 400;
+        }
+
         std::vector<phantom_node_pair> phantom_node_pair_list(route_parameters.coordinates.size());
         const bool checksum_OK = (route_parameters.check_sum == facade->GetCheckSum());
 
@@ -96,8 +103,10 @@ template <class DataFacadeT> class ViaRoutePlugin final : public BasePlugin
                 }
             }
             std::vector<PhantomNode> phantom_node_vector;
+            int bearing = input_bearings.size() > 0 ? input_bearings[i] : 0;
+            int range = input_bearings.size() > 0 ? 8 : 180;
             if (facade->IncrementalFindPhantomNodeForCoordinate(route_parameters.coordinates[i],
-                                                                phantom_node_vector, 1))
+                                                                phantom_node_vector, 1, bearing, range))
             {
                 BOOST_ASSERT(!phantom_node_vector.empty());
                 phantom_node_pair_list[i].first = phantom_node_vector.front();

--- a/server/api_grammar.hpp
+++ b/server/api_grammar.hpp
@@ -40,7 +40,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     {
         api_call = qi::lit('/') >> string[boost::bind(&HandlerT::setService, handler, ::_1)] >>
                    *(query) >> -(uturns);
-        query = ('?') >> (+(zoom | output | jsonp | checksum | location | hint | timestamp | u | cmp |
+        query = ('?') >> (+(zoom | output | jsonp | checksum | location | hint | timestamp | bearing | u | cmp |
                             language | instruction | geometry | alt_route | old_API | num_results |
                             matching_beta | gps_precision | classify | locs));
 
@@ -65,6 +65,8 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                stringwithDot[boost::bind(&HandlerT::addHint, handler, ::_1)];
         timestamp = (-qi::lit('&')) >> qi::lit("t") >> '=' >>
                qi::uint_[boost::bind(&HandlerT::addTimestamp, handler, ::_1)];
+        bearing = (-qi::lit('&')) >> qi::lit("b") >> '=' >>
+               qi::int_[boost::bind(&HandlerT::addBearing, handler, ::_1, ::_2, ::_3)];
         u = (-qi::lit('&')) >> qi::lit("u") >> '=' >>
             qi::bool_[boost::bind(&HandlerT::setUTurn, handler, ::_1)];
         uturns = (-qi::lit('&')) >> qi::lit("uturns") >> '=' >>
@@ -95,7 +97,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
 
     qi::rule<Iterator> api_call, query;
     qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location,
-        hint, timestamp, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
+        hint, timestamp, bearing, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
         uturns, old_API, num_results, matching_beta, gps_precision, classify, locs, stringforPolyline;
 
     HandlerT *handler;

--- a/server/data_structures/datafacade_base.hpp
+++ b/server/data_structures/datafacade_base.hpp
@@ -99,7 +99,8 @@ template <class EdgeDataT> class BaseDataFacade
     virtual bool
     IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate &input_coordinate,
                                             std::vector<PhantomNode> &resulting_phantom_node_vector,
-                                            const unsigned number_of_results) = 0;
+                                            const unsigned number_of_results,
+                                            const int bearing = 0, const int bearing_range = 180) = 0;
 
     virtual bool
     IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate &input_coordinate,
@@ -107,7 +108,7 @@ template <class EdgeDataT> class BaseDataFacade
     virtual bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &resulting_phantom_node_vector,
-        const double max_distance) = 0;
+        const double max_distance, const int bearing = 0, const int bearing_range = 180) = 0;
 
     virtual unsigned GetCheckSum() const = 0;
 

--- a/server/data_structures/internal_datafacade.hpp
+++ b/server/data_structures/internal_datafacade.hpp
@@ -388,7 +388,8 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
     bool
     IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate &input_coordinate,
                                             std::vector<PhantomNode> &resulting_phantom_node_vector,
-                                            const unsigned number_of_results) override final
+                                            const unsigned number_of_results,
+                                            const int bearing = 0, const int range = 180) override final
     {
         if (!m_static_rtree.get())
         {
@@ -396,13 +397,15 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
         }
 
         return m_static_rtree->IncrementalFindPhantomNodeForCoordinate(
-            input_coordinate, resulting_phantom_node_vector, number_of_results);
+            input_coordinate, resulting_phantom_node_vector, number_of_results, bearing, range);
     }
 
     bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &resulting_phantom_node_vector,
-        const double max_distance) override final
+        const double max_distance,
+        const int bearing = 0,
+        const int bearing_range = 180) override final
     {
         if (!m_static_rtree.get())
         {
@@ -410,7 +413,7 @@ template <class EdgeDataT> class InternalDataFacade final : public BaseDataFacad
         }
 
         return m_static_rtree->IncrementalFindPhantomNodeForCoordinateWithDistance(
-            input_coordinate, resulting_phantom_node_vector, max_distance);
+            input_coordinate, resulting_phantom_node_vector, max_distance, bearing, bearing_range);
     }
 
     unsigned GetCheckSum() const override final { return m_check_sum; }

--- a/server/data_structures/shared_datafacade.hpp
+++ b/server/data_structures/shared_datafacade.hpp
@@ -409,7 +409,8 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
     bool
     IncrementalFindPhantomNodeForCoordinate(const FixedPointCoordinate &input_coordinate,
                                             std::vector<PhantomNode> &resulting_phantom_node_vector,
-                                            const unsigned number_of_results) override final
+                                            const unsigned number_of_results,
+                                            const int bearing = 0, const int range = 180) override final
     {
         if (!m_static_rtree.get() || CURRENT_TIMESTAMP != m_static_rtree->first)
         {
@@ -417,13 +418,15 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         }
 
         return m_static_rtree->second->IncrementalFindPhantomNodeForCoordinate(
-            input_coordinate, resulting_phantom_node_vector, number_of_results);
+            input_coordinate, resulting_phantom_node_vector, number_of_results, bearing, range);
     }
 
     bool IncrementalFindPhantomNodeForCoordinateWithMaxDistance(
         const FixedPointCoordinate &input_coordinate,
         std::vector<std::pair<PhantomNode, double>> &resulting_phantom_node_vector,
-        const double max_distance) override final
+        const double max_distance,
+        const int bearing = 0,
+        const int bearing_range = 180) override final
     {
         if (!m_static_rtree.get() || CURRENT_TIMESTAMP != m_static_rtree->first)
         {
@@ -431,7 +434,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         }
 
         return m_static_rtree->second->IncrementalFindPhantomNodeForCoordinateWithDistance(
-            input_coordinate, resulting_phantom_node_vector, max_distance);
+            input_coordinate, resulting_phantom_node_vector, max_distance, bearing, bearing_range);
     }
 
     unsigned GetCheckSum() const override final { return m_check_sum; }


### PR DESCRIPTION
This adds a new `b=` parameter to `match` and `viaroute` requests which restricts Nearest Neighbor selection when finding phantom nodes.

If bearing hints are available to the user (i.e. from vehicle GPS traces), this can help get better snapping by not selecting road lanes going in the opposite direction to what was actually being travelled.

The parameter is optional, and if omitted, the current behaviour remains unchanged.

Like the `timestamp` parameter, if present, one `b` parameter is required for each coordinate pair.

The filter limits are currently hard-coded, but could probably be made configurable.  The intent at this stage is mostly to reduce matching edges going opposite to that which is desired, so a fairly broad matching angle is permissible.

The filter is implemented in the StaticRTree, so this could be trivially exposed for `/nearest`, and all other APIs that provide coordinates.