### PR TITLE
Rips out dead code from the container.hpp and creates for_each_pair.hpp

### DIFF
--- a/include/contractor/contractor_options.hpp
+++ b/include/contractor/contractor_options.hpp
@@ -19,7 +19,7 @@ enum class return_code : unsigned
 
 struct ContractorConfig
 {
-    ContractorConfig() noexcept : requested_num_threads(0) {}
+    ContractorConfig() : requested_num_threads(0) {}
 
     boost::filesystem::path config_file_path;
     boost::filesystem::path osrm_input_path;

--- a/include/engine/guidance/segment_list.hpp
+++ b/include/engine/guidance/segment_list.hpp
@@ -9,7 +9,7 @@
 #include "engine/segment_information.hpp"
 #include "util/integer_range.hpp"
 #include "util/coordinate_calculation.hpp"
-#include "util/container.hpp"
+#include "util/for_each_pair.hpp"
 #include "extractor/turn_instructions.hpp"
 
 #include <boost/assert.hpp>

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -6,6 +6,7 @@
 #include "engine/api_response_generator.hpp"
 #include "engine/object_encoder.hpp"
 #include "engine/search_engine.hpp"
+#include "util/for_each_pair.hpp"
 #include "util/integer_range.hpp"
 #include "util/json_renderer.hpp"
 #include "util/make_unique.hpp"

--- a/include/engine/routing_algorithms/alternative_path.hpp
+++ b/include/engine/routing_algorithms/alternative_path.hpp
@@ -4,10 +4,11 @@
 #include "engine/routing_algorithms/routing_base.hpp"
 #include "engine/search_engine_data.hpp"
 #include "util/integer_range.hpp"
-#include "util/container.hpp"
 
 #include <boost/assert.hpp>
 
+#include <algorithm>
+#include <iterator>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -148,7 +149,9 @@ class AlternativeRouting final
             return;
         }
 
-        util::sort_unique_resize(via_node_candidate_list);
+        std::sort(begin(via_node_candidate_list), end(via_node_candidate_list));
+        auto unique_end = std::unique(begin(via_node_candidate_list), end(via_node_candidate_list));
+        via_node_candidate_list.resize(unique_end - begin(via_node_candidate_list));
 
         std::vector<NodeID> packed_forward_path;
         std::vector<NodeID> packed_reverse_path;
@@ -439,10 +442,10 @@ class AlternativeRouting final
                                           partially_unpacked_shortest_path.size())) -
             1;
         for (int64_t current_node = 0; (current_node < packed_path_length) &&
-                                       (partially_unpacked_via_path[current_node] ==
-                                            partially_unpacked_shortest_path[current_node] &&
-                                        partially_unpacked_via_path[current_node + 1] ==
-                                            partially_unpacked_shortest_path[current_node + 1]);
+                                           (partially_unpacked_via_path[current_node] ==
+                                                partially_unpacked_shortest_path[current_node] &&
+                                            partially_unpacked_via_path[current_node + 1] ==
+                                                partially_unpacked_shortest_path[current_node + 1]);
              ++current_node)
         {
             EdgeID selected_edge =

--- a/include/extractor/extractor_options.hpp
+++ b/include/extractor/extractor_options.hpp
@@ -19,7 +19,7 @@ enum class return_code : unsigned
 
 struct ExtractorConfig
 {
-    ExtractorConfig() noexcept : requested_num_threads(0) {}
+    ExtractorConfig() : requested_num_threads(0) {}
     boost::filesystem::path config_file_path;
     boost::filesystem::path input_path;
     boost::filesystem::path profile_path;

--- a/include/util/container.hpp
+++ b/include/util/container.hpp
@@ -1,78 +1,10 @@
 #ifndef CONTAINER_HPP
 #define CONTAINER_HPP
 
-#include <algorithm>
-#include <iterator>
-#include <vector>
-
 namespace osrm
 {
 namespace util
 {
-
-namespace detail
-{
-// Culled by SFINAE if reserve does not exist or is not accessible
-template <typename T>
-constexpr auto has_resize_method(T &t) noexcept -> decltype(t.resize(0), bool())
-{
-    return true;
-}
-
-// Used as fallback when SFINAE culls the template method
-constexpr bool has_resize_method(...) noexcept { return false; }
-}
-
-template <typename Container> void sort_unique_resize(Container &vector) noexcept
-{
-    std::sort(std::begin(vector), std::end(vector));
-    const auto number_of_unique_elements =
-        std::unique(std::begin(vector), std::end(vector)) - std::begin(vector);
-    if (detail::has_resize_method(vector))
-    {
-        vector.resize(number_of_unique_elements);
-    }
-}
-
-// template <typename T> inline void sort_unique_resize_shrink_vector(std::vector<T> &vector)
-// {
-//     sort_unique_resize(vector);
-//     vector.shrink_to_fit();
-// }
-
-// template <typename T> inline void remove_consecutive_duplicates_from_vector(std::vector<T>
-// &vector)
-// {
-//     const auto number_of_unique_elements = std::unique(vector.begin(), vector.end()) -
-//     vector.begin();
-//     vector.resize(number_of_unique_elements);
-// }
-
-template <typename ForwardIterator, typename Function>
-Function for_each_pair(ForwardIterator begin, ForwardIterator end, Function function)
-{
-    if (begin == end)
-    {
-        return function;
-    }
-
-    auto next = begin;
-    next = std::next(next);
-
-    while (next != end)
-    {
-        function(*begin, *next);
-        begin = std::next(begin);
-        next = std::next(next);
-    }
-    return function;
-}
-
-template <class ContainerT, typename Function>
-Function for_each_pair(ContainerT &container, Function function)
-{
-    return for_each_pair(std::begin(container), std::end(container), function);
-}
 
 template <class Container> void append_to_container(Container &&) {}
 
@@ -82,8 +14,7 @@ void append_to_container(Container &&container, T value, Args &&... args)
     container.emplace_back(value);
     append_to_container(std::forward<Container>(container), std::forward<Args>(args)...);
 }
-
-} // namespace osrm
+}
 }
 
