### PR TITLE
Catch `std::bad_alloc` at the top and translate to human readable messages

### DIFF
--- a/datastore.cpp
+++ b/datastore.cpp
@@ -93,360 +93,437 @@ void delete_region(const SharedDataType region)
     }
 }
 
-int main(const int argc, const char *argv[])
+int main(const int argc, const char *argv[]) try
 {
     LogPolicy::GetInstance().Unmute();
     SharedBarriers barrier;
 
-    try
-    {
 #ifdef __linux__
-        // try to disable swapping on Linux
-        const bool lock_flags = MCL_CURRENT | MCL_FUTURE;
-        if (-1 == mlockall(lock_flags))
-        {
-            SimpleLogger().Write(logWARNING) << "Process " << argv[0]
-                                             << " could not request RAM lock";
-        }
-#endif
-        try
-        {
-            boost::interprocess::scoped_lock<boost::interprocess::named_mutex> pending_lock(
-                barrier.pending_update_mutex);
-        }
-        catch (...)
-        {
-            // hard unlock in case of any exception.
-            barrier.pending_update_mutex.unlock();
-        }
-    }
-    catch (const std::exception &e)
+    // try to disable swapping on Linux
+    const bool lock_flags = MCL_CURRENT | MCL_FUTURE;
+    if (-1 == mlockall(lock_flags))
     {
-        SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+        SimpleLogger().Write(logWARNING) << "Process " << argv[0] << " could not request RAM lock";
     }
+#endif
 
     try
     {
-        SimpleLogger().Write(logDEBUG) << "Checking input parameters";
+        boost::interprocess::scoped_lock<boost::interprocess::named_mutex> pending_lock(
+            barrier.pending_update_mutex);
+    }
+    catch (...)
+    {
+        // hard unlock in case of any exception.
+        barrier.pending_update_mutex.unlock();
+    }
 
-        ServerPaths server_paths;
-        if (!GenerateDataStoreOptions(argc, argv, server_paths))
-        {
-            return 0;
-        }
+    SimpleLogger().Write(logDEBUG) << "Checking input parameters";
 
-        if (server_paths.find("hsgrdata") == server_paths.end())
-        {
-            throw osrm::exception("no hsgr file found");
-        }
-        if (server_paths.find("ramindex") == server_paths.end())
-        {
-            throw osrm::exception("no ram index file found");
-        }
-        if (server_paths.find("fileindex") == server_paths.end())
-        {
-            throw osrm::exception("no leaf index file found");
-        }
-        if (server_paths.find("nodesdata") == server_paths.end())
-        {
-            throw osrm::exception("no nodes file found");
-        }
-        if (server_paths.find("edgesdata") == server_paths.end())
-        {
-            throw osrm::exception("no edges file found");
-        }
-        if (server_paths.find("namesdata") == server_paths.end())
-        {
-            throw osrm::exception("no names file found");
-        }
-        if (server_paths.find("geometry") == server_paths.end())
-        {
-            throw osrm::exception("no geometry file found");
-        }
-        if (server_paths.find("core") == server_paths.end())
-        {
-            throw osrm::exception("no core file found");
-        }
+    ServerPaths server_paths;
+    if (!GenerateDataStoreOptions(argc, argv, server_paths))
+    {
+        return 0;
+    }
 
-        ServerPaths::const_iterator paths_iterator = server_paths.find("hsgrdata");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &hsgr_path = paths_iterator->second;
-        paths_iterator = server_paths.find("timestamp");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &timestamp_path = paths_iterator->second;
-        paths_iterator = server_paths.find("ramindex");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &ram_index_path = paths_iterator->second;
-        paths_iterator = server_paths.find("fileindex");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path index_file_path_absolute =
-            boost::filesystem::canonical(paths_iterator->second);
-        const std::string &file_index_path = index_file_path_absolute.string();
-        paths_iterator = server_paths.find("nodesdata");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &nodes_data_path = paths_iterator->second;
-        paths_iterator = server_paths.find("edgesdata");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &edges_data_path = paths_iterator->second;
-        paths_iterator = server_paths.find("namesdata");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &names_data_path = paths_iterator->second;
-        paths_iterator = server_paths.find("geometry");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &geometries_data_path = paths_iterator->second;
-        paths_iterator = server_paths.find("core");
-        BOOST_ASSERT(server_paths.end() != paths_iterator);
-        BOOST_ASSERT(!paths_iterator->second.empty());
-        const boost::filesystem::path &core_marker_path = paths_iterator->second;
+    if (server_paths.find("hsgrdata") == server_paths.end())
+    {
+        throw osrm::exception("no hsgr file found");
+    }
+    if (server_paths.find("ramindex") == server_paths.end())
+    {
+        throw osrm::exception("no ram index file found");
+    }
+    if (server_paths.find("fileindex") == server_paths.end())
+    {
+        throw osrm::exception("no leaf index file found");
+    }
+    if (server_paths.find("nodesdata") == server_paths.end())
+    {
+        throw osrm::exception("no nodes file found");
+    }
+    if (server_paths.find("edgesdata") == server_paths.end())
+    {
+        throw osrm::exception("no edges file found");
+    }
+    if (server_paths.find("namesdata") == server_paths.end())
+    {
+        throw osrm::exception("no names file found");
+    }
+    if (server_paths.find("geometry") == server_paths.end())
+    {
+        throw osrm::exception("no geometry file found");
+    }
+    if (server_paths.find("core") == server_paths.end())
+    {
+        throw osrm::exception("no core file found");
+    }
 
-        // determine segment to use
-        bool segment2_in_use = SharedMemory::RegionExists(LAYOUT_2);
-        const SharedDataType layout_region = [&]
-        {
-            return segment2_in_use ? LAYOUT_1 : LAYOUT_2;
-        }();
-        const SharedDataType data_region = [&]
-        {
-            return segment2_in_use ? DATA_1 : DATA_2;
-        }();
-        const SharedDataType previous_layout_region = [&]
-        {
-            return segment2_in_use ? LAYOUT_2 : LAYOUT_1;
-        }();
-        const SharedDataType previous_data_region = [&]
-        {
-            return segment2_in_use ? DATA_2 : DATA_1;
-        }();
+    ServerPaths::const_iterator paths_iterator = server_paths.find("hsgrdata");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &hsgr_path = paths_iterator->second;
+    paths_iterator = server_paths.find("timestamp");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &timestamp_path = paths_iterator->second;
+    paths_iterator = server_paths.find("ramindex");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &ram_index_path = paths_iterator->second;
+    paths_iterator = server_paths.find("fileindex");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path index_file_path_absolute =
+        boost::filesystem::canonical(paths_iterator->second);
+    const std::string &file_index_path = index_file_path_absolute.string();
+    paths_iterator = server_paths.find("nodesdata");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &nodes_data_path = paths_iterator->second;
+    paths_iterator = server_paths.find("edgesdata");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &edges_data_path = paths_iterator->second;
+    paths_iterator = server_paths.find("namesdata");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &names_data_path = paths_iterator->second;
+    paths_iterator = server_paths.find("geometry");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &geometries_data_path = paths_iterator->second;
+    paths_iterator = server_paths.find("core");
+    BOOST_ASSERT(server_paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &core_marker_path = paths_iterator->second;
 
-        // Allocate a memory layout in shared memory, deallocate previous
-        SharedMemory *layout_memory =
-            SharedMemoryFactory::Get(layout_region, sizeof(SharedDataLayout));
-        SharedDataLayout *shared_layout_ptr = new (layout_memory->Ptr()) SharedDataLayout();
+    // determine segment to use
+    bool segment2_in_use = SharedMemory::RegionExists(LAYOUT_2);
+    const SharedDataType layout_region = [&]
+    {
+        return segment2_in_use ? LAYOUT_1 : LAYOUT_2;
+    }();
+    const SharedDataType data_region = [&]
+    {
+        return segment2_in_use ? DATA_1 : DATA_2;
+    }();
+    const SharedDataType previous_layout_region = [&]
+    {
+        return segment2_in_use ? LAYOUT_2 : LAYOUT_1;
+    }();
+    const SharedDataType previous_data_region = [&]
+    {
+        return segment2_in_use ? DATA_2 : DATA_1;
+    }();
 
-        shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::FILE_INDEX_PATH,
-                                              file_index_path.length() + 1);
+    // Allocate a memory layout in shared memory, deallocate previous
+    SharedMemory *layout_memory = SharedMemoryFactory::Get(layout_region, sizeof(SharedDataLayout));
+    SharedDataLayout *shared_layout_ptr = new (layout_memory->Ptr()) SharedDataLayout();
 
-        // collect number of elements to store in shared memory object
-        SimpleLogger().Write() << "load names from: " << names_data_path;
-        // number of entries in name index
-        boost::filesystem::ifstream name_stream(names_data_path, std::ios::binary);
-        unsigned name_blocks = 0;
-        name_stream.read((char *)&name_blocks, sizeof(unsigned));
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::NAME_OFFSETS, name_blocks);
-        shared_layout_ptr->SetBlockSize<typename RangeTable<16, true>::BlockT>(
-            SharedDataLayout::NAME_BLOCKS, name_blocks);
-        SimpleLogger().Write() << "name offsets size: " << name_blocks;
-        BOOST_ASSERT_MSG(0 != name_blocks, "name file broken");
+    shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::FILE_INDEX_PATH,
+                                          file_index_path.length() + 1);
 
