### PR TITLE
Move PostProcessing onto Route Steps

### DIFF
--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -127,6 +127,7 @@ class RouteAPI : public BaseAPI
                  */
 
                  leg.steps = guidance::postProcess(std::move(steps));
+                 leg_geometry = guidance::resyncGeometry(std::move(leg_geometry),leg.steps);
             }
 
             leg_geometries.push_back(std::move(leg_geometry));

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -51,6 +51,7 @@ LegGeometry assembleGeometry(const DataFacadeT &facade,
         current_distance +=
             util::coordinate_calculation::haversineDistance(prev_coordinate, coordinate);
 
+        //all changes to this check have to be matched with assemble_steps
         if (path_point.turn_instruction.type != extractor::guidance::TurnType::NoTurn)
         {
             geometry.segment_distances.push_back(current_distance);

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -51,7 +51,7 @@ LegGeometry assembleGeometry(const DataFacadeT &facade,
         current_distance +=
             util::coordinate_calculation::haversineDistance(prev_coordinate, coordinate);
 
-        if (!isSilent(path_point.turn_instruction))
+        if (path_point.turn_instruction.type != extractor::guidance::TurnType::NoTurn)
         {
             geometry.segment_distances.push_back(current_distance);
             geometry.segment_offsets.push_back(geometry.locations.size());

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -51,7 +51,7 @@ LegGeometry assembleGeometry(const DataFacadeT &facade,
         current_distance +=
             util::coordinate_calculation::haversineDistance(prev_coordinate, coordinate);
 
-        //all changes to this check have to be matched with assemble_steps
+        // all changes to this check have to be matched with assemble_steps
         if (path_point.turn_instruction.type != extractor::guidance::TurnType::NoTurn)
         {
             geometry.segment_distances.push_back(current_distance);

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -27,8 +27,7 @@ namespace detail
 StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
                                       const WaypointType waypoint_type,
                                       const LegGeometry &leg_geometry,
-                                      const std::size_t segment_index,
-                                      const unsigned exit);
+                                      const std::size_t segment_index);
 } // ns detail
 
 template <typename DataFacadeT>
@@ -78,7 +77,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         StepManeuver maneuver = detail::stepManeuverFromGeometry(
             extractor::guidance::TurnInstruction{extractor::guidance::TurnType::NoTurn,
                                                  initial_modifier},
-            WaypointType::Depart, leg_geometry, segment_index, INVALID_EXIT_NR);
+            WaypointType::Depart, leg_geometry, segment_index);
 
         // PathData saves the information we need of the segment _before_ the turn,
         // but a RouteStep is with regard to the segment after the turn.
@@ -89,7 +88,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         {
             segment_duration += path_point.duration_until_turn;
 
-            if (path_point.turn_instruction != extractor::guidance::TurnInstruction::NO_TURN())
+            if (path_point.turn_instruction.type != extractor::guidance::TurnType::NoTurn)
             {
                 BOOST_ASSERT(segment_duration >= 0);
                 const auto name = facade.GetNameForID(path_point.name_id);
@@ -104,7 +103,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                                           leg_geometry.BackIndex(segment_index) + 1});
                 maneuver = detail::stepManeuverFromGeometry(path_point.turn_instruction,
                                                             WaypointType::None, leg_geometry,
-                                                            segment_index, path_point.exit);
+                                                            segment_index);
                 segment_index++;
                 segment_duration = 0;
             }
@@ -136,6 +135,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                                  extractor::guidance::TurnInstruction{
                                      extractor::guidance::TurnType::NoTurn, initial_modifier},
                                  WaypointType::Depart,
+                                 INVALID_EXIT_NR,
                                  INVALID_EXIT_NR};
         int duration = target_duration - source_duration;
         BOOST_ASSERT(duration >= 0);
@@ -174,6 +174,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                                extractor::guidance::TurnInstruction{
                                    extractor::guidance::TurnType::NoTurn, final_modifier},
                                WaypointType::Arrive,
