### PR TITLE
Support rectangular matrix with less sources than targets

### DIFF
--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 RouteParameters::RouteParameters()
     : zoom_level(18), print_instructions(false), alternate_route(true), geometry(true),
-      compression(true), deprecatedAPI(false), uturn_default(false), classify(false),
+      compression(true), deprecatedAPI(false), uturn_default(false), classify(false), mapped_points(true),
       matching_beta(5), gps_precision(5), check_sum(-1), num_results(1)
 {
 }
@@ -144,6 +144,14 @@ void RouteParameters::addCoordinate(
     const boost::fusion::vector<double, double> &received_coordinates)
 {
     coordinates.emplace_back(
+        static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<0>(received_coordinates)),
+        static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
+}
+
+void RouteParameters::addDestination(
+    const boost::fusion::vector<double, double> &received_coordinates)
+{
+    destinations.emplace_back(
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<0>(received_coordinates)),
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
 }

--- a/data_structures/route_parameters.cpp
+++ b/data_structures/route_parameters.cpp
@@ -148,8 +148,18 @@ void RouteParameters::addCoordinate(
         static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
 }
 
+void RouteParameters::addSource(
+    const boost::fusion::vector<double, double> &received_coordinates)
+{
+    sources.emplace_back(
+        static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<0>(received_coordinates)),
+        static_cast<int>(COORDINATE_PRECISION * boost::fusion::at_c<1>(received_coordinates)));
+}
+
 void RouteParameters::getCoordinatesFromGeometry(const std::string &geometry_string)
 {
     PolylineCompressor pc;
     coordinates = pc.decode_string(geometry_string);
 }
+
+void RouteParameters::setMappedPointsFlag(const bool flag) { mapped_points = flag; }

--- a/features/step_definitions/distance_matrix.rb
+++ b/features/step_definitions/distance_matrix.rb
@@ -4,15 +4,20 @@ When /^I request a travel time matrix I should get$/ do |table|
   raise "*** Top-left cell of matrix table must be empty" unless table.headers[0]==""
   
   nodes = []
+  sources = []
   column_headers = table.headers[1..-1]
   row_headers = table.rows.map { |h| h.first }
-  unless column_headers==row_headers || @query_params['src']
-    raise "*** Column and row headers must match in matrix table, got #{column_headers.inspect} and #{row_headers.inspect}"
-  end
   column_headers.each do |node_name|
     node = find_node_by_name(node_name)
     raise "*** unknown node '#{node_name}" unless node
     nodes << node
+  end
+  if column_headers!=row_headers
+    row_headers.each do |node_name|
+      node = find_node_by_name(node_name)
+      raise "*** unknown node '#{node_name}" unless node
+      sources << node
+    end
   end
   
   reprocess
@@ -22,11 +27,7 @@ When /^I request a travel time matrix I should get$/ do |table|
     
     # compute matrix
     params = @query_params
-    if params['src']
-      node = find_node_by_name(params['src'])
-      params['src'] = node.lat + ',' + node.lon
-    end
-    response = request_table nodes, params
+    response = request_table nodes, sources, params
     if response.body.empty? == false
       json = JSON.parse response.body
       result = json['distance_table']

--- a/features/step_definitions/distance_matrix.rb
+++ b/features/step_definitions/distance_matrix.rb
@@ -1,5 +1,4 @@
 When /^I request a travel time matrix I should get$/ do |table|
-  
   no_route = 2147483647   # MAX_INT
   
   raise "*** Top-left cell of matrix table must be empty" unless table.headers[0]==""
@@ -7,7 +6,7 @@ When /^I request a travel time matrix I should get$/ do |table|
   nodes = []
   column_headers = table.headers[1..-1]
   row_headers = table.rows.map { |h| h.first }
-  unless column_headers==row_headers
+  unless column_headers==row_headers || @query_params['src']
     raise "*** Column and row headers must match in matrix table, got #{column_headers.inspect} and #{row_headers.inspect}"
   end
   column_headers.each do |node_name|
