### PR TITLE
Fix 'egdes' typo, replace with 'edges'.

### DIFF
--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -612,7 +612,7 @@ void Extractor::WriteEdgeBasedGraph(
     const util::FingerPrint fingerprint = util::FingerPrint::GetValid();
     file_out_stream.write((char *)&fingerprint, sizeof(util::FingerPrint));
 
-    util::SimpleLogger().Write() << "[extractor] Writing edge-based-graph egdes       ... "
+    util::SimpleLogger().Write() << "[extractor] Writing edge-based-graph edges       ... "
                                  << std::flush;
     TIMER_START(write_edges);
 


### PR DESCRIPTION
The lintian QA tool reported this spelling error for the recent rebuild of the OSRM 4.9.1 Debian package with GDAL 1.11.4 and 2.0.2.