-        unsigned number_of_chars = 0;
-        name_stream.read((char *)&number_of_chars, sizeof(unsigned));
-        shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::NAME_CHAR_LIST, number_of_chars);
+    // collect number of elements to store in shared memory object
+    SimpleLogger().Write() << "load names from: " << names_data_path;
+    // number of entries in name index
+    boost::filesystem::ifstream name_stream(names_data_path, std::ios::binary);
+    unsigned name_blocks = 0;
+    name_stream.read((char *)&name_blocks, sizeof(unsigned));
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::NAME_OFFSETS, name_blocks);
+    shared_layout_ptr->SetBlockSize<typename RangeTable<16, true>::BlockT>(
+        SharedDataLayout::NAME_BLOCKS, name_blocks);
+    SimpleLogger().Write() << "name offsets size: " << name_blocks;
+    BOOST_ASSERT_MSG(0 != name_blocks, "name file broken");
 
-        // Loading information for original edges
-        boost::filesystem::ifstream edges_input_stream(edges_data_path, std::ios::binary);
-        unsigned number_of_original_edges = 0;
-        edges_input_stream.read((char *)&number_of_original_edges, sizeof(unsigned));
+    unsigned number_of_chars = 0;
+    name_stream.read((char *)&number_of_chars, sizeof(unsigned));
+    shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::NAME_CHAR_LIST, number_of_chars);
 
-        // note: settings this all to the same size is correct, we extract them from the same struct
-        shared_layout_ptr->SetBlockSize<NodeID>(SharedDataLayout::VIA_NODE_LIST,
+    // Loading information for original edges
+    boost::filesystem::ifstream edges_input_stream(edges_data_path, std::ios::binary);
+    unsigned number_of_original_edges = 0;
+    edges_input_stream.read((char *)&number_of_original_edges, sizeof(unsigned));
+
+    // note: settings this all to the same size is correct, we extract them from the same struct
+    shared_layout_ptr->SetBlockSize<NodeID>(SharedDataLayout::VIA_NODE_LIST,
+                                            number_of_original_edges);
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::NAME_ID_LIST,
+                                              number_of_original_edges);
+    shared_layout_ptr->SetBlockSize<TravelMode>(SharedDataLayout::TRAVEL_MODE,
                                                 number_of_original_edges);
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::NAME_ID_LIST,
-                                                  number_of_original_edges);
-        shared_layout_ptr->SetBlockSize<TravelMode>(SharedDataLayout::TRAVEL_MODE,
-                                                    number_of_original_edges);
-        shared_layout_ptr->SetBlockSize<TurnInstruction>(SharedDataLayout::TURN_INSTRUCTION,
-                                                         number_of_original_edges);
-        // note: there are 32 geometry indicators in one unsigned block
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_INDICATORS,
-                                                  number_of_original_edges);
+    shared_layout_ptr->SetBlockSize<TurnInstruction>(SharedDataLayout::TURN_INSTRUCTION,
+                                                     number_of_original_edges);
+    // note: there are 32 geometry indicators in one unsigned block
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_INDICATORS,
+                                              number_of_original_edges);
 
-        boost::filesystem::ifstream hsgr_input_stream(hsgr_path, std::ios::binary);
+    boost::filesystem::ifstream hsgr_input_stream(hsgr_path, std::ios::binary);
 
