### PR TITLE
Dynamic offset calc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ add_executable(util-tests EXCLUDE_FROM_ALL unit_tests/util_tests.cpp ${UtilTests
 # Benchmarks
 add_executable(rtree-bench EXCLUDE_FROM_ALL src/benchmarks/static_rtree.cpp $<TARGET_OBJECTS:UTIL>)
 
+target_include_directories(util-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
+target_include_directories(rtree-bench PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
+
 # Check the release mode
 if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_BUILD_TYPE Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 
 # Configuring compilers
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=2 -D_FORTIFY_SOURCE=2 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=2 -D_FORTIFY_SOURCE=2 -fPIC -fcolor-diagnostics")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(COLOR_FLAG "-fdiagnostics-color=auto")
   check_cxx_compiler_flag("-fdiagnostics-color=auto" HAS_COLOR_FLAG)

--- a/features/car/traffic.feature
+++ b/features/car/traffic.feature
@@ -1,0 +1,47 @@
+@routing @speed @traffic
+Feature: Traffic - speeds
+
+    Background: Use specific speeds
+        Given the node locations
+            | node | lat        | lon      |
+            | a    | 0.1        | 0.1      |
+            | b    | .05        | 0.1      |
+            | c    | 0.0        | 0.1      |
+            | d    | .05        | .03      |
+            | e    | .05        | .066     |
+            | f    | .075       | .066     |
+            | g    | .075       | 0.1      |
+        And the ways
+            | nodes | highway |
+            | ab    | primary |
+            | ad    | primary |
+            | bc    | primary |
+            | dc    | primary |
+            | de    | primary |
+            | eb    | primary |
+            | df    | primary |
+            | fb    | primary |
+        And the speed file
+        """
+        1,2,27
+        2,1,27
+        2,3,27
+        3,2,27
+        1,4,27
+        4,1,27
+        """
+
+    Scenario: Weighting not based on raster sources
+        Given the profile "testbot"
+        Given the extract extra arguments "--generate-edge-lookup"
+        Given the prepare extra arguments "--segment-speed-file speeds.csv"
+        And I route I should get
+            | from | to | route | speed   |
+            | a    | b  | ab    | 27 km/h |
+            | a    | c  | ab,bc | 27 km/h |
+            | b    | c  | bc    | 27 km/h |
+            | a    | d  | ad    | 27 km/h |
+            | d    | c  | dc    | 36 km/h |
+            | g    | b  | ab    | 27 km/h |
+            | a    | g  | ab    | 27 km/h |
+

--- a/features/car/traffic.feature
+++ b/features/car/traffic.feature
@@ -34,7 +34,7 @@ Feature: Traffic - speeds
     Scenario: Weighting not based on raster sources
         Given the profile "testbot"
         Given the extract extra arguments "--generate-edge-lookup"
-        Given the prepare extra arguments "--segment-speed-file speeds.csv"
+        Given the contract extra arguments "--segment-speed-file speeds.csv"
         And I route I should get
             | from | to | route | speed   |
             | a    | b  | ab    | 27 km/h |

--- a/features/options/routed/files.feature
+++ b/features/options/routed/files.feature
@@ -4,8 +4,8 @@ Feature: osrm-routed command line options: files
 # For testing program options, the --trial option is used, which causes osrm-routed to quit
 # immediately after initialization. This makes testing easier and faster.
 # 
-# The {prepared_base} part of the options to osrm-routed will be expanded to the actual base path of
-# the prepared input file.
+# The {contracted_base} part of the options to osrm-routed will be expanded to the actual base path of
+# the contracted input file.
 
 # TODO
 # Since we're not using osmr-datastore for all testing, osrm-routed is kept running.
@@ -19,10 +19,10 @@ Feature: osrm-routed command line options: files
         And the ways
             | nodes |
             | ab    |
-        And the data has been prepared
+        And the data has been contracted
 
     Scenario: osrm-routed - Passing base file
-        When I run "osrm-routed {prepared_base}.osrm --trial"
+        When I run "osrm-routed {contracted_base}.osrm --trial"
         Then stdout should contain /^\[info\] starting up engines/
         And stdout should contain /\d{1,2}\.\d{1,2}\.\d{1,2}/
         And stdout should contain /compiled at/

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -10,8 +10,8 @@ Given /^the extract extra arguments "(.*?)"$/ do |args|
     set_extract_args args
 end
 
-Given /^the prepare extra arguments "(.*?)"$/ do |args|
-    set_prepare_args args
+Given /^the contract extra arguments "(.*?)"$/ do |args|
+    set_contract_args args
 end
 
 Given /^a grid size of (\d+) meters$/ do |meters|

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -173,7 +173,7 @@ Given /^the data has been extracted$/ do
   end
 end
 
-Given /^the data has been prepared$/ do
+Given /^the data has been contracted$/ do
   begin
     reprocess
   rescue OSRMError => e

--- a/features/step_definitions/data.rb
+++ b/features/step_definitions/data.rb
@@ -10,6 +10,10 @@ Given /^the extract extra arguments "(.*?)"$/ do |args|
     set_extract_args args
 end
 
+Given /^the prepare extra arguments "(.*?)"$/ do |args|
+    set_prepare_args args
+end
+
 Given /^a grid size of (\d+) meters$/ do |meters|
   set_grid_size meters
 end
@@ -143,6 +147,12 @@ end
 Given /^the raster source$/ do |data|
   Dir.chdir TEST_FOLDER do
     File.open("rastersource.asc", "w") {|f| f.write(data)}
+  end
+end
+
+Given /^the speed file$/ do |data|
+  Dir.chdir TEST_FOLDER do
+    File.open("speeds.csv", "w") {|f| f.write(data)}
   end
 end
 

--- a/features/step_definitions/distance_matrix.rb
+++ b/features/step_definitions/distance_matrix.rb
@@ -29,7 +29,7 @@ When /^I request a travel time matrix I should get$/ do |table|
   reprocess
   actual = []
   actual << table.headers
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     
     # compute matrix
     params = @query_params

--- a/features/step_definitions/matching.rb
+++ b/features/step_definitions/matching.rb
@@ -1,7 +1,7 @@
 When /^I match I should get$/ do |table|
   reprocess
   actual = []
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     table.hashes.each_with_index do |row,ri|
       if row['request']
         got = {'request' => row['request'] }

--- a/features/step_definitions/nearest.rb
+++ b/features/step_definitions/nearest.rb
@@ -1,7 +1,7 @@
 When /^I request nearest I should get$/ do |table|
   reprocess
   actual = []
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     table.hashes.each_with_index do |row,ri|
       in_node = find_node_by_name row['in']
       raise "*** unknown in-node '#{row['in']}" unless in_node

--- a/features/step_definitions/requests.rb
+++ b/features/step_definitions/requests.rb
@@ -1,6 +1,6 @@
 When /^I request \/(.*)$/ do |path|
   reprocess
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     @response = request_path path, []
   end
 end

--- a/features/step_definitions/routability.rb
+++ b/features/step_definitions/routability.rb
@@ -44,7 +44,7 @@ Then /^routability should be$/ do |table|
   if table.headers&["forw","backw","bothw"] == []
     raise "*** routability tabel must contain either 'forw', 'backw' or 'bothw' column"
   end
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     table.hashes.each_with_index do |row,i|
       output_row = row.dup
       attempts = []

--- a/features/step_definitions/routing.rb
+++ b/features/step_definitions/routing.rb
@@ -1,7 +1,7 @@
 When /^I route I should get$/ do |table|
   reprocess
   actual = []
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     table.hashes.each_with_index do |row,ri|
       if row['request']
         got = {'request' => row['request'] }

--- a/features/step_definitions/trip.rb
+++ b/features/step_definitions/trip.rb
@@ -1,7 +1,7 @@
 When /^I plan a trip I should get$/ do |table|
   reprocess
   actual = []
-  OSRMLoader.load(self,"#{prepared_file}.osrm") do
+  OSRMLoader.load(self,"#{contracted_file}.osrm") do
     table.hashes.each_with_index do |row,ri|
       if row['request']
         got = {'request' => row['request'] }

--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -14,3 +14,7 @@ end
 def set_extract_args args
     @extract_args = args
 end
+
+def set_prepare_args args
+    @prepare_args = args
+end

--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -15,6 +15,6 @@ def set_extract_args args
     @extract_args = args
 end
 
-def set_prepare_args args
-    @prepare_args = args
+def set_contract_args args
+    @contract_args = args
 end

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -218,8 +218,8 @@ def extracted_file
   @extracted_file ||= "#{osm_file}_#{fingerprint_extract}"
 end
 
-def prepared_file
-  @prepared_file ||= "#{osm_file}_#{fingerprint_extract}_#{fingerprint_prepare}"
+def contracted_file
+  @contracted_file ||= "#{osm_file}_#{fingerprint_extract}_#{fingerprint_prepare}"
 end
 
 def write_osm
@@ -237,14 +237,14 @@ def extracted?
   end
 end
 
-def prepared?
+def contracted?
   Dir.chdir TEST_FOLDER do
-    File.exist?("#{prepared_file}.osrm.hsgr")
+    File.exist?("#{contracted_file}.osrm.hsgr")
   end
 end
 
 def write_timestamp
-  File.open( "#{prepared_file}.osrm.timestamp", 'w') {|f| f.write(OSM_TIMESTAMP) }
+  File.open( "#{contracted_file}.osrm.timestamp", 'w') {|f| f.write(OSM_TIMESTAMP) }
 end
 
 def write_input_data
@@ -295,16 +295,16 @@ def prepare_data
     end
     begin
       ["osrm.hsgr","osrm.fileIndex","osrm.geometry","osrm.nodes","osrm.ramIndex","osrm.core","osrm.edges"].each do |file|
-        log "Renaming #{extracted_file}.#{file} to #{prepared_file}.#{file}", :preprocess
-        File.rename "#{extracted_file}.#{file}", "#{prepared_file}.#{file}"
+        log "Renaming #{extracted_file}.#{file} to #{contracted_file}.#{file}", :preprocess
+        File.rename "#{extracted_file}.#{file}", "#{contracted_file}.#{file}"
       end
     rescue Exception => e
       raise FileError.new nil, "failed to rename data file after preparing."
     end
     begin
       ["osrm.names","osrm.restrictions","osrm"].each do |file|
-        log "Copying #{extracted_file}.#{file} to #{prepared_file}.#{file}", :preprocess
-        FileUtils.cp "#{extracted_file}.#{file}", "#{prepared_file}.#{file}"
+        log "Copying #{extracted_file}.#{file} to #{contracted_file}.#{file}", :preprocess
+        FileUtils.cp "#{extracted_file}.#{file}", "#{contracted_file}.#{file}"
       end
     rescue Exception => e
       raise FileError.new nil, "failed to copy data file after preparing."
@@ -316,6 +316,6 @@ end
 def reprocess
   write_input_data
   extract_data unless extracted?
-  prepare_data unless prepared?
+  prepare_data unless contracted?
   log_preprocess_done
 end

--- a/features/support/data.rb
+++ b/features/support/data.rb
@@ -288,8 +288,8 @@ def prepare_data
   Dir.chdir TEST_FOLDER do
     log_preprocess_info
     log "== Preparing #{extracted_file}.osm...", :preprocess
-    log "#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-contract #{@prepare_args} #{extracted_file}.osrm >>#{PREPROCESS_LOG_FILE} 2>&1"
-    unless system "#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-contract #{@prepare_args} #{extracted_file}.osrm >>#{PREPROCESS_LOG_FILE} 2>&1"
+    log "#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-contract #{@contract_args} #{extracted_file}.osrm >>#{PREPROCESS_LOG_FILE} 2>&1"
+    unless system "#{LOAD_LIBRARIES}#{BIN_PATH}/osrm-contract #{@contract_args} #{extracted_file}.osrm >>#{PREPROCESS_LOG_FILE} 2>&1"
       log "*** Exited with code #{$?.exitstatus}.", :preprocess
       raise PrepareError.new $?.exitstatus, "osrm-contract exited with code #{$?.exitstatus}."
     end

--- a/features/support/run.rb
+++ b/features/support/run.rb
@@ -12,9 +12,9 @@ def run_bin bin, options
       opt.gsub! "{extracted_base}", "#{extracted_file}" 
     end
 
-    if opt.include? '{prepared_base}'
-      raise "*** {prepared_base} is missing" unless prepared_file
-      opt.gsub! "{prepared_base}", "#{prepared_file}" 
+    if opt.include? '{contracted_base}'
+      raise "*** {contracted_base} is missing" unless contracted_file
+      opt.gsub! "{contracted_base}", "#{contracted_file}" 
     end
     if opt.include? '{profile}'
       opt.gsub! "{profile}", "#{PROFILES_PATH}/#{@profile}.lua" 

--- a/features/testbot/bad.feature
+++ b/features/testbot/bad.feature
@@ -11,7 +11,7 @@ Feature: Handle bad data in a graceful manner
         Given the ways
             | nodes |
 
-        When the data has been prepared
+        When the data has been contracted
         Then "osrm-extract" should return code 1
 
     Scenario: Only dead-end oneways

--- a/include/contractor/contractor.hpp
+++ b/include/contractor/contractor.hpp
@@ -7,6 +7,7 @@
 #include "contractor/contractor_config.hpp"
 #include "contractor/query_edge.hpp"
 #include "extractor/edge_based_edge.hpp"
+#include "extractor/edge_based_node.hpp"
 #include "util/static_graph.hpp"
 #include "util/deallocating_vector.hpp"
 #include "util/node_based_graph.hpp"
@@ -22,7 +23,6 @@ namespace osrm
 namespace extractor
 {
 struct SpeedProfileProperties;
-struct EdgeBasedNode;
 struct EdgeBasedEdge;
 }
 namespace contractor
@@ -66,7 +66,10 @@ class Contractor
                           util::DeallocatingVector<extractor::EdgeBasedEdge> &edge_based_edge_list,
                           const std::string &edge_segment_lookup_path,
                           const std::string &edge_penalty_path,
-                          const std::string &segment_speed_path);
+                          const std::string &segment_speed_path,
+                          const std::string &nodes_filename,
+                          const std::string &geometry_filename,
+                          const std::string &rtree_leaf_filename);
 };
 }
 }

