### PR TITLE
Configurable snapping

### DIFF
--- a/data_structures/deallocating_vector.hpp
+++ b/data_structures/deallocating_vector.hpp
@@ -237,6 +237,12 @@ class DeallocatingVectorRemoveIterator
     }
 };
 
+template <typename ElementT, std::size_t ELEMENTS_PER_BLOCK>
+class DeallocatingVector;
+
+template<typename T, std::size_t S>
+void swap(DeallocatingVector<T, S>& lhs, DeallocatingVector<T, S>& rhs);
+
 template <typename ElementT, std::size_t ELEMENTS_PER_BLOCK = 8388608 / sizeof(ElementT)>
 class DeallocatingVector
 {
@@ -256,6 +262,8 @@ class DeallocatingVector
     }
 
     ~DeallocatingVector() { clear(); }
+
+    friend void swap<>(DeallocatingVector<ElementT, ELEMENTS_PER_BLOCK>& lhs, DeallocatingVector<ElementT, ELEMENTS_PER_BLOCK>& rhs);
 
     void swap(DeallocatingVector<ElementT, ELEMENTS_PER_BLOCK> &other)
     {
@@ -385,5 +393,11 @@ class DeallocatingVector
         }
     }
 };
+
+template<typename T, std::size_t S>
+void swap(DeallocatingVector<T, S>& lhs, DeallocatingVector<T, S>& rhs)
+{
+    lhs.swap(rhs);
+}
 
 #endif /* DEALLOCATING_VECTOR_HPP */

--- a/data_structures/import_edge.cpp
+++ b/data_structures/import_edge.cpp
@@ -50,7 +50,7 @@ bool NodeBasedEdge::operator<(const NodeBasedEdge &other) const
 NodeBasedEdge::NodeBasedEdge()
     : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight(0), forward(false),
       backward(false), roundabout(false),
-      access_restricted(false), is_split(false), travel_mode(false)
+      access_restricted(false), startpoint(true), is_split(false), travel_mode(false)
 {
 }
 
@@ -62,11 +62,12 @@ NodeBasedEdge::NodeBasedEdge(NodeID source,
                              bool backward,
                              bool roundabout,
                              bool access_restricted,
+                             bool startpoint,
                              TravelMode travel_mode,
                              bool is_split)
     : source(source), target(target), name_id(name_id), weight(weight), forward(forward),
       backward(backward), roundabout(roundabout),
-      access_restricted(access_restricted), is_split(is_split), travel_mode(travel_mode)
+      access_restricted(access_restricted), startpoint(startpoint), is_split(is_split), travel_mode(travel_mode)
 {
 }
 

--- a/data_structures/import_edge.hpp
+++ b/data_structures/import_edge.hpp
@@ -44,6 +44,7 @@ struct NodeBasedEdge
                            bool backward,
                            bool roundabout,
                            bool access_restricted,
+                           bool startpoint,
                            TravelMode travel_mode,
                            bool is_split);
 
@@ -55,6 +56,7 @@ struct NodeBasedEdge
     bool backward : 1;
     bool roundabout : 1;
     bool access_restricted : 1;
+    bool startpoint : 1;
     bool is_split : 1;
     TravelMode travel_mode : 4;
 };
@@ -69,9 +71,10 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
                            bool backward,
                            bool roundabout,
                            bool access_restricted,
+                           bool startpoint,
                            TravelMode travel_mode,
                            bool is_split)
-        : NodeBasedEdge(SPECIAL_NODEID, SPECIAL_NODEID, name_id, weight, forward, backward, roundabout, access_restricted, travel_mode, is_split),
+        : NodeBasedEdge(SPECIAL_NODEID, SPECIAL_NODEID, name_id, weight, forward, backward, roundabout, access_restricted, startpoint, travel_mode, is_split),
         osm_source_id(source), osm_target_id(target) {}
 
     OSMNodeID osm_source_id;

--- a/data_structures/node_based_graph.hpp
+++ b/data_structures/node_based_graph.hpp
@@ -47,10 +47,10 @@ struct NodeBasedEdgeData
 
     NodeBasedEdgeData(int distance, unsigned edge_id, unsigned name_id,
             bool access_restricted, bool reversed,
-            bool roundabout, TravelMode travel_mode)
+            bool roundabout, bool startpoint, TravelMode travel_mode)
         : distance(distance), edge_id(edge_id), name_id(name_id),
           access_restricted(access_restricted), reversed(reversed),
