### PR TITLE
Fix race condition in osrm-routed HTTP server

### DIFF
--- a/include/server/connection.hpp
+++ b/include/server/connection.hpp
@@ -63,6 +63,8 @@ class Connection : public std::enable_shared_from_this<Connection>
     http::request current_request;
     http::reply current_reply;
     std::vector<char> compressed_output;
+    // Header compression_header;
+    std::vector<boost::asio::const_buffer> output_buffer;
 };
 }
 }

--- a/src/server/connection.cpp
+++ b/src/server/connection.cpp
@@ -52,9 +52,6 @@ void Connection::handle_read(const boost::system::error_code &error, std::size_t
         current_request.endpoint = TCP_socket.remote_endpoint().address();
         request_handler.handle_request(current_request, current_reply);
 
-        // Header compression_header;
-        std::vector<boost::asio::const_buffer> output_buffer;
-
         // compress the result w/ gzip/deflate if requested
         switch (compression_type)
         {


### PR DESCRIPTION
Stumbled upon this one by accident.

It goes like this:

- `output_buffer` is function-local
- we pass it to async_write and leave the scope
- `output_buffers` goes out of scope
- bad things happen, sometimes

The fix is to, again, put it inside the connection that handles itself
via the enable_shared_from_this idiom.

We had a similar issue a few month ago --- argh routed!

/cc @danpat @TheMarex unrelated to the current datastore problem

References:

- http://www.boost.org/doc/libs/1_59_0/doc/html/boost_asio/reference/async_write/overload1.html
- https://github.com/Project-OSRM/osrm-backend/pull/1690