### PR TITLE
Don't delete shared memory segments if we're about to use them

### DIFF
--- a/include/datastore/shared_memory_factory.hpp
+++ b/include/datastore/shared_memory_factory.hpp
@@ -77,6 +77,7 @@ class SharedMemory
 
     SharedMemory() = delete;
     SharedMemory(const SharedMemory &) = delete;
+    SharedMemory &operator=(const SharedMemory &) = delete;
 
     template <typename IdentifierT>
     SharedMemory(const boost::filesystem::path &lock_file,
@@ -187,11 +188,13 @@ class SharedMemory
 class SharedMemory
 {
     SharedMemory(const SharedMemory &) = delete;
+    SharedMemory &operator=(const SharedMemory &) = delete;
     // Remove shared memory on destruction
     class shm_remove
     {
       private:
         shm_remove(const shm_remove &) = delete;
+        shm_remove &operator=(const shm_remove &) = delete;
         char *m_shmid;
         bool m_initialized;
 
@@ -355,6 +358,7 @@ template <class LockFileT = OSRMLockFile> class SharedMemoryFactory_tmpl
 
     SharedMemoryFactory_tmpl() = delete;
     SharedMemoryFactory_tmpl(const SharedMemoryFactory_tmpl &) = delete;
+    SharedMemoryFactory_tmpl &operator=(const SharedMemoryFactory_tmpl &) = delete;
 };
 
 using SharedMemoryFactory = SharedMemoryFactory_tmpl<>;


### PR DESCRIPTION
If `osrm-datastore` is run an even number of times, it will set the layout back to the currently used one.  This code changes the `SharedDataFacade` to check if the new layout is still referring to the same one.  The re-initialization is only done if the timestamp has also changed.

This is a partial fix to https://github.com/Project-OSRM/osrm-backend/issues/1888

It fixes the "simple reproduction recipe", but I can still cause errors if I run `osrm-datastore` and `curl` in tight loops.  However, running `osrm-datastore` in a tight loop seems like a really oddball case.