+                               INVALID_EXIT_NR,
                                INVALID_EXIT_NR},
                   leg_geometry.locations.size(),
                   leg_geometry.locations.size()});

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -43,7 +43,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                                      const bool source_traversed_in_reverse,
                                      const bool target_traversed_in_reverse)
 {
-    const double constexpr ZERO_DURACTION = 0., ZERO_DISTANCE = 0.;
+    const double constexpr ZERO_DURATION = 0., ZERO_DISTANCE = 0.;
     const EdgeWeight source_duration =
         source_traversed_in_reverse ? source_node.reverse_weight : source_node.forward_weight;
     const auto source_mode = source_traversed_in_reverse ? source_node.backward_travel_mode
@@ -167,7 +167,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         WaypointType::Arrive, leg_geometry);
     steps.push_back(RouteStep{target_node.name_id,
                               facade.GetNameForID(target_node.name_id),
-                              ZERO_DURACTION,
+                              ZERO_DURATION,
                               ZERO_DISTANCE,
                               target_mode,
                               final_maneuver,

--- a/include/engine/guidance/post_processing.hpp
+++ b/include/engine/guidance/post_processing.hpp
@@ -1,7 +1,7 @@
 #ifndef ENGINE_GUIDANCE_POST_PROCESSING_HPP
 #define ENGINE_GUIDANCE_POST_PROCESSING_HPP
 
-#include "engine/internal_route_result.hpp"
+#include "engine/guidance/route_step.hpp"
 
 #include <vector>
 
@@ -12,7 +12,8 @@ namespace engine
 namespace guidance
 {
 
-std::vector<std::vector<PathData>> postProcess(std::vector<std::vector<PathData>> path_data);
+//passed as none-reference to modify in-place and move out again
+std::vector<RouteStep> postProcess(std::vector<RouteStep> steps);
 
 } // namespace guidance
 } // namespace engine

--- a/include/engine/guidance/post_processing.hpp
+++ b/include/engine/guidance/post_processing.hpp
@@ -2,6 +2,7 @@
 #define ENGINE_GUIDANCE_POST_PROCESSING_HPP
 
 #include "engine/guidance/route_step.hpp"
+#include "engine/guidance/leg_geometry.hpp"
 
 #include <vector>
 
@@ -12,8 +13,15 @@ namespace engine
 namespace guidance
 {
 
-//passed as none-reference to modify in-place and move out again
+// passed as none-reference to modify in-place and move out again
 std::vector<RouteStep> postProcess(std::vector<RouteStep> steps);
+
+// postProcess will break the connection between the leg geometry
+// for which a segment is supposed to represent exactly the coordinates
+// between routing maneuvers and the route steps itself.
+// If required, we can get both in sync again using this function.
+// Move in LegGeometry for modification in place.
+LegGeometry resyncGeometry(LegGeometry leg_geometry, const std::vector<RouteStep> &steps);
 
 } // namespace guidance
 } // namespace engine

--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -28,6 +28,7 @@ struct StepManeuver
     extractor::guidance::TurnInstruction instruction;
     WaypointType waypoint_type;
     unsigned exit;
+    unsigned intersection;
 };
 } // namespace guidance
 } // namespace engine

--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -5,6 +5,7 @@
 #include "extractor/guidance/turn_instruction.hpp"
 
 #include <cstdint>
+#include <vector>
 
 namespace osrm
 {
@@ -20,6 +21,14 @@ enum class WaypointType : std::uint8_t
     Depart,
 };
 
+//A represenetation of intermediate intersections
+struct IntermediateIntersection
+{
+    double duration;
+    double distance;
+    util::Coordinate location;
+};
+
 struct StepManeuver
 {
     util::Coordinate location;
@@ -28,7 +37,7 @@ struct StepManeuver
     extractor::guidance::TurnInstruction instruction;
     WaypointType waypoint_type;
     unsigned exit;
-    unsigned intersection;
+    std::vector<IntermediateIntersection> intersections;
 };
 } // namespace guidance
 } // namespace engine

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -29,8 +29,6 @@ struct PathData
     extractor::guidance::TurnInstruction turn_instruction;
     // travel mode of the street that leads to the turn
     extractor::TravelMode travel_mode : 4;
-    // exit ID of highway exit, roundabout exit, intersection nr
-    unsigned exit;
 };
 
 struct InternalRouteResult

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -321,8 +321,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 {
                     unpacked_path.push_back(
                         PathData{id_vector[i], name_index, weight_vector[i],
-                                 extractor::guidance::TurnInstruction::NO_TURN(), travel_mode,
-                                 INVALID_EXIT_NR});
+                                 extractor::guidance::TurnInstruction::NO_TURN(), travel_mode});
                 }
                 BOOST_ASSERT(unpacked_path.size() > 0);
                 unpacked_path.back().turn_instruction = turn_instruction;
