### PR TITLE
[ready] fixes local unpacking/identical coordinate issues

### DIFF
--- a/include/engine/guidance/assemble_leg.hpp
+++ b/include/engine/guidance/assemble_leg.hpp
@@ -118,7 +118,7 @@ RouteLeg assembleLeg(const DataFacadeT &facade,
 
     //                 s
     //                 |
-    // Given a route a---b---c  where there is a right turn at b.
+    // Given a route a---b---c  where there is a right turn at c.
     //                       |
     //                       d
     //                       |--t


### PR DESCRIPTION
This pull request fixes an issue if both source/target phantom snap to the same segment. In these cases, the unpacking would include the weight of the target node twice.

It uncovers a problem with the weight vectors, though. @danpat The weight we see [here](https://github.com/Project-OSRM/osrm-backend/blob/fix/advisory/include/engine/routing_algorithms/routing_base.hpp#L412-L430) should theoretically be equal to zero in all cases. For some reason it isn't, though, showing that https://github.com/Project-OSRM/osrm-backend/blob/fix/advisory/include/engine/routing_algorithms/routing_base.hpp#L403 is off. It looks like the weight-vectors might include the turn-penalty, which leads to inconsistencies with the phantom-nodes.

This pull request solves: https://github.com/Project-OSRM/osrm-backend/issues/2162
and https://github.com/Project-OSRM/osrm-backend/issues/2161 (at least offers more consistency)

 - [X] @daniel-j-h :eyes: 
 - [x] requires https://github.com/Project-OSRM/osrm-backend/pull/2166 merged