--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -24,6 +24,8 @@ struct ContractorConfig
         edge_segment_lookup_path = osrm_input_path.string() + ".edge_segment_lookup";
         edge_penalty_path = osrm_input_path.string() + ".edge_penalties";
         node_based_graph_path = osrm_input_path.string() + ".nodes";
+        geometry_path = osrm_input_path.string() + ".geometry";
+        rtree_leaf_path = osrm_input_path.string() + ".fileIndex";
     }
 
     boost::filesystem::path config_file_path;
@@ -37,6 +39,8 @@ struct ContractorConfig
     std::string edge_segment_lookup_path;
     std::string edge_penalty_path;
     std::string node_based_graph_path;
+    std::string geometry_path;
+    std::string rtree_leaf_path;
     bool use_cached_priority;
 
     unsigned requested_num_threads;

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -69,8 +69,13 @@ template <class EdgeDataT> class BaseDataFacade
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const = 0;
 
-    virtual void GetUncompressedGeometry(const unsigned id,
-                                         std::vector<unsigned> &result_nodes) const = 0;
+    virtual void GetUncompressedGeometry(const EdgeID id,
+                                         std::vector<NodeID> &result_nodes) const = 0;
+
+    // Gets the weight values for each segment in an uncompressed geometry.
+    // Should always be 1 shorter than GetUncompressedGeometry
+    virtual void GetUncompressedWeights(const EdgeID id,
+                                         std::vector<EdgeWeight> &result_weights) const = 0;
 
     virtual extractor::TurnInstruction GetTurnInstructionForEdgeID(const unsigned id) const = 0;
 

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -50,7 +50,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
     using RTreeLeaf = typename super::RTreeLeaf;
     using SharedRTree =
         util::StaticRTree<RTreeLeaf, util::ShM<util::FixedPointCoordinate, true>::vector, true>;
-    using SharedGeospatialQuery = GeospatialQuery<SharedRTree>;
+    using SharedGeospatialQuery = GeospatialQuery<SharedRTree, BaseDataFacade<EdgeDataT>>;
     using TimeStampedRTreePair = std::pair<unsigned, std::shared_ptr<SharedRTree>>;
     using RTreeNode = typename SharedRTree::TreeNode;
 
@@ -77,7 +77,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
     util::ShM<unsigned, true>::vector m_name_begin_indices;
     util::ShM<bool, true>::vector m_edge_is_compressed;
     util::ShM<unsigned, true>::vector m_geometry_indices;
-    util::ShM<unsigned, true>::vector m_geometry_list;
+    util::ShM<extractor::CompressedEdgeContainer::CompressedEdge, true>::vector m_geometry_list;
     util::ShM<bool, true>::vector m_is_core_node;
 
     boost::thread_specific_ptr<std::pair<unsigned, std::shared_ptr<SharedRTree>>> m_static_rtree;
@@ -115,7 +115,7 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
                 tree_ptr, data_layout->num_entries[storage::SharedDataLayout::R_SEARCH_TREE],
                 file_index_path, m_coordinate_list)));
         m_geospatial_query.reset(
-            new SharedGeospatialQuery(*m_static_rtree->second, m_coordinate_list));
+            new SharedGeospatialQuery(*m_static_rtree->second, m_coordinate_list, *this));
     }
 
     void LoadGraph()
@@ -221,9 +221,10 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
             data_layout->num_entries[storage::SharedDataLayout::GEOMETRIES_INDEX]);
         m_geometry_indices = std::move(geometry_begin_indices);
 
-        auto geometries_list_ptr = data_layout->GetBlockPtr<unsigned>(
-            shared_memory, storage::SharedDataLayout::GEOMETRIES_LIST);
-        typename util::ShM<unsigned, true>::vector geometry_list(
+        auto geometries_list_ptr =
+            data_layout->GetBlockPtr<extractor::CompressedEdgeContainer::CompressedEdge>(
+                    shared_memory, storage::SharedDataLayout::GEOMETRIES_LIST);
+        typename util::ShM<extractor::CompressedEdgeContainer::CompressedEdge, true>::vector geometry_list(
             geometries_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::GEOMETRIES_LIST]);
         m_geometry_list = std::move(geometry_list);
@@ -382,15 +383,27 @@ template <class EdgeDataT> class SharedDataFacade final : public BaseDataFacade<
         return m_edge_is_compressed.at(id);
     }
 
-    virtual void GetUncompressedGeometry(const unsigned id,
-                                         std::vector<unsigned> &result_nodes) const override final
+    virtual void GetUncompressedGeometry(const EdgeID id,
+                                         std::vector<NodeID> &result_nodes) const override final
     {
         const unsigned begin = m_geometry_indices.at(id);
         const unsigned end = m_geometry_indices.at(id + 1);
 
         result_nodes.clear();
-        result_nodes.insert(result_nodes.begin(), m_geometry_list.begin() + begin,
-                            m_geometry_list.begin() + end);
+        result_nodes.reserve(end - begin);
+        std::for_each(m_geometry_list.begin() + begin, m_geometry_list.begin() + end, [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge){ result_nodes.emplace_back(edge.node_id); });
+    }
+
+    virtual void GetUncompressedWeights(const EdgeID id,
+                                        std::vector<EdgeWeight> &result_weights) const override final
+    {
+        const unsigned begin = m_geometry_indices.at(id);
+        const unsigned end = m_geometry_indices.at(id + 1);
+
+        result_weights.clear();
+        result_weights.reserve(end - begin);
+        std::for_each(m_geometry_list.begin() + begin, m_geometry_list.begin() + end, [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge){ result_weights.emplace_back(edge.weight); });
+
     }
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const override final

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -22,14 +22,14 @@ namespace engine
 // Implements complex queries on top of an RTree and builds PhantomNodes from it.
 //
 // Only holds a weak reference on the RTree!
-template <typename RTreeT> class GeospatialQuery
+template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 {
     using EdgeData = typename RTreeT::EdgeData;
     using CoordinateList = typename RTreeT::CoordinateList;
 
   public:
-    GeospatialQuery(RTreeT &rtree_, std::shared_ptr<CoordinateList> coordinates_)
-        : rtree(rtree_), coordinates(std::move(coordinates_))
+    GeospatialQuery(RTreeT &rtree_, std::shared_ptr<CoordinateList> coordinates_, DataFacadeT &datafacade_)
+        : rtree(rtree_), coordinates(std::move(coordinates_)), datafacade(datafacade_)
     {
     }
 
@@ -150,19 +150,51 @@ template <typename RTreeT> class GeospatialQuery
                 coordinates->at(data.u), coordinates->at(data.v), input_coordinate,
                 point_on_segment, ratio);
 
-        auto transformed = PhantomNodeWithDistance{PhantomNode{data, point_on_segment},
-                                                   current_perpendicular_distance};
+        // Find the node-based-edge that this belongs to, and directly
+        // calculate the forward_weight, forward_offset, reverse_weight, reverse_offset
+
+        int forward_offset = 0, forward_weight = 0;
+        int reverse_offset = 0, reverse_weight = 0;
+
+        if (data.forward_packed_geometry_id != SPECIAL_EDGEID) {
+            std::vector<EdgeWeight> forward_weight_vector;
+            datafacade.GetUncompressedWeights(data.forward_packed_geometry_id,
+                                            forward_weight_vector);
+            for (std::size_t i = 0; i < data.fwd_segment_position; i++)
+            {
+                forward_offset += forward_weight_vector[i];
+            }
+            forward_weight = forward_weight_vector[data.fwd_segment_position];
+        }
+
+        if (data.reverse_packed_geometry_id != SPECIAL_EDGEID) {
+            std::vector<EdgeWeight> reverse_weight_vector;
+            datafacade.GetUncompressedWeights(data.reverse_packed_geometry_id,
+                                              reverse_weight_vector);
+
+            //BOOST_ASSERT(reverse_weight_vector.size() == forward_weight_vector.size());
+            BOOST_ASSERT(data.fwd_segment_position < reverse_weight_vector.size());
+
+            for (std::size_t i = 0; i < reverse_weight_vector.size() - data.fwd_segment_position - 1; i++)
+            {
+                reverse_offset += reverse_weight_vector[i];
+            }
+            reverse_weight = reverse_weight_vector[reverse_weight_vector.size() -
+                                                   data.fwd_segment_position - 1];
+        }
 
         ratio = std::min(1.0, std::max(0.0, ratio));
