### PR TITLE
Distance table consistent snapping

### DIFF
--- a/extractor/extractor.cpp
+++ b/extractor/extractor.cpp
@@ -436,7 +436,7 @@ void extractor::FindComponents(unsigned max_edge_id,
                          component_search.get_component_id(node.reverse_edge_based_node_id));
 
         const unsigned component_size = component_search.get_component_size(forward_component);
-        node.component.is_tiny = component_size < 1000;
+        node.component.is_tiny = component_size < config.small_component_size;
         node.component.id = 1 + forward_component;
     }
 }

--- a/extractor/extractor_options.cpp
+++ b/extractor/extractor_options.cpp
@@ -64,7 +64,11 @@ ExtractorOptions::ParseArguments(int argc, char *argv[], ExtractorConfig &extrac
         "Number of threads to use")(
             "generate-edge-lookup",boost::program_options::value<bool>(
                                                 &extractor_config.generate_edge_lookup)->implicit_value(true)->default_value(false),
-                                 "Generate a lookup table for internal edge-expanded-edge IDs to OSM node pairs");
+                                 "Generate a lookup table for internal edge-expanded-edge IDs to OSM node pairs")(
+        "small-component-size",
+        boost::program_options::value<unsigned int>(&extractor_config.small_component_size)
+            ->default_value(1000),
+        "Number of nodes required before a strongly-connected-componennt is considered big (affects nearest neighbor snapping)");
 
 #ifdef DEBUG_GEOMETRY
         config_options.add_options()("debug-turns",

--- a/extractor/extractor_options.hpp
+++ b/extractor/extractor_options.hpp
@@ -58,6 +58,7 @@ struct ExtractorConfig
     std::string rtree_leafs_output_path;
 
     unsigned requested_num_threads;
+    unsigned small_component_size;
 
     bool generate_edge_lookup;
     std::string edge_penalty_path;

--- a/features/options/extract/help.feature
+++ b/features/options/extract/help.feature
@@ -16,7 +16,8 @@ Feature: osrm-extract command line options: help
         And stdout should contain "--profile"
         And stdout should contain "--threads"
         And stdout should contain "--generate-edge-lookup"
-        And stdout should contain 16 lines
+        And stdout should contain "--small-component-size"
+        And stdout should contain 20 lines
         And it should exit with code 0
 
     Scenario: osrm-extract - Help, short
@@ -31,7 +32,8 @@ Feature: osrm-extract command line options: help
         And stdout should contain "--profile"
         And stdout should contain "--threads"
         And stdout should contain "--generate-edge-lookup"
-        And stdout should contain 16 lines
+        And stdout should contain "--small-component-size"
+        And stdout should contain 20 lines
         And it should exit with code 0
 
     Scenario: osrm-extract - Help, long
@@ -46,5 +48,6 @@ Feature: osrm-extract command line options: help
         And stdout should contain "--profile"
         And stdout should contain "--threads"
         And stdout should contain "--generate-edge-lookup"
-        And stdout should contain 16 lines
+        And stdout should contain "--small-component-size"
+        And stdout should contain 20 lines
         And it should exit with code 0

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -6,6 +6,10 @@ Given(/^the import format "(.*?)"$/) do |format|
   set_input_format format
 end
 
+Given /^the extract extra arguments "(.*?)"$/ do |args|
+    set_extract_args args
+end
+
 Given /^a grid size of (\d+) meters$/ do |meters|
   set_grid_size meters
 end

--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -10,3 +10,7 @@ end
 def set_profile profile
   @profile = profile
 end
+
+def set_extract_args args
+    @extract_args = args
+end

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -274,7 +274,7 @@ def extract_data
   Dir.chdir TEST_FOLDER do
     log_preprocess_info
     log "== Extracting #{osm_file}.osm...", :preprocess
-    unless system "#{BIN_PATH}/osrm-extract #{osm_file}.osm#{'.pbf' if pbf?} --profile #{PROFILES_PATH}/#{@profile}.lua >>#{PREPROCESS_LOG_FILE} 2>&1"
+    unless system "#{BIN_PATH}/osrm-extract #{osm_file}.osm#{'.pbf' if pbf?} #{@extract_args} --profile #{PROFILES_PATH}/#{@profile}.lua >>#{PREPROCESS_LOG_FILE} 2>&1"
       log "*** Exited with code #{$?.exitstatus}.", :preprocess
       raise ExtractError.new $?.exitstatus, "osrm-extract exited with code #{$?.exitstatus}."
     end

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -135,3 +135,30 @@ Feature: Basic Distance Matrix
             |   | b   | e   | f   |
             | a | 100 | 200 | 300 |
             | b | 0   | 100 | 200 |
+
+    # There is a 1100m limit when searching for nearest neighbours
+    # so we set the grid size to something that makes it easy to
+    # put nodes inside/outside that limit
+    Scenario: Testbog - Check snapping on on small components
+        Given a grid size of 300 meters
+        Given the extract extra arguments "--small-component-size 4"
+        Given the node map
+            | a | b |  |   | m |  | x |
+            | d | e |  |   | n |  | y |
+
+        And the ways
+            | nodes |
+            | ab    |
+            | be    |
+            | ed    |
+            | da    |
+            | xy    |
+
+        When I request a travel time matrix I should get
+            |   | a   | b   | x   | y   | m   | n   |
+            | a | 0   | 300 |     |     | 300 | 600 |
+            | b | 300 |  0  |     |     | 0   | 300 |
+            | x |     |     | 0   | 300 |     |     |
+            | y |     |     | 300 | 0   |     |     |
+            | m | 300 | 0   |     |     | 0   | 300 |
+            | n | 600 | 300 |     |     | 300 | 0   |

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -136,15 +136,12 @@ Feature: Basic Distance Matrix
             | a | 100 | 200 | 300 |
             | b | 0   | 100 | 200 |
 
-    # There is a 1100m limit when searching for nearest neighbours
-    # so we set the grid size to something that makes it easy to
-    # put nodes inside/outside that limit
-    Scenario: Testbog - Check snapping on on small components
+    Scenario: Testbog - All coordinates are from same small component
         Given a grid size of 300 meters
         Given the extract extra arguments "--small-component-size 4"
         Given the node map
-            | a | b |  |   | m |  | x |
-            | d | e |  |   | n |  | y |
+            | a | b |  | f |
+            | d | e |  | g |
 
         And the ways
             | nodes |
@@ -152,13 +149,33 @@ Feature: Basic Distance Matrix
             | be    |
             | ed    |
             | da    |
-            | xy    |
+            | fg    |
 
         When I request a travel time matrix I should get
-            |   | a   | b   | x   | y   | m   | n   |
-            | a | 0   | 300 |     |     | 300 | 600 |
-            | b | 300 |  0  |     |     | 0   | 300 |
-            | x |     |     | 0   | 300 |     |     |
-            | y |     |     | 300 | 0   |     |     |
-            | m | 300 | 0   |     |     | 0   | 300 |
-            | n | 600 | 300 |     |     | 300 | 0   |
+            |   | f   | g   |
+            | f | 0   | 300 |
+            | g | 300 |  0  |
+
+    Scenario: Testbog - Coordinates are from different small component and snap to big CC
+        Given a grid size of 300 meters
+        Given the extract extra arguments "--small-component-size 4"
+        Given the node map
+            | a | b |  | f | h |
+            | d | e |  | g | i |
+
+        And the ways
+            | nodes |
+            | ab    |
+            | be    |
+            | ed    |
+            | da    |
+            | fg    |
+            | hi    |
+
+        When I request a travel time matrix I should get
+            |   | f   | g   | h   | i   |
+            | f | 0   | 300 | 0   | 300 |
+            | g | 300 |  0  | 300 | 0   |
+            | h | 0   | 300 | 0   | 300 |
+            | i | 300 |  0  | 300 | 0   |
+

--- a/plugins/distance_table.hpp
+++ b/plugins/distance_table.hpp
@@ -175,10 +175,14 @@ template <class DataFacadeT> class DistanceTablePlugin final : public BasePlugin
                 phantom_node_target_out_iter++;
             }
         }
