### PR TITLE
Preserve information about big components and exit early

### DIFF
--- a/data_structures/edge_based_node.hpp
+++ b/data_structures/edge_based_node.hpp
@@ -46,7 +46,7 @@ struct EdgeBasedNode
           u(SPECIAL_NODEID), v(SPECIAL_NODEID), name_id(0),
           forward_weight(INVALID_EDGE_WEIGHT >> 1), reverse_weight(INVALID_EDGE_WEIGHT >> 1),
           forward_offset(0), reverse_offset(0), packed_geometry_id(SPECIAL_EDGEID),
-          component_id(-1), fwd_segment_position(std::numeric_limits<unsigned short>::max()),
+          component{false, INVALID_COMPONENTID}, fwd_segment_position(std::numeric_limits<unsigned short>::max()),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
@@ -62,6 +62,7 @@ struct EdgeBasedNode
                            int forward_offset,
                            int reverse_offset,
                            unsigned packed_geometry_id,
+                           bool is_tiny_component,
                            unsigned component_id,
                            unsigned short fwd_segment_position,
                            TravelMode forward_travel_mode,
@@ -70,7 +71,7 @@ struct EdgeBasedNode
           reverse_edge_based_node_id(reverse_edge_based_node_id), u(u), v(v), name_id(name_id),
           forward_weight(forward_weight), reverse_weight(reverse_weight),
           forward_offset(forward_offset), reverse_offset(reverse_offset),
