### PR TITLE
Add support for 64bit OSM node identifiers

### DIFF
--- a/data_structures/external_memory_node.cpp
+++ b/data_structures/external_memory_node.cpp
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <limits>
 
 ExternalMemoryNode::ExternalMemoryNode(
-    int lat, int lon, unsigned int node_id, bool barrier, bool traffic_lights)
+    int lat, int lon, OSMNodeID node_id, bool barrier, bool traffic_lights)
     : QueryNode(lat, lon, node_id), barrier(barrier), traffic_lights(traffic_lights)
 {
 }
@@ -40,13 +40,13 @@ ExternalMemoryNode::ExternalMemoryNode() : barrier(false), traffic_lights(false)
 
 ExternalMemoryNode ExternalMemoryNode::min_value()
 {
-    return ExternalMemoryNode(0, 0, 0, false, false);
+    return ExternalMemoryNode(0, 0, MIN_OSM_NODEID, false, false);
 }
 
 ExternalMemoryNode ExternalMemoryNode::max_value()
 {
     return ExternalMemoryNode(std::numeric_limits<int>::max(), std::numeric_limits<int>::max(),
-                              std::numeric_limits<unsigned>::max(), false, false);
+                              MAX_OSM_NODEID, false, false);
 }
 
 bool ExternalMemoryNodeSTXXLCompare::operator()(const ExternalMemoryNode &left,

--- a/data_structures/external_memory_node.hpp
+++ b/data_structures/external_memory_node.hpp
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct ExternalMemoryNode : QueryNode
 {
-    ExternalMemoryNode(int lat, int lon, NodeID id, bool barrier, bool traffic_light);
+    ExternalMemoryNode(int lat, int lon, OSMNodeID id, bool barrier, bool traffic_light);
 
     ExternalMemoryNode();
 

--- a/data_structures/import_edge.hpp
+++ b/data_structures/import_edge.hpp
@@ -59,6 +59,25 @@ struct NodeBasedEdge
     TravelMode travel_mode : 4;
 };
 
+struct NodeBasedEdgeWithOSM : NodeBasedEdge
+{
+    explicit NodeBasedEdgeWithOSM(OSMNodeID source,
+                           OSMNodeID target,
+                           NodeID name_id,
+                           EdgeWeight weight,
+                           bool forward,
+                           bool backward,
+                           bool roundabout,
+                           bool access_restricted,
+                           TravelMode travel_mode,
+                           bool is_split)
+        : NodeBasedEdge(SPECIAL_NODEID, SPECIAL_NODEID, name_id, weight, forward, backward, roundabout, access_restricted, travel_mode, is_split),
+        osm_source_id(source), osm_target_id(target) {}
+
+    OSMNodeID osm_source_id;
+    OSMNodeID osm_target_id;
+};
+
 struct EdgeBasedEdge
 {
 

--- a/data_structures/node_based_graph.hpp
+++ b/data_structures/node_based_graph.hpp
@@ -75,7 +75,7 @@ using NodeBasedDynamicGraph = DynamicGraph<NodeBasedEdgeData>;
 /// The since DynamicGraph expects directed edges, we need to insert
 /// two edges for undirected edges.
 inline std::shared_ptr<NodeBasedDynamicGraph>
-NodeBasedDynamicGraphFromEdges(int number_of_nodes, const std::vector<NodeBasedEdge> &input_edge_list)
+NodeBasedDynamicGraphFromEdges(std::size_t number_of_nodes, const std::vector<NodeBasedEdge> &input_edge_list)
 {
     auto edges_list = directedEdgesFromCompressed<NodeBasedDynamicGraph::InputEdge>(input_edge_list,
         [](NodeBasedDynamicGraph::InputEdge& output_edge, const NodeBasedEdge& input_edge)

--- a/data_structures/node_id.hpp
+++ b/data_structures/node_id.hpp
@@ -32,10 +32,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct Cmp
 {
-    using value_type = NodeID;
-    bool operator()(const NodeID left, const NodeID right) const { return left < right; }
-    value_type max_value() { return 0xffffffff; }
-    value_type min_value() { return 0x0; }
+    using value_type = OSMNodeID;
+    bool operator()(const value_type left, const value_type right) const { return left < right; }
+    value_type max_value() { return MAX_OSM_NODEID; }
+    value_type min_value() { return MIN_OSM_NODEID; }
 };
 
 #endif // NODE_ID_HPP

--- a/data_structures/query_node.hpp
+++ b/data_structures/query_node.hpp
@@ -38,32 +38,32 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct QueryNode
 {
-    using key_type = NodeID; // type of NodeID
+    using key_type = OSMNodeID; // type of NodeID
     using value_type = int;  // type of lat,lons
 
-    explicit QueryNode(int lat, int lon, NodeID node_id) : lat(lat), lon(lon), node_id(node_id) {}
+    explicit QueryNode(int lat, int lon, OSMNodeID node_id) : lat(lat), lon(lon), node_id(node_id) {}
     QueryNode()
         : lat(std::numeric_limits<int>::max()), lon(std::numeric_limits<int>::max()),
-          node_id(std::numeric_limits<unsigned>::max())
+          node_id(SPECIAL_OSM_NODEID)
     {
     }
 
     int lat;
     int lon;
-    NodeID node_id;
+    OSMNodeID node_id;
 
     static QueryNode min_value()
     {
         return QueryNode(static_cast<int>(-90 * COORDINATE_PRECISION),
                          static_cast<int>(-180 * COORDINATE_PRECISION),
-                         std::numeric_limits<NodeID>::min());
+                         MIN_OSM_NODEID);
     }
 
     static QueryNode max_value()
     {
         return QueryNode(static_cast<int>(90 * COORDINATE_PRECISION),
                          static_cast<int>(180 * COORDINATE_PRECISION),
-                         std::numeric_limits<NodeID>::max());
+                         MAX_OSM_NODEID);
     }
 
     value_type operator[](const std::size_t n) const

--- a/data_structures/restriction.hpp
+++ b/data_structures/restriction.hpp
@@ -36,8 +36,8 @@ struct TurnRestriction
 {
     union WayOrNode
     {
-        NodeID node;
-        EdgeID way;
+        OSMNodeID_weak node;
+        OSMEdgeID_weak way;
     };
     WayOrNode via;
     WayOrNode from;

--- a/data_structures/restriction_map.cpp
+++ b/data_structures/restriction_map.cpp
@@ -33,10 +33,16 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
     // a pair of starting edge and a list of all end nodes
     for (auto &restriction : restriction_list)
     {
+        // This downcasting is OK because when this is called, the node IDs have been
+        // renumbered into internal values, which should be well under 2^32
+        // This will be a problem if we have more than 2^32 actual restrictions
+        BOOST_ASSERT(restriction.from.node < std::numeric_limits<NodeID>::max());
+        BOOST_ASSERT(restriction.via.node < std::numeric_limits<NodeID>::max());
         m_restriction_start_nodes.insert(restriction.from.node);
         m_no_turn_via_node_set.insert(restriction.via.node);
 
-        RestrictionSource restriction_source = {restriction.from.node, restriction.via.node};
+        // This explicit downcasting is also OK for the same reason.
+        RestrictionSource restriction_source = {static_cast<NodeID>(restriction.from.node), static_cast<NodeID>(restriction.via.node)};
 
         std::size_t index;
         auto restriction_iter = m_restriction_map.find(restriction_source);
@@ -62,6 +68,7 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
             }
         }
         ++m_count;
+        BOOST_ASSERT(restriction.to.node < std::numeric_limits<NodeID>::max());
         m_restriction_bucket_list.at(index)
             .emplace_back(restriction.to.node, restriction.flags.is_only);
     }

--- a/extractor/edge_based_graph_factory.cpp
+++ b/extractor/edge_based_graph_factory.cpp
@@ -518,6 +518,9 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                 BOOST_ASSERT(SPECIAL_NODEID != edge_data1.edge_id);
                 BOOST_ASSERT(SPECIAL_NODEID != edge_data2.edge_id);
 
+
+                // NOTE: potential overflow here if we hit 2^32 routable edges
+                BOOST_ASSERT(m_edge_based_edge_list.size() <= std::numeric_limits<NodeID>::max());
                 m_edge_based_edge_list.emplace_back(edge_data1.edge_id, edge_data2.edge_id,
                                   m_edge_based_edge_list.size(), distance, true, false);
 

--- a/extractor/extraction_containers.hpp
+++ b/extractor/extraction_containers.hpp
@@ -61,7 +61,7 @@ class ExtractionContainers
     void WriteEdges(std::ofstream& file_out_stream) const;
     void WriteNames(const std::string& names_file_name) const;
   public:
-    using STXXLNodeIDVector = stxxl::vector<NodeID>;
+    using STXXLNodeIDVector = stxxl::vector<OSMNodeID>;
     using STXXLNodeVector = stxxl::vector<ExternalMemoryNode>;
     using STXXLEdgeVector = stxxl::vector<InternalExtractorEdge>;
     using STXXLStringVector = stxxl::vector<std::string>;
@@ -74,7 +74,7 @@ class ExtractionContainers
     STXXLStringVector name_list;
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
-    std::unordered_map<NodeID, NodeID> external_to_internal_node_id_map;
+    std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;
     unsigned max_internal_node_id;
 
     ExtractionContainers();

--- a/extractor/extractor_callbacks.cpp
+++ b/extractor/extractor_callbacks.cpp
@@ -63,7 +63,7 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
     external_memory.all_nodes_list.push_back(
         {static_cast<int>(input_node.location().lat() * COORDINATE_PRECISION),
          static_cast<int>(input_node.location().lon() * COORDINATE_PRECISION),
-         static_cast<NodeID>(input_node.id()),
+         OSMNodeID(input_node.id()),
          result_node.barrier,
          result_node.traffic_lights});
 }
@@ -175,7 +175,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                    std::back_inserter(external_memory.used_node_id_list),
                    [](const osmium::NodeRef &ref)
                    {
-                       return ref.ref();
+                       return OSMNodeID(ref.ref());
                    });
 
     const bool is_opposite_way = TRAVEL_MODE_INACCESSIBLE == parsed_way.forward_travel_mode;
