### PR TITLE
[not ready] Adds ability to dump GeoJSON with detailed edge weight data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ if(WIN32 AND MSVC_VERSION LESS 1800)
 endif()
 
 option(ENABLE_JSON_LOGGING "Adds additional JSON debug logging to the response" OFF)
+option(DEBUG_GEOMETRY "Enables an option to dump GeoJSON of the final routing graph" OFF)
 option(BUILD_TOOLS "Build OSRM tools" OFF)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -330,6 +331,11 @@ target_link_libraries(osrm-routed ${ZLIB_LIBRARY})
 if (ENABLE_JSON_LOGGING)
   message(STATUS "Enabling json logging")
   add_definitions(-DENABLE_JSON_LOGGING)
+endif()
+
+if (DEBUG_GEOMETRY)
+  message(STATUS "Enabling final edge weight GeoJSON output option")
+  add_definitions(-DDEBUG_GEOMETRY)
 endif()
 
 if(BUILD_TOOLS)

--- a/appveyor-build.bat
+++ b/appveyor-build.bat
@@ -6,6 +6,8 @@ ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SET PROJECT_DIR=%CD%
 ECHO PROJECT_DIR^: %PROJECT_DIR%
+ECHO NUMBER_OF_PROCESSORS^: %NUMBER_OF_PROCESSORS%
+ECHO cmake^: && cmake --version
 
 ECHO activating VS command prompt ...
 SET PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
@@ -50,7 +52,7 @@ set TBB_ARCH_PLATFORM=intel64/vc14
 
 ECHO calling cmake ....
 cmake .. ^
--G "Visual Studio 14 Win64" ^
+-G "Visual Studio 14 2015 Win64" ^
 -DBOOST_ROOT=%BOOST_ROOT% ^
 -DBoost_ADDITIONAL_VERSIONS=1.58 ^
 -DBoost_USE_MULTITHREADED=ON ^

--- a/build-local.bat
+++ b/build-local.bat
@@ -11,7 +11,8 @@ SET CONFIGURATION=Release
 FOR /F "tokens=*" %%i in ('git rev-parse --abbrev-ref HEAD') do SET APPVEYOR_REPO_BRANCH=%%i
 ECHO APPVEYOR_REPO_BRANCH^: %APPVEYOR_REPO_BRANCH%
 
-SET PATH=C:\mb\windows-builds-64\tmp-bin\cmake-3.1.0-win32-x86\bin;%PATH%
+::SET PATH=C:\mb\windows-builds-64\tmp-bin\cmake-3.1.0-win32-x86\bin;%PATH%
+SET PATH=C:\mb\windows-builds-64\tmp-bin\cmake-3.4.0-win32-x86\bin;%PATH%
 SET PATH=C:\Program Files\7-Zip;%PATH%
 
 powershell Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted -Force

--- a/contractor/contractor.hpp
+++ b/contractor/contractor.hpp
@@ -55,6 +55,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Contractor
 {
+  public:
+    struct RemainingNodeData
+    {
+        RemainingNodeData() : id(0), is_independent(false) {}
+        NodeID id : 31;
+        bool is_independent : 1;
+    };
+
 
   private:
     struct ContractorEdgeData
@@ -125,13 +133,6 @@ class Contractor
               original_edges_added_count(0)
         {
         }
-    };
-
-    struct RemainingNodeData
-    {
-        RemainingNodeData() : id(0), is_independent(false) {}
-        NodeID id : 31;
-        bool is_independent : 1;
     };
 
     struct ThreadDataContainer