-          packed_geometry_id(packed_geometry_id), component_id(component_id),
+          packed_geometry_id(packed_geometry_id), component{is_tiny_component, component_id},
           fwd_segment_position(fwd_segment_position), forward_travel_mode(forward_travel_mode),
           backward_travel_mode(backward_travel_mode)
     {
@@ -90,8 +91,6 @@ struct EdgeBasedNode
 
     bool IsCompressed() const { return packed_geometry_id != SPECIAL_EDGEID; }
 
-    bool is_in_tiny_cc() const { return 0 != component_id; }
-
     NodeID forward_edge_based_node_id; // needed for edge-expanded graph
     NodeID reverse_edge_based_node_id; // needed for edge-expanded graph
     NodeID u;                          // indices into the coordinates array
@@ -102,7 +101,10 @@ struct EdgeBasedNode
     int forward_offset;          // prefix sum of the weight up the edge TODO: short must suffice
     int reverse_offset;          // prefix sum of the weight from the edge TODO: short must suffice
     unsigned packed_geometry_id; // if set, then the edge represents a packed geometry
-    unsigned component_id;
+    struct {
+        bool is_tiny : 1;
+        unsigned id : 31;
+    } component;
     unsigned short fwd_segment_position; // segment id in a compressed geometry
     TravelMode forward_travel_mode : 4;
     TravelMode backward_travel_mode : 4;

--- a/data_structures/edge_based_node.hpp
+++ b/data_structures/edge_based_node.hpp
@@ -46,7 +46,7 @@ struct EdgeBasedNode
           u(SPECIAL_NODEID), v(SPECIAL_NODEID), name_id(0),
           forward_weight(INVALID_EDGE_WEIGHT >> 1), reverse_weight(INVALID_EDGE_WEIGHT >> 1),
           forward_offset(0), reverse_offset(0), packed_geometry_id(SPECIAL_EDGEID),
-          component{false, INVALID_COMPONENTID}, fwd_segment_position(std::numeric_limits<unsigned short>::max()),
+          component{INVALID_COMPONENTID, false}, fwd_segment_position(std::numeric_limits<unsigned short>::max()),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
@@ -71,7 +71,7 @@ struct EdgeBasedNode
           reverse_edge_based_node_id(reverse_edge_based_node_id), u(u), v(v), name_id(name_id),
           forward_weight(forward_weight), reverse_weight(reverse_weight),
           forward_offset(forward_offset), reverse_offset(reverse_offset),
-          packed_geometry_id(packed_geometry_id), component{is_tiny_component, component_id},
+          packed_geometry_id(packed_geometry_id), component{component_id, is_tiny_component},
           fwd_segment_position(fwd_segment_position), forward_travel_mode(forward_travel_mode),
           backward_travel_mode(backward_travel_mode)
     {
@@ -102,8 +102,8 @@ struct EdgeBasedNode
     int reverse_offset;          // prefix sum of the weight from the edge TODO: short must suffice
     unsigned packed_geometry_id; // if set, then the edge represents a packed geometry
     struct {
-        bool is_tiny : 1;
         unsigned id : 31;
+        bool is_tiny : 1;
     } component;
     unsigned short fwd_segment_position; // segment id in a compressed geometry
     TravelMode forward_travel_mode : 4;

--- a/data_structures/phantom_node.cpp
+++ b/data_structures/phantom_node.cpp
@@ -51,7 +51,7 @@ PhantomNode::PhantomNode(NodeID forward_node_id,
     : forward_node_id(forward_node_id), reverse_node_id(reverse_node_id), name_id(name_id),
       forward_weight(forward_weight), reverse_weight(reverse_weight),
       forward_offset(forward_offset), reverse_offset(reverse_offset),
-      packed_geometry_id(packed_geometry_id), component{is_tiny_component, component_id}, location(location),
+      packed_geometry_id(packed_geometry_id), component{component_id, is_tiny_component}, location(location),
       fwd_segment_position(fwd_segment_position), forward_travel_mode(forward_travel_mode),
       backward_travel_mode(backward_travel_mode)
 {
@@ -61,7 +61,7 @@ PhantomNode::PhantomNode()
     : forward_node_id(SPECIAL_NODEID), reverse_node_id(SPECIAL_NODEID),
       name_id(std::numeric_limits<unsigned>::max()), forward_weight(INVALID_EDGE_WEIGHT),
       reverse_weight(INVALID_EDGE_WEIGHT), forward_offset(0), reverse_offset(0),
-      packed_geometry_id(SPECIAL_EDGEID), component{false, INVALID_COMPONENTID},
+      packed_geometry_id(SPECIAL_EDGEID), component{INVALID_COMPONENTID, false},
       fwd_segment_position(0), forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
       backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
 {

--- a/data_structures/phantom_node.cpp
+++ b/data_structures/phantom_node.cpp
@@ -42,6 +42,7 @@ PhantomNode::PhantomNode(NodeID forward_node_id,
                          int forward_offset,
                          int reverse_offset,
                          unsigned packed_geometry_id,
+                         bool is_tiny_component,
                          unsigned component_id,
                          FixedPointCoordinate &location,
                          unsigned short fwd_segment_position,
@@ -50,7 +51,7 @@ PhantomNode::PhantomNode(NodeID forward_node_id,
     : forward_node_id(forward_node_id), reverse_node_id(reverse_node_id), name_id(name_id),
       forward_weight(forward_weight), reverse_weight(reverse_weight),
       forward_offset(forward_offset), reverse_offset(reverse_offset),
-      packed_geometry_id(packed_geometry_id), component_id(component_id), location(location),
+      packed_geometry_id(packed_geometry_id), component{is_tiny_component, component_id}, location(location),
       fwd_segment_position(fwd_segment_position), forward_travel_mode(forward_travel_mode),
       backward_travel_mode(backward_travel_mode)
 {
@@ -60,7 +61,7 @@ PhantomNode::PhantomNode()
     : forward_node_id(SPECIAL_NODEID), reverse_node_id(SPECIAL_NODEID),
       name_id(std::numeric_limits<unsigned>::max()), forward_weight(INVALID_EDGE_WEIGHT),
       reverse_weight(INVALID_EDGE_WEIGHT), forward_offset(0), reverse_offset(0),
-      packed_geometry_id(SPECIAL_EDGEID), component_id(std::numeric_limits<unsigned>::max()),
+      packed_geometry_id(SPECIAL_EDGEID), component{false, INVALID_COMPONENTID},
       fwd_segment_position(0), forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
       backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
 {
@@ -96,10 +97,8 @@ bool PhantomNode::is_valid(const unsigned number_of_nodes) const
     return location.is_valid() &&
            ((forward_node_id < number_of_nodes) || (reverse_node_id < number_of_nodes)) &&
            ((forward_weight != INVALID_EDGE_WEIGHT) || (reverse_weight != INVALID_EDGE_WEIGHT)) &&
-           (name_id != INVALID_NAMEID);
+           (component.id != INVALID_COMPONENTID) && (name_id != INVALID_NAMEID);
 }
-
-bool PhantomNode::is_in_tiny_component() const { return component_id != 0; }
 
 bool PhantomNode::is_valid() const { return location.is_valid() && (name_id != INVALID_NAMEID); }
 

--- a/data_structures/phantom_node.hpp
+++ b/data_structures/phantom_node.hpp
@@ -47,6 +47,7 @@ struct PhantomNode
                 int forward_offset,
                 int reverse_offset,
                 unsigned packed_geometry_id,
+                bool is_tiny_component,
                 unsigned component_id,
                 FixedPointCoordinate &location,
                 unsigned short fwd_segment_position,
@@ -68,7 +69,9 @@ struct PhantomNode
         reverse_offset = other.reverse_offset;
 
         packed_geometry_id = other.packed_geometry_id;
-        component_id = other.component_id;
+
+        component.id = other.component.id;
+        component.is_tiny = other.component.is_tiny;
 
         location = foot_point;
         fwd_segment_position = other.fwd_segment_position;
@@ -85,7 +88,10 @@ struct PhantomNode
     int forward_offset;
     int reverse_offset;
     unsigned packed_geometry_id;
-    unsigned component_id;
+    struct {
+        bool is_tiny : 1;
+        unsigned id : 31;
+    } component;
     FixedPointCoordinate location;
     unsigned short fwd_segment_position;
     // note 4 bits would suffice for each,
@@ -104,8 +110,6 @@ struct PhantomNode
     bool is_valid(const unsigned numberOfNodes) const;
 
     bool is_valid() const;
-
-    bool is_in_tiny_component() const;
 
     bool operator==(const PhantomNode &other) const;
 };
@@ -147,7 +151,7 @@ inline std::ostream &operator<<(std::ostream &out, const PhantomNode &pn)
         << "fwd-o: " << pn.forward_offset << ", "
         << "rev-o: " << pn.reverse_offset << ", "
         << "geom: " << pn.packed_geometry_id << ", "
-        << "comp: " << pn.component_id << ", "
+        << "comp: " << pn.component.is_tiny << " / " << pn.component.id << ", "
         << "pos: " << pn.fwd_segment_position << ", "
         << "loc: " << pn.location;
     return out;

--- a/data_structures/phantom_node.hpp
+++ b/data_structures/phantom_node.hpp
@@ -88,10 +88,14 @@ struct PhantomNode
     int forward_offset;
     int reverse_offset;
     unsigned packed_geometry_id;
-    struct {
+    struct ComponentType {
+        uint32_t id : 31;
         bool is_tiny : 1;
-        unsigned id : 31;
     } component;
+// bit-fields are broken on Windows
+#ifndef _MSC_VER
+    static_assert(sizeof(ComponentType) == 4, "ComponentType needs to 4 bytes big");
+#endif
     FixedPointCoordinate location;
     unsigned short fwd_segment_position;
     // note 4 bits would suffice for each,
@@ -114,7 +118,9 @@ struct PhantomNode
     bool operator==(const PhantomNode &other) const;
 };
 
+#ifndef _MSC_VER
 static_assert(sizeof(PhantomNode) == 48, "PhantomNode has more padding then expected");
+#endif
 
 using PhantomNodeArray = std::vector<std::vector<PhantomNode>>;
 

--- a/data_structures/static_rtree.hpp
+++ b/data_structures/static_rtree.hpp
@@ -603,7 +603,7 @@ class StaticRTree
                     for (uint32_t i = 0; i < current_leaf_node.object_count; ++i)
                     {
                         EdgeDataT const &current_edge = current_leaf_node.objects[i];
-                        if (ignore_tiny_components && current_edge.component_id != 0)
+                        if (ignore_tiny_components && current_edge.component.is_tiny)
                         {
                             continue;
                         }
@@ -767,7 +767,7 @@ class StaticRTree
                 // continue searching for the first segment from a big component
                 if (number_of_elements_from_big_cc == 0 &&
                     number_of_elements_from_tiny_cc >= max_number_of_phantom_nodes &&
-                    current_segment.is_in_tiny_cc())
+                    current_segment.component.is_tiny)
                 {
                     continue;
                 }
@@ -821,7 +821,7 @@ class StaticRTree
                                                          result_phantom_node_vector.back());
 
                 // update counts on what we found from which result class
-                if (current_segment.is_in_tiny_cc())
+                if (current_segment.component.is_tiny)
                 { // found an element in tiny component
                     ++number_of_elements_from_tiny_cc;
                 }
@@ -976,14 +976,7 @@ class StaticRTree
 
                 // store phantom node in result vector
                 result_phantom_node_vector.emplace_back(
-                    PhantomNode(
-                        current_segment.forward_edge_based_node_id,
-                        current_segment.reverse_edge_based_node_id, current_segment.name_id,
-                        current_segment.forward_weight, current_segment.reverse_weight,
-                        current_segment.forward_offset, current_segment.reverse_offset,
-                        current_segment.packed_geometry_id, current_segment.component_id,
-                        foot_point_coordinate_on_segment, current_segment.fwd_segment_position,
-                        current_segment.forward_travel_mode, current_segment.backward_travel_mode),
+                    PhantomNode {current_segment, foot_point_coordinate_on_segment},
                     current_perpendicular_distance);
 
                 if (!forward_bearing_valid)
@@ -1043,7 +1036,7 @@ class StaticRTree
                     for (uint32_t i = 0; i < current_leaf_node.object_count; ++i)
                     {
                         const EdgeDataT &current_edge = current_leaf_node.objects[i];
-                        if (ignore_tiny_components && current_edge.component_id != 0)
+                        if (ignore_tiny_components && current_edge.component.is_tiny != 0)
                         {
                             continue;
                         }
@@ -1062,19 +1055,7 @@ class StaticRTree
                             !osrm::epsilon_compare(current_perpendicular_distance, min_dist))
                         { // found a new minimum
                             min_dist = current_perpendicular_distance;
-                            result_phantom_node = {current_edge.forward_edge_based_node_id,
-                                                   current_edge.reverse_edge_based_node_id,
-                                                   current_edge.name_id,
-                                                   current_edge.forward_weight,
-                                                   current_edge.reverse_weight,
-                                                   current_edge.forward_offset,
-                                                   current_edge.reverse_offset,
-                                                   current_edge.packed_geometry_id,
-                                                   current_edge.component_id,
-                                                   nearest,
-                                                   current_edge.fwd_segment_position,
-                                                   current_edge.forward_travel_mode,
-                                                   current_edge.backward_travel_mode};
+                            result_phantom_node = {current_edge, nearest};
                             nearest_edge = current_edge;
                         }
                     }

--- a/descriptors/json_descriptor.hpp
+++ b/descriptors/json_descriptor.hpp
@@ -105,7 +105,6 @@ template <class DataFacadeT> class JSONDescriptor final : public BaseDescriptor<
             // We do not need to do much, if there is no route ;-)
             json_result.values["status"] = 207;
             json_result.values["status_message"] = "Cannot find route between points";
-            // osrm::json::render(reply.content, json_result);
             return;
         }
 

--- a/extractor/edge_based_graph_factory.cpp
+++ b/extractor/edge_based_graph_factory.cpp
@@ -164,7 +164,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u,
                 forward_data.name_id, forward_geometry[i].second,
                 reverse_geometry[geometry_size - 1 - i].second, forward_dist_prefix_sum[i],
                 reverse_dist_prefix_sum[i], m_compressed_edge_container.GetPositionForID(edge_id_1),
-                INVALID_COMPONENTID, i, forward_data.travel_mode, reverse_data.travel_mode);
+                false, INVALID_COMPONENTID, i, forward_data.travel_mode, reverse_data.travel_mode);
             current_edge_source_coordinate_id = current_edge_target_coordinate_id;
 
             BOOST_ASSERT(m_edge_based_node_list.back().IsCompressed());
@@ -207,7 +207,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u,
         m_edge_based_node_list.emplace_back(
             forward_data.edge_id, reverse_data.edge_id, node_u, node_v,
             forward_data.name_id, forward_data.distance, reverse_data.distance, 0, 0, SPECIAL_EDGEID,
-            INVALID_COMPONENTID, 0, forward_data.travel_mode, reverse_data.travel_mode);
+            false, INVALID_COMPONENTID, 0, forward_data.travel_mode, reverse_data.travel_mode);
         BOOST_ASSERT(!m_edge_based_node_list.back().IsCompressed());
     }
 }

