### PR TITLE
Fix OSX Travis builds for recent images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,8 @@ install:
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
 
     elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      brew install cmake boost libzip libstxxl libxml2 lua51 luabind tbb GDAL md5sha1sum
+      # implicit deps, but seem to be installed by default with recent images: libxml2 GDAL boost
+      brew install cmake libzip libstxxl lua51 luabind tbb md5sha1sum
     fi
 
 before_script:


### PR DESCRIPTION
Our Travis OSX builds are broken since a few days (?). It seems like the OXS image now comes with libxml2, GDAl and boost installed by default. Installing libxml2 and GDAL only shows a warning, trying to install Boost throws an error. Here's an example log: https://travis-ci.org/Project-OSRM/osrm-backend/jobs/115030045#L60

The trivial fix here is to assume libxml2, GDAL and boost as implicit dependencies (ugly).

Is there a way to pin versions or at least specify all dependencies explicitly? From searching around this is a wontfix in brew. /cc OSX users for ideas @MoKob @danpat @springmeyer 