-        FingerPrint fingerprint_valid = FingerPrint::GetValid();
-        FingerPrint fingerprint_loaded;
-        hsgr_input_stream.read((char *)&fingerprint_loaded, sizeof(FingerPrint));
-        if (fingerprint_loaded.TestGraphUtil(fingerprint_valid))
+    FingerPrint fingerprint_valid = FingerPrint::GetValid();
+    FingerPrint fingerprint_loaded;
+    hsgr_input_stream.read((char *)&fingerprint_loaded, sizeof(FingerPrint));
+    if (fingerprint_loaded.TestGraphUtil(fingerprint_valid))
+    {
+        SimpleLogger().Write(logDEBUG) << "Fingerprint checked out ok";
+    }
+    else
+    {
+        SimpleLogger().Write(logWARNING) << ".hsgr was prepared with different build. "
+                                            "Reprocess to get rid of this warning.";
+    }
+
+    // load checksum
+    unsigned checksum = 0;
+    hsgr_input_stream.read((char *)&checksum, sizeof(unsigned));
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::HSGR_CHECKSUM, 1);
+    // load graph node size
+    unsigned number_of_graph_nodes = 0;
+    hsgr_input_stream.read((char *)&number_of_graph_nodes, sizeof(unsigned));
+
+    BOOST_ASSERT_MSG((0 != number_of_graph_nodes), "number of nodes is zero");
+    shared_layout_ptr->SetBlockSize<QueryGraph::NodeArrayEntry>(SharedDataLayout::GRAPH_NODE_LIST,
+                                                                number_of_graph_nodes);
+
+    // load graph edge size
+    unsigned number_of_graph_edges = 0;
+    hsgr_input_stream.read((char *)&number_of_graph_edges, sizeof(unsigned));
+    // BOOST_ASSERT_MSG(0 != number_of_graph_edges, "number of graph edges is zero");
+    shared_layout_ptr->SetBlockSize<QueryGraph::EdgeArrayEntry>(SharedDataLayout::GRAPH_EDGE_LIST,
+                                                                number_of_graph_edges);
+
+    // load rsearch tree size
+    boost::filesystem::ifstream tree_node_file(ram_index_path, std::ios::binary);
+
+    uint32_t tree_size = 0;
+    tree_node_file.read((char *)&tree_size, sizeof(uint32_t));
+    shared_layout_ptr->SetBlockSize<RTreeNode>(SharedDataLayout::R_SEARCH_TREE, tree_size);
+
+    // load timestamp size
+    std::string m_timestamp;
+    if (boost::filesystem::exists(timestamp_path))
+    {
+        boost::filesystem::ifstream timestamp_stream(timestamp_path);
+        if (!timestamp_stream)
         {
-            SimpleLogger().Write(logDEBUG) << "Fingerprint checked out ok";
+            SimpleLogger().Write(logWARNING) << timestamp_path << " not found. setting to default";
         }
         else
         {
-            SimpleLogger().Write(logWARNING) << ".hsgr was prepared with different build. "
-                                                "Reprocess to get rid of this warning.";
+            getline(timestamp_stream, m_timestamp);
+            timestamp_stream.close();
         }
+    }
+    if (m_timestamp.empty())
+    {
+        m_timestamp = "n/a";
+    }
+    if (25 < m_timestamp.length())
+    {
+        m_timestamp.resize(25);
+    }
+    shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::TIMESTAMP, m_timestamp.length());
 
-        // load checksum
-        unsigned checksum = 0;
-        hsgr_input_stream.read((char *)&checksum, sizeof(unsigned));
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::HSGR_CHECKSUM, 1);
-        // load graph node size
-        unsigned number_of_graph_nodes = 0;
-        hsgr_input_stream.read((char *)&number_of_graph_nodes, sizeof(unsigned));
+    // load core marker size
+    boost::filesystem::ifstream core_marker_file(core_marker_path, std::ios::binary);
 
-        BOOST_ASSERT_MSG((0 != number_of_graph_nodes), "number of nodes is zero");
-        shared_layout_ptr->SetBlockSize<QueryGraph::NodeArrayEntry>(
-            SharedDataLayout::GRAPH_NODE_LIST, number_of_graph_nodes);
+    uint32_t number_of_core_markers = 0;
+    core_marker_file.read((char *)&number_of_core_markers, sizeof(uint32_t));
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::CORE_MARKER,
+                                              number_of_core_markers);
 
-        // load graph edge size
-        unsigned number_of_graph_edges = 0;
-        hsgr_input_stream.read((char *)&number_of_graph_edges, sizeof(unsigned));
-        // BOOST_ASSERT_MSG(0 != number_of_graph_edges, "number of graph edges is zero");
-        shared_layout_ptr->SetBlockSize<QueryGraph::EdgeArrayEntry>(
-            SharedDataLayout::GRAPH_EDGE_LIST, number_of_graph_edges);
+    // load coordinate size
+    boost::filesystem::ifstream nodes_input_stream(nodes_data_path, std::ios::binary);
+    unsigned coordinate_list_size = 0;
+    nodes_input_stream.read((char *)&coordinate_list_size, sizeof(unsigned));
+    shared_layout_ptr->SetBlockSize<FixedPointCoordinate>(SharedDataLayout::COORDINATE_LIST,
+                                                          coordinate_list_size);
 
-        // load rsearch tree size
-        boost::filesystem::ifstream tree_node_file(ram_index_path, std::ios::binary);
+    // load geometries sizes
+    std::ifstream geometry_input_stream(geometries_data_path.string().c_str(), std::ios::binary);
+    unsigned number_of_geometries_indices = 0;
+    unsigned number_of_compressed_geometries = 0;
 
-        uint32_t tree_size = 0;
-        tree_node_file.read((char *)&tree_size, sizeof(uint32_t));
-        shared_layout_ptr->SetBlockSize<RTreeNode>(SharedDataLayout::R_SEARCH_TREE, tree_size);
+    geometry_input_stream.read((char *)&number_of_geometries_indices, sizeof(unsigned));
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_INDEX,
+                                              number_of_geometries_indices);
+    boost::iostreams::seek(geometry_input_stream, number_of_geometries_indices * sizeof(unsigned),
+                           BOOST_IOS::cur);
+    geometry_input_stream.read((char *)&number_of_compressed_geometries, sizeof(unsigned));
+    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_LIST,
+                                              number_of_compressed_geometries);
+    // allocate shared memory block
+    SimpleLogger().Write() << "allocating shared memory of " << shared_layout_ptr->GetSizeOfLayout()
+                           << " bytes";
+    SharedMemory *shared_memory =
+        SharedMemoryFactory::Get(data_region, shared_layout_ptr->GetSizeOfLayout());
+    char *shared_memory_ptr = static_cast<char *>(shared_memory->Ptr());
 