@@ -396,8 +395,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 id_vector[i], phantom_node_pair.target_phantom.name_id, weight_vector[i],
                 extractor::guidance::TurnInstruction::NO_TURN(),
                 target_traversed_in_reverse ? phantom_node_pair.target_phantom.backward_travel_mode
-                                            : phantom_node_pair.target_phantom.forward_travel_mode,
-                INVALID_EXIT_NR});
+                                            : phantom_node_pair.target_phantom.forward_travel_mode});
         }
 
         if (is_local_path && unpacked_path.size() > 0)

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -150,10 +150,10 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
     if (maneuver.exit != 0)
         step_maneuver.values["exit"] = maneuver.exit;
 
-    //TODO currently we need this to comply with the api.
-    //We should move this to an additional entry, the moment we
-    //actually compute the correct locations of the intersections
-    if (!maneuver.intersections.empty() && maneuver.exit == 0 )
+    // TODO currently we need this to comply with the api.
+    // We should move this to an additional entry, the moment we
+    // actually compute the correct locations of the intersections
+    if (!maneuver.intersections.empty() && maneuver.exit == 0)
         step_maneuver.values["exit"] = maneuver.intersections.size();
     return step_maneuver;
 }

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -153,8 +153,8 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
     //TODO currently we need this to comply with the api.
     //We should move this to an additional entry, the moment we
     //actually compute the correct locations of the intersections
-    if (maneuver.intersection != 0 && maneuver.exit == 0 )
-        step_maneuver.values["exit"] = maneuver.intersection;
+    if (!maneuver.intersections.empty() && maneuver.exit == 0 )
+        step_maneuver.values["exit"] = maneuver.intersections.size();
     return step_maneuver;
 }
 

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -149,6 +149,12 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
     step_maneuver.values["bearing_after"] = maneuver.bearing_after;
     if (maneuver.exit != 0)
         step_maneuver.values["exit"] = maneuver.exit;
+
+    //TODO currently we need this to comply with the api.
+    //We should move this to an additional entry, the moment we
+    //actually compute the correct locations of the intersections
+    if (maneuver.intersection != 0 && maneuver.exit == 0 )
+        step_maneuver.values["exit"] = maneuver.intersection;
     return step_maneuver;
 }
 

--- a/src/engine/guidance/assemble_steps.cpp
+++ b/src/engine/guidance/assemble_steps.cpp
@@ -15,12 +15,11 @@ namespace detail
 StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
                                       const WaypointType waypoint_type,
                                       const LegGeometry &leg_geometry,
-                                      const std::size_t segment_index,
-                                      const unsigned exit)
+                                      const std::size_t segment_index)
 {
     auto turn_index = leg_geometry.BackIndex(segment_index);
     BOOST_ASSERT(turn_index > 0);
-    BOOST_ASSERT(turn_index < leg_geometry.locations.size());
+    BOOST_ASSERT(turn_index + 1 < leg_geometry.locations.size());
 
     // TODO chose a bigger look-a-head to smooth complex geometry
     const auto pre_turn_coordinate = leg_geometry.locations[turn_index - 1];
@@ -32,7 +31,13 @@ StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instr
     const double post_turn_bearing =
         util::coordinate_calculation::bearing(turn_coordinate, post_turn_coordinate);
 
-    return StepManeuver{turn_coordinate, pre_turn_bearing, post_turn_bearing, instruction, waypoint_type, exit};
+    return StepManeuver{turn_coordinate,
+                        pre_turn_bearing,
+                        post_turn_bearing,
+                        instruction,
+                        waypoint_type,
+                        INVALID_EXIT_NR,
+                        INVALID_EXIT_NR};
 }
 } // ns detail
 } // ns engine

--- a/src/engine/guidance/assemble_steps.cpp
+++ b/src/engine/guidance/assemble_steps.cpp
@@ -37,13 +37,15 @@ StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instr
         pre_turn_bearing =
             util::coordinate_calculation::bearing(pre_turn_coordinate, turn_coordinate);
     }
