### PR TITLE
Include real coordinates in debug geojson mode

### DIFF
--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -23,6 +23,7 @@ struct ContractorConfig
         edge_based_graph_path = osrm_input_path.string() + ".ebg";
         edge_segment_lookup_path = osrm_input_path.string() + ".edge_segment_lookup";
         edge_penalty_path = osrm_input_path.string() + ".edge_penalties";
+        node_based_graph_path = osrm_input_path.string() + ".nodes";
     }
 
     boost::filesystem::path config_file_path;
@@ -36,6 +37,7 @@ struct ContractorConfig
 
     std::string edge_segment_lookup_path;
     std::string edge_penalty_path;
+    std::string node_based_graph_path;
     bool use_cached_priority;
 
     unsigned requested_num_threads;


### PR DESCRIPTION
https://github.com/Project-OSRM/osrm-backend/issues/1956

For building with the `DEBUG_GEOMETRY=ON`, previously the output geojson only has OSM node ids in the coordinates field, this uses the osrm.nodes file to lookup real lon/lat coordinates and write them.

@danpat @TheMarex 