@@ -189,18 +189,18 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                             [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node)
                             {
                                 external_memory.all_edges_list.push_back(InternalExtractorEdge(
-                                    first_node.ref(), last_node.ref(), name_id,
+                                    OSMNodeID(first_node.ref()), OSMNodeID(last_node.ref()), name_id,
                                     backward_weight_data, true, false, parsed_way.roundabout,
                                     parsed_way.is_access_restricted,
                                     parsed_way.backward_travel_mode, false));
                             });
 
         external_memory.way_start_end_id_list.push_back(
-            {static_cast<EdgeID>(input_way.id()),
-             static_cast<NodeID>(input_way.nodes().back().ref()),
-             static_cast<NodeID>(input_way.nodes()[input_way.nodes().size() - 2].ref()),
-             static_cast<NodeID>(input_way.nodes()[1].ref()),
-             static_cast<NodeID>(input_way.nodes()[0].ref())});
+            {OSMWayID(input_way.id()),
+             OSMNodeID(input_way.nodes().back().ref()),
+             OSMNodeID(input_way.nodes()[input_way.nodes().size() - 2].ref()),
+             OSMNodeID(input_way.nodes()[1].ref()),
+             OSMNodeID(input_way.nodes()[0].ref())});
     }
     else
     {
@@ -210,7 +210,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                             [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node)
                             {
                                 external_memory.all_edges_list.push_back(InternalExtractorEdge(
-                                    first_node.ref(), last_node.ref(), name_id, forward_weight_data,
+                                    OSMNodeID(first_node.ref()), OSMNodeID(last_node.ref()), name_id, forward_weight_data,
                                     true, !forward_only, parsed_way.roundabout,
                                     parsed_way.is_access_restricted, parsed_way.forward_travel_mode,
                                     split_edge));
@@ -223,17 +223,17 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                 [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node)
                 {
                     external_memory.all_edges_list.push_back(InternalExtractorEdge(
-                        first_node.ref(), last_node.ref(), name_id, backward_weight_data, false,
+                        OSMNodeID(first_node.ref()), OSMNodeID(last_node.ref()), name_id, backward_weight_data, false,
                         true, parsed_way.roundabout, parsed_way.is_access_restricted,
                         parsed_way.backward_travel_mode, true));
                 });
         }
 
         external_memory.way_start_end_id_list.push_back(
-            {static_cast<EdgeID>(input_way.id()),
-             static_cast<NodeID>(input_way.nodes().back().ref()),
-             static_cast<NodeID>(input_way.nodes()[input_way.nodes().size() - 2].ref()),
-             static_cast<NodeID>(input_way.nodes()[1].ref()),
-             static_cast<NodeID>(input_way.nodes()[0].ref())});
+            {OSMWayID(input_way.id()),
+             OSMNodeID(input_way.nodes().back().ref()),
+             OSMNodeID(input_way.nodes()[input_way.nodes().size() - 2].ref()),
+             OSMNodeID(input_way.nodes()[1].ref()),
+             OSMNodeID(input_way.nodes()[0].ref())});
     }
 }

