### PR TITLE
Shm vector wrapper cleanup and undefined behavior

### DIFF
--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -14,8 +14,11 @@
 
 #include "osrm/coordinate.hpp"
 
+#include <cstddef>
+
+#include <vector>
+#include <utility>
 #include <string>
-#include <boost/optional.hpp>
 
 namespace osrm
 {

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -18,9 +18,24 @@
 
 #include "osrm/coordinate.hpp"
 
-#include <boost/thread.hpp>
+#include <cstddef>
+#include <cstdlib>
 
+#include <algorithm>
+#include <fstream>
+#include <ios>
 #include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/assert.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/thread/tss.hpp>
 
 namespace osrm
 {

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -134,7 +134,6 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
 
     void LoadNodeAndEdgeInformation()
     {
-
         auto coordinate_list_ptr = data_layout->GetBlockPtr<util::FixedPointCoordinate>(
             shared_memory, storage::SharedDataLayout::COORDINATE_LIST);
         m_coordinate_list = util::make_unique<util::ShM<util::FixedPointCoordinate, true>::vector>(
@@ -145,20 +144,20 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
             shared_memory, storage::SharedDataLayout::TRAVEL_MODE);
         typename util::ShM<extractor::TravelMode, true>::vector travel_mode_list(
             travel_mode_list_ptr, data_layout->num_entries[storage::SharedDataLayout::TRAVEL_MODE]);
-        m_travel_mode_list.swap(travel_mode_list);
+        m_travel_mode_list = std::move(travel_mode_list);
 
         auto turn_instruction_list_ptr = data_layout->GetBlockPtr<extractor::TurnInstruction>(
             shared_memory, storage::SharedDataLayout::TURN_INSTRUCTION);
         typename util::ShM<extractor::TurnInstruction, true>::vector turn_instruction_list(
             turn_instruction_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::TURN_INSTRUCTION]);
-        m_turn_instruction_list.swap(turn_instruction_list);
+        m_turn_instruction_list = std::move(turn_instruction_list);
 
         auto name_id_list_ptr = data_layout->GetBlockPtr<unsigned>(
             shared_memory, storage::SharedDataLayout::NAME_ID_LIST);
         typename util::ShM<unsigned, true>::vector name_id_list(
             name_id_list_ptr, data_layout->num_entries[storage::SharedDataLayout::NAME_ID_LIST]);
-        m_name_ID_list.swap(name_id_list);
+        m_name_ID_list = std::move(name_id_list);
     }
 
     void LoadViaNodeList()
@@ -167,7 +166,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
             shared_memory, storage::SharedDataLayout::VIA_NODE_LIST);
         typename util::ShM<NodeID, true>::vector via_node_list(
             via_node_list_ptr, data_layout->num_entries[storage::SharedDataLayout::VIA_NODE_LIST]);
-        m_via_node_list.swap(via_node_list);
+        m_via_node_list = std::move(via_node_list);
     }
 
     void LoadNames()
@@ -188,7 +187,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         m_name_table = util::make_unique<util::RangeTable<16, true>>(
             name_offsets, name_blocks, static_cast<unsigned>(names_char_list.size()));
 
-        m_names_char_list.swap(names_char_list);
+        m_names_char_list = std::move(names_char_list);
     }
 
     void LoadCoreInformation()
@@ -202,7 +201,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
             shared_memory, storage::SharedDataLayout::CORE_MARKER);
         typename util::ShM<bool, true>::vector is_core_node(
             core_marker_ptr, data_layout->num_entries[storage::SharedDataLayout::CORE_MARKER]);
-        m_is_core_node.swap(is_core_node);
+        m_is_core_node = std::move(is_core_node);
     }
 
     void LoadGeometries()
@@ -212,21 +211,21 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         typename util::ShM<bool, true>::vector edge_is_compressed(
             geometries_compressed_ptr,
             data_layout->num_entries[storage::SharedDataLayout::GEOMETRIES_INDICATORS]);
