### PR TITLE
[ready] adds a distinction between roundabouts and rotaries

### DIFF
--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -44,6 +44,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                                      const bool target_traversed_in_reverse)
 {
     const double constexpr ZERO_DURATION = 0., ZERO_DISTANCE = 0.;
+    const constexpr char* NO_ROTARY_NAME = "";
     const EdgeWeight source_duration =
         source_traversed_in_reverse ? source_node.reverse_weight : source_node.forward_weight;
     const auto source_mode = source_traversed_in_reverse ? source_node.backward_travel_mode
@@ -86,6 +87,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                 const auto distance = leg_geometry.segment_distances[segment_index];
                 steps.push_back(RouteStep{path_point.name_id,
                                           name,
+                                          NO_ROTARY_NAME,
                                           segment_duration / 10.0,
                                           distance,
                                           path_point.travel_mode,
@@ -103,6 +105,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         BOOST_ASSERT(duration >= 0);
         steps.push_back(RouteStep{target_node.name_id,
                                   facade.GetNameForID(target_node.name_id),
+                                  NO_ROTARY_NAME,
                                   duration / 10.,
                                   distance,
                                   target_mode,
@@ -126,6 +129,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
 
         steps.push_back(RouteStep{source_node.name_id,
                                   facade.GetNameForID(source_node.name_id),
+                                  NO_ROTARY_NAME,
                                   duration / 10.,
                                   leg_geometry.segment_distances[segment_index],
                                   source_mode,
@@ -140,6 +144,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         extractor::guidance::TurnInstruction::NO_TURN(), WaypointType::Arrive, leg_geometry);
     steps.push_back(RouteStep{target_node.name_id,
                               facade.GetNameForID(target_node.name_id),
+                              NO_ROTARY_NAME,
                               ZERO_DURATION,
                               ZERO_DISTANCE,
                               target_mode,

--- a/include/engine/guidance/route_step.hpp
+++ b/include/engine/guidance/route_step.hpp
@@ -25,6 +25,7 @@ struct RouteStep
 {
     unsigned name_id;
     std::string name;
+    std::string rotary_name;
     double duration;
     double distance;
     extractor::TravelMode mode;

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -350,7 +350,8 @@ inline bool requiresNameAnnounced(const std::string &from, const std::string &to
         const auto ref_begin = name.find_first_of('(');
         if (ref_begin != std::string::npos)
         {
-            out_name = name.substr(0, ref_begin);
+            //we might need to trim a space, if there is a reference
+            out_name = name.substr(0, ref_begin - (ref_begin > 0 && name[ref_begin-1] == ' '));
             out_ref = name.substr(ref_begin + 1, name.find_first_of(')') - 1);
         }
         else

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -112,7 +112,8 @@ class TurnAnalysis
     // Processing of roundabouts
     // Produces instructions to enter/exit a roundabout or to stay on it.
     // Performs the distinction between roundabout and rotaries.
-    std::vector<ConnectedRoad> handleRoundabouts(const EdgeID via_edge,
+    std::vector<ConnectedRoad> handleRoundabouts(const bool is_rotary,
+                                                 const EdgeID via_edge,
                                                  const bool on_roundabout,
                                                  const bool can_exit_roundabout,
                                                  std::vector<ConnectedRoad> intersection) const;
@@ -152,8 +153,8 @@ class TurnAnalysis
                                                  std::vector<ConnectedRoad> intersection) const;
 
     // Any Junction containing motorways
-    std::vector<ConnectedRoad> handleMotorwayJunction(
-        const EdgeID via_edge, std::vector<ConnectedRoad> intersection) const;
+    std::vector<ConnectedRoad>
+    handleMotorwayJunction(const EdgeID via_edge, std::vector<ConnectedRoad> intersection) const;
 
     std::vector<ConnectedRoad> handleFromMotorway(const EdgeID via_edge,
                                                   std::vector<ConnectedRoad> intersection) const;
@@ -193,6 +194,7 @@ class TurnAnalysis
                                                 std::vector<ConnectedRoad> intersection,
                                                 const std::size_t up_to) const;
 
+    bool isRotary(const NodeID nid) const;
 }; // class TurnAnalysis
 
 } // namespace guidance

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -89,24 +89,32 @@ struct TurnInstruction
         return TurnInstruction(TurnType::NoTurn, DirectionModifier::UTurn);
     }
 
-    static TurnInstruction REMAIN_ROUNDABOUT(const DirectionModifier modifier)
+    static TurnInstruction REMAIN_ROUNDABOUT(bool is_rotary, const DirectionModifier modifier)
     {
+        (void)is_rotary; // staying does not require a different instruction at the moment
         return TurnInstruction(TurnType::StayOnRoundabout, modifier);
     }
 
-    static TurnInstruction ENTER_ROUNDABOUT(const DirectionModifier modifier)
+    static TurnInstruction ENTER_ROUNDABOUT(bool is_rotary, const DirectionModifier modifier)
     {
-        return TurnInstruction(TurnType::EnterRoundabout, modifier);
+        return {is_rotary ? TurnType::EnterRotary : TurnType::EnterRoundabout, modifier};
     }
 
-    static TurnInstruction EXIT_ROUNDABOUT(const DirectionModifier modifier)
+    static TurnInstruction EXIT_ROUNDABOUT(bool is_rotary, const DirectionModifier modifier)
     {
-        return TurnInstruction(TurnType::ExitRoundabout, modifier);
+        return {is_rotary ? TurnType::ExitRotary : TurnType::ExitRoundabout, modifier};
+    }
+
+    static TurnInstruction ENTER_AND_EXIT_ROUNDABOUT(bool is_rotary,
+                                                     const DirectionModifier modifier)
+    {
+        return {is_rotary ? TurnType::EnterAndExitRotary : TurnType::EnterAndExitRoundabout,
+                modifier};
     }
 
     static TurnInstruction SUPPRESSED(const DirectionModifier modifier)
     {
-        return TurnInstruction{TurnType::Suppressed, modifier};
+        return {TurnType::Suppressed, modifier};
     }
 };
 

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -4,6 +4,7 @@
 #include "util/coordinate.hpp"
 
 #include <boost/math/constants/constants.hpp>
+#include <boost/optional.hpp>
 
 #include <utility>
 
@@ -60,6 +61,16 @@ double bearing(const Coordinate first_coordinate, const Coordinate second_coordi
 
 // Get angle of line segment (A,C)->(C,B)
 double computeAngle(const Coordinate first, const Coordinate second, const Coordinate third);
+
+// find the center of a circle through three coordinates
+boost::optional<Coordinate> circleCenter(const Coordinate first_coordinate,
+                                         const Coordinate second_coordinate,
+                                         const Coordinate third_coordinate);
+
+// find the radius of a circle through three coordinates
+double circleRadius(const Coordinate first_coordinate,
+                    const Coordinate second_coordinate,
+                    const Coordinate third_coordinate);
 
 // factor in [0,1]. Returns point along the straight line between from and to. 0 returns from, 1
 // returns to


### PR DESCRIPTION
Some larger rotaries have distinct names and should be handled differently from the pure roundabouts.
A roundabout is usually a small circle at an intersection.

This will unlock instructions of the form `at Logan Circle take the 4th exit` and the roundabout-turns (`at the roundabout turn left`).

Tasks:
 - [x] compute radius of roundabout
       - [x] implement radius of a circle
       - [x] find consistent roundabout size

 - [x] determine threshold / rules for distinction between rotary and roundabout (see below)
 - [x] implement distinction in `handleRoundabouts` moved to a dedicated function

 - [x] reviewed @daniel-j-h
 - [ ] on merge: update API for new instruction/new data and handle in API (@karenzshea)
       Proposal: `rotary | a special (often named) roundabout -- can offer additional_name as attribute`
       or: `additional_name` a roundabout may specify an `additional_name` to indicate the name of the roundabout itself. 