-        // load timestamp size
-        std::string m_timestamp;
-        if (boost::filesystem::exists(timestamp_path))
+    // read actual data into shared memory object //
+
+    // hsgr checksum
+    unsigned *checksum_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::HSGR_CHECKSUM);
+    *checksum_ptr = checksum;
+
+    // ram index file name
+    char *file_index_path_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
+        shared_memory_ptr, SharedDataLayout::FILE_INDEX_PATH);
+    // make sure we have 0 ending
+    std::fill(file_index_path_ptr,
+              file_index_path_ptr +
+                  shared_layout_ptr->GetBlockSize(SharedDataLayout::FILE_INDEX_PATH),
+              0);
+    std::copy(file_index_path.begin(), file_index_path.end(), file_index_path_ptr);
+
+    // Loading street names
+    unsigned *name_offsets_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::NAME_OFFSETS);
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_OFFSETS) > 0)
+    {
+        name_stream.read((char *)name_offsets_ptr,
+                         shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_OFFSETS));
+    }
+
+    unsigned *name_blocks_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::NAME_BLOCKS);
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_BLOCKS) > 0)
+    {
+        name_stream.read((char *)name_blocks_ptr,
+                         shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_BLOCKS));
+    }
+
+    char *name_char_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
+        shared_memory_ptr, SharedDataLayout::NAME_CHAR_LIST);
+    unsigned temp_length;
+    name_stream.read((char *)&temp_length, sizeof(unsigned));
+
+    BOOST_ASSERT_MSG(temp_length ==
+                         shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_CHAR_LIST),
+                     "Name file corrupted!");
+
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_CHAR_LIST) > 0)
+    {
+        name_stream.read(name_char_ptr,
+                         shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_CHAR_LIST));
+    }
+
+    name_stream.close();
+
+    // load original edge information
+    NodeID *via_node_ptr = shared_layout_ptr->GetBlockPtr<NodeID, true>(
+        shared_memory_ptr, SharedDataLayout::VIA_NODE_LIST);
+
+    unsigned *name_id_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::NAME_ID_LIST);
+
+    TravelMode *travel_mode_ptr = shared_layout_ptr->GetBlockPtr<TravelMode, true>(
+        shared_memory_ptr, SharedDataLayout::TRAVEL_MODE);
+
+    TurnInstruction *turn_instructions_ptr = shared_layout_ptr->GetBlockPtr<TurnInstruction, true>(
+        shared_memory_ptr, SharedDataLayout::TURN_INSTRUCTION);
+
+    unsigned *geometries_indicator_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::GEOMETRIES_INDICATORS);
+
+    OriginalEdgeData current_edge_data;
+    for (unsigned i = 0; i < number_of_original_edges; ++i)
+    {
+        edges_input_stream.read((char *)&(current_edge_data), sizeof(OriginalEdgeData));
+        via_node_ptr[i] = current_edge_data.via_node;
+        name_id_ptr[i] = current_edge_data.name_id;
+        travel_mode_ptr[i] = current_edge_data.travel_mode;
+        turn_instructions_ptr[i] = current_edge_data.turn_instruction;
+
+        const unsigned bucket = i / 32;
+        const unsigned offset = i % 32;
+        const unsigned value = [&]
         {
-            boost::filesystem::ifstream timestamp_stream(timestamp_path);
-            if (!timestamp_stream)
+            unsigned return_value = 0;
+            if (0 != offset)
             {
-                SimpleLogger().Write(logWARNING) << timestamp_path
-                                                 << " not found. setting to default";
+                return_value = geometries_indicator_ptr[bucket];
             }
-            else
-            {
-                getline(timestamp_stream, m_timestamp);
-                timestamp_stream.close();
-            }
-        }
-        if (m_timestamp.empty())
+            return return_value;
+        }();
+        if (current_edge_data.compressed_geometry)
         {
-            m_timestamp = "n/a";
+            geometries_indicator_ptr[bucket] = (value | (1 << offset));
         }
