### PR TITLE
Prefer `inline` over `static inline` for free standing functions

### DIFF
--- a/include/util/string_util.hpp
+++ b/include/util/string_util.hpp
@@ -15,7 +15,7 @@ namespace util
 // precision:  position after decimal point
 // length: maximum number of digits including comma and decimals
 // work with negative values to prevent overflowing when taking -value
-template <int length, int precision> static inline char *printInt(char *buffer, int value)
+template <int length, int precision> char *printInt(char *buffer, int value)
 {
     static_assert(length > 0, "length must be positive");
     static_assert(precision > 0, "precision must be positive");


### PR DESCRIPTION
When you mark free standing functions as `static inline` instead
of just `inline` for their definition in headers they can not get
merged across TUs and therefore introduce code bloat which
is bad for the binaries' size, the CPU's instruction cache, and so
on.

Please also see the discussion at:

- https://groups.google.com/forum/#!topic/mozilla.dev.platform/Ulw9HoZbSyQ
- http://stackoverflow.com/a/12836392

Note that non-fully specialized templates (i.e. with a kind of at
least `Template :: * -> *`) are `inline` by default.

/cc @TheMarex