### PR TITLE
Add max values for viaroute and trip and reorganize return code handling

### DIFF
--- a/features/options/routed/help.feature
+++ b/features/options/routed/help.feature
@@ -25,9 +25,11 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--port"
         And stdout should contain "--threads"
         And stdout should contain "--shared-memory"
+        And stdout should contain "--max-viaroute-size"
+        And stdout should contain "--max-trip-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
-        And stdout should contain 27 lines
+        And stdout should contain 30 lines
         And it should exit with code 0
 
     Scenario: osrm-routed - Help, short
@@ -51,9 +53,11 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--port"
         And stdout should contain "--threads"
         And stdout should contain "--shared-memory"
+        And stdout should contain "--max-viaroute-size"
+        And stdout should contain "--max-trip-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
-        And stdout should contain 27 lines
+        And stdout should contain 30 lines
         And it should exit with code 0
 
     Scenario: osrm-routed - Help, long
@@ -77,7 +81,9 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--port"
         And stdout should contain "--threads"
         And stdout should contain "--shared-memory"
+        And stdout should contain "--max-trip-size"
+        And stdout should contain "--max-table-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
-        And stdout should contain 27 lines
+        And stdout should contain 30 lines
         And it should exit with code 0

--- a/features/step_definitions/nearest.rb
+++ b/features/step_definitions/nearest.rb
@@ -12,7 +12,7 @@ When /^I request nearest I should get$/ do |table|
       response = request_nearest in_node, @query_params
       if response.code == "200" && response.body.empty? == false
         json = JSON.parse response.body
-        if json['status'] == 0
+        if json['status'] == 200
           coord =  json['mapped_coordinate']
         end
       end

--- a/features/step_definitions/routability.rb
+++ b/features/step_definitions/routability.rb
@@ -8,8 +8,8 @@ def test_routability_row i
     r[:query] = @query
     r[:json] = JSON.parse(r[:response].body)
 
-    r[:status] = route_status r[:response]
-    if r[:status].empty? == false
+    r[:status] = (route_status r[:response]) == 200 ? 'x' : nil
+    if r[:status] then
       r[:route] = way_list r[:json]['route_instructions']
 
       if r[:route]=="w#{i}"

--- a/features/step_definitions/routing.rb
+++ b/features/step_definitions/routing.rb
@@ -56,7 +56,7 @@ When /^I route I should get$/ do |table|
       end
 
       if response.body.empty? == false
-        if json['status'] == 0
+        if json['status'] == 200
           instructions = way_list json['route_instructions']
           bearings = bearing_list json['route_instructions']
           compasses = compass_list json['route_instructions']
@@ -77,65 +77,63 @@ When /^I route I should get$/ do |table|
         got['#'] = row['#']           # copy value so it always match
       end
 
-      if response.code == "200"
-        if table.headers.include? 'start'
-          got['start'] = instructions ? json['route_summary']['start_point'] : nil
-        end
-        if table.headers.include? 'end'
-          got['end'] = instructions ? json['route_summary']['end_point'] : nil
-        end
-        if table.headers.include? 'geometry'
-            got['geometry'] = json['route_geometry']
-        end
-        if table.headers.include? 'route'
-          got['route'] = (instructions || '').strip
-          if table.headers.include?('alternative')
-            got['alternative'] =
-              if json['found_alternative']
-                way_list json['alternative_instructions'].first
-              else
-                ""
-              end
-          end
-          if table.headers.include?('distance')
-            if row['distance']!=''
-              raise "*** Distance must be specied in meters. (ex: 250m)" unless row['distance'] =~ /\d+m/
-            end
-            got['distance'] = instructions ? "#{json['route_summary']['total_distance'].to_s}m" : ''
-          end
-          if table.headers.include?('time')
-            raise "*** Time must be specied in seconds. (ex: 60s)" unless row['time'] =~ /\d+s/
-            got['time'] = instructions ? "#{json['route_summary']['total_time'].to_s}s" : ''
-          end
-          if table.headers.include?('speed')
-            if row['speed'] != '' && instructions
-              raise "*** Speed must be specied in km/h. (ex: 50 km/h)" unless row['speed'] =~ /\d+ km\/h/
-                time = json['route_summary']['total_time']
-                distance = json['route_summary']['total_distance']
-                speed = time>0 ? (3.6*distance/time).round : nil
-                got['speed'] =  "#{speed} km/h"
+      if table.headers.include? 'start'
+        got['start'] = instructions ? json['route_summary']['start_point'] : nil
+      end
+      if table.headers.include? 'end'
+        got['end'] = instructions ? json['route_summary']['end_point'] : nil
+      end
+      if table.headers.include? 'geometry'
+          got['geometry'] = json['route_geometry']
+      end
+      if table.headers.include? 'route'
+        got['route'] = (instructions || '').strip
+        if table.headers.include?('alternative')
+          got['alternative'] =
+            if json['found_alternative']
+              way_list json['alternative_instructions'].first
             else
