### PR TITLE
Via way restrictions [WIP]

### DIFF
--- a/data_structures/restriction.hpp
+++ b/data_structures/restriction.hpp
@@ -79,7 +79,7 @@ struct TurnRestriction
 
 /**
  * This is just a wrapper around TurnRestriction used in the extractor.
- * 
+ *
  * Could be merged with TurnRestriction. For now the type-destiction makes sense
  * as the format in which the restriction is presented in the extractor and in the
  * preprocessing is different. (see restriction_parser.cpp)
@@ -98,6 +98,7 @@ struct InputRestrictionContainer
     {
         restriction.from.way = SPECIAL_EDGEID;
         restriction.to.way = SPECIAL_EDGEID;
+        restriction.via.way = SPECIAL_EDGEID;
         restriction.via.node = SPECIAL_NODEID;
         restriction.flags.is_only = is_only;
     }

--- a/data_structures/restriction.hpp
+++ b/data_structures/restriction.hpp
@@ -46,14 +46,14 @@ struct TurnRestriction
     struct Bits
     { // mostly unused
         Bits()
-            : is_only(false), uses_via_way(false), unused2(false), unused3(false), unused4(false),
+            : is_only(false), uses_via_way(false), ignore_write(false), unused3(false), unused4(false),
               unused5(false), unused6(false), unused7(false)
         {
         }
 
         bool is_only : 1;
         bool uses_via_way : 1;
-        bool unused2 : 1;
+        bool ignore_write : 1;
         bool unused3 : 1;
         bool unused4 : 1;
         bool unused5 : 1;
@@ -127,6 +127,17 @@ struct CmpRestrictionContainerByTo
     bool operator()(const InputRestrictionContainer &a, const InputRestrictionContainer &b) const
     {
         return a.restriction.to.way < b.restriction.to.way;
+    }
+    value_type max_value() const { return InputRestrictionContainer::max_value(); }
+    value_type min_value() const { return InputRestrictionContainer::min_value(); }
+};
+
+struct CmpRestrictionContainerByVia
+{
+    using value_type = InputRestrictionContainer;
+    bool operator()(const InputRestrictionContainer &a, const InputRestrictionContainer &b) const
+    {
+        return a.restriction.via.way < b.restriction.via.way;
     }
     value_type max_value() const { return InputRestrictionContainer::max_value(); }
     value_type min_value() const { return InputRestrictionContainer::min_value(); }

--- a/data_structures/restriction_map.cpp
+++ b/data_structures/restriction_map.cpp
@@ -86,6 +86,7 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
                 BOOST_ASSERT(via_way_target.via_nodes.size() == 0 && via_way_target.target_node == SPECIAL_NODEID);
 
                 m_restriction_start_nodes.insert(restriction.from.node);
+                m_no_turn_via_node_set.insert(restriction.via.node);
 
                 RestrictionSource restriction_source = {static_cast<NodeID>(restriction.from.node), static_cast<NodeID>(restriction.via.node)};
 
@@ -99,11 +100,14 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
             }
             else if (IsViaWay(restriction))
             {
+                m_no_turn_via_node_set.insert(restriction.via.node);
                 via_way_target.via_nodes.push_back(restriction.via.node);
             }
             else if (IsToWay(restriction))
             {
                 BOOST_ASSERT(via_way_targets.via_nodes.size() >= 1);
+                m_no_turn_via_node_set.insert(restriction.via.node);
+                m_no_turn_via_node_set.insert(restriction.to.node);
 
                 via_way_target.via_nodes.push_back(restriction.via.node);
                 via_way_target.via_nodes.push_back(restriction.to.node);

--- a/data_structures/restriction_map.hpp
+++ b/data_structures/restriction_map.hpp
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
+#include <algorithm>
 #include <vector>
 
 struct RestrictionSource
@@ -56,12 +57,30 @@ struct RestrictionTarget
 {
     NodeID target_node;
     bool is_only;
+    // If restriction is a via_way, via_nodes will be populated with nodes from restriction
+    std::vector<NodeID> via_nodes;
 
     explicit RestrictionTarget(NodeID target, bool only) : target_node(target), is_only(only) {}
 
+    explicit RestrictionTarget() : target_node(SPECIAL_NODEID), is_only(false) {}
+
+    void reset()
+    {
+        target_node = SPECIAL_NODEID;
+        is_only = false;
+        via_nodes.clear();
+    }
+
     friend inline bool operator==(const RestrictionTarget &lhs, const RestrictionTarget &rhs)
     {
-        return (lhs.target_node == rhs.target_node && lhs.is_only == rhs.is_only);
+        return (lhs.target_node == rhs.target_node && lhs.is_only == rhs.is_only) &&
+            (lhs.via_nodes.size() == rhs.via_nodes.size()) &&
+            (std::equal(
+                lhs.via_nodes.begin(),
+                lhs.via_nodes.begin() + lhs.via_nodes.size(),
+                rhs.via_nodes.begin()
+                )
+            );
     }
 };
 
@@ -144,6 +163,9 @@ class RestrictionMap
     }
 
     bool IsViaNode(const NodeID node) const;
+    bool IsFromWay(const TurnRestriction &restriction) const;
+    bool IsViaWay(const TurnRestriction &restriction) const;
+    bool IsToWay(const TurnRestriction &restriction) const;
 
     // Replaces start edge (v, w) with (u, w). Only start node changes.
     void
@@ -155,6 +177,11 @@ class RestrictionMap
     // Checks if turn <u,v,w> is actually a turn restriction.
     bool
     CheckIfTurnIsRestricted(const NodeID node_u, const NodeID node_v, const NodeID node_w) const;
+
+    // Checks if a turn restriction is a via way restriction and returns the nodes associated with
+    // the restriction.
+    std::vector<std::vector<NodeID>>
+    CheckForViaWayRestrictions(const NodeID node_u, const NodeID node_v) const;
 
     std::size_t size() const { return m_count; }
 

--- a/data_structures/restriction_map.hpp
+++ b/data_structures/restriction_map.hpp
@@ -154,9 +154,14 @@ class RestrictionMap
 
             for (RestrictionTarget &restriction_target : bucket)
             {
+                unsigned via_ways_length = restriction_target.via_ways.size();
                 if (node_v == restriction_target.target_node)
                 {
                     restriction_target.target_node = node_w;
+                }
+                else if (via_ways_length && node_v == restriction_target.via_ways[via_ways_length - 1])
+                {
+                    restriction_target.via_ways[via_ways_length - 1] = node_w;
                 }
             }
         }

--- a/extractor/extraction_containers.cpp
+++ b/extractor/extraction_containers.cpp
@@ -581,9 +581,12 @@ void ExtractionContainers::WriteRestrictions(const std::string& path) const
 
     for (const auto &restriction_container : restrictions_list)
     {
-        if (SPECIAL_NODEID != restriction_container.restriction.from.node &&
+        if ((SPECIAL_NODEID != restriction_container.restriction.from.node &&
             SPECIAL_NODEID != restriction_container.restriction.via.node &&
-            SPECIAL_NODEID != restriction_container.restriction.to.node)
+            SPECIAL_NODEID != restriction_container.restriction.to.node) ||
+            (SPECIAL_EDGEID != restriction_container.restriction.from.way &&
+            SPECIAL_EDGEID != restriction_container.restriction.via.way &&
+            SPECIAL_EDGEID != restriction_container.restriction.to.way))
         {
             restrictions_out_stream.write((char *)&(restriction_container.restriction),
                                           sizeof(TurnRestriction));

--- a/extractor/extraction_containers.cpp
+++ b/extractor/extraction_containers.cpp
@@ -103,6 +103,7 @@ void ExtractionContainers::PrepareData(const std::string &output_file_name,
         file_out_stream.close();
 
         PrepareRestrictions();
+        PrepareViaWayRestrictions();
         WriteRestrictions(restrictions_file_name);
 
         WriteNames(name_file_name);
@@ -570,6 +571,7 @@ void ExtractionContainers::WriteNodes(std::ofstream& file_out_stream) const
 
 void ExtractionContainers::WriteRestrictions(const std::string& path) const
 {
+
     // serialize restrictions
     std::ofstream restrictions_out_stream;
     unsigned written_restriction_count = 0;
@@ -581,12 +583,11 @@ void ExtractionContainers::WriteRestrictions(const std::string& path) const
 
     for (const auto &restriction_container : restrictions_list)
     {
-        if ((SPECIAL_NODEID != restriction_container.restriction.from.node &&
+        if (((SPECIAL_NODEID != restriction_container.restriction.from.node &&
             SPECIAL_NODEID != restriction_container.restriction.via.node &&
             SPECIAL_NODEID != restriction_container.restriction.to.node) ||
-            (SPECIAL_EDGEID != restriction_container.restriction.from.way &&
-            SPECIAL_EDGEID != restriction_container.restriction.via.way &&
-            SPECIAL_EDGEID != restriction_container.restriction.to.way))
+            restriction_container.restriction.flags.uses_via_way) &&
+            !restriction_container.restriction.flags.ignore_write)
         {
             restrictions_out_stream.write((char *)&(restriction_container.restriction),
                                           sizeof(TurnRestriction));
@@ -597,6 +598,22 @@ void ExtractionContainers::WriteRestrictions(const std::string& path) const
     restrictions_out_stream.write((char *)&written_restriction_count, sizeof(unsigned));
     restrictions_out_stream.close();
     SimpleLogger().Write() << "usable restrictions: " << written_restriction_count;
+}
+
+// Finds node ID that connects the end points of two ways. If no node connects the ends of the ways, this returns
+// the SPECIAL_NODEID
+NodeID ExtractionContainers::findConnectingNodeID(const std::vector<InternalExtractorEdge> &way_edges1, const std::vector<InternalExtractorEdge> &way_edges2) {
+    if ((way_edges1.front().result.source == way_edges2.front().result.source) ||
+        (way_edges1.front().result.source == way_edges2.back().result.target))
+    {
+        return way_edges1.front().result.source;
+    }
+    else if ((way_edges1.back().result.target == way_edges2.back().result.target) ||
+             (way_edges1.back().result.target == way_edges2.front().result.source))
+    {
+        return way_edges1.back().result.target;
+    }
+    return SPECIAL_NODEID;
 }
 
 void ExtractionContainers::PrepareRestrictions()
@@ -626,6 +643,12 @@ void ExtractionContainers::PrepareRestrictions()
     while (way_start_and_end_iterator != way_start_end_id_list_end &&
            restrictions_iterator != restrictions_list_end)
     {
+        // Skip via-way restrictions (we'll deal with these later)
+        if (restrictions_iterator->restriction.flags.uses_via_way) {
+            ++restrictions_iterator++;
+            continue;
+        }
+
         if (way_start_and_end_iterator->way_id < OSMWayID(restrictions_iterator->restriction.from.way))
         {
             ++way_start_and_end_iterator;
@@ -694,6 +717,12 @@ void ExtractionContainers::PrepareRestrictions()
     while (way_start_and_end_iterator != way_start_end_id_list_end_ &&
            restrictions_iterator != restrictions_list_end_)
     {
+        // Skip via-way restrictions (we'll deal with these later)
+        if (restrictions_iterator->restriction.flags.uses_via_way) {
+            ++restrictions_iterator;
+            continue;
+        }
+
         if (way_start_and_end_iterator->way_id < OSMWayID(restrictions_iterator->restriction.to.way))
         {
             ++way_start_and_end_iterator;
@@ -739,4 +768,127 @@ void ExtractionContainers::PrepareRestrictions()
     }
     TIMER_STOP(fix_restriction_ends);
     std::cout << "ok, after " << TIMER_SEC(fix_restriction_ends) << "s" << std::endl;
+}
+
+/**
+* Prepares via-way restrictions by unfolds them into multiple lines each (one for each node in the via way and
+* two total for the from-way and to-way).
+* For example, a via-way restriction a->b->c with nodes:
+* a: [0,1,2], b:[2,3,4], c:[4,5,6] will be split into 3 restrictions (in order):
+*
+* Restriction# |        from (node)     |       to (node)       |       via (node)
+* -------------|------------------------|-----------------------|---------------------
+*            0 |            1           |     SPECIAL_NODE_ID   |           2
+*            1 |      SPECIAL_NODE_ID   |           3           |     SPECIAL_NODE_ID
+*            2 |      SPECIAL_NODE_ID   |           5           |           4
+*
+*/
+void ExtractionContainers::PrepareViaWayRestrictions()
+{
+    std::cout << "[extractor] Sorting restrictions. by via way ... " << std::flush;
+    TIMER_START(sort_restrictions_via);
+    stxxl::sort(restrictions_list.begin(), restrictions_list.end(),
+                CmpRestrictionContainerByVia(), stxxl_memory);
+    TIMER_STOP(sort_restrictions_via);
+    std::cout << "ok, after " << TIMER_SEC(sort_restrictions_via) << "s" << std::endl;
+
+    std::cout << "[extractor] Unfolding via-way restrictions  ... " << std::flush;
+    TIMER_START(unfold_via_ways);
+    int unfolded_restrictions_count = 0;
+    auto restrictions_iterator = restrictions_list.begin();
+
+    while (restrictions_iterator != restrictions_list.end())
+    {
+        if (!restrictions_iterator->restriction.flags.uses_via_way) {
+            ++restrictions_iterator;
+            continue;
+        }
+
+        const std::vector<InternalExtractorEdge> from_edges = way_to_edges_map[OSMWayID(restrictions_iterator->restriction.from.way)];
+        const std::vector<InternalExtractorEdge> via_edges  = way_to_edges_map[OSMWayID(restrictions_iterator->restriction.via.way)];
+        const std::vector<InternalExtractorEdge> to_edges   = way_to_edges_map[OSMWayID(restrictions_iterator->restriction.to.way)];
+
+        if (from_edges.size() == 0 || via_edges.size() == 0 || to_edges.size() == 0) {
+            SimpleLogger().Write(LogLevel::logDEBUG) << "Invalid via-way restriction: " << restrictions_iterator->restriction.via.way;
+            ++restrictions_iterator;
+            continue;
+        }
+
+        NodeID from_via_node_id = findConnectingNodeID(from_edges, via_edges);
+        NodeID via_to_node_id = findConnectingNodeID(via_edges, to_edges);
+
+        if (from_via_node_id == SPECIAL_NODEID || via_to_node_id == SPECIAL_NODEID)
+        {
+            SimpleLogger().Write(LogLevel::logDEBUG) << "Invalid via-way restriction: " << restrictions_iterator->restriction.via.way;
+            ++restrictions_iterator;
+            continue;
+        }
+
+        // Ensure the connecting nodes connect all the ways correctly
+        BOOST_ASSERT(from_edges.front().result.source == from_via_node_id || from_edges.back().result.target == from_via_node_id);
+        BOOST_ASSERT(via_edges.front().result.source == from_via_node_id || via_edges.back().result.target == from_via_node_id);
+        BOOST_ASSERT(via_edges.front().result.source == via_to_node_id || via_edges.back().result.target == via_to_node_id);
+        BOOST_ASSERT(to_edges.front().result.source == via_to_node_id || to_edges.back().result.target == via_to_node_id);
+
+        InputRestrictionContainer from_restriction;
+        InputRestrictionContainer to_restriction;
+        from_restriction.restriction.flags.uses_via_way = true;
+        to_restriction.restriction.flags.uses_via_way = true;
+
+        if (from_edges.front().result.source == from_via_node_id) {
+            from_restriction.restriction.from.node = from_edges.front().result.target;
+            from_restriction.restriction.via.node = from_via_node_id;
+        }
+        else {
+            from_restriction.restriction.from.node = from_edges.back().result.source;
+            from_restriction.restriction.via.node = from_via_node_id;
+        }
+
+        if (to_edges.front().result.source == via_to_node_id) {
+            to_restriction.restriction.via.node = via_to_node_id;
+            to_restriction.restriction.to.node = to_edges.front().result.target;
+        }
+        else {
+            to_restriction.restriction.via.node = via_to_node_id;
+            to_restriction.restriction.to.node = to_edges.back().result.source;
+        }
+
+        // Write the unfolded restriction to the restrictions_list
+        restrictions_list.push_back(from_restriction);
+
+        // Traverse forwards
+        if (via_edges.front().result.source == from_via_node_id) {
+            for (auto edge_iterator = via_edges.begin(); edge_iterator != via_edges.end(); ++edge_iterator) {
+                if (edge_iterator->result.target == via_to_node_id) {
+                    break;
+                }
+                InputRestrictionContainer via_restriction;
+                via_restriction.restriction.flags.uses_via_way = true;
+                via_restriction.restriction.via.node = edge_iterator->result.target;
+                restrictions_list.push_back(via_restriction);
+            }
+        }
+        // Traverse backwards
+        else {
+            for (auto edge_iterator = via_edges.end()-1; edge_iterator >= via_edges.begin(); --edge_iterator) {
+                if (edge_iterator->result.target == from_via_node_id) {
+                    break;
+                }
+                InputRestrictionContainer via_restriction;
+                via_restriction.restriction.flags.uses_via_way = true;
+                via_restriction.restriction.via.node = edge_iterator->result.target;
+                restrictions_list.push_back(via_restriction);
+            }
+        }
+
+        restrictions_list.push_back(to_restriction);
+        ++unfolded_restrictions_count;
+
+        ++restrictions_iterator;
+    }
+
+    TIMER_STOP(unfold_via_ways);
+    SimpleLogger().Write() << "ok, after " << TIMER_SEC(unfold_via_ways) << "s";
+
+    SimpleLogger().Write() << "Number of unfolded restrictions: " << unfolded_restrictions_count;
 }

