### PR TITLE
[WIP] introduce barrier penalties to handle gated areas

### DIFF
--- a/features/support/route.rb
+++ b/features/support/route.rb
@@ -156,7 +156,8 @@ def turn_list instructions
       14 => :start_end_of_street,
       15 => :destination,
       16 => :enter_contraflow,
-      17 => :leave_contraflow
+      17 => :leave_contraflow,
+      129 => :barrier
     }
     # replace instructions codes with strings
     # "11-3" (enter roundabout and leave a 3rd exit) gets converted to "enter_roundabout-3"

--- a/features/testbot/barrier.feature
+++ b/features/testbot/barrier.feature
@@ -1,0 +1,36 @@
+@routing @testbot @alternative
+Feature: Alternative route
+
+    Background:
+        Given the profile "testbot"
+
+        And the node map
+            |   | f | g | h |   |
+            |   |   | e |   |   |
+            | a | b | c | d | z |
+
+        And the nodes
+            | node | barrier |
+            | b    | gate    |
+            | e    | gate    |
+            | d    | gate    |
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | cd    |
+            | dz    |
+            | af    |
+            | fg    |
+            | ge    |
+            | ec    |
+            | gh    |
+            | hz    |
+
+    Scenario: Route Around
+
+        When I route I should get
+            | from | to | route       | turns                                               |
+            | a    | z  | af,fg,gh,hz | head,slight_right,straight,slight_right,destination |
+            | c    | g  | ec,ge       | head,barrier,destination                            |

--- a/include/engine/guidance/segment_list.hpp
+++ b/include/engine/guidance/segment_list.hpp
@@ -242,6 +242,10 @@ void SegmentList<DataFacadeT>::Finalize(const bool extract_alternative,
         segments[i - 1].name_id = segments[i].name_id;
         segments[i].length = util::coordinate_calculation::greatCircleDistance(
             segments[i - 1].location, segments[i].location);
+        if( segments[i].turn_instruction == extractor::TurnInstruction::AccessRestrictionPenalty ){
+          segments[i].duration -= ACCESS_RESTRICTED_PENALTY;
+          segments[i].necessary = true;
+        }
     }
 
     float segment_length = 0.;

--- a/include/engine/routing_algorithms/alternative_path.hpp
+++ b/include/engine/routing_algorithms/alternative_path.hpp
@@ -313,14 +313,14 @@ class AlternativeRouting final
             raw_route_data.target_traversed_in_reverse.push_back(
                 (packed_shortest_path.back() != phantom_node_pair.target_phantom.forward_node_id));
 
-            super::UnpackPath(
+            raw_route_data.shortest_path_length = upper_bound_to_shortest_path_distance;
+            raw_route_data.shortest_path_length -= super::UnpackPath(
                 // -- packed input
                 packed_shortest_path.begin(), packed_shortest_path.end(),
                 // -- start of route
                 phantom_node_pair,
                 // -- unpacked output
                 raw_route_data.unpacked_path_segments.front());
-            raw_route_data.shortest_path_length = upper_bound_to_shortest_path_distance;
         }
 
         if (SPECIAL_NODEID != selected_via_node)
@@ -336,10 +336,10 @@ class AlternativeRouting final
                 (packed_alternate_path.back() != phantom_node_pair.target_phantom.forward_node_id));
 
             // unpack the alternate path
-            super::UnpackPath(packed_alternate_path.begin(), packed_alternate_path.end(),
-                              phantom_node_pair, raw_route_data.unpacked_alternative);
-
             raw_route_data.alternative_path_length = length_of_via_path;
+            raw_route_data.alternative_path_length -=
+                super::UnpackPath(packed_alternate_path.begin(), packed_alternate_path.end(),
+                                  phantom_node_pair, raw_route_data.unpacked_alternative);
         }
         else
         {

--- a/include/engine/routing_algorithms/direct_shortest_path.hpp
+++ b/include/engine/routing_algorithms/direct_shortest_path.hpp
@@ -131,8 +131,9 @@ class DirectShortestPathRouting final
         raw_route_data.target_traversed_in_reverse.push_back(
             (packed_leg.back() != phantom_node_pair.target_phantom.forward_node_id));
 
-        super::UnpackPath(packed_leg.begin(), packed_leg.end(), phantom_node_pair,
-                          raw_route_data.unpacked_path_segments.front());
+        raw_route_data.shortest_path_length -=
+            super::UnpackPath(packed_leg.begin(), packed_leg.end(), phantom_node_pair,
+                              raw_route_data.unpacked_path_segments.front());
     }
 };
 }

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -212,11 +212,12 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
     }
 
     template <typename RandomIter>