@@ -23,6 +22,10 @@ When /^I request a travel time matrix I should get$/ do |table|
     
     # compute matrix
     params = @query_params
+    if params['src']
+      node = find_node_by_name(params['src'])
+      params['src'] = node.lat + ',' + node.lon
+    end
     response = request_table nodes, params
     if response.body.empty? == false
       json = JSON.parse response.body

--- a/features/support/route.rb
+++ b/features/support/route.rb
@@ -41,9 +41,13 @@ def request_route waypoints, params={}
   request_path "viaroute", waypoints, defaults.merge(params)
 end
 
-def request_table waypoints, params={}
+def request_table waypoints, sources, params={}
   defaults = { 'output' => 'json' }
-  request_path "table", waypoints, defaults.merge(params)
+  options = defaults.merge(params)
+  locs = (sources.size > 0) ? (waypoints.compact.map { |w| "dst=#{w.lat},#{w.lon}" } + sources.compact.map { |w| "src=#{w.lat},#{w.lon}" }) : waypoints.compact.map { |w| "loc=#{w.lat},#{w.lon}" }
+  params = (locs + options.to_param).join('&')
+  uri = generate_request_url ("table" + '?' + params)
+  response = send_request uri, waypoints, options, sources
 end
 
 def got_route? response

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -116,8 +116,25 @@ Feature: Basic Distance Matrix
 
         And the query options
             | mapped_points | true |
-            | src | a |
 
         When I request a travel time matrix I should get
             |   | a   | b   | e   | f   |
             | a | 0   | 100 | 200 | 300 |
+
+     Scenario: Testbot - Travel time 3x2 matrix
+        Given the node map
+            | a | b | c |
+            | d | e | f |
+
+        And the ways
+            | nodes |
+            | abc   |
+            | def   |
+            | ad    |
+            | be    |
+            | cf    |
+
+        When I request a travel time matrix I should get
+            |   | b   | e   | f   |
+            | a | 100 | 200 | 300 |
+            | b | 0   | 100 | 200 |

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -100,3 +100,24 @@ Feature: Basic Distance Matrix
             | y | 500 | 0   | 300 | 200 |
             | d | 200 | 300 | 0   | 300 |
             | e | 300 | 400 | 100 | 0   |
+
+    Scenario: Testbot - Travel time matrix and mapped coordinates with only one source
+        Given the node map
+            | a | b | c |
+            | d | e | f |
+
+        And the ways
+            | nodes |
+            | abc   |
+            | def   |
+            | ad    |
+            | be    |
+            | cf    |
+
+        And the query options
+            | mapped_points | true |
+            | src | a |
+
+        When I request a travel time matrix I should get
+            |   | a   | b   | e   | f   |
+            | a | 0   | 100 | 200 | 300 |

--- a/include/osrm/route_parameters.hpp
+++ b/include/osrm/route_parameters.hpp
@@ -82,7 +82,11 @@ struct RouteParameters
 
     void addCoordinate(const boost::fusion::vector<double, double> &received_coordinates);
 
+    void addSource(const boost::fusion::vector<double, double> &received_coordinates);
+
     void getCoordinatesFromGeometry(const std::string &geometry_string);
+
+    void setMappedPointsFlag(const bool flag);
 
     short zoom_level;
     bool print_instructions;
@@ -92,6 +96,7 @@ struct RouteParameters
     bool deprecatedAPI;
     bool uturn_default;
     bool classify;
+    bool mapped_points;
     double matching_beta;
     double gps_precision;
     unsigned check_sum;
@@ -105,6 +110,7 @@ struct RouteParameters
     std::vector<std::pair<const int,const boost::optional<int>>> bearings;
     std::vector<bool> uturns;
     std::vector<FixedPointCoordinate> coordinates;
+    std::vector<FixedPointCoordinate> sources;
 };
 
 #endif // ROUTE_PARAMETERS_HPP

