### PR TITLE
[suggestion] performance fix for map-matching on core chs

### DIFF
--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -315,7 +315,8 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
         SubMatchingList sub_matchings;
         search_engine_ptr->map_matching(candidates_lists, input_coords, input_timestamps,
                                         route_parameters.matching_beta,
-                                        route_parameters.gps_precision, sub_matchings);
+                                        route_parameters.gps_precision, sub_matchings,
+                                        route_parameters.matching_prune_factor );
 
         util::json::Array matchings;
         for (auto &sub : sub_matchings)

--- a/include/engine/route_parameters.hpp
+++ b/include/engine/route_parameters.hpp
@@ -60,6 +60,8 @@ struct RouteParameters
 
     void SetGPSPrecision(const double precision);
 
+    void SetMatchingPruneFactor(const double factor);
+
     void SetDeprecatedAPIFlag(const std::string &);
 
     void SetChecksum(const unsigned check_sum);
@@ -102,6 +104,7 @@ struct RouteParameters
     bool classify;
     double matching_beta;
     double gps_precision;
+    double matching_prune_factor;
     unsigned check_sum;
     short num_results;
     std::string service;

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -220,10 +220,12 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                     forward_heap.Clear();
                     reverse_heap.Clear();
 
+                    const auto time_at_ultra_low_speed = 400 * haversine_distance; //25cm/s = walking speed
+
                     // get distance diff between loc1/2 and locs/s_prime
                     const auto network_distance = super::get_network_distance(
                         forward_heap, reverse_heap, prev_unbroken_timestamps_list[s].phantom_node,
-                        current_timestamps_list[s_prime].phantom_node);
+                        current_timestamps_list[s_prime].phantom_node, time_at_ultra_low_speed );
 
                     const auto d_t = std::abs(network_distance - haversine_distance);
 

--- a/include/server/api_grammar.hpp
+++ b/include/server/api_grammar.hpp
@@ -106,7 +106,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                         qi::float_[boost::bind(&HandlerT::SetMatchingBeta, handler, ::_1)];
         gps_precision = (-qi::lit('&')) >> qi::lit("gps_precision") >> '=' >>
                         qi::float_[boost::bind(&HandlerT::SetGPSPrecision, handler, ::_1)];
-        gps_precision = (-qi::lit('&')) >> qi::lit("matching_prune_factor") >> '=' >>
+        matching_prune_factor = (-qi::lit('&')) >> qi::lit("matching_prune_factor") >> '=' >>
                         qi::float_[boost::bind(&HandlerT::SetMatchingPruneFactor, handler, ::_1)];
         classify = (-qi::lit('&')) >> qi::lit("classify") >> '=' >>
                    qi::bool_[boost::bind(&HandlerT::SetClassify, handler, ::_1)];

--- a/include/server/api_grammar.hpp
+++ b/include/server/api_grammar.hpp
@@ -47,7 +47,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
         query = ('?') >> +(zoom | output | jsonp | checksum | uturns | location_with_options |
                            destination_with_options | source_with_options | cmp | language |
                            instruction | geometry | alt_route | old_API | num_results |
-                           matching_beta | gps_precision | classify | locs);
+                           matching_beta | gps_precision | matching_prune_factor | classify | locs);
         // all combinations of timestamp, uturn, hint and bearing without duplicates
         t_u = (u >> -timestamp) | (timestamp >> -u);
         t_h = (hint >> -timestamp) | (timestamp >> -hint);
@@ -125,7 +125,7 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
     qi::rule<Iterator, std::string()> service, zoom, output, string, jsonp, checksum, location,
         destination, source, hint, timestamp, bearing, stringwithDot, stringwithPercent, language,
         geometry, cmp, alt_route, u, uturns, old_API, num_results, matching_beta, gps_precision,
-        classify, locs, instruction, stringforPolyline;
+        matching_prune_factor, classify, locs, instruction, stringforPolyline;
 
     HandlerT *handler;
 };

--- a/include/server/api_grammar.hpp
+++ b/include/server/api_grammar.hpp
@@ -106,6 +106,8 @@ template <typename Iterator, class HandlerT> struct APIGrammar : qi::grammar<Ite
                         qi::float_[boost::bind(&HandlerT::SetMatchingBeta, handler, ::_1)];
         gps_precision = (-qi::lit('&')) >> qi::lit("gps_precision") >> '=' >>
                         qi::float_[boost::bind(&HandlerT::SetGPSPrecision, handler, ::_1)];
+        gps_precision = (-qi::lit('&')) >> qi::lit("matching_prune_factor") >> '=' >>
+                        qi::float_[boost::bind(&HandlerT::SetMatchingPruneFactor, handler, ::_1)];
         classify = (-qi::lit('&')) >> qi::lit("classify") >> '=' >>
                    qi::bool_[boost::bind(&HandlerT::SetClassify, handler, ::_1)];
         locs = (-qi::lit('&')) >> qi::lit("locs") >> '=' >>

--- a/src/engine/route_parameters.cpp
+++ b/src/engine/route_parameters.cpp
@@ -14,7 +14,7 @@ namespace engine
 RouteParameters::RouteParameters()
     : zoom_level(18), print_instructions(false), alternate_route(true), geometry(true),
       compression(true), deprecatedAPI(false), uturn_default(false), classify(false),
-      matching_beta(5), gps_precision(5), check_sum(-1), num_results(1)
+      matching_beta(5), gps_precision(5), matching_prune_factor(0), check_sum(-1), num_results(1)
 {
 }
 
@@ -67,6 +67,8 @@ void RouteParameters::SetClassify(const bool flag) { classify = flag; }
 void RouteParameters::SetMatchingBeta(const double beta) { matching_beta = beta; }
 
 void RouteParameters::SetGPSPrecision(const double precision) { gps_precision = precision; }
+
+void RouteParameters::SetMatchingPruneFactor(const double factor) { matching_prune_factor = factor; }
 
 void RouteParameters::SetOutputFormat(const std::string &format) { output_format = format; }
 


### PR DESCRIPTION
Introduces a pruning weight for the `get_network_distance` function.
This addresses time-outs for map-matching on a core-ch with a large core.