### PR TITLE
improve comments for gps_precision

### DIFF
--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -85,8 +85,9 @@ template <class DataFacadeT> class MapMatchingPlugin : public BasePlugin
     {
         CandidateLists candidates_lists;
 
-        // assuming the gps_precision is the standart-diviation of normal distribution that models
-        // GPS noise (in this model) this should give us the correct candidate with >0.95
+        // assuming gps_precision is the standard deviation of a normal distribution that
+        // models GPS noise (in this model), this should give us the correct search radius
+        // with > 99% confidence
         double query_radius = 3 * gps_precision;
         double last_distance =
             util::coordinate_calculation::haversineDistance(input_coords[0], input_coords[1]);


### PR DESCRIPTION
fixed some typos and changed >95% to >99% (3 sigma of normal distribution)

One thing to note is that the assumption about the relationship between GPS precision and the correct search radius may be a bit misleading, since the search radius should really also depend on the width of the road. Let's say a road has a large width (e.g. large number of lanes) and a trace is on a lane that's the farthest away from the road line. Then one would still want the search radius to reach the road even if the GPS precision is really high.