### PR TITLE
Bugfix: set initial uturn indicators

### DIFF
--- a/src/engine/route_parameters.cpp
+++ b/src/engine/route_parameters.cpp
@@ -142,6 +142,8 @@ void RouteParameters::AddSource(const double latitude, const double longitude)
 void RouteParameters::SetCoordinatesFromGeometry(const std::string &geometry_string)
 {
     coordinates = polylineDecode(geometry_string);
+    uturns.clear();
+    uturns.resize(coordinates.size(), uturn_default);
 }
 
 bool RouteParameters::SetX(const int x_)


### PR DESCRIPTION
Viaroute requests in the following style will crash the server, because the uturn indicators are not set.

Example: /viaroute?locs=mqb|H}}rm@ofd@lz{@?? (Note: The geometry has a coordinate precision of five, but this will also crash a server with a coordinate precision of six)

This pull request will fix this issue. 

Question: Should "is_source" and "is_destination" also be set in "SetCoordinatesFromGeometry"?