--- a/extractor/extractor.cpp
+++ b/extractor/extractor.cpp
@@ -436,8 +436,8 @@ void extractor::FindComponents(unsigned max_edge_id,
                          component_search.get_component_id(node.reverse_edge_based_node_id));
 
         const unsigned component_size = component_search.get_component_size(forward_component);
-        const bool is_tiny_component = component_size < 1000;
-        node.component_id = is_tiny_component ? (1 + forward_component) : 0;
+        node.component.is_tiny = component_size < 1000;
+        node.component.id = 1 + forward_component;
     }
 }
 

--- a/features/testbot/status.feature
+++ b/features/testbot/status.feature
@@ -32,8 +32,8 @@ Feature: Status messages
             | from | to | route | status | message                          |
             | a    | b  | ab    | 0      | Found route between points       |
             | c    | d  | cd    | 0      | Found route between points       |
-            | a    | c  |       | 207    | Cannot find route between points |
-            | b    | d  |       | 207    | Cannot find route between points |
+            | a    | c  |       | 207    | Impossible route between points. |
+            | b    | d  |       | 207    | Impossible route between points. |
 
     Scenario: Malformed requests
         Given the node locations

--- a/plugins/viaroute.hpp
+++ b/plugins/viaroute.hpp
@@ -215,7 +215,7 @@ template <class DataFacadeT> class ViaRoutePlugin final : public BasePlugin
         // allow for connection in one direction.
         if (!all_in_same_component && no_route)
         {
-            json_result.values["status"] = "Impossible route";
+            json_result.values["status_message"] = "Impossible route between points.";
             return 400;
         }
 