-          roundabout(roundabout), travel_mode(travel_mode)
+          roundabout(roundabout), startpoint(startpoint), travel_mode(travel_mode)
     {
     }
 
@@ -60,6 +60,7 @@ struct NodeBasedEdgeData
     bool access_restricted : 1;
     bool reversed : 1;
     bool roundabout : 1;
+    bool startpoint : 1;
     TravelMode travel_mode : 4;
 
     bool IsCompatibleTo(const NodeBasedEdgeData &other) const
@@ -72,7 +73,7 @@ struct NodeBasedEdgeData
 using NodeBasedDynamicGraph = DynamicGraph<NodeBasedEdgeData>;
 
 /// Factory method to create NodeBasedDynamicGraph from NodeBasedEdges
-/// The since DynamicGraph expects directed edges, we need to insert
+/// Since DynamicGraph expects directed edges, we need to insert
 /// two edges for undirected edges.
 inline std::shared_ptr<NodeBasedDynamicGraph>
 NodeBasedDynamicGraphFromEdges(std::size_t number_of_nodes, const std::vector<NodeBasedEdge> &input_edge_list)
@@ -87,6 +88,7 @@ NodeBasedDynamicGraphFromEdges(std::size_t number_of_nodes, const std::vector<No
             output_edge.data.name_id = input_edge.name_id;
             output_edge.data.access_restricted = input_edge.access_restricted;
             output_edge.data.travel_mode = input_edge.travel_mode;
+            output_edge.data.startpoint = input_edge.startpoint;
         }
     );
 

--- a/extractor/edge_based_graph_factory.cpp
+++ b/extractor/edge_based_graph_factory.cpp
@@ -61,7 +61,8 @@ EdgeBasedGraphFactory::EdgeBasedGraphFactory(
 void EdgeBasedGraphFactory::GetEdgeBasedEdges(DeallocatingVector<EdgeBasedEdge> &output_edge_list)
 {
     BOOST_ASSERT_MSG(0 == output_edge_list.size(), "Vector is not empty");
-    std::swap(m_edge_based_edge_list, output_edge_list);
+    using std::swap; // Koenig swap
+    swap(m_edge_based_edge_list, output_edge_list);
 }
 
 void EdgeBasedGraphFactory::GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes)
@@ -75,12 +76,14 @@ void EdgeBasedGraphFactory::GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes)
         BOOST_ASSERT(m_node_info_list.at(node.v).lat != INT_MAX);
     }
 #endif
-    std::swap(nodes, m_edge_based_node_list);
+    using std::swap; // Koenig swap
+    swap(nodes, m_edge_based_node_list);
 }
 
 void EdgeBasedGraphFactory::GetStartPointMarkers(std::vector<bool> &node_is_startpoint)
 {
-    std::swap(m_edge_based_node_is_startpoint, node_is_startpoint);
+    using std::swap; // Koenig swap
+    swap(m_edge_based_node_is_startpoint, node_is_startpoint);
 }
 
 unsigned EdgeBasedGraphFactory::GetHighestEdgeID()

--- a/extractor/edge_based_graph_factory.cpp
+++ b/extractor/edge_based_graph_factory.cpp
@@ -61,7 +61,7 @@ EdgeBasedGraphFactory::EdgeBasedGraphFactory(
 void EdgeBasedGraphFactory::GetEdgeBasedEdges(DeallocatingVector<EdgeBasedEdge> &output_edge_list)
 {
     BOOST_ASSERT_MSG(0 == output_edge_list.size(), "Vector is not empty");
-    m_edge_based_edge_list.swap(output_edge_list);
+    std::swap(m_edge_based_edge_list, output_edge_list);
 }
 
 void EdgeBasedGraphFactory::GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes)
@@ -75,12 +75,12 @@ void EdgeBasedGraphFactory::GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes)
         BOOST_ASSERT(m_node_info_list.at(node.v).lat != INT_MAX);
     }
 #endif