-        if (25 < m_timestamp.length())
+    }
+    edges_input_stream.close();
+
+    // load compressed geometry
+    unsigned temporary_value;
+    unsigned *geometries_index_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::GEOMETRIES_INDEX);
+    geometry_input_stream.seekg(0, geometry_input_stream.beg);
+    geometry_input_stream.read((char *)&temporary_value, sizeof(unsigned));
+    BOOST_ASSERT(temporary_value ==
+                 shared_layout_ptr->num_entries[SharedDataLayout::GEOMETRIES_INDEX]);
+
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_INDEX) > 0)
+    {
+        geometry_input_stream.read(
+            (char *)geometries_index_ptr,
+            shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_INDEX));
+    }
+    unsigned *geometries_list_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::GEOMETRIES_LIST);
+
+    geometry_input_stream.read((char *)&temporary_value, sizeof(unsigned));
+    BOOST_ASSERT(temporary_value ==
+                 shared_layout_ptr->num_entries[SharedDataLayout::GEOMETRIES_LIST]);
+
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_LIST) > 0)
+    {
+        geometry_input_stream.read(
+            (char *)geometries_list_ptr,
+            shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_LIST));
+    }
+
+    // Loading list of coordinates
+    FixedPointCoordinate *coordinates_ptr =
+        shared_layout_ptr->GetBlockPtr<FixedPointCoordinate, true>(
+            shared_memory_ptr, SharedDataLayout::COORDINATE_LIST);
+
+    QueryNode current_node;
+    for (unsigned i = 0; i < coordinate_list_size; ++i)
+    {
+        nodes_input_stream.read((char *)&current_node, sizeof(QueryNode));
+        coordinates_ptr[i] = FixedPointCoordinate(current_node.lat, current_node.lon);
+    }
+    nodes_input_stream.close();
+
+    // store timestamp
+    char *timestamp_ptr =
+        shared_layout_ptr->GetBlockPtr<char, true>(shared_memory_ptr, SharedDataLayout::TIMESTAMP);
+    std::copy(m_timestamp.c_str(), m_timestamp.c_str() + m_timestamp.length(), timestamp_ptr);
+
+    // store search tree portion of rtree
+    char *rtree_ptr = shared_layout_ptr->GetBlockPtr<char, true>(shared_memory_ptr,
+                                                                 SharedDataLayout::R_SEARCH_TREE);
+
+    if (tree_size > 0)
+    {
+        tree_node_file.read(rtree_ptr, sizeof(RTreeNode) * tree_size);
+    }
+    tree_node_file.close();
+
+    // load core markers
+    std::vector<char> unpacked_core_markers(number_of_core_markers);
+    core_marker_file.read((char *)unpacked_core_markers.data(),
+                          sizeof(char) * number_of_core_markers);
+
+    unsigned *core_marker_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+        shared_memory_ptr, SharedDataLayout::CORE_MARKER);
+
+    for (auto i = 0u; i < number_of_core_markers; ++i)
+    {
+        BOOST_ASSERT(unpacked_core_markers[i] == 0 || unpacked_core_markers[i] == 1);
+
+        if (unpacked_core_markers[i] == 1)
         {
-            m_timestamp.resize(25);
-        }
-        shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::TIMESTAMP, m_timestamp.length());
-
-        // load core marker size
-        boost::filesystem::ifstream core_marker_file(core_marker_path, std::ios::binary);
-
-        uint32_t number_of_core_markers = 0;
-        core_marker_file.read((char *)&number_of_core_markers, sizeof(uint32_t));
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::CORE_MARKER, number_of_core_markers);
-
-        // load coordinate size
-        boost::filesystem::ifstream nodes_input_stream(nodes_data_path, std::ios::binary);
-        unsigned coordinate_list_size = 0;
-        nodes_input_stream.read((char *)&coordinate_list_size, sizeof(unsigned));
-        shared_layout_ptr->SetBlockSize<FixedPointCoordinate>(SharedDataLayout::COORDINATE_LIST,
-                                                              coordinate_list_size);
-
-        // load geometries sizes
-        std::ifstream geometry_input_stream(geometries_data_path.string().c_str(),
-                                            std::ios::binary);
-        unsigned number_of_geometries_indices = 0;
-        unsigned number_of_compressed_geometries = 0;
-
-        geometry_input_stream.read((char *)&number_of_geometries_indices, sizeof(unsigned));
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_INDEX,
-                                                  number_of_geometries_indices);
-        boost::iostreams::seek(geometry_input_stream,
-                               number_of_geometries_indices * sizeof(unsigned), BOOST_IOS::cur);
-        geometry_input_stream.read((char *)&number_of_compressed_geometries, sizeof(unsigned));
-        shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_LIST,
-                                                  number_of_compressed_geometries);
-        // allocate shared memory block
-        SimpleLogger().Write() << "allocating shared memory of "
-                               << shared_layout_ptr->GetSizeOfLayout() << " bytes";
-        SharedMemory *shared_memory =
-            SharedMemoryFactory::Get(data_region, shared_layout_ptr->GetSizeOfLayout());
-        char *shared_memory_ptr = static_cast<char *>(shared_memory->Ptr());
-
-        // read actual data into shared memory object //
-
-        // hsgr checksum
-        unsigned *checksum_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::HSGR_CHECKSUM);
-        *checksum_ptr = checksum;
-
-        // ram index file name
-        char *file_index_path_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
-            shared_memory_ptr, SharedDataLayout::FILE_INDEX_PATH);
-        // make sure we have 0 ending
-        std::fill(file_index_path_ptr,
-                  file_index_path_ptr +
-                      shared_layout_ptr->GetBlockSize(SharedDataLayout::FILE_INDEX_PATH),
-                  0);
-        std::copy(file_index_path.begin(), file_index_path.end(), file_index_path_ptr);
-
-        // Loading street names
-        unsigned *name_offsets_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::NAME_OFFSETS);
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_OFFSETS) > 0)
-        {
-            name_stream.read((char *)name_offsets_ptr,
-                             shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_OFFSETS));
-        }
-
-        unsigned *name_blocks_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::NAME_BLOCKS);
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_BLOCKS) > 0)
-        {
-            name_stream.read((char *)name_blocks_ptr,
-                             shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_BLOCKS));
-        }
-
-        char *name_char_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
-            shared_memory_ptr, SharedDataLayout::NAME_CHAR_LIST);
-        unsigned temp_length;
-        name_stream.read((char *)&temp_length, sizeof(unsigned));
-
-        BOOST_ASSERT_MSG(temp_length ==
-                             shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_CHAR_LIST),
-                         "Name file corrupted!");
-
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_CHAR_LIST) > 0)
-        {
-            name_stream.read(name_char_ptr,
-                             shared_layout_ptr->GetBlockSize(SharedDataLayout::NAME_CHAR_LIST));
-        }
-
-        name_stream.close();
-
-        // load original edge information
-        NodeID *via_node_ptr = shared_layout_ptr->GetBlockPtr<NodeID, true>(
-            shared_memory_ptr, SharedDataLayout::VIA_NODE_LIST);
-
-        unsigned *name_id_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::NAME_ID_LIST);
-
-        TravelMode *travel_mode_ptr = shared_layout_ptr->GetBlockPtr<TravelMode, true>(
-            shared_memory_ptr, SharedDataLayout::TRAVEL_MODE);
-
-        TurnInstruction *turn_instructions_ptr =
-            shared_layout_ptr->GetBlockPtr<TurnInstruction, true>(
-                shared_memory_ptr, SharedDataLayout::TURN_INSTRUCTION);
-
-        unsigned *geometries_indicator_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::GEOMETRIES_INDICATORS);
-
-        OriginalEdgeData current_edge_data;
-        for (unsigned i = 0; i < number_of_original_edges; ++i)
-        {
-            edges_input_stream.read((char *)&(current_edge_data), sizeof(OriginalEdgeData));
-            via_node_ptr[i] = current_edge_data.via_node;
-            name_id_ptr[i] = current_edge_data.name_id;
-            travel_mode_ptr[i] = current_edge_data.travel_mode;
-            turn_instructions_ptr[i] = current_edge_data.turn_instruction;
-
             const unsigned bucket = i / 32;
             const unsigned offset = i % 32;
             const unsigned value = [&]
@@ -454,154 +531,61 @@ int main(const int argc, const char *argv[])
                 unsigned return_value = 0;
                 if (0 != offset)
                 {
-                    return_value = geometries_indicator_ptr[bucket];
+                    return_value = core_marker_ptr[bucket];
                 }
                 return return_value;
             }();
