### PR TITLE
Define compile-time constants for coordinate calculation only once

### DIFF
--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -9,6 +9,11 @@ namespace osrm
 namespace util
 {
 
+const constexpr long double RAD = 0.017453292519943295769236907684886;
+// earth radius varies between 6,356.750-6,378.135 km (3,949.901-3,963.189mi)
+// The IUGG value for the equatorial radius is 6378.137 km (3963.19 miles)
+const constexpr long double EARTH_RADIUS = 6372797.560856;
+
 struct FixedPointCoordinate;
 
 namespace coordinate_calculation

--- a/src/engine/douglas_peucker.cpp
+++ b/src/engine/douglas_peucker.cpp
@@ -1,4 +1,5 @@
 #include "engine/douglas_peucker.hpp"
+#include "util/coordinate_calculation.hpp"
 
 #include <boost/assert.hpp>
 #include "osrm/coordinate.hpp"
@@ -23,30 +24,27 @@ struct CoordinatePairCalculator
                              const util::FixedPointCoordinate &coordinate_b)
     {
         // initialize distance calculator with two fixed coordinates a, b
-        const float RAD = 0.017453292519943295769236907684886f;
-        first_lat = (coordinate_a.lat / COORDINATE_PRECISION) * RAD;
-        first_lon = (coordinate_a.lon / COORDINATE_PRECISION) * RAD;
-        second_lat = (coordinate_b.lat / COORDINATE_PRECISION) * RAD;
-        second_lon = (coordinate_b.lon / COORDINATE_PRECISION) * RAD;
+        first_lat = (coordinate_a.lat / COORDINATE_PRECISION) * util::RAD;
+        first_lon = (coordinate_a.lon / COORDINATE_PRECISION) * util::RAD;
+        second_lat = (coordinate_b.lat / COORDINATE_PRECISION) * util::RAD;
+        second_lon = (coordinate_b.lon / COORDINATE_PRECISION) * util::RAD;
     }
 
     int operator()(util::FixedPointCoordinate &other) const
     {
         // set third coordinate c
-        const float RAD = 0.017453292519943295769236907684886f;
-        const float earth_radius = 6372797.560856f;
-        const float float_lat1 = (other.lat / COORDINATE_PRECISION) * RAD;
-        const float float_lon1 = (other.lon / COORDINATE_PRECISION) * RAD;
+        const float float_lat1 = (other.lat / COORDINATE_PRECISION) * util::RAD;
+        const float float_lon1 = (other.lon / COORDINATE_PRECISION) * util::RAD;
 
         // compute distance (a,c)
         const float x_value_1 = (first_lon - float_lon1) * cos((float_lat1 + first_lat) / 2.f);
         const float y_value_1 = first_lat - float_lat1;
-        const float dist1 = std::hypot(x_value_1, y_value_1) * earth_radius;
+        const float dist1 = std::hypot(x_value_1, y_value_1) * util::EARTH_RADIUS;
 
         // compute distance (b,c)
         const float x_value_2 = (second_lon - float_lon1) * cos((float_lat1 + second_lat) / 2.f);
         const float y_value_2 = second_lat - float_lat1;
-        const float dist2 = std::hypot(x_value_2, y_value_2) * earth_radius;
+        const float dist2 = std::hypot(x_value_2, y_value_2) * util::EARTH_RADIUS;
 
         // return the minimum
         return static_cast<int>(std::min(dist1, dist2));

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -15,15 +15,6 @@ namespace osrm
 {
 namespace util
 {
-
-namespace
-{
-constexpr static const double RAD = 0.017453292519943295769236907684886;
-// earth radius varies between 6,356.750-6,378.135 km (3,949.901-3,963.189mi)
-// The IUGG value for the equatorial radius is 6378.137 km (3963.19 miles)
-constexpr static const double earth_radius = 6372797.560856;
-}
-
 namespace coordinate_calculation
 {
 
@@ -49,7 +40,7 @@ double haversineDistance(const int lat1, const int lon1, const int lat2, const i
     const double aharv = std::pow(std::sin(dlat / 2.0), 2.0) +
                          std::cos(dlat1) * std::cos(dlat2) * std::pow(std::sin(dlong / 2.), 2);
     const double charv = 2. * std::atan2(std::sqrt(aharv), std::sqrt(1.0 - aharv));
-    return earth_radius * charv;
+    return EARTH_RADIUS * charv;
 }
 
 double haversineDistance(const FixedPointCoordinate &coordinate_1,
@@ -80,7 +71,7 @@ double greatCircleDistance(const int lat1, const int lon1, const int lat2, const
 
     const double x_value = (float_lon2 - float_lon1) * std::cos((float_lat1 + float_lat2) / 2.0);
     const double y_value = float_lat2 - float_lat1;
-    return std::hypot(x_value, y_value) * earth_radius;
+    return std::hypot(x_value, y_value) * EARTH_RADIUS;
 }
 
 double perpendicularDistance(const FixedPointCoordinate &source_coordinate,


### PR DESCRIPTION
In addition, make them more precise (probably does not matter). Closes #1327.