-              got['speed'] = ''
+              ""
             end
+        end
+        if table.headers.include?('distance')
+          if row['distance']!=''
+            raise "*** Distance must be specied in meters. (ex: 250m)" unless row['distance'] =~ /\d+m/
           end
-          if table.headers.include? 'bearing'
-            got['bearing'] = instructions ? bearings : ''
+          got['distance'] = instructions ? "#{json['route_summary']['total_distance'].to_s}m" : ''
+        end
+        if table.headers.include?('time')
+          raise "*** Time must be specied in seconds. (ex: 60s)" unless row['time'] =~ /\d+s/
+          got['time'] = instructions ? "#{json['route_summary']['total_time'].to_s}s" : ''
+        end
+        if table.headers.include?('speed')
+          if row['speed'] != '' && instructions
+            raise "*** Speed must be specied in km/h. (ex: 50 km/h)" unless row['speed'] =~ /\d+ km\/h/
+              time = json['route_summary']['total_time']
+              distance = json['route_summary']['total_distance']
+              speed = time>0 ? (3.6*distance/time).round : nil
+              got['speed'] =  "#{speed} km/h"
+          else
+            got['speed'] = ''
           end
-          if table.headers.include? 'compass'
-            got['compass'] = instructions ? compasses : ''
-          end
-          if table.headers.include? 'turns'
-            got['turns'] = instructions ? turns : ''
-          end
-          if table.headers.include? 'modes'
-            got['modes'] = instructions ? modes : ''
-          end
-          if table.headers.include? 'times'
-            got['times'] = instructions ? times : ''
-          end
-          if table.headers.include? 'distances'
-            got['distances'] = instructions ? distances : ''
-          end
+        end
+        if table.headers.include? 'bearing'
+          got['bearing'] = instructions ? bearings : ''
+        end
+        if table.headers.include? 'compass'
+          got['compass'] = instructions ? compasses : ''
+        end
+        if table.headers.include? 'turns'
+          got['turns'] = instructions ? turns : ''
+        end
+        if table.headers.include? 'modes'
+          got['modes'] = instructions ? modes : ''
+        end
+        if table.headers.include? 'times'
+          got['times'] = instructions ? times : ''
+        end
+        if table.headers.include? 'distances'
+          got['distances'] = instructions ? distances : ''
         end
       end
 

--- a/features/support/route.rb
+++ b/features/support/route.rb
@@ -99,7 +99,7 @@ end
 def got_route? response
   if response.code == "200" && !response.body.empty?
     json = JSON.parse response.body
-    if json['status'] == 0
+    if json['status'] == 200
       return way_list( json['route_instructions']).empty? == false
     end
   end
@@ -109,17 +109,7 @@ end
 def route_status response
   if response.code == "200" && !response.body.empty?
     json = JSON.parse response.body
-    if json['status'] == 0
-      if way_list(json['route_instructions']).empty?
-        return 'Empty route'
-      else
-        return 'x'
-      end
-    elsif json['status'] == 207
-      ''
-    else
-      "Status #{json['status']}"
-    end
+    return json['status']
   else
     "HTTP #{response.code}"
   end

--- a/features/testbot/status.feature
+++ b/features/testbot/status.feature
@@ -14,8 +14,8 @@ Feature: Status messages
 
         When I route I should get
             | from | to | route | status | message                    |
-            | a    | b  | ab    | 0      | Found route between points |
-            | b    | a  | ab    | 0      | Found route between points |
+            | a    | b  | ab    | 200    | Found route between points |
+            | b    | a  | ab    | 200    | Found route between points |
 
     Scenario: No route found
         Given the node map
@@ -30,8 +30,8 @@ Feature: Status messages
 
         When I route I should get
             | from | to | route | status | message                          |
-            | a    | b  | ab    | 0      | Found route between points       |
-            | c    | d  | cd    | 0      | Found route between points       |
+            | a    | b  | ab    | 200    | Found route between points       |
+            | c    | d  | cd    | 200    | Found route between points       |
             | a    | c  |       | 207    | Impossible route between points. |
             | b    | d  |       | 207    | Impossible route between points. |
 
@@ -46,22 +46,22 @@ Feature: Status messages
             | ab    |
 
         When I route I should get
