### PR TITLE
Support multiple traffic update files, and include filename in debug tile metadata

### DIFF
--- a/include/contractor/contractor.hpp
+++ b/include/contractor/contractor.hpp
@@ -83,9 +83,11 @@ class Contractor
                           util::DeallocatingVector<extractor::EdgeBasedEdge> &edge_based_edge_list,
                           const std::string &edge_segment_lookup_path,
                           const std::string &edge_penalty_path,
-                          const std::string &segment_speed_path,
+                          const std::vector<std::string> &segment_speed_path,
                           const std::string &nodes_filename,
                           const std::string &geometry_filename,
+                          const std::string &datasource_names_filename,
+                          const std::string &datasource_indexes_filename,
                           const std::string &rtree_leaf_filename);
 };
 }

--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -53,6 +53,8 @@ struct ContractorConfig
         node_based_graph_path = osrm_input_path.string() + ".nodes";
         geometry_path = osrm_input_path.string() + ".geometry";
         rtree_leaf_path = osrm_input_path.string() + ".fileIndex";
+        datasource_names_path = osrm_input_path.string() + ".datasource_names";
+        datasource_indexes_path = osrm_input_path.string() + ".datasource_indexes";
     }
 
     boost::filesystem::path config_file_path;
@@ -78,11 +80,9 @@ struct ContractorConfig
     //(e.g. 0.8 contracts 80 percent of the hierarchy, leaving a core of 20%)
     double core_factor;
 
-    std::string segment_speed_lookup_path;
-
-#ifdef DEBUG_GEOMETRY
-    std::string debug_geometry_path;
-#endif
+    std::vector<std::string> segment_speed_lookup_paths;
+    std::string datasource_indexes_path;
+    std::string datasource_names_path;
 };
 }
 }

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -78,6 +78,14 @@ class BaseDataFacade
     virtual void GetUncompressedWeights(const EdgeID id,
                                         std::vector<EdgeWeight> &result_weights) const = 0;
 
+    // Returns the data source ids that were used to supply the edge
+    // weights.  Will return an empty array when only the base profile is used.
+    virtual void GetUncompressedDatasources(const EdgeID id,
+                                            std::vector<uint8_t> &data_sources) const = 0;
+
+    // Gets the name of a datasource
+    virtual std::string GetDatasourceName(const uint8_t datasource_name_id) const = 0;
+
     virtual extractor::guidance::TurnInstruction
     GetTurnInstructionForEdgeID(const unsigned id) const = 0;
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -78,6 +78,8 @@ class InternalDataFacade final : public BaseDataFacade
     util::ShM<extractor::CompressedEdgeContainer::CompressedEdge, false>::vector m_geometry_list;
     util::ShM<bool, false>::vector m_is_core_node;
     util::ShM<unsigned, false>::vector m_segment_weights;
+    util::ShM<uint8_t, false>::vector m_datasource_list;
+    util::ShM<std::string, false>::vector m_datasource_names;
 
     boost::thread_specific_ptr<InternalRTree> m_static_rtree;
     boost::thread_specific_ptr<InternalGeospatialQuery> m_geospatial_query;
@@ -222,6 +224,34 @@ class InternalDataFacade final : public BaseDataFacade
         }
     }
 
+    void LoadDatasourceInfo(const boost::filesystem::path &datasource_names_file,
+                            const boost::filesystem::path &datasource_indexes_file)
+    {
+        std::ifstream datasources_stream(datasource_indexes_file.c_str(), std::ios::binary);
+        if (datasources_stream)
+        {
+            std::size_t number_of_datasources = 0;
+            datasources_stream.read(reinterpret_cast<char *>(&number_of_datasources),
+                                    sizeof(std::size_t));
+            if (number_of_datasources > 0)
+            {
+                m_datasource_list.resize(number_of_datasources);
+                datasources_stream.read(reinterpret_cast<char *>(&(m_datasource_list[0])),
+                                        number_of_datasources * sizeof(uint8_t));
+            }
+        }
+
+        std::ifstream datasourcenames_stream(datasource_names_file.c_str(), std::ios::binary);
+        if (datasourcenames_stream)
+        {
+            std::string name;
+            while (std::getline(datasourcenames_stream, name))
+            {
+                m_datasource_names.push_back(name);
+            }
+        }
+    }
+
     void LoadRTree()
     {
         BOOST_ASSERT_MSG(!m_coordinate_list->empty(), "coordinates must be loaded before r-tree");
@@ -269,6 +299,14 @@ class InternalDataFacade final : public BaseDataFacade
             return it->second;
         };
 
+        const auto optional_file_for = [&server_paths, &end_it](const std::string &path)
+        {
+            const auto it = server_paths.find(path);
+            if (it == end_it)
+                throw util::exception("no valid " + path + " file given in ini file");
+            return it->second;
+        };
+
         ram_index_path = file_for("ramindex");
         file_index_path = file_for("fileindex");
 
