### PR TITLE
Fix 'occured' typo, replace with 'occurred'.

### DIFF
--- a/extractor/extractor.cpp
+++ b/extractor/extractor.cpp
@@ -342,14 +342,14 @@ void extractor::SetupScriptingEnvironment(lua_State *lua_state,
     if (0 != luaL_dofile(lua_state, config.profile_path.string().c_str()))
     {
         std::stringstream msg;
-        msg << lua_tostring(lua_state, -1) << " occured in scripting block";
+        msg << lua_tostring(lua_state, -1) << " occurred in scripting block";
         throw osrm::exception(msg.str());
     }
 
     if (0 != luaL_dostring(lua_state, "return traffic_signal_penalty\n"))
     {
         std::stringstream msg;
-        msg << lua_tostring(lua_state, -1) << " occured in scripting block";
+        msg << lua_tostring(lua_state, -1) << " occurred in scripting block";
         throw osrm::exception(msg.str());
     }
     speed_profile.traffic_signal_penalty = 10 * lua_tointeger(lua_state, -1);
@@ -359,7 +359,7 @@ void extractor::SetupScriptingEnvironment(lua_State *lua_state,
     if (0 != luaL_dostring(lua_state, "return u_turn_penalty\n"))
     {
         std::stringstream msg;
-        msg << lua_tostring(lua_state, -1) << " occured in scripting block";
+        msg << lua_tostring(lua_state, -1) << " occurred in scripting block";
         throw osrm::exception(msg.str());
     }
 

--- a/extractor/restriction_parser.cpp
+++ b/extractor/restriction_parser.cpp
@@ -51,7 +51,7 @@ namespace
 int lua_error_callback(lua_State *lua_state)
 {
     std::string error_msg = lua_tostring(lua_state, -1);
-    throw osrm::exception("ERROR occured in profile script:\n" + error_msg);
+    throw osrm::exception("ERROR occurred in profile script:\n" + error_msg);
 }
 }
 

--- a/extractor/scripting_environment.cpp
+++ b/extractor/scripting_environment.cpp
@@ -59,7 +59,7 @@ int lua_error_callback(lua_State *L) // This is so I can use my own function as 
     std::string error_msg = lua_tostring(L, -1);
     std::ostringstream error_stream;
     error_stream << error_msg;
-    throw osrm::exception("ERROR occured in profile script:\n" + error_stream.str());
+    throw osrm::exception("ERROR occurred in profile script:\n" + error_stream.str());
 }
 }
 
@@ -154,7 +154,7 @@ void ScriptingEnvironment::init_lua_state(lua_State *lua_state)
         luabind::object error_msg(luabind::from_stack(lua_state, -1));
         std::ostringstream error_stream;
         error_stream << error_msg;
-        throw osrm::exception("ERROR occured in profile script:\n" + error_stream.str());
+        throw osrm::exception("ERROR occurred in profile script:\n" + error_stream.str());
     }
 }
 


### PR DESCRIPTION
The lintian QA tool reported the spelling error as part of the Debian package build for 4.9.0.