+        if (SPECIAL_NODEID != data.forward_edge_based_node_id) {
+            forward_weight *= ratio;
+        }
+        if (SPECIAL_NODEID != data.reverse_edge_based_node_id) {
+            reverse_weight *= 1.0 - ratio;
+        }
 
-        if (SPECIAL_NODEID != transformed.phantom_node.forward_node_id)
-        {
-            transformed.phantom_node.forward_weight *= ratio;
-        }
-        if (SPECIAL_NODEID != transformed.phantom_node.reverse_node_id)
-        {
-            transformed.phantom_node.reverse_weight *= 1.0 - ratio;
-        }
+        auto transformed = PhantomNodeWithDistance{PhantomNode{data, forward_weight, forward_offset,
+            reverse_weight, reverse_offset, point_on_segment},
+                                                   current_perpendicular_distance};
+
         return transformed;
     }
 
@@ -190,6 +222,7 @@ template <typename RTreeT> class GeospatialQuery
 
     RTreeT &rtree;
     const std::shared_ptr<CoordinateList> coordinates;
+    DataFacadeT &datafacade;
 };
 }
 }

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -172,7 +172,6 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
             datafacade.GetUncompressedWeights(data.reverse_packed_geometry_id,
                                               reverse_weight_vector);
 
-            //BOOST_ASSERT(reverse_weight_vector.size() == forward_weight_vector.size());
             BOOST_ASSERT(data.fwd_segment_position < reverse_weight_vector.size());
 
             for (std::size_t i = 0; i < reverse_weight_vector.size() - data.fwd_segment_position - 1; i++)

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -24,7 +24,8 @@ struct PhantomNode
                 int reverse_weight,
                 int forward_offset,
                 int reverse_offset,
-                unsigned packed_geometry_id,
+                unsigned forward_packed_geometry_id_,
+                unsigned reverse_packed_geometry_id_,
                 bool is_tiny_component,
                 unsigned component_id,
                 util::FixedPointCoordinate location,
@@ -34,7 +35,9 @@ struct PhantomNode
         : forward_node_id(forward_node_id), reverse_node_id(reverse_node_id), name_id(name_id),
           forward_weight(forward_weight), reverse_weight(reverse_weight),
           forward_offset(forward_offset), reverse_offset(reverse_offset),
-          packed_geometry_id(packed_geometry_id), component{component_id, is_tiny_component},
+          forward_packed_geometry_id(forward_packed_geometry_id_),
+          reverse_packed_geometry_id(reverse_packed_geometry_id_),
+          component{component_id, is_tiny_component},
           location(std::move(location)), fwd_segment_position(fwd_segment_position),
           forward_travel_mode(forward_travel_mode), backward_travel_mode(backward_travel_mode)
     {
@@ -44,7 +47,9 @@ struct PhantomNode
         : forward_node_id(SPECIAL_NODEID), reverse_node_id(SPECIAL_NODEID),
           name_id(std::numeric_limits<unsigned>::max()), forward_weight(INVALID_EDGE_WEIGHT),
           reverse_weight(INVALID_EDGE_WEIGHT), forward_offset(0), reverse_offset(0),
-          packed_geometry_id(SPECIAL_EDGEID), component{INVALID_COMPONENTID, false},
+          forward_packed_geometry_id(SPECIAL_EDGEID),
+          reverse_packed_geometry_id(SPECIAL_EDGEID),
+          component{INVALID_COMPONENTID, false},
           fwd_segment_position(0), forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
@@ -89,19 +94,20 @@ struct PhantomNode
     bool operator==(const PhantomNode &other) const { return location == other.location; }
 
     template <class OtherT>
-    PhantomNode(const OtherT &other, const util::FixedPointCoordinate foot_point)
+    PhantomNode(const OtherT &other, int forward_weight_, int forward_offset_, int reverse_weight_, int reverse_offset_, const util::FixedPointCoordinate foot_point)
     {
         forward_node_id = other.forward_edge_based_node_id;
         reverse_node_id = other.reverse_edge_based_node_id;
         name_id = other.name_id;
 
-        forward_weight = other.forward_weight;
-        reverse_weight = other.reverse_weight;
+        forward_weight = forward_weight_;
+        reverse_weight = reverse_weight_;
 
-        forward_offset = other.forward_offset;
-        reverse_offset = other.reverse_offset;
+        forward_offset = forward_offset_;
+        reverse_offset = reverse_offset_;
 
-        packed_geometry_id = other.packed_geometry_id;
+        forward_packed_geometry_id = other.forward_packed_geometry_id;
+        reverse_packed_geometry_id = other.reverse_packed_geometry_id;
 
         component.id = other.component.id;
         component.is_tiny = other.component.is_tiny;
@@ -120,7 +126,8 @@ struct PhantomNode
     int reverse_weight;
     int forward_offset;
     int reverse_offset;
-    unsigned packed_geometry_id;
+    unsigned forward_packed_geometry_id;
+    unsigned reverse_packed_geometry_id;
     struct ComponentType
     {
         uint32_t id : 31;
@@ -139,7 +146,7 @@ struct PhantomNode
 };
 
 #ifndef _MSC_VER
-static_assert(sizeof(PhantomNode) == 48, "PhantomNode has more padding then expected");
+static_assert(sizeof(PhantomNode) == 52, "PhantomNode has more padding then expected");
 #endif
 
 using PhantomNodePair = std::pair<PhantomNode, PhantomNode>;
@@ -172,7 +179,8 @@ inline std::ostream &operator<<(std::ostream &out, const PhantomNode &pn)
         << "rev-w: " << pn.reverse_weight << ", "
         << "fwd-o: " << pn.forward_offset << ", "
         << "rev-o: " << pn.reverse_offset << ", "
-        << "geom: " << pn.packed_geometry_id << ", "
+        << "fwd_geom: " << pn.forward_packed_geometry_id << ", "
+        << "rev_geom: " << pn.reverse_packed_geometry_id << ", "
         << "comp: " << pn.component.is_tiny << " / " << pn.component.id << ", "
         << "pos: " << pn.fwd_segment_position << ", "
         << "loc: " << pn.location;

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 #include <stack>
+#include <numeric>
 
 namespace osrm
 {
@@ -302,9 +303,19 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 }
                 else
                 {
-                    std::vector<unsigned> id_vector;
+                    std::vector<NodeID> id_vector;
                     facade->GetUncompressedGeometry(facade->GetGeometryIndexForEdgeID(ed.id),
                                                     id_vector);
+
+                    std::vector<EdgeWeight> weight_vector;
+                    facade->GetUncompressedWeights(facade->GetGeometryIndexForEdgeID(ed.id),
+                                                   weight_vector);
+
+                    int total_weight = std::accumulate(weight_vector.begin(), weight_vector.end(), 0);
+
+                    BOOST_ASSERT(weight_vector.size() == id_vector.size());
+                    // ed.distance should be total_weight + penalties (turn, stop, etc)
+                    BOOST_ASSERT(ed.distance >= total_weight);
 
                     const std::size_t start_index =
                         (unpacked_path.empty()
@@ -320,58 +331,57 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                     for (std::size_t i = start_index; i < end_index; ++i)
                     {
                         unpacked_path.emplace_back(id_vector[i], name_index,
-                                                   extractor::TurnInstruction::NoTurn, 0,
+                                                   extractor::TurnInstruction::NoTurn, weight_vector[i],
                                                    travel_mode);
                     }
                     unpacked_path.back().turn_instruction = turn_instruction;
-                    unpacked_path.back().segment_duration = ed.distance;
+                    unpacked_path.back().segment_duration += (ed.distance - total_weight);
                 }
             }
         }
-        if (SPECIAL_EDGEID != phantom_node_pair.target_phantom.packed_geometry_id)
+        std::vector<unsigned> id_vector;
+        facade->GetUncompressedGeometry(phantom_node_pair.target_phantom.forward_packed_geometry_id,
+                                        id_vector);
+        const bool is_local_path = (phantom_node_pair.source_phantom.forward_packed_geometry_id ==
+                                    phantom_node_pair.target_phantom.forward_packed_geometry_id) &&
+                                    unpacked_path.empty();
+
+        std::cout << "Got id vector of size " << id_vector.size() << "\n";
+
+        std::size_t start_index = 0;
+        if (is_local_path)
         {
-            std::vector<unsigned> id_vector;
-            facade->GetUncompressedGeometry(phantom_node_pair.target_phantom.packed_geometry_id,
-                                            id_vector);
-            const bool is_local_path = (phantom_node_pair.source_phantom.packed_geometry_id ==
-                                        phantom_node_pair.target_phantom.packed_geometry_id) &&
-                                       unpacked_path.empty();
-
-            std::size_t start_index = 0;
-            if (is_local_path)
-            {
-                start_index = phantom_node_pair.source_phantom.fwd_segment_position;
-                if (target_traversed_in_reverse)
-                {
-                    start_index =
-                        id_vector.size() - phantom_node_pair.source_phantom.fwd_segment_position;
-                }
-            }
-
-            std::size_t end_index = phantom_node_pair.target_phantom.fwd_segment_position;
+            start_index = phantom_node_pair.source_phantom.fwd_segment_position;
             if (target_traversed_in_reverse)
             {
-                std::reverse(id_vector.begin(), id_vector.end());
-                end_index =
-                    id_vector.size() - phantom_node_pair.target_phantom.fwd_segment_position;
+                start_index =
+                    id_vector.size() - phantom_node_pair.source_phantom.fwd_segment_position;
             }
+        }
 
-            if (start_index > end_index)
-            {
-                start_index = std::min(start_index, id_vector.size() - 1);
-            }
+        std::size_t end_index = phantom_node_pair.target_phantom.fwd_segment_position;
+        if (target_traversed_in_reverse)
+        {
+            std::reverse(id_vector.begin(), id_vector.end());
+            end_index =
+                id_vector.size() - phantom_node_pair.target_phantom.fwd_segment_position;
+        }
 
-            for (std::size_t i = start_index; i != end_index; (start_index < end_index ? ++i : --i))
-            {
-                BOOST_ASSERT(i < id_vector.size());
-                BOOST_ASSERT(phantom_node_pair.target_phantom.forward_travel_mode > 0);
-                unpacked_path.emplace_back(
-                    PathData{id_vector[i], phantom_node_pair.target_phantom.name_id,
-                             extractor::TurnInstruction::NoTurn, 0,
-                             target_traversed_in_reverse
-                                 ? phantom_node_pair.target_phantom.backward_travel_mode
-                                 : phantom_node_pair.target_phantom.forward_travel_mode});
-            }
+        if (start_index > end_index)
+        {
+            start_index = std::min(start_index, id_vector.size() - 1);
+        }
+
+        for (std::size_t i = start_index; i != end_index; (start_index < end_index ? ++i : --i))
+        {
+            BOOST_ASSERT(i < id_vector.size());
+            BOOST_ASSERT(phantom_node_pair.target_phantom.forward_travel_mode > 0);
+            unpacked_path.emplace_back(
+                PathData{id_vector[i], phantom_node_pair.target_phantom.name_id,
+                         extractor::TurnInstruction::NoTurn, 0,
+                         target_traversed_in_reverse
+                             ? phantom_node_pair.target_phantom.backward_travel_mode
+                             : phantom_node_pair.target_phantom.forward_travel_mode});
         }
 
         // there is no equivalent to a node-based node in an edge-expanded graph.

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -346,8 +346,6 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                                     phantom_node_pair.target_phantom.forward_packed_geometry_id) &&
                                     unpacked_path.empty();
 
