### PR TITLE
Inline mercator transformations; no need for separate translation unit

### DIFF
--- a/include/util/compute_angle.hpp
+++ b/include/util/compute_angle.hpp
@@ -16,11 +16,11 @@ inline double ComputeAngle(const FixedPointCoordinate first,
                            const FixedPointCoordinate third) noexcept
 {
     const double v1x = (first.lon - second.lon) / COORDINATE_PRECISION;
-    const double v1y = mercator::lat2y(first.lat / COORDINATE_PRECISION) -
-                       mercator::lat2y(second.lat / COORDINATE_PRECISION);
+    const double v1y = mercator::latToY(first.lat / COORDINATE_PRECISION) -
+                       mercator::latToY(second.lat / COORDINATE_PRECISION);
     const double v2x = (third.lon - second.lon) / COORDINATE_PRECISION;
-    const double v2y = mercator::lat2y(third.lat / COORDINATE_PRECISION) -
-                       mercator::lat2y(second.lat / COORDINATE_PRECISION);
+    const double v2y = mercator::latToY(third.lat / COORDINATE_PRECISION) -
+                       mercator::latToY(second.lat / COORDINATE_PRECISION);
 
     double angle = (atan2_lookup(v2y, v2x) - atan2_lookup(v1y, v1x)) * 180. / M_PI;
 

--- a/include/util/mercator.hpp
+++ b/include/util/mercator.hpp
@@ -1,17 +1,25 @@
 #ifndef MERCATOR_HPP
 #define MERCATOR_HPP
 
+#include <cmath>
+
 namespace osrm
 {
 namespace util
 {
-
-struct mercator
+namespace mercator
 {
-    static double y2lat(const double value) noexcept;
 
-    static double lat2y(const double latitude) noexcept;
-};
+inline double yToLat(const double value) noexcept
+{
+    return 180. * M_1_PI * (2. * std::atan(std::exp(value * M_PI / 180.)) - M_PI_2);
+}
+
+inline double latToY(const double latitude) noexcept
+{
+    return 180. * M_1_PI * std::log(std::tan(M_PI_4 + latitude * (M_PI / 180.) / 2.));
+}
+}
 }
 }
 

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -144,7 +144,7 @@ class StaticRTree
                                              coordinate_list.at(current_element.v).lon));
                     current_centroid.lat =
                         COORDINATE_PRECISION *
-                        mercator::lat2y(current_centroid.lat / COORDINATE_PRECISION);
+                        mercator::latToY(current_centroid.lat / COORDINATE_PRECISION);
 
                     current_wrapper.m_hilbert_value = get_hilbert_number(current_centroid);
                 }
@@ -345,7 +345,7 @@ class StaticRTree
     {
         std::vector<EdgeDataT> results;
         std::pair<double, double> projected_coordinate = {
-            mercator::lat2y(input_coordinate.lat / COORDINATE_PRECISION),
+            mercator::latToY(input_coordinate.lat / COORDINATE_PRECISION),
             input_coordinate.lon / COORDINATE_PRECISION};
 
         // initialize queue with root element

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -102,7 +102,7 @@ double perpendicularDistance(const FixedPointCoordinate &segment_source,
 {
     return perpendicularDistanceFromProjectedCoordinate(
         segment_source, segment_target, query_location,
-        {mercator::lat2y(query_location.lat / COORDINATE_PRECISION),
+        {mercator::latToY(query_location.lat / COORDINATE_PRECISION),
          query_location.lon / COORDINATE_PRECISION},
         nearest_location, ratio);
 }
@@ -134,9 +134,9 @@ perpendicularDistanceFromProjectedCoordinate(const FixedPointCoordinate &segment
     // initialize values
     const double x = projected_coordinate.first;
     const double y = projected_coordinate.second;
-    const double a = mercator::lat2y(segment_source.lat / COORDINATE_PRECISION);
+    const double a = mercator::latToY(segment_source.lat / COORDINATE_PRECISION);
     const double b = segment_source.lon / COORDINATE_PRECISION;
-    const double c = mercator::lat2y(segment_target.lat / COORDINATE_PRECISION);
+    const double c = mercator::latToY(segment_target.lat / COORDINATE_PRECISION);
     const double d = segment_target.lon / COORDINATE_PRECISION;
     double p, q /*,mX*/, new_y;
     if (std::abs(a - c) > std::numeric_limits<double>::epsilon())
@@ -190,7 +190,7 @@ perpendicularDistanceFromProjectedCoordinate(const FixedPointCoordinate &segment
     else
     {
         // point lies in between
-        nearest_location.lat = static_cast<int>(mercator::y2lat(p) * COORDINATE_PRECISION);
+        nearest_location.lat = static_cast<int>(mercator::yToLat(p) * COORDINATE_PRECISION);
         nearest_location.lon = static_cast<int>(q * COORDINATE_PRECISION);
     }
     BOOST_ASSERT(nearest_location.IsValid());

--- a/src/util/mercator.cpp
+++ b/src/util/mercator.cpp
@@ -6,15 +6,5 @@ namespace osrm
 {
 namespace util
 {
-
-double mercator::y2lat(const double value) noexcept
-{
-    return 180. * M_1_PI * (2. * std::atan(std::exp(value * M_PI / 180.)) - M_PI_2);
-}
-
-double mercator::lat2y(const double latitude) noexcept
-{
-    return 180. * M_1_PI * std::log(std::tan(M_PI_4 + latitude * (M_PI / 180.) / 2.));
-}
 }
 }


### PR DESCRIPTION
Does what it says: no need for mercator to be a struct with two static functions, a namespace suffices (looks like we missed that in the other PR). No need for a header / impl. split for these one liners; let the optimizer see the body. Oh, and lat2y -> latToY, y2lat -> yToLat.