-    return StepManeuver{turn_coordinate,
-                        pre_turn_bearing,
-                        post_turn_bearing,
-                        instruction,
-                        waypoint_type,
-                        INVALID_EXIT_NR,
-                        INVALID_EXIT_NR};
+    return StepManeuver{
+        std::move(turn_coordinate),
+        pre_turn_bearing,
+        post_turn_bearing,
+        std::move(instruction),
+        waypoint_type,
+        INVALID_EXIT_NR,
+        {} // no intermediate intersections
+    };
 }
 
 StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
@@ -64,13 +66,15 @@ StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instr
     const double post_turn_bearing =
         util::coordinate_calculation::bearing(turn_coordinate, post_turn_coordinate);
 
-    return StepManeuver{turn_coordinate,
-                        pre_turn_bearing,
-                        post_turn_bearing,
-                        instruction,
-                        WaypointType::None,
-                        INVALID_EXIT_NR,
-                        INVALID_EXIT_NR};
+    return StepManeuver{
+        std::move(turn_coordinate),
+        pre_turn_bearing,
+        post_turn_bearing,
+        std::move(instruction),
+        WaypointType::None,
+        INVALID_EXIT_NR,
+        {} // no intermediate intersections
+    };
 }
 } // ns detail
 } // ns engine

--- a/src/engine/guidance/assemble_steps.cpp
+++ b/src/engine/guidance/assemble_steps.cpp
@@ -12,8 +12,41 @@ namespace guidance
 {
 namespace detail
 {
+
 StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
                                       const WaypointType waypoint_type,
+                                      const LegGeometry &leg_geometry)
+{
+    BOOST_ASSERT(waypoint_type != WaypointType::None);
+    BOOST_ASSERT(leg_geometry.locations.size() >= 2);
+
+    double pre_turn_bearing = 0, post_turn_bearing = 0;
+    Coordinate turn_coordinate;
+    if (waypoint_type == WaypointType::Arrive)
+    {
+        turn_coordinate = leg_geometry.locations.front();
+        const auto post_turn_coordinate = *(leg_geometry.locations.begin() + 1);
+        post_turn_bearing =
+            util::coordinate_calculation::bearing(turn_coordinate, post_turn_coordinate);
+    }
+    else
+    {
+        BOOST_ASSERT(waypoint_type == WaypointType::Depart);
+        turn_coordinate = leg_geometry.locations.back();
+        const auto pre_turn_coordinate = *(leg_geometry.locations.end() - 2);
+        pre_turn_bearing =
+            util::coordinate_calculation::bearing(pre_turn_coordinate, turn_coordinate);
+    }
+    return StepManeuver{turn_coordinate,
+                        pre_turn_bearing,
+                        post_turn_bearing,
+                        instruction,
+                        waypoint_type,
+                        INVALID_EXIT_NR,
+                        INVALID_EXIT_NR};
+}
+
+StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instruction,
                                       const LegGeometry &leg_geometry,
                                       const std::size_t segment_index)
 {
@@ -35,7 +68,7 @@ StepManeuver stepManeuverFromGeometry(extractor::guidance::TurnInstruction instr
                         pre_turn_bearing,
                         post_turn_bearing,
                         instruction,
-                        waypoint_type,
+                        WaypointType::None,
                         INVALID_EXIT_NR,
                         INVALID_EXIT_NR};
 }

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -54,9 +54,9 @@ void fixFinalRoundabout(std::vector<RouteStep> &steps)
         }
         else if (propagation_step.maneuver.instruction.type == TurnType::StayOnRoundabout)
         {
-            //TODO this operates on the data that is in the instructions.
-            //We are missing out on the final segment after the last stay-on-roundabout
-            //instruction though. it is not contained somewhere until now
+            // TODO this operates on the data that is in the instructions.
+            // We are missing out on the final segment after the last stay-on-roundabout
+            // instruction though. it is not contained somewhere until now
             steps[propagation_index - 1] =
                 forwardInto(std::move(steps[propagation_index - 1]), propagation_step);
             propagation_step.maneuver.instruction =
@@ -290,6 +290,29 @@ std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
     print(steps);
 #endif
     return steps;
+}
+
+LegGeometry resyncGeometry(LegGeometry leg_geometry, const std::vector<RouteStep> &steps)
+{
+    // The geometry uses an adjacency array-like structure for representation.
+    // To sync it back up with the steps, we cann add a segment for every step.
+    leg_geometry.segment_offsets.clear();
+    leg_geometry.segment_distances.clear();
+    leg_geometry.segment_offsets.push_back(0);
+
+    for (const auto &step : steps)
+    {
+        leg_geometry.segment_distances.push_back(step.distance);
+        // the leg geometry does not follow the begin/end-convetion. So we have to subtract one
+        // to get the back-index.
+        leg_geometry.segment_offsets.push_back(step.geometry_end - 1);
+    }
+
+    //remove the data fromt the reached-target step again
+    leg_geometry.segment_offsets.pop_back();
+    leg_geometry.segment_distances.pop_back();
+
+    return leg_geometry;
 }
 
 } // namespace guidance

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -20,194 +20,231 @@ namespace guidance
 
 namespace detail
 {
-bool canMergeTrivially(const PathData &destination, const PathData &source)
+bool canMergeTrivially(const RouteStep &destination, const RouteStep &source)
 {
-    return destination.exit == 0 && destination.name_id == source.name_id &&
-           destination.travel_mode == source.travel_mode && isSilent(source.turn_instruction);
+    return destination.maneuver.exit == 0 && destination.name_id == source.name_id &&
+           isSilent(source.maneuver.instruction);
 }
 
-PathData forwardInto(PathData destination, const PathData &source)
+RouteStep forwardInto(RouteStep destination, const RouteStep &source)
 {
     // Merge a turn into a silent turn
     // Overwrites turn instruction and increases exit NR
-    destination.exit = source.exit;
-    return destination;
-}
-
-PathData accumulateInto(PathData destination, const PathData &source)
-{
-    // Merge a turn into a silent turn
-    // Overwrites turn instruction and increases exit NR
-    BOOST_ASSERT(canMergeTrivially(destination, source));
-    destination.exit = source.exit + 1;
-    return destination;
-}
-
-PathData mergeInto(PathData destination, const PathData &source)
-{
-    if (source.turn_instruction == TurnInstruction::NO_TURN())
-    {
-        BOOST_ASSERT(canMergeTrivially(destination, source));
-        return detail::forwardInto(destination, source);
-    }
-    if (source.turn_instruction.type == TurnType::Suppressed)
-    {
-        return detail::forwardInto(destination, source);
-    }
-    if (source.turn_instruction.type == TurnType::StayOnRoundabout)
-    {
-        return detail::forwardInto(destination, source);
-    }
-    if (entersRoundabout(source.turn_instruction))
-    {
-        return detail::forwardInto(destination, source);
-    }
+    destination.duration += source.duration;
+    destination.distance += source.distance;
+    destination.geometry_begin = std::min( destination.geometry_begin, source.geometry_begin );
+    destination.geometry_end = std::max( destination.geometry_end, source.geometry_end );
     return destination;
 }
 
 } // namespace detail
 