-        std::cout << "Got id vector of size " << id_vector.size() << "\n";
-
         std::size_t start_index = 0;
         if (is_local_path)
         {

--- a/include/extractor/compressed_edge_container.hpp
+++ b/include/extractor/compressed_edge_container.hpp
@@ -16,8 +16,13 @@ namespace extractor
 class CompressedEdgeContainer
 {
   public:
-    using CompressedNode = std::pair<NodeID, EdgeWeight>;
-    using EdgeBucket = std::vector<CompressedNode>;
+    struct CompressedEdge
+    {
+    public:
+        NodeID node_id;  // refers to an internal node-based-node
+        EdgeWeight weight;  // the weight of the edge leading to this node
+    };
+    using EdgeBucket = std::vector<CompressedEdge>;
 
     CompressedEdgeContainer();
     void CompressEdge(const EdgeID surviving_edge_id,
@@ -26,6 +31,10 @@ class CompressedEdgeContainer
                       const NodeID target_node,
                       const EdgeWeight weight1,
                       const EdgeWeight weight2);
+
+    void AddUncompressedEdge(const EdgeID edgei_id, 
+                             const NodeID target_node,
+                             const EdgeWeight weight);
 
     bool HasEntryForID(const EdgeID edge_id) const;
     void PrintStatistics() const;

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -43,7 +43,7 @@ class EdgeBasedGraphFactory
     EdgeBasedGraphFactory &operator=(const EdgeBasedGraphFactory &) = delete;
 
     explicit EdgeBasedGraphFactory(std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
-                                   CompressedEdgeContainer &compressed_edge_container,
+                                   const CompressedEdgeContainer &compressed_edge_container,
                                    const std::unordered_set<NodeID> &barrier_nodes,
                                    const std::unordered_set<NodeID> &traffic_lights,
                                    std::shared_ptr<const RestrictionMap> restriction_map,
@@ -99,7 +99,7 @@ class EdgeBasedGraphFactory
 
     const std::unordered_set<NodeID> &m_barrier_nodes;
     const std::unordered_set<NodeID> &m_traffic_lights;
-    CompressedEdgeContainer &m_compressed_edge_container;
+    const CompressedEdgeContainer &m_compressed_edge_container;
 
     SpeedProfileProperties speed_profile;
 

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -43,7 +43,7 @@ class EdgeBasedGraphFactory
     EdgeBasedGraphFactory &operator=(const EdgeBasedGraphFactory &) = delete;
 
     explicit EdgeBasedGraphFactory(std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
-                                   const CompressedEdgeContainer &compressed_edge_container,
+                                   CompressedEdgeContainer &compressed_edge_container,
                                    const std::unordered_set<NodeID> &barrier_nodes,
                                    const std::unordered_set<NodeID> &traffic_lights,
                                    std::shared_ptr<const RestrictionMap> restriction_map,
@@ -99,7 +99,7 @@ class EdgeBasedGraphFactory
 
     const std::unordered_set<NodeID> &m_barrier_nodes;
     const std::unordered_set<NodeID> &m_traffic_lights;
-    const CompressedEdgeContainer &m_compressed_edge_container;
+    CompressedEdgeContainer &m_compressed_edge_container;
 
     SpeedProfileProperties speed_profile;
 

--- a/include/extractor/edge_based_node.hpp
+++ b/include/extractor/edge_based_node.hpp
@@ -22,8 +22,8 @@ struct EdgeBasedNode
     EdgeBasedNode()
         : forward_edge_based_node_id(SPECIAL_NODEID), reverse_edge_based_node_id(SPECIAL_NODEID),
           u(SPECIAL_NODEID), v(SPECIAL_NODEID), name_id(0),
-          forward_weight(INVALID_EDGE_WEIGHT >> 1), reverse_weight(INVALID_EDGE_WEIGHT >> 1),
-          forward_offset(0), reverse_offset(0), packed_geometry_id(SPECIAL_EDGEID),
+          forward_packed_geometry_id(SPECIAL_EDGEID),
+          reverse_packed_geometry_id(SPECIAL_EDGEID),
           component{INVALID_COMPONENTID, false},
           fwd_segment_position(std::numeric_limits<unsigned short>::max()),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
@@ -36,11 +36,8 @@ struct EdgeBasedNode
                            NodeID u,
                            NodeID v,
                            unsigned name_id,
-                           int forward_weight,
-                           int reverse_weight,
-                           int forward_offset,
-                           int reverse_offset,
-                           unsigned packed_geometry_id,
+                           unsigned forward_weight_or_packed_geometry_id_,
+                           unsigned reverse_weight_or_packed_geometry_id_,
                            bool is_tiny_component,
                            unsigned component_id,
                            unsigned short fwd_segment_position,
@@ -48,9 +45,9 @@ struct EdgeBasedNode
                            TravelMode backward_travel_mode)
         : forward_edge_based_node_id(forward_edge_based_node_id),
           reverse_edge_based_node_id(reverse_edge_based_node_id), u(u), v(v), name_id(name_id),
-          forward_weight(forward_weight), reverse_weight(reverse_weight),
-          forward_offset(forward_offset), reverse_offset(reverse_offset),
-          packed_geometry_id(packed_geometry_id), component{component_id, is_tiny_component},
+          forward_packed_geometry_id(forward_weight_or_packed_geometry_id_),
+          reverse_packed_geometry_id(reverse_weight_or_packed_geometry_id_),
+          component{component_id, is_tiny_component},
           fwd_segment_position(fwd_segment_position), forward_travel_mode(forward_travel_mode),
           backward_travel_mode(backward_travel_mode)
     {
@@ -68,18 +65,14 @@ struct EdgeBasedNode
         return centroid;
     }
 
-    bool IsCompressed() const { return packed_geometry_id != SPECIAL_EDGEID; }
-
     NodeID forward_edge_based_node_id; // needed for edge-expanded graph
     NodeID reverse_edge_based_node_id; // needed for edge-expanded graph
     NodeID u;                          // indices into the coordinates array
     NodeID v;                          // indices into the coordinates array
     unsigned name_id;                  // id of the edge name
-    int forward_weight;                // weight of the edge
-    int reverse_weight;                // weight in the other direction (may be different)
-    int forward_offset;          // prefix sum of the weight up the edge TODO: short must suffice
-    int reverse_offset;          // prefix sum of the weight from the edge TODO: short must suffice
-    unsigned packed_geometry_id; // if set, then the edge represents a packed geometry
+
+    unsigned forward_packed_geometry_id;
+    unsigned reverse_packed_geometry_id;
     struct
     {
         unsigned id : 31;

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -59,6 +59,13 @@ class StaticRTree
         std::uint32_t children[BRANCHING_FACTOR];
     };
 
+    struct LeafNode
+    {
+        LeafNode() : object_count(0), objects() {}
+        uint32_t object_count;
+        std::array<EdgeDataT, LEAF_NODE_SIZE> objects;
+    };
+
   private:
     struct WrappedInputElement
     {
@@ -77,13 +84,6 @@ class StaticRTree
         {
             return m_hilbert_value < other.m_hilbert_value;
         }
-    };
-
-    struct LeafNode
-    {
-        LeafNode() : object_count(0), objects() {}
-        std::uint32_t object_count;
-        std::array<EdgeDataT, LEAF_NODE_SIZE> objects;
     };
 
     using QueryNodeType = mapbox::util::variant<TreeNode, EdgeDataT>;

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -3,8 +3,7 @@
 #include "extractor/edge_based_node.hpp"
 #include "engine/geospatial_query.hpp"
 #include "util/timing_util.hpp"
-#include "engine/datafacade/datafacade_base.hpp"
-#include "contractor/query_edge.hpp"
+#include "mocks/mock_datafacade.hpp"
 
 #include "osrm/coordinate.hpp"
 
@@ -16,83 +15,7 @@ namespace osrm
 namespace benchmarks
 {
 
-template <class EdgeDataT> class MockDataFacadeT final : public osrm::engine::datafacade::BaseDataFacade<EdgeDataT>
-{
-    private:
-        EdgeDataT foo;
-    public:
-    unsigned GetNumberOfNodes() const { return 0; }
-    unsigned GetNumberOfEdges() const { return 0; }
-    unsigned GetOutDegree(const NodeID /* n */) const { return 0; }
-    NodeID GetTarget(const EdgeID /* e */) const { return SPECIAL_NODEID; }
-    const EdgeDataT &GetEdgeData(const EdgeID /* e */) const { 
-        return foo;
-    }
-    EdgeID BeginEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
-    EdgeID EndEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
-    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const {
-        return util::irange(static_cast<EdgeID>(0),static_cast<EdgeID>(0));
-    }
-    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
-    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
-    EdgeID
-    FindEdgeIndicateIfReverse(const NodeID /* from */, const NodeID /* to */, bool & /* result */) const { return SPECIAL_EDGEID; }
-    util::FixedPointCoordinate GetCoordinateOfNode(const unsigned /* id */) const {
-        FixedPointCoordinate foo(0,0);
-        return foo;
-    }
-    bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
-    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const { return SPECIAL_NODEID; }
-    void GetUncompressedGeometry(const EdgeID /* id */,
-                                         std::vector<NodeID> &/* result_nodes */) const {}
-    void GetUncompressedWeights(const EdgeID /* id */,
-                                         std::vector<EdgeWeight> & /* result_weights */) const {}
-    extractor::TurnInstruction GetTurnInstructionForEdgeID(const unsigned /* id */) const {
-        return osrm::extractor::TurnInstruction::NoTurn;
-    }
-    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const 
-    {
-        return TRAVEL_MODE_DEFAULT;
-    }
-    std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> GetEdgesInBox(const util::FixedPointCoordinate & /* south_west */,
-                                                 const util::FixedPointCoordinate & /*north_east */) {
-        std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> foo;
-        return foo;
-    }
-    std::vector<osrm::engine::PhantomNodeWithDistance>
-    NearestPhantomNodesInRange(const util::FixedPointCoordinate /* input_coordinate */,
-                               const float /* max_distance */,
-                               const int /* bearing = 0 */,
-                               const int /* bearing_range = 180 */) {
-        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
-        return foo;
-    }
-    std::vector<osrm::engine::PhantomNodeWithDistance>
-    NearestPhantomNodes(const util::FixedPointCoordinate /* input_coordinate */,
-                        const unsigned /* max_results */,
-                        const int /* bearing = 0 */,
-                        const int /* bearing_range = 180 */) {
-        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
-        return foo;
-    }
-    std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::FixedPointCoordinate /* input_coordinate */,
-        const int /* bearing = 0 */,
-        const int /* bearing_range = 180 */) {
-        std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> foo;
-        return foo;
-    }
-    unsigned GetCheckSum() const { return 0; }
-    bool IsCoreNode(const NodeID /* id */) const { return false; }
-    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const { return 0; }
-    std::string get_name_for_id(const unsigned /* name_id */) const { return ""; }
-    std::size_t GetCoreSize() const { return 0; }
-    std::string GetTimestamp() const { return ""; }
-
-};
-
-using MockDataFacade = MockDataFacadeT<contractor::QueryEdge::EdgeData>;
-
+using namespace osrm::test;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 13;

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -3,6 +3,8 @@
 #include "extractor/edge_based_node.hpp"
 #include "engine/geospatial_query.hpp"
 #include "util/timing_util.hpp"
+#include "engine/datafacade/datafacade_base.hpp"
+#include "contractor/query_edge.hpp"
 
 #include "osrm/coordinate.hpp"
 
@@ -13,6 +15,84 @@ namespace osrm
 {
 namespace benchmarks
 {
+
+template <class EdgeDataT> class MockDataFacadeT final : public osrm::engine::datafacade::BaseDataFacade<EdgeDataT>
+{
+    private:
+        EdgeDataT foo;
+    public:
+    unsigned GetNumberOfNodes() const { return 0; }
+    unsigned GetNumberOfEdges() const { return 0; }
+    unsigned GetOutDegree(const NodeID /* n */) const { return 0; }
+    NodeID GetTarget(const EdgeID /* e */) const { return SPECIAL_NODEID; }
+    const EdgeDataT &GetEdgeData(const EdgeID /* e */) const { 
+        return foo;
+    }
+    EdgeID BeginEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
+    EdgeID EndEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
+    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const {
+        return util::irange(static_cast<EdgeID>(0),static_cast<EdgeID>(0));
+    }
+    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
+    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
+    EdgeID
+    FindEdgeIndicateIfReverse(const NodeID /* from */, const NodeID /* to */, bool & /* result */) const { return SPECIAL_EDGEID; }
+    util::FixedPointCoordinate GetCoordinateOfNode(const unsigned /* id */) const {
+        FixedPointCoordinate foo(0,0);
+        return foo;
+    }
+    bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
+    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const { return SPECIAL_NODEID; }
+    void GetUncompressedGeometry(const EdgeID /* id */,
+                                         std::vector<NodeID> &/* result_nodes */) const {}
+    void GetUncompressedWeights(const EdgeID /* id */,
+                                         std::vector<EdgeWeight> & /* result_weights */) const {}
+    extractor::TurnInstruction GetTurnInstructionForEdgeID(const unsigned /* id */) const {
+        return osrm::extractor::TurnInstruction::NoTurn;
+    }
+    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const 
+    {
+        return TRAVEL_MODE_DEFAULT;
+    }
+    std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> GetEdgesInBox(const util::FixedPointCoordinate & /* south_west */,
+                                                 const util::FixedPointCoordinate & /*north_east */) {
+        std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> foo;
+        return foo;
+    }
+    std::vector<osrm::engine::PhantomNodeWithDistance>
+    NearestPhantomNodesInRange(const util::FixedPointCoordinate /* input_coordinate */,
+                               const float /* max_distance */,
+                               const int /* bearing = 0 */,
+                               const int /* bearing_range = 180 */) {
+        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
+        return foo;
+    }
+    std::vector<osrm::engine::PhantomNodeWithDistance>
+    NearestPhantomNodes(const util::FixedPointCoordinate /* input_coordinate */,
+                        const unsigned /* max_results */,
+                        const int /* bearing = 0 */,
+                        const int /* bearing_range = 180 */) {
+        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
+        return foo;
+    }
+    std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
+        const util::FixedPointCoordinate /* input_coordinate */,
+        const int /* bearing = 0 */,
+        const int /* bearing_range = 180 */) {
+        std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> foo;
+        return foo;
+    }
+    unsigned GetCheckSum() const { return 0; }
+    bool IsCoreNode(const NodeID /* id */) const { return false; }
+    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const { return 0; }
+    std::string get_name_for_id(const unsigned /* name_id */) const { return ""; }
+    std::size_t GetCoreSize() const { return 0; }
+    std::string GetTimestamp() const { return ""; }
+
+};
+
+using MockDataFacade = MockDataFacadeT<contractor::QueryEdge::EdgeData>;
+
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 13;
@@ -25,7 +105,7 @@ using RTreeLeaf = extractor::EdgeBasedNode;
 using FixedPointCoordinateListPtr = std::shared_ptr<std::vector<util::FixedPointCoordinate>>;
 using BenchStaticRTree =
     util::StaticRTree<RTreeLeaf, util::ShM<util::FixedPointCoordinate, false>::vector, false>;
-using BenchQuery = engine::GeospatialQuery<BenchStaticRTree>;
+using BenchQuery = engine::GeospatialQuery<BenchStaticRTree, MockDataFacade>;
 
 FixedPointCoordinateListPtr loadCoordinates(const boost::filesystem::path &nodes_file)
 {
@@ -128,7 +208,8 @@ int main(int argc, char **argv)
     auto coords = osrm::benchmarks::loadCoordinates(nodes_path);
 
     osrm::benchmarks::BenchStaticRTree rtree(ram_path, file_path, coords);
-    osrm::benchmarks::BenchQuery query(rtree, coords);
+    std::unique_ptr<osrm::benchmarks::MockDataFacade> mockfacade_ptr(new osrm::benchmarks::MockDataFacade);
+    osrm::benchmarks::BenchQuery query(rtree, coords, *mockfacade_ptr);
 
     osrm::benchmarks::benchmark(rtree, query, 10000);
 

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -2,6 +2,9 @@
 #include "contractor/graph_contractor.hpp"
 
 #include "extractor/edge_based_edge.hpp"
+#include "extractor/compressed_edge_container.hpp"
+
+#include "util/static_rtree.hpp"
 
 #include "util/deallocating_vector.hpp"
 
@@ -31,6 +34,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <iterator>
 
 namespace std
 {
@@ -74,8 +78,10 @@ int Contractor::Run()
     util::DeallocatingVector<extractor::EdgeBasedEdge> edge_based_edge_list;
 
     std::size_t max_edge_id = LoadEdgeExpandedGraph(
-        config.edge_based_graph_path, edge_based_edge_list, config.edge_segment_lookup_path,
-        config.edge_penalty_path, config.segment_speed_lookup_path);
+        config.edge_based_graph_path, edge_based_edge_list, 
+        config.edge_segment_lookup_path, config.edge_penalty_path, 
+        config.segment_speed_lookup_path, config.node_based_graph_path,
+        config.geometry_path, config.rtree_leaf_path);
 
     // Contracting the edge-expanded graph
 
@@ -130,7 +136,10 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
     util::DeallocatingVector<extractor::EdgeBasedEdge> &edge_based_edge_list,
     const std::string &edge_segment_lookup_filename,
     const std::string &edge_penalty_filename,
-    const std::string &segment_speed_filename)
+    const std::string &segment_speed_filename,
+    const std::string &nodes_filename,
+    const std::string &geometry_filename,
+    const std::string &rtree_leaf_filename)
 {
     util::SimpleLogger().Write() << "Opening " << edge_based_graph_filename;
     boost::filesystem::ifstream input_stream(edge_based_graph_filename, std::ios::binary);
@@ -184,6 +193,170 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
             segment_speed_lookup[std::make_pair(OSMNodeID(from_node_id), OSMNodeID(to_node_id))] =
                 speed;
         }
+
+        std::vector<extractor::QueryNode> internal_to_external_node_map;
+
+        // Here, we have to update the compressed geometry weights
+        // First, we need the external-to-internal node lookup table
+        {
+            boost::filesystem::ifstream nodes_input_stream(nodes_filename, std::ios::binary);
+
+            if (!nodes_input_stream)
+            {
+                throw util::exception("Failed to open "+nodes_filename);
+            }
+
+            unsigned number_of_nodes = 0;
+            nodes_input_stream.read((char *)&number_of_nodes, sizeof(unsigned));
+            internal_to_external_node_map.resize(number_of_nodes);
+
+            // Load all the query nodes into a vector
+            nodes_input_stream.read(reinterpret_cast<char *>(&(internal_to_external_node_map[0])), number_of_nodes * sizeof(extractor::QueryNode));
+            nodes_input_stream.close();
+        }
+
+        std::vector<unsigned> m_geometry_indices;
+        std::vector<extractor::CompressedEdgeContainer::CompressedEdge> m_geometry_list;
+
+        {
+            std::ifstream geometry_stream(geometry_filename, std::ios::binary);
+            if (!geometry_stream)
+            {
+                throw util::exception("Failed to open "+geometry_filename);
+            }
+            unsigned number_of_indices = 0;
+            unsigned number_of_compressed_geometries = 0;
+
+            geometry_stream.read((char *)&number_of_indices, sizeof(unsigned));
+
+            m_geometry_indices.resize(number_of_indices);
+            if (number_of_indices > 0)
+            {
+                geometry_stream.read((char *)&(m_geometry_indices[0]),
+                                    number_of_indices * sizeof(unsigned));
+            }
+
+            geometry_stream.read((char *)&number_of_compressed_geometries, sizeof(unsigned));
+
+            BOOST_ASSERT(m_geometry_indices.back() == number_of_compressed_geometries);
+            m_geometry_list.resize(number_of_compressed_geometries);
+    
+            if (number_of_compressed_geometries > 0)
+            {
+                geometry_stream.read((char *)&(m_geometry_list[0]),
+                                    number_of_compressed_geometries * sizeof(extractor::CompressedEdgeContainer::CompressedEdge));
+            }
+            geometry_stream.close();
+        }
+
+        // Now, we iterate over all the segments stored in the StaticRTree, updating
+        // the packed geometry weights in the `.geometries` file (note: we do not
+        // update the RTree itself, we just use the leaf nodes to iterate over all segments)
+        {
+
+            using LeafNode = util::StaticRTree<extractor::EdgeBasedNode>::LeafNode;
+
+            // Open file for reading *and* writing
+            std::ifstream leaf_node_file(rtree_leaf_filename, std::ios::binary | std::ios::in);
+            if (!leaf_node_file)
+            {
+                throw util::exception("Failed to open "+rtree_leaf_filename);
+            }
+            uint64_t m_element_count;
+            leaf_node_file.read((char *)&m_element_count, sizeof(uint64_t));
+
+            LeafNode current_node;
+            while (m_element_count > 0)
+            {
+                leaf_node_file.read(reinterpret_cast<char *>(&current_node), sizeof(current_node));
+
+                for (size_t i=0; i< current_node.object_count; i++)
+                {
+                    auto & leaf_object = current_node.objects[i];
+                    extractor::QueryNode *u;
+                    extractor::QueryNode *v;
+
+                    if (leaf_object.forward_packed_geometry_id != SPECIAL_EDGEID)
+                    {
+                        const unsigned forward_begin = m_geometry_indices.at(leaf_object.forward_packed_geometry_id);
+
+                        if (leaf_object.fwd_segment_position == 0)
+                        {
+                            u = &(internal_to_external_node_map[leaf_object.u]);
+                            v = &(internal_to_external_node_map[m_geometry_list[forward_begin].node_id]);
+                        }
+                        else
+                        {
+                            u = &(internal_to_external_node_map[m_geometry_list[forward_begin + leaf_object.fwd_segment_position - 1].node_id]);
+                            v = &(internal_to_external_node_map[m_geometry_list[forward_begin + leaf_object.fwd_segment_position].node_id]);
+                        }
+                        const double segment_length =
+                                util::coordinate_calculation::greatCircleDistance(
+                                        u->lat, u->lon, v->lat, v->lon);
+
+                        auto forward_speed_iter = segment_speed_lookup.find(std::make_pair(u->node_id, v->node_id));
+                        if (forward_speed_iter != segment_speed_lookup.end())
+                        {
+                            int new_segment_weight =
+                                std::max(1, static_cast<int>(std::floor(
+                                            (segment_length * 10.) / (forward_speed_iter->second / 3.6) + .5)));
+                            m_geometry_list[forward_begin + leaf_object.fwd_segment_position].weight = new_segment_weight;
+                        }
+                    }
+                    if (leaf_object.reverse_packed_geometry_id != SPECIAL_EDGEID)
+                    {
+                        const unsigned reverse_begin = m_geometry_indices.at(leaf_object.reverse_packed_geometry_id);
+                        const unsigned reverse_end = m_geometry_indices.at(leaf_object.reverse_packed_geometry_id + 1);
+
+                        int rev_segment_position = (reverse_end - reverse_begin) - leaf_object.fwd_segment_position - 1;
+                        if (rev_segment_position == 0)
+                        {
+                            u = &(internal_to_external_node_map[leaf_object.v]);
+                            v = &(internal_to_external_node_map[m_geometry_list[reverse_begin].node_id]);
+                        }
+                        else
+                        {
+                            u = &(internal_to_external_node_map[m_geometry_list[reverse_begin + rev_segment_position - 1].node_id]);
+                            v = &(internal_to_external_node_map[m_geometry_list[reverse_begin + rev_segment_position].node_id]);
+                        }
+                        const double segment_length =
+                                util::coordinate_calculation::greatCircleDistance(
+                                        u->lat, u->lon, v->lat, v->lon);
+
+                        auto reverse_speed_iter = segment_speed_lookup.find(std::make_pair(u->node_id, v->node_id));
+                        if (reverse_speed_iter != segment_speed_lookup.end())
+                        {
+                            int new_segment_weight =
+                                std::max(1, static_cast<int>(std::floor(
+                                            (segment_length * 10.) / (reverse_speed_iter->second / 3.6) + .5)));
+                            m_geometry_list[reverse_begin + rev_segment_position].weight = new_segment_weight;
+                        }
+                    }
+                }
+                m_element_count -= current_node.object_count;
+
+            }
+            leaf_node_file.close();
+
+        }
+        
+        // Now save out the updated compressed geometries
+        {
+            std::ofstream geometry_stream(geometry_filename, std::ios::binary);
+            if (!geometry_stream)
+            {
+                throw util::exception("Failed to open "+geometry_filename+" for writing");
+            }
+            const unsigned number_of_indices = m_geometry_indices.size();
+            const unsigned number_of_compressed_geometries = m_geometry_list.size();
+            geometry_stream.write(reinterpret_cast<const char *>(&number_of_indices), sizeof(unsigned));
+            geometry_stream.write(reinterpret_cast<char *>(&(m_geometry_indices[0])), number_of_indices * sizeof(unsigned));
+            geometry_stream.write(reinterpret_cast<const char *>(&number_of_compressed_geometries), sizeof(unsigned));
+            geometry_stream.write(reinterpret_cast<char *>(&(m_geometry_list[0])), number_of_compressed_geometries * sizeof(extractor::CompressedEdgeContainer::CompressedEdge));
+            geometry_stream.close();
+        }
+
+
     }
 
     // TODO: can we read this in bulk?  util::DeallocatingVector isn't necessarily

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -189,9 +189,6 @@ void CompressedEdgeContainer::AddUncompressedEdge(const EdgeID edge_id,
     BOOST_ASSERT(SPECIAL_NODEID != target_node_id);
     BOOST_ASSERT(INVALID_EDGE_WEIGHT != weight);
 
-    // There should be no entry for uncompressed edges
-    BOOST_ASSERT(!HasEntryForID(edge_id));
-
     // Add via node id. List is created if it does not exist
     if (!HasEntryForID(edge_id))
     {
@@ -215,10 +212,9 @@ void CompressedEdgeContainer::AddUncompressedEdge(const EdgeID edge_id,
 
     std::vector<CompressedEdge> &edge_bucket_list = m_compressed_geometries[edge_bucket_id];
 
-    // We're adding uncompressed edges, there should be no entry
-    BOOST_ASSERT(edge_bucket_list.empty());
     // note we don't save the start coordinate: it is implicitly given by edge_id
     // weight is the distance to the (currently) last coordinate in the bucket
+    // Don't re-add this if it's already in there.
     if (edge_bucket_list.empty())
     {
         edge_bucket_list.emplace_back(CompressedEdge { target_node_id, weight });

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -45,7 +45,7 @@ const double constexpr DESIRED_SEGMENT_LENGTH = 10.;
 
 EdgeBasedGraphFactory::EdgeBasedGraphFactory(
     std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
-    CompressedEdgeContainer &compressed_edge_container,
+    const CompressedEdgeContainer &compressed_edge_container,
     const std::unordered_set<NodeID> &barrier_nodes,
     const std::unordered_set<NodeID> &traffic_lights,
     std::shared_ptr<const RestrictionMap> restriction_map,
@@ -127,7 +127,8 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_1));
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_2));
     const auto &forward_geometry = m_compressed_edge_container.GetBucketReference(edge_id_1);
-    BOOST_ASSERT(forward_geometry.size() == m_compressed_edge_container.GetBucketReference(edge_id_2).size());
+    BOOST_ASSERT(forward_geometry.size() ==
+                 m_compressed_edge_container.GetBucketReference(edge_id_2).size());
     const unsigned geometry_size = static_cast<unsigned>(forward_geometry.size());
 
     // There should always be some geometry
@@ -149,10 +150,10 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
             // build edges
             m_edge_based_node_list.emplace_back(
                 forward_data.edge_id, reverse_data.edge_id, current_edge_source_coordinate_id,
-                current_edge_target_coordinate_id, forward_data.name_id, 
+                current_edge_target_coordinate_id, forward_data.name_id,
                 m_compressed_edge_container.GetPositionForID(edge_id_1),
-                m_compressed_edge_container.GetPositionForID(edge_id_2),
-                false, INVALID_COMPONENTID, i, forward_data.travel_mode, reverse_data.travel_mode);
+                m_compressed_edge_container.GetPositionForID(edge_id_2), false, INVALID_COMPONENTID,
+                i, forward_data.travel_mode, reverse_data.travel_mode);
 
             m_edge_based_node_is_startpoint.push_back(forward_data.startpoint ||
                                                       reverse_data.startpoint);
@@ -194,8 +195,8 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
         m_edge_based_node_list.emplace_back(
             forward_data.edge_id, reverse_data.edge_id, node_u, node_v, forward_data.name_id,
             m_compressed_edge_container.GetPositionForID(edge_id_1),
-            m_compressed_edge_container.GetPositionForID(edge_id_2),
-            false, INVALID_COMPONENTID, 0, forward_data.travel_mode, reverse_data.travel_mode);
+            m_compressed_edge_container.GetPositionForID(edge_id_2), false, INVALID_COMPONENTID, 0,
+            forward_data.travel_mode, reverse_data.travel_mode);
         m_edge_based_node_is_startpoint.push_back(forward_data.startpoint ||
                                                   reverse_data.startpoint);
     }
