### PR TITLE
make it possible to disable max_locations in map_matching

### DIFF
--- a/include/util/routed_options.hpp
+++ b/include/util/routed_options.hpp
@@ -237,7 +237,7 @@ GenerateServerProgramOptions(const int argc,
     {
         throw exception("Max location for distance table must be at least two");
     }
-    if (2 > max_locations_map_matching)
+    if (max_locations_map_matching > 0 && 2 > max_locations_map_matching)
     {
         throw exception("Max location for map matching must be at least two");
     }


### PR DESCRIPTION
Currently there's no way to disable the `max_locations_map_matching` check in the `match` plugin. Setting the `--max-matching-size=-1` in `osrm-routed`  will result in the following exception

```
[warn] [exception] Max location for map matching must be at least two`
```

this PR makes it possible to disable the max locations check by setting `--max-matching-size=-1`