### PR TITLE
Fix pkgconfig cmake template

### DIFF
--- a/cmake/pkgconfig.in
+++ b/cmake/pkgconfig.in
@@ -1,5 +1,5 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-includedir=${prefix}/include/osrm
+includedir=${prefix}/include
 libdir=${prefix}/lib
 
 Name: libOSRM


### PR DESCRIPTION
Hello,
I've fixed pkgconfig.in template file in order to be able to use `node-pre-gyp --build-from-source` in node-osrm project.
'osrm'  is still referenced in includes from node-osrm poject:
- json_v8_renderer.hpp
- node_osrm.cpp

Fabien 