@@ -745,8 +746,8 @@ bool EdgeBasedGraphFactory::isObviousChoice(EdgeID via_eid,
 
     const auto &candidate_to_the_right = turn_candidates[getRight(turn_index)];
 
-    const auto hasValidRatio =
-        [](const TurnCandidate &left, const TurnCandidate &center, const TurnCandidate &right)
+    const auto hasValidRatio = [](const TurnCandidate &left, const TurnCandidate &center,
+                                  const TurnCandidate &right)
     {
         auto angle_left = (left.angle > 180) ? angularDeviation(left.angle, STRAIGHT_ANGLE) : 180;
         auto angle_right =
@@ -1080,9 +1081,9 @@ QueryNode EdgeBasedGraphFactory::getRepresentativeCoordinate(const NodeID src,
         double this_dist = 0;
         NodeID prev_id = INVERTED ? tgt : src;
 
-        const auto selectBestCandidate =
-            [this](const NodeID current, const double current_distance, const NodeID previous,
-                   const double previous_distance)
+        const auto selectBestCandidate = [this](const NodeID current, const double current_distance,
+                                                const NodeID previous,
+                                                const double previous_distance)
         {
             if (current_distance < DESIRED_SEGMENT_LENGTH ||
                 current_distance - DESIRED_SEGMENT_LENGTH <

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -127,14 +127,18 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_1));
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_2));
     const auto &forward_geometry = m_compressed_edge_container.GetBucketReference(edge_id_1);
-    const auto &reverse_geometry = m_compressed_edge_container.GetBucketReference(edge_id_2);
-    BOOST_ASSERT(forward_geometry.size() == reverse_geometry.size());
-    BOOST_ASSERT(0 != forward_geometry.size());
     const unsigned geometry_size = static_cast<unsigned>(forward_geometry.size());
 
+    // There should always be some geometry
+    BOOST_ASSERT(0 != geometry_size);
+
+    // If there is more than one, this is a compressed geometry
     if (geometry_size > 1)
     {
         NodeID current_edge_source_coordinate_id = node_u;
+
+        const auto &reverse_geometry = m_compressed_edge_container.GetBucketReference(edge_id_2);
+        BOOST_ASSERT(forward_geometry.size() == reverse_geometry.size());
 
         // traverse arrays from start and end respectively
         for (const auto i : util::irange(0u, geometry_size))
@@ -165,10 +169,9 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
 
         BOOST_ASSERT(current_edge_source_coordinate_id == node_v);
     }
+    // Otherwise, it's an uncompressed (single-segment) geometry
     else
     {
-        //BOOST_ASSERT(!m_compressed_edge_container.HasEntryForID(edge_id_2));
-
         if (forward_data.edge_id != SPECIAL_NODEID)
         {
             BOOST_ASSERT(!forward_data.reversed);
@@ -189,9 +192,6 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
 
         BOOST_ASSERT(forward_data.edge_id != SPECIAL_NODEID ||
                      reverse_data.edge_id != SPECIAL_NODEID);
-
-        //m_compressed_edge_container.AddUncompressedEdge(edge_id_1, node_v, forward_data.distance);
-        //m_compressed_edge_container.AddUncompressedEdge(edge_id_2, node_u, reverse_data.distance);
 
         m_edge_based_node_list.emplace_back(
             forward_data.edge_id, reverse_data.edge_id, node_u, node_v, forward_data.name_id,

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -124,43 +124,16 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
 
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_1) ==
                  m_compressed_edge_container.HasEntryForID(edge_id_2));
-    if (m_compressed_edge_container.HasEntryForID(edge_id_1))
+    BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_1));
+    BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_2));
+    const auto &forward_geometry = m_compressed_edge_container.GetBucketReference(edge_id_1);
+    const auto &reverse_geometry = m_compressed_edge_container.GetBucketReference(edge_id_2);
+    BOOST_ASSERT(forward_geometry.size() == reverse_geometry.size());
+    BOOST_ASSERT(0 != forward_geometry.size());
+    const unsigned geometry_size = static_cast<unsigned>(forward_geometry.size());
+
+    if (geometry_size > 1)
     {
-        BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_2));
-
-        // reconstruct geometry and put in each individual edge with its offset
-        const auto &forward_geometry = m_compressed_edge_container.GetBucketReference(edge_id_1);
-        const auto &reverse_geometry = m_compressed_edge_container.GetBucketReference(edge_id_2);
-        BOOST_ASSERT(forward_geometry.size() == reverse_geometry.size());
-        BOOST_ASSERT(0 != forward_geometry.size());
-        const unsigned geometry_size = static_cast<unsigned>(forward_geometry.size());
-        BOOST_ASSERT(geometry_size > 1);
-
-        // reconstruct bidirectional edge with individual weights and put each into the NN index
-
-        std::vector<int> forward_offsets(forward_geometry.size(), 0);
-        std::vector<int> reverse_offsets(reverse_geometry.size(), 0);
-
-        // quick'n'dirty prefix sum as std::partial_sum needs addtional casts
-        // TODO: move to lambda function with C++11
-        int temp_sum = 0;
-
-        for (const auto i : util::irange(0u, geometry_size))
-        {
-            forward_offsets[i] = temp_sum;
-            temp_sum += forward_geometry[i].weight;
-
-            BOOST_ASSERT(forward_data.distance >= temp_sum);
-        }
-
-        temp_sum = 0;
-        for (const auto i : util::irange(0u, geometry_size))
-        {
-            temp_sum += reverse_geometry[reverse_geometry.size() - 1 - i].weight;
-            reverse_offsets[i] = reverse_data.distance - temp_sum;
-            // BOOST_ASSERT(reverse_data.distance >= temp_sum);
-        }
-
         NodeID current_edge_source_coordinate_id = node_u;
 
         // traverse arrays from start and end respectively
