### PR TITLE
[not ready] Modular Buildsystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,9 +159,9 @@ script:
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       sudo ldconfig
     fi
-  - ./extractor-tests
-  - ./engine-tests
-  - ./util-tests
+  - ./unit_tests/extractor-tests
+  - ./unit_tests/engine-tests
+  - ./unit_tests/util-tests
   - popd
   - npm test
   - make -C test/data benchmark

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,9 @@ add_custom_target(FingerPrintConfigure ALL ${CMAKE_COMMAND}
   COMMENT "Configuring revision fingerprint"
   VERBATIM)
 
-add_custom_target(tests DEPENDS engine-tests extractor-tests util-tests)
 add_custom_target(benchmarks DEPENDS rtree-bench)
 
-set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread unit_test_framework)
+set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/util/version.hpp.in
@@ -60,10 +59,6 @@ file(GLOB ContractorGlob src/contractor/*.cpp)
 file(GLOB StorageGlob src/storage/*.cpp)
 file(GLOB ServerGlob src/server/*.cpp src/server/**/*.cpp)
 file(GLOB EngineGlob src/engine/*.cpp src/engine/**/*.cpp)
-file(GLOB ExtractorTestsGlob unit_tests/extractor/*.cpp)
-file(GLOB EngineTestsGlob unit_tests/engine/*.cpp)
-file(GLOB UtilTestsGlob unit_tests/util/*.cpp)
-file(GLOB IOTestsGlob unit_tests/io/*.cpp)
 
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})
@@ -84,15 +79,9 @@ add_library(osrm_extract $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_contract $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
 
-# Unit tests
-add_executable(engine-tests EXCLUDE_FROM_ALL unit_tests/engine_tests.cpp ${EngineTestsGlob} $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:UTIL>)
-add_executable(extractor-tests EXCLUDE_FROM_ALL unit_tests/extractor_tests.cpp ${ExtractorTestsGlob} $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
-add_executable(util-tests EXCLUDE_FROM_ALL unit_tests/util_tests.cpp ${UtilTestsGlob} $<TARGET_OBJECTS:UTIL>)
-
 # Benchmarks
 add_executable(rtree-bench EXCLUDE_FROM_ALL src/benchmarks/static_rtree.cpp $<TARGET_OBJECTS:UTIL>)
 
-target_include_directories(util-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
 target_include_directories(rtree-bench PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
 
 # Check the release mode
@@ -235,11 +224,13 @@ find_package(Osmium REQUIRED COMPONENTS io)
 include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
 
 
-find_package(Boost 1.49.0 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.49.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 if(NOT WIN32)
   add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
-add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3 -DBOOST_RESULT_OF_USE_DECLTYPE)
+add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
+add_definitions(-DBOOST_RESULT_OF_USE_DECLTYPE)
+add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)
@@ -250,7 +241,7 @@ if(WIN32 AND CMAKE_BUILD_TYPE MATCHES Debug)
   set(TBB_LIBRARIES ${TBB_DEBUG_LIBRARIES})
 endif()
 
-find_package( Luabind REQUIRED )
+find_package(Luabind REQUIRED)
 include(check_luabind)
 include_directories(SYSTEM ${LUABIND_INCLUDE_DIR})
 
@@ -312,6 +303,8 @@ set(CONTRACTOR_LIBRARIES
 set(ENGINE_LIBRARIES
     ${Boost_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
+    ${LUABIND_LIBRARY}
+    ${USED_LUA_LIBRARIES}
     ${STXXL_LIBRARY}
     ${TBB_LIBRARIES}
     ${MAYBE_RT_LIBRARY})
@@ -330,11 +323,9 @@ target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES})
 target_link_libraries(osrm_extract ${EXTRACTOR_LIBRARIES})
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
-# Tests
-target_link_libraries(engine-tests ${ENGINE_LIBRARIES})
-target_link_libraries(extractor-tests ${EXTRACTOR_LIBRARIES})
+
+# Benchmarks
 target_link_libraries(rtree-bench ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${TBB_LIBRARIES})
-target_link_libraries(util-tests ${UTIL_LIBRARIES})
 
 if(BUILD_TOOLS)
   message(STATUS "Activating OSRM internal tools")
@@ -445,3 +436,7 @@ configure_file(
 
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake)
+
+# Modularizing the build system: each directory registered here provides its own CMakeLists.txt
+add_subdirectory(unit_tests)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,10 +139,6 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
   endif()
 endif()
 
-if(NOT WIN32)
-  add_definitions(-DBOOST_TEST_DYN_LINK)
-endif()
-
 # Configuring compilers
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=2 -D_FORTIFY_SOURCE=2 -fPIC -fcolor-diagnostics")
@@ -230,7 +226,8 @@ if(NOT WIN32)
 endif()
 add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
 add_definitions(-DBOOST_RESULT_OF_USE_DECLTYPE)
-add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED)
+# Add this once we're clean of deprecated Boost.Filesystem features
+# add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)

--- a/appveyor-build.bat
+++ b/appveyor-build.bat
@@ -117,13 +117,13 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 SET PATH=%PROJECT_DIR%\osrm-deps\libs\bin;%PATH%
 
 ECHO running engine-tests.exe ...
-%Configuration%\engine-tests.exe
+%Configuration%\unit_tests\engine-tests.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO running extractor-tests.exe ...
-%Configuration%\extractor-tests.exe
+%Configuration%\unit_tests\extractor-tests.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO running util-tests.exe ...
-%Configuration%\util-tests.exe
+%Configuration%\unit_tests\util-tests.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 IF NOT "%APPVEYOR_REPO_BRANCH%"=="develop" GOTO DONE

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -33,7 +33,11 @@ add_executable(util-tests
 set(AllBoostLibrariesExceptUnitTest ${Boost_LIBRARIES})
 
 find_package(Boost 1.49.0 REQUIRED COMPONENTS unit_test_framework)
-add_definitions(-DBOOST_TEST_DYN_LINK)
+
+if(NOT WIN32)
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
+
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,0 +1,69 @@
+set(ExtractorTest_SOURCES
+	extractor_tests.cpp
+	extractor/compressed_edge_container.cpp
+	extractor/graph_compressor.cpp
+	extractor/raster_source.cpp)
+
+set(EngineTest_SOURCES
+	engine_tests.cpp
+	engine/douglas_peucker.cpp
+	engine/geometry_string.cpp)
+
+set(UtilTest_SOURCES
+	util_tests.cpp
+	util/bearing.cpp
+	util/binary_heap.cpp
+	util/coordinate.cpp
+	util/duration_parsing.cpp
+	util/dynamic_graph.cpp
+	util/io.cpp
+	util/range_table.cpp
+	util/static_graph.cpp
+	util/static_rtree.cpp
+	util/string_util.cpp)
+
+
+add_executable(extractor-tests
+	EXCLUDE_FROM_ALL
+	${ExtractorTest_SOURCES}
+	$<TARGET_OBJECTS:EXTRACTOR>
+	$<TARGET_OBJECTS:UTIL>)
+
+add_executable(engine-tests
+	EXCLUDE_FROM_ALL
+	${EngineTest_SOURCES}
+	$<TARGET_OBJECTS:EXTRACTOR>
+	$<TARGET_OBJECTS:UTIL>)
+
+add_executable(util-tests
+	EXCLUDE_FROM_ALL
+	${UtilTest_SOURCES}
+	$<TARGET_OBJECTS:UTIL>)
+
+
+# FindPackage below overwrites Boost_LIBRARIES
+set(AllBoostLibrariesExceptUnitTest ${Boost_LIBRARIES})
+
+find_package(Boost 1.49.0 REQUIRED COMPONENTS unit_test_framework)
+add_definitions(-DBOOST_TEST_DYN_LINK)
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+
+
+target_include_directories(extractor-tests PUBLIC ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(engine-tests PUBLIC ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(util-tests PUBLIC ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+
+
+# Strictly speaking we only need to link against a subset of all osrm libs, but it seems like the tests depend not strictly on their lib counterpart (e.g. extractor test not only depends on EXTRACTOR_LIBRARIES) --- this should be fixed in the future.
+set(OSRMLibraries osrm osrm_contract osrm_extract osrm_store)
+
+target_link_libraries(extractor-tests ${OSRMLibraries} ${AllBoostLibrariesExceptUnitTest} ${Boost_LIBRARIES})
+target_link_libraries(engine-tests ${OSRMLibraries} ${AllBoostLibrariesExceptUnitTest} ${Boost_LIBRARIES})
+target_link_libraries(util-tests ${OSRMLibraries} ${AllBoostLibrariesExceptUnitTest} ${Boost_LIBRARIES})
+
+
+add_custom_target(tests
+	DEPENDS
+	engine-tests
+	extractor-tests
+	util-tests)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,26 +1,14 @@
-set(ExtractorTest_SOURCES
+file(GLOB ExtractorTest_SOURCES
 	extractor_tests.cpp
-	extractor/compressed_edge_container.cpp
-	extractor/graph_compressor.cpp
-	extractor/raster_source.cpp)
+	extractor/*.cpp)
 
-set(EngineTest_SOURCES
+file(GLOB EngineTest_SOURCES
 	engine_tests.cpp
-	engine/douglas_peucker.cpp
-	engine/geometry_string.cpp)
+	engine/*.cpp)
 
-set(UtilTest_SOURCES
+file(GLOB UtilTest_SOURCES
 	util_tests.cpp
-	util/bearing.cpp
-	util/binary_heap.cpp
-	util/coordinate.cpp
-	util/duration_parsing.cpp
-	util/dynamic_graph.cpp
-	util/io.cpp
-	util/range_table.cpp
-	util/static_graph.cpp
-	util/static_rtree.cpp
-	util/string_util.cpp)
+	util/*)
 
 
 add_executable(extractor-tests


### PR DESCRIPTION
Root `CMakeLists.txt` calls `add_subdirectory`. Sub directories provide their own `CMakeLists.txt` setting up dependencies, include paths and libraries to link in.

This is a first try to modularize the 500 lines of `CMakeLists.txt` mess we're in.