### PR TITLE
Ensure key command line programs can be run before running cucumber tests

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -76,6 +76,10 @@ def verify_existance_of_binaries
     unless File.exists? "#{BIN_PATH}/#{bin}#{EXE}"
       raise "*** #{BIN_PATH}/#{bin}#{EXE} is missing. Build failed?"
     end
+    unless system "#{BIN_PATH}/#{bin}#{EXE} --help"
+      log "*** Exited with code #{$?.exitstatus}.", :preprocess
+      raise "*** #{BIN_PATH}/#{bin}#{EXE} --help exited with code #{$?.exitstatus}."
+    end
   end
 end
 


### PR DESCRIPTION

This adds a check up front that will abort the tests if a command like `osrm-extract --help` does not work (without crashing or otherwise returning a non-zero exit code).

  - Otherwise, currently, if osrm-extract crashes at startup then
    the tests continue on and will crash many many times.
  - This also tests that --help returns an exit code of zero and will
    catch if this behavior ever changes or is inconsistent between
    the command line programs

My case: I had a build issue locally that caused `osrm-extract` to crash at startup. This change will make this situation easier to debug in the future by avoiding every cucumber test to run and fail.