@@ -194,7 +167,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     }
     else
     {
-        BOOST_ASSERT(!m_compressed_edge_container.HasEntryForID(edge_id_2));
+        //BOOST_ASSERT(!m_compressed_edge_container.HasEntryForID(edge_id_2));
 
         if (forward_data.edge_id != SPECIAL_NODEID)
         {
@@ -217,8 +190,8 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
         BOOST_ASSERT(forward_data.edge_id != SPECIAL_NODEID ||
                      reverse_data.edge_id != SPECIAL_NODEID);
 
-        m_compressed_edge_container.AddUncompressedEdge(edge_id_1, node_v, forward_data.distance);
-        m_compressed_edge_container.AddUncompressedEdge(edge_id_2, node_u, reverse_data.distance);
+        //m_compressed_edge_container.AddUncompressedEdge(edge_id_1, node_v, forward_data.distance);
+        //m_compressed_edge_container.AddUncompressedEdge(edge_id_2, node_u, reverse_data.distance);
 
         m_edge_based_node_list.emplace_back(
             forward_data.edge_id, reverse_data.edge_id, node_u, node_v, forward_data.name_id,

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -127,6 +127,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_1));
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_2));
     const auto &forward_geometry = m_compressed_edge_container.GetBucketReference(edge_id_1);
