### PR TITLE
Use ccache by default if available and a suitable compiler is used.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,3 +409,13 @@ WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 COMMENT "Generating API documentation with Doxygen" VERBATIM
 )
 endif()
+
+# prefix compilation with ccache by default if available and on clang or gcc
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+  find_program(CCACHE_FOUND ccache)
+  if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    set(ENV{CCACHE_CPP2} "true")
+  endif()
+endif()


### PR DESCRIPTION
This checks if `ccache` is available, and if so uses it.
The user can stil disable it via the ccache env variable, quoting:

    disable (CCACHE_DISABLE) [boolean]
        When true, ccache will just call the real compiler, bypassing the cache completely. The default is false.

At least Clang required `CCACHE_CPP2`.

The user does not have to set up anything, just to install ccache.
Of course, things like the cache's max size, its location and so on can
be configured.

References:

- https://ccache.samba.org/manual.html