-            | request                     | status | message                                    |
-            | viaroute?loc=1,1&loc=1.01,1 | 0      | Found route between points                 |
-            | nonsense                    | 400    | Bad Request                                |
-            | nonsense?loc=1,1&loc=1.01,1 | 400    | Bad Request                                |
-            |                             | 400    | Query string malformed close to position 0 |
-            | /                           | 400    | Query string malformed close to position 0 |
-            | ?                           | 400    | Query string malformed close to position 0 |
-            | viaroute/loc=               | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1              | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1            | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1,1          | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=x              | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=x,y            | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1&loc=       | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1&loc=1      | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1&loc=1,1    | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1&loc=1,1,1  | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1&loc=x      | 400    | Query string malformed close to position 9 |
-            | viaroute/loc=1,1&loc=x,y    | 400    | Query string malformed close to position 9 |
+            | request                     | status | message                                     |
+            | viaroute?loc=1,1&loc=1.01,1 | 200    | Found route between points                  |
+            | nonsense                    | 400    | Service not found                           |
+            | nonsense?loc=1,1&loc=1.01,1 | 400    | Service not found                           |
+            |                             | 400    | Query string malformed close to position 0  |
+            | /                           | 400    | Query string malformed close to position 0  |
+            | ?                           | 400    | Query string malformed close to position 0  |
+            | viaroute?loc=               | 400    | Query string malformed close to position 9  |
+            | viaroute?loc=1              | 400    | Query string malformed close to position 9  |
+            | viaroute?loc=1,1            | 400    | Invalid coordinates.                        |
+            | viaroute?loc=1,1,1          | 400    | Query string malformed close to position 17 |
+            | viaroute?loc=x              | 400    | Query string malformed close to position 9  |
+            | viaroute?loc=x,y            | 400    | Query string malformed close to position 9  |
+            | viaroute?loc=1,1&loc=       | 400    | Query string malformed close to position 17 |
+            | viaroute?loc=1,1&loc=1      | 400    | Query string malformed close to position 17 |
+            | viaroute?loc=1,1&loc=1,1    | 200    | Found route between points                  |
+            | viaroute?loc=1,1&loc=1,1,1  | 400    | Query string malformed close to position 25 |
+            | viaroute?loc=1,1&loc=x      | 400    | Query string malformed close to position 17 |
+            | viaroute?loc=1,1&loc=x,y    | 400    | Query string malformed close to position 17 |