+    BOOST_ASSERT(forward_geometry.size() == m_compressed_edge_container.GetBucketReference(edge_id_2).size());
     const unsigned geometry_size = static_cast<unsigned>(forward_geometry.size());
 
     // There should always be some geometry
@@ -136,9 +137,6 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     if (geometry_size > 1)
     {
         NodeID current_edge_source_coordinate_id = node_u;
-
-        const auto &reverse_geometry = m_compressed_edge_container.GetBucketReference(edge_id_2);
-        BOOST_ASSERT(forward_geometry.size() == reverse_geometry.size());
 
         // traverse arrays from start and end respectively
         for (const auto i : util::irange(0u, geometry_size))

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -263,13 +263,13 @@ int Extractor::run()
 
         TIMER_START(expansion);
 
-        std::vector<EdgeBasedNode> node_based_edge_list;
+        std::vector<EdgeBasedNode> edge_based_node_list;
         util::DeallocatingVector<EdgeBasedEdge> edge_based_edge_list;
         std::vector<bool> node_is_startpoint;
         std::vector<EdgeWeight> edge_based_node_weights;
         std::vector<QueryNode> internal_to_external_node_map;
         auto graph_size = BuildEdgeExpandedGraph(internal_to_external_node_map,
-                                                 node_based_edge_list, node_is_startpoint,
+                                                 edge_based_node_list, node_is_startpoint,
                                                  edge_based_node_weights, edge_based_edge_list);
 
         auto number_of_node_based_nodes = graph_size.first;
@@ -288,9 +288,9 @@ int Extractor::run()
         util::SimpleLogger().Write() << "building r-tree ...";
         TIMER_START(rtree);
 
-        FindComponents(max_edge_id, edge_based_edge_list, node_based_edge_list);
+        FindComponents(max_edge_id, edge_based_edge_list, edge_based_node_list);
 
-        BuildRTree(std::move(node_based_edge_list), std::move(node_is_startpoint),
+        BuildRTree(std::move(edge_based_node_list), std::move(node_is_startpoint),
                    internal_to_external_node_map);
 
         TIMER_STOP(rtree);

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -522,7 +522,6 @@ Extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
         std::const_pointer_cast<RestrictionMap const>(restriction_map),
         internal_to_external_node_map, speed_profile);
 
-    compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
 
     edge_based_graph_factory.Run(config.edge_output_path, lua_state,
                                  config.edge_segment_lookup_path, config.edge_penalty_path,
@@ -532,6 +531,12 @@ Extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
                                  config.debug_turns_path
 #endif
                                  );
+
+    // Note: this needs to be done *after* the edge-based-graph-factory runs,
+    // becase it will insert all the uncompressable segments into the compressed
+    // edge container (necessary for later use)
+    compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
+
     lua_close(lua_state);
 
     edge_based_graph_factory.GetEdgeBasedEdges(edge_based_edge_list);

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -517,11 +517,12 @@ Extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
     graph_compressor.Compress(barrier_nodes, traffic_lights, *restriction_map, *node_based_graph,
                               compressed_edge_container);
 
+    compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
+
     EdgeBasedGraphFactory edge_based_graph_factory(
         node_based_graph, compressed_edge_container, barrier_nodes, traffic_lights,
         std::const_pointer_cast<RestrictionMap const>(restriction_map),
         internal_to_external_node_map, speed_profile);
-
 
     edge_based_graph_factory.Run(config.edge_output_path, lua_state,
                                  config.edge_segment_lookup_path, config.edge_penalty_path,
@@ -531,11 +532,6 @@ Extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
                                  config.debug_turns_path
 #endif
                                  );
-
-    // Note: this needs to be done *after* the edge-based-graph-factory runs,
-    // becase it will insert all the uncompressable segments into the compressed
-    // edge container (necessary for later use)
-    compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
 
     lua_close(lua_state);
 

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -166,6 +166,20 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
     }
 
     PrintStatistics(original_number_of_nodes, original_number_of_edges, graph);
+
+    // Repeate the loop, but now add all edges as uncompressed values.
+    // The function AddUncompressedEdge does nothing if the edge is already
+    // in the CompressedEdgeContainer.
+    for (const NodeID node_u : util::irange(0u, original_number_of_nodes))
+    {
+        for (const auto edge_id : util::irange(graph.BeginEdges(node_u), graph.EndEdges(node_u)))
+        {
+            const EdgeData &data = graph.GetEdgeData(edge_id);
+            const NodeID target = graph.GetTarget(edge_id);
+            geometry_compressor.AddUncompressedEdge(edge_id, target, data.distance);
+        }
+    }
+
 }
 
 void GraphCompressor::PrintStatistics(unsigned original_number_of_nodes,

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -2,6 +2,7 @@
 #include "util/range_table.hpp"
 #include "contractor/query_edge.hpp"
 #include "extractor/query_node.hpp"
+#include "extractor/compressed_edge_container.hpp"
 #include "util/shared_memory_vector_wrapper.hpp"
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
@@ -326,7 +327,7 @@ int Storage::Run()
     boost::iostreams::seek(geometry_input_stream, number_of_geometries_indices * sizeof(unsigned),
                            BOOST_IOS::cur);
     geometry_input_stream.read((char *)&number_of_compressed_geometries, sizeof(unsigned));
-    shared_layout_ptr->SetBlockSize<unsigned>(SharedDataLayout::GEOMETRIES_LIST,
+    shared_layout_ptr->SetBlockSize<extractor::CompressedEdgeContainer::CompressedEdge>(SharedDataLayout::GEOMETRIES_LIST,
                                               number_of_compressed_geometries);
     // allocate shared memory block
     util::SimpleLogger().Write() << "allocating shared memory of "
@@ -445,7 +446,7 @@ int Storage::Run()
             (char *)geometries_index_ptr,
             shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_INDEX));
     }
-    unsigned *geometries_list_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
+    extractor::CompressedEdgeContainer::CompressedEdge *geometries_list_ptr = shared_layout_ptr->GetBlockPtr<extractor::CompressedEdgeContainer::CompressedEdge, true>(
         shared_memory_ptr, SharedDataLayout::GEOMETRIES_LIST);
 
     geometry_input_stream.read((char *)&temporary_value, sizeof(unsigned));

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -1,0 +1,91 @@
+#ifndef MOCK_DATAFACADE_HPP
+#define MOCK_DATAFACADE_HPP
+
+// implements all data storage when shared memory _IS_ used
+
+#include "engine/datafacade/datafacade_base.hpp"
+#include "contractor/query_edge.hpp"
+
+namespace osrm {
+namespace test {
+
+template <class EdgeDataT> class MockDataFacadeT final : public osrm::engine::datafacade::BaseDataFacade<EdgeDataT>
+{
+    private:
+        EdgeDataT foo;
+    public:
+    unsigned GetNumberOfNodes() const { return 0; }
+    unsigned GetNumberOfEdges() const { return 0; }
+    unsigned GetOutDegree(const NodeID /* n */) const { return 0; }
+    NodeID GetTarget(const EdgeID /* e */) const { return SPECIAL_NODEID; }
+    const EdgeDataT &GetEdgeData(const EdgeID /* e */) const { 
+        return foo;
+    }
+    EdgeID BeginEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
+    EdgeID EndEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
+    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const {
+        return util::irange(static_cast<EdgeID>(0),static_cast<EdgeID>(0));
+    }
+    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
+    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
+    EdgeID
+    FindEdgeIndicateIfReverse(const NodeID /* from */, const NodeID /* to */, bool & /* result */) const { return SPECIAL_EDGEID; }
+    util::FixedPointCoordinate GetCoordinateOfNode(const unsigned /* id */) const {
+        FixedPointCoordinate foo(0,0);
+        return foo;
+    }
+    bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
+    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const { return SPECIAL_NODEID; }
+    void GetUncompressedGeometry(const EdgeID /* id */,
+                                         std::vector<NodeID> &/* result_nodes */) const {}
+    void GetUncompressedWeights(const EdgeID /* id */,
+                                         std::vector<EdgeWeight> & /* result_weights */) const {}
+    extractor::TurnInstruction GetTurnInstructionForEdgeID(const unsigned /* id */) const {
+        return osrm::extractor::TurnInstruction::NoTurn;
+    }
+    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const 
+    {
+        return TRAVEL_MODE_DEFAULT;
+    }
+    std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> GetEdgesInBox(const util::FixedPointCoordinate & /* south_west */,
+                                                 const util::FixedPointCoordinate & /*north_east */) {
+        std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> foo;
+        return foo;
+    }
+    std::vector<osrm::engine::PhantomNodeWithDistance>
+    NearestPhantomNodesInRange(const util::FixedPointCoordinate /* input_coordinate */,
+                               const float /* max_distance */,
+                               const int /* bearing = 0 */,
+                               const int /* bearing_range = 180 */) {
+        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
+        return foo;
+    }
+    std::vector<osrm::engine::PhantomNodeWithDistance>
+    NearestPhantomNodes(const util::FixedPointCoordinate /* input_coordinate */,
+                        const unsigned /* max_results */,
+                        const int /* bearing = 0 */,
+                        const int /* bearing_range = 180 */) {
+        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
+        return foo;
+    }
+    std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
+        const util::FixedPointCoordinate /* input_coordinate */,
+        const int /* bearing = 0 */,
+        const int /* bearing_range = 180 */) {
+        std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> foo;
+        return foo;
+    }
+    unsigned GetCheckSum() const { return 0; }
+    bool IsCoreNode(const NodeID /* id */) const { return false; }
+    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const { return 0; }
+    std::string get_name_for_id(const unsigned /* name_id */) const { return ""; }
+    std::size_t GetCoreSize() const { return 0; }
+    std::string GetTimestamp() const { return ""; }
+
+};
+
+using MockDataFacade = MockDataFacadeT<contractor::QueryEdge::EdgeData>;
+} // osrm::test::
+} // osrm::
+
+#endif // MOCK_DATAFACADE_HPP

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -7,6 +7,9 @@
 #include "util/rectangle.hpp"
 #include "util/exception.hpp"
 