-            if (current_edge_data.compressed_geometry)
-            {
-                geometries_indicator_ptr[bucket] = (value | (1 << offset));
-            }
+
+            core_marker_ptr[bucket] = (value | (1 << offset));
         }
-        edges_input_stream.close();
-
-        // load compressed geometry
-        unsigned temporary_value;
-        unsigned *geometries_index_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::GEOMETRIES_INDEX);
-        geometry_input_stream.seekg(0, geometry_input_stream.beg);
-        geometry_input_stream.read((char *)&temporary_value, sizeof(unsigned));
-        BOOST_ASSERT(temporary_value ==
-                     shared_layout_ptr->num_entries[SharedDataLayout::GEOMETRIES_INDEX]);
-
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_INDEX) > 0)
-        {
-            geometry_input_stream.read(
-                (char *)geometries_index_ptr,
-                shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_INDEX));
-        }
-        unsigned *geometries_list_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::GEOMETRIES_LIST);
-
-        geometry_input_stream.read((char *)&temporary_value, sizeof(unsigned));
-        BOOST_ASSERT(temporary_value ==
-                     shared_layout_ptr->num_entries[SharedDataLayout::GEOMETRIES_LIST]);
-
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_LIST) > 0)
-        {
-            geometry_input_stream.read(
-                (char *)geometries_list_ptr,
-                shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_LIST));
-        }
-
-        // Loading list of coordinates
-        FixedPointCoordinate *coordinates_ptr =
-            shared_layout_ptr->GetBlockPtr<FixedPointCoordinate, true>(
-                shared_memory_ptr, SharedDataLayout::COORDINATE_LIST);
-
-        QueryNode current_node;
-        for (unsigned i = 0; i < coordinate_list_size; ++i)
-        {
-            nodes_input_stream.read((char *)&current_node, sizeof(QueryNode));
-            coordinates_ptr[i] = FixedPointCoordinate(current_node.lat, current_node.lon);
-        }
-        nodes_input_stream.close();
-
-        // store timestamp
-        char *timestamp_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
-            shared_memory_ptr, SharedDataLayout::TIMESTAMP);
-        std::copy(m_timestamp.c_str(), m_timestamp.c_str() + m_timestamp.length(), timestamp_ptr);
-
-        // store search tree portion of rtree
-        char *rtree_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
-            shared_memory_ptr, SharedDataLayout::R_SEARCH_TREE);
-
-        if (tree_size > 0)
-        {
-            tree_node_file.read(rtree_ptr, sizeof(RTreeNode) * tree_size);
-        }
-        tree_node_file.close();
-
-        // load core markers
-        std::vector<char> unpacked_core_markers(number_of_core_markers);
-        core_marker_file.read((char *)unpacked_core_markers.data(), sizeof(char)*number_of_core_markers);
-
-        unsigned *core_marker_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
-            shared_memory_ptr, SharedDataLayout::CORE_MARKER);
-
-        for (auto i = 0u; i < number_of_core_markers; ++i)
-        {
-            BOOST_ASSERT(unpacked_core_markers[i] == 0 || unpacked_core_markers[i] == 1);
-
-            if (unpacked_core_markers[i] == 1)
-            {
-                const unsigned bucket = i / 32;
-                const unsigned offset = i % 32;
-                const unsigned value = [&]
-                {
-                    unsigned return_value = 0;
-                    if (0 != offset)
-                    {
-                        return_value = core_marker_ptr[bucket];
-                    }
-                    return return_value;
-                }();
-
-                core_marker_ptr[bucket] = (value | (1 << offset));
-            }
-        }
-
-        // load the nodes of the search graph
-        QueryGraph::NodeArrayEntry *graph_node_list_ptr =
-            shared_layout_ptr->GetBlockPtr<QueryGraph::NodeArrayEntry, true>(
-                shared_memory_ptr, SharedDataLayout::GRAPH_NODE_LIST);
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_NODE_LIST) > 0)
-        {
-            hsgr_input_stream.read(
-                (char *)graph_node_list_ptr,
-                shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_NODE_LIST));
-        }
-
-        // load the edges of the search graph
-        QueryGraph::EdgeArrayEntry *graph_edge_list_ptr =
-            shared_layout_ptr->GetBlockPtr<QueryGraph::EdgeArrayEntry, true>(
-                shared_memory_ptr, SharedDataLayout::GRAPH_EDGE_LIST);
-        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_EDGE_LIST) > 0)
-        {
-            hsgr_input_stream.read(
-                (char *)graph_edge_list_ptr,
-                shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_EDGE_LIST));
-        }
-        hsgr_input_stream.close();
-
-        // acquire lock
-        SharedMemory *data_type_memory =
-            SharedMemoryFactory::Get(CURRENT_REGIONS, sizeof(SharedDataTimestamp), true, false);
-        SharedDataTimestamp *data_timestamp_ptr =
-            static_cast<SharedDataTimestamp *>(data_type_memory->Ptr());
-
-        boost::interprocess::scoped_lock<boost::interprocess::named_mutex> query_lock(
-            barrier.query_mutex);
-
-        // notify all processes that were waiting for this condition
-        if (0 < barrier.number_of_queries)
-        {
-            barrier.no_running_queries_condition.wait(query_lock);
-        }
-
-        data_timestamp_ptr->layout = layout_region;
-        data_timestamp_ptr->data = data_region;
-        data_timestamp_ptr->timestamp += 1;
-        delete_region(previous_data_region);
-        delete_region(previous_layout_region);
-        SimpleLogger().Write() << "all data loaded";
-
-        shared_layout_ptr->PrintInformation();
     }
-    catch (const std::exception &e)
+
+    // load the nodes of the search graph
+    QueryGraph::NodeArrayEntry *graph_node_list_ptr =
+        shared_layout_ptr->GetBlockPtr<QueryGraph::NodeArrayEntry, true>(
+            shared_memory_ptr, SharedDataLayout::GRAPH_NODE_LIST);
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_NODE_LIST) > 0)
     {
-        SimpleLogger().Write(logWARNING) << "caught exception: " << e.what();
+        hsgr_input_stream.read((char *)graph_node_list_ptr,
+                               shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_NODE_LIST));
     }
 