--- a/extractor/first_and_last_segment_of_way.hpp
+++ b/extractor/first_and_last_segment_of_way.hpp
@@ -36,21 +36,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct FirstAndLastSegmentOfWay
 {
-    EdgeID way_id;
-    NodeID first_segment_source_id;
-    NodeID first_segment_target_id;
-    NodeID last_segment_source_id;
-    NodeID last_segment_target_id;
+    OSMWayID way_id;
+    OSMNodeID first_segment_source_id;
+    OSMNodeID first_segment_target_id;
+    OSMNodeID last_segment_source_id;
+    OSMNodeID last_segment_target_id;
+
     FirstAndLastSegmentOfWay()
-        : way_id(std::numeric_limits<EdgeID>::max()),
-          first_segment_source_id(std::numeric_limits<NodeID>::max()),
-          first_segment_target_id(std::numeric_limits<NodeID>::max()),
-          last_segment_source_id(std::numeric_limits<NodeID>::max()),
-          last_segment_target_id(std::numeric_limits<NodeID>::max())
+        : way_id(SPECIAL_OSM_WAYID),
+          first_segment_source_id(SPECIAL_OSM_NODEID),
+          first_segment_target_id(SPECIAL_OSM_NODEID),
+          last_segment_source_id(SPECIAL_OSM_NODEID),
+          last_segment_target_id(SPECIAL_OSM_NODEID)
     {
     }
 
-    FirstAndLastSegmentOfWay(EdgeID w, NodeID fs, NodeID ft, NodeID ls, NodeID lt)
+    FirstAndLastSegmentOfWay(OSMWayID w, OSMNodeID fs, OSMNodeID ft, OSMNodeID ls, OSMNodeID lt)
         : way_id(w), first_segment_source_id(fs), first_segment_target_id(ft),
           last_segment_source_id(ls), last_segment_target_id(lt)
     {
@@ -58,19 +59,19 @@ struct FirstAndLastSegmentOfWay
 
     static FirstAndLastSegmentOfWay min_value()
     {
-        return {std::numeric_limits<EdgeID>::min(),
-                std::numeric_limits<NodeID>::min(),
-                std::numeric_limits<NodeID>::min(),
-                std::numeric_limits<NodeID>::min(),
-                std::numeric_limits<NodeID>::min()};
+        return {MIN_OSM_WAYID,
+                MIN_OSM_NODEID,
+                MIN_OSM_NODEID,
+                MIN_OSM_NODEID,
+                MIN_OSM_NODEID};
     }
     static FirstAndLastSegmentOfWay max_value()
     {
-        return {std::numeric_limits<EdgeID>::max(),
-                std::numeric_limits<NodeID>::max(),
-                std::numeric_limits<NodeID>::max(),
-                std::numeric_limits<NodeID>::max(),
-                std::numeric_limits<NodeID>::max()};
+        return {MAX_OSM_WAYID,
+                MAX_OSM_NODEID,
+                MAX_OSM_NODEID,
+                MAX_OSM_NODEID,
+                MAX_OSM_NODEID};
     }
 };
 

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -28,7 +28,7 @@ Given /^the node map$/ do |table|
         raise "*** invalid node name '#{name}', must me alphanumeric" unless name.match /[a-z0-9]/
         if name.match /[a-z]/
           raise "*** duplicate node '#{name}'" if name_node_hash[name]
-          add_osm_node name, *table_coord_to_lonlat(ci,ri)
+          add_osm_node name, *table_coord_to_lonlat(ci,ri), nil
         else
           raise "*** duplicate node '#{name}'" if location_hash[name]
           add_location name, *table_coord_to_lonlat(ci,ri)
@@ -43,7 +43,9 @@ Given /^the node locations$/ do |table|
     name = row['node']
     raise "*** duplicate node '#{name}'" if find_node_by_name name
     if name.match /[a-z]/
-      add_osm_node name, row['lon'].to_f, row['lat'].to_f
+      id = row['id']
+      id = id.to_i if id
+      add_osm_node name, row['lon'].to_f, row['lat'].to_f, id
     else
       add_location name, row['lon'].to_f, row['lat'].to_f
     end

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -123,8 +123,9 @@ def table_coord_to_lonlat ci,ri
   [@origin[0]+ci*@zoom, @origin[1]-ri*@zoom]
 end
 
-def add_osm_node name,lon,lat
-  node = OSM::Node.new make_osm_id, OSM_USER, OSM_TIMESTAMP, lon, lat
+def add_osm_node name,lon,lat,id
+  id = make_osm_id if id == nil
+  node = OSM::Node.new id, OSM_USER, OSM_TIMESTAMP, lon, lat
   node << { :name => name }
   node.uid = OSM_UID
   osm_db << node

--- a/features/testbot/64bit.feature
+++ b/features/testbot/64bit.feature
@@ -1,0 +1,23 @@
+@testbot
+Feature: Support 64bit node IDs
+
+    # Without 64bit support, this test should fail
+    Scenario: 64bit overflow conflicts
+        Given the node locations
+            | node | lat       | lon       | id         |
+            | a    | 55.660778 | 12.573909 | 1          |
+            | b    | 55.660672 | 12.573693 | 2          |
+            | c    | 55.660128 | 12.572546 | 3          |
+            | d    | 55.660015 | 12.572476 | 4294967297 |
+            | e    | 55.660119 | 12.572325 | 4294967298 |
+            | x    | 55.660818 | 12.574051 | 4294967299 |
+            | y    | 55.660073 | 12.574067 | 4294967300 |
+
+        And the ways
+            | nodes |
+            | abc   |
+            | cdec  |
+
+        When I route I should get
+            | from | to | route | turns            |
+            | x    | y  | abc   | head,destination |

--- a/include/osrm/strong_typedef.hpp
+++ b/include/osrm/strong_typedef.hpp
@@ -1,0 +1,68 @@
+#ifndef OSRM_STRONG_TYPEDEF_HPP
+#define OSRM_STRONG_TYPEDEF_HPP
+
+/*
+
+Copyright (c) 2015, Project OSRM contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <type_traits>
+#include <functional>
+
+/* Creates strongly typed wrappers around scalar types.
+ * Useful for stopping accidental assignment of lats to lons,
+ * etc.  Also clarifies what this random "int" value is
+ * being used for.
+ */
+#define OSRM_STRONG_TYPEDEF(From, To)                 \
+  class To final {                                      \
+    static_assert(std::is_arithmetic<From>(), "");      \
+    From x;                                             \
+                                                        \
+   public:                                              \
+    To() = default;                                     \
+    explicit To(const From x_) : x(x_) {}                     \
+    explicit operator From&() { return x; }             \
+    explicit operator const From&() const { return x; } \
+    bool operator <(const To &z_) const { return x < static_cast<const From>(z_) ; } \
+    bool operator >(const To &z_) const { return x > static_cast<const From>(z_) ; } \
+    bool operator <=(const To &z_) const { return x <= static_cast<const From>(z_) ; } \
+    bool operator >=(const To &z_) const { return x >= static_cast<const From>(z_) ; } \
+    bool operator ==(const To &z_) const { return x == static_cast<const From>(z_) ; } \
+    bool operator !=(const To &z_) const { return x != static_cast<const From>(z_) ; } \
+  };                                                    \
+  inline From To##_to_##From(To to) { return static_cast<From>(to); } \
+  namespace std { \
+  template <> \
+  struct hash<To> \
+  { \
+    std::size_t operator()(const To& k) const \
+    { \
+      return std::hash<From>()(static_cast<const From>(k)); \
+    } \
+  }; \
+  }
+
+#endif // OSRM_STRONG_TYPEDEF_HPP

--- a/typedefs.h
+++ b/typedefs.h
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TYPEDEFS_H
 
 #include <limits>
+#include <osrm/strong_typedef.hpp>
+#include <cstddef>
 
 // Necessary workaround for Windows as VS doesn't implement C99
 #ifdef _MSC_VER
@@ -37,6 +39,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define M_PI 3.14159265358979323846
 #endif
 #endif
+
+// OpenStreetMap node ids are higher than 2^32
+OSRM_STRONG_TYPEDEF(uint64_t, OSMNodeID)
+OSRM_STRONG_TYPEDEF(uint32_t, OSMWayID)
+
+static const OSMNodeID SPECIAL_OSM_NODEID = OSMNodeID(std::numeric_limits<std::uint64_t>::max());
+static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID(std::numeric_limits<std::uint32_t>::max());
+
+static const OSMNodeID MAX_OSM_NODEID = OSMNodeID(std::numeric_limits<std::uint64_t>::max());
+static const OSMNodeID MIN_OSM_NODEID = OSMNodeID(std::numeric_limits<std::uint64_t>::min());
+static const OSMWayID MAX_OSM_WAYID = OSMWayID(std::numeric_limits<std::uint32_t>::max());
+static const OSMWayID MIN_OSM_WAYID = OSMWayID(std::numeric_limits<std::uint32_t>::min());
+
+using OSMNodeID_weak = std::uint64_t;
+using OSMEdgeID_weak = std::uint64_t;
 
 using NodeID = unsigned int;
 using EdgeID = unsigned int;

--- a/unit_tests/data_structures/static_rtree.cpp
+++ b/unit_tests/data_structures/static_rtree.cpp
@@ -211,7 +211,7 @@ template <unsigned NUM_NODES, unsigned NUM_EDGES> struct RandomGraphFixture
         {
             int lat = lat_udist(g);
             int lon = lon_udist(g);
-            nodes.emplace_back(QueryNode(lat, lon, i));
+            nodes.emplace_back(QueryNode(lat, lon, OSMNodeID(i)));
             coords->emplace_back(FixedPointCoordinate(lat, lon));
         }
 
@@ -251,7 +251,7 @@ struct GraphFixture
             FixedPointCoordinate c(input_coords[i].first * COORDINATE_PRECISION,
                                    input_coords[i].second * COORDINATE_PRECISION);
             coords->emplace_back(c);
-            nodes.emplace_back(QueryNode(c.lat, c.lon, i));
+            nodes.emplace_back(QueryNode(c.lat, c.lon, OSMNodeID(i)));
         }
 
         for (const auto &pair : input_edges)

