### PR TITLE
Fixes the edge-based-graph factory's edge counter serialization.

### DIFF
--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -310,7 +310,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     }
 
     // writes a dummy value that is updated later
-    edge_data_file.write((char *)&original_edges_counter, sizeof(unsigned));
+    edge_data_file.write(reinterpret_cast<const char *>(&original_edges_counter),
+                         sizeof(original_edges_counter));
 
     std::vector<OriginalEdgeData> original_edge_data_vector;
     original_edge_data_vector.reserve(1024 * 1024);
@@ -475,7 +476,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     FlushVectorToStream(edge_data_file, original_edge_data_vector);
 
     edge_data_file.seekp(std::ios::beg);
-    edge_data_file.write((char *)&original_edges_counter, sizeof(unsigned));
+    edge_data_file.write(reinterpret_cast<char *>(&original_edges_counter),
+                         sizeof(original_edges_counter));
 
     util::SimpleLogger().Write() << "Generated " << m_edge_based_node_list.size()
                                  << " edge based nodes";


### PR DESCRIPTION
The counter for original edges is of type `std::size_t`, but we
serialized `sizeof(unsigned)` number of bytes out to the `.osrm.edges`
file.

We should probably check all writes (analogous for reads) and make the
count parameter dependent on `sizeof(variable)`.

    ag '\.write\((.*), sizeof\((.*)\)\);'


References:
- Moritz's original report at https://gist.github.com/MoKob/76287bafd3afcf32a947