-    void UnpackPath(RandomIter packed_path_begin,
+    EdgeWeight UnpackPath(RandomIter packed_path_begin,
                     RandomIter packed_path_end,
                     const PhantomNodes &phantom_node_pair,
                     std::vector<PathData> &unpacked_path) const
     {
+        EdgeWeight applied_path_penalties = 0;
         const bool start_traversed_in_reverse =
             (*packed_path_begin != phantom_node_pair.source_phantom.forward_node_id);
         const bool target_traversed_in_reverse =
@@ -286,9 +287,12 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
             {
                 BOOST_ASSERT_MSG(!ed.shortcut, "original edge flagged as shortcut");
                 unsigned name_index = facade->GetNameIndexFromEdgeID(ed.id);
-                const extractor::TurnInstruction turn_instruction =
+                const auto turn_instruction =
                     facade->GetTurnInstructionForEdgeID(ed.id);
-                const extractor::TravelMode travel_mode = facade->GetTravelModeForEdgeID(ed.id);
+                const auto travel_mode = facade->GetTravelModeForEdgeID(ed.id);
+
+                if( turn_instruction == extractor::TurnInstruction::AccessRestrictionPenalty )
+                  applied_path_penalties += ACCESS_RESTRICTED_PENALTY;
 
                 if (!facade->EdgeIsCompressed(ed.id))
                 {
@@ -367,7 +371,6 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                              phantom_node_pair.target_phantom.forward_travel_mode});
             }
         }
-
         // there is no equivalent to a node-based node in an edge-expanded graph.
         // two equivalent routes may start (or end) at different node-based edges
         // as they are added with the offset how much "distance" on the edge
@@ -387,6 +390,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
             }
             BOOST_ASSERT(!unpacked_path.empty());
         }
+        return applied_path_penalties;
     }
 
     void UnpackEdge(const NodeID s, const NodeID t, std::vector<NodeID> &unpacked_path) const

--- a/include/engine/routing_algorithms/shortest_path.hpp
+++ b/include/engine/routing_algorithms/shortest_path.hpp
@@ -36,8 +36,9 @@ class ShortestPathRouting final
 
     ~ShortestPathRouting() {}
 