--- a/include/osrm/route_parameters.hpp
+++ b/include/osrm/route_parameters.hpp
@@ -82,6 +82,8 @@ struct RouteParameters
 
     void addCoordinate(const boost::fusion::vector<double, double> &received_coordinates);
 
+    void addDestination(const boost::fusion::vector<double, double> &received_coordinates);
+
     void addSource(const boost::fusion::vector<double, double> &received_coordinates);
 
     void getCoordinatesFromGeometry(const std::string &geometry_string);
@@ -110,6 +112,7 @@ struct RouteParameters
     std::vector<std::pair<const int,const boost::optional<int>>> bearings;
     std::vector<bool> uturns;
     std::vector<FixedPointCoordinate> coordinates;
+    std::vector<FixedPointCoordinate> destinations;
     std::vector<FixedPointCoordinate> sources;
 };
 

--- a/plugins/distance_table.hpp
+++ b/plugins/distance_table.hpp
@@ -70,13 +70,14 @@ template <class DataFacadeT> class DistanceTablePlugin final : public BasePlugin
     int HandleRequest(const RouteParameters &route_parameters,
                       osrm::json::Object &json_result) override final
     {
-        if (!check_all_coordinates(route_parameters.coordinates))
+        if (!check_all_coordinates(route_parameters.coordinates) ||
+            (route_parameters.sources.size() && !check_all_coordinates(route_parameters.sources, 1)))
         {
             return 400;
         }
 
         const auto &input_bearings = route_parameters.bearings;
-        if (input_bearings.size() > 0 && route_parameters.coordinates.size() != input_bearings.size())
+        if (input_bearings.size() > 0 && route_parameters.coordinates.size() + route_parameters.sources.size() != input_bearings.size())
         {
             json_result.values["status"] = "Number of bearings does not match number of coordinates .";
             return 400;
@@ -87,7 +88,7 @@ template <class DataFacadeT> class DistanceTablePlugin final : public BasePlugin
             std::min(static_cast<unsigned>(max_locations_distance_table),
                      static_cast<unsigned>(route_parameters.coordinates.size()));
 
-        PhantomNodeArray phantom_node_vector(max_locations);
+        PhantomNodeArray phantom_node_target_vector(max_locations);
         for (const auto i : osrm::irange(0u, max_locations))
         {
             if (checksum_OK && i < route_parameters.hints.size() &&
@@ -97,21 +98,49 @@ template <class DataFacadeT> class DistanceTablePlugin final : public BasePlugin
                 ObjectEncoder::DecodeFromBase64(route_parameters.hints[i], current_phantom_node);
                 if (current_phantom_node.is_valid(facade->GetNumberOfNodes()))
                 {
-                    phantom_node_vector[i].emplace_back(std::move(current_phantom_node));
+                    phantom_node_target_vector[i].emplace_back(std::move(current_phantom_node));
                     continue;
                 }
             }
             const int bearing = input_bearings.size() > 0 ? input_bearings[i].first : 0;
             const int range = input_bearings.size() > 0 ? (input_bearings[i].second?*input_bearings[i].second:10) : 180;
             facade->IncrementalFindPhantomNodeForCoordinate(route_parameters.coordinates[i],
-                                                            phantom_node_vector[i], 1, bearing, range);
+                                                            phantom_node_target_vector[i], 1, bearing, range);
 
-            BOOST_ASSERT(phantom_node_vector[i].front().is_valid(facade->GetNumberOfNodes()));
+            BOOST_ASSERT(phantom_node_target_vector[i].front().is_valid(facade->GetNumberOfNodes()));
+        }
+        unsigned nb_coordinates = route_parameters.coordinates.size();
+        max_locations = 0;
+        if (route_parameters.sources.size())
+        {
+            max_locations = std::min(static_cast<unsigned>(max_locations_distance_table),
+                                     static_cast<unsigned>(route_parameters.sources.size()));
+        }
+        PhantomNodeArray phantom_node_source_vector(max_locations);
+        for (const auto i : osrm::irange(0u, max_locations))
+        {
+            if (checksum_OK && i < route_parameters.hints.size() - route_parameters.coordinates.size() &&
+                !route_parameters.hints[i+route_parameters.coordinates.size()].empty())
+            {
+                PhantomNode current_phantom_node;
+                ObjectEncoder::DecodeFromBase64(route_parameters.hints[i+route_parameters.coordinates.size()], current_phantom_node);
+                if (current_phantom_node.is_valid(facade->GetNumberOfNodes()))
+                {
+                    phantom_node_source_vector[i].emplace_back(std::move(current_phantom_node));
+                    continue;
+                }
+            }
+            const int bearing = input_bearings.size() > 0 ? input_bearings[nb_coordinates + i].first : 0;
+            const int range = input_bearings.size() > 0 ? (input_bearings[nb_coordinates + i].second?*input_bearings[nb_coordinates + i].second:10) : 180;
+            facade->IncrementalFindPhantomNodeForCoordinate(route_parameters.sources[i],
+                                                            phantom_node_source_vector[i], 1, bearing, range);
+
+            BOOST_ASSERT(phantom_node_source_vector[i].front().is_valid(facade->GetNumberOfNodes()));
         }
 
         // TIMER_START(distance_table);
         std::shared_ptr<std::vector<EdgeWeight>> result_table =
-            search_engine_ptr->distance_table(phantom_node_vector);
+            search_engine_ptr->distance_table(phantom_node_target_vector, phantom_node_source_vector);
         // TIMER_STOP(distance_table);
 
         if (!result_table)
@@ -119,17 +148,41 @@ template <class DataFacadeT> class DistanceTablePlugin final : public BasePlugin
             return 400;
         }
 
