### PR TITLE
Provide a Makefile wrapping the beast that CMake is

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+default: all
+
+BUILD_TYPE ?= Release
+BUILD_DIR := build/${BUILD_TYPE}
+ROOT_DIR := $(shell pwd)
+
+NPROCS:=1
+OS:=$(shell uname -s)
+
+ifeq ($(OS),Linux)
+	NPROCS := $(shell nproc)
+else ifeq ($(OS),Darwin)
+	NPROCS := $(shell sysctl hw.ncpu | awk '{print $$2}')
+endif
+
+${BUILD_DIR}/Makefile: CMakeLists.txt
+	@mkdir -p ${BUILD_DIR}
+	@cd ${BUILD_DIR} && cmake ${ROOT_DIR} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+
+all: ${BUILD_DIR}/Makefile
+	@${MAKE} -C ${BUILD_DIR} -j ${NPROCS}
+
+clean:
+	@${RM} -rf ${BUILD_DIR}
+
+.PHONE: all clean


### PR DESCRIPTION
This provides an easy to use Makefile, that wraps the build process
behind a simple `make` command. In particular, it builds in release mode
and in parallel by default. It also separates release builds from debug
builds, in the build directory.

No more

    mkdir build
    cd build
    cmake .. -DCMAKE_BUILD_TYPE=Release
    cmake --build -- .

from now on just do

    make

Discussion: should be update all our documentation, readmes and wikis,
to simply invoke `make`?

To be done:

- the raster unit tests hardcode "../unit_tests/" as path prefix; this
  breaks with a build directory such as "build/Release/"

- the cucumber setup assumes the osrm binaries are located in "build/"

/cc @lbud @emiltin 