@@ -283,6 +321,10 @@ class InternalDataFacade final : public BaseDataFacade
 
         util::SimpleLogger().Write() << "loading geometries";
         LoadGeometries(file_for("geometries"));
+
+        util::SimpleLogger().Write() << "loading datasource info";
+        LoadDatasourceInfo(optional_file_for("datasource_names"),
+                           optional_file_for("datasource_indexes"));
 
         util::SimpleLogger().Write() << "loading timestamp";
         LoadTimestamp(file_for("timestamp"));
@@ -590,6 +632,47 @@ class InternalDataFacade final : public BaseDataFacade
                       {
                           result_weights.emplace_back(edge.weight);
                       });
+    }
+
+    // Returns the data source ids that were used to supply the edge
+    // weights.
+    virtual void
+    GetUncompressedDatasources(const EdgeID id,
+                               std::vector<uint8_t> &result_datasources) const override final
+    {
+        const unsigned begin = m_geometry_indices.at(id);
+        const unsigned end = m_geometry_indices.at(id + 1);
+
+        result_datasources.clear();
+        result_datasources.reserve(end - begin);
+
+        // If there was no datasource info, return an array of 0's.
+        if (m_datasource_list.empty())
+        {
+            for (unsigned i = 0; i < end - begin; ++i)
+            {
+                result_datasources.push_back(0);
+            }
+        }
+        else
+        {
+            std::for_each(m_datasource_list.begin() + begin, m_datasource_list.begin() + end,
+                          [&](const uint8_t &datasource_id)
+                          {
+                              result_datasources.push_back(datasource_id);
+                          });
+        }
+    }
+
+    virtual std::string GetDatasourceName(const uint8_t datasource_name_id) const override final
+    {
+        if (m_datasource_names.empty() || datasource_name_id > m_datasource_names.size())
+        {
+            if (datasource_name_id == 0)
+                return "lua profile";
+            return "UNKNOWN";
+        }
+        return m_datasource_names[datasource_name_id];
     }
 
     std::string GetTimestamp() const override final { return m_timestamp; }

--- a/include/engine/engine_config.hpp
+++ b/include/engine/engine_config.hpp
@@ -52,6 +52,8 @@ struct EngineConfig
                        {"coredata", base.string() + ".core"},
                        {"geometries", base.string() + ".geometry"},
                        {"timestamp", base.string() + ".timestamp"},
+                       {"datasource_names", base.string() + ".datasource_names"},
+                       {"datasource_indexes", base.string() + ".datasource_indexes"},
                        {"namesdata", base.string() + ".names"}}
     {
     }

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -109,20 +109,11 @@ class EdgeBasedGraphFactory
     void CompressGeometry();
     unsigned RenumberEdges();
     void GenerateEdgeExpandedNodes();
-#ifdef DEBUG_GEOMETRY
-    void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
-                                   lua_State *lua_state,
-                                   const std::string &edge_segment_lookup_filename,
-                                   const std::string &edge_fixed_penalties_filename,
-                                   const bool generate_edge_lookup,
-                                   const std::string &debug_turns_path);
-#else
     void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
                                    lua_State *lua_state,
                                    const std::string &edge_segment_lookup_filename,
                                    const std::string &edge_fixed_penalties_filename,
                                    const bool generate_edge_lookup);
-#endif
 
     void InsertEdgeBasedNode(const NodeID u, const NodeID v);
 

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -38,6 +38,10 @@ struct SharedDataLayout
         TIMESTAMP,
         FILE_INDEX_PATH,
         CORE_MARKER,
+        DATASOURCES_LIST,
+        DATASOURCE_NAME_DATA,
+        DATASOURCE_NAME_OFFSETS,
+        DATASOURCE_NAME_LENGTHS,
         NUM_BLOCKS
     };
 

--- a/include/util/routed_options.hpp
+++ b/include/util/routed_options.hpp
@@ -53,6 +53,10 @@ populate_base_path(std::unordered_map<std::string, boost::filesystem::path> &ser
         BOOST_ASSERT(server_paths.find("namesdata") != server_paths.end());
         server_paths["timestamp"] = base_string + ".timestamp";
         BOOST_ASSERT(server_paths.find("timestamp") != server_paths.end());
+        server_paths["datasource_indexes"] = base_string + ".datasource_indexes";
+        BOOST_ASSERT(server_paths.find("timestamp") != server_paths.end());
+        server_paths["datasource_names"] = base_string + ".datasource_names";
+        BOOST_ASSERT(server_paths.find("timestamp") != server_paths.end());
     }
 
     // check if files are give and whether they exist at all

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -528,12 +528,7 @@ Extractor::BuildEdgeExpandedGraph(std::vector<QueryNode> &internal_to_external_n
 
     edge_based_graph_factory.Run(config.edge_output_path, lua_state,
                                  config.edge_segment_lookup_path, config.edge_penalty_path,
-                                 config.generate_edge_lookup
-#ifdef DEBUG_GEOMETRY
-                                 ,
-                                 config.debug_turns_path
-#endif
-                                 );
+                                 config.generate_edge_lookup);
 
     lua_close(lua_state);
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -131,6 +131,14 @@ int Storage::Run()
     {
         throw util::exception("no core file found");
     }
