### PR TITLE
fixes missing overrides in mock data facade

### DIFF
--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -18,57 +18,67 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     EdgeData foo;
 
   public:
-    unsigned GetNumberOfNodes() const { return 0; }
-    unsigned GetNumberOfEdges() const { return 0; }
-    unsigned GetOutDegree(const NodeID /* n */) const { return 0; }
-    NodeID GetTarget(const EdgeID /* e */) const { return SPECIAL_NODEID; }
-    const EdgeData &GetEdgeData(const EdgeID /* e */) const { return foo; }
-    EdgeID BeginEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
-    EdgeID EndEdges(const NodeID /* n */) const { return SPECIAL_EDGEID; }
-    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const
+    unsigned GetNumberOfNodes() const override { return 0; }
+    unsigned GetNumberOfEdges() const override { return 0; }
+    unsigned GetOutDegree(const NodeID /* n */) const override { return 0; }
+    NodeID GetTarget(const EdgeID /* e */) const override { return SPECIAL_NODEID; }
+    const EdgeData &GetEdgeData(const EdgeID /* e */) const override { return foo; }
+    EdgeID BeginEdges(const NodeID /* n */) const override { return SPECIAL_EDGEID; }
+    EdgeID EndEdges(const NodeID /* n */) const override { return SPECIAL_EDGEID; }
+    osrm::engine::datafacade::EdgeRange GetAdjacentEdgeRange(const NodeID /* node */) const override
     {
         return util::irange(static_cast<EdgeID>(0), static_cast<EdgeID>(0));
     }
-    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const { return SPECIAL_EDGEID; }
-    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const
+    EdgeID FindEdge(const NodeID /* from */, const NodeID /* to */) const override
+    {
+        return SPECIAL_EDGEID;
+    }
+    EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const override
     {
         return SPECIAL_EDGEID;
     }
     EdgeID FindEdgeIndicateIfReverse(const NodeID /* from */,
                                      const NodeID /* to */,
-                                     bool & /* result */) const
+                                     bool & /* result */) const override
     {
         return SPECIAL_EDGEID;
     }
-    util::Coordinate GetCoordinateOfNode(const unsigned /* id */) const
+    util::Coordinate GetCoordinateOfNode(const unsigned /* id */) const override
     {
         return {util::FixedLongitude{0}, util::FixedLatitude{0}};
     }
     bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
-    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const { return SPECIAL_NODEID; }
+    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const override
+    {
+        return SPECIAL_NODEID;
+    }
     void GetUncompressedGeometry(const EdgeID /* id */,
-                                 std::vector<NodeID> & /* result_nodes */) const
+                                 std::vector<NodeID> & /* result_nodes */) const override
     {
     }
     void GetUncompressedWeights(const EdgeID /* id */,
-                                std::vector<EdgeWeight> & /* result_weights */) const
+                                std::vector<EdgeWeight> & /* result_weights */) const override
     {
     }
     void GetUncompressedDatasources(const EdgeID /*id*/,
-                                    std::vector<uint8_t> & /*data_sources*/) const
+                                    std::vector<uint8_t> & /*data_sources*/) const override
     {
     }
-    std::string GetDatasourceName(const uint8_t /*datasource_name_id*/) const { return ""; }
-    extractor::guidance::TurnInstruction GetTurnInstructionForEdgeID(const unsigned /* id */) const
+    std::string GetDatasourceName(const uint8_t /*datasource_name_id*/) const override
+    {
+        return "";
+    }
+    extractor::guidance::TurnInstruction
+    GetTurnInstructionForEdgeID(const unsigned /* id */) const override
     {
         return extractor::guidance::TurnInstruction::NO_TURN();
     }
-    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const
+    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const override
     {
         return TRAVEL_MODE_INACCESSIBLE;
     }
     std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate /* south_west */,
-                                         const util::Coordinate /*north_east */)
+                                         const util::Coordinate /*north_east */) override
     {
         return {};
     }
@@ -77,14 +87,14 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     NearestPhantomNodesInRange(const util::Coordinate /*input_coordinate*/,
                                const float /*max_distance*/,
                                const int /*bearing*/,
-                               const int /*bearing_range*/)
+                               const int /*bearing_range*/) override
     {
         return {};
     }
 
     std::vector<engine::PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate /*input_coordinate*/,
-                               const float /*max_distance*/)
+                               const float /*max_distance*/) override
     {
         return {};
     }
@@ -94,7 +104,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
                         const unsigned /*max_results*/,
                         const double /*max_distance*/,
                         const int /*bearing*/,
-                        const int /*bearing_range*/)
+                        const int /*bearing_range*/) override
     {
         return {};
     }
@@ -103,13 +113,14 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     NearestPhantomNodes(const util::Coordinate /*input_coordinate*/,
                         const unsigned /*max_results*/,
                         const int /*bearing*/,
-                        const int /*bearing_range*/)
+                        const int /*bearing_range*/) override
     {
         return {};
     }
 
     std::vector<engine::PhantomNodeWithDistance>
-    NearestPhantomNodes(const util::Coordinate /*input_coordinate*/, const unsigned /*max_results*/)
+    NearestPhantomNodes(const util::Coordinate /*input_coordinate*/,
+                        const unsigned /*max_results*/) override
     {
         return {};
     }
@@ -117,20 +128,21 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     std::vector<engine::PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate /*input_coordinate*/,
                         const unsigned /*max_results*/,
-                        const double /*max_distance*/)
+                        const double /*max_distance*/) override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/)
+    NearestPhantomNodeWithAlternativeFromBigComponent(
+        const util::Coordinate /*input_coordinate*/) override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
-                                                      const double /*max_distance*/)
+                                                      const double /*max_distance*/) override
     {
         return {};
     }
@@ -139,7 +151,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
                                                       const double /*max_distance*/,
                                                       const int /*bearing*/,
-                                                      const int /*bearing_range*/)
+                                                      const int /*bearing_range*/) override
     {
         return {};
     }
@@ -147,17 +159,17 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     std::pair<engine::PhantomNode, engine::PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
                                                       const int /*bearing*/,
-                                                      const int /*bearing_range*/)
+                                                      const int /*bearing_range*/) override
     {
         return {};
     };
 
-    unsigned GetCheckSum() const { return 0; }
-    bool IsCoreNode(const NodeID /* id */) const { return false; }
-    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const { return 0; }
-    std::string GetNameForID(const unsigned /* name_id */) const { return ""; }
-    std::size_t GetCoreSize() const { return 0; }
-    std::string GetTimestamp() const { return ""; }
+    unsigned GetCheckSum() const override { return 0; }
+    bool IsCoreNode(const NodeID /* id */) const override { return false; }
+    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const override { return 0; }
+    std::string GetNameForID(const unsigned /* name_id */) const override { return ""; }
+    std::size_t GetCoreSize() const override { return 0; }
+    std::string GetTimestamp() const override { return ""; }
     bool GetUTurnsDefault() const override { return true; }
 };
 } // ns test


### PR DESCRIPTION
Currently the mock-datafacade is littered with compiler warnings on MacOS. This pull requests adds the missing tags to get rid of these warnings.