### PR TITLE
Do not use an incomplete type with value semantics

### DIFF
--- a/extractor/restriction_parser.hpp
+++ b/extractor/restriction_parser.hpp
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../data_structures/restriction.hpp"
 
-#include <boost/optional/optional_fwd.hpp>
+#include <boost/optional/optional.hpp>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
> Any of the following contexts requires class T to be complete:
>   - definition or function call to a function with return type T or argument type T; 

Let's wait for Travis on this one!

Reference:

- http://en.cppreference.com/w/cpp/language/type#Incomplete_type