--- a/contractor/contractor_options.cpp
+++ b/contractor/contractor_options.cpp
@@ -56,12 +56,19 @@ ContractorOptions::ParseArguments(int argc, char *argv[], ContractorConfig &cont
         boost::program_options::value<unsigned int>(&contractor_config.requested_num_threads)
             ->default_value(tbb::task_scheduler_init::default_num_threads()),
         "Number of threads to use")(
-        "core,k",
-        boost::program_options::value<double>(&contractor_config.core_factor)->default_value(1.0),
-        "Percentage of the graph (in vertices) to contract [0.1]")(
+		"core,k", boost::program_options::value<double>(&contractor_config.core_factor)
+						 ->default_value(1.0),"Percentage of the graph (in vertices) to contract [0..1]")(
+		"segment-speed-file", boost::program_options::value<std::string>(&contractor_config.segment_speed_lookup_path),
+						 "Lookup file containing nodeA,nodeB,speed data to adjust edge weights")(
         "level-cache,o",
         boost::program_options::value<bool>(&contractor_config.use_cached_priority)->default_value(false),
         "Use .level file to retain the contaction level for each node from the last run.");
+
+#ifdef DEBUG_GEOMETRY
+    config_options.add_options()(
+		"debug-geometry", boost::program_options::value<std::string>(&contractor_config.debug_geometry_path)
+						 ,"Write out edge-weight debugging geometry data in GeoJSON format to this file");
+#endif
 
     // hidden options, will be allowed both on command line and in config file, but will not be
     // shown to the user

--- a/contractor/contractor_options.hpp
+++ b/contractor/contractor_options.hpp
@@ -66,6 +66,9 @@ struct ContractorConfig
 
     std::string segment_speed_lookup_path;
 
+#ifdef DEBUG_GEOMETRY
+    std::string debug_geometry_path;
+#endif
 };
 
 struct ContractorOptions

--- a/contractor/processing_chain.hpp
+++ b/contractor/processing_chain.hpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef PROCESSING_CHAIN_HPP
 #define PROCESSING_CHAIN_HPP
 
+#include "contractor.hpp"
 #include "contractor_options.hpp"
 #include "../data_structures/query_edge.hpp"
 #include "../data_structures/static_graph.hpp"

--- a/extractor/edge_based_graph_factory.hpp
+++ b/extractor/edge_based_graph_factory.hpp
@@ -50,6 +50,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_set>
 #include <vector>
 
+#include <boost/filesystem/fstream.hpp>
+
 struct lua_State;
 
 class EdgeBasedGraphFactory
@@ -66,12 +68,20 @@ class EdgeBasedGraphFactory
                                    const std::vector<QueryNode> &node_info_list,
                                    SpeedProfileProperties speed_profile);
 
+#ifdef DEBUG_GEOMETRY
     void Run(const std::string &original_edge_data_filename,
              lua_State *lua_state,
              const std::string &edge_segment_lookup_filename,
              const std::string &edge_penalty_filename,
-             const bool generate_edge_lookup
-             );
+             const bool generate_edge_lookup,
+             const std::string &debug_turns_path);
+#else
+    void Run(const std::string &original_edge_data_filename,
+             lua_State *lua_state,
+             const std::string &edge_segment_lookup_filename,
+             const std::string &edge_penalty_filename,
+             const bool generate_edge_lookup);
+#endif
 
     void GetEdgeBasedEdges(DeallocatingVector<EdgeBasedEdge> &edges);
 
@@ -103,12 +113,20 @@ class EdgeBasedGraphFactory
     void CompressGeometry();
     unsigned RenumberEdges();
     void GenerateEdgeExpandedNodes();
+#ifdef DEBUG_GEOMETRY
     void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
                                    lua_State *lua_state,
                                    const std::string &edge_segment_lookup_filename,
                                    const std::string &edge_fixed_penalties_filename,
-                                   const bool generate_edge_lookup
-                                   );
+                                   const bool generate_edge_lookup,
+                                   const std::string &debug_turns_path);
+#else
+    void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
+                                   lua_State *lua_state,
+                                   const std::string &edge_segment_lookup_filename,
+                                   const std::string &edge_fixed_penalties_filename,
+                                   const bool generate_edge_lookup);
+#endif 
 
     void InsertEdgeBasedNode(const NodeID u, const NodeID v);
 

--- a/extractor/extractor.cpp
+++ b/extractor/extractor.cpp
@@ -536,17 +536,15 @@ extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
             config.edge_segment_lookup_path,
             config.edge_penalty_path,
             config.generate_edge_lookup