+    if (paths.find("datasource_indexes") == paths.end())
+    {
+        throw util::exception("no datasource_indexes file found");
+    }
+    if (paths.find("datasource_names") == paths.end())
+    {
+        throw util::exception("no datasource_names file found");
+    }
 
     auto paths_iterator = paths.find("hsgrdata");
     BOOST_ASSERT(paths.end() != paths_iterator);
@@ -170,6 +178,14 @@ int Storage::Run()
     BOOST_ASSERT(paths.end() != paths_iterator);
     BOOST_ASSERT(!paths_iterator->second.empty());
     const boost::filesystem::path &core_marker_path = paths_iterator->second;
+    paths_iterator = paths.find("datasource_indexes");
+    BOOST_ASSERT(paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &datasource_indexes_path = paths_iterator->second;
+    paths_iterator = paths.find("datasource_names");
+    BOOST_ASSERT(paths.end() != paths_iterator);
+    BOOST_ASSERT(!paths_iterator->second.empty());
+    const boost::filesystem::path &datasource_names_path = paths_iterator->second;
 
     // determine segment to use
     bool segment2_in_use = SharedMemory::RegionExists(LAYOUT_2);
@@ -325,6 +341,45 @@ int Storage::Run()
     geometry_input_stream.read((char *)&number_of_compressed_geometries, sizeof(unsigned));
     shared_layout_ptr->SetBlockSize<extractor::CompressedEdgeContainer::CompressedEdge>(
         SharedDataLayout::GEOMETRIES_LIST, number_of_compressed_geometries);
+
+    // load datasource sizes.  This file is optional, and it's non-fatal if it doesn't
+    // exist.
+    std::ifstream geometry_datasource_input_stream(datasource_indexes_path.c_str(),
+                                                   std::ios::binary);
+    if (geometry_datasource_input_stream)
+    {
+        std::size_t number_of_compressed_datasources = 0;
+        geometry_datasource_input_stream.read(
+            reinterpret_cast<char *>(&number_of_compressed_datasources), sizeof(std::size_t));
+        shared_layout_ptr->SetBlockSize<uint8_t>(SharedDataLayout::DATASOURCES_LIST,
+                                                 number_of_compressed_datasources);
+    }
+
+    // Load datasource name sizes.  This file is optional, and it's non-fatal if it doesn't
+    // exist
+    std::ifstream datasource_names_input_stream(datasource_names_path.c_str(), std::ios::binary);
+    std::vector<char> m_datasource_name_data;
+    std::vector<std::size_t> m_datasource_name_offsets;
+    std::vector<std::size_t> m_datasource_name_lengths;
+    if (datasource_names_input_stream)
+    {
+        std::string name;
+        while (std::getline(datasource_names_input_stream, name))
+        {
+            m_datasource_name_offsets.push_back(m_datasource_name_data.size());
+            std::copy(name.c_str(), name.c_str() + name.size(),
+                      std::back_inserter(m_datasource_name_data));
+            m_datasource_name_lengths.push_back(name.size());
+        }
+
+        shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::DATASOURCE_NAME_DATA,
+                                              m_datasource_name_data.size());
+        shared_layout_ptr->SetBlockSize<std::size_t>(SharedDataLayout::DATASOURCE_NAME_OFFSETS,
+                                                m_datasource_name_offsets.size());
+        shared_layout_ptr->SetBlockSize<std::size_t>(SharedDataLayout::DATASOURCE_NAME_LENGTHS,
+                                                m_datasource_name_lengths.size());
+    }
+
     // allocate shared memory block
     util::SimpleLogger().Write() << "allocating shared memory of "
                                  << shared_layout_ptr->GetSizeOfLayout() << " bytes";
@@ -455,6 +510,50 @@ int Storage::Run()
         geometry_input_stream.read(
             (char *)geometries_list_ptr,
             shared_layout_ptr->GetBlockSize(SharedDataLayout::GEOMETRIES_LIST));
