### PR TITLE
fix negative weight

### DIFF
--- a/include/engine/guidance/assemble_leg.hpp
+++ b/include/engine/guidance/assemble_leg.hpp
@@ -142,7 +142,11 @@ RouteLeg assembleLeg(const DataFacadeT &facade,
     // a duration value since its the only point associated with a turn.
     // As such we want to slice of the duration for (a,s) and add the duration for
     // (c,d,t)
-    duration = duration - source_duration + target_duration;
+    // if there is an duration, it is already corrected for source offset
+    if (duration)
+        duration = duration + target_duration;
+    else
+        duration = target_duration - source_duration;
     auto summary_array = detail::summarizeRoute<detail::MAX_USED_SEGMENTS>(route_data);
 
     BOOST_ASSERT(detail::MAX_USED_SEGMENTS > 0);

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -198,6 +198,7 @@ std::vector<std::vector<PathData>> postProcess(std::vector<std::vector<PathData>
     // silence silent turns for good
     for (auto &path_data : leg_data)
     {
+        unsigned last = path_data.back().duration_until_turn;
         for (auto &data : path_data)
         {
             if (isSilent(data.turn_instruction) || (leavesRoundabout(data.turn_instruction) &&
@@ -208,6 +209,7 @@ std::vector<std::vector<PathData>> postProcess(std::vector<std::vector<PathData>
                 data.exit = 0;
             }
         }
+        path_data.back().duration_until_turn = last;
     }
 
     return leg_data;


### PR DESCRIPTION
Fixes the negative weight that can occur in current routing request.

I've found the reason for the problem. Its a combination of an error made by me based on a comment of @TheMarex in `assemble_leg.hpp` and a variation in the paradigm assumed by @TheMarex due to the fixes for the offsets in the R-Tree done by @danpat .

To try and explain the situation:

Assemble Leg assumes positive weights to be located at only certain elements (https://github.com/Project-OSRM/osrm-backend/blob/fix/negative-cost/include/engine/guidance/assemble_leg.hpp#L141-L142) . Due to the offsets by @danpat , this assumption is broken. I tried to keep it true and deleted the travel-time when no turn instruction was issued. This is fixed [here](https://github.com/Project-OSRM/osrm-backend/pull/2107/files#diff-99adcb8bccf8e94a176bdf92509ff070).

The other problem is that the new offsets are corrected for the source-phantom already. So if the duration of the path crosses an intersection, subtracting the source_duration ([see here](https://github.com/Project-OSRM/osrm-backend/blob/fix/negative-cost/include/engine/guidance/assemble_leg.hpp#L150)) is no longer valid.

This pull request offers a way of dealing with it, I am unsure whether we should rather correctly handle the offset weights, or if other parts of the code are affected of this as well.

