### PR TITLE
Integrate core search in multi-waypoint search and map matching

### DIFF
--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -18,6 +18,20 @@ Feature: Basic Map Matching
             | trace | timestamps | matchings |
             | abcd  | 0 1 62 63  | ab,cd     |
 
+    Scenario: Testbot - Map matching with core factor
+        Given the contract extra arguments "--core 0.8"
+        Given the node map
+            | a | b | c | d |
+            |   |   | e |   |
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | timestamps | matchings |
+            | abcd  | 0 1 2 3    | abcd      |
+
     Scenario: Testbot - Map matching with small distortion
         Given the node map
             | a | b | c | d | e |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -15,6 +15,20 @@ Feature: Via points
         When I route I should get
             | waypoints | route   |
             | a,b,c     | abc,abc |
+
+    Scenario: Simple via point with core factor
+        Given the contract extra arguments "--core 0.8"
+        Given the node map
+            | a | b | c |
+
+        And the ways
+            | nodes |
+            | abc   |
+
+        When I route I should get
+            | waypoints | route   |
+            | a,b,c     | abc,abc |
+            | c,b,a     | abc,abc |
             | c,b,a     | abc,abc |
 
     Scenario: Via point at a dead end

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -40,6 +40,7 @@ using SubMatchingList = std::vector<SubMatching>;
 constexpr static const unsigned MAX_BROKEN_STATES = 10;
 constexpr static const double MAX_SPEED = 180 / 3.6; // 180km -> m/s
 constexpr static const unsigned SUSPICIOUS_DISTANCE_DELTA = 100;
+constexpr static const double MAX_DISTANCE_DELTA = 2000.;
 
 // implements a hidden markov model map matching algorithm
 template <class DataFacadeT>
@@ -102,7 +103,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
             }
             else
             {
-                return std::numeric_limits<double>::max();
+                return MAX_DISTANCE_DELTA;
             }
         }();
 
@@ -200,6 +201,8 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
 
             const auto haversine_distance = util::coordinate_calculation::haversineDistance(
                 prev_coordinate, current_coordinate);
+            // assumes minumum of 0.1 m/s
+            const int duration_uppder_bound = ((haversine_distance + max_distance_delta) * 0.25) * 10;
 
             // compute d_t for this timestamp and the next one
             for (const auto s : util::irange<std::size_t>(0u, prev_viterbi.size()))
@@ -224,7 +227,6 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                     forward_heap.Clear();
                     reverse_heap.Clear();
 
-                    // get distance diff between loc1/2 and locs/s_prime
                     double network_distance;
                     if (super::facade->GetCoreSize() > 0)
                     {
@@ -233,7 +235,8 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                         network_distance = super::GetNetworkDistanceWithCore(
                             forward_heap, reverse_heap, forward_core_heap, reverse_core_heap,
                             prev_unbroken_timestamps_list[s].phantom_node,
-                            current_timestamps_list[s_prime].phantom_node);
+                            current_timestamps_list[s_prime].phantom_node,
+                            duration_uppder_bound);
                     }
                     else
                     {
@@ -243,6 +246,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                             current_timestamps_list[s_prime].phantom_node);
                     }
 
+                    // get distance diff between loc1/2 and locs/s_prime
                     const auto d_t = std::abs(network_distance - haversine_distance);
 
                     // very low probability transition -> prune

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -500,9 +500,11 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 std::int32_t &distance,
                 std::vector<NodeID> &packed_leg,
                 const bool force_loop_forward,
-                const bool force_loop_reverse) const
+                const bool force_loop_reverse,
+                const int duration_uppder_bound=INVALID_EDGE_WEIGHT) const
     {
         NodeID middle = SPECIAL_NODEID;
+        distance = duration_uppder_bound;
 
         // get offset to account for offsets on phantom nodes on compressed edges
         const auto min_edge_offset = std::min(0, forward_heap.MinKey());
@@ -527,8 +529,9 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         }
 
         // No path found for both target nodes?
-        if (INVALID_EDGE_WEIGHT == distance || SPECIAL_NODEID == middle)
+        if (duration_uppder_bound <= distance || SPECIAL_NODEID == middle)
         {
+            distance = INVALID_EDGE_WEIGHT;
             return;
         }
 
@@ -567,10 +570,11 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                         int &distance,
                         std::vector<NodeID> &packed_leg,
                         const bool force_loop_forward,