--- a/util/debug_geometry.hpp
+++ b/util/debug_geometry.hpp
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 inline void DEBUG_GEOMETRY_START(ContractorConfig & /* config */) {}
 inline void DEBUG_GEOMETRY_EDGE(int /* new_segment_weight */ , double /* segment_length */,
-        NodeID /* previous_osm_node_id */, NodeID /* this_osm_node_id */) {}
+        OSMNodeID /* previous_osm_node_id */, OSMNodeID /* this_osm_node_id */) {}
 inline void DEBUG_GEOMETRY_STOP() {}
 
 inline void DEBUG_TURNS_START(const std::string & /* debug_turns_filename */) {}
@@ -86,7 +86,7 @@ inline void DEBUG_GEOMETRY_START(const ContractorConfig &config)
     }
 }
 
-inline void DEBUG_GEOMETRY_EDGE(int new_segment_weight, double segment_length, NodeID previous_osm_node_id, NodeID this_osm_node_id)
+inline void DEBUG_GEOMETRY_EDGE(int new_segment_weight, double segment_length, OSMNodeID previous_osm_node_id, OSMNodeID this_osm_node_id)
 {
     if (dg_output_debug_geometry)
     {


### PR DESCRIPTION
This PR is to address https://github.com/Project-OSRM/osrm-backend/issues/322

It adds support for 64bit OSM node id values.  Without this change, OSM id values greater than 2^32 will overflow, and potentially conflict with other values.  I.e. currently, OSRM sees 4294967296 as the same as 1.  We expect to hit the unsigned 2^32 ceiling in the next few months.

This adds some overhead during processing: we need extra space to store the 64bit identifiers.  The main increases are:

  - during `osrm-extract`, the `all_nodes_list` and `used_nodes_list` will double in size.  These are both STXXL vectors, so the main impact will be on disk space and I/O during sorting.

  - the same applies for turn restrictions - we will now hold 64bit IDs in memory instead of 32bit IDs until we can re-number the identifiers.

Run-time memory performance for `osrm-routed` and `osrm-prepare` should be relatively unchanged.  By this stage of the pipeline, we are using mostly internal 32bit identifiers.  There will be some additional I/O when loading the `.nodes` file, because it contains the original OSM 64bit IDs (this file will double in size), but this cost should be relatively small.

Still TODO:

 - [ ] 64bit ID test - I have manually constructed a test file that demonstrates the conflicting IDs, but I still need to integrate it into the test suite.

Because of the ubiquitous use of the `NodeID` type, I implemented a strictly typed (based on `BOOST_STRICT_TYPEDEF`) `NodeID64` which does not allow automatic type conversion.  This should help avoid any type confusion in the future, as we'll get compiler errors if someone tries to assign a NodeID to a NodeID64, or vice-versa.  At least with GCC4.9 and `clang` from XCode 7 on OSX, the strict typedef object is fully optimized away under `-O3`, so it incurs no runtime overhead for production systems.