### PR TITLE
Use a std::vector in place of stxxl:vector for the names list

### DIFF
--- a/extractor/extraction_containers.hpp
+++ b/extractor/extraction_containers.hpp
@@ -70,7 +70,8 @@ class ExtractionContainers
     STXXLNodeIDVector used_node_id_list;
     STXXLNodeVector all_nodes_list;
     STXXLEdgeVector all_edges_list;
-    std::vector<std::string> name_list;
+    stxxl::vector<char> name_char_data;
+    std::vector<unsigned> name_offsets;
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;

--- a/extractor/extraction_containers.hpp
+++ b/extractor/extraction_containers.hpp
@@ -64,14 +64,13 @@ class ExtractionContainers
     using STXXLNodeIDVector = stxxl::vector<OSMNodeID>;
     using STXXLNodeVector = stxxl::vector<ExternalMemoryNode>;
     using STXXLEdgeVector = stxxl::vector<InternalExtractorEdge>;
-    using STXXLStringVector = stxxl::vector<std::string>;
     using STXXLRestrictionsVector = stxxl::vector<InputRestrictionContainer>;
     using STXXLWayIDStartEndVector = stxxl::vector<FirstAndLastSegmentOfWay>;
 
     STXXLNodeIDVector used_node_id_list;
     STXXLNodeVector all_nodes_list;
     STXXLEdgeVector all_edges_list;
-    STXXLStringVector name_list;
+    std::vector<std::string> name_list;
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;

--- a/extractor/extractor_callbacks.cpp
+++ b/extractor/extractor_callbacks.cpp
@@ -153,10 +153,21 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
 
     // Get the unique identifier for the street name
     const auto &string_map_iterator = string_map.find(parsed_way.name);
-    unsigned name_id = external_memory.name_list.size();
+    unsigned name_id = external_memory.name_offsets.size();
     if (string_map.end() == string_map_iterator)
     {
-        external_memory.name_list.push_back(parsed_way.name);
+        unsigned name_length = 0;
+        for (const char &c : parsed_way.name)
+        {
+            // Cap name length at 255 characters
+            if (name_length == 255u)
+            {
+                break;
+            }
+            external_memory.name_char_data.push_back(c);
+            name_length++;
+        }
+        external_memory.name_offsets.push_back(name_length);
         string_map.insert(std::make_pair(parsed_way.name, name_id));
     }
     else


### PR DESCRIPTION
-For large datasets with very many unique names, stxxl::vector can corrupt
 data. Technically, we should only be using stxxl:vectors with POD. Other
 types might lead to strange/unpredictable behavior as we noticed here.
-See http://algo2.iti.kit.edu/dementiev/stxxl/trunk/FAQ.html

@danpat @TheMarex 