-void print(const std::vector<std::vector<PathData>> &leg_data)
+void print(const std::vector<RouteStep> &steps)
 {
     std::cout << "Path\n";
-    int legnr = 0;
-    for (const auto &leg : leg_data)
+    int segment = 0;
+    for (const auto &step : steps)
     {
-        std::cout << "\tLeg: " << ++legnr << "\n";
-        int segment = 0;
-        for (const auto &data : leg)
-        {
-            const auto type = static_cast<int>(data.turn_instruction.type);
-            const auto modifier = static_cast<int>(data.turn_instruction.direction_modifier);
+        const auto type = static_cast<int>(step.maneuver.instruction.type);
+        const auto modifier = static_cast<int>(step.maneuver.instruction.direction_modifier);
 
-            std::cout << "\t\t[" << ++segment << "]: " << type << " " << modifier
-                      << " exit: " << data.exit << "\n";
-        }
+        std::cout << "\t[" << ++segment << "]: " << type << " " << modifier
+                  << " Duration: " << step.duration << " Distance: " << step.distance
+                  << " Geometry: " << step.geometry_begin << " " << step.geometry_end
+                  << " exit: " << step.maneuver.exit << " Intersection: " << step.maneuver.intersection << " name[" << step.name_id
+                  << "]: " << step.name << std::endl;
     }
-    std::cout << std::endl;
 }
 
