### PR TITLE
Fix compile on OS X

### DIFF
--- a/include/util/json_util.hpp
+++ b/include/util/json_util.hpp
@@ -36,28 +36,6 @@ template <typename... Args> Array make_array(Args... args)
     return a;
 }
 
-template <typename T> Array make_array(const std::vector<T> &vector)
-{
-    Array a;
-    for (const auto &v : vector)
-    {
-        a.values.emplace_back(v);
-    }
-    return a;
-}
-
-//// template specialization needed as clang does not play nice
-//// FIXME this now causes compile errors on g++ -_-
-//template <> Array make_array(const std::vector<bool> &vector)
-//{
-//    Array a;
-//    for (const bool v : vector)
-//    {
-//        a.values.emplace_back(v);
-//    }
-//    return a;
-//}
-
 // Easy acces to object hierachies
 inline Value &get(Value &value) { return value; }
 

--- a/include/util/matching_debug_info.hpp
+++ b/include/util/matching_debug_info.hpp
@@ -120,7 +120,15 @@ struct MatchingDebugInfo
             return;
         }
 
-        json::get(*object, "breakage") = json::make_array(breakage);
+        // convert std::vector<bool> to osrm::json::Array
+        json::Array a;
+        for (const bool v : breakage)
+        {
+            if (v) a.values.emplace_back(json::True());
+            else a.values.emplace_back(json::False());
+        }
+
+        json::get(*object, "breakage") = std::move(a);
     }
 
     const json::Logger *logger;


### PR DESCRIPTION
Fixes this compile error on OS X:

```
In file included from /Users/dane/projects/osrm-backend/src/engine/plugins/match.cpp:1:
In file included from /Users/dane/projects/osrm-backend/include/engine/plugins/plugin_base.hpp:4:
In file included from /Users/dane/projects/osrm-backend/include/engine/datafacade/datafacade_base.hpp:6:
In file included from /Users/dane/projects/osrm-backend/include/extractor/edge_based_node.hpp:5:
In file included from /Users/dane/projects/osrm-backend/include/util/typedefs.hpp:4:
In file included from /Users/dane/projects/osrm-backend/include/util/strong_typedef.hpp:4:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__locale:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:439:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:628:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:1673:31: error: no matching constructor for initialization of 'mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>'
            ::new((void*)__p) _Up(std::__1::forward<_Args>(__args)...);
                              ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:1600:18: note: in instantiation of function template specialization 'std::__1::allocator<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null> >::construct<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>, const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > > &>' requested here
            {__a.construct(__p, std::__1::forward<_Args>(__args)...);}
                 ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:1453:14: note: in instantiation of function template specialization 'std::__1::allocator_traits<std::__1::allocator<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null> > >::__construct<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>, const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > > &>' requested here
            {__construct(__has_construct<allocator_type, _Tp*, _Args...>(),
             ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/vector:1643:25: note: in instantiation of function template specialization 'std::__1::allocator_traits<std::__1::allocator<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null> > >::construct<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>, const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > > &>' requested here
        __alloc_traits::construct(this->__alloc(),
                        ^
/Users/dane/projects/osrm-backend/include/util/json_util.hpp:44:18: note: in instantiation of function template specialization 'std::__1::vector<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>, std::__1::allocator<mapbox::util::variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null> > >::emplace_back<const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > > &>' requested here
        a.values.emplace_back(v);
                 ^
/Users/dane/projects/osrm-backend/include/util/matching_debug_info.hpp:123:48: note: in instantiation of function template specialization 'osrm::util::json::make_array<bool>' requested here
        json::get(*object, "breakage") = json::make_array(breakage);
                                               ^
/Users/dane/projects/osrm-backend/third_party/variant/variant.hpp:568:43: note: candidate constructor not viable: no known conversion from 'const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > >' to 'mapbox::util::no_init' for 1st argument
    inline __attribute__((always_inline)) variant(no_init)
                                          ^
/Users/dane/projects/osrm-backend/third_party/variant/variant.hpp:582:43: note: candidate constructor not viable: no known conversion from 'const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > >' to 'const variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>' for 1st argument
    inline __attribute__((always_inline)) variant(variant<Types...> const& old)
                                          ^
/Users/dane/projects/osrm-backend/third_party/variant/variant.hpp:588:43: note: candidate constructor not viable: no known conversion from 'const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > >' to 'variant<osrm::util::json::String, osrm::util::json::Number, mapbox::util::recursive_wrapper<osrm::util::json::Object>, mapbox::util::recursive_wrapper<osrm::util::json::Array>, osrm::util::json::True, osrm::util::json::False, osrm::util::json::Null>' for 1st argument
    inline __attribute__((always_inline)) variant(variant<Types...>&& old) noexcept
                                          ^
/Users/dane/projects/osrm-backend/third_party/variant/variant.hpp:573:27: note: candidate template ignored: disabled by 'enable_if' [with T = const std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > > &]
                          detail::is_valid_type<typename std::remove_reference<T>::type, Types...>::value>::type>
                          ^
/Users/dane/projects/osrm-backend/third_party/variant/variant.hpp:562:43: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
    inline __attribute__((always_inline)) variant()
                                          ^
5 warnings and 1 error generated.
make[2]: *** [CMakeFiles/ENGINE.dir/src/engine/plugins/match.cpp.o] Error 1
```

Note: this broke on OS X due to this commenting of a template specialization: https://github.com/Project-OSRM/osrm-backend/commit/36b31b5c5f97efa5616aac219c8116a2777a9371#diff-ff0ac185ed66e9230ad0017a43868e42R49

/cc @TheMarex 