### PR TITLE
Takes care of proper special member generation globally, fixes #1689

### DIFF
--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -46,7 +46,10 @@ class Engine final
 
   public:
     Engine(EngineConfig &config_);
+
     Engine(const Engine &) = delete;
+    Engine &operator=(const Engine &) = delete;
+
     int RunQuery(const RouteParameters &route_parameters, util::json::Object &json_result);
 
   private:

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -42,10 +42,11 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
     DataFacadeT *facade;
 
   public:
-    BasicRoutingInterface() = delete;
-    BasicRoutingInterface(const BasicRoutingInterface &) = delete;
     explicit BasicRoutingInterface(DataFacadeT *facade) : facade(facade) {}
     ~BasicRoutingInterface() {}
+
+    BasicRoutingInterface(const BasicRoutingInterface &) = delete;
+    BasicRoutingInterface &operator=(const BasicRoutingInterface &) = delete;
 
     /*
     min_edge_offset is needed in case we use multiple
@@ -98,7 +99,8 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                     (!force_loop_forward ||
                      forward_heap.GetData(node).parent !=
                          node) // if loops are forced, they are so at the source
-                    && (!force_loop_reverse || reverse_heap.GetData(node).parent != node))
+                    &&
+                    (!force_loop_reverse || reverse_heap.GetData(node).parent != node))
                 {
                     middle_node_id = node;
                     upper_bound = new_distance;
@@ -362,8 +364,10 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 BOOST_ASSERT(i < id_vector.size());
                 BOOST_ASSERT(phantom_node_pair.target_phantom.forward_travel_mode > 0);
                 unpacked_path.emplace_back(
-                    PathData{id_vector[i], phantom_node_pair.target_phantom.name_id,
-                             extractor::TurnInstruction::NoTurn, 0,
+                    PathData{id_vector[i],
+                             phantom_node_pair.target_phantom.name_id,
+                             extractor::TurnInstruction::NoTurn,
+                             0,
                              phantom_node_pair.target_phantom.forward_travel_mode});
             }
         }
@@ -601,8 +605,8 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
 
         // TODO check if unordered_set might be faster
         // sort by id and increasing by distance
-        auto entry_point_comparator = [](const std::pair<NodeID, EdgeWeight> &lhs,
-                                         const std::pair<NodeID, EdgeWeight> &rhs)
+        auto entry_point_comparator =
+            [](const std::pair<NodeID, EdgeWeight> &lhs, const std::pair<NodeID, EdgeWeight> &rhs)
         {
             return lhs.first < rhs.first || (lhs.first == rhs.first && lhs.second < rhs.second);
         };

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -36,8 +36,8 @@ namespace extractor
 class EdgeBasedGraphFactory
 {
   public:
-    EdgeBasedGraphFactory() = delete;
     EdgeBasedGraphFactory(const EdgeBasedGraphFactory &) = delete;
+    EdgeBasedGraphFactory &operator=(const EdgeBasedGraphFactory &) = delete;
 
     explicit EdgeBasedGraphFactory(std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
                                    const CompressedEdgeContainer &compressed_edge_container,
@@ -62,7 +62,7 @@ class EdgeBasedGraphFactory
              const bool generate_edge_lookup);
 #endif
 
-    //The following get access functions destroy the content in the factory
+    // The following get access functions destroy the content in the factory
     void GetEdgeBasedEdges(util::DeallocatingVector<EdgeBasedEdge> &edges);
     void GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes);
     void GetStartPointMarkers(std::vector<bool> &node_is_startpoint);

--- a/include/extractor/extractor_callbacks.hpp
+++ b/include/extractor/extractor_callbacks.hpp
@@ -38,9 +38,10 @@ class ExtractorCallbacks
     ExtractionContainers &external_memory;
 
   public:
-    ExtractorCallbacks() = delete;
-    ExtractorCallbacks(const ExtractorCallbacks &) = delete;
     explicit ExtractorCallbacks(ExtractionContainers &extraction_containers);
+
+    ExtractorCallbacks(const ExtractorCallbacks &) = delete;
+    ExtractorCallbacks &operator=(const ExtractorCallbacks &) = delete;
 
     // warning: caller needs to take care of synchronization!
     void ProcessNode(const osmium::Node &current_node, const ExtractionNode &result_node);

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -23,8 +23,10 @@ namespace extractor
 class ScriptingEnvironment
 {
   public:
-    ScriptingEnvironment() = delete;
     explicit ScriptingEnvironment(const std::string &file_name);
+
+    ScriptingEnvironment(const ScriptingEnvironment &) = delete;
+    ScriptingEnvironment &operator=(const ScriptingEnvironment &) = delete;
 
     lua_State *GetLuaState();
 

--- a/include/server/connection.hpp
+++ b/include/server/connection.hpp
@@ -39,7 +39,7 @@ class Connection : public std::enable_shared_from_this<Connection>
   public:
     explicit Connection(boost::asio::io_service &io_service, RequestHandler &handler);
     Connection(const Connection &) = delete;
-    Connection() = delete;
+    Connection &operator=(const Connection &) = delete;
 
     boost::asio::ip::tcp::socket &socket();
 

--- a/include/server/request_handler.hpp
+++ b/include/server/request_handler.hpp
@@ -28,6 +28,7 @@ class RequestHandler
 
     RequestHandler();
     RequestHandler(const RequestHandler &) = delete;
+    RequestHandler &operator=(const RequestHandler &) = delete;
 
     void handle_request(const http::request &current_request, http::reply &current_reply);
     void RegisterRoutingMachine(OSRM *osrm);

--- a/include/util/simple_logger.hpp
+++ b/include/util/simple_logger.hpp
@@ -29,6 +29,7 @@ class LogPolicy
     static LogPolicy &GetInstance();
 
     LogPolicy(const LogPolicy &) = delete;
+    LogPolicy &operator=(const LogPolicy &) = delete;
 
   private:
     LogPolicy() : m_is_mute(true) {}

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -106,8 +106,8 @@ class StaticRTree
     boost::filesystem::ifstream leaves_stream;
 
   public:
-    StaticRTree() = delete;
     StaticRTree(const StaticRTree &) = delete;
+    StaticRTree &operator=(const StaticRTree &) = delete;
 
     template <typename CoordinateT>
     // Construct a packed Hilbert-R-Tree with Kamel-Faloutsos algorithm [1]

--- a/src/engine/douglas_peucker.cpp
+++ b/src/engine/douglas_peucker.cpp
@@ -19,7 +19,6 @@ namespace
 {
 struct CoordinatePairCalculator
 {
-    CoordinatePairCalculator() = delete;
     CoordinatePairCalculator(const util::FixedPointCoordinate coordinate_a,
                              const util::FixedPointCoordinate coordinate_b)
     {

--- a/src/server/request_handler.cpp
+++ b/src/server/request_handler.cpp
@@ -147,7 +147,6 @@ void RequestHandler::handle_request(const http::request &current_request,
     catch (const std::exception &e)
     {
         current_reply = http::reply::stock_reply(http::reply::internal_server_error);
-        ;
         util::SimpleLogger().Write(logWARNING) << "[server error] code: " << e.what()
                                                << ", uri: " << current_request.uri;
     }


### PR DESCRIPTION
Phew, a lot of classes were affected by this. The rationale for the
changes are as follows:

- When a type X declares any constructor, the default constructor is
  not declared, so there is no need for X() = delete there. In fact,
  there is brutal difference between those two: deleted members
  participate in overload resolution, but not-declared members do not!

- When a type X wants to be non-copyable (e.g. to be only movable, like
  threads, unique_ptrs, and so on), you can either do it by inheriting
  from boost::noncopyable (the old way), or better declare both (!) the
  copy constructor _and_ the copy assignment operator as deleted:

      X(X const&) = delete;
      X& operator=(X const&) = delete;

  We had tons of types with deleted copy constructors that were lacking
  a corresponding deleted copy assignment operator, making them still
  copyable and you wouldn't even notice (read: scary)!

References:

- http://accu.org/content/conf2014/Howard_Hinnant_Accu_2014.pdf
- http://www.boost.org/doc/libs/master/libs/core/doc/html/core/noncopyable.html

Note: I know, I'm quoting Hinnant's extraordinary slides a lot, but
getting the sematic right here is so incredibly important.