### PR TITLE
Shortest path loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_custom_target(FingerPrintConfigure ALL ${CMAKE_COMMAND}
   COMMENT "Configuring revision fingerprint"
   VERBATIM)
 
-add_custom_target(tests DEPENDS engine-tests extractor-tests util-tests)
+add_custom_target(tests DEPENDS engine-tests extractor-tests util-tests io-tests)
 add_custom_target(benchmarks DEPENDS rtree-bench)
 
 set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread unit_test_framework)
@@ -61,6 +61,7 @@ file(GLOB EngineGlob src/engine/*.cpp src/engine/**/*.cpp)
 file(GLOB ExtractorTestsGlob unit_tests/extractor/*.cpp)
 file(GLOB EngineTestsGlob unit_tests/engine/*.cpp)
 file(GLOB UtilTestsGlob unit_tests/util/*.cpp)
+file(GLOB IOTestsGlob unit_tests/io/*.cpp)
 
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})
@@ -85,6 +86,7 @@ target_link_libraries(osrm-routed OSRM)
 add_executable(engine-tests EXCLUDE_FROM_ALL unit_tests/engine_tests.cpp ${EngineTestsGlob} $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:GRAPH>)
 add_executable(extractor-tests EXCLUDE_FROM_ALL unit_tests/extractor_tests.cpp ${ExtractorTestsGlob} $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_executable(util-tests EXCLUDE_FROM_ALL unit_tests/util_tests.cpp ${UtilTestsGlob} $<TARGET_OBJECTS:PHANTOM> $<TARGET_OBJECTS:UTIL>)
+add_executable(io-tests EXCLUDE_FROM_ALL unit_tests/io_tests.cpp ${IOTestsGlob} $<TARGET_OBJECTS:UTIL>)
 
 # Benchmarks
 add_executable(rtree-bench EXCLUDE_FROM_ALL src/benchmarks/static_rtree.cpp $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:PHANTOM>)
@@ -248,6 +250,7 @@ target_link_libraries(engine-tests ${Boost_LIBRARIES})
 target_link_libraries(extractor-tests ${Boost_LIBRARIES})
 target_link_libraries(util-tests ${Boost_LIBRARIES})
 target_link_libraries(rtree-bench ${Boost_LIBRARIES})
+target_link_libraries(io-tests ${Boost_LIBRARIES})
 
 find_package(Threads REQUIRED)
 target_link_libraries(osrm-extract ${CMAKE_THREAD_LIBS_INIT})

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -263,7 +263,7 @@ def extract_data
       raise ExtractError.new $?.exitstatus, "osrm-extract exited with code #{$?.exitstatus}."
     end
     begin
-      ["osrm","osrm.names","osrm.restrictions","osrm.ebg","osrm.edges","osrm.fileIndex","osrm.geometry","osrm.nodes","osrm.ramIndex"].each do |file|
+      ["osrm","osrm.names","osrm.restrictions","osrm.ebg","osrm.enw","osrm.edges","osrm.fileIndex","osrm.geometry","osrm.nodes","osrm.ramIndex"].each do |file|
         log "Renaming #{osm_file}.#{file} to #{extracted_file}.#{file}", :preprocess
         File.rename "#{osm_file}.#{file}", "#{extracted_file}.#{file}"
       end

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -29,7 +29,7 @@ Feature: Basic Distance Matrix
             | ab    | primary   |
             | bc    | secondary |
             | cd    | tertiary  |
-            
+
         When I request a travel time matrix I should get
             |   | a   | b   | c   | d   |
             | a | 0   | 100 | 300 | 600 |
@@ -49,7 +49,7 @@ Feature: Basic Distance Matrix
             |   | a       | b        |
             | a | 0       | 95 +- 10 |
             | b | 95 ~10% | 0        |
-    
+
     Scenario: Testbot - Travel time matrix of small grid
         Given the node map
             | a | b | c |
@@ -82,7 +82,7 @@ Feature: Basic Distance Matrix
             |   | a  | b   |
             | a | 0  | 100 |
             | b |    | 0   |
-    
+
     Scenario: Testbot - Travel time matrix of network with oneways
         Given the node map
             | x | a | b | y |
@@ -136,7 +136,7 @@ Feature: Basic Distance Matrix
             | a | 100 | 200 | 300 |
             | b | 0   | 100 | 200 |
 
-    Scenario: Testbog - All coordinates are from same small component
+    Scenario: Testbot - All coordinates are from same small component
         Given a grid size of 300 meters
         Given the extract extra arguments "--small-component-size 4"
         Given the node map
@@ -156,7 +156,7 @@ Feature: Basic Distance Matrix
             | f | 0   | 300 |
             | g | 300 |  0  |
 
-    Scenario: Testbog - Coordinates are from different small component and snap to big CC
+    Scenario: Testbot - Coordinates are from different small component and snap to big CC
         Given a grid size of 300 meters
         Given the extract extra arguments "--small-component-size 4"
         Given the node map
@@ -179,3 +179,21 @@ Feature: Basic Distance Matrix
             | h | 0   | 300 | 0   | 300 |
             | i | 300 |  0  | 300 | 0   |
 
+    Scenario: Testbot - Travel time matrix with loops
+        Given the node map
+            | a | 1 | 2 | b |
+            | d | 4 | 3 | c |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | yes |
+            | bc    | yes |
+            | cd    | yes |
+            | da    | yes |
+
+        When I request a travel time matrix I should get
+            |   | 1   | 2   | 3   | 4   |
+            | 1 | 0   | 100 +-1 | 400 +-1 | 500 +-1 |
+            | 2 | 700 +-1 | 0   | 300 +-1 | 400 +-1 |
+            | 3 | 400 +-1 | 500 +-1 | 0   | 100 +-1 |
+            | 4 | 300 +-1 | 400 +-1 | 700 +-1 | 0   |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -93,8 +93,6 @@ Feature: Via points
             | 1,3,2     | ab,bc,cd,cd,de,ef,fa,ab,bc | 1600m +-1 | head,straight,straight,via,right,right,right,right,straight,destination |
             | 3,2,1     | cd,de,ef,fa,ab,bc,bc,cd,de,ef,fa,ab | 2400m +-1 | head,right,right,right,right,straight,via,straight,right,right,right,right,destination |
 
-    # TODO: Remove this ignore when https://github.com/Project-OSRM/osrm-backend/issues/1863 gets fixed
-    @ignore-platform-mac
     Scenario: Via points on ring on the same oneway
     # xa it to avoid only having a single ring, which cna trigger edge cases
         Given the node map
@@ -117,7 +115,6 @@ Feature: Via points
             | 1,2,3     | ab,ab                      | 200m +-1  | head,via,destination                                             |
             | 1,3,2     | ab,ab,bc,cd,da,ab          | 1100m +-1 | head,via,right,right,right,right,destination                     |
             | 3,2,1     | ab,bc,cd,da,ab,ab,bc,cd,da,ab | 1800m     | head,right,right,right,right,via,right,right,right,right,destination |
-
 
     # See issue #1896
     Scenario: Via point at a dead end with oneway
@@ -162,3 +159,45 @@ Feature: Via points
             | waypoints | route            |
             | a,1,c     | abc,bd,bd,bd,abc |
             | c,1,a     | abc,bd,bd,bd,abc |
+
+    Scenario: Via points on ring on the same oneway, forces one of the vertices to be top node
+        Given the node map
+            | a | 1 | 2 | b |
+            | 8 |   |   | 3 |
+            | 7 |   |   | 4 |
+            | d | 6 | 5 | c |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | yes    |
+            | bc    | yes    |
+            | cd    | yes    |
+            | da    | yes    |
+
+        When I route I should get
+            | waypoints | route                      | distance  | turns                                                            |
+            | 2,1       | ab,bc,cd,da,ab             | 1100m +-1  | head,right,right,right,right,destination                         |
+            | 4,3       | bc,cd,da,ab,bc             | 1100m +-1  | head,right,right,right,right,destination                         |
+            | 6,5       | cd,da,ab,bc,cd             | 1100m +-1  | head,right,right,right,right,destination                         |
+            | 8,7       | da,ab,bc,cd,da             | 1100m +-1  | head,right,right,right,right,destination                         |
+
+    Scenario: Multiple Via points on ring on the same oneway, forces one of the vertices to be top node
+        Given the node map
+            | a | 1 | 2 | 3 | b |
+            |   |   |   |   | 4 |
+            |   |   |   |   | 5 |
+            |   |   |   |   | 6 |
+            | d | 9 | 8 | 7 | c |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | yes    |
+            | bc    | yes    |
+            | cd    | yes    |
+            | da    | yes    |
+
+        When I route I should get
+            | waypoints | route                      | distance  | turns                                                            |
+            | 3,2,1     | ab,bc,cd,da,ab,ab,bc,cd,da,ab | 3000m +-1    | head,right,right,right,right,via,right,right,right,right,destination |
+            | 6,5,4     | bc,cd,da,ab,bc,bc,cd,da,ab,bc | 3000m +-1    | head,right,right,right,right,via,right,right,right,right,destination |
+            | 9,8,7     | cd,da,ab,bc,cd,cd,da,ab,bc,cd | 3000m +-1    | head,right,right,right,right,via,right,right,right,right,destination |

--- a/include/contractor/processing_chain.hpp
+++ b/include/contractor/processing_chain.hpp
@@ -11,6 +11,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <cstddef>
+
 #include <vector>
 
 struct lua_State;
@@ -43,6 +45,7 @@ class Prepare
     void ContractGraph(const unsigned max_edge_id,
                        util::DeallocatingVector<extractor::EdgeBasedEdge> &edge_based_edge_list,
                        util::DeallocatingVector<QueryEdge> &contracted_edge_list,
+                       std::vector<EdgeWeight> &&node_weights,
                        std::vector<bool> &is_core_node,
                        std::vector<float> &node_levels) const;
     void WriteCoreNodeMarker(std::vector<bool> &&is_core_node) const;

--- a/include/engine/routing_algorithms/alternative_path.hpp
+++ b/include/engine/routing_algorithms/alternative_path.hpp
@@ -156,8 +156,23 @@ class AlternativeRouting final
         std::vector<NodeID> packed_forward_path;
         std::vector<NodeID> packed_reverse_path;
 
-        super::RetrievePackedPathFromSingleHeap(forward_heap1, middle_node, packed_forward_path);
-        super::RetrievePackedPathFromSingleHeap(reverse_heap1, middle_node, packed_reverse_path);
+        if (upper_bound_to_shortest_path_distance !=
+            forward_heap1.GetKey(middle_node) + reverse_heap1.GetKey(middle_node))
+        {
+            // Self Loop
+            BOOST_ASSERT(forward_heap1.GetData(middle_node).parent == middle_node &&
+                         reverse_heap1.GetData(middle_node).parent == middle_node);
+            packed_forward_path.push_back(middle_node);
+            packed_forward_path.push_back(middle_node);
+        }
+        else
+        {
+
+            super::RetrievePackedPathFromSingleHeap(forward_heap1, middle_node,
+                                                    packed_forward_path);
+            super::RetrievePackedPathFromSingleHeap(reverse_heap1, middle_node,
+                                                    packed_reverse_path);
+        }
 
         // this set is is used as an indicator if a node is on the shortest path
         std::unordered_set<NodeID> nodes_in_path(packed_forward_path.size() +
@@ -382,10 +397,13 @@ class AlternativeRouting final
         int upper_bound_s_v_path_length = INVALID_EDGE_WEIGHT;
         new_reverse_heap.Insert(via_node, 0, via_node);
         // compute path <s,..,v> by reusing forward search from s
+        const bool constexpr STALLING_ENABLED = true;
+        const bool constexpr DO_NOT_FORCE_LOOPS = false;
         while (!new_reverse_heap.Empty())
         {
             super::RoutingStep(new_reverse_heap, existing_forward_heap, s_v_middle,
-                               upper_bound_s_v_path_length, min_edge_offset, false);
+                               upper_bound_s_v_path_length, min_edge_offset, false,
+                               STALLING_ENABLED, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
         }
         // compute path <v,..,t> by reusing backward search from node t
         NodeID v_t_middle = SPECIAL_NODEID;
@@ -394,7 +412,8 @@ class AlternativeRouting final
         while (!new_forward_heap.Empty())
         {
             super::RoutingStep(new_forward_heap, existing_reverse_heap, v_t_middle,
-                               upper_bound_of_v_t_path_length, min_edge_offset, true);
+                               upper_bound_of_v_t_path_length, min_edge_offset, true,
+                               STALLING_ENABLED, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
         }
         *real_length_of_via_path = upper_bound_s_v_path_length + upper_bound_of_v_t_path_length;
 
@@ -442,10 +461,10 @@ class AlternativeRouting final
                                           partially_unpacked_shortest_path.size())) -
             1;
         for (int64_t current_node = 0; (current_node < packed_path_length) &&
-                                           (partially_unpacked_via_path[current_node] ==
-                                                partially_unpacked_shortest_path[current_node] &&
-                                            partially_unpacked_via_path[current_node + 1] ==
-                                                partially_unpacked_shortest_path[current_node + 1]);
+                                       (partially_unpacked_via_path[current_node] ==
+                                            partially_unpacked_shortest_path[current_node] &&
+                                        partially_unpacked_via_path[current_node + 1] ==
+                                            partially_unpacked_shortest_path[current_node + 1]);
              ++current_node)
         {
             EdgeID selected_edge =
@@ -600,6 +619,18 @@ class AlternativeRouting final
                     //     << "
                     //     at distance " << new_distance;
                 }
+                else
+                {
+                    // check whether there is a loop present at the node
+                    const auto loop_distance = super::GetLoopWeight(node);
+                    const int new_distance_with_loop = new_distance + loop_distance;
+                    if (loop_distance != INVALID_EDGE_WEIGHT &&
+                        new_distance_with_loop <= *upper_bound_to_shortest_path_distance)
+                    {
+                        *middle_node = node;
+                        *upper_bound_to_shortest_path_distance = loop_distance;
+                    }
+                }
             }
         }
 
@@ -655,10 +686,13 @@ class AlternativeRouting final
         int upper_bound_s_v_path_length = INVALID_EDGE_WEIGHT;
         // compute path <s,..,v> by reusing forward search from s
         new_reverse_heap.Insert(candidate.node, 0, candidate.node);
+        const bool constexpr STALLING_ENABLED = true;
+        const bool constexpr DO_NOT_FORCE_LOOPS = false;
         while (new_reverse_heap.Size() > 0)
         {
             super::RoutingStep(new_reverse_heap, existing_forward_heap, *s_v_middle,
-                               upper_bound_s_v_path_length, min_edge_offset, false);
+                               upper_bound_s_v_path_length, min_edge_offset, false,
+                               STALLING_ENABLED, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
         }
 
         if (INVALID_EDGE_WEIGHT == upper_bound_s_v_path_length)
@@ -673,7 +707,8 @@ class AlternativeRouting final
         while (new_forward_heap.Size() > 0)
         {
             super::RoutingStep(new_forward_heap, existing_reverse_heap, *v_t_middle,
-                               upper_bound_of_v_t_path_length, min_edge_offset, true);
+                               upper_bound_of_v_t_path_length, min_edge_offset, true,
+                               STALLING_ENABLED, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
         }
 
         if (INVALID_EDGE_WEIGHT == upper_bound_of_v_t_path_length)
@@ -841,12 +876,14 @@ class AlternativeRouting final
             if (!forward_heap3.Empty())
             {
                 super::RoutingStep(forward_heap3, reverse_heap3, middle, upper_bound,
-                                   min_edge_offset, true);
+                                   min_edge_offset, true, STALLING_ENABLED, DO_NOT_FORCE_LOOPS,
+                                   DO_NOT_FORCE_LOOPS);
             }
             if (!reverse_heap3.Empty())
             {
                 super::RoutingStep(reverse_heap3, forward_heap3, middle, upper_bound,
-                                   min_edge_offset, false);
+                                   min_edge_offset, false, STALLING_ENABLED, DO_NOT_FORCE_LOOPS,
+                                   DO_NOT_FORCE_LOOPS);
             }
         }
         return (upper_bound <= t_test_path_length);

--- a/include/engine/routing_algorithms/direct_shortest_path.hpp
+++ b/include/engine/routing_algorithms/direct_shortest_path.hpp
@@ -93,6 +93,9 @@ class DirectShortestPathRouting final
         int distance = INVALID_EDGE_WEIGHT;
         std::vector<NodeID> packed_leg;
 
+        const bool constexpr DO_NOT_FORCE_LOOPS =
+            false; // prevents forcing of loops, since offsets are set correctly
+
         if (super::facade->GetCoreSize() > 0)
         {
             engine_working_data.InitializeOrClearSecondThreadLocalStorage(
@@ -103,11 +106,12 @@ class DirectShortestPathRouting final
             reverse_core_heap.Clear();
 
             super::SearchWithCore(forward_heap, reverse_heap, forward_core_heap, reverse_core_heap,
-                                  distance, packed_leg);
+                                  distance, packed_leg, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
         }
         else
         {
-            super::Search(forward_heap, reverse_heap, distance, packed_leg);
+            super::Search(forward_heap, reverse_heap, distance, packed_leg, DO_NOT_FORCE_LOOPS,
+                          DO_NOT_FORCE_LOOPS);
         }
 
         // No path found for both target nodes?

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -139,14 +139,21 @@ class ManyToManyRouting final
                 // get target id from bucket entry
                 const unsigned target_id = current_bucket.target_id;
                 const int target_distance = current_bucket.distance;
-                const EdgeWeight current_distance =
-                    (*result_table)[source_id * number_of_targets + target_id];
+                auto &current_distance = (*result_table)[source_id * number_of_targets + target_id];
                 // check if new distance is better
                 const EdgeWeight new_distance = source_distance + target_distance;
-                if (new_distance >= 0 && new_distance < current_distance)
+                if (new_distance < 0)
                 {
-                    (*result_table)[source_id * number_of_targets + target_id] =
-                        (source_distance + target_distance);
+                    const EdgeWeight loop_weight = super::GetLoopWeight(node);
+                    const int new_distance_with_loop = new_distance + loop_weight;
+                    if (loop_weight != INVALID_EDGE_WEIGHT && new_distance_with_loop >= 0)
+                    {
+                        current_distance = std::min(current_distance, new_distance_with_loop);
+                    }
+                }
+                else if (new_distance < current_distance)
+                {
+                    (*result_table)[source_id * number_of_targets + target_id] = new_distance;
                 }
             }
         }

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -62,10 +62,11 @@ class EdgeBasedGraphFactory
              const bool generate_edge_lookup);
 #endif
 
+    //The following get access functions destroy the content in the factory
     void GetEdgeBasedEdges(util::DeallocatingVector<EdgeBasedEdge> &edges);
-
     void GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes);
     void GetStartPointMarkers(std::vector<bool> &node_is_startpoint);
+    void GetEdgeBasedNodeWeights(std::vector<EdgeWeight> &output_node_weights);
 
     unsigned GetHighestEdgeID();
 
@@ -80,6 +81,11 @@ class EdgeBasedGraphFactory
     //! maps index from m_edge_based_node_list to ture/false if the node is an entry point to the
     //! graph
     std::vector<bool> m_edge_based_node_is_startpoint;
+
+    //! node weights that indicate the length of the segment (node based) represented by the
+    //! edge-based node
+    std::vector<EdgeWeight> m_edge_based_node_weights;
+
     //! list of edge based nodes (compressed segments)
     std::vector<EdgeBasedNode> m_edge_based_node_list;
     util::DeallocatingVector<EdgeBasedEdge> m_edge_based_edge_list;

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -6,24 +6,28 @@
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/graph_compressor.hpp"
 
+#include "util/typedefs.hpp"
+
 namespace osrm
 {
 namespace extractor
 {
 
-class extractor
+class Extractor
 {
   public:
-    extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
+    Extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
     int run();
 
   private:
     ExtractorConfig config;
+
     void SetupScriptingEnvironment(lua_State *myLuaState, SpeedProfileProperties &speed_profile);
     std::pair<std::size_t, std::size_t>
     BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_node_map,
                            std::vector<EdgeBasedNode> &node_based_edge_list,
                            std::vector<bool> &node_is_startpoint,
+                           std::vector<EdgeWeight> &edge_based_node_weights,
                            util::DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list);
     void WriteNodeMapping(const std::vector<QueryNode> &internal_to_external_node_map);
     void FindComponents(unsigned max_edge_id,
@@ -38,8 +42,8 @@ class extractor
                        std::unordered_set<NodeID> &traffic_lights,
                        std::vector<QueryNode> &internal_to_external_node_map);
 
-    void WriteEdgeBasedGraph(std::string const &output_file_filename,
-                             size_t const max_edge_id,
+    void WriteEdgeBasedGraph(const std::string &output_file_filename,
+                             const size_t max_edge_id,
                              util::DeallocatingVector<EdgeBasedEdge> const &edge_based_edge_list);
 };
 }

--- a/include/extractor/extractor_options.hpp
+++ b/include/extractor/extractor_options.hpp
@@ -35,6 +35,11 @@ struct ExtractorConfig
     std::string rtree_nodes_output_path;
     std::string rtree_leafs_output_path;
 
+    // every edge based node represents a segment in the original graph. During contraciton we need
+    // to know about this segment length, as we might have to add self-loops in cases of shorter
+    // parts than the segment represents itself
+    std::string edge_based_node_weights_output_path;
+
     unsigned requested_num_threads;
     unsigned small_component_size;
 

--- a/include/util/io.hpp
+++ b/include/util/io.hpp
@@ -1,0 +1,127 @@
+#ifndef OSRM_INCLUDE_UTIL_IO_HPP_
+#define OSRM_INCLUDE_UTIL_IO_HPP_
+
+#include "util/simple_logger.hpp"
+
+#include <boost/filesystem.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+#include <fstream>
+#include <bitset>
+#include <vector>
+
+#include "util/fingerprint.hpp"
+
+namespace osrm
+{
+namespace util
+{
+
+inline bool writeFingerprint(std::ostream &stream)
+{
+    const auto fingerprint = FingerPrint::GetValid();
+    stream.write(reinterpret_cast<const char *>(&fingerprint), sizeof(fingerprint));
+    return static_cast<bool>(stream);
+}
+
+inline bool readAndCheckFingerprint(std::istream &stream)
+{
+    FingerPrint fingerprint;
+    const auto valid = FingerPrint::GetValid();
+    stream.read(reinterpret_cast<char *>(&fingerprint), sizeof(fingerprint));
+    // compare the compilation state stored in the fingerprint
+    return static_cast<bool>(stream) && valid.IsMagicNumberOK(fingerprint) &&
+           valid.TestPrepare(fingerprint) && valid.TestGraphUtil(fingerprint) &&
+           valid.TestRTree(fingerprint) && valid.TestQueryObjects(fingerprint);
+}
+
+template <typename simple_type>
+bool serializeVector(const std::string &filename, const std::vector<simple_type> &data)
+{
+    std::ofstream stream(filename, std::ios::binary);
+
+    writeFingerprint(stream);
+
+    std::uint64_t count = data.size();
+    stream.write(reinterpret_cast<const char *>(&count), sizeof(count));
+    if (!data.empty())
+        stream.write(reinterpret_cast<const char *>(&data[0]), sizeof(simple_type) * count);
+    return static_cast<bool>(stream);
+}
+
+template <typename simple_type>
+bool deserializeVector(const std::string &filename, std::vector<simple_type> &data)
+{
+    std::ifstream stream(filename, std::ios::binary);
+
+    if (!readAndCheckFingerprint(stream))
+        return false;
+
+    std::uint64_t count = 0;
+    stream.read(reinterpret_cast<char *>(&count), sizeof(count));
+    data.resize(count);
+    if (count)
+        stream.read(reinterpret_cast<char *>(&data[0]), sizeof(simple_type) * count);
+    return static_cast<bool>(stream);
+}
+
+inline bool serializeFlags(const boost::filesystem::path &path, const std::vector<bool> &flags)
+{
+    // TODO this should be replaced with a FILE-based write using error checking
+    std::ofstream flag_stream(path.string(), std::ios::binary);
+
+    writeFingerprint(flag_stream);
+
+    std::uint32_t number_of_bits = flags.size();
+    flag_stream.write(reinterpret_cast<const char *>(&number_of_bits), sizeof(number_of_bits));
+    // putting bits in ints
+    std::uint32_t chunk = 0;
+    std::size_t chunk_count = 0;
+    for (std::size_t bit_nr = 0; bit_nr < number_of_bits;)
+    {
+        std::bitset<32> chunk_bitset;
+        for (std::size_t chunk_bit = 0; chunk_bit < 32 && bit_nr < number_of_bits;
+             ++chunk_bit, ++bit_nr)
+            chunk_bitset[chunk_bit] = flags[bit_nr];
+
+        chunk = chunk_bitset.to_ulong();
+        ++chunk_count;
+        flag_stream.write(reinterpret_cast<const char *>(&chunk), sizeof(chunk));
+    }
+    SimpleLogger().Write() << "Wrote " << number_of_bits << " bits in " << chunk_count
+                           << " chunks (Flags).";
+    return static_cast<bool>(flag_stream);
+}
+
+inline bool deserializeFlags(const boost::filesystem::path &path, std::vector<bool> &flags)
+{
+    SimpleLogger().Write() << "Reading flags from " << path;
+    std::ifstream flag_stream(path.string(), std::ios::binary);
+
+    if (!readAndCheckFingerprint(flag_stream))
+        return false;
+
+    std::uint32_t number_of_bits;
+    flag_stream.read(reinterpret_cast<char *>(&number_of_bits), sizeof(number_of_bits));
+    flags.resize(number_of_bits);
+    // putting bits in ints
+    std::uint32_t chunks = (number_of_bits + 31) / 32;
+    std::size_t bit_position = 0;
+    std::uint32_t chunk;
+    for (std::size_t chunk_id = 0; chunk_id < chunks; ++chunk_id)
+    {
+        flag_stream.read(reinterpret_cast<char *>(&chunk), sizeof(chunk));
+        std::bitset<32> chunk_bits(chunk);
+        for (std::size_t bit = 0; bit < 32 && bit_position < number_of_bits; ++bit, ++bit_position)
+            flags[bit_position] = chunk_bits[bit];
+    }
+    SimpleLogger().Write() << "Read " << number_of_bits << " bits in " << chunks
+                           << " Chunks from disk.";
+    return static_cast<bool>(flag_stream);
+}
+} // namespace util
+} // namespace osrm
+
+#endif // OSRM_INCLUDE_UTIL_IO_HPP_

--- a/src/extractor/extractor_options.cpp
+++ b/src/extractor/extractor_options.cpp
@@ -142,6 +142,7 @@ void ExtractorOptions::GenerateOutputFilesNames(ExtractorConfig &extractor_confi
     extractor_config.geometry_output_path = input_path.string();
     extractor_config.edge_output_path = input_path.string();
     extractor_config.edge_graph_output_path = input_path.string();
+    extractor_config.edge_based_node_weights_output_path = input_path.string();
     extractor_config.node_output_path = input_path.string();
     extractor_config.rtree_nodes_output_path = input_path.string();
     extractor_config.rtree_leafs_output_path = input_path.string();
@@ -173,6 +174,7 @@ void ExtractorOptions::GenerateOutputFilesNames(ExtractorConfig &extractor_confi
             extractor_config.node_output_path.append(".osrm.nodes");
             extractor_config.edge_output_path.append(".osrm.edges");
             extractor_config.edge_graph_output_path.append(".osrm.ebg");
+            extractor_config.edge_based_node_weights_output_path.append(".osrm.enw");
             extractor_config.rtree_nodes_output_path.append(".osrm.ramIndex");
             extractor_config.rtree_leafs_output_path.append(".osrm.fileIndex");
             extractor_config.edge_segment_lookup_path.append(".osrm.edge_segment_lookup");
@@ -188,6 +190,7 @@ void ExtractorOptions::GenerateOutputFilesNames(ExtractorConfig &extractor_confi
             extractor_config.node_output_path.replace(pos, 5, ".osrm.nodes");
             extractor_config.edge_output_path.replace(pos, 5, ".osrm.edges");
             extractor_config.edge_graph_output_path.replace(pos, 5, ".osrm.ebg");
+            extractor_config.edge_based_node_weights_output_path.replace(pos, 5, ".osrm.enw");
             extractor_config.rtree_nodes_output_path.replace(pos, 5, ".osrm.ramIndex");
             extractor_config.rtree_leafs_output_path.replace(pos, 5, ".osrm.fileIndex");
             extractor_config.edge_segment_lookup_path.replace(pos, 5, ".osrm.edge_segment_lookup");
@@ -204,6 +207,7 @@ void ExtractorOptions::GenerateOutputFilesNames(ExtractorConfig &extractor_confi
         extractor_config.node_output_path.replace(pos, 8, ".osrm.nodes");
         extractor_config.edge_output_path.replace(pos, 8, ".osrm.edges");
         extractor_config.edge_graph_output_path.replace(pos, 8, ".osrm.ebg");
+        extractor_config.edge_based_node_weights_output_path.replace(pos, 8, ".osrm.enw");
         extractor_config.rtree_nodes_output_path.replace(pos, 8, ".osrm.ramIndex");
         extractor_config.rtree_leafs_output_path.replace(pos, 8, ".osrm.fileIndex");
         extractor_config.edge_segment_lookup_path.replace(pos, 8, ".osrm.edge_segment_lookup");

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) try
             << "Profile " << extractor_config.profile_path.string() << " not found!";
         return EXIT_FAILURE;
     }
-    return extractor::extractor(extractor_config).run();
+    return extractor::Extractor(extractor_config).run();
 }
 catch (const std::bad_alloc &e)
 {

--- a/unit_tests/io/io.cpp
+++ b/unit_tests/io/io.cpp
@@ -1,0 +1,43 @@
+#include "util/io.hpp"
+#include "util/typedefs.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_case_template.hpp>
+
+#include <string>
+
+const static std::string IO_TMP_FILE = "test_io.tmp";
+
+BOOST_AUTO_TEST_SUITE(osrm_io)
+
+BOOST_AUTO_TEST_CASE(io_flags)
+{
+    std::vector<bool> flags_in, flags_out;
+    flags_in.resize(53);
+    for (std::size_t i = 0; i < flags_in.size(); ++i)
+        flags_in[i] = ((i % 2) == 1);
+
+    osrm::util::serializeFlags(IO_TMP_FILE, flags_in);
+    osrm::util::deserializeFlags(IO_TMP_FILE, flags_out);
+
+    BOOST_REQUIRE_EQUAL(flags_in.size(), flags_out.size());
+    BOOST_CHECK_EQUAL_COLLECTIONS(flags_out.begin(), flags_out.end(), flags_in.begin(),
+                                  flags_in.end());
+}
+
+BOOST_AUTO_TEST_CASE(io_data)
+{
+    std::vector<int> data_in, data_out;
+    data_in.resize(53);
+    for (std::size_t i = 0; i < data_in.size(); ++i)
+        data_in[i] = i;
+
+    osrm::util::serializeVector(IO_TMP_FILE, data_in);
+    osrm::util::deserializeVector(IO_TMP_FILE, data_out);
+
+    BOOST_REQUIRE_EQUAL(data_in.size(), data_out.size());
+    BOOST_CHECK_EQUAL_COLLECTIONS(data_out.begin(), data_out.end(), data_in.begin(),
+                                  data_in.end());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/io_tests.cpp
+++ b/unit_tests/io_tests.cpp
@@ -1,0 +1,7 @@
+#define BOOST_TEST_MODULE io tests
+
+#include <boost/test/unit_test.hpp>
+
+/*
+ * This file will contain an automatically generated main function.
+ */


### PR DESCRIPTION
Addressing https://github.com/Project-OSRM/osrm-backend/issues/1863, this pull request fixes a problem were routing actually requires a loop to work correctly.

Opposed to node based routing, starting and ending on a road can require more than just driving along the road itself. In case of one-way streets, we can end up requiring a loop that starts late on the segment and arrives early on the segment. (E.g. how do I get to the beginning of that oneway street).