### PR TITLE
Experimental: reproducible development environment via nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+# Nix development environment for reproducible builds.
+# Enter development environment via `nix-shell`.
+#
+# Resources:
+# - http://nixos.org/nix/
+# - https://nixos.org/nix/manual/#chap-quick-start
+# - https://nixos.org/nixpkgs/manual/
+
+with import <nixpkgs> {}; {
+  devEnv = stdenv.mkDerivation {
+    name = "osrm-backend";
+    buildInputs = [ cmake boost tbb stxxl luabind lua expat bzip2 zlib ];
+  };
+}


### PR DESCRIPTION
This adds a basix `shell.nix` file (similar to requirements.txt for
Python's pip), for reliable and reproducible builds.

Enter the environment:

    nix-shell

Or enter the environment without system binaries available:

    nix-shell --pure

This is similar to a negation of `pyvenv --system-side-packages`.

On first invocation all dependencies (i.e. compiler, build system,
dependencies) are downloaded by means of resolving a dependency tree
down to libc. Because this tree can be hashed at nodes, binary packages
can be fetched for the common packages and verified against hashes.

In case we have ABI mismatches, e.g. because we want to use gcc5 with
its stdlib, we can override the dependencies' environment. Nix then looks
for binary caches for those packages with the gcc5 stdlib and if they
are not available, builds the dependency tree with the new environment.

    buildInputs = map (pkg: pkg.override { stdenv = overrideCC stdenv gcc5; }) [ gcc5 cmake .. ];

Note: this is a first try in providing a development environment that
allows for reproducible builds. Building osrm-backend works, but I did
not (yet?) add all dependencies e.g. for the tools (gdal etc.).

To test it yourself, either enter the dev environment via `nix-shell`,
or run the build command once inside the env:

    nix-shell --run 'mkdir build && cd build && cmake .. && cmake --build .'

If you ever used Gentoo, it's like a modern and better Portage with
optional binary caches. Currently the Haskell community uses nix
in order to get out of cabal and dependency hell.

Please see the quickstart guide below, and give it a try.

Resources:

- http://nixos.org/nix/
- https://nixos.org/nix/manual/#chap-quick-start
- https://nixos.org/nixpkgs/manual/

/cc @springmeyer @danpat @TheMarex 