### PR TITLE
report depart/arrive instead of waypoints

### DIFF
--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -36,8 +36,7 @@ class RouteAPI : public BaseAPI
     {
     }
 
-    void MakeResponse(const InternalRouteResult &raw_route,
-                      util::json::Object &response) const
+    void MakeResponse(const InternalRouteResult &raw_route, util::json::Object &response) const
     {
         auto number_of_routes = raw_route.has_alternative() ? 2UL : 1UL;
         util::json::Array routes;
@@ -102,7 +101,6 @@ class RouteAPI : public BaseAPI
                 leg.steps = guidance::assembleSteps(
                     BaseAPI::facade, path_data, leg_geometry, phantoms.source_phantom,
                     phantoms.target_phantom, reversed_source, reversed_target);
-                ;
             }
 
             leg_geometries.push_back(std::move(leg_geometry));

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -25,6 +25,7 @@ namespace guidance
 namespace detail
 {
 StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
+                                      const WaypointType waypoint_type,
                                       const LegGeometry &leg_geometry,
                                       const std::size_t segment_index,
                                       const unsigned exit);
@@ -71,8 +72,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
     {
 
         StepManeuver maneuver = detail::stepManeuverFromGeometry(
-            extractor::guidance::TurnInstruction{extractor::guidance::TurnType::Location,
+            extractor::guidance::TurnInstruction{extractor::guidance::TurnType::NoTurn,
                                                  initial_modifier},
+            WaypointType::Depart,
             leg_geometry, segment_index, INVALID_EXIT_NR);
 
         // PathData saves the information we need of the segment _before_ the turn,
@@ -90,7 +92,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                     path_point.travel_mode, maneuver, leg_geometry.FrontIndex(segment_index),
                     leg_geometry.BackIndex(segment_index) + 1});
                 maneuver = detail::stepManeuverFromGeometry(
-                    path_point.turn_instruction, leg_geometry, segment_index, path_point.exit);
+                    path_point.turn_instruction, WaypointType::None, leg_geometry, segment_index, path_point.exit);
                 segment_index++;
             }
         }
@@ -109,7 +111,8 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         //       |-------| duration
         StepManeuver maneuver = {source_node.location, 0., 0.,
                                  extractor::guidance::TurnInstruction{
-                                     extractor::guidance::TurnType::Location, initial_modifier},
+                                     extractor::guidance::TurnType::NoTurn, initial_modifier},
+                                     WaypointType::Depart,
                                  INVALID_EXIT_NR};
 
         steps.push_back(RouteStep{source_node.name_id, facade.get_name_for_id(source_node.name_id),
@@ -131,8 +134,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
     steps.push_back(RouteStep{
         target_node.name_id, facade.get_name_for_id(target_node.name_id), 0., 0., target_mode,
         StepManeuver{target_node.location, 0., 0.,
-                     extractor::guidance::TurnInstruction{extractor::guidance::TurnType::Location,
+                     extractor::guidance::TurnInstruction{extractor::guidance::TurnType::NoTurn,
                                                           final_modifier},
+                     WaypointType::Arrive,
                      INVALID_EXIT_NR},
         leg_geometry.locations.size(), leg_geometry.locations.size()});
 

--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -4,6 +4,8 @@
 #include "util/coordinate.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
 
+#include <cstdint>
+
 namespace osrm
 {
 namespace engine
@@ -11,12 +13,20 @@ namespace engine
 namespace guidance
 {
 
+enum class WaypointType : std::uint8_t
+{
+    None,
+    Arrive,
+    Depart,
+};
+
 struct StepManeuver
 {
     util::Coordinate location;
     double bearing_before;
     double bearing_after;
     extractor::guidance::TurnInstruction instruction;
+    WaypointType waypoint_type;
     unsigned exit;
 };
 } // namespace guidance

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -37,8 +37,7 @@ enum DirectionModifier
 enum TurnType // at the moment we can support 32 turn types, without increasing memory consumption
 {
     Invalid,                // no valid turn instruction
-    NoTurn,                 // end of segment without turn
-    Location,               // start,end,via
+    NoTurn,                 // end of segment without turn/middle of a segment
     Suppressed,             // location that suppresses a turn
     NewName,                // no turn, but name changes
     Continue,               // remain on a street

--- a/src/engine/guidance/assemble_steps.cpp
+++ b/src/engine/guidance/assemble_steps.cpp
@@ -13,6 +13,7 @@ namespace guidance
 namespace detail
 {
 StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
+                                      const WaypointType waypoint_type,
                                       const LegGeometry &leg_geometry,
                                       const std::size_t segment_index,
                                       const unsigned exit)
@@ -31,7 +32,7 @@ StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instr
     const double post_turn_bearing =
         util::coordinate_calculation::bearing(turn_coordinate, post_turn_coordinate);
 
-    return StepManeuver{turn_coordinate, pre_turn_bearing, post_turn_bearing, instruction, exit};
+    return StepManeuver{turn_coordinate, pre_turn_bearing, post_turn_bearing, instruction, waypoint_type, exit};
 }
 } // ns detail
 } // ns engine


### PR DESCRIPTION
Adds Depart/Arrive to the API response.

I kept this not as additional instruction, as this would remove space for turn-instructions stored at arcs.