### PR TITLE
Remove uneeded and deprecated usage of mapbox::util::static_visitor

### DIFF
--- a/include/util/json_renderer.hpp
+++ b/include/util/json_renderer.hpp
@@ -16,7 +16,7 @@ namespace util
 namespace json
 {
 
-struct Renderer : mapbox::util::static_visitor<>
+struct Renderer
 {
     explicit Renderer(std::ostream &_out) : out(_out) {}
 
@@ -72,7 +72,7 @@ struct Renderer : mapbox::util::static_visitor<>
     std::ostream &out;
 };
 
-struct ArrayRenderer : mapbox::util::static_visitor<>
+struct ArrayRenderer
 {
     explicit ArrayRenderer(std::vector<char> &_out) : out(_out) {}
 


### PR DESCRIPTION
As per https://github.com/mapbox/variant/pull/75. This is the only change needed to upgrade `osrm-backend` to the upcoming `mapbox::variant` [v1.1.0 release](https://github.com/mapbox/variant/milestones/1.1.0) (I'll provide a followup PR to do that upgrade after this is merged).