+    }
+
+    // load datasource information (if it exists)
+    if (geometry_datasource_input_stream)
+    {
+        uint8_t *datasources_list_ptr = shared_layout_ptr->GetBlockPtr<uint8_t, true>(
+            shared_memory_ptr, SharedDataLayout::DATASOURCES_LIST);
+        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCES_LIST) > 0)
+        {
+            geometry_datasource_input_stream.read(
+                reinterpret_cast<char *>(datasources_list_ptr),
+                shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCES_LIST));
+        }
+    }
+
+    // load datasource name information (if it exists)
+    if (!m_datasource_name_data.empty())
+    {
+        char *datasource_name_data_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
+            shared_memory_ptr, SharedDataLayout::DATASOURCE_NAME_DATA);
+        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCE_NAME_DATA) > 0)
+        {
+            std::cout << "Copying "
+                      << (m_datasource_name_data.end() - m_datasource_name_data.begin())
+                      << " chars into name data ptr\n";
+            std::copy(m_datasource_name_data.begin(), m_datasource_name_data.end(),
+                      datasource_name_data_ptr);
+        }
+
+        auto datasource_name_offsets_ptr = shared_layout_ptr->GetBlockPtr<std::size_t, true>(
+            shared_memory_ptr, SharedDataLayout::DATASOURCE_NAME_OFFSETS);
+        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCE_NAME_OFFSETS) > 0)
+        {
+            std::copy(m_datasource_name_offsets.begin(), m_datasource_name_offsets.end(),
+                      datasource_name_offsets_ptr);
+        }
+
+        auto datasource_name_lengths_ptr = shared_layout_ptr->GetBlockPtr<std::size_t, true>(
+            shared_memory_ptr, SharedDataLayout::DATASOURCE_NAME_LENGTHS);
+        if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCE_NAME_LENGTHS) > 0)
+        {
+            std::copy(m_datasource_name_lengths.begin(), m_datasource_name_lengths.end(),
+                      datasource_name_lengths_ptr);
+        }
     }
 
     // Loading list of coordinates

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -39,9 +39,10 @@ return_code parseArguments(int argc, char *argv[], contractor::ContractorConfig 
         "core,k",
         boost::program_options::value<double>(&contractor_config.core_factor)->default_value(1.0),
         "Percentage of the graph (in vertices) to contract [0..1]")(
-        "segment-speed-file",
-        boost::program_options::value<std::string>(&contractor_config.segment_speed_lookup_path),
-        "Lookup file containing nodeA,nodeB,speed data to adjust edge weights")(
+        "segment-speed-file", boost::program_options::value<std::vector<std::string>>(
+                                  &contractor_config.segment_speed_lookup_paths)
+                                  ->composing(),
+        "Lookup files containing nodeA, nodeB, speed data to adjust edge weights")(
         "level-cache,o", boost::program_options::value<bool>(&contractor_config.use_cached_priority)
                              ->default_value(false),
         "Use .level file to retain the contaction level for each node from the last run.");

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -38,7 +38,13 @@ bool generateDataStoreOptions(const int argc, const char *argv[], storage::DataP
         "namesdata", boost::program_options::value<boost::filesystem::path>(&paths["namesdata"]),
         ".names file")("timestamp",
                        boost::program_options::value<boost::filesystem::path>(&paths["timestamp"]),
-                       ".timestamp file");
+                       ".timestamp file")(
+        "datasource_names",
+        boost::program_options::value<boost::filesystem::path>(&paths["datasource_names"]),
+        ".datasource_names file")(
+        "datasource_indexes",
+        boost::program_options::value<boost::filesystem::path>(&paths["datasource_indexes"]),
+        ".datasource_indexes file");
 
     // hidden options, will be allowed on command line but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");
@@ -143,6 +149,18 @@ bool generateDataStoreOptions(const int argc, const char *argv[], storage::DataP
     if (path_iterator != paths.end())
     {
         path_iterator->second = base_string + ".timestamp";
+    }
+
+    path_iterator = paths.find("datasource_indexes");
+    if (path_iterator != paths.end())
+    {
+        path_iterator->second = base_string + ".datasource_indexes";
+    }
+
+    path_iterator = paths.find("datasource_names");
+    if (path_iterator != paths.end())
+    {
+        path_iterator->second = base_string + ".datasource_names";
     }
 
     path_iterator = paths.find("hsgrdata");


### PR DESCRIPTION
This change adds support for `--segment-speed-file file1 --segment-speed-file file2` to `osrm-contract`.

It also saves the filenames, and remembers which file was the source of the data used to update each edge weight.

If the `--segment-speed-file` option is not used, there is no overhead to this feature.  When it is used, there is an extra 0.25 * (size of compressed geometries).

Two new files are written out when this feature is used:

  `.osrm.datasource_indexes`  <- these link the compressed geometry segments to datasource name that sourced their data
  `.osrm.datasource_names`  <- this is the list of datasource names used, in order of priority (least to most)