-        osrm::json::Array json_array;
-        const auto number_of_locations = phantom_node_vector.size();
-        for (const auto row : osrm::irange<std::size_t>(0, number_of_locations))
+        osrm::json::Array matrix_json_array;
+        const auto number_of_targets = phantom_node_target_vector.size();
+        const auto number_of_sources = (phantom_node_source_vector.size()) ? phantom_node_source_vector.size() : number_of_targets;
+        for (const auto row : osrm::irange<std::size_t>(0, number_of_sources))
         {
             osrm::json::Array json_row;
-            auto row_begin_iterator = result_table->begin() + (row * number_of_locations);
-            auto row_end_iterator = result_table->begin() + ((row + 1) * number_of_locations);
+            auto row_begin_iterator = result_table->begin() + (row * number_of_targets);
+            auto row_end_iterator = result_table->begin() + ((row + 1) * number_of_targets);
             json_row.values.insert(json_row.values.end(), row_begin_iterator, row_end_iterator);
-            json_array.values.push_back(json_row);
+            matrix_json_array.values.push_back(json_row);
         }
-        json_result.values["distance_table"] = json_array;
+        json_result.values["distance_table"] = matrix_json_array;
+        if (route_parameters.mapped_points) {
+            osrm::json::Array target_coord_json_array;
+            for (const std::vector<PhantomNode> &phantom_node_vector : phantom_node_target_vector)
+            {
+                osrm::json::Array json_coord;
+                FixedPointCoordinate coord = phantom_node_vector[0].location;
+                json_coord.values.push_back(coord.lat / COORDINATE_PRECISION);
+                json_coord.values.push_back(coord.lon / COORDINATE_PRECISION);
+                target_coord_json_array.values.push_back(json_coord);
+            }
+            json_result.values["target_mapped_coordinates"] = target_coord_json_array;
+            osrm::json::Array source_coord_json_array;
+            for (const std::vector<PhantomNode> &phantom_node_vector : phantom_node_source_vector)
+            {
+                osrm::json::Array json_coord;
+                FixedPointCoordinate coord = phantom_node_vector[0].location;
+                json_coord.values.push_back(coord.lat / COORDINATE_PRECISION);
+                json_coord.values.push_back(coord.lon / COORDINATE_PRECISION);
+                source_coord_json_array.values.push_back(json_coord);
+            }
+            if (source_coord_json_array.values.size())
+                json_result.values["source_mapped_coordinates"] = source_coord_json_array;
+        }
         // osrm::json::render(reply.content, json_object);
         return 200;
     }