--- a/extractor/extraction_containers.hpp
+++ b/extractor/extraction_containers.hpp
@@ -28,14 +28,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef EXTRACTION_CONTAINERS_HPP
 #define EXTRACTION_CONTAINERS_HPP
 
-#include "internal_extractor_edge.hpp"
 #include "first_and_last_segment_of_way.hpp"
 #include "scripting_environment.hpp"
+#include "internal_extractor_edge.hpp"
+
 #include "../data_structures/external_memory_node.hpp"
 #include "../data_structures/restriction.hpp"
 
 #include <stxxl/vector>
 #include <unordered_map>
+#include <vector>
 
 /**
  * Uses external memory containers from stxxl to store all the data that
@@ -54,12 +56,16 @@ class ExtractionContainers
 #endif
     void PrepareNodes();
     void PrepareRestrictions();
+    void PrepareViaWayRestrictions();
     void PrepareEdges(lua_State *segment_state);
 
     void WriteNodes(std::ofstream& file_out_stream) const;
     void WriteRestrictions(const std::string& restrictions_file_name) const;
     void WriteEdges(std::ofstream& file_out_stream) const;
     void WriteNames(const std::string& names_file_name) const;
+
+    NodeID findConnectingNodeID(const std::vector<InternalExtractorEdge> &way_edges1, const std::vector<InternalExtractorEdge> &way_edges2);
+
   public:
     using STXXLNodeIDVector = stxxl::vector<OSMNodeID>;
     using STXXLNodeVector = stxxl::vector<ExternalMemoryNode>;
@@ -73,8 +79,10 @@ class ExtractionContainers
     stxxl::vector<char> name_char_data;
     stxxl::vector<unsigned> name_lengths;
     STXXLRestrictionsVector restrictions_list;
+    std::vector<InputRestrictionContainer> unfolded_restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;
+    std::unordered_map<OSMWayID, std::vector<InternalExtractorEdge>> way_to_edges_map;
     unsigned max_internal_node_id;
 
     ExtractionContainers();

--- a/extractor/restriction_parser.cpp
+++ b/extractor/restriction_parser.cpp
@@ -213,10 +213,11 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
             {
                 if (restriction_container.restriction.via.way == SPECIAL_EDGEID) {
                     restriction_container.restriction.flags.uses_via_way = true;
+                    restriction_container.restriction.flags.ignore_write = true;
                     restriction_container.restriction.via.way = member.ref();
                 }
                 else {
-                    return mapbox::util::optional<InputRestrictionContainer>();
+                    return boost::optional<InputRestrictionContainer>();
                 }
             }
             break;

--- a/extractor/restriction_parser.cpp
+++ b/extractor/restriction_parser.cpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../util/lua_util.hpp"
 #include "../util/osrm_exception.hpp"
 #include "../util/simple_logger.hpp"
+#include "../typedefs.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/regex.hpp>
@@ -207,11 +208,17 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
             {
                 restriction_container.restriction.to.way = member.ref();
             }
-            // else if (0 == strcmp("via", role))
-            // {
-            //     not yet suppported
-            //     restriction_container.restriction.via.way = member.ref();
-            // }
+            // For now we'll only deal with 3-member via-way turn restrictions.
+            else if (0 == strcmp("via", role))
+            {
+                if (restriction_container.restriction.via.way == SPECIAL_EDGEID) {
+                    restriction_container.restriction.flags.uses_via_way = true;
+                    restriction_container.restriction.via.way = member.ref();
+                }
+                else {
+                    return mapbox::util::optional<InputRestrictionContainer>();
+                }
+            }
             break;
         case osmium::item_type::relation:
             // not yet supported, but who knows what the future holds...


### PR DESCRIPTION
This is a branch under development to incorporate via way restrictions, currently with the 'no_' case with a 3-member restriction (from, via, to). 

This will work as follows:
- [x] Read in restrictions if they are a "no_*" restriction on three ways: `a->b->c`
- [x] Write out the turn restrictions to the `.restrictions` file along with the regular restrictions in a special format (documented in the code)
- [x] Parse in restrictions and during the edge based graph building phase
- [ ] Create extra edge based nodes for the middle way (the via), which essentially retain the state of coming from the "from" way.

Concretely, let's say we have three ways in the restriction: `a->b->c` (`a` is the from, `b` is the via, `c` is the to). We create a new edge based node (`b'`) and take all of the *outgoing* edge_based_edges of `b` and duplicate them so that `b'` also has those outgoing edges. Next we delete the edge_based_edge connecting `a` to `b` and create an identically weighted one from `a` to `b'`. Finally we delete the edge from `b'` to `c`.

I'll be adding commits to this branch, but would love feedback as I continue development.

@TheMarex @danpat