-#endif /* CONTAINER_HPP */
+#endif

--- a/include/util/for_each_pair.hpp
+++ b/include/util/for_each_pair.hpp
@@ -1,0 +1,45 @@
+#ifndef FOR_EACH_PAIR_HPP
+#define FOR_EACH_PAIR_HPP
+
+#include <numeric>
+#include <iterator>
+
+namespace osrm
+{
+namespace util
+{
+
+// TODO: check why this is not an option here:
+// std::adjacent_find(begin, end, [=](const auto& l, const auto& r){ return function(), false; });
+template <typename ForwardIterator, typename Function>
+Function for_each_pair(ForwardIterator begin, ForwardIterator end, Function function)
+{
+    if (begin == end)
+    {
+        return function;
+    }
+
+    auto next = begin;
+    next = std::next(next);
+
+    while (next != end)
+    {
+        function(*begin, *next);
+        begin = std::next(begin);
+        next = std::next(next);
+    }
+    return function;
+}
+
+template <class ContainerT, typename Function>
+Function for_each_pair(ContainerT &container, Function function)
+{
+    using std::begin;
+    using std::end;
+    return for_each_pair(begin(container), end(container), function);
+}
+
+} // namespace util
+} // namespace osrm
+
+#endif /* FOR_EACH_PAIR_HPP */

--- a/include/util/json_util.hpp
+++ b/include/util/json_util.hpp
@@ -2,6 +2,7 @@
 #define JSON_UTIL_HPP
 
 #include "osrm/json_container.hpp"
+#include "util/container.hpp"
 
 #include <cmath>
 #include <limits>
@@ -31,6 +32,7 @@ template <typename T> T clamp_float(T d)
 template <typename... Args> Array make_array(Args... args)
 {
     Array a;
+    // TODO: check why a.values.emplace_back(args...); is not an option here
     append_to_container(a.values, args...);
     return a;
 }

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -5,8 +5,8 @@
 
 #include "extractor/external_memory_node.hpp"
 #include "extractor/restriction.hpp"
-#include "util/container.hpp"
 #include "util/simple_logger.hpp"
+#include "util/for_each_pair.hpp"
 
 #include <boost/optional/optional.hpp>
 


### PR DESCRIPTION
Note: after merging https://github.com/Project-OSRM/osrm-backend/issues/1660 is resolved; close the issue.

I manually checked all the occurrences in the code base (phew..); where it is placed but an exception might get thrown, we might as well take the `std::terminate` that comes with it (e.g. in not being able to log). I also added two TODOs that I would like to address in the future.