+#include "engine/datafacade/datafacade_base.hpp"
+#include "contractor/query_edge.hpp"
+
 #include <boost/functional/hash.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_case_template.hpp>
@@ -24,6 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
+
 BOOST_AUTO_TEST_SUITE(static_rtree)
 
 using namespace osrm;
@@ -39,6 +43,83 @@ using TestStaticRTree = StaticRTree<TestData,
                                     TEST_BRANCHING_FACTOR,
                                     TEST_LEAF_NODE_SIZE>;
 using MiniStaticRTree = StaticRTree<TestData, std::vector<FixedPointCoordinate>, false, 2, 3>;
+
+template <class EdgeDataT> class MockDataFacadeT final : public osrm::engine::datafacade::BaseDataFacade<EdgeDataT>
+{
+    private:
+        EdgeDataT foo;
+    public:
+    unsigned GetNumberOfNodes() const { return 0; }
+    unsigned GetNumberOfEdges() const { return 0; }
+    unsigned GetOutDegree(const NodeID /* n */) const { return 0; }
+    NodeID GetTarget(const EdgeID /* e */) const { return SPECIAL_NODEID; }
+    const EdgeDataT &GetEdgeData(const EdgeID /* e */) const { 
+        return foo;
+    }
+    EdgeID BeginEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
+    EdgeID EndEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
+    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const {
+        return irange(static_cast<EdgeID>(0),static_cast<EdgeID>(0));
+    }
+    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
+    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
+    EdgeID
+    FindEdgeIndicateIfReverse(const NodeID /* from */, const NodeID /* to */, bool & /* result */) const { return SPECIAL_EDGEID; }
+    util::FixedPointCoordinate GetCoordinateOfNode(const unsigned /* id */) const {
+        FixedPointCoordinate foo(0,0);
+        return foo;
+    }
+    bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
+    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const { return SPECIAL_NODEID; }
+    void GetUncompressedGeometry(const EdgeID /* id */,
+                                         std::vector<NodeID> &/* result_nodes */) const {}
+    void GetUncompressedWeights(const EdgeID /* id */,
+                                         std::vector<EdgeWeight> & /* result_weights */) const {}
+    extractor::TurnInstruction GetTurnInstructionForEdgeID(const unsigned /* id */) const {
+        return osrm::extractor::TurnInstruction::NoTurn;
+    }
+    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const 
+    {
+        return TRAVEL_MODE_DEFAULT;
+    }
+    std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> GetEdgesInBox(const util::FixedPointCoordinate & /* south_west */,
+                                                 const util::FixedPointCoordinate & /*north_east */) {
+        std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> foo;
+        return foo;
+    }
+    std::vector<osrm::engine::PhantomNodeWithDistance>
+    NearestPhantomNodesInRange(const util::FixedPointCoordinate /* input_coordinate */,
+                               const float /* max_distance */,
+                               const int /* bearing = 0 */,
+                               const int /* bearing_range = 180 */) {
+        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
+        return foo;
+    }
+    std::vector<osrm::engine::PhantomNodeWithDistance>
+    NearestPhantomNodes(const util::FixedPointCoordinate /* input_coordinate */,
+                        const unsigned /* max_results */,
+                        const int /* bearing = 0 */,
+                        const int /* bearing_range = 180 */) {
+        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
+        return foo;
+    }
+    std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
+        const util::FixedPointCoordinate /* input_coordinate */,
+        const int /* bearing = 0 */,
+        const int /* bearing_range = 180 */) {
+        std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> foo;
+        return foo;
+    }
+    unsigned GetCheckSum() const { return 0; }
+    bool IsCoreNode(const NodeID /* id */) const { return false; }
+    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const { return 0; }
+    std::string get_name_for_id(const unsigned /* name_id */) const { return ""; }
+    std::size_t GetCoreSize() const { return 0; }
+    std::string GetTimestamp() const { return ""; }
+
+};
+
+using MockDataFacade = MockDataFacadeT<contractor::QueryEdge::EdgeData>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 42;
@@ -417,7 +498,8 @@ BOOST_AUTO_TEST_CASE(bearing_tests)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_bearing", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    engine::GeospatialQuery<MiniStaticRTree> query(rtree, fixture.coords);
+    std::unique_ptr<MockDataFacade> mockfacade_ptr(new MockDataFacade);
+    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade> query(rtree, fixture.coords, *mockfacade_ptr);
 
     FixedPointCoordinate input(5.0 * COORDINATE_PRECISION, 5.1 * COORDINATE_PRECISION);
 
@@ -477,7 +559,8 @@ BOOST_AUTO_TEST_CASE(bbox_search_tests)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_bbox", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    engine::GeospatialQuery<MiniStaticRTree> query(rtree, fixture.coords);
+    std::unique_ptr<MockDataFacade> mockfacade_ptr(new MockDataFacade);
+    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade> query(rtree, fixture.coords, *mockfacade_ptr);
 
     {
         RectangleInt2D bbox = {static_cast<uint32_t>(0.5 * COORDINATE_PRECISION),

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -7,8 +7,7 @@
 #include "util/rectangle.hpp"
 #include "util/exception.hpp"
 
-#include "engine/datafacade/datafacade_base.hpp"
-#include "contractor/query_edge.hpp"
+#include "mocks/mock_datafacade.hpp"
 
 #include <boost/functional/hash.hpp>
 #include <boost/test/unit_test.hpp>
@@ -32,6 +31,7 @@ BOOST_AUTO_TEST_SUITE(static_rtree)
 
 using namespace osrm;
 using namespace osrm::util;
+using namespace osrm::test;
 
 constexpr uint32_t TEST_BRANCHING_FACTOR = 8;
 constexpr uint32_t TEST_LEAF_NODE_SIZE = 64;
@@ -43,83 +43,6 @@ using TestStaticRTree = StaticRTree<TestData,
                                     TEST_BRANCHING_FACTOR,
                                     TEST_LEAF_NODE_SIZE>;
 using MiniStaticRTree = StaticRTree<TestData, std::vector<FixedPointCoordinate>, false, 2, 3>;
-
-template <class EdgeDataT> class MockDataFacadeT final : public osrm::engine::datafacade::BaseDataFacade<EdgeDataT>
-{
-    private:
-        EdgeDataT foo;
-    public:
-    unsigned GetNumberOfNodes() const { return 0; }
-    unsigned GetNumberOfEdges() const { return 0; }
-    unsigned GetOutDegree(const NodeID /* n */) const { return 0; }
-    NodeID GetTarget(const EdgeID /* e */) const { return SPECIAL_NODEID; }
-    const EdgeDataT &GetEdgeData(const EdgeID /* e */) const { 
-        return foo;
-    }
-    EdgeID BeginEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
-    EdgeID EndEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
-    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const {
-        return irange(static_cast<EdgeID>(0),static_cast<EdgeID>(0));
-    }
-    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
-    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
-    EdgeID
-    FindEdgeIndicateIfReverse(const NodeID /* from */, const NodeID /* to */, bool & /* result */) const { return SPECIAL_EDGEID; }
-    util::FixedPointCoordinate GetCoordinateOfNode(const unsigned /* id */) const {
-        FixedPointCoordinate foo(0,0);
-        return foo;
-    }
-    bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
-    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const { return SPECIAL_NODEID; }
-    void GetUncompressedGeometry(const EdgeID /* id */,
-                                         std::vector<NodeID> &/* result_nodes */) const {}
-    void GetUncompressedWeights(const EdgeID /* id */,
-                                         std::vector<EdgeWeight> & /* result_weights */) const {}
-    extractor::TurnInstruction GetTurnInstructionForEdgeID(const unsigned /* id */) const {
-        return osrm::extractor::TurnInstruction::NoTurn;
-    }
-    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const 
-    {
-        return TRAVEL_MODE_DEFAULT;
-    }
-    std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> GetEdgesInBox(const util::FixedPointCoordinate & /* south_west */,
-                                                 const util::FixedPointCoordinate & /*north_east */) {
-        std::vector<typename osrm::engine::datafacade::BaseDataFacade<EdgeDataT>::RTreeLeaf> foo;
-        return foo;
-    }
-    std::vector<osrm::engine::PhantomNodeWithDistance>
-    NearestPhantomNodesInRange(const util::FixedPointCoordinate /* input_coordinate */,
-                               const float /* max_distance */,
-                               const int /* bearing = 0 */,
-                               const int /* bearing_range = 180 */) {
-        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
-        return foo;
-    }
-    std::vector<osrm::engine::PhantomNodeWithDistance>
-    NearestPhantomNodes(const util::FixedPointCoordinate /* input_coordinate */,
-                        const unsigned /* max_results */,
-                        const int /* bearing = 0 */,
-                        const int /* bearing_range = 180 */) {
-        std::vector<osrm::engine::PhantomNodeWithDistance> foo;
-        return foo;
-    }
-    std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::FixedPointCoordinate /* input_coordinate */,
-        const int /* bearing = 0 */,
-        const int /* bearing_range = 180 */) {
-        std::pair<osrm::engine::PhantomNode, osrm::engine::PhantomNode> foo;
-        return foo;
-    }
-    unsigned GetCheckSum() const { return 0; }
-    bool IsCoreNode(const NodeID /* id */) const { return false; }
-    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const { return 0; }
-    std::string get_name_for_id(const unsigned /* name_id */) const { return ""; }
-    std::size_t GetCoreSize() const { return 0; }
-    std::string GetTimestamp() const { return ""; }
-
-};
-
-using MockDataFacade = MockDataFacadeT<contractor::QueryEdge::EdgeData>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 42;


### PR DESCRIPTION
This PR removes the forward/reverse weight/offset values from the StaticRTree and calculates them dynamically at query time.

This means that the values can be updated trivially during imports of traffic data without requiring rebuilding the RTree.