### PR TITLE
Conditional memlock

### DIFF
--- a/routed.cpp
+++ b/routed.cpp
@@ -93,7 +93,7 @@ int main(int argc, const char *argv[]) try
     {
         explicit MemoryLocker(bool shouldLock_) : shouldLock(shouldLock_)
         {
-            if (-1 == mlockall(MCL_CURRENT | MCL_FUTURE))
+            if (shouldLock && -1 == mlockall(MCL_CURRENT | MCL_FUTURE))
             {
                 couldLock = false;
                 SimpleLogger().Write(logWARNING) << "memory could not be locked to RAM";
@@ -101,7 +101,7 @@ int main(int argc, const char *argv[]) try
         }
         ~MemoryLocker()
         {
-            if (couldLock)
+            if (shouldLock && couldLock)
                 (void)munlockall();
         }
         bool shouldLock = false, couldLock = true;

--- a/routed.cpp
+++ b/routed.cpp
@@ -104,7 +104,7 @@ int main(int argc, const char *argv[]) try
             if (couldLock)
                 (void)munlockall();
         }
-        bool shouldLock = false, couldLock = false;
+        bool shouldLock = false, couldLock = true;
     } memoryLocker(lib_config.use_shared_memory);
 #endif
     SimpleLogger().Write() << "starting up engines, " << OSRM_VERSION;


### PR DESCRIPTION
Note: the noise comes from the 2nd commit, flattening plus clang-format.

-------------------------------------------------------------------------------

Only lock the virtual address space when shared memory was requested.

In addition, some improvements:

- unlock only when locking succeeded
- scoped exception safe RAII locker

Reference:

- #1698 (comment)