-    return 0;
+    // load the edges of the search graph
+    QueryGraph::EdgeArrayEntry *graph_edge_list_ptr =
+        shared_layout_ptr->GetBlockPtr<QueryGraph::EdgeArrayEntry, true>(
+            shared_memory_ptr, SharedDataLayout::GRAPH_EDGE_LIST);
+    if (shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_EDGE_LIST) > 0)
+    {
+        hsgr_input_stream.read((char *)graph_edge_list_ptr,
+                               shared_layout_ptr->GetBlockSize(SharedDataLayout::GRAPH_EDGE_LIST));
+    }
+    hsgr_input_stream.close();
+
+    // acquire lock
+    SharedMemory *data_type_memory =
+        SharedMemoryFactory::Get(CURRENT_REGIONS, sizeof(SharedDataTimestamp), true, false);
+    SharedDataTimestamp *data_timestamp_ptr =
+        static_cast<SharedDataTimestamp *>(data_type_memory->Ptr());
+
+    boost::interprocess::scoped_lock<boost::interprocess::named_mutex> query_lock(
+        barrier.query_mutex);
+
+    // notify all processes that were waiting for this condition
+    if (0 < barrier.number_of_queries)
+    {
+        barrier.no_running_queries_condition.wait(query_lock);
+    }
+
+    data_timestamp_ptr->layout = layout_region;
+    data_timestamp_ptr->data = data_region;
+    data_timestamp_ptr->timestamp += 1;
+    delete_region(previous_data_region);
+    delete_region(previous_layout_region);
+    SimpleLogger().Write() << "all data loaded";
+
+    shared_layout_ptr->PrintInformation();
+}
+catch (const std::exception &e)
+{
+    SimpleLogger().Write(logWARNING) << "caught exception: " << e.what();
 }

--- a/datastore.cpp
+++ b/datastore.cpp
@@ -62,6 +62,7 @@ using QueryGraph = StaticGraph<QueryEdge::EdgeData>;
 
 #include <fstream>
 #include <string>
+#include <new>
 
 // delete a shared memory region. report warning if it could not be deleted
 void delete_region(const SharedDataType region)