--- a/include/osrm/libosrm_config.hpp
+++ b/include/osrm/libosrm_config.hpp
@@ -36,6 +36,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 struct LibOSRMConfig
 {
     std::unordered_map<std::string, boost::filesystem::path> server_paths;
+    int max_locations_trip = -1;
+    int max_locations_viaroute = -1;
     int max_locations_distance_table = -1;
     int max_locations_map_matching = -1;
     bool use_shared_memory = true;

--- a/library/osrm_impl.cpp
+++ b/library/osrm_impl.cpp
@@ -111,7 +111,7 @@ int OSRM::OSRM_impl::RunQuery(const RouteParameters &route_parameters, osrm::jso
     increase_concurrent_query_count();
     auto return_code = plugin_iterator->second->HandleRequest(route_parameters, json_result);
     decrease_concurrent_query_count();
-    return return_code;
+    return static_cast<int>(return_code);
 }
 
 // decrease number of concurrent queries

--- a/plugins/hello_world.hpp
+++ b/plugins/hello_world.hpp
@@ -46,7 +46,7 @@ class HelloWorldPlugin final : public BasePlugin
     virtual ~HelloWorldPlugin() {}
     const std::string GetDescriptor() const override final { return descriptor_string; }
 
-    int HandleRequest(const RouteParameters &routeParameters,
+    Status HandleRequest(const RouteParameters &routeParameters,
                       osrm::json::Object &json_result) override final
     {
         std::string temp_string;
@@ -96,7 +96,7 @@ class HelloWorldPlugin final : public BasePlugin
             ++counter;
         }
         json_result.values["hints"] = json_hints;
-        return 200;
+        return Status::Ok;
     }
 
   private:

--- a/plugins/match.hpp
+++ b/plugins/match.hpp
@@ -272,10 +272,17 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
     int HandleRequest(const RouteParameters &route_parameters,
                       osrm::json::Object &json_result) final override
     {
+        // enforce maximum number of locations for performance reasons
+        if (max_locations_map_matching > 0 &&
+            static_cast<int>(route_parameters.coordinates.size()) > max_locations_map_matching)
+        {
+            json_result.values["status_message"] = "Too many coodindates.";
+            return 400;
+        }
+
         // check number of parameters
         if (!check_all_coordinates(route_parameters.coordinates))
         {
-            json_result.values["status"] = 400;
             json_result.values["status_message"] = "Invalid coordinates.";
             return 400;
         }
@@ -287,31 +294,19 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         const auto &input_bearings = route_parameters.bearings;
         if (input_timestamps.size() > 0 && input_coords.size() != input_timestamps.size())
         {
-            json_result.values["status"] = 400;
             json_result.values["status_message"] = "Number of timestamps does not match number of coordinates.";
             return 400;
         }
 
         if (input_bearings.size() > 0 && input_coords.size() != input_bearings.size())
         {
-            json_result.values["status"] = 400;
             json_result.values["status_message"] = "Number of bearings does not match number of coordinates.";
-            return 400;
-        }
-
-        // enforce maximum number of locations for performance reasons
-        if (max_locations_map_matching > 0 &&
-            static_cast<int>(input_coords.size()) > max_locations_map_matching)
-        {
-            json_result.values["status"] = 400;
-            json_result.values["status_message"] = "Too many coodindates.";
             return 400;
         }
 
         // enforce maximum number of locations for performance reasons
         if (static_cast<int>(input_coords.size()) < 2)
         {
-            json_result.values["status"] = 400;
             json_result.values["status_message"] = "At least two coordinates needed.";
             return 400;
         }
@@ -320,7 +315,6 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
             getCandidates(input_coords, input_bearings, route_parameters.gps_precision, sub_trace_lengths, candidates_lists);
         if (!found_candidates)
         {
-            json_result.values["status"] = 400;
             json_result.values["status_message"] = "No suitable matching candidates found.";
             return 400;
         }
@@ -385,15 +379,11 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
 
         if (sub_matchings.empty())
         {
-            json_result.values["status"] = 207;
             json_result.values["status_message"] = "Cannot find matchings.";
-        }
-        else
-        {
-            json_result.values["status"] = 0;
-            json_result.values["status_message"] = "Found matchings.";
+            return 207;
         }
 
+        json_result.values["status_message"] = "Found matchings.";
         return 200;
     }
 

--- a/plugins/nearest.hpp
+++ b/plugins/nearest.hpp
@@ -62,7 +62,7 @@ template <class DataFacadeT> class NearestPlugin final : public BasePlugin
         const auto &input_bearings = route_parameters.bearings;
         if (input_bearings.size() > 0 && route_parameters.coordinates.size() != input_bearings.size())
         {
-            json_result.values["status"] = "Number of bearings does not match number of coordinates .";
+            json_result.values["status_message"] = "Number of bearings does not match number of coordinates.";
             return 400;
         }
 
@@ -73,13 +73,12 @@ template <class DataFacadeT> class NearestPlugin final : public BasePlugin
 
         if (phantom_node_vector.empty() || !phantom_node_vector.front().phantom_node.is_valid())
         {
-            json_result.values["status"] = 207;
+            json_result.values["status_message"] = "No nearest edge found.";
+            return 207;
         }
         else
         {
-            // reply.status = http::Reply::ok;
-            json_result.values["status"] = 0;
-
+            json_result.values["status_message"] = "Found nearest edge.";
             if (number_of_results > 1)
             {
                 osrm::json::Array results;

--- a/plugins/nearest.hpp
+++ b/plugins/nearest.hpp
@@ -49,32 +49,39 @@ template <class DataFacadeT> class NearestPlugin final : public BasePlugin
 
     const std::string GetDescriptor() const override final { return descriptor_string; }
 
-    int HandleRequest(const RouteParameters &route_parameters,
+    Status HandleRequest(const RouteParameters &route_parameters,
                       osrm::json::Object &json_result) override final
     {
         // check number of parameters
         if (route_parameters.coordinates.empty() ||
             !route_parameters.coordinates.front().is_valid())
         {
-            return 400;
+            return Status::Error;
         }
 
         const auto &input_bearings = route_parameters.bearings;
-        if (input_bearings.size() > 0 && route_parameters.coordinates.size() != input_bearings.size())
+        if (input_bearings.size() > 0 &&
+            route_parameters.coordinates.size() != input_bearings.size())
         {
-            json_result.values["status_message"] = "Number of bearings does not match number of coordinates.";
-            return 400;
+            json_result.values["status_message"] =
+                "Number of bearings does not match number of coordinates.";
+            return Status::Error;
         }
 
         auto number_of_results = static_cast<std::size_t>(route_parameters.num_results);
         const int bearing = input_bearings.size() > 0 ? input_bearings.front().first : 0;
-        const int range = input_bearings.size() > 0 ? (input_bearings.front().second?*input_bearings.front().second:10) : 180;
-        auto phantom_node_vector = facade->NearestPhantomNodes(route_parameters.coordinates.front(), number_of_results, bearing, range);
+        const int range =
+            input_bearings.size() > 0
+                ? (input_bearings.front().second ? *input_bearings.front().second : 10)
+                : 180;
+        auto phantom_node_vector = facade->NearestPhantomNodes(route_parameters.coordinates.front(),
+                                                               number_of_results, bearing, range);
 
-        if (phantom_node_vector.empty() || !phantom_node_vector.front().phantom_node.is_valid())
+        if (phantom_node_vector.empty())
         {
-            json_result.values["status_message"] = "No nearest edge found.";
-            return 207;
+            json_result.values["status_message"] =
+                std::string("Could not find a matching segments for coordinate.");
+            return Status::NoSegment;
         }
         else
         {
@@ -87,14 +94,13 @@ template <class DataFacadeT> class NearestPlugin final : public BasePlugin
                 for (const auto i :
                      osrm::irange<std::size_t>(0, std::min(number_of_results, vector_length)))
                 {
-                    const auto& node = phantom_node_vector[i].phantom_node;
+                    const auto &node = phantom_node_vector[i].phantom_node;
                     osrm::json::Array json_coordinate;
                     osrm::json::Object result;
                     json_coordinate.values.push_back(node.location.lat / COORDINATE_PRECISION);
                     json_coordinate.values.push_back(node.location.lon / COORDINATE_PRECISION);
                     result.values["mapped coordinate"] = json_coordinate;
-                    result.values["name"] =
-                        facade->get_name_for_id(node.name_id);
+                    result.values["name"] = facade->get_name_for_id(node.name_id);
                     results.values.push_back(result);
                 }
                 json_result.values["results"] = results;
@@ -102,16 +108,16 @@ template <class DataFacadeT> class NearestPlugin final : public BasePlugin
             else
             {
                 osrm::json::Array json_coordinate;
-                json_coordinate.values.push_back(phantom_node_vector.front().phantom_node.location.lat /
-                                                 COORDINATE_PRECISION);
-                json_coordinate.values.push_back(phantom_node_vector.front().phantom_node.location.lon /
-                                                 COORDINATE_PRECISION);
+                json_coordinate.values.push_back(
+                    phantom_node_vector.front().phantom_node.location.lat / COORDINATE_PRECISION);
+                json_coordinate.values.push_back(
+                    phantom_node_vector.front().phantom_node.location.lon / COORDINATE_PRECISION);
                 json_result.values["mapped_coordinate"] = json_coordinate;
                 json_result.values["name"] =
                     facade->get_name_for_id(phantom_node_vector.front().phantom_node.name_id);
             }
         }
-        return 200;
+        return Status::Ok;
     }
 
   private:

--- a/plugins/plugin_base.hpp
+++ b/plugins/plugin_base.hpp
@@ -41,11 +41,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class BasePlugin
 {
   public:
+    enum class Status : int
+    {
+      Ok = 200,
+      EmptyResult = 207,
+      NoSegment = 208,
+      Error = 400
+    };
+
     BasePlugin() {}
     // Maybe someone can explain the pure virtual destructor thing to me (dennis)
     virtual ~BasePlugin() {}
     virtual const std::string GetDescriptor() const = 0;
-    virtual int HandleRequest(const RouteParameters &, osrm::json::Object &) = 0;
+    virtual Status HandleRequest(const RouteParameters &, osrm::json::Object &) = 0;
     virtual bool check_all_coordinates(const std::vector<FixedPointCoordinate> &coordinates,
                                        const unsigned min = 2) const final
     {

--- a/plugins/timestamp.hpp
+++ b/plugins/timestamp.hpp
@@ -44,15 +44,14 @@ template <class DataFacadeT> class TimestampPlugin final : public BasePlugin
     {
     }
     const std::string GetDescriptor() const override final { return descriptor_string; }
-    int HandleRequest(const RouteParameters &route_parameters,
+    Status HandleRequest(const RouteParameters &route_parameters,
                       osrm::json::Object &json_result) override final
     {
         (void)route_parameters; // unused
 
-        json_result.values["status"] = 0;
         const std::string timestamp = facade->GetTimestamp();
         json_result.values["timestamp"] = timestamp;
-        return 200;
+        return Status::Ok;
     }
 
   private:

--- a/routed.cpp
+++ b/routed.cpp
@@ -77,7 +77,7 @@ int main(int argc, const char *argv[]) try
     LibOSRMConfig lib_config;
     const unsigned init_result = GenerateServerProgramOptions(
         argc, argv, lib_config.server_paths, ip_address, ip_port, requested_thread_num,
-        lib_config.use_shared_memory, trial_run, lib_config.max_locations_viaroute, lib_config.max_locations_trip,
+        lib_config.use_shared_memory, trial_run, lib_config.max_locations_trip, lib_config.max_locations_viaroute,
         lib_config.max_locations_distance_table,
         lib_config.max_locations_map_matching);
     if (init_result == INIT_OK_DO_NOT_START_ENGINE)

--- a/routed.cpp
+++ b/routed.cpp
@@ -77,7 +77,8 @@ int main(int argc, const char *argv[]) try
     LibOSRMConfig lib_config;
     const unsigned init_result = GenerateServerProgramOptions(
         argc, argv, lib_config.server_paths, ip_address, ip_port, requested_thread_num,
-        lib_config.use_shared_memory, trial_run, lib_config.max_locations_distance_table,
+        lib_config.use_shared_memory, trial_run, lib_config.max_locations_viaroute, lib_config.max_locations_trip,
+        lib_config.max_locations_distance_table,
         lib_config.max_locations_map_matching);
     if (init_result == INIT_OK_DO_NOT_START_ENGINE)
     {

--- a/server/request_handler.cpp
+++ b/server/request_handler.cpp
@@ -52,6 +52,8 @@ RequestHandler::RequestHandler() : routing_machine(nullptr) {}
 void RequestHandler::handle_request(const http::request &current_request,
                                     http::reply &current_reply)
 {
+    osrm::json::Object json_result;
+
     // parse command
     try
     {
@@ -93,40 +95,40 @@ void RequestHandler::handle_request(const http::request &current_request,
         const bool result =
             boost::spirit::qi::parse(api_iterator, request_string.end(), api_parser);
 
-        osrm::json::Object json_result;
         // check if the was an error with the request
-        if (!result || (api_iterator != request_string.end()))
+        if (result && api_iterator == request_string.end())
         {
-            current_reply = http::reply::stock_reply(http::reply::bad_request);
-            current_reply.content.clear();
+            // parsing done, lets call the right plugin to handle the request
+            BOOST_ASSERT_MSG(routing_machine != nullptr, "pointer not init'ed");
+
+            if (!route_parameters.jsonp_parameter.empty())
+            { // prepend response with jsonp parameter
+                const std::string json_p = (route_parameters.jsonp_parameter + "(");
+                current_reply.content.insert(current_reply.content.end(), json_p.begin(), json_p.end());
+            }
+
+            const int return_code = routing_machine->RunQuery(route_parameters, json_result);
+            json_result.values["status"] = return_code;
+            // 4xx bad request return code
+            if (return_code / 100 == 4)
+            {
+                current_reply.status = http::reply::bad_request;
+                current_reply.content.clear();
+                route_parameters.output_format.clear();
+            }
+            else
+            {
+                // 2xx valid request
+                BOOST_ASSERT(return_code / 100 == 2);
+            }
+        }
+        else
+        {
             const auto position = std::distance(request_string.begin(), api_iterator);
 
-            json_result.values["status"] = 400;
-            std::string message = "Query string malformed close to position ";
-            message += std::to_string(position);
-            json_result.values["status_message"] = message;
-            osrm::json::render(current_reply.content, json_result);
-            return;
-        }
-
-        // parsing done, lets call the right plugin to handle the request
-        BOOST_ASSERT_MSG(routing_machine != nullptr, "pointer not init'ed");
-
-        if (!route_parameters.jsonp_parameter.empty())
-        { // prepend response with jsonp parameter
-            const std::string json_p = (route_parameters.jsonp_parameter + "(");
-            current_reply.content.insert(current_reply.content.end(), json_p.begin(), json_p.end());
-        }
-        const auto return_code = routing_machine->RunQuery(route_parameters, json_result);
-        if (200 != return_code)
-        {
-            current_reply = http::reply::stock_reply(http::reply::bad_request);
-            current_reply.content.clear();
-            json_result.values["status"] = 400;
-            std::string message = "Bad Request";
-            json_result.values["status_message"] = message;
-            osrm::json::render(current_reply.content, json_result);
-            return;
+            current_reply.status = http::reply::bad_request;
+            json_result.values["status"] = http::reply::bad_request;
+            json_result.values["status_message"] = "Query string malformed close to position " + std::to_string(position);
         }
 
         current_reply.headers.emplace_back("Access-Control-Allow-Origin", "*");
@@ -166,10 +168,9 @@ void RequestHandler::handle_request(const http::request &current_request,
     }
     catch (const std::exception &e)
     {
-        current_reply = http::reply::stock_reply(http::reply::internal_server_error);
+        current_reply = http::reply::stock_reply(http::reply::internal_server_error);;
         SimpleLogger().Write(logWARNING) << "[server error] code: " << e.what()
                                          << ", uri: " << current_request.uri;
-        return;
     }
 }
 

--- a/tools/simpleclient.cpp
+++ b/tools/simpleclient.cpp
@@ -43,13 +43,14 @@ int main(int argc, const char *argv[])
     try
     {
         std::string ip_address;
-        int ip_port, requested_thread_num, max_locations_map_matching;
+        int ip_port, requested_thread_num;
         bool trial_run = false;
         LibOSRMConfig lib_config;
         const unsigned init_result = GenerateServerProgramOptions(
             argc, argv, lib_config.server_paths, ip_address, ip_port, requested_thread_num,
-            lib_config.use_shared_memory, trial_run, lib_config.max_locations_distance_table,
-            max_locations_map_matching);
+            lib_config.use_shared_memory, trial_run, lib_config.max_locations_trip,
+            lib_config.max_locations_viaroute, lib_config.max_locations_distance_table,
+            lib_config.max_locations_map_matching);
 
         if (init_result == INIT_OK_DO_NOT_START_ENGINE)
         {

--- a/util/routed_options.hpp
+++ b/util/routed_options.hpp
@@ -43,7 +43,8 @@ const static unsigned INIT_OK_START_ENGINE = 0;
 const static unsigned INIT_OK_DO_NOT_START_ENGINE = 1;
 const static unsigned INIT_FAILED = -1;
 
-inline void populate_base_path(std::unordered_map<std::string, boost::filesystem::path> &server_paths)
+inline void
+populate_base_path(std::unordered_map<std::string, boost::filesystem::path> &server_paths)
 {
     // populate the server_path object
     auto path_iterator = server_paths.find("base");
@@ -135,67 +136,69 @@ inline void populate_base_path(std::unordered_map<std::string, boost::filesystem
 }
 
 // generate boost::program_options object for the routing part
-inline unsigned GenerateServerProgramOptions(const int argc,
-                                             const char *argv[],
-                                             std::unordered_map<std::string, boost::filesystem::path> &paths,
-                                             std::string &ip_address,
-                                             int &ip_port,
-                                             int &requested_num_threads,
-                                             bool &use_shared_memory,
-                                             bool &trial,
-                                             int &max_locations_distance_table,
-                                             int &max_locations_map_matching)
+inline unsigned
+GenerateServerProgramOptions(const int argc,
+                             const char *argv[],
+                             std::unordered_map<std::string, boost::filesystem::path> &paths,
+                             std::string &ip_address,
+                             int &ip_port,
+                             int &requested_num_threads,
+                             bool &use_shared_memory,
+                             bool &trial,
+                             int &max_locations_trip,
+                             int &max_locations_viaroute,
+                             int &max_locations_distance_table,
+                             int &max_locations_map_matching)
 {
+    using boost::program_options::value;
+    using boost::filesystem::path;
+
     // declare a group of options that will be allowed only on command line
     boost::program_options::options_description generic_options("Options");
-    generic_options.add_options()("version,v", "Show version")("help,h", "Show this help message")(
-        "config,c", boost::program_options::value<boost::filesystem::path>(&paths["config"])
-                        ->default_value("server.ini"),
-        "Path to a configuration file")(
-        "trial", boost::program_options::value<bool>(&trial)->implicit_value(true),
-        "Quit after initialization");
+    generic_options.add_options()                                         //
+        ("version,v", "Show version")("help,h", "Show this help message") //
+        ("config,c", value<boost::filesystem::path>(&paths["config"])->default_value("server.ini"),
+         "Path to a configuration file") //
+        ("trial", value<bool>(&trial)->implicit_value(true), "Quit after initialization");
 
     // declare a group of options that will be allowed both on command line
     // as well as in a config file
     boost::program_options::options_description config_options("Configuration");
-    config_options.add_options()(
-        "hsgrdata", boost::program_options::value<boost::filesystem::path>(&paths["hsgrdata"]),
-        ".hsgr file")("nodesdata",
-                      boost::program_options::value<boost::filesystem::path>(&paths["nodesdata"]),
-                      ".nodes file")(
-        "edgesdata", boost::program_options::value<boost::filesystem::path>(&paths["edgesdata"]),
-        ".edges file")("geometry",
-                       boost::program_options::value<boost::filesystem::path>(&paths["geometries"]),
-                       ".geometry file")(
-        "ramindex", boost::program_options::value<boost::filesystem::path>(&paths["ramindex"]),
-        ".ramIndex file")(
-        "fileindex", boost::program_options::value<boost::filesystem::path>(&paths["fileindex"]),
-        "File index file")(
-        "namesdata", boost::program_options::value<boost::filesystem::path>(&paths["namesdata"]),
-        ".names file")("timestamp",
-                       boost::program_options::value<boost::filesystem::path>(&paths["timestamp"]),
-                       ".timestamp file")(
-        "ip,i", boost::program_options::value<std::string>(&ip_address)->default_value("0.0.0.0"),
-        "IP address")("port,p", boost::program_options::value<int>(&ip_port)->default_value(5000),
-                      "TCP/IP port")(
-        "threads,t", boost::program_options::value<int>(&requested_num_threads)->default_value(8),
-        "Number of threads to use")(
-        "shared-memory,s",
-        boost::program_options::value<bool>(&use_shared_memory)->implicit_value(true)->default_value(false),
-        "Load data from shared memory")(
-        "max-table-size",
-        boost::program_options::value<int>(&max_locations_distance_table)->default_value(100),
-        "Max. locations supported in distance table query")(
-        "max-matching-size",
-        boost::program_options::value<int>(&max_locations_map_matching)->default_value(100),
-        "Max. locations supported in map matching query");
+    config_options.add_options()                                                             //
+        ("hsgrdata", value<boost::filesystem::path>(&paths["hsgrdata"]), ".hsgr file")       //
+        ("nodesdata", value<boost::filesystem::path>(&paths["nodesdata"]), ".nodes file")    //
+        ("edgesdata", value<boost::filesystem::path>(&paths["edgesdata"]), ".edges file")    //
+        ("geometry", value<boost::filesystem::path>(&paths["geometries"]), ".geometry file") //
+        ("ramindex", value<boost::filesystem::path>(&paths["ramindex"]), ".ramIndex file")   //
+        ("fileindex", value<boost::filesystem::path>(&paths["fileindex"]),
+         "File index file") //
+        ("namesdata", value<boost::filesystem::path>(&paths["namesdata"]),
+         ".names file") //
+        ("timestamp", value<boost::filesystem::path>(&paths["timestamp"]),
+         ".timestamp file") //
+        ("ip,i", value<std::string>(&ip_address)->default_value("0.0.0.0"),
+         "IP address") //
+        ("port,p", value<int>(&ip_port)->default_value(5000),
+         "TCP/IP port") //
+        ("threads,t", value<int>(&requested_num_threads)->default_value(8),
+         "Number of threads to use") //
+        ("shared-memory,s",
+         value<bool>(&use_shared_memory)->implicit_value(true)->default_value(false),
+         "Load data from shared memory") //
+        ("max-viaroute-size", value<int>(&max_locations_viaroute)->default_value(500),
+         "Max. locations supported in viaroute query") //
+        ("max-trip-size", value<int>(&max_locations_trip)->default_value(100),
+         "Max. locations supported in trip query") //
+        ("max-table-size", value<int>(&max_locations_distance_table)->default_value(100),
+         "Max. locations supported in distance table query") //
+        ("max-matching-size", value<int>(&max_locations_map_matching)->default_value(100),
+         "Max. locations supported in map matching query");
 
     // hidden options, will be allowed both on command line and in config
     // file, but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");
-    hidden_options.add_options()(
-        "base,b", boost::program_options::value<boost::filesystem::path>(&paths["base"]),
-        "base path to .osrm file");
+    hidden_options.add_options()("base,b", value<boost::filesystem::path>(&paths["base"]),
+                                 "base path to .osrm file");
 
     // positional option
     boost::program_options::positional_options_description positional_options;
@@ -273,7 +276,6 @@ inline unsigned GenerateServerProgramOptions(const int argc,
     {
         SimpleLogger().Write(logWARNING) << "Shared memory settings conflict with path settings.";
     }
-
 
     SimpleLogger().Write() << visible_options;
     return INIT_OK_DO_NOT_START_ENGINE;


### PR DESCRIPTION
"status" is now always:

* 200 if the request was successful
* 207 if the result is empty (no path found)
* 208 if no edge for snapping was found
* 400 if the request is invalid

 viaroute and trip now have a maximum of 500 and 100 locations
 respectively. Override with the `--max-viaroute-size` and `--max-trip-size`
 parameters.