### PR TITLE
static turn instructions

### DIFF
--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -1,0 +1,202 @@
+@routing  @guidance
+Feature: Basic Roundabout
+
+    Background:
+        Given the profile "testbot"
+        Given a grid size of 10 meters
+
+    Scenario: Ramp Exit Right
+        Given the node map
+            | a | b | c | d | e |
+            |   |   |   | f | g |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | bfg    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                             |
+            | a,e       | abcde, abcde    | depart, arrive                    |
+            | a,g       | abcde, bfg, bfg | depart, ramp-slight-right, arrive |
+
+    Scenario: Ramp Exit Right Curved Right
+        Given the node map
+            | a | b | c |   |   |
+            |   |   | f | d |   |
+            |   |   |   | g | e |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | bfg    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                             |
+            | a,e       | abcde, abcde    | depart, arrive                    |
+            | a,g       | abcde, bfg, bfg | depart, ramp-slight-right, arrive |
+
+    Scenario: Ramp Exit Right Curved Left
+        Given the node map
+            |   |   |   |   | e |
+            |   |   |   | d | g |
+            | a | b | c | f |   |
+
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | cfg    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                             |
+            | a,e       | abcde, abcde    | depart, arrive                    |
+            | a,g       | abcde, cfg, cfg | depart, ramp-slight-right, arrive |
+
+
+    Scenario: Ramp Exit Left
+        Given the node map
+            |   |   |   | f | g |
+            | a | b | c | d | e |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | bfg    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                            |
+            | a,e       | abcde, abcde    | depart, arrive                   |
+            | a,g       | abcde, bfg, bfg | depart, ramp-slight-left, arrive |
+
+    Scenario: Ramp Exit Left Curved Left
+        Given the node map
+            |   |   |   | g | e |
+            |   |   | f | d |   |
+            | a | b | c |   |   |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | bfg    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                            |
+            | a,e       | abcde, abcde    | depart, arrive                   |
+            | a,g       | abcde, bfg, bfg | depart, ramp-slight-left, arrive |
+
+    Scenario: Ramp Exit Left Curved Right
+        Given the node map
+            | a | b | c | f |   |
+            |   |   |   | d | g |
+            |   |   |   |   | e |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | cfg    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                            |
+            | a,e       | abcde, abcde    | depart, arrive                   |
+            | a,g       | abcde, cfg, cfg | depart, ramp-slight-left, arrive |
+
+    Scenario: On Ramp Right
+        Given the node map
+            | a | b | c | d | e |
+            | f | g |   |   |   |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | fgd    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                             |
+            | a,e       | abcde, abcde    | depart, arrive                    |
+            | f,e       | abcde, fgd, fgd | depart, merge-slight-left, arrive |
+
+    Scenario: On Ramp Left
+        Given the node map
+            | f | g |   |   |   |
+            | a | b | c | d | e |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | fgd    | motorway_link |
+
+       When I route I should get
+            | waypoints | route           | turns                              |
+            | a,e       | abcde, abcde    | depart, arrive                     |
+            | f,e       | abcde, fgd, fgd | depart, merge-slight-right, arrive |
+
+    Scenario: Highway Fork
+        Given the node map
+            |   |   |   |   | d | e |
+            | a | b | c |   |   |   |
+            |   |   |   |   | f | g |
+
+        And the ways
+            | nodes  | highway  |
+            | abcde  | motorway |
+            | cfg    | motorway |
+
+       When I route I should get
+            | waypoints | route               | turns                      |
+            | a,e       | abcde, abcde, abcde | depart, fork-left, arrive  |
+            | a,g       | abcde, cfg, cfg     | depart, fork-right, arrive |
+
+     Scenario: Fork After Ramp
+       Given the node map
+            |   |   |   |   | d | e |
+            | a | b | c |   |   |   |
+            |   |   |   |   | f | g |
+
+        And the ways
+            | nodes  | highway       |
+            | abc    | motorway_link |
+            | cde    | motorway      |
+            | cfg    | motorway      |
+
+       When I route I should get
+            | waypoints | route         | turns                      |
+            | a,e       | abc, cde, cde | depart, fork-left, arrive  |
+            | a,g       | abc, cfg, cfg | depart, fork-right, arrive |
+
+     Scenario: On And Off Ramp Right
+       Given the node map
+            | a | b |   | c |   | d | e |
+            | f | g |   |   |   | h | i |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | fgc    | motorway_link |
+            | chi    | motorway_link |
+
+       When I route I should get
+            | waypoints | route             | turns                             |
+            | a,e       | abcde, abcde      | depart, arrive                    |
+            | f,e       | fgc, abcde, abcde | depart, merge-slight-left, arrive |
+            | a,i       | abcde, chi, chi   | depart, ramp-slight-right, arrive |
+            | f,i       | fgc, chi, chi     | depart, turn-slight-right, arrive |
+
+    Scenario: On And Off Ramp Left
+       Given the node map
+            | f | g |   |   |   | h | i |
+            | a | b |   | c |   | d | e |
+
+        And the ways
+            | nodes  | highway       |
+            | abcde  | motorway      |
+            | fgc    | motorway_link |
+            | chi    | motorway_link |
+
+       When I route I should get
+            | waypoints | route             | turns                              |
+            | a,e       | abcde, abcde      | depart, arrive                     |
+            | f,e       | fgc, abcde, abcde | depart, merge-slight-right, arrive |
+            | a,i       | abcde, chi, chi   | depart, ramp-slight-left, arrive   |
+            | f,i       | fgc, chi, chi     | depart, turn-slight-left, arrive   |
+

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -1,0 +1,140 @@
+@routing  @guidance
+Feature: Basic Roundabout
+
+    Background:
+        Given the profile "testbot"
+        Given a grid size of 10 meters
+
+    Scenario: Enter and Exit
+        Given the node map
+            |   |   | a  |   |   |
+            |   |   | b  |   |   |
+            | h | g |    | c | d |
+            |   |   | e  |   |   |
+            |   |   | f  |   |   |
+
+       And the ways
+            | nodes  | roundabout |
+            | ab     | false      |
+            | cd     | false      |
+            | ef     | false      |
+            | gh     | false      |
+            | bcegb  | true       |
+
+       When I route I should get
+           | waypoints | route    | turns                             |
+           | a,d       | ab,cd,cd | depart, roundabout-exit-1, arrive |
+           | a,f       | ab,ef,ef | depart, roundabout-exit-2, arrive |
+           | a,h       | ab,gh,gh | depart, roundabout-exit-3, arrive |
+           | d,f       | cd,ef,ef | depart, roundabout-exit-1, arrive |
+           | d,h       | cd,gh,gh | depart, roundabout-exit-2, arrive |
+           | d,a       | cd,ab,ab | depart, roundabout-exit-3, arrive |
+           | f,h       | ef,gh,gh | depart, roundabout-exit-1, arrive |
+           | f,a       | ef,ab,ab | depart, roundabout-exit-2, arrive |
+           | f,d       | ef,cd,cd | depart, roundabout-exit-3, arrive |
+           | h,a       | gh,ab,ab | depart, roundabout-exit-1, arrive |
+           | h,d       | gh,cd,cd | depart, roundabout-exit-2, arrive |
+           | h,f       | gh,ef,ef | depart, roundabout-exit-3, arrive |
+
+    Scenario: Only Enter
+        Given the node map
+            |   |   | a  |   |   |
+            |   |   | b  |   |   |
+            | h | g |    | c | d |
+            |   |   | e  |   |   |
+            |   |   | f  |   |   |
+
+       And the ways
+            | nodes  | roundabout |
+            | ab     | false      |
+            | cd     | false      |
+            | ef     | false      |
+            | gh     | false      |
+            | bcegb  | true       |
+
+       When I route I should get
+           | waypoints | route    | turns                            |
+           | a,b       | ab,ab    | depart, arrive                   |
+           | a,c       | ab,bcegb | depart, roundabout-enter, arrive |
+           | a,e       | ab,bcegb | depart, roundabout-enter, arrive |
+           | a,g       | ab,bcegb | depart, roundabout-enter, arrive |
+           | d,c       | cd,cd    | depart, arrive                   |
+           | d,e       | cd,bcegb | depart, roundabout-enter, arrive |
+           | d,g       | cd,bcegb | depart, roundabout-enter, arrive |
+           | d,b       | cd,bcegb | depart, roundabout-enter, arrive |
+           | f,e       | ef,ef    | depart, arrive                   |
+           | f,g       | ef,bcegb | depart, roundabout-enter, arrive |
+           | f,b       | ef,bcegb | depart, roundabout-enter, arrive |
+           | f,c       | ef,bcegb | depart, roundabout-enter, arrive |
+           | h,g       | gh,gh    | depart, arrive                   |
+           | h,b       | gh,bcegb | depart, roundabout-enter, arrive |
+           | h,c       | gh,bcegb | depart, roundabout-enter, arrive |
+           | h,e       | gh,bcegb | depart, roundabout-enter, arrive |
+
+    Scenario: Only Exit
+        Given the node map
+            |   |   | a  |   |   |
+            |   |   | b  |   |   |
+            | h | g |    | c | d |
+            |   |   | e  |   |   |
+            |   |   | f  |   |   |
+
+       And the ways
+            | nodes  | roundabout |
+            | ab     | false      |
+            | cd     | false      |
+            | ef     | false      |
+            | gh     | false      |
+            | bcegb  | true       |
+
+       When I route I should get
+           | waypoints | route       | turns                             |
+           | b,a       | ab,ab       | depart, arrive                    |
+           | b,d       | bcegb,cd,cd | depart, roundabout-exit-1, arrive |
+           | b,f       | bcegb,ef,ef | depart, roundabout-exit-2, arrive |
+           | b,h       | bcegb,gh,gh | depart, roundabout-exit-3, arrive |
+           | c,d       | cd,cd       | depart, arrive                    |
+           | c,f       | bcegb,ef,ef | depart, roundabout-exit-1, arrive |
+           | c,h       | bcegb,gh,gh | depart, roundabout-exit-2, arrive |
+           | c,a       | bcegb,ab,ab | depart, roundabout-exit-3, arrive |
+           | e,f       | ef,ef       | depart, arrive                    |
+           | e,h       | bcegb,gh,gh | depart, roundabout-exit-1, arrive |
+           | e,a       | bcegb,ab,ab | depart, roundabout-exit-2, arrive |
+           | e,d       | bcegb,cd,cd | depart, roundabout-exit-3, arrive |
+           | g,h       | gh,gh       | depart, arrive                    |
+           | g,a       | bcegb,ab,ab | depart, roundabout-exit-1, arrive |
+           | g,d       | bcegb,cd,cd | depart, roundabout-exit-2, arrive |
+           | g,f       | bcegb,ef,ef | depart, roundabout-exit-3, arrive |
+
+    Scenario: Drive Around
+        Given the node map
+            |   |   | a  |   |   |
+            |   |   | b  |   |   |
+            | h | g |    | c | d |
+            |   |   | e  |   |   |
+            |   |   | f  |   |   |
+
+       And the ways
+            | nodes  | roundabout |
+            | ab     | false      |
+            | cd     | false      |
+            | ef     | false      |
+            | gh     | false      |
+            | bcegb  | true       |
+
+       When I route I should get
+           | waypoints | route       | turns          |
+           | b,c       | bcegb,bcegb | depart, arrive |
+           | b,e       | bcegb,bcegb | depart, arrive |
+           | b,g       | bcegb,bcegb | depart, arrive |
+           | c,e       | bcegb,bcegb | depart, arrive |
+           | c,g       | bcegb,bcegb | depart, arrive |
+           | c,b       | bcegb,bcegb | depart, arrive |
+           | e,g       | bcegb,bcegb | depart, arrive |
+           | e,b       | bcegb,bcegb | depart, arrive |
+           | e,c       | bcegb,bcegb | depart, arrive |
+           | g,b       | bcegb,bcegb | depart, arrive |
+           | g,c       | bcegb,bcegb | depart, arrive |
+           | g,e       | bcegb,bcegb | depart, arrive |
+
+     Scenario: Mixed Entry and Exit

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -7,19 +7,19 @@ Feature: Basic Roundabout
 
     Scenario: Enter and Exit
         Given the node map