-std::vector<std::vector<PathData>> postProcess(std::vector<std::vector<PathData>> leg_data)
+// Every Step Maneuver consists of the information until the turn.
+// This list contains a set of instructions, called silent, which should
+// not be part of the final output.
+// They are required for maintenance purposes. We can calculate the number
+// of exits to pass in a roundabout and the number of intersections
+// that we come across.
+
+std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
 {
-    if (leg_data.empty())
-        return leg_data;
+    // the steps should always include the first/last step in form of a location
+    BOOST_ASSERT(steps.size() >= 2);
+    if (steps.size() == 2)
+        return steps;
 
 #define PRINT_DEBUG 0
-    unsigned carry_exit = 0;
 #if PRINT_DEBUG
     std::cout << "[POSTPROCESSING ITERATION]" << std::endl;
     std::cout << "Input\n";
-    print(leg_data);
+    print(steps);
 #endif
     // Count Street Exits forward
     bool on_roundabout = false;
-    for (auto &path_data : leg_data)
+
+    // count the exits forward. if enter/exit roundabout happen both, no further treatment is
+    // required. We might end up with only one of them (e.g. starting within a roundabout)
+    // or having a via-point in the roundabout.
+    // In this case, exits are numbered from the start of the lag.
+    std::size_t last_valid_instruction = 0;
+    for (std::size_t step_index = 0; step_index < steps.size(); ++step_index)
     {
-        if (not path_data.empty())
-            path_data[0].exit = carry_exit;
-
-        for (std::size_t data_index = 0; data_index + 1 < path_data.size(); ++data_index)
+        auto &step = steps[step_index];
+        const auto instruction = step.maneuver.instruction;
+        if (entersRoundabout(instruction))
         {
-            if (entersRoundabout(path_data[data_index].turn_instruction))
+            last_valid_instruction = step_index;
+            // basic entry into a roundabout
+            // Special case handling, if an entry is directly tied to an exit
+            if (instruction.type == TurnType::EnterRotaryAtExit ||
+                instruction.type == TurnType::EnterRoundaboutAtExit)
             {
-                path_data[data_index].exit += 1;
+                step.maneuver.exit = 1;
+                // prevent futher special case handling of these two.
+                if (instruction.type == TurnType::EnterRotaryAtExit)
+                    step.maneuver.instruction = TurnType::EnterRotary;
+                else
+                    step.maneuver.instruction = TurnType::EnterRoundabout;
+            }
+
+            if (leavesRoundabout(instruction))
+            {
+                step.maneuver.exit = 1; // count the otherwise missing exit
+                if (instruction.type == TurnType::EnterRotaryAtExit)
+                    step.maneuver.instruction = TurnType::EnterRotary;
+                else
+                    step.maneuver.instruction = TurnType::EnterRoundabout;
+            }
+            else
+            {
                 on_roundabout = true;
+                if (step_index + 1 < steps.size())
+                    steps[step_index + 1].maneuver.exit = step.maneuver.exit;
+            }
+        }
+        else if (instruction.type == TurnType::StayOnRoundabout)
+        {
+            // increase the exit number we require passing the exit
+            step.maneuver.exit += 1;
+            if (step_index + 1 < steps.size())
+                steps[step_index + 1].maneuver.exit = step.maneuver.exit;
+        }
+        else if (leavesRoundabout(instruction))
+        {
+            // count the exit (0 based vs 1 based counting)
+            step.maneuver.exit += 1;
+            if (!on_roundabout)
+            {
+
+                // We reached a special case that requires the addition of a special route step in
+                // the beginning.
+                // We started in a roundabout, so to announce the exit, we move use the exit
+                // instruction and
+                // move it right to the beginning to make sure to immediately announce the exit.
+                BOOST_ASSERT(leavesRoundabout(steps[1].maneuver.instruction) ||
+                             steps[1].maneuver.instruction.type == TurnType::StayOnRoundabout);
+                steps[0].geometry_end = 1;
+                steps[1] = detail::forwardInto(steps[1], steps[0]);
+                steps[0].duration = 0;
+                steps[0].distance = 0;
+                steps[1].maneuver.instruction.type =
+                    step.maneuver.instruction.type == TurnType::ExitRotary
+                        ? TurnType::EnterRotary
+                        : TurnType::EnterRoundabout;
+
+                //remember the now enter-instruction as valid
+                last_valid_instruction = 1;
             }
 
-            if (isSilent(path_data[data_index].turn_instruction) &&
-                path_data[data_index].turn_instruction != TurnInstruction::NO_TURN())
+            // Normal exit from the roundabout, or exit from a previously fixed roundabout.
+            // Propagate the index back to the entering
+            // location and
+            // prepare the current silent set of instructions for removal.
+            if (step_index > 1)
             {
-                path_data[data_index].exit += 1;
-            }
-            if (leavesRoundabout(path_data[data_index].turn_instruction))
-            {
-                if (!on_roundabout)
+                // The very first route-step is head, so we cannot iterate past that one
+                for (std::size_t propagation_index = step_index - 1; propagation_index > 0;
+                     --propagation_index)
                 {
-                    BOOST_ASSERT(leg_data[0][0].turn_instruction.type ==
-                                 TurnInstruction::NO_TURN());
-                    if (path_data[data_index].turn_instruction.type == TurnType::ExitRoundabout)
-                        leg_data[0][0].turn_instruction.type = TurnType::EnterRoundabout;
-                    if (path_data[data_index].turn_instruction.type == TurnType::ExitRotary)
-                        leg_data[0][0].turn_instruction.type = TurnType::EnterRotary;
-                    path_data[data_index].exit += 1;
+                    auto &propagation_step = steps[propagation_index];
+                    propagation_step =
+                        detail::forwardInto(propagation_step, steps[propagation_index + 1]);
+                    if (entersRoundabout(propagation_step.maneuver.instruction))
+                    {
+                        // TODO at this point, we can remember the additional name for a rotary
+                        // This requires some initial thought on the data format, though
+                        propagation_step.maneuver.exit = step.maneuver.exit;
+                        propagation_step.geometry_end = step.geometry_end;
+                        propagation_step.name = step.name;
+                        propagation_step.name_id = step.name_id;
+                        break;
+                    }
+                    else
+                    {
+                        BOOST_ASSERT(propagation_step.maneuver.instruction.type =
+                                         TurnType::StayOnRoundabout);
+                        propagation_step.maneuver.instruction =
+                            TurnInstruction::NO_TURN(); // mark intermediate instructions invalid
+                    }
                 }
-                on_roundabout = false;
+                // remove exit
+                step.maneuver.instruction = TurnInstruction::NO_TURN();
             }
-            if (path_data[data_index].turn_instruction.type == TurnType::EnterRoundaboutAtExit)
-            {
-                path_data[data_index].exit += 1;
-                path_data[data_index].turn_instruction.type = TurnType::EnterRoundabout;
-            }
-            else if (path_data[data_index].turn_instruction.type == TurnType::EnterRotaryAtExit)
-            {
-                path_data[data_index].exit += 1;
-                path_data[data_index].turn_instruction.type = TurnType::EnterRotary;
-            }
+            on_roundabout = false;
+        }
+        else if (instruction.type == TurnType::Suppressed)
+        {
+            // count intersections. We cannot use exit, since intersections can follow directly after a roundabout
+            steps[last_valid_instruction].maneuver.intersection += 1;
 
-            if (isSilent(path_data[data_index].turn_instruction) ||
-                entersRoundabout(path_data[data_index].turn_instruction))
-            {
-                path_data[data_index + 1] =
-                    detail::mergeInto(path_data[data_index + 1], path_data[data_index]);
-            }
-            carry_exit = path_data[data_index].exit;
+            steps[last_valid_instruction] =
+                detail::forwardInto(steps[last_valid_instruction], step);
+            step.maneuver.instruction = TurnInstruction::NO_TURN();
+        }
+        else if( !isSilent(instruction) )
+        {
+            // Remember the last non silent instruction
+            last_valid_instruction = step_index;
         }
     }
+    // unterminated roundabout
+    // Move backwards through the instructions until the start and remove the exit number
+    // A roundabout without exit translates to enter-roundabout.
+    if (on_roundabout)
+    {
+        for (std::size_t propagation_index = steps.size() - 1; propagation_index > 0;
+             --propagation_index)
+        {
+            auto &propagation_step = steps[propagation_index];
+            if (entersRoundabout(propagation_step.maneuver.instruction))
+            {
+                propagation_step.maneuver.exit = 0;
+                break;
+            }
+            else if (propagation_step.maneuver.instruction == TurnType::StayOnRoundabout)
+            {
+                propagation_step.maneuver.instruction =
+                    TurnInstruction::NO_TURN(); // mark intermediate instructions invalid
+            }
+        }
+    }
+
+    // finally clean up the post-processed instructions.
+    // Remove all, now NO_TURN instructions for the set of steps
+    auto pos = steps.begin();
+    for (auto check = steps.begin(); check != steps.end(); ++check)
+    {
+        // keep valid instrucstions
+        if (check->maneuver.instruction != TurnInstruction::NO_TURN() ||
+            check->maneuver.waypoint_type != WaypointType::None)
+        {
+            *pos = *check;
+            ++pos;
+        }
+    }
+    steps.erase(pos, steps.end());
 #if PRINT_DEBUG
     std::cout << "Merged\n";
-    print(leg_data);
+    print(steps);
 #endif
-    on_roundabout = false;
-    // Move Roundabout exit numbers to front
-    for (auto rev_itr = leg_data.rbegin(); rev_itr != leg_data.rend(); ++rev_itr)
-    {
-        auto &path_data = *rev_itr;
-        for (std::size_t data_index = path_data.size(); data_index > 1; --data_index)
-        {
-            if (entersRoundabout(path_data[data_index - 1].turn_instruction))
-            {
-                if (!on_roundabout && !leavesRoundabout(path_data[data_index - 1].turn_instruction))
-                    path_data[data_index - 1].exit = 0;
-                on_roundabout = false;
-            }
-            if (on_roundabout)
-            {
-                path_data[data_index - 2].exit = path_data[data_index - 1].exit;
-            }
-            if (leavesRoundabout(path_data[data_index - 1].turn_instruction) &&
-                !entersRoundabout(path_data[data_index - 1].turn_instruction))
-            {
-                path_data[data_index - 2].exit = path_data[data_index - 1].exit;
-                on_roundabout = true;
-            }
-        }
-        auto prev_leg = std::next(rev_itr);
-        if (!path_data.empty() && prev_leg != leg_data.rend())
-        {
-            if (on_roundabout && path_data[0].exit)
-                prev_leg->back().exit = path_data[0].exit;
-        }
-    }
-
-#if PRINT_DEBUG
-    std::cout << "Move To Front\n";
-    print(leg_data);
-#endif
-    // silence silent turns for good
-    for (auto &path_data : leg_data)
-    {
-        for (auto &data : path_data)
-        {
-            if (isSilent(data.turn_instruction) || (leavesRoundabout(data.turn_instruction) &&
-                                                    !entersRoundabout(data.turn_instruction)))
-            {
-                data.turn_instruction = TurnInstruction::NO_TURN();
-                data.exit = 0;
-            }
-        }
-    }
-
-    return leg_data;
+    return steps;
 }
 
 } // namespace guidance


