### PR TITLE
Pedantic clang-format checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,5 +166,5 @@ script:
   - popd
   - |
     if [ -n "$RUN_CLANG_FORMAT" ]; then
-      ./scripts/format.sh
+      ./scripts/format.sh || true # we don't want to fail just yet
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         apt:
           sources: ['llvm-toolchain-precise', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'rubygems-integration', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: COMPILER='clang++-3.8' BUILD_TYPE='Debug'
+      env: COMPILER='clang++-3.8' BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON
 
     - os: osx
       osx_image: xcode7
@@ -139,7 +139,7 @@ before_script:
   - rvm use 1.9.3
   - gem install bundler
   - bundle install
-  - mkdir build && cd build
+  - mkdir build && pushd build
   - export CXX=${COMPILER}
   - export OSRM_PORT=5000 OSRM_TIMEOUT=60
   - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} -DBUILD_TOOLS=1
@@ -156,10 +156,15 @@ script:
   - ./extractor-tests
   - ./engine-tests
   - ./util-tests
-  - cd ..
+  - popd
   - cucumber -p verify
   - make -C test/data
-  - mkdir example/build && cd example/build
+  - mkdir example/build && pushd example/build
   - cmake ..
   - make
   - ./osrm-example ../../test/data/berlin-latest.osrm
+  - popd
+  - |
+    if [ -n "$RUN_CLANG_FORMAT" ]; then
+      ./scripts/format.sh
+    fi

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Runs the Clang Formatter in parallel on the code base.
+# Return codes:
+#  - 1 there are files to be formatted
+#  - 0 everything looks fine
+
+set -eu -o pipefail
+
+find src include unit_tests example -type f -name '*.hpp' -o -name '*.cpp' \
+  | xargs -I{} -P $(nproc) clang-format -i -style=file {}
+
+
+dirty=$(git ls-files --modified)
+
+if [[ $dirty ]]; then
+    echo "The following files do not adhere to the .clang-format style file:"
+    echo $dirty
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
A few weeks after we touched literally every file in the code base and neatly formatted them adhering to our .clang-format style we again already have 36 files that violate the style.

This small pull request makes Travis angry when your files violate the style. :angry:

Discussion: I put in the check at the end, so that even when the style check fails at least we can see that it's only coming from those checks and the build still would succeed otherwise.