### PR TITLE
Support passing OSRM_SHARED_LIBRARY_PATH env variable for cucumber tests

### DIFF
--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -258,7 +258,7 @@ def extract_data
   Dir.chdir TEST_FOLDER do
     log_preprocess_info
     log "== Extracting #{osm_file}.osm...", :preprocess
-    unless system "#{BIN_PATH}/osrm-extract #{osm_file}.osm #{@extract_args} --profile #{PROFILES_PATH}/#{@profile}.lua >>#{PREPROCESS_LOG_FILE} 2>&1"
+    unless system "#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-extract #{osm_file}.osm #{@extract_args} --profile #{PROFILES_PATH}/#{@profile}.lua >>#{PREPROCESS_LOG_FILE} 2>&1"
       log "*** Exited with code #{$?.exitstatus}.", :preprocess
       raise ExtractError.new $?.exitstatus, "osrm-extract exited with code #{$?.exitstatus}."
     end
@@ -277,7 +277,7 @@ def prepare_data
   Dir.chdir TEST_FOLDER do
     log_preprocess_info
     log "== Preparing #{extracted_file}.osm...", :preprocess
-    unless system "#{BIN_PATH}/osrm-prepare #{extracted_file}.osrm  --profile #{PROFILES_PATH}/#{@profile}.lua >>#{PREPROCESS_LOG_FILE} 2>&1"
+    unless system "#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-prepare #{extracted_file}.osrm  --profile #{PROFILES_PATH}/#{@profile}.lua >>#{PREPROCESS_LOG_FILE} 2>&1"
       log "*** Exited with code #{$?.exitstatus}.", :preprocess
       raise PrepareError.new $?.exitstatus, "osrm-prepare exited with code #{$?.exitstatus}."
     end

--- a/features/support/launch.rb
+++ b/features/support/launch.rb
@@ -92,7 +92,7 @@ class OSRMLoader
 
     def osrm_up
       return if @@pid
-      @@pid = Process.spawn("#{BIN_PATH}/osrm-routed #{@input_file} --port #{OSRM_PORT}",:out=>OSRM_ROUTED_LOG_FILE, :err=>OSRM_ROUTED_LOG_FILE)
+      @@pid = Process.spawn("#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-routed #{@input_file} --port #{OSRM_PORT}",:out=>OSRM_ROUTED_LOG_FILE, :err=>OSRM_ROUTED_LOG_FILE)
       Process.detach(@@pid)    # avoid zombie processes
     end
 
@@ -118,7 +118,7 @@ class OSRMLoader
 
     def osrm_up
       return if osrm_up?
-      @@pid = Process.spawn("#{BIN_PATH}/osrm-routed --shared-memory=1 --port #{OSRM_PORT}",:out=>OSRM_ROUTED_LOG_FILE, :err=>OSRM_ROUTED_LOG_FILE)
+      @@pid = Process.spawn("#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-routed --shared-memory=1 --port #{OSRM_PORT}",:out=>OSRM_ROUTED_LOG_FILE, :err=>OSRM_ROUTED_LOG_FILE)
       Process.detach(@@pid)    # avoid zombie processes
     end
   end

--- a/features/support/run.rb
+++ b/features/support/run.rb
@@ -20,7 +20,7 @@ def run_bin bin, options
       opt.gsub! "{profile}", "#{PROFILES_PATH}/#{@profile}.lua" 
     end
 
-    cmd = "#{QQ}#{BIN_PATH}/#{bin}#{EXE}#{QQ} #{opt} 2>error.log"
+    cmd = "#{QQ}#{LOAD_LIBRARIES}#{BIN_PATH}/#{bin}#{EXE}#{QQ} #{opt} 2>error.log"
     @stdout = `#{cmd}`
     @stderr = File.read 'error.log'
     @exit_code = $?.exitstatus


### PR DESCRIPTION
The need for this is that:

  - On OS X if libraries are stored in custom locations (not /usr/lib or /usr/local)
    and they do not embed an rpath (which is common to not have) then the developer
    needs to set DYLD_LIBRARY_PATH to ensure that osrm tools can find dependent libraries
    at runtime (this is normal and common).
  - But as of OS X > 10.11 DYLD_LIBRARY_PATH no longer is inherited. While it works in
    the main shell when running a command like `osrm-extract` you will find that when
    `osrm-extract` is run by cucumber (ruby child process) then DYLD_LIBRARY_PATH
    is blocked and the command cannot start.
  - So, this introduces the ability to pass in a variable that the cucumber tests will
    understand and can manually forward along to ensure that DYLD_LIBRARY_PATH is respected
    where it counts.

The intended usage of this is therefore:

    # set the environment variable
    export OSRM_SHARED_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
    # then run cucumber tests
    cucumber -p verify