-    inline bool
-    forceLoop(bool forward, const PhantomNode &source_phantom, const PhantomNode &target_phantom) const
+    inline bool forceLoop(bool forward,
+                          const PhantomNode &source_phantom,
+                          const PhantomNode &target_phantom) const
     {
         if (forward)
             return source_phantom.forward_node_id == target_phantom.forward_node_id &&
@@ -191,8 +192,9 @@ class ShortestPathRouting final
             auto leg_begin = total_packed_path.begin() + packed_leg_begin[current_leg];
             auto leg_end = total_packed_path.begin() + packed_leg_begin[current_leg + 1];
             const auto &unpack_phantom_node_pair = phantom_nodes_vector[current_leg];
-            super::UnpackPath(leg_begin, leg_end, unpack_phantom_node_pair,
-                              raw_route_data.unpacked_path_segments[current_leg]);
+            raw_route_data.shortest_path_length -=
+                super::UnpackPath(leg_begin, leg_end, unpack_phantom_node_pair,
+                                  raw_route_data.unpacked_path_segments[current_leg]);
 
             raw_route_data.source_traversed_in_reverse.push_back(
                 (*leg_begin != phantom_nodes_vector[current_leg].source_phantom.forward_node_id));

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -41,7 +41,7 @@ class EdgeBasedGraphFactory
 
     explicit EdgeBasedGraphFactory(std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
                                    const CompressedEdgeContainer &compressed_edge_container,
-                                   const std::unordered_set<NodeID> &barrier_nodes,
+                                   const std::unordered_map<NodeID,bool> &barrier_nodes,
                                    const std::unordered_set<NodeID> &traffic_lights,
                                    std::shared_ptr<const RestrictionMap> restriction_map,
                                    const std::vector<QueryNode> &node_info_list,
@@ -95,7 +95,7 @@ class EdgeBasedGraphFactory
     std::shared_ptr<util::NodeBasedDynamicGraph> m_node_based_graph;
     std::shared_ptr<RestrictionMap const> m_restriction_map;
 
-    const std::unordered_set<NodeID> &m_barrier_nodes;
+    const std::unordered_map<NodeID,bool> &m_barrier_nodes;
     const std::unordered_set<NodeID> &m_traffic_lights;
     const CompressedEdgeContainer &m_compressed_edge_container;
 

--- a/include/extractor/external_memory_node.hpp
+++ b/include/extractor/external_memory_node.hpp
@@ -12,25 +12,32 @@ namespace extractor
 
 struct ExternalMemoryNode : QueryNode
 {
-    ExternalMemoryNode(int lat, int lon, OSMNodeID node_id, bool barrier, bool traffic_lights)
-        : QueryNode(lat, lon, node_id), barrier(barrier), traffic_lights(traffic_lights)
+    ExternalMemoryNode(int lat,
+                       int lon,
+                       OSMNodeID node_id,
+                       bool barrier,
+                       bool access_restricted,
+                       bool traffic_lights)
+        : QueryNode(lat, lon, node_id), barrier(barrier), access_restricted(access_restricted),
+          traffic_lights(traffic_lights)
     {
     }
 
-    ExternalMemoryNode() : barrier(false), traffic_lights(false) {}
+    ExternalMemoryNode() : barrier(false), access_restricted(false), traffic_lights(false) {}
 
     static ExternalMemoryNode min_value()
     {
-        return ExternalMemoryNode(0, 0, MIN_OSM_NODEID, false, false);
+        return ExternalMemoryNode(0, 0, MIN_OSM_NODEID, false, false, false);
     }
 
     static ExternalMemoryNode max_value()
     {
         return ExternalMemoryNode(std::numeric_limits<int>::max(), std::numeric_limits<int>::max(),
-                                  MAX_OSM_NODEID, false, false);
+                                  MAX_OSM_NODEID, false, false, false);
     }
 
     bool barrier;
+    bool access_restricted;
     bool traffic_lights;
 };
 

--- a/include/extractor/extraction_node.hpp
+++ b/include/extractor/extraction_node.hpp
@@ -8,10 +8,11 @@ namespace extractor
 
 struct ExtractionNode
 {
-    ExtractionNode() : traffic_lights(false), barrier(false) {}
-    void clear() { traffic_lights = barrier = false; }
+    ExtractionNode() : traffic_lights(false), barrier(false), access_restricted(false) {}
+    void clear() { traffic_lights = barrier = access_restricted = false; }
     bool traffic_lights;
     bool barrier;
+    bool access_restricted;
 };
 }
 }

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -8,6 +8,11 @@
 
 #include "util/typedefs.hpp"
 
+#include <memory>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+
 namespace osrm
 {
 namespace extractor
@@ -38,7 +43,7 @@ class Extractor
                     const std::vector<QueryNode> &internal_to_external_node_map);
     std::shared_ptr<RestrictionMap> LoadRestrictionMap();
     std::shared_ptr<util::NodeBasedDynamicGraph>
