### PR TITLE
Add a summary to each match result

### DIFF
--- a/features/step_definitions/matching.rb
+++ b/features/step_definitions/matching.rb
@@ -156,6 +156,7 @@ When /^I match with turns I should get$/ do |table|
           modes = mode_list json['matchings'][0]['instructions']
           times = time_list json['matchings'][0]['instructions']
           distances = distance_list json['matchings'][0]['instructions']
+          summary = json['matchings'][0]['route_summary']
         end
       end
       
@@ -167,6 +168,9 @@ When /^I match with turns I should get$/ do |table|
       end
       if table.headers.include? '#'   # comment column
         got['#'] = row['#']           # copy value so it always match
+      end
+      if table.headers.include? 'duration'
+          got['duration'] = "#{summary["total_time"]}"
       end
 
       sub_matchings = []

--- a/features/testbot/matching_turns.feature
+++ b/features/testbot/matching_turns.feature
@@ -80,3 +80,38 @@ Feature: Turn directions/codes
             | go    | xg,xo | head,straight,destination     | go        |
             | ga    | xg,xa | head,slight_right,destination | ga        |
             | gc    | xg,xc | head,right,destination        | gc        |
+
+    Scenario: Turn directions
+        Given the node map
+            | o | p | a | b | c |
+            | n |   |   |   | d |
+            | m |   | x |   | e |
+            | l |   |   |   | f |
+            | k | j | i | h | g |
+
+        And the ways
+            | nodes |
+            | xa    |
+            | xb    |
+            | xc    |
+            | xd    |
+            | xe    |
+            | xf    |
+            | xg    |
+            | xh    |
+            | xi    |
+            | xj    |
+            | xk    |
+            | xl    |
+            | xm    |
+            | xn    |
+            | xo    |
+            | xp    |
+
+        When I match with turns I should get
+            | trace | route | turns                         | matchings | duration |
+            | im    | xi,xm | head,left,destination         | im        | 80       |
+            | io    | xi,xo | head,slight_left,destination  | io        | 88       |
+            | ia    | xi,xa | head,straight,destination     | ia        | 80       |
+            | ic    | xi,xc | head,slight_right,destination | ic        | 88       |
+            | ie    | xi,xe | head,right,destination        | ie        | 60       |

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -238,6 +238,12 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
                 subtrace.values["instructions"] = json_descriptor.BuildTextualDescription(factory, temp_segments);
             }
 
+            factory.BuildRouteSummary(factory.get_entire_length(),
+                                              raw_route.shortest_path_length);
+            osrm::json::Object json_route_summary;
+            json_route_summary.values["total_distance"] = factory.summary.distance;
+            json_route_summary.values["total_time"] = factory.summary.duration;
+            subtrace.values["route_summary"] = json_route_summary;
         }
 
         subtrace.values["indices"] = osrm::json::make_array(sub.indices);


### PR DESCRIPTION
Useful for comparing real-world data against the OSRM internal edge weighting.