### PR TITLE
A side_road tag support for the OSRM car profile.

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -131,6 +131,8 @@ maxspeed_table = {
 traffic_signal_penalty          = 2
 use_turn_restrictions           = true
 
+side_road_speed_multiplier      = 0.8
+
 local turn_penalty              = 10
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
@@ -308,6 +310,14 @@ function way_function (way, result)
 
   if -1 == result.forward_speed and -1 == result.backward_speed then
     return
+  end
+
+  -- reduce speed on special side roads
+  local sideway = way:get_value_by_key("side_road")
+  if "yes" == sideway or
+  "rotary" == sideway then
+    result.forward_speed = result.forward_speed * side_road_speed_multiplier
+    result.backward_speed = result.backward_speed * side_road_speed_multiplier
   end
 
   -- reduce speed on bad surfaces


### PR DESCRIPTION
This PR adds support for the side_road tag. http://wiki.openstreetmap.org/wiki/Key:side_road
Without this processing the router tends to use these roads instead of main roads. 
http://map.project-osrm.org/?z=15&center=59.845456%2C30.276743&loc=59.851963%2C30.282558&loc=59.843198%2C30.276518&hl=en&ly=&alt=&df=&srv=
The actual speed on side roads is usually lower than the speed limit.