-            |   |   | a  |   |   |
-            |   |   | b  |   |   |
-            | h | g |    | c | d |
-            |   |   | e  |   |   |
-            |   |   | f  |   |   |
+            |   |   | a |   |   |
+            |   |   | b |   |   |
+            | h | g |   | c | d |
+            |   |   | e |   |   |
+            |   |   | f |   |   |
 
        And the ways
             | nodes  | roundabout |
-            | ab     | false      |
-            | cd     | false      |
-            | ef     | false      |
-            | gh     | false      |
-            | bcegb  | true       |
+            | ab     | no         |
+            | cd     | no         |
+            | ef     | no         |
+            | gh     | no         |
+            | bcegb  | yes        |
 
        When I route I should get
            | waypoints | route    | turns                             |
@@ -38,19 +38,19 @@ Feature: Basic Roundabout
 
     Scenario: Only Enter
         Given the node map
-            |   |   | a  |   |   |
-            |   |   | b  |   |   |
-            | h | g |    | c | d |
-            |   |   | e  |   |   |
-            |   |   | f  |   |   |
+            |   |   | a |   |   |
+            |   |   | b |   |   |
+            | h | g |   | c | d |
+            |   |   | e |   |   |
+            |   |   | f |   |   |
 
        And the ways
             | nodes  | roundabout |
-            | ab     | false      |
-            | cd     | false      |
-            | ef     | false      |
-            | gh     | false      |
-            | bcegb  | true       |
+            | ab     | no         |
+            | cd     | no         |
+            | ef     | no         |
+            | gh     | no         |
+            | bcegb  | yes        |
 
        When I route I should get
            | waypoints | route    | turns                            |
@@ -73,19 +73,19 @@ Feature: Basic Roundabout
 
     Scenario: Only Exit
         Given the node map
-            |   |   | a  |   |   |
-            |   |   | b  |   |   |
-            | h | g |    | c | d |
-            |   |   | e  |   |   |
-            |   |   | f  |   |   |
+            |   |   | a |   |   |
+            |   |   | b |   |   |
+            | h | g |   | c | d |
+            |   |   | e |   |   |
+            |   |   | f |   |   |
 
        And the ways
             | nodes  | roundabout |
-            | ab     | false      |
-            | cd     | false      |
-            | ef     | false      |
-            | gh     | false      |
-            | bcegb  | true       |
+            | ab     | no         |
+            | cd     | no         |
+            | ef     | no         |
+            | gh     | no         |
+            | bcegb  | yes        |
 
        When I route I should get
            | waypoints | route       | turns                             |
@@ -108,19 +108,19 @@ Feature: Basic Roundabout
 
     Scenario: Drive Around
         Given the node map