+
         BOOST_ASSERT((phantom_node_source_out_iter - phantom_node_source_vector.begin()) ==
                      number_of_sources);
         BOOST_ASSERT((phantom_node_target_out_iter - phantom_node_target_vector.begin()) ==
                      number_of_destination);
+
+        snapPhantomNodes(phantom_node_source_vector);
+        snapPhantomNodes(phantom_node_target_vector);
 
         std::shared_ptr<std::vector<EdgeWeight>> result_table = search_engine_ptr->distance_table(
             phantom_node_source_vector, phantom_node_target_vector);

--- a/plugins/plugin_base.hpp
+++ b/plugins/plugin_base.hpp
@@ -105,6 +105,8 @@ class BasePlugin
             // update check with new component ids
             all_in_same_component = check_all_in_same_component(phantom_node_pair_list);
         }
+
+        return all_in_same_component;
     }
 };
 

--- a/plugins/viaroute.hpp
+++ b/plugins/viaroute.hpp
@@ -115,47 +115,7 @@ template <class DataFacadeT> class ViaRoutePlugin final : public BasePlugin
             BOOST_ASSERT(phantom_node_pair_list[i].second.is_valid(facade->GetNumberOfNodes()));
         }
 
-        const auto check_component_id_is_tiny = [](const PhantomNodePair &phantom_pair)
-        {
-            return phantom_pair.first.component.is_tiny;
-        };
-
-        const bool every_phantom_is_in_tiny_cc =
-            std::all_of(std::begin(phantom_node_pair_list), std::end(phantom_node_pair_list),
-                        check_component_id_is_tiny);
-
-        // are all phantoms from a tiny cc?
-        const auto check_all_in_same_component = [](const std::vector<PhantomNodePair> &nodes)
-        {
-            const auto component_id = nodes.front().first.component.id;
-
-            return std::all_of(std::begin(nodes), std::end(nodes),
-                               [component_id](const PhantomNodePair &phantom_pair)
-                               {
-                                   return component_id == phantom_pair.first.component.id;
-                               });
-        };
-
-        auto swap_phantom_from_big_cc_into_front = [](PhantomNodePair &phantom_pair)
-        {
-            if (phantom_pair.first.component.is_tiny && phantom_pair.second.is_valid() && !phantom_pair.second.component.is_tiny)
-            {
-                using namespace std;
-                swap(phantom_pair.first, phantom_pair.second);
-            }
-        };
-
-        auto all_in_same_component = check_all_in_same_component(phantom_node_pair_list);
-
-        // this case is true if we take phantoms from the big CC
-        if (every_phantom_is_in_tiny_cc && !all_in_same_component)
-        {
-            std::for_each(std::begin(phantom_node_pair_list), std::end(phantom_node_pair_list),
-                          swap_phantom_from_big_cc_into_front);
-
-            // update check with new component ids
-            all_in_same_component = check_all_in_same_component(phantom_node_pair_list);
-        }
+        auto all_in_same_component = snapPhantomNodes(phantom_node_pair_list);
 
         InternalRouteResult raw_route;
         auto build_phantom_pairs =


### PR DESCRIPTION
This commit is to address https://github.com/Project-OSRM/osrm-backend/issues/1447

It makes a few changes to the way the `distance_table` plugin selects phantom nodes.  The new rules are:

  - Only one is selected for each candidate location
  - If all candidates are big components, things proceed as before
  - If some candidates are on a small component, but are near a big component, they are snapped to the big component
  - If some candidates are on a small component and are *not* near a big component, they remain on their small components
  - If all candidates are on small components, then these are used, we do not search for the nearest big component.

A couple of extra changes had to happen to make this work:

  - Needed to expose the `max_checked_elements` in `IncrementalFindPhantomNodeForCoordinate` so that we would *not* return big components that are outside `max_distance`
  - Made the `small_component_size` configurable on the command line, to support testability.  It still defaults to the previously hard-coded value of 1000

I'm not 100% confident that this is the behaviour we want, but the test case included should demonstrate the new behaviour (this test fails with the old behaviour).  Please review and discuss the approach.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/project-osrm/osrm-backend/1798)
<!-- Reviewable:end -->
