### PR TITLE
name_lengths std::vector --> stxxl::vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,7 @@ include_directories(SYSTEM ${STXXL_INCLUDE_DIR})
 target_link_libraries(OSRM ${STXXL_LIBRARY})
 target_link_libraries(osrm-extract ${STXXL_LIBRARY})
 target_link_libraries(osrm-prepare ${STXXL_LIBRARY})
+target_link_libraries(datastructure-tests ${STXXL_LIBRARY})
 
 set(OpenMP_FIND_QUIETLY ON)
 find_package(OpenMP)

--- a/data_structures/range_table.hpp
+++ b/data_structures/range_table.hpp
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <vector>
 #include <array>
+#include <stxxl/vector>
 
 /*
  * These pre-declarations are needed because parsing C++ is hard
@@ -82,7 +83,7 @@ template <unsigned BLOCK_SIZE, bool USE_SHARED_MEMORY> class RangeTable
     }
 
     // construct table from length vector
-    explicit RangeTable(const std::vector<unsigned> &lengths)
+    explicit RangeTable(const stxxl::vector<unsigned> &lengths)
     {
         const unsigned number_of_blocks = [&lengths]()
         {

--- a/extractor/extraction_containers.hpp
+++ b/extractor/extraction_containers.hpp
@@ -71,7 +71,7 @@ class ExtractionContainers
     STXXLNodeVector all_nodes_list;
     STXXLEdgeVector all_edges_list;
     stxxl::vector<char> name_char_data;
-    std::vector<unsigned> name_lengths;
+    stxxl::vector<unsigned> name_lengths;
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;

--- a/unit_tests/data_structures/range_table.cpp
+++ b/unit_tests/data_structures/range_table.cpp
@@ -38,7 +38,7 @@ typedef RangeTable<BLOCK_SIZE, false> TestRangeTable;
 
 BOOST_AUTO_TEST_SUITE(range_table)
 
-void ConstructionTest(std::vector<unsigned> lengths, std::vector<unsigned> offsets)
+void ConstructionTest(stxxl::vector<unsigned> lengths, std::vector<unsigned> offsets)
 {
     BOOST_ASSERT(lengths.size() == offsets.size() - 1);
 
@@ -52,7 +52,7 @@ void ConstructionTest(std::vector<unsigned> lengths, std::vector<unsigned> offse
     }
 }
 
-void ComputeLengthsOffsets(std::vector<unsigned> &lengths,
+void ComputeLengthsOffsets(stxxl::vector<unsigned> &lengths,
                            std::vector<unsigned> &offsets,
                            unsigned num)
 {
@@ -76,7 +76,7 @@ void ComputeLengthsOffsets(std::vector<unsigned> &lengths,
 
 BOOST_AUTO_TEST_CASE(serialization_test)
 {
-    std::vector<unsigned> lengths;
+    stxxl::vector<unsigned> lengths;
     std::vector<unsigned> offsets;
     ComputeLengthsOffsets(lengths, offsets, (BLOCK_SIZE + 1) * 10);
 
@@ -98,10 +98,12 @@ BOOST_AUTO_TEST_CASE(serialization_test)
 BOOST_AUTO_TEST_CASE(construction_test)
 {
     // only offset empty block
-    ConstructionTest({1}, {0, 1});
+    stxxl::vector<unsigned> empty_lengths;
+    empty_lengths.push_back(1);
+    ConstructionTest(empty_lengths, {0, 1});
     // first block almost full => sentinel is last element of block
     // [0] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, (16)}
-    std::vector<unsigned> almost_full_lengths;
+    stxxl::vector<unsigned> almost_full_lengths;
     std::vector<unsigned> almost_full_offsets;
     ComputeLengthsOffsets(almost_full_lengths, almost_full_offsets, BLOCK_SIZE);
     ConstructionTest(almost_full_lengths, almost_full_offsets);
@@ -109,7 +111,7 @@ BOOST_AUTO_TEST_CASE(construction_test)
     // first block full => sentinel is offset of new block, next block empty
     // [0]     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
     // [(153)] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-    std::vector<unsigned> full_lengths;
+    stxxl::vector<unsigned> full_lengths;
     std::vector<unsigned> full_offsets;
     ComputeLengthsOffsets(full_lengths, full_offsets, BLOCK_SIZE + 1);
     ConstructionTest(full_lengths, full_offsets);
@@ -117,13 +119,13 @@ BOOST_AUTO_TEST_CASE(construction_test)
     // first block full and offset of next block not sentinel, but the first differential value
     // [0]   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
     // [153] {(17), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-    std::vector<unsigned> over_full_lengths;
+    stxxl::vector<unsigned> over_full_lengths;
     std::vector<unsigned> over_full_offsets;
     ComputeLengthsOffsets(over_full_lengths, over_full_offsets, BLOCK_SIZE + 2);
     ConstructionTest(over_full_lengths, over_full_offsets);
 
     // test multiple blocks
-    std::vector<unsigned> multiple_lengths;
+    stxxl::vector<unsigned> multiple_lengths;
     std::vector<unsigned> multiple_offsets;
     ComputeLengthsOffsets(multiple_lengths, multiple_offsets, (BLOCK_SIZE + 1) * 10);
     ConstructionTest(multiple_lengths, multiple_offsets);


### PR DESCRIPTION
@TheMarex 

This is following through with a suggestion you had made earlier on making this `name_lengths` vector stxxl as well. This PR does that and links the STXXL libs to the `datastructure-tests` so that the tests will succeed.