+#ifdef DEBUG_GEOMETRY
+            , config.debug_turns_path
+#endif
             );
     lua_close(lua_state);
 
     edge_based_graph_factory.GetEdgeBasedEdges(edge_based_edge_list);
     edge_based_graph_factory.GetEdgeBasedNodes(node_based_edge_list);
     auto max_edge_id = edge_based_graph_factory.GetHighestEdgeID();
-
-    // danpat TODO: somewhere right around here, we will need to
-    // use the internal_to_external_node_map (which contains original OSM node ids)
-    // the edges from the compressed edge container
-    // and the edge-based-edges
 
     const std::size_t number_of_node_based_nodes = node_based_graph->GetNumberOfNodes();
     return std::make_pair(number_of_node_based_nodes, max_edge_id);

--- a/extractor/extractor_options.cpp
+++ b/extractor/extractor_options.cpp
@@ -66,6 +66,12 @@ ExtractorOptions::ParseArguments(int argc, char *argv[], ExtractorConfig &extrac
                                                 &extractor_config.generate_edge_lookup)->implicit_value(true)->default_value(false),
                                  "Generate a lookup table for internal edge-expanded-edge IDs to OSM node pairs");
 
+#ifdef DEBUG_GEOMETRY
+        config_options.add_options()("debug-turns",
+            boost::program_options::value<std::string>(&extractor_config.debug_turns_path),
+            "Write out GeoJSON with turn penalty data");
+#endif // DEBUG_GEOMETRY
+
     // hidden options, will be allowed both on command line and in config file, but will not be
     // shown to the user
     boost::program_options::options_description hidden_options("Hidden options");

--- a/extractor/extractor_options.hpp
+++ b/extractor/extractor_options.hpp
@@ -62,6 +62,9 @@ struct ExtractorConfig
     bool generate_edge_lookup;
     std::string edge_penalty_path;
     std::string edge_segment_lookup_path;
+#ifdef DEBUG_GEOMETRY
+    std::string debug_turns_path;
+#endif
 };
 
 struct ExtractorOptions

--- a/features/options/prepare/help.feature
+++ b/features/options/prepare/help.feature
@@ -17,7 +17,8 @@ Feature: osrm-prepare command line options: help
         And stdout should contain "--threads"
         And stdout should contain "--core"
         And stdout should contain "--level-cache"
-        And stdout should contain 18 lines
+        And stdout should contain "--segment-speed-file"
+        And stdout should contain 21 lines
         And it should exit with code 1
 
     Scenario: osrm-prepare - Help, short
@@ -33,7 +34,8 @@ Feature: osrm-prepare command line options: help
         And stdout should contain "--threads"
         And stdout should contain "--core"
         And stdout should contain "--level-cache"
-        And stdout should contain 18 lines
+        And stdout should contain "--segment-speed-file"
+        And stdout should contain 21 lines
         And it should exit with code 0
 
     Scenario: osrm-prepare - Help, long
@@ -49,5 +51,6 @@ Feature: osrm-prepare command line options: help
         And stdout should contain "--threads"
         And stdout should contain "--core"
         And stdout should contain "--level-cache"
-        And stdout should contain 18 lines
+        And stdout should contain "--segment-speed-file"
+        And stdout should contain 21 lines
         And it should exit with code 0

