### PR TITLE
correct handling of travel modes

### DIFF
--- a/features/testbot/mode.feature
+++ b/features/testbot/mode.feature
@@ -25,6 +25,22 @@ Feature: Testbot - Travel mode
         When I route I should get
             | from | to | route        | modes |
             | a    | d  | foo,foo,foo  | 1,3,1 |
+            | b    | d  | foo,foo      | 3,1   |
+
+    Scenario: Testbot - Compressed Modes
+        Given the node map
+            | a | b | c | d | e | f | g |
+
+        And the ways
+            | nodes | highway     | name   |
+            | abc   | residential | road   |
+            | cde   | river       | liquid |
+            | efg   | residential | solid  |
+
+        When I route I should get
+            | from | to | route              | modes | turns                              |
+            | a    | g  | road,liquid,solid  | 1,3,1 | head,straight,straight,destination |
+            | c    | g  | liquid,solid       | 3,1   | head,straight,destination          |
 
     Scenario: Testbot - Modes in each direction, different forward/backward speeds
         Given the node map

--- a/include/engine/guidance/textual_route_annotation.hpp
+++ b/include/engine/guidance/textual_route_annotation.hpp
@@ -44,8 +44,9 @@ inline util::json::Array AnnotateRoute(const std::vector<SegmentInformation> &ro
     extractor::TravelMode last_travel_mode = TRAVEL_MODE_DEFAULT;
 
     // Generate annotations for every segment
-    for (const SegmentInformation &segment : route_segments)
+    for (std::size_t i = 0; i < route_segments.size(); ++i)
     {
+        const auto &segment = route_segments[i];
         util::json::Array json_instruction_row;
         extractor::TurnInstruction current_instruction = segment.turn_instruction;
         if (extractor::isTurnNecessary(current_instruction))
@@ -89,8 +90,17 @@ inline util::json::Array AnnotateRoute(const std::vector<SegmentInformation> &ro
                 json_instruction_row.values.push_back(
                     static_cast<std::uint32_t>(std::round(post_turn_bearing_value)));
 
-                json_instruction_row.values.push_back(segment.travel_mode);
-                last_travel_mode = segment.travel_mode;
+                if (i + 1 < route_segments.size())
+                {
+                    // anounce next travel mode with turn
+                    json_instruction_row.values.push_back(route_segments[i + 1].travel_mode);
+                    last_travel_mode = segment.travel_mode;
+                }
+                else
+                {
+                    json_instruction_row.values.push_back(segment.travel_mode);
+                    last_travel_mode = segment.travel_mode;
+                }
 
                 // pre turn bearing
                 const double pre_turn_bearing_value = (segment.pre_turn_bearing / 10.);

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -180,6 +180,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
                 reverse_geometry[geometry_size - 1 - i].second, forward_dist_prefix_sum[i],
                 reverse_dist_prefix_sum[i], m_compressed_edge_container.GetPositionForID(edge_id_1),
                 false, INVALID_COMPONENTID, i, forward_data.travel_mode, reverse_data.travel_mode);
+
             m_edge_based_node_is_startpoint.push_back(forward_data.startpoint ||
                                                       reverse_data.startpoint);
             current_edge_source_coordinate_id = current_edge_target_coordinate_id;
@@ -483,7 +484,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     (edge_is_compressed ? m_compressed_edge_container.GetPositionForID(edge_form_u)
                                         : node_v),
                     edge_data1.name_id, turn_instruction, edge_is_compressed,
-                    edge_data2.travel_mode);
+                    edge_data1.travel_mode);
 
                 ++original_edges_counter;
 


### PR DESCRIPTION
At the moment, travel modes are handled in a very unintuitive way.
The travel mode of a segment cannot be deduced from its own ID but only from the turn-id it has been reached from (and the phantom node itself).

This comes with additional implied behaviour for the turn-by-turn generation.

To allow fine grained weights (like in https://github.com/Project-OSRM/osrm-backend/pull/1970) along edges, we need the travel mode to not run into problems with this implied behaviour.

In addition, it allows us to do better instructions based on travel modes (e.g. in the tunnel, take the fork on the right) or similar stuff.