-    nodes.swap(m_edge_based_node_list);
+    std::swap(nodes, m_edge_based_node_list);
 }
 
 void EdgeBasedGraphFactory::GetStartPointMarkers(std::vector<bool> &node_is_startpoint)
 {
-    m_edge_based_node_is_startpoint.swap(node_is_startpoint);
+    std::swap(m_edge_based_node_is_startpoint, node_is_startpoint);
 }
 
 unsigned EdgeBasedGraphFactory::GetHighestEdgeID()

--- a/extractor/edge_based_graph_factory.cpp
+++ b/extractor/edge_based_graph_factory.cpp
@@ -78,6 +78,11 @@ void EdgeBasedGraphFactory::GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes)
     nodes.swap(m_edge_based_node_list);
 }
 
+void EdgeBasedGraphFactory::GetStartPointMarkers(std::vector<bool> &node_is_startpoint)
+{
+    m_edge_based_node_is_startpoint.swap(node_is_startpoint);
+}
+
 unsigned EdgeBasedGraphFactory::GetHighestEdgeID()
 {
     return m_max_edge_id;
@@ -165,6 +170,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u,
                 reverse_geometry[geometry_size - 1 - i].second, forward_dist_prefix_sum[i],
                 reverse_dist_prefix_sum[i], m_compressed_edge_container.GetPositionForID(edge_id_1),
                 false, INVALID_COMPONENTID, i, forward_data.travel_mode, reverse_data.travel_mode);
+            m_edge_based_node_is_startpoint.push_back(forward_data.startpoint || reverse_data.startpoint);
             current_edge_source_coordinate_id = current_edge_target_coordinate_id;
 
             BOOST_ASSERT(m_edge_based_node_list.back().IsCompressed());
@@ -208,6 +214,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u,
             forward_data.edge_id, reverse_data.edge_id, node_u, node_v,
             forward_data.name_id, forward_data.distance, reverse_data.distance, 0, 0, SPECIAL_EDGEID,
             false, INVALID_COMPONENTID, 0, forward_data.travel_mode, reverse_data.travel_mode);
+        m_edge_based_node_is_startpoint.push_back(forward_data.startpoint || reverse_data.startpoint);
         BOOST_ASSERT(!m_edge_based_node_list.back().IsCompressed());
     }
 }
@@ -335,6 +342,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedNodes()
             }
         }
     }
+
+    BOOST_ASSERT(m_edge_based_node_list.size() == m_edge_based_node_is_startpoint.size());
 
     SimpleLogger().Write() << "Generated " << m_edge_based_node_list.size()
                            << " nodes in edge-expanded graph";

--- a/extractor/edge_based_graph_factory.hpp
+++ b/extractor/edge_based_graph_factory.hpp
@@ -86,6 +86,7 @@ class EdgeBasedGraphFactory
     void GetEdgeBasedEdges(DeallocatingVector<EdgeBasedEdge> &edges);
 
     void GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes);
+    void GetStartPointMarkers(std::vector<bool> &node_is_startpoint);
 
     unsigned GetHighestEdgeID();
 
@@ -96,6 +97,9 @@ class EdgeBasedGraphFactory
   private:
     using EdgeData = NodeBasedDynamicGraph::EdgeData;
 
+    //! maps index from m_edge_based_node_list to ture/false if the node is an entry point to the graph
+    std::vector<bool> m_edge_based_node_is_startpoint;
+    //! list of edge based nodes (compressed segments)
     std::vector<EdgeBasedNode> m_edge_based_node_list;
     DeallocatingVector<EdgeBasedEdge> m_edge_based_edge_list;
     unsigned m_max_edge_id;

--- a/extractor/extraction_way.hpp
+++ b/extractor/extraction_way.hpp
@@ -50,6 +50,7 @@ struct ExtractionWay
         backward_speed = -1;
         duration = -1;
         roundabout = false;
+        is_startpoint = true;
         is_access_restricted = false;
         name.clear();
         forward_travel_mode = TRAVEL_MODE_DEFAULT;
@@ -120,6 +121,7 @@ struct ExtractionWay
     std::string name;
     bool roundabout;
     bool is_access_restricted;
+    bool is_startpoint;
     TravelMode forward_travel_mode : 4;
     TravelMode backward_travel_mode : 4;
 };