--- a/util/debug_geometry.hpp
+++ b/util/debug_geometry.hpp
@@ -1,0 +1,198 @@
+/*
+
+Copyright (c) 2015, Project OSRM contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef DEBUG_GEOMETRY_H
+#define DEBUG_GEOMETRY_H
+
+#include "../contractor/contractor_options.hpp"
+#include "../data_structures/query_node.hpp"
+
+#ifndef DEBUG_GEOMETRY
+
+inline void DEBUG_GEOMETRY_START(ContractorConfig & /* config */) {}
+inline void DEBUG_GEOMETRY_EDGE(int /* new_segment_weight */ , double /* segment_length */,
+        NodeID /* previous_osm_node_id */, NodeID /* this_osm_node_id */) {}
+inline void DEBUG_GEOMETRY_STOP() {}
+
+inline void DEBUG_TURNS_START(const std::string & /* debug_turns_filename */) {}
+inline void DEBUG_TURN( const NodeID /* node */, const std::vector<QueryNode>& /* m_node_info_list */,
+        const FixedPointCoordinate & /* first_coordinate */, const int /* turn_angle */,
+        const int /* turn_penalty */) {}
+inline void DEBUG_UTURN( const NodeID /* node */, const std::vector<QueryNode>& /* m_node_info_list */,
+        const int /* uturn_penalty */ ) {}
+inline void DEBUG_SIGNAL( const NodeID /* node */, const std::vector<QueryNode>& /* m_node_info_list */,
+        const int /* signal_penalty */ ) {}
+
+inline void DEBUG_TURNS_STOP() {}
+
+#else // DEBUG_GEOMETRY
+
+#include <boost/filesystem.hpp>
+#include <ctime>
+#include <string>
+#include <iomanip>
+#include <iostream>
+
+#include "../include/osrm/coordinate.hpp"
+#include "../algorithms/coordinate_calculation.hpp"
+
+boost::filesystem::ofstream debug_geometry_file;
+bool dg_output_debug_geometry = false;
+bool dg_first_debug_geometry = true;
+char dg_time_buffer[80];
+
+boost::filesystem::ofstream dg_debug_turns_file;
+bool dg_output_turn_debug = false;
+bool dg_first_turn_debug = true;
+
+inline void DEBUG_GEOMETRY_START(const ContractorConfig &config)
+{
+    time_t raw_time;
+    struct tm *timeinfo;
+    time(&raw_time);
+    timeinfo = localtime(&raw_time);
+    strftime(dg_time_buffer, 80, "%Y-%m-%d %H:%M %Z", timeinfo);
+
+    dg_output_debug_geometry = config.debug_geometry_path != "";
+
+    if (dg_output_debug_geometry)
+    {
+        debug_geometry_file.open(config.debug_geometry_path, std::ios::binary);
+        debug_geometry_file << "{\"type\":\"FeatureCollection\", \"features\":[" << std::endl;
+    }
+}
+
+inline void DEBUG_GEOMETRY_EDGE(int new_segment_weight, double segment_length, NodeID previous_osm_node_id, NodeID this_osm_node_id)
+{
+    if (dg_output_debug_geometry)
+    {
+        if (!dg_first_debug_geometry)
+            debug_geometry_file << "," << std::endl;
+        debug_geometry_file
+            << "{ \"type\":\"Feature\",\"properties\":{\"original\":false, "
+               "\"weight\":"
+            << new_segment_weight / 10.0 << ",\"speed\":"
+            << static_cast<int>(
+                   std::floor((segment_length / new_segment_weight) * 10. * 3.6))
+            << ",";
+        debug_geometry_file << "\"from_node\": " << previous_osm_node_id
+                            << ", \"to_node\": " << this_osm_node_id << ",";
+        debug_geometry_file << "\"timestamp\": \"" << dg_time_buffer << "\"},";
+        debug_geometry_file
+            << "\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[!!"
+            << previous_osm_node_id << "!!],[!!" << this_osm_node_id << "!!]]}}"
+            << std::endl;
+        dg_first_debug_geometry = false;
+    }
+}
+
+inline void DEBUG_GEOMETRY_STOP()
+{
+    if (dg_output_debug_geometry)
+    {
+        debug_geometry_file << std::endl << "]}" << std::endl;
+        debug_geometry_file.close();
+    }
+}
+
+
+inline void DEBUG_TURNS_START(const std::string & debug_turns_path)
+{   
+    dg_output_turn_debug = debug_turns_path != "";
+    if (dg_output_turn_debug) 
+    {
+        dg_debug_turns_file.open(debug_turns_path);
+        dg_debug_turns_file << "{\"type\":\"FeatureCollection\", \"features\":[" << std::endl;
+    }
+} 
+
+inline void DEBUG_SIGNAL(
+        const NodeID node, 
+        const std::vector<QueryNode>& m_node_info_list,
+        const int traffic_signal_penalty)
+{
+    if (dg_output_turn_debug)
+    {
+        const QueryNode &nodeinfo = m_node_info_list[node];
+        if (!dg_first_turn_debug) dg_debug_turns_file << "," << std::endl;
+        dg_debug_turns_file << "{ \"type\":\"Feature\",\"properties\":{\"type\":\"trafficlights\",\"cost\":" << traffic_signal_penalty/10. << "},";
+        dg_debug_turns_file << " \"geometry\":{\"type\":\"Point\",\"coordinates\":[" << std::setprecision(12) << nodeinfo.lon/COORDINATE_PRECISION << "," << nodeinfo.lat/COORDINATE_PRECISION << "]}}";
+        dg_first_turn_debug = false;
+    }
+}
+
+inline void DEBUG_UTURN(
+        const NodeID node, 
+        const std::vector<QueryNode>& m_node_info_list,
+        const int traffic_signal_penalty)
+{
+    if (dg_output_turn_debug)
+    {
+        const QueryNode &nodeinfo = m_node_info_list[node];
+        if (!dg_first_turn_debug) dg_debug_turns_file << "," << std::endl;
+        dg_debug_turns_file << "{ \"type\":\"Feature\",\"properties\":{\"type\":\"trafficlights\",\"cost\":" << traffic_signal_penalty/10. << "},";
+        dg_debug_turns_file << " \"geometry\":{\"type\":\"Point\",\"coordinates\":[" << std::setprecision(12) << nodeinfo.lon/COORDINATE_PRECISION << "," << nodeinfo.lat/COORDINATE_PRECISION << "]}}";
+        dg_first_turn_debug = false;
+    }
+}
+
+
+inline void DEBUG_TURN(
+        const NodeID node, 
+        const std::vector<QueryNode>& m_node_info_list,
+        const FixedPointCoordinate & first_coordinate,
+        const int turn_angle,
+        const int turn_penalty)
+{
+    if (turn_penalty > 0 && dg_output_turn_debug) 
+    {
+        const QueryNode &v = m_node_info_list[node];
+
+        const float bearing_uv = coordinate_calculation::bearing(first_coordinate,v);
+        float uvw_normal = bearing_uv + turn_angle/2;
+        while (uvw_normal >= 360.) { uvw_normal -= 360.; }
+
+        if (!dg_first_turn_debug) dg_debug_turns_file << "," << std::endl;
+        dg_debug_turns_file << "{ \"type\":\"Feature\",\"properties\":{\"type\":\"turn\",\"cost\":" << turn_penalty/10. << ",\"turn_angle\":" << static_cast<int>(turn_angle) << ",\"normal\":" << static_cast<int>(uvw_normal) << "},";
+        dg_debug_turns_file << " \"geometry\":{\"type\":\"Point\",\"coordinates\":[" << std::setprecision(12) << v.lon/COORDINATE_PRECISION << "," << v.lat/COORDINATE_PRECISION << "]}}";
+        dg_first_turn_debug = false;
+    }
+}
+
+inline void DEBUG_TURNS_STOP()
+{
+    if (dg_output_turn_debug)
+    {
+        dg_debug_turns_file << std::endl << "]}" << std::endl;
+        dg_debug_turns_file.close();
+    }
+}
+
+#endif // DEBUG_GEOMETRY
+
+
+#endif // DEBUG_GEOMETRY_H


### PR DESCRIPTION
Useful for debugging.  

Adds a new compile-time flag to enable:  `cmake -DDEBUG_GEOMETRY=ON`

This unlocks two new runtime options.
For `osrm-extract`, it's `--debug-turns <filename>`
For `osrm-prepare`, it's `--debug-geometry <filename>`

This will give you point data for turns (with heading and value meta-data in the `properties` of each GeoJSON), and lines for each edge, with weight data attached.  There is one two-point line segment for every node-based edge in the graph, and they are not bidirectional (i.e. you get two for each one-way street, oriented in the direction of travel).

Still todo:
 - [x] Move code into utility functions to minimize the `#ifdef` impact