--- a/typedefs.h
+++ b/typedefs.h
@@ -45,7 +45,7 @@ using EdgeWeight = int;
 static const NodeID SPECIAL_NODEID = std::numeric_limits<unsigned>::max();
 static const EdgeID SPECIAL_EDGEID = std::numeric_limits<unsigned>::max();
 static const unsigned INVALID_NAMEID = std::numeric_limits<unsigned>::max();
-static const unsigned INVALID_COMPONENTID = std::numeric_limits<unsigned>::max();
+static const unsigned INVALID_COMPONENTID = 0;
 static const EdgeWeight INVALID_EDGE_WEIGHT = std::numeric_limits<int>::max();
 
 #endif /* TYPEDEFS_H */

--- a/unit_tests/data_structures/static_rtree.cpp
+++ b/unit_tests/data_structures/static_rtree.cpp
@@ -109,13 +109,13 @@ class LinearSearchNN
 
     bool FindPhantomNodeForCoordinate(const FixedPointCoordinate &input_coordinate,
                                       PhantomNode &result_phantom_node,
-                                      const unsigned zoom_level)
+                                      const unsigned)
     {
         float min_dist = std::numeric_limits<float>::max();
         TestData nearest_edge;
         for (const TestData &e : edges)
         {
-            if (e.component_id != 0)
+            if (e.component.is_tiny)
                 continue;
 
             float current_ratio = 0.;
@@ -136,7 +136,8 @@ class LinearSearchNN
                                        e.forward_offset,
                                        e.reverse_offset,
                                        e.packed_geometry_id,
-                                       e.component_id,
+                                       e.component.is_tiny,
+                                       e.component.id,
                                        nearest,
                                        e.fwd_segment_position,
                                        e.forward_travel_mode,
@@ -226,7 +227,7 @@ template <unsigned NUM_NODES, unsigned NUM_EDGES> struct RandomGraphFixture
             if (used_edges.find(std::pair<unsigned, unsigned>(
                     std::min(data.u, data.v), std::max(data.u, data.v))) == used_edges.end())
             {
-                data.component_id = 0;
+                data.component.id = 0;
                 edges.emplace_back(data);
                 used_edges.emplace(std::min(data.u, data.v), std::max(data.u, data.v));
             }


### PR DESCRIPTION
This uses a bit flag to differenciate between small and big components
and keeps the ids for both. This makes it easy to decide if two
coordinates are on different continets.