-        m_edge_is_compressed.swap(edge_is_compressed);
+        m_edge_is_compressed = std::move(edge_is_compressed);
 
         auto geometries_index_ptr = data_layout->GetBlockPtr<unsigned>(
             shared_memory, storage::SharedDataLayout::GEOMETRIES_INDEX);
         typename util::ShM<unsigned, true>::vector geometry_begin_indices(
             geometries_index_ptr,
             data_layout->num_entries[storage::SharedDataLayout::GEOMETRIES_INDEX]);
-        m_geometry_indices.swap(geometry_begin_indices);
+        m_geometry_indices = std::move(geometry_begin_indices);
 
         auto geometries_list_ptr = data_layout->GetBlockPtr<unsigned>(
             shared_memory, storage::SharedDataLayout::GEOMETRIES_LIST);
         typename util::ShM<unsigned, true>::vector geometry_list(
             geometries_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::GEOMETRIES_LIST]);
-        m_geometry_list.swap(geometry_list);
+        m_geometry_list = std::move(geometry_list);
     }
 
   public:

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -26,7 +26,7 @@
 #include <boost/assert.hpp>
 #include <boost/thread/tss.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/thread/synchronized_value.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 namespace osrm
 {
@@ -260,7 +260,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         {
             // Get exclusive lock
             util::SimpleLogger().Write(logDEBUG) << "Updates available, getting exclusive lock";
-            boost::unique_lock<boost::shared_mutex> lock(data_mutex);
+            const boost::lock_guard<boost::shared_mutex> lock(data_mutex);
 
             if (CURRENT_LAYOUT != data_timestamp_ptr->layout ||
                 CURRENT_DATA != data_timestamp_ptr->data)

--- a/include/util/range_table.hpp
+++ b/include/util/range_table.hpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <array>
+#include <utility>
 
 namespace osrm
 {
@@ -52,8 +53,9 @@ template <unsigned BLOCK_SIZE, bool USE_SHARED_MEMORY> class RangeTable
                         const unsigned sum_lengths)
         : sum_lengths(sum_lengths)
     {
-        block_offsets.swap(external_offsets);
-        diff_blocks.swap(external_blocks);
+        using std::swap;
+        swap(block_offsets, external_offsets);
+        swap(diff_blocks, external_blocks);
     }
 
     // construct table from length vector

--- a/include/util/shared_memory_vector_wrapper.hpp
+++ b/include/util/shared_memory_vector_wrapper.hpp
@@ -98,7 +98,7 @@ template <> class SharedMemoryWrapper<bool>
     {
         const std::size_t bucket = index / 32;
         const unsigned offset = static_cast<unsigned>(index % 32);
-        return m_ptr[bucket] & (1 << offset);
+        return m_ptr[bucket] & (1u << offset);
     }
 
     std::size_t size() const { return m_size; }
@@ -110,7 +110,7 @@ template <> class SharedMemoryWrapper<bool>
         BOOST_ASSERT_MSG(index < m_size, "invalid size");
         const unsigned bucket = index / 32;
         const unsigned offset = index % 32;
-        return m_ptr[bucket] & (1 << offset);
+        return m_ptr[bucket] & (1u << offset);
     }
 
     template <typename T>

--- a/include/util/shared_memory_vector_wrapper.hpp
+++ b/include/util/shared_memory_vector_wrapper.hpp
@@ -55,13 +55,6 @@ template <typename DataT> class SharedMemoryWrapper
 
     SharedMemoryWrapper(DataT *ptr, std::size_t size) : m_ptr(ptr), m_size(size) {}
 
-    void swap(SharedMemoryWrapper<DataT> &other)
-    {
-        // BOOST_ASSERT_MSG(m_size != 0 || other.size() != 0, "size invalid");
-        std::swap(m_size, other.m_size);
-        std::swap(m_ptr, other.m_ptr);
-    }
-
     DataT &at(const std::size_t index) { return m_ptr[index]; }
 
     const DataT &at(const std::size_t index) const { return m_ptr[index]; }
@@ -85,6 +78,9 @@ template <typename DataT> class SharedMemoryWrapper
         BOOST_ASSERT_MSG(index < m_size, "invalid size");
         return m_ptr[index];
     }