@@ -123,7 +124,7 @@ int main(const int argc, const char *argv[]) try
     ServerPaths server_paths;
     if (!GenerateDataStoreOptions(argc, argv, server_paths))
     {
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     if (server_paths.find("hsgrdata") == server_paths.end())
@@ -584,6 +585,13 @@ int main(const int argc, const char *argv[]) try
     SimpleLogger().Write() << "all data loaded";
 
     shared_layout_ptr->PrintInformation();
+}
+catch (const std::bad_alloc &e)
+{
+    SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+    SimpleLogger().Write(logWARNING) << "Please provide more memory or disable locking the virtual "
+                                        "address space (note: this makes OSRM swap, i.e. slow)";
+    return EXIT_FAILURE;
 }
 catch (const std::exception &e)
 {

--- a/extract.cpp
+++ b/extract.cpp
@@ -31,53 +31,51 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/filesystem.hpp>
 
+#include <cstdlib>
 #include <exception>
 
-int main(int argc, char *argv[])
+int main(int argc, char *argv[]) try
 {
-    try
+    LogPolicy::GetInstance().Unmute();
+    ExtractorConfig extractor_config;
+
+    const return_code result = ExtractorOptions::ParseArguments(argc, argv, extractor_config);
+
+    if (return_code::fail == result)
     {
-        LogPolicy::GetInstance().Unmute();
-        ExtractorConfig extractor_config;
-
-        const return_code result = ExtractorOptions::ParseArguments(argc, argv, extractor_config);
-
-        if (return_code::fail == result)
-        {
-            return 1;
-        }
-
-        if (return_code::exit == result)
-        {
-            return 0;
-        }
-
-        ExtractorOptions::GenerateOutputFilesNames(extractor_config);
-
-        if (1 > extractor_config.requested_num_threads)
-        {
-            SimpleLogger().Write(logWARNING) << "Number of threads must be 1 or larger";
-            return 1;
-        }
-
-        if (!boost::filesystem::is_regular_file(extractor_config.input_path))
-        {
-            SimpleLogger().Write(logWARNING)
-                << "Input file " << extractor_config.input_path.string() << " not found!";
-            return 1;
-        }
-
-        if (!boost::filesystem::is_regular_file(extractor_config.profile_path))
-        {
-            SimpleLogger().Write(logWARNING) << "Profile " << extractor_config.profile_path.string()
-                                             << " not found!";
-            return 1;
-        }
-        return extractor(extractor_config).run();
+        return EXIT_FAILURE;
     }
-    catch (const std::exception &e)
+
+    if (return_code::exit == result)
     {
-        SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
-        return 1;
+        return EXIT_SUCCESS;
     }
+
+    ExtractorOptions::GenerateOutputFilesNames(extractor_config);
+
+    if (1 > extractor_config.requested_num_threads)
+    {
+        SimpleLogger().Write(logWARNING) << "Number of threads must be 1 or larger";
+        return EXIT_FAILURE;
+    }
+
+    if (!boost::filesystem::is_regular_file(extractor_config.input_path))
+    {
+        SimpleLogger().Write(logWARNING) << "Input file " << extractor_config.input_path.string()
+                                         << " not found!";
+        return EXIT_FAILURE;
+    }
+
+    if (!boost::filesystem::is_regular_file(extractor_config.profile_path))
+    {
+        SimpleLogger().Write(logWARNING) << "Profile " << extractor_config.profile_path.string()
+                                         << " not found!";
+        return EXIT_FAILURE;
+    }
+    return extractor(extractor_config).run();
+}
+catch (const std::exception &e)
+{
+    SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+    return EXIT_FAILURE;
 }

--- a/extract.cpp
+++ b/extract.cpp
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdlib>
 #include <exception>
+#include <new>
 
 int main(int argc, char *argv[]) try
 {
@@ -73,6 +74,13 @@ int main(int argc, char *argv[]) try
         return EXIT_FAILURE;
     }
     return extractor(extractor_config).run();
+}
+catch (const std::bad_alloc &e)
+{
+    SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+    SimpleLogger().Write(logWARNING)
+        << "Please provide more memory or consider using a larger swapfile";
+    return EXIT_FAILURE;
 }
 catch (const std::exception &e)
 {

--- a/prepare.cpp
+++ b/prepare.cpp
@@ -33,70 +33,69 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <tbb/task_scheduler_init.h>
 
+#include <cstdlib>
 #include <exception>
 #include <ostream>
 
-int main(int argc, char *argv[])
+int main(int argc, char *argv[]) try
 {
-    try
+    LogPolicy::GetInstance().Unmute();
+    ContractorConfig contractor_config;
+
+    const return_code result = ContractorOptions::ParseArguments(argc, argv, contractor_config);
+
+    if (return_code::fail == result)
     {
-        LogPolicy::GetInstance().Unmute();
-        ContractorConfig contractor_config;
-
-        const return_code result = ContractorOptions::ParseArguments(argc, argv, contractor_config);
-
-        if (return_code::fail == result)
-        {
-            return 1;
-        }
-
-        if (return_code::exit == result)
-        {
-            return 0;
-        }
-
-        ContractorOptions::GenerateOutputFilesNames(contractor_config);
-
-        if (1 > contractor_config.requested_num_threads)
-        {
-            SimpleLogger().Write(logWARNING) << "Number of threads must be 1 or larger";
-            return 1;
-        }
-
-        const unsigned recommended_num_threads = tbb::task_scheduler_init::default_num_threads();
-
-        if (recommended_num_threads != contractor_config.requested_num_threads)
-        {
-            SimpleLogger().Write(logWARNING) << "The recommended number of threads is "
-                                             << recommended_num_threads
-                                             << "! This setting may have performance side-effects.";
-        }
-
-        if (!boost::filesystem::is_regular_file(contractor_config.osrm_input_path))
-        {
-            SimpleLogger().Write(logWARNING)
-                << "Input file " << contractor_config.osrm_input_path.string() << " not found!";
-            return 1;
-        }
-
-        if (!boost::filesystem::is_regular_file(contractor_config.profile_path))
-        {
-            SimpleLogger().Write(logWARNING) << "Profile " << contractor_config.profile_path.string()
-                                             << " not found!";
-            return 1;
-        }
-
-        SimpleLogger().Write() << "Input file: " << contractor_config.osrm_input_path.filename().string();
-        SimpleLogger().Write() << "Profile: " << contractor_config.profile_path.filename().string();
-        SimpleLogger().Write() << "Threads: " << contractor_config.requested_num_threads;
-
-        tbb::task_scheduler_init init(contractor_config.requested_num_threads);
-
-        return Prepare(contractor_config).Run();
-    }
-    catch (const std::exception &e)
-    {
-        SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
         return 1;
     }
+
+    if (return_code::exit == result)
+    {
+        return 0;
+    }
+
+    ContractorOptions::GenerateOutputFilesNames(contractor_config);
+
+    if (1 > contractor_config.requested_num_threads)
+    {
+        SimpleLogger().Write(logWARNING) << "Number of threads must be 1 or larger";
+        return 1;
+    }
+
+    const unsigned recommended_num_threads = tbb::task_scheduler_init::default_num_threads();
+
+    if (recommended_num_threads != contractor_config.requested_num_threads)
+    {
+        SimpleLogger().Write(logWARNING) << "The recommended number of threads is "
+                                         << recommended_num_threads
+                                         << "! This setting may have performance side-effects.";
+    }
+
+    if (!boost::filesystem::is_regular_file(contractor_config.osrm_input_path))
+    {
+        SimpleLogger().Write(logWARNING)
+            << "Input file " << contractor_config.osrm_input_path.string() << " not found!";
+        return 1;
+    }
+
+    if (!boost::filesystem::is_regular_file(contractor_config.profile_path))
+    {
+        SimpleLogger().Write(logWARNING) << "Profile " << contractor_config.profile_path.string()
+                                         << " not found!";
+        return 1;
+    }
+
+    SimpleLogger().Write() << "Input file: "
+                           << contractor_config.osrm_input_path.filename().string();
+    SimpleLogger().Write() << "Profile: " << contractor_config.profile_path.filename().string();
+    SimpleLogger().Write() << "Threads: " << contractor_config.requested_num_threads;
+
+    tbb::task_scheduler_init init(contractor_config.requested_num_threads);
+
+    return Prepare(contractor_config).Run();
+}
+catch (const std::exception &e)
+{
+    SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+    return EXIT_FAILURE;
 }

--- a/routed.cpp
+++ b/routed.cpp
@@ -43,6 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <future>
 #include <iostream>
 #include <thread>
+#include <new>
 
 #ifdef _WIN32
 boost::function0<void> console_ctrl_function;
@@ -81,11 +82,11 @@ int main(int argc, const char *argv[]) try
         lib_config.max_locations_map_matching);
     if (init_result == INIT_OK_DO_NOT_START_ENGINE)
     {
-        return 0;
+        return EXIT_SUCCESS;
     }
     if (init_result == INIT_FAILED)
     {
-        return 1;
+        return EXIT_FAILURE;
     }
 
 #ifdef __linux__
@@ -117,6 +118,7 @@ int main(int argc, const char *argv[]) try
     SimpleLogger().Write(logDEBUG) << "Threads:\t" << requested_thread_num;
     SimpleLogger().Write(logDEBUG) << "IP address:\t" << ip_address;
     SimpleLogger().Write(logDEBUG) << "IP port:\t" << ip_port;
+
 #ifndef _WIN32
     int sig = 0;
     sigset_t new_mask;
@@ -182,8 +184,15 @@ int main(int argc, const char *argv[]) try
     routing_server.reset();
     SimpleLogger().Write() << "shutdown completed";
 }
+catch (const std::bad_alloc &e)
+{
+    SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+    SimpleLogger().Write(logWARNING)
+        << "Please provide more memory or consider using a larger swapfile";
+    return EXIT_FAILURE;
+}
 catch (const std::exception &e)
 {
-    SimpleLogger().Write(logWARNING) << "exception: " << e.what();
-    return 1;
+    SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
+    return EXIT_FAILURE;
 }


### PR DESCRIPTION
This catches `std::bad_alloc` in the executables' main entry points and provides basic human readable error messages. Feel free to improve those messages.

Also, for the datastore I would like to get in https://github.com/Project-OSRM/osrm-backend/pull/1731 first, otherwise the locking / unlocking is ugly.

Note: noise from flattening plus clang-format, see specific commit.

References:

- https://github.com/Project-OSRM/osrm-backend/issues/1729