-            |   |   | a  |   |   |
-            |   |   | b  |   |   |
-            | h | g |    | c | d |
-            |   |   | e  |   |   |
-            |   |   | f  |   |   |
+            |   |   | a |   |   |
+            |   |   | b |   |   |
+            | h | g |   | c | d |
+            |   |   | e |   |   |
+            |   |   | f |   |   |
 
        And the ways
             | nodes  | roundabout |
-            | ab     | false      |
-            | cd     | false      |
-            | ef     | false      |
-            | gh     | false      |
-            | bcegb  | true       |
+            | ab     | no         |
+            | cd     | no         |
+            | ef     | no         |
+            | gh     | no         |
+            | bcegb  | yes        |
 
        When I route I should get
            | waypoints | route       | turns          |
@@ -138,3 +138,36 @@ Feature: Basic Roundabout
            | g,e       | bcegb,bcegb | depart, arrive |
 
      Scenario: Mixed Entry and Exit
+        Given the node map
+           |   | a |   | c |   |
+           | l |   | b |   | d |
+           |   | k |   | e |   |
+           | j |   | h |   | f |
+           |   | i |   | g |   |
+
+        And the ways
+           | nodes | roundabout | oneway |
+           | abc   | no         | yes    |
+           | def   | no         | yes    |
+           | ghi   | no         | yes    |
+           | jkl   | no         | yes    |
+           | behkb | yes        | yes    |
+
+        When I route I should get
+           | waypoints | route       | turns                             |
+           | a,c       | abc,abc,abc | depart, roundabout-exit-1, arrive |
+           | a,f       | abc,def,def | depart, roundabout-exit-2, arrive |
+           | a,i       | abc,ghi,ghi | depart, roundabout-exit-3, arrive |
+           | a,l       | abc,jkl,jkl | depart, roundabout-exit-4, arrive |
+           | d,f       | def,def,def | depart, roundabout-exit-1, arrive |
+           | d,i       | def,ghi,ghi | depart, roundabout-exit-2, arrive |
+           | d,l       | def,jkl,jkl | depart, roundabout-exit-3, arrive |
+           | d,c       | def,abc,abc | depart, roundabout-exit-4, arrive |
+           | g,i       | ghi,ghi,ghi | depart, roundabout-exit-1, arrive |
+           | g,l       | ghi,jkl,jkl | depart, roundabout-exit-2, arrive |
+           | g,c       | ghi,abc,abc | depart, roundabout-exit-3, arrive |
+           | g,f       | ghi,edf,edf | depart, roundabout-exit-4, arrive |
+           | j,l       | jkl,jkl,jkl | depart, roundabout-exit-1, arrive |
+           | j,c       | jkl,abc,abc | depart, roundabout-exit-2, arrive |
+           | j,f       | jkl,def,def | depart, roundabout-exit-3, arrive |
+           | j,i       | jkl,ghi,ghi | depart, roundabout-exit-4, arrive |

--- a/include/engine/api/base_api.hpp
+++ b/include/engine/api/base_api.hpp
@@ -48,7 +48,7 @@ class BaseAPI
   protected:
     util::json::Object MakeWaypoint(const PhantomNode &phantom) const
     {
-        return json::makeWaypoint(phantom.location, facade.get_name_for_id(phantom.name_id),
+        return json::makeWaypoint(phantom.location, facade.GetNameForID(phantom.name_id),
                                   Hint{phantom, facade.GetCheckSum()});
     }
 

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -138,7 +138,7 @@ class BaseDataFacade
 
     virtual unsigned GetNameIndexFromEdgeID(const unsigned id) const = 0;
 
-    virtual std::string get_name_for_id(const unsigned name_id) const = 0;
+    virtual std::string GetNameForID(const unsigned name_id) const = 0;
 
     virtual std::size_t GetCoreSize() const = 0;
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -551,7 +551,7 @@ class InternalDataFacade final : public BaseDataFacade
         return m_name_ID_list.at(id);
     }
 
