### PR TITLE
modified local state of u_turn_penalty_variable

### DIFF
--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -95,7 +95,7 @@ use_turn_restrictions           = false
 
 local obey_oneway               = true
 local ignore_areas              = true
-local u_turn_penalty            = 20
+u_turn_penalty            = 20
 local turn_penalty              = 60
 local turn_bias                 = 1.4
 -- reduce the driving speed by 30% for unsafe roads

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -95,7 +95,7 @@ use_turn_restrictions           = false
 
 local obey_oneway               = true
 local ignore_areas              = true
-u_turn_penalty            = 20
+u_turn_penalty                  = 20
 local turn_penalty              = 60
 local turn_bias                 = 1.4
 -- reduce the driving speed by 30% for unsafe roads

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -138,7 +138,7 @@ local turn_bias                 = 1.2
 
 local obey_oneway               = true
 local ignore_areas              = true
-u_turn_penalty            		= 20
+u_turn_penalty                  = 20
 
 local abs = math.abs
 local min = math.min

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -138,7 +138,7 @@ local turn_bias                 = 1.2
 
 local obey_oneway               = true
 local ignore_areas              = true
-local u_turn_penalty            = 20
+u_turn_penalty            		= 20
 
 local abs = math.abs
 local min = math.min


### PR DESCRIPTION
The current profiles do not result in an applied path penalty.
The local state of the variable results in a penalty of 0, no matter what value is specified.
For correct u-turn penalisation, the state needs to be switched to a global variable.