--- a/plugins/plugin_base.hpp
+++ b/plugins/plugin_base.hpp
@@ -45,9 +45,9 @@ class BasePlugin
     virtual const std::string GetDescriptor() const = 0;
     virtual int HandleRequest(const RouteParameters &, osrm::json::Object &) = 0;
     virtual bool
-    check_all_coordinates(const std::vector<FixedPointCoordinate> &coordinates) const final
+    check_all_coordinates(const std::vector<FixedPointCoordinate> &coordinates, const unsigned min = 2) const final
     {
-        if (2 > coordinates.size() || std::any_of(std::begin(coordinates), std::end(coordinates),
+        if (min > coordinates.size() || std::any_of(std::begin(coordinates), std::end(coordinates),
                                                   [](const FixedPointCoordinate &coordinate)
                                                   {
                                                       return !coordinate.is_valid();

--- a/server/api_grammar.hpp
+++ b/server/api_grammar.hpp
@@ -40,9 +40,9 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     {
         api_call = qi::lit('/') >> string[boost::bind(&HandlerT::setService, handler, ::_1)] >>
                    *(query) >> -(uturns);
-        query = ('?') >> (+(zoom | output | jsonp | checksum | location | hint | timestamp | bearing | u | cmp |
+        query = ('?') >> (+(zoom | output | jsonp | checksum | location | source | hint | timestamp | bearing | u | cmp |
                             language | instruction | geometry | alt_route | old_API | num_results |
-                            matching_beta | gps_precision | classify | locs));
+                            matching_beta | gps_precision | classify | locs | mapped_points));
 
         zoom = (-qi::lit('&')) >> qi::lit('z') >> '=' >>
                qi::short_[boost::bind(&HandlerT::setZoomLevel, handler, ::_1)];
@@ -61,6 +61,9 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
         location = (-qi::lit('&')) >> qi::lit("loc") >> '=' >>
                    (qi::double_ >> qi::lit(',') >>
                     qi::double_)[boost::bind(&HandlerT::addCoordinate, handler, ::_1)];
+        source = (-qi::lit('&')) >> qi::lit("src") >> '=' >>
+                   (qi::double_ >> qi::lit(',') >>
+                    qi::double_)[boost::bind(&HandlerT::addSource, handler, ::_1)];
         hint = (-qi::lit('&')) >> qi::lit("hint") >> '=' >>
                stringwithDot[boost::bind(&HandlerT::addHint, handler, ::_1)];
         timestamp = (-qi::lit('&')) >> qi::lit("t") >> '=' >>
@@ -87,6 +90,8 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
             qi::bool_[boost::bind(&HandlerT::setClassify, handler, ::_1)];
         locs = (-qi::lit('&')) >> qi::lit("locs") >> '=' >>
             stringforPolyline[boost::bind(&HandlerT::getCoordinatesFromGeometry, handler, ::_1)];
+        mapped_points = (-qi::lit('&')) >> qi::lit("mapped_points") >> '=' >>
+                      qi::bool_[boost::bind(&HandlerT::setMappedPointsFlag, handler, ::_1)];
 
         string = +(qi::char_("a-zA-Z"));
         stringwithDot = +(qi::char_("a-zA-Z0-9_.-"));
@@ -96,9 +101,9 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     }
 
     qi::rule<Iterator> api_call, query;
-    qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location,
+    qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location, source,
         hint, timestamp, bearing, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
-        uturns, old_API, num_results, matching_beta, gps_precision, classify, locs, stringforPolyline;
+        uturns, old_API, num_results, matching_beta, gps_precision, classify, locs, mapped_points, stringforPolyline;
 
     HandlerT *handler;
 };

--- a/server/api_grammar.hpp
+++ b/server/api_grammar.hpp
@@ -40,7 +40,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     {
         api_call = qi::lit('/') >> string[boost::bind(&HandlerT::setService, handler, ::_1)] >>
                    *(query) >> -(uturns);
-        query = ('?') >> (+(zoom | output | jsonp | checksum | location | source | hint | timestamp | bearing | u | cmp |
+        query = ('?') >> (+(zoom | output | jsonp | checksum | location | destination | source | hint | timestamp | bearing | u | cmp |
                             language | instruction | geometry | alt_route | old_API | num_results |
                             matching_beta | gps_precision | classify | locs | mapped_points));
 
@@ -61,6 +61,9 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
         location = (-qi::lit('&')) >> qi::lit("loc") >> '=' >>
                    (qi::double_ >> qi::lit(',') >>
                     qi::double_)[boost::bind(&HandlerT::addCoordinate, handler, ::_1)];
+        destination = (-qi::lit('&')) >> qi::lit("dst") >> '=' >>
+                   (qi::double_ >> qi::lit(',') >>
+                    qi::double_)[boost::bind(&HandlerT::addDestination, handler, ::_1)];
         source = (-qi::lit('&')) >> qi::lit("src") >> '=' >>
                    (qi::double_ >> qi::lit(',') >>
                     qi::double_)[boost::bind(&HandlerT::addSource, handler, ::_1)];
@@ -101,7 +104,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     }
 
     qi::rule<Iterator> api_call, query;
-    qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location, source,
+    qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location, destination, source,
         hint, timestamp, bearing, stringwithDot, stringwithPercent, language, instruction, geometry, cmp, alt_route, u,
         uturns, old_API, num_results, matching_beta, gps_precision, classify, locs, mapped_points, stringforPolyline;
 


### PR DESCRIPTION
Hello,
I've modified table plugin to support rectangular matrix and return mapped coordinates.
One simple test has been added with a 1x4 matrix.
If you are ok with this pull request, here the help to replace in osrm wiki:

## Service `table`

This computes distance tables for the given via points. Please note that the distance in this case is the _travel time_ which is the default metric used by OSRM.
If only `loc` parameter is used, all pair-wise distances are computed.
If `src` parameter is combined with `loc` parameter, only pairs between scr/loc are computed.

### Query

```
http://{server}/table?loc={lat,lon}&loc={lat,lon}<&loc={lat,lon} ...>
```

|Parameter    |Values                    |Description                                                   |
|-------------|--------------------------|--------------------------------------------------------------|
|loc          |lat,lon                   |Location of the via point                                     |
|src          |lat,lon                   |Location of the source point                                  |
|mapped_points|`true`, `false` (default) |Return the mapped coordinates                                 |

### Response

* `distance_table` array of arrays that stores the matrix in row-major order. `distance_table[i][j]` gives the travel time from
  the i-th via to the j-th via point. Values are given in 10th of a second.
* `target_mapped_coordinates` array of arrays that contains the `[lat, lon]` pair of the snapped coordinate
* `source_mapped_coordinates` array of arrays that contains the `[lat, lon]` pair of the snapped coordinate

### Example

```
http://router.project-osrm.org/table?loc=52.554070,13.160621&loc=52.431272,13.720654&loc=52.554070,13.720654&loc=52.554070,13.160621
```

```JSON
{
    "distance_table": [
        [
            0,
            31089,
            31224,
            0
        ],
        [
            31248,
            0,
            13138,
            31248
        ],
        [
            31167,
            13188,
            0,
            31167
        ],
        [
            0,
            31089,
            31224,
            0
        ]
    ]
}
```

```
http://router.project-osrm.org/table?loc=52.554070,13.160621&loc=52.431272,13.720654&loc=52.554070,13.720654&src=52.554070,13.160621
```

```JSON
{
    "distance_table": [
        [
            0,
            31089,
            31224
        ]
    ]
}
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/project-osrm/osrm-backend/1760)
<!-- Reviewable:end -->