-    LoadNodeBasedGraph(std::unordered_set<NodeID> &barrier_nodes,
+    LoadNodeBasedGraph(std::unordered_map<NodeID,bool> &barrier_nodes,
                        std::unordered_set<NodeID> &traffic_lights,
                        std::vector<QueryNode> &internal_to_external_node_map);
 

--- a/include/extractor/graph_compressor.hpp
+++ b/include/extractor/graph_compressor.hpp
@@ -7,6 +7,7 @@
 #include "util/node_based_graph.hpp"
 
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace osrm
@@ -24,7 +25,7 @@ class GraphCompressor
   public:
     GraphCompressor(SpeedProfileProperties speed_profile);
 
-    void Compress(const std::unordered_set<NodeID> &barrier_nodes,
+    void Compress(const std::unordered_map<NodeID,bool> &barrier_nodes,
                   const std::unordered_set<NodeID> &traffic_lights,
                   RestrictionMap &restriction_map,
                   util::NodeBasedDynamicGraph &graph,

--- a/include/util/graph_loader.hpp
+++ b/include/util/graph_loader.hpp
@@ -20,6 +20,7 @@
 
 #include <fstream>
 #include <ios>
+#include <utility>
 #include <vector>
 
 namespace osrm
@@ -63,7 +64,7 @@ unsigned loadRestrictionsFromFile(std::istream &input_stream,
  *  - nodes indexed by their internal (non-osm) id
  */
 NodeID loadNodesFromFile(std::istream &input_stream,
-                         std::vector<NodeID> &barrier_node_list,
+                         std::vector<std::pair<NodeID,bool>> &barrier_node_list,
                          std::vector<NodeID> &traffic_light_node_list,
                          std::vector<extractor::QueryNode> &node_array)
 {
@@ -89,7 +90,7 @@ NodeID loadNodesFromFile(std::istream &input_stream,
         node_array.emplace_back(current_node.lat, current_node.lon, current_node.node_id);
         if (current_node.barrier)
         {
-            barrier_node_list.emplace_back(i);
+            barrier_node_list.emplace_back(std::make_pair(i,current_node.access_restricted));
         }
         if (current_node.traffic_lights)
         {

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -39,4 +39,6 @@ static const unsigned INVALID_NAMEID = std::numeric_limits<unsigned>::max();
 static const unsigned INVALID_COMPONENTID = 0;
 static const EdgeWeight INVALID_EDGE_WEIGHT = std::numeric_limits<int>::max();
 
+static const EdgeWeight ACCESS_RESTRICTED_PENALTY = 10000000;
+
 #endif /* TYPEDEFS_H */

--- a/profiles/testbot.lua
+++ b/profiles/testbot.lua
@@ -52,6 +52,17 @@ function node_function (node, result)
     result.traffic_lights = true
     -- TODO: a way to set the penalty value
   end
+  local barrier = node:get_value_by_key("barrier")
+  if barrier and "" ~= barrier then
+  --  make an exception for rising bollard barriers
+     local bollard = node:get_value_by_key("bollard")
+     local rising_bollard = bollard and "rising" == bollard
+
+     if not rising_bollard then
+         result.barrier = true
+         result.access_restricted = false --allow access, but only at a penalty
+     end
+  end
 end
 
 function way_function (way, result)

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -41,7 +41,7 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
     external_memory.all_nodes_list.push_back(
         {static_cast<int>(input_node.location().lat() * COORDINATE_PRECISION),
          static_cast<int>(input_node.location().lon() * COORDINATE_PRECISION),
-         OSMNodeID(input_node.id()), result_node.barrier, result_node.traffic_lights});
+         OSMNodeID(input_node.id()), result_node.barrier, result_node.access_restricted, result_node.traffic_lights});
 }
 
 void ExtractorCallbacks::ProcessRestriction(

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -18,7 +18,7 @@ GraphCompressor::GraphCompressor(SpeedProfileProperties speed_profile)
 {
 }
 
-void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
+void GraphCompressor::Compress(const std::unordered_map<NodeID, bool> &barrier_nodes,
                                const std::unordered_set<NodeID> &traffic_lights,
                                RestrictionMap &restriction_map,
                                util::NodeBasedDynamicGraph &graph,
@@ -50,6 +50,7 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
         {
             continue;
         }
+
 
         //    reverse_e2   forward_e2
         // u <---------- v -----------> w

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace osrm
@@ -63,7 +64,7 @@ std::size_t loadGraph(const char *path,
     // load graph data
     std::vector<extractor::NodeBasedEdge> edge_list;
     std::vector<NodeID> traffic_light_node_list;
-    std::vector<NodeID> barrier_node_list;
+    std::vector<std::pair<NodeID,bool>> barrier_node_list;
 
     auto number_of_nodes = util::loadNodesFromFile(input_stream, barrier_node_list,
                                                    traffic_light_node_list, coordinate_list);


### PR DESCRIPTION
Many gated areas (like gated communities, factories ... ) exist in the graph. Usually they are separated from the rest of the graph by a barrier of some form.
In the current way of handling, we have no way of avoiding them.

This pull requests uses the turn_instruction `access_restriction_penalty`  to introduce a behaviour in which we can route **out/into** such areas but **not pass through** them.

This pull request has two problems:
 * It only works for barriers at the moment, but at least in Germany there exists a traffic sign requesting no through traffic (Anlieger frei -- essentially saying only enter if you have a good reason to go here)
 * It cannot handle the many-to-many plugin, as we do not extract paths in that scenario. To handle the many-to-many plugin, we would need https://github.com/Project-OSRM/osrm-backend/issues/77 