### PR TITLE
Send the Connection: close response header

### DIFF
--- a/src/server/http/reply.cpp
+++ b/src/server/http/reply.cpp
@@ -103,7 +103,11 @@ boost::asio::const_buffer reply::status_to_buffer(const reply::status_type statu
     return boost::asio::buffer(http_bad_request_string);
 }
 
-reply::reply() : status(ok) {}
+reply::reply() : status(ok)
+{
+    // We do not currently support keep alive. Always set 'Connection: close'.
+    headers.emplace_back("Connection", "close");
+}
 }
 }
 }


### PR DESCRIPTION
so that proxy servers don't try to reuse the connection. 

Given that osrm-routed does *not* support keepalive the Connection: close response header should be set.