--- a/extractor/extractor.hpp
+++ b/extractor/extractor.hpp
@@ -34,29 +34,33 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class extractor
 {
-public:
-  extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
+  public:
+    extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
     int run();
-private:
+
+  private:
     ExtractorConfig config;
-    void SetupScriptingEnvironment(lua_State *myLuaState,
-                               SpeedProfileProperties &speed_profile);
+    void SetupScriptingEnvironment(lua_State *myLuaState, SpeedProfileProperties &speed_profile);
     std::pair<std::size_t, std::size_t>
     BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_node_map,
-                                       std::vector<EdgeBasedNode> &node_based_edge_list,
-                                       DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list);
-    void WriteNodeMapping(const std::vector<QueryNode> & internal_to_external_node_map);
-    void FindComponents(unsigned max_edge_id, const DeallocatingVector<EdgeBasedEdge>& edges, std::vector<EdgeBasedNode>& nodes) const;
-    void BuildRTree(const std::vector<EdgeBasedNode> &node_based_edge_list,
+                           std::vector<EdgeBasedNode> &node_based_edge_list,
+                           std::vector<bool> &node_is_startpoint,
+                           DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list);
+    void WriteNodeMapping(const std::vector<QueryNode> &internal_to_external_node_map);
+    void FindComponents(unsigned max_edge_id,
+                        const DeallocatingVector<EdgeBasedEdge> &edges,
+                        std::vector<EdgeBasedNode> &nodes) const;
+    void BuildRTree(std::vector<EdgeBasedNode> node_based_edge_list,
+                    std::vector<bool> node_is_startpoint,
                     const std::vector<QueryNode> &internal_to_external_node_map);
     std::shared_ptr<RestrictionMap> LoadRestrictionMap();
     std::shared_ptr<NodeBasedDynamicGraph>
     LoadNodeBasedGraph(std::unordered_set<NodeID> &barrier_nodes,
                        std::unordered_set<NodeID> &traffic_lights,
-                       std::vector<QueryNode>& internal_to_external_node_map);
+                       std::vector<QueryNode> &internal_to_external_node_map);
 
-    void WriteEdgeBasedGraph(std::string const &output_file_filename, 
-                             size_t const max_edge_id, 
-                             DeallocatingVector<EdgeBasedEdge> const & edge_based_edge_list);
+    void WriteEdgeBasedGraph(std::string const &output_file_filename,
+                             size_t const max_edge_id,
+                             DeallocatingVector<EdgeBasedEdge> const &edge_based_edge_list);
 };
 #endif /* EXTRACTOR_HPP */

--- a/extractor/extractor_callbacks.cpp
+++ b/extractor/extractor_callbacks.cpp
@@ -193,7 +193,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                 external_memory.all_edges_list.push_back(InternalExtractorEdge(
                                     OSMNodeID(first_node.ref()), OSMNodeID(last_node.ref()), name_id,
                                     backward_weight_data, true, false, parsed_way.roundabout,
-                                    parsed_way.is_access_restricted,
+                                    parsed_way.is_access_restricted, parsed_way.is_startpoint,
                                     parsed_way.backward_travel_mode, false));
                             });
 
@@ -214,7 +214,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                 external_memory.all_edges_list.push_back(InternalExtractorEdge(
                                     OSMNodeID(first_node.ref()), OSMNodeID(last_node.ref()), name_id, forward_weight_data,
                                     true, !forward_only, parsed_way.roundabout,
-                                    parsed_way.is_access_restricted, parsed_way.forward_travel_mode,
+                                    parsed_way.is_access_restricted, parsed_way.is_startpoint, parsed_way.forward_travel_mode,
                                     split_edge));
                             });
         if (split_edge)
@@ -227,7 +227,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                     external_memory.all_edges_list.push_back(InternalExtractorEdge(
                         OSMNodeID(first_node.ref()), OSMNodeID(last_node.ref()), name_id, backward_weight_data, false,
                         true, parsed_way.roundabout, parsed_way.is_access_restricted,
-                        parsed_way.backward_travel_mode, true));
+                        parsed_way.is_startpoint, parsed_way.backward_travel_mode, true));
                 });
         }
 

--- a/extractor/internal_extractor_edge.hpp
+++ b/extractor/internal_extractor_edge.hpp
@@ -63,7 +63,7 @@ struct InternalExtractorEdge
     };
 
     explicit InternalExtractorEdge()