-                        const bool force_loop_reverse) const
+                        const bool force_loop_reverse,
+                        int duration_uppder_bound = INVALID_EDGE_WEIGHT) const
     {
         NodeID middle = SPECIAL_NODEID;
-        distance = INVALID_EDGE_WEIGHT;
+        distance = duration_uppder_bound;
 
         std::vector<std::pair<NodeID, EdgeWeight>> forward_entry_points;
         std::vector<std::pair<NodeID, EdgeWeight>> reverse_entry_points;
@@ -678,8 +682,9 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         }
 
         // No path found for both target nodes?
-        if (INVALID_EDGE_WEIGHT == distance || SPECIAL_NODEID == middle)
+        if (duration_uppder_bound <= distance || SPECIAL_NODEID == middle)
         {
+            distance = INVALID_EDGE_WEIGHT;
             return;
         }
 
@@ -776,7 +781,8 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                                       SearchEngineData::QueryHeap &forward_core_heap,
                                       SearchEngineData::QueryHeap &reverse_core_heap,
                                       const PhantomNode &source_phantom,
-                                      const PhantomNode &target_phantom) const
+                                      const PhantomNode &target_phantom,
+                                      int duration_uppder_bound=INVALID_EDGE_WEIGHT) const
     {
         BOOST_ASSERT(forward_heap.Empty());
         BOOST_ASSERT(reverse_heap.Empty());
@@ -813,7 +819,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         int duration = INVALID_EDGE_WEIGHT;
         std::vector<NodeID> packed_path;
         SearchWithCore(forward_heap, reverse_heap, forward_core_heap, reverse_core_heap, duration,
-                       packed_path, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
+                       packed_path, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS, duration_uppder_bound);
 
         double distance = std::numeric_limits<double>::max();
         if (duration != INVALID_EDGE_WEIGHT)
@@ -829,7 +835,8 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
     double GetNetworkDistance(SearchEngineData::QueryHeap &forward_heap,
                               SearchEngineData::QueryHeap &reverse_heap,
                               const PhantomNode &source_phantom,
-                              const PhantomNode &target_phantom) const
+                              const PhantomNode &target_phantom,
+                              int duration_uppder_bound=INVALID_EDGE_WEIGHT) const
     {
         BOOST_ASSERT(forward_heap.Empty());
         BOOST_ASSERT(reverse_heap.Empty());
@@ -865,7 +872,8 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
 
         int duration = INVALID_EDGE_WEIGHT;
         std::vector<NodeID> packed_path;
-        Search(forward_heap, reverse_heap, duration, packed_path, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS);
+        Search(forward_heap, reverse_heap, duration, packed_path, DO_NOT_FORCE_LOOPS,
+               DO_NOT_FORCE_LOOPS, duration_uppder_bound);
 
         if (duration == INVALID_EDGE_WEIGHT)
         {


### PR DESCRIPTION
As super simple test using [this route](http://map.project-osrm.org/?z=14&center=52.524969,13.413019&loc=52.517037,13.388860&loc=52.514654,13.389587&loc=52.514941,13.392763&loc=52.513237,13.393450&loc=52.511311,13.393707&loc=52.508542,13.401260&loc=52.508529,13.402880&loc=52.508170,13.405219&loc=52.509117,13.406582&loc=52.509796,13.411045&loc=52.508020,13.414221&loc=52.509594,13.415401&loc=52.510906,13.416892&loc=52.511624,13.421774&loc=52.515020,13.426409&loc=52.516064,13.432417&loc=52.518206,13.429756&loc=52.520817,13.429756&loc=52.525569,13.429198&loc=52.526770,13.426838&hl=en&ly=&alt=&df=&srv=) (20 coordinates) on a core factor of `0.8`.

| Service | k=1.0 | k=0.8 (before) | k=0.8 (after) | speedup |
|------------|---------|----------------------|------------------|--------------|
| match | 56 ms | 645ms | 438 ms | x1.47 |
| viaroute | 4.21 ms | 96ms | 0.6 ms | x160 |

The viaroute probably hits an effect were contraction is bad for very local searches. For [this](http://map.project-osrm.org/?z=10&center=52.581774,13.705444&loc=52.565499,13.510437&loc=52.512460,13.428040&loc=52.475357,13.306847&hl=en&ly=&alt=&df=&srv=) request I see the following behaviour:

| Service | k=1.0 | k=0.8 (before) | k=0.8 (after) | speedup |
|------------|---------|----------------------|------------------|--------------|
| viaroute | 1.1ms | 68ms | 9.6 ms | x7.3 |