+
+    template <typename T>
+    friend void swap(SharedMemoryWrapper<T> &, SharedMemoryWrapper<T> &) noexcept;
 };
 
 template <> class SharedMemoryWrapper<bool>
@@ -97,13 +93,6 @@ template <> class SharedMemoryWrapper<bool>
     SharedMemoryWrapper() : m_ptr(nullptr), m_size(0) {}
 
     SharedMemoryWrapper(unsigned *ptr, std::size_t size) : m_ptr(ptr), m_size(size) {}
-
-    void swap(SharedMemoryWrapper<bool> &other)
-    {
-        // BOOST_ASSERT_MSG(m_size != 0 || other.size() != 0, "size invalid");
-        std::swap(m_size, other.m_size);
-        std::swap(m_ptr, other.m_ptr);
-    }
 
     bool at(const std::size_t index) const
     {
@@ -123,7 +112,18 @@ template <> class SharedMemoryWrapper<bool>
         const unsigned offset = index % 32;
         return m_ptr[bucket] & (1 << offset);
     }
+
+    template <typename T>
+    friend void swap(SharedMemoryWrapper<T> &, SharedMemoryWrapper<T> &) noexcept;
 };
+
+// Both SharedMemoryWrapper<T> and the SharedMemoryWrapper<bool> specializations share this impl.
+template <typename DataT>
+void swap(SharedMemoryWrapper<DataT> &lhs, SharedMemoryWrapper<DataT> &rhs) noexcept
+{
+    std::swap(lhs.m_ptr, rhs.m_ptr);
+    std::swap(lhs.m_size, rhs.m_size);
+}
 
 template <typename DataT, bool UseSharedMemory> struct ShM
 {

--- a/include/util/shared_memory_vector_wrapper.hpp
+++ b/include/util/shared_memory_vector_wrapper.hpp
@@ -3,10 +3,13 @@
 
 #include <boost/assert.hpp>
 
+#include <cstddef>
+
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
 #include <vector>
+#include <utility>
 
 namespace osrm
 {

--- a/include/util/static_graph.hpp
+++ b/include/util/static_graph.hpp
@@ -105,8 +105,9 @@ template <typename EdgeDataT, bool UseSharedMemory = false> class StaticGraph
         number_of_nodes = static_cast<decltype(number_of_nodes)>(nodes.size() - 1);
         number_of_edges = static_cast<decltype(number_of_edges)>(edges.size());
 
-        node_array.swap(nodes);
-        edge_array.swap(edges);
+        using std::swap;
+        swap(node_array, nodes);
+        swap(edge_array, edges);
     }
 
     unsigned GetNumberOfNodes() const { return number_of_nodes; }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -425,7 +425,7 @@ int Storage::Run()
         }();
         if (current_edge_data.compressed_geometry)
         {
-            geometries_indicator_ptr[bucket] = (value | (1 << offset));
+            geometries_indicator_ptr[bucket] = (value | (1u << offset));
         }
     }
     edges_input_stream.close();
@@ -513,7 +513,7 @@ int Storage::Run()
                 return return_value;
             }();
 
-            core_marker_ptr[bucket] = (value | (1 << offset));
+            core_marker_ptr[bucket] = (value | (1u << offset));
         }
     }
 


### PR DESCRIPTION
I started looking at the facades and especially how the shm datafacade wraps the memory region it owns. Turns out the shared memory wrapper we're using is more or less

```cpp
boost::const_multi_array_ref<T, 1> array_view{first, boost::extents[last - first]};
```
That is, a non-owning [array_view](http://www.boost.org/doc/libs/1_60_0/libs/multi_array/doc/reference.html#const_multi_array_ref
) wrapper around a memory range; iteratable, size, data, and so on.

This pull request contains the following fixes:
- refactors the shm vector wrapper's swap semantics
- makes swap noexcept (as it always should be!)
- fixes misuse of member function swaps
- fixes undefined behavior in the shm vector wrapper by shifting into the sign bit (reminder: integer literals are signed by default!)


And sorry for the noise, this comes from clang-format. We have to get the pedantic clang-format pull request merged already!