### PR DESCRIPTION
This pull request tracks the progress of moving the Guidance Post-Processing options onto the Route Step.

It consists of the following task:
 ~~-[]Adjust turn collapsing in [assemble_leg.hpp](https://github.com/Project-OSRM/osrm-backend/blob/rewrite/new-api/include/engine/guidance/assemble_leg.hpp#L36-L54): This process assumes name-ids to be the only decision that decides whether a turn is kept or not. This needs to be adjusted to compress only no-turns. Some instructions are actually required to stay on a road.~~
 Since this is only a heuristic for the route name and would require a lot of changes, keeping the name as only source of naming the route seems like the better option.

- [x] Move Post Processing away from `PathData` and past `assemble_steps.cpp` to work on route-steps. This would require the insertion of temporary route steps for silent instructions that can then be collapsed, or a full integration of the post-processing with assemble_steps. I'd prefer the former (@themarex, whats your take on this?)

- [x] Post-Process Temporary Route Steps: Due to the adjustment above, some silent instructions might remain in the route-steps. Post-processing has to combine these accordingly.
     - [x] we have to count exits for roundabouts
     - [x] In addition, we can add information on intersections in between the instructions. Every silent turn can be added to a list of intersections with respective distances along the current step geometry (thank you for the proposal @TheMarex)

- [x] clean up silent instructions -- remove silent instructions from output to prevent them from being shown in the json result.
    - [x] remove silent instructions from output
    - [x] potentially sync leg-geometry with new instructions?

- [x] https://github.com/Project-OSRM/osrm-backend/pull/2080 needs to be merged prior to this

- [x] find out why path length and segments do not match 

- [x] get @daniel-j-h 's blessing