-    std::string get_name_for_id(const unsigned name_id) const override final
+    std::string GetNameForID(const unsigned name_id) const override final
     {
         if (std::numeric_limits<unsigned>::max() == name_id)
         {

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -621,7 +621,7 @@ class SharedDataFacade final : public BaseDataFacade
         return m_name_ID_list.at(id);
     }
 
-    std::string get_name_for_id(const unsigned name_id) const override final
+    std::string GetNameForID(const unsigned name_id) const override final
     {
         if (std::numeric_limits<unsigned>::max() == name_id)
         {

--- a/include/engine/guidance/assemble_leg.hpp
+++ b/include/engine/guidance/assemble_leg.hpp
@@ -139,12 +139,12 @@ RouteLeg assembleLeg(const DataFacadeT &facade,
     BOOST_ASSERT(summary_array.begin() != summary_array.end());
     std::string summary =
         std::accumulate(std::next(summary_array.begin()), summary_array.end(),
-                        facade.get_name_for_id(summary_array.front()),
+                        facade.GetNameForID(summary_array.front()),
                         [&facade](std::string previous, const std::uint32_t name_id)
                         {
                             if (name_id != 0)
                             {
-                                previous += ", " + facade.get_name_for_id(name_id);
+                                previous += ", " + facade.GetNameForID(name_id);
                             }
                             return previous;
                         });

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -92,7 +92,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
             if (path_point.turn_instruction != extractor::guidance::TurnInstruction::NO_TURN())
             {
                 BOOST_ASSERT(segment_duration >= 0);
-                const auto name = facade.get_name_for_id(path_point.name_id);
+                const auto name = facade.GetNameForID(path_point.name_id);
                 const auto distance = leg_geometry.segment_distances[segment_index];
                 steps.push_back(RouteStep{path_point.name_id,
                                           name,
@@ -113,7 +113,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         const int duration = segment_duration + target_duration;
         BOOST_ASSERT(duration >= 0);
         steps.push_back(RouteStep{target_node.name_id,
-                                  facade.get_name_for_id(target_node.name_id),
+                                  facade.GetNameForID(target_node.name_id),
                                   duration / 10.,
                                   distance,
                                   target_mode,
@@ -141,7 +141,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         BOOST_ASSERT(duration >= 0);
 
         steps.push_back(RouteStep{source_node.name_id,
-                                  facade.get_name_for_id(source_node.name_id),
+                                  facade.GetNameForID(source_node.name_id),
                                   duration / 10.,
                                   leg_geometry.segment_distances[segment_index],
                                   source_mode,
@@ -164,7 +164,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
     // This step has length zero, the only reason we need it is the target location
     steps.push_back(
         RouteStep{target_node.name_id,
-                  facade.get_name_for_id(target_node.name_id),
+                  facade.GetNameForID(target_node.name_id),
                   ZERO_DURACTION,
                   ZERO_DISTANCE,
                   target_mode,

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -17,6 +17,7 @@
 #include "util/node_based_graph.hpp"
 #include "util/typedefs.hpp"
 #include "util/deallocating_vector.hpp"
+#include "util/name_table.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -51,7 +52,8 @@ class EdgeBasedGraphFactory
                                    const std::unordered_set<NodeID> &traffic_lights,
                                    std::shared_ptr<const RestrictionMap> restriction_map,
                                    const std::vector<QueryNode> &node_info_list,
-                                   SpeedProfileProperties speed_profile);
+                                   SpeedProfileProperties speed_profile,
+                                   const util::NameTable &name_table);
 
     void Run(const std::string &original_edge_data_filename,
              lua_State *lua_state,
@@ -105,6 +107,8 @@ class EdgeBasedGraphFactory
     const CompressedEdgeContainer &m_compressed_edge_container;
 
     SpeedProfileProperties speed_profile;
+
+    const util::NameTable &name_table;
 
     void CompressGeometry();
     unsigned RenumberEdges();

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -249,10 +249,11 @@ inline double angularDeviation(const double angle, const double from)
     return std::min(360 - deviation, deviation);
 }
 
-inline double getAngularPenalty(const double angle, TurnInstruction instruction)
+inline double getAngularPenalty(const double angle, DirectionModifier modifier)
 {
+    // these are not aligned with getTurnDirection but represent an ideal center
     const double center[] = {0, 45, 90, 135, 180, 225, 270, 315};
-    return angularDeviation(center[static_cast<int>(instruction.direction_modifier)], angle);
+    return angularDeviation(center[static_cast<int>(modifier)], angle);
 }
 
 inline double getTurnConfidence(const double angle, TurnInstruction instruction)
@@ -262,8 +263,8 @@ inline double getTurnConfidence(const double angle, TurnInstruction instruction)
     if (!isBasic(instruction.type) || instruction.direction_modifier == DirectionModifier::UTurn)
         return 1.0;
 
-    const double deviations[] = {0, 45, 50, 35, 10, 35, 50, 45};
-    const double difference = getAngularPenalty(angle, instruction);
+    const double deviations[] = {0, 45, 50, 30, 20, 30, 50, 45};
+    const double difference = getAngularPenalty(angle, instruction.direction_modifier);
     const double max_deviation = deviations[static_cast<int>(instruction.direction_modifier)];
     return 1.0 - (difference / max_deviation) * (difference / max_deviation);
 }
@@ -281,7 +282,7 @@ inline DirectionModifier getTurnDirection(const double angle)
         return DirectionModifier::Right;
     if (angle >= 140 && angle < 170)
         return DirectionModifier::SlightRight;
-    if (angle >= 170 && angle <= 190)
+    if (angle >= 165 && angle <= 195)
         return DirectionModifier::Straight;
     if (angle > 190 && angle <= 220)
         return DirectionModifier::SlightLeft;
@@ -295,10 +296,14 @@ inline DirectionModifier getTurnDirection(const double angle)
 // swaps left <-> right modifier types
 inline DirectionModifier mirrorDirectionModifier(const DirectionModifier modifier)
 {
-    const constexpr DirectionModifier results[] = {
-        DirectionModifier::UTurn,      DirectionModifier::SharpLeft, DirectionModifier::Left,
-        DirectionModifier::SlightLeft, DirectionModifier::Straight,  DirectionModifier::SlightRight,
-        DirectionModifier::Right,      DirectionModifier::SharpRight};
+    const constexpr DirectionModifier results[] = {DirectionModifier::UTurn,
+                                                   DirectionModifier::SharpLeft,
+                                                   DirectionModifier::Left,
+                                                   DirectionModifier::SlightLeft,
+                                                   DirectionModifier::Straight,
+                                                   DirectionModifier::SlightRight,
+                                                   DirectionModifier::Right,
+                                                   DirectionModifier::SharpRight};
     return results[modifier];
 }
 
@@ -313,6 +318,17 @@ inline bool isLowPriorityRoadClass(const FunctionalRoadClass road_class)
 {
     return road_class == FunctionalRoadClass::LOW_PRIORITY_ROAD ||
            road_class == FunctionalRoadClass::SERVICE;
+}
+
+inline bool isDistinct(const DirectionModifier first, const DirectionModifier second)
+{
+    if ((first + 1) % detail::num_direction_modifiers == second)
+        return false;
+
+    if ((second + 1) % detail::num_direction_modifiers == first)
+        return false;
+
+    return true;
 }
 
 } // namespace guidance

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -17,7 +17,6 @@
 #include <cmath>
 #include <cstdint>
 #include <string>
-#include <iostream>
 
 namespace osrm
 {
@@ -391,6 +390,9 @@ inline bool requiresNameAnnounced(const std::string &from, const std::string &to
 
 inline int getPriority( const FunctionalRoadClass road_class )
 {
+    //The road priorities indicate which roads can bee seen as more or less equal.
+    //They are used in Fork-Discovery. Possibly should be moved to profiles post v5?
+    //A fork can happen between road types that are at most 1 priority apart from each other
     const constexpr int road_priority[] = {10, 0, 10, 2, 10, 4, 10, 6, 10, 8, 10, 11, 10, 12, 10, 14};
     return road_priority[static_cast<int>(road_class)];
 }
@@ -398,6 +400,9 @@ inline int getPriority( const FunctionalRoadClass road_class )
 inline bool canBeSeenAsFork(const FunctionalRoadClass first, const FunctionalRoadClass second)
 {
     // forks require similar road categories
+    // Based on the priorities assigned above, we can set forks only if the road priorities match closely.
+    // Potentially we could include features like number of lanes here and others?
+    // Should also be moved to profiles
     return std::abs(getPriority(first) - getPriority(second)) <= 1;
 }
 

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -6,6 +6,8 @@
 #include "extractor/restriction_map.hpp"
 #include "extractor/compressed_edge_container.hpp"
 
+#include "util/name_table.hpp"
+
 #include <cstdint>
 
 #include <string>
@@ -53,7 +55,8 @@ class TurnAnalysis
                  const std::vector<QueryNode> &node_info_list,
                  const RestrictionMap &restriction_map,
                  const std::unordered_set<NodeID> &barrier_nodes,
-                 const CompressedEdgeContainer &compressed_edge_container);
+                 const CompressedEdgeContainer &compressed_edge_container,
+                 const util::NameTable &name_table);
 
     // the entry into the turn analysis
     std::vector<TurnCandidate> getTurns(const NodeID from_node, const EdgeID via_eid) const;
@@ -64,6 +67,7 @@ class TurnAnalysis
     const RestrictionMap &restriction_map;
     const std::unordered_set<NodeID> &barrier_nodes;
     const CompressedEdgeContainer &compressed_edge_container;
+    const util::NameTable &name_table;
 
     // Check for restrictions/barriers and generate a list of valid and invalid turns present at the
     // node reached

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -23,33 +23,49 @@ namespace extractor
 namespace guidance
 {
 
-struct TurnCandidate
+// What is exposed to the outside
+struct TurnOperation final
 {
-    EdgeID eid;   // the id of the arc
-    bool valid;   // a turn may be relevant to good instructions, even if we cannot take the road
-    double angle; // the approximated angle of the turn
-    TurnInstruction instruction; // a proposed instruction
-    double confidence;           // how close to the border is the turn?
+    EdgeID eid;
+    double angle;
+    TurnInstruction instruction;
+};
+
+// For the turn analysis, we require a full list of all connected roads to determine the outcome.
+// Invalid turns can influence the perceived angles
+//
+// aaa(2)aa
+//          a - bbbbb
+// aaa(1)aa
+//
+// will not be perceived as a turn from (1) -> b, and as a U-turn from (1) -> (2).
+// In addition, they can influence whether a turn is obvious or not.
+struct ConnectedRoad final
+{
+    ConnectedRoad(const TurnOperation turn, const bool entry_allowed = false);
+
+    TurnOperation turn;
+    bool entry_allowed; // a turn may be relevant to good instructions, even if we cannot take
+                        // the road
 
     std::string toString() const
     {
-        std::string result = "[turn] ";
-        result += std::to_string(eid);
-        result += " valid: ";
-        result += std::to_string(valid);
+        std::string result = "[connection] ";
+        result += std::to_string(turn.eid);
+        result += " allows entry: ";
+        result += std::to_string(entry_allowed);
         result += " angle: ";
-        result += std::to_string(angle);
+        result += std::to_string(turn.angle);
         result += " instruction: ";
-        result += std::to_string(static_cast<std::int32_t>(instruction.type)) + " " +
-                  std::to_string(static_cast<std::int32_t>(instruction.direction_modifier));
-        result += " confidence: ";
-        result += std::to_string(confidence);
+        result += std::to_string(static_cast<std::int32_t>(turn.instruction.type)) + " " +
+                  std::to_string(static_cast<std::int32_t>(turn.instruction.direction_modifier));
         return result;
     }
 };
 
 class TurnAnalysis
 {
+
   public:
     TurnAnalysis(const util::NodeBasedDynamicGraph &node_based_graph,
                  const std::vector<QueryNode> &node_info_list,
@@ -59,7 +75,7 @@ class TurnAnalysis
                  const util::NameTable &name_table);
 
     // the entry into the turn analysis
-    std::vector<TurnCandidate> getTurns(const NodeID from_node, const EdgeID via_eid) const;
+    std::vector<TurnOperation> getTurns(const NodeID from_node, const EdgeID via_eid) const;
 
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;
@@ -69,11 +85,12 @@ class TurnAnalysis
     const CompressedEdgeContainer &compressed_edge_container;
     const util::NameTable &name_table;
 
-    // Check for restrictions/barriers and generate a list of valid and invalid turns present at the
+    // Check for restrictions/barriers and generate a list of valid and invalid turns present at
+    // the
     // node reached
     // from `from_node` via `via_eid`
     // The resulting candidates have to be analysed for their actual instructions later on.
-    std::vector<TurnCandidate> getTurnCandidates(const NodeID from_node,
+    std::vector<ConnectedRoad> getConnectedRoads(const NodeID from_node,
                                                  const EdgeID via_eid) const;
 
     // Merge segregated roads to omit invalid turns in favor of treating segregated roads as
@@ -87,10 +104,7 @@ class TurnAnalysis
     //
     // The treatment results in a straight turn angle of 180º rather than a turn angle of approx
     // 160
-    std::vector<TurnCandidate>
-    mergeSegregatedRoads(const NodeID from_node,
-                         const EdgeID via_eid,
-                         std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> mergeSegregatedRoads(std::vector<ConnectedRoad> intersection) const;
 
     // TODO distinguish roundabouts and rotaries
     // TODO handle bike/walk cases that allow crossing a roundabout!
@@ -98,108 +112,86 @@ class TurnAnalysis
     // Processing of roundabouts
     // Produces instructions to enter/exit a roundabout or to stay on it.
     // Performs the distinction between roundabout and rotaries.
-    std::vector<TurnCandidate> handleRoundabouts(const NodeID from,
-                                                 const EdgeID via_edge,
+    std::vector<ConnectedRoad> handleRoundabouts(const EdgeID via_edge,
                                                  const bool on_roundabout,
-                                                 const bool can_enter_roundabout,
                                                  const bool can_exit_roundabout,
-                                                 std::vector<TurnCandidate> turn_candidates) const;
+                                                 std::vector<ConnectedRoad> intersection) const;
 
     // Indicates a Junction containing a motoryway
-    bool isMotorwayJunction(const NodeID from,
-                            const EdgeID via_edge,
-                            const std::vector<TurnCandidate> &turn_candidates) const;
+    bool isMotorwayJunction(const EdgeID via_edge,
+                            const std::vector<ConnectedRoad> &intersection) const;
 
     // Decide whether a turn is a turn or a ramp access
-    TurnType findBasicTurnType(const EdgeID via_edge, const TurnCandidate &candidate) const;
+    TurnType findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;
 
     // Get the Instruction for an obvious turn
     // Instruction will be a silent instruction
     TurnInstruction getInstructionForObvious(const std::size_t number_of_candidates,
                                              const EdgeID via_edge,
-                                             const TurnCandidate &candidate) const;
+                                             const ConnectedRoad &candidate) const;
 
     // Helper Function that decides between NoTurn or NewName
     TurnInstruction
-    noTurnOrNewName(const NodeID from, const EdgeID via_edge, const TurnCandidate &candidate) const;
+    noTurnOrNewName(const NodeID from, const EdgeID via_edge, const ConnectedRoad &candidate) const;
 
     // Basic Turn Handling
 
     // Dead end.
-    std::vector<TurnCandidate> handleOneWayTurn(const NodeID from,
-                                                const EdgeID via_edge,
-                                                std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> handleOneWayTurn(std::vector<ConnectedRoad> intersection) const;
 
     // Mode Changes, new names...
-    std::vector<TurnCandidate> handleTwoWayTurn(const NodeID from,
-                                                const EdgeID via_edge,
-                                                std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> handleTwoWayTurn(const EdgeID via_edge,
+                                                std::vector<ConnectedRoad> intersection) const;
 
     // Forks, T intersections and similar
-    std::vector<TurnCandidate> handleThreeWayTurn(const NodeID from,
-                                                  const EdgeID via_edge,
-                                                  std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> handleThreeWayTurn(const EdgeID via_edge,
+                                                  std::vector<ConnectedRoad> intersection) const;
 
-    // Normal Intersection. Can still contain forks...
-    std::vector<TurnCandidate> handleFourWayTurn(const NodeID from,
-                                                 const EdgeID via_edge,
-                                                 std::vector<TurnCandidate> turn_candidates) const;
-
-    // Fallback for turns of high complexion
-    std::vector<TurnCandidate> handleComplexTurn(const NodeID from,
-                                                 const EdgeID via_edge,
-                                                 std::vector<TurnCandidate> turn_candidates) const;
+    // Handling of turns larger then degree three
+    std::vector<ConnectedRoad> handleComplexTurn(const EdgeID via_edge,
+                                                 std::vector<ConnectedRoad> intersection) const;
 
     // Any Junction containing motorways
-    std::vector<TurnCandidate> handleMotorwayJunction(
-        const NodeID from, const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> handleMotorwayJunction(
+        const EdgeID via_edge, std::vector<ConnectedRoad> intersection) const;
 
-    std::vector<TurnCandidate> handleFromMotorway(const NodeID from,
-                                                  const EdgeID via_edge,
-                                                  std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> handleFromMotorway(const EdgeID via_edge,
+                                                  std::vector<ConnectedRoad> intersection) const;
 
-    std::vector<TurnCandidate> handleMotorwayRamp(const NodeID from,
-                                                  const EdgeID via_edge,
-                                                  std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad> handleMotorwayRamp(const EdgeID via_edge,
+                                                  std::vector<ConnectedRoad> intersection) const;
 
     // Utility function, setting basic turn types. Prepares for normal turn handling.
-    std::vector<TurnCandidate> setTurnTypes(const NodeID from,
+    std::vector<ConnectedRoad> setTurnTypes(const NodeID from,
                                             const EdgeID via_edge,
-                                            std::vector<TurnCandidate> turn_candidates) const;
-
-    // Utility function to handle direction modifier conflicts if reasonably possible
-    std::vector<TurnCandidate> handleConflicts(const NodeID from,
-                                               const EdgeID via_edge,
-                                               std::vector<TurnCandidate> turn_candidates) const;
-
-    // node_u -- (edge_1) --> node_v -- (edge_2) --> node_w
-    TurnInstruction AnalyzeTurn(const NodeID node_u,
-                                const EdgeID edge1,
-                                const NodeID node_v,
-                                const EdgeID edge2,
-                                const NodeID node_w,
-                                const double angle) const;
+                                            std::vector<ConnectedRoad> intersection) const;
 
     // Assignment of specific turn types
-    void assignFork(const EdgeID via_edge, TurnCandidate &left, TurnCandidate &right) const;
+    void assignFork(const EdgeID via_edge, ConnectedRoad &left, ConnectedRoad &right) const;
     void assignFork(const EdgeID via_edge,
-                    TurnCandidate &left,
-                    TurnCandidate &center,
-                    TurnCandidate &right) const;
+                    ConnectedRoad &left,
+                    ConnectedRoad &center,
+                    ConnectedRoad &right) const;
 
     void
-    handleDistinctConflict(const EdgeID via_edge, TurnCandidate &left, TurnCandidate &right) const;
+    handleDistinctConflict(const EdgeID via_edge, ConnectedRoad &left, ConnectedRoad &right) const;
 
     // Type specific fallbacks
-    std::vector<TurnCandidate>
-    fallbackTurnAssignmentMotorway(std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<ConnectedRoad>
+    fallbackTurnAssignmentMotorway(std::vector<ConnectedRoad> intersection) const;
 
-    //Classification
-    std::size_t findObviousTurn( const EdgeID via_edge, const std::vector<TurnCandidate> &turn_candidates) const;
-    std::pair<std::size_t,std::size_t> findFork( const EdgeID via_edge, const std::vector<TurnCandidate> &turn_candidates) const;
+    // Classification
+    std::size_t findObviousTurn(const EdgeID via_edge,
+                                const std::vector<ConnectedRoad> &intersection) const;
+    std::pair<std::size_t, std::size_t>
+    findFork(const std::vector<ConnectedRoad> &intersection) const;
 
-    std::vector<TurnCandidate> assignLeftTurns( const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates, const std::size_t starting_at ) const;
-    std::vector<TurnCandidate> assignRightTurns( const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates, const std::size_t up_to ) const;
+    std::vector<ConnectedRoad> assignLeftTurns(const EdgeID via_edge,
+                                               std::vector<ConnectedRoad> intersection,
+                                               const std::size_t starting_at) const;
+    std::vector<ConnectedRoad> assignRightTurns(const EdgeID via_edge,
+                                                std::vector<ConnectedRoad> intersection,
+                                                const std::size_t up_to) const;
 
 }; // class TurnAnalysis
 

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <utility>
 #include <unordered_set>
 
 namespace osrm
@@ -149,11 +150,13 @@ class TurnAnalysis
     std::vector<TurnCandidate> handleMotorwayJunction(
         const NodeID from, const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates) const;
 
-    std::vector<TurnCandidate> handleFromMotorway(
-        const NodeID from, const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<TurnCandidate> handleFromMotorway(const NodeID from,
+                                                  const EdgeID via_edge,
+                                                  std::vector<TurnCandidate> turn_candidates) const;
 
-    std::vector<TurnCandidate> handleMotorwayRamp(
-        const NodeID from, const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates) const;
+    std::vector<TurnCandidate> handleMotorwayRamp(const NodeID from,
+                                                  const EdgeID via_edge,
+                                                  std::vector<TurnCandidate> turn_candidates) const;
 
     // Utility function, setting basic turn types. Prepares for normal turn handling.
     std::vector<TurnCandidate> setTurnTypes(const NodeID from,
@@ -164,20 +167,6 @@ class TurnAnalysis
     std::vector<TurnCandidate> handleConflicts(const NodeID from,
                                                const EdgeID via_edge,
                                                std::vector<TurnCandidate> turn_candidates) const;
-
-    // Old fallbacks, to be removed
-    std::vector<TurnCandidate> optimizeRamps(const EdgeID via_edge,
-                                             std::vector<TurnCandidate> turn_candidates) const;
-
-    std::vector<TurnCandidate> optimizeCandidates(const EdgeID via_eid,
-                                                  std::vector<TurnCandidate> turn_candidates) const;
-
-    bool isObviousChoice(const EdgeID via_eid,
-                         const std::size_t turn_index,
-                         const std::vector<TurnCandidate> &turn_candidates) const;
-
-    std::vector<TurnCandidate> suppressTurns(const EdgeID via_eid,
-                                             std::vector<TurnCandidate> turn_candidates) const;
 
     // node_u -- (edge_1) --> node_v -- (edge_2) --> node_w
     TurnInstruction AnalyzeTurn(const NodeID node_u,
@@ -194,9 +183,19 @@ class TurnAnalysis
                     TurnCandidate &center,
                     TurnCandidate &right) const;
 
-    //Type specific fallbacks
+    void
+    handleDistinctConflict(const EdgeID via_edge, TurnCandidate &left, TurnCandidate &right) const;
+
+    // Type specific fallbacks
     std::vector<TurnCandidate>
     fallbackTurnAssignmentMotorway(std::vector<TurnCandidate> turn_candidates) const;
+
+    //Classification
+    std::size_t findObviousTurn( const EdgeID via_edge, const std::vector<TurnCandidate> &turn_candidates) const;
+    std::pair<std::size_t,std::size_t> findFork( const EdgeID via_edge, const std::vector<TurnCandidate> &turn_candidates) const;
+
+    std::vector<TurnCandidate> assignLeftTurns( const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates, const std::size_t starting_at ) const;
+    std::vector<TurnCandidate> assignRightTurns( const EdgeID via_edge, std::vector<TurnCandidate> turn_candidates, const std::size_t up_to ) const;
 
 }; // class TurnAnalysis
 

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -42,8 +42,16 @@ enum TurnType // at the moment we can support 32 turn types, without increasing 
     NewName,                // no turn, but name changes
     Continue,               // remain on a street
     Turn,                   // basic turn
+    FirstTurn,              // First of x turns
+    SecondTurn,             // Second of x turns
+    ThirdTurn,              // Third of x turns
+    FourthTurn,             // Fourth of x turns
     Merge,                  // merge onto a street
     Ramp,                   // special turn (highway ramp exits)
+    FirstRamp,              // first turn onto a ramp
+    SecondRamp,             // second turn onto a ramp
+    ThirdRamp,              // third turn onto a ramp
+    FourthRamp,             // fourth turn onto a ramp
     Fork,                   // fork road splitting up
     EndOfRoad,              // T intersection
     EnterRoundabout,        // Entering a small Roundabout

--- a/include/util/name_table.hpp
+++ b/include/util/name_table.hpp
@@ -1,0 +1,26 @@
+#ifndef OSRM_UTIL_NAME_TABLE_HPP
+#define OSRM_UTIL_NAME_TABLE_HPP
+
+#include "util/shared_memory_vector_wrapper.hpp"
+#include "util/range_table.hpp"
+
+#include <string>
+
+namespace osrm
+{
+namespace util
+{
+class NameTable
+{
+  private:
+    //FIXME should this use shared memory
+    RangeTable<16, false> m_name_table;
+    ShM<char, false>::vector m_names_char_list;
+  public:
+    NameTable( const std::string &filename );
+    std::string get_name_for_id(const unsigned name_id) const;
+};
+} // namespace util
+} // namespace osrm
+
+#endif // OSRM_UTIL_NAME_TABLE_HPP

--- a/include/util/name_table.hpp
+++ b/include/util/name_table.hpp
@@ -10,14 +10,19 @@ namespace osrm
 {
 namespace util
 {
+
+// While this could, theoretically, hold any names in the fitting format,
+// the NameTable allows access to a part of the Datafacade to allow
+// processing based on name indices.
 class NameTable
 {
   private:
-    //FIXME should this use shared memory
+    // FIXME should this use shared memory
     RangeTable<16, false> m_name_table;
     ShM<char, false>::vector m_names_char_list;
+
   public:
-    NameTable( const std::string &filename );
+    NameTable(const std::string &filename);
     std::string get_name_for_id(const unsigned name_id) const;
 };
 } // namespace util

--- a/include/util/name_table.hpp
+++ b/include/util/name_table.hpp
@@ -23,7 +23,7 @@ class NameTable
 
   public:
     NameTable(const std::string &filename);
-    std::string get_name_for_id(const unsigned name_id) const;
+    std::string GetNameForID(const unsigned name_id) const;
 };
 } // namespace util
 } // namespace osrm

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -28,23 +28,17 @@ namespace json
 namespace detail
 {
 
-const constexpr char *modifier_names[] = {"uturn",
-                                          "sharp right",
-                                          "right",
-                                          "slight right",
-                                          "straight",
-                                          "slight left",
-                                          "left",
-                                          "sharp left"};
+const constexpr char *modifier_names[] = {"uturn",    "sharp right", "right", "slight right",
+                                          "straight", "slight left", "left",  "sharp left"};
 
 // translations of TurnTypes. Not all types are exposed to the outside world.
 // invalid types should never be returned as part of the API
 const constexpr char *turn_type_names[] = {
     "invalid",    "no turn",     "invalid",        "new name",    "continue",       "turn",
-    "merge",      "ramp",        "fork",           "end of road", "roundabout",     "invalid",
+    "turn",       "turn",        "turn",           "merge",       "ramp",           "ramp",
+    "ramp",       "ramp",        "fork",           "end of road", "roundabout",     "invalid",
     "roundabout", "invalid",     "traffic circle", "invalid",     "traffic circle", "invalid",
     "invalid",    "restriction", "notification"};
-
 const constexpr char *waypoint_type_names[] = {"invalid", "arrive", "depart"};
 
 // Check whether to include a modifier in the result of the API
@@ -54,6 +48,23 @@ inline bool isValidModifier(const guidance::StepManeuver maneuver)
         maneuver.instruction.direction_modifier == DirectionModifier::UTurn)
         return false;
     return true;
+}
+
+inline bool isMultiTurn(const TurnType type)
+{
+    return (type == TurnType::FirstTurn || type == TurnType::SecondTurn ||
+            type == TurnType::ThirdTurn);
+}
+
+inline std::string getCount(const TurnType type)
+{
+    if (type == TurnType::FirstTurn)
+        return "1";
+    if (type == TurnType::SecondTurn)
+        return "2";
+    if (type == TurnType::ThirdTurn)
+        return "3";
+    return "0";
 }
 
 std::string instructionTypeToString(const TurnType type)
@@ -141,6 +152,8 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
     else
         step_maneuver.values["type"] = detail::waypointTypeToString(maneuver.waypoint_type);
 
+    if (detail::isMultiTurn(maneuver.instruction.type))
+        step_maneuver.values["count"] = detail::getCount(maneuver.instruction.type);
     if (detail::isValidModifier(maneuver))
         step_maneuver.values["modifier"] =
             detail::instructionModifierToString(maneuver.instruction.direction_modifier);

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -28,17 +28,23 @@ namespace json
 namespace detail
 {
 
-const constexpr char *modifier_names[] = {"uturn",    "sharp right", "right", "slight right",
-                                          "straight", "slight left", "left",  "sharp left"};
+const constexpr char *modifier_names[] = {"uturn",
+                                          "sharp right",
+                                          "right",
+                                          "slight right",
+                                          "straight",
+                                          "slight left",
+                                          "left",
+                                          "sharp left"};
 
 // translations of TurnTypes. Not all types are exposed to the outside world.
 // invalid types should never be returned as part of the API
 const constexpr char *turn_type_names[] = {
-    "invalid",    "no turn",     "invalid",        "new name",    "continue",       "turn",
-    "turn",       "turn",        "turn",           "merge",       "ramp",           "ramp",
-    "ramp",       "ramp",        "fork",           "end of road", "roundabout",     "invalid",
-    "roundabout", "invalid",     "traffic circle", "invalid",     "traffic circle", "invalid",
-    "invalid",    "restriction", "notification"};
+    "invalid",        "no turn", "invalid",    "new name",    "continue",       "turn",
+    "turn",           "turn",    "turn",       "turn",        "merge",          "ramp",
+    "ramp",           "ramp",    "ramp",       "ramp",        "fork",           "end of road",
+    "roundabout",     "invalid", "roundabout", "invalid",     "traffic circle", "invalid",
+    "traffic circle", "invalid", "invalid",    "restriction", "notification"};
 const constexpr char *waypoint_type_names[] = {"invalid", "arrive", "depart"};
 
 // Check whether to include a modifier in the result of the API
@@ -48,23 +54,6 @@ inline bool isValidModifier(const guidance::StepManeuver maneuver)
         maneuver.instruction.direction_modifier == DirectionModifier::UTurn)
         return false;
     return true;
-}
-
-inline bool isMultiTurn(const TurnType type)
-{
-    return (type == TurnType::FirstTurn || type == TurnType::SecondTurn ||
-            type == TurnType::ThirdTurn);
-}
-
-inline std::string getCount(const TurnType type)
-{
-    if (type == TurnType::FirstTurn)
-        return "1";
-    if (type == TurnType::SecondTurn)
-        return "2";
-    if (type == TurnType::ThirdTurn)
-        return "3";
-    return "0";
 }
 
 std::string instructionTypeToString(const TurnType type)
@@ -152,8 +141,6 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
     else
         step_maneuver.values["type"] = detail::waypointTypeToString(maneuver.waypoint_type);
 
-    if (detail::isMultiTurn(maneuver.instruction.type))
-        step_maneuver.values["count"] = detail::getCount(maneuver.instruction.type);
     if (detail::isValidModifier(maneuver))
         step_maneuver.values["modifier"] =
             detail::instructionModifierToString(maneuver.instruction.direction_modifier);

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -34,12 +34,13 @@ EdgeBasedGraphFactory::EdgeBasedGraphFactory(
     const std::unordered_set<NodeID> &traffic_lights,
     std::shared_ptr<const RestrictionMap> restriction_map,
     const std::vector<QueryNode> &node_info_list,
-    SpeedProfileProperties speed_profile)
+    SpeedProfileProperties speed_profile,
+    const util::NameTable &name_table)
     : m_max_edge_id(0), m_node_info_list(node_info_list),
       m_node_based_graph(std::move(node_based_graph)),
       m_restriction_map(std::move(restriction_map)), m_barrier_nodes(barrier_nodes),
       m_traffic_lights(traffic_lights), m_compressed_edge_container(compressed_edge_container),
-      speed_profile(std::move(speed_profile))
+      speed_profile(std::move(speed_profile)), name_table(name_table)
 {
 }
 
@@ -123,10 +124,9 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     // traverse arrays from start and end respectively
     for (const auto i : util::irange(0UL, geometry_size))
     {
-        BOOST_ASSERT(
-            current_edge_source_coordinate_id ==
-            m_compressed_edge_container.GetBucketReference(edge_id_2)[geometry_size - 1 - i]
-                .node_id);
+        BOOST_ASSERT(current_edge_source_coordinate_id ==
+                     m_compressed_edge_container.GetBucketReference(
+                                                     edge_id_2)[geometry_size - 1 - i].node_id);
         const NodeID current_edge_target_coordinate_id = forward_geometry[i].node_id;
         BOOST_ASSERT(current_edge_target_coordinate_id != current_edge_source_coordinate_id);
 
@@ -302,8 +302,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     // Three nested loop look super-linear, but we are dealing with a (kind of)
     // linear number of turns only.
     util::Percent progress(m_node_based_graph->GetNumberOfNodes());
-    guidance::TurnAnalysis turn_analysis( *m_node_based_graph, m_node_info_list,
-                                       *m_restriction_map, m_barrier_nodes, m_compressed_edge_container );
+    guidance::TurnAnalysis turn_analysis(*m_node_based_graph, m_node_info_list, *m_restriction_map,
+                                         m_barrier_nodes, m_compressed_edge_container, name_table);
     for (const auto node_u : util::irange(0u, m_node_based_graph->GetNumberOfNodes()))
     {
         // progress.printStatus(node_u);

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -315,15 +315,12 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
             }
 
             ++node_based_edge_counter;
-            auto turn_candidates = turn_analysis.getTurns(node_u, edge_from_u);
+            auto possible_turns = turn_analysis.getTurns(node_u, edge_from_u);
 
             const NodeID node_v = m_node_based_graph->GetTarget(edge_from_u);
 
-            for (const auto turn : turn_candidates)
+            for (const auto turn : possible_turns)
             {
-                if (!turn.valid)
-                    continue;
-
                 const double turn_angle = turn.angle;
 
                 // only add an edge if turn is not prohibited

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -15,6 +15,7 @@
 #include "util/timing_util.hpp"
 #include "util/lua_util.hpp"
 #include "util/graph_loader.hpp"
+#include "util/name_table.hpp"
 
 #include "util/typedefs.hpp"
 
@@ -521,10 +522,12 @@ Extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
 
     compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
 
+    util::NameTable name_table(config.names_file_name);
+
     EdgeBasedGraphFactory edge_based_graph_factory(
         node_based_graph, compressed_edge_container, barrier_nodes, traffic_lights,
         std::const_pointer_cast<RestrictionMap const>(restriction_map),
-        internal_to_external_node_map, speed_profile);
+        internal_to_external_node_map, speed_profile, name_table);
 
     edge_based_graph_factory.Run(config.edge_output_path, lua_state,
                                  config.edge_segment_lookup_path, config.edge_penalty_path,

--- a/src/extractor/guidance/turn_analysis.cpp
+++ b/src/extractor/guidance/turn_analysis.cpp
@@ -752,8 +752,8 @@ TurnInstruction TurnAnalysis::getInstructionForObvious(const std::size_t num_roa
         const auto &in_data = node_based_graph.GetEdgeData(via_edge);
         const auto &out_data = node_based_graph.GetEdgeData(road.turn.eid);
         if (in_data.name_id != out_data.name_id &&
-            requiresNameAnnounced(name_table.get_name_for_id(in_data.name_id),
-                                  name_table.get_name_for_id(out_data.name_id)))
+            requiresNameAnnounced(name_table.GetNameForID(in_data.name_id),
+                                  name_table.GetNameForID(out_data.name_id)))
             return {TurnType::NewName, getTurnDirection(road.turn.angle)};
         else
             return {TurnType::Suppressed, getTurnDirection(road.turn.angle)};

--- a/src/extractor/guidance/turn_analysis.cpp
+++ b/src/extractor/guidance/turn_analysis.cpp
@@ -794,12 +794,13 @@ TurnAnalysis::handleThreeWayTurn(const EdgeID via_edge,
                                  std::vector<ConnectedRoad> intersection) const
 {
     BOOST_ASSERT(intersection[0].turn.angle < 0.001);
-    const auto isObviousOfTwo = [](const ConnectedRoad turn, const ConnectedRoad other)
+    const auto isObviousOfTwo = [](const ConnectedRoad road, const ConnectedRoad other)
     {
-        return (angularDeviation(turn.turn.angle, STRAIGHT_ANGLE) < NARROW_TURN_ANGLE &&
+        return (angularDeviation(road.turn.angle, STRAIGHT_ANGLE) < NARROW_TURN_ANGLE &&
                 angularDeviation(other.turn.angle, STRAIGHT_ANGLE) > 85) ||
+               (angularDeviation(road.turn.angle,STRAIGHT_ANGLE) < std::numeric_limits<double>::epsilon()) ||
                (angularDeviation(other.turn.angle, STRAIGHT_ANGLE) /
-                    angularDeviation(turn.turn.angle, STRAIGHT_ANGLE) >
+                    angularDeviation(road.turn.angle, STRAIGHT_ANGLE) >
                 1.4);
     };
 

--- a/src/util/name_table.cpp
+++ b/src/util/name_table.cpp
@@ -1,0 +1,52 @@
+#include "util/name_table.hpp"
+#include "util/simple_logger.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <fstream>
+
+#include <boost/filesystem/fstream.hpp>
+
+namespace osrm
+{
+namespace util
+{
+
+NameTable::NameTable(const std::string &filename)
+{
+    boost::filesystem::ifstream name_stream(filename, std::ios::binary);
+
+    name_stream >> m_name_table;
+
+    unsigned number_of_chars = 0;
+    name_stream.read(reinterpret_cast<char *>(&number_of_chars), sizeof(number_of_chars));
+    BOOST_ASSERT_MSG(0 != number_of_chars, "name file broken");
+    m_names_char_list.resize(number_of_chars + 1); //+1 gives sentinel element
+    name_stream.read(reinterpret_cast<char *>(&m_names_char_list[0]),
+                     number_of_chars * sizeof(m_names_char_list[0]));
+    if (0 == m_names_char_list.size())
+    {
+        util::SimpleLogger().Write(logWARNING) << "list of street names is empty";
+    }
+}
+
+std::string NameTable::get_name_for_id(const unsigned name_id) const
+{
+    if (std::numeric_limits<unsigned>::max() == name_id)
+    {
+        return "";
+    }
+    auto range = m_name_table.GetRange(name_id);
+
+    std::string result;
+    result.reserve(range.size());
+    if (range.begin() != range.end())
+    {
+        result.resize(range.back() - range.front() + 1);
+        std::copy(m_names_char_list.begin() + range.front(),
+                  m_names_char_list.begin() + range.back() + 1, result.begin());
+    }
+    return result;
+}
+} // namespace util
+} // namespace osrm

--- a/src/util/name_table.cpp
+++ b/src/util/name_table.cpp
@@ -40,7 +40,7 @@ NameTable::NameTable(const std::string &filename)
     }
 }
 
-std::string NameTable::get_name_for_id(const unsigned name_id) const
+std::string NameTable::GetNameForID(const unsigned name_id) const
 {
     if (std::numeric_limits<unsigned>::max() == name_id)
     {


### PR DESCRIPTION
For this branch to be merged, the following needs to happen:

 - [x] do not expose the internal conflict resolution
 - [x] do not expose `new name` on near identical names
 - [x] add road classes (e.g. [primary vs residential](http://www.openstreetmap.org/edit#map=18/41.69060/-120.37531)) to fork detection
 - [x] clean-up response to only return valid turn candidates
 
~~- [ ] add cucumber tests for static turn instructions~~
~~- [x] motorways~~
~~- [ ] fork~~
~~- [ ] end of road~~
~~- [ ] new name~~
~~- [ ] suppressed~~
~~- [ ] continue~~
~~- [ ] merge~~
~~- [ ] ramp~~
 - [x] test roundabouts
      - [x] enter
      - [x] immediately exit
      - [x] enter and exit
      - [x] only exit
 - [x] review, I am looking at you @daniel-j-h 