-        : result(MIN_OSM_NODEID, MIN_OSM_NODEID, 0, 0, false, false, false, false,
+        : result(MIN_OSM_NODEID, MIN_OSM_NODEID, 0, 0, false, false, false, false, true,
                 TRAVEL_MODE_INACCESSIBLE, false)
     {
     }
@@ -76,6 +76,7 @@ struct InternalExtractorEdge
                                    bool backward,
                                    bool roundabout,
                                    bool access_restricted,
+                                   bool startpoint,
                                    TravelMode travel_mode,
                                    bool is_split)
         : result(OSMNodeID(source),
@@ -86,6 +87,7 @@ struct InternalExtractorEdge
                  backward,
                  roundabout,
                  access_restricted,
+                 startpoint,
                  travel_mode,
                  is_split),
           weight_data(std::move(weight_data))
@@ -104,12 +106,12 @@ struct InternalExtractorEdge
     static InternalExtractorEdge min_osm_value()
     {
         return InternalExtractorEdge(MIN_OSM_NODEID, MIN_OSM_NODEID, 0, WeightData(), false, false, false,
-                                     false, TRAVEL_MODE_INACCESSIBLE, false);
+                                     false, true, TRAVEL_MODE_INACCESSIBLE, false);
     }
     static InternalExtractorEdge max_osm_value()
     {
         return InternalExtractorEdge(MAX_OSM_NODEID, MAX_OSM_NODEID, 0, WeightData(), false,
-                                     false, false, false, TRAVEL_MODE_INACCESSIBLE, false);
+                                     false, false, false, true, TRAVEL_MODE_INACCESSIBLE, false);
     }
 
     static InternalExtractorEdge min_internal_value()

--- a/extractor/scripting_environment.cpp
+++ b/extractor/scripting_environment.cpp
@@ -117,6 +117,7 @@ void ScriptingEnvironment::init_lua_state(lua_State *lua_state)
             .def_readwrite("name", &ExtractionWay::name)
             .def_readwrite("roundabout", &ExtractionWay::roundabout)
             .def_readwrite("is_access_restricted", &ExtractionWay::is_access_restricted)
+            .def_readwrite("is_startpoint", &ExtractionWay::is_startpoint)
             .def_readwrite("duration", &ExtractionWay::duration)
             .property("forward_mode", &ExtractionWay::get_forward_mode,
                       &ExtractionWay::set_forward_mode)

--- a/features/car/mode.feature
+++ b/features/car/mode.feature
@@ -1,0 +1,40 @@
+@routing @car @mode
+Feature: Car - Mode flag
+    Background:
+        Given the profile "car"
+
+    Scenario: Car - Mode when using a ferry
+        Given the node map
+            | a | b |   |
+            |   | c | d |
+
+        And the ways
+            | nodes | highway | route | duration |
+            | ab    | primary |       |          |
+            | bc    |         | ferry | 0:01     |
+            | cd    | primary |       |          |
+
+        When I route I should get
+            | from | to | route    | turns                       | modes |
+            | a    | d  | ab,bc,cd | head,right,left,destination | 1,2,1 |
+            | d    | a  | cd,bc,ab | head,right,left,destination | 1,2,1 |
+            | c    | a  | bc,ab    | head,left,destination       | 2,1   |
+            | d    | b  | cd,bc    | head,right,destination      | 1,2   |
+            | a    | c  | ab,bc    | head,right,destination      | 1,2   |
+            | b    | d  | bc,cd    | head,left,destination       | 2,1   |
+
+    Scenario: Car - Snapping when using a ferry
+        Given the node map
+            | a | b |   | c | d |   | e | f |
+
+        And the ways
+            | nodes | highway | route | duration |
+            | ab    | primary |       |          |
+            | bcde  |         | ferry | 0:10     |
+            | ef    | primary |       |          |
+
+        When I route I should get
+            | from | to | route | turns            | modes   | time  |
+            | c    | d  | bcde  | head,destination | 2       | 600s  |
+
+

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -448,6 +448,9 @@ function way_function (way, result)
     end
     result.backward_speed = math.min(penalized_speed, scaled_speed)
   end
+
+  -- only allow this road as start point if it not a ferry
+  result.is_startpoint = result.forward_mode == mode_normal or result.backward_mode == mode_normal
 end
 
 function turn_function (angle)

--- a/routing_algorithms/routing_base.hpp
+++ b/routing_algorithms/routing_base.hpp
@@ -183,8 +183,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         const bool target_traversed_in_reverse =
             (*std::prev(packed_path_end) != phantom_node_pair.target_phantom.forward_node_id);
 
-        const auto packed_path_size = std::distance(packed_path_begin, packed_path_end);
-        BOOST_ASSERT(packed_path_size > 0);
+        BOOST_ASSERT(std::distance(packed_path_begin, packed_path_end) > 0);
         std::stack<std::pair<NodeID, NodeID>> recursion_stack;
 
         // We have to push the path in reverse order onto the stack because it's LIFO.

--- a/unit_tests/algorithms/graph_compressor.cpp
+++ b/unit_tests/algorithms/graph_compressor.cpp
@@ -28,14 +28,14 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     using InputEdge = NodeBasedDynamicGraph::InputEdge;
     std::vector<InputEdge> edges = {
         // source, target, distance, edge_id, name_id, access_restricted, reversed, roundabout, travel_mode
-        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 3, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {3, 2, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {3, 4, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {4, 3, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT}
+        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 3, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {3, 2, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {3, 4, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {4, 3, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT}
     };
 
     BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[2].data));
@@ -70,18 +70,18 @@ BOOST_AUTO_TEST_CASE(loop_test)
     using InputEdge = NodeBasedDynamicGraph::InputEdge;
     std::vector<InputEdge> edges = {
         // source, target, distance, edge_id, name_id, access_restricted, forward, backward, roundabout, travel_mode
-        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {0, 5, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 3, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {3, 2, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {3, 4, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {4, 3, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {4, 5, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {5, 0, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {5, 4, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
+        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {0, 5, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 3, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {3, 2, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {3, 4, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {4, 3, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {4, 5, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {5, 0, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {5, 4, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
     };
 
     BOOST_ASSERT(edges.size() == 12);
@@ -127,12 +127,12 @@ BOOST_AUTO_TEST_CASE(t_intersection)
     using InputEdge = NodeBasedDynamicGraph::InputEdge;
     std::vector<InputEdge> edges = {
         // source, target, distance, edge_id, name_id, access_restricted, reversed, roundabout, travel_mode
-        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 3, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {3, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
+        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 3, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {3, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
     };
 
     BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[1].data));
@@ -165,10 +165,10 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
     using InputEdge = NodeBasedDynamicGraph::InputEdge;
     std::vector<InputEdge> edges = {
         // source, target, distance, edge_id, name_id, access_restricted, forward, backward, roundabout, travel_mode
-        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 2, 1, SPECIAL_EDGEID, 1, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 1, 1, SPECIAL_EDGEID, 1, false, false, false, TRAVEL_MODE_DEFAULT},
+        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 0, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 2, 1, SPECIAL_EDGEID, 1, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 1, 1, SPECIAL_EDGEID, 1, false, false, false, true, TRAVEL_MODE_DEFAULT},
     };
 
     BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[1].data));
@@ -197,10 +197,10 @@ BOOST_AUTO_TEST_CASE(direction_changes)
     using InputEdge = NodeBasedDynamicGraph::InputEdge;
     std::vector<InputEdge> edges = {
         // source, target, distance, edge_id, name_id, access_restricted, reverse, roundabout, travel_mode
-        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {1, 0, 1, SPECIAL_EDGEID, 0, false, true,  false, TRAVEL_MODE_DEFAULT},
-        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
-        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, TRAVEL_MODE_DEFAULT},
+        {0, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {1, 0, 1, SPECIAL_EDGEID, 0, false, true,  false, true, TRAVEL_MODE_DEFAULT},
+        {1, 2, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
+        {2, 1, 1, SPECIAL_EDGEID, 0, false, false, false, true, TRAVEL_MODE_DEFAULT},
     };
 
     NodeBasedDynamicGraph graph(5, edges);


### PR DESCRIPTION
This makes it configurable from profiles whether to not snap to road or not. This is useful for ferries and the like where snapping makes no sense.

- [x] Rebase on develop
- [x] Write test to verify the behaviour
- [x] Fix routability cucumber tests that rely on snapping to ferry roads _doesn't seem to be an issue for the car profile_