### PR TITLE
Fix raster_source + tests

### DIFF
--- a/features/raster/weights.feature
+++ b/features/raster/weights.feature
@@ -61,7 +61,7 @@ Feature: Raster - weights
             | d    | b  | de,eb | 10 km/h |
 
     Scenario: Weighting based on raster sources
-        Given the profile "rasterbot-interp"
+        Given the profile "rasterbotinterp"
         When I run "osrm-extract {osm_base}.osm -p {profile}"
         Then stdout should contain "evaluating segment"
         And I run "osrm-contract {osm_base}.osm"

--- a/include/extractor/raster_source.hpp
+++ b/include/extractor/raster_source.hpp
@@ -2,6 +2,7 @@
 #define RASTER_SOURCE_HPP
 
 #include "util/exception.hpp"
+#include "util/coordinate.hpp"
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -141,9 +142,9 @@ class SourceContainer
                          std::size_t nrows,
                          std::size_t ncols);
 
-    RasterDatum getRasterDataFromSource(unsigned int source_id, int lon, int lat);
+    RasterDatum getRasterDataFromSource(unsigned int source_id, double lon, double lat);
 
-    RasterDatum getRasterInterpolateFromSource(unsigned int source_id, int lon, int lat);
+    RasterDatum getRasterInterpolateFromSource(unsigned int source_id, double lon, double lat);
 
   private:
     std::vector<RasterSource> LoadedSources;

--- a/profiles/rasterbot.lua
+++ b/profiles/rasterbot.lua
@@ -33,7 +33,6 @@ function source_function ()
 end
 
 function segment_function (source, target, distance, weight)
-  io.write("lookup for " .. source.lon .. "," .. source.lat .. "  " .. target.lon .. "," .. target.lat .. "\n")
   local sourceData = sources:query(raster_source, source.lon, source.lat)
   local targetData = sources:query(raster_source, target.lon, target.lat)
   io.write("evaluating segment: " .. sourceData.datum .. " " .. targetData.datum .. "\n")

--- a/profiles/rasterbot.lua
+++ b/profiles/rasterbot.lua
@@ -13,6 +13,9 @@ function way_function (way, result)
     result.name = name
   end
 
+  result.forward_mode = mode.cycling
+  result.backward_mode = mode.cycling
+
   result.forward_speed = 15
   result.backward_speed = 15
 end
@@ -30,6 +33,7 @@ function source_function ()
 end
 
 function segment_function (source, target, distance, weight)
+  io.write("lookup for " .. source.lon .. "," .. source.lat .. "  " .. target.lon .. "," .. target.lat .. "\n")
   local sourceData = sources:query(raster_source, source.lon, source.lat)
   local targetData = sources:query(raster_source, target.lon, target.lat)
   io.write("evaluating segment: " .. sourceData.datum .. " " .. targetData.datum .. "\n")

--- a/profiles/rasterbotinterp.lua
+++ b/profiles/rasterbotinterp.lua
@@ -13,6 +13,9 @@ function way_function (way, result)
     result.name = name
   end
 
+  result.forward_mode = mode.cycling
+  result.backward_mode = mode.cycling
+
   result.forward_speed = 15
   result.backward_speed = 15
 end

--- a/src/extractor/raster_source.cpp
+++ b/src/extractor/raster_source.cpp
@@ -3,8 +3,6 @@
 #include "util/simple_logger.hpp"
 #include "util/timing_util.hpp"
 
-#include "osrm/coordinate.hpp"
-
 #include <cmath>
 
 namespace osrm
@@ -84,10 +82,10 @@ int SourceContainer::loadRasterSource(const std::string &path_string,
                                       std::size_t nrows,
                                       std::size_t ncols)
 {
-    const auto _xmin = static_cast<int>(xmin * COORDINATE_PRECISION);
-    const auto _xmax = static_cast<int>(xmax * COORDINATE_PRECISION);
-    const auto _ymin = static_cast<int>(ymin * COORDINATE_PRECISION);
-    const auto _ymax = static_cast<int>(ymax * COORDINATE_PRECISION);
+    const auto _xmin = static_cast<int>(util::toFixed(util::FloatLongitude(xmin)));
+    const auto _xmax = static_cast<int>(util::toFixed(util::FloatLongitude(xmax)));
+    const auto _ymin = static_cast<int>(util::toFixed(util::FloatLatitude(ymin)));
+    const auto _ymax = static_cast<int>(util::toFixed(util::FloatLatitude(ymax)));
 
     const auto itr = LoadedSourcePaths.find(path_string);
     if (itr != LoadedSourcePaths.end())
@@ -122,38 +120,40 @@ int SourceContainer::loadRasterSource(const std::string &path_string,
 }
 
 // External function for looking up nearest data point from a specified source
-RasterDatum SourceContainer::getRasterDataFromSource(unsigned int source_id, int lon, int lat)
+RasterDatum SourceContainer::getRasterDataFromSource(unsigned int source_id, double lon, double lat)
 {
     if (LoadedSources.size() < source_id + 1)
     {
         throw util::exception("error reading: no such loaded source");
     }
 
-    BOOST_ASSERT(lat < (90 * COORDINATE_PRECISION));
-    BOOST_ASSERT(lat > (-90 * COORDINATE_PRECISION));
-    BOOST_ASSERT(lon < (180 * COORDINATE_PRECISION));
-    BOOST_ASSERT(lon > (-180 * COORDINATE_PRECISION));
+    BOOST_ASSERT(lat < 90);
+    BOOST_ASSERT(lat > -90);
+    BOOST_ASSERT(lon < 180);
+    BOOST_ASSERT(lon > -180);
 
     const auto &found = LoadedSources[source_id];
-    return found.getRasterData(lon, lat);
+    return found.getRasterData(static_cast<int>(util::toFixed(util::FloatLongitude(lon))),
+                               static_cast<int>(util::toFixed(util::FloatLatitude(lat))));
 }
 
 // External function for looking up interpolated data from a specified source
 RasterDatum
-SourceContainer::getRasterInterpolateFromSource(unsigned int source_id, int lon, int lat)
+SourceContainer::getRasterInterpolateFromSource(unsigned int source_id, double lon, double lat)
 {
     if (LoadedSources.size() < source_id + 1)
     {
         throw util::exception("error reading: no such loaded source");
     }
 
-    BOOST_ASSERT(lat < (90 * COORDINATE_PRECISION));
-    BOOST_ASSERT(lat > (-90 * COORDINATE_PRECISION));
-    BOOST_ASSERT(lon < (180 * COORDINATE_PRECISION));
-    BOOST_ASSERT(lon > (-180 * COORDINATE_PRECISION));
+    BOOST_ASSERT(lat < 90);
+    BOOST_ASSERT(lat > -90);
+    BOOST_ASSERT(lon < 180);
+    BOOST_ASSERT(lon > -180);
 
     const auto &found = LoadedSources[source_id];
-    return found.getRasterInterpolate(lon, lat);
+    return found.getRasterInterpolate(static_cast<int>(util::toFixed(util::FloatLongitude(lon))),
+                                      static_cast<int>(util::toFixed(util::FloatLatitude(lat))));
 }
 }
 }

--- a/unit_tests/extractor/raster_source.cpp
+++ b/unit_tests/extractor/raster_source.cpp
@@ -16,12 +16,12 @@ int normalize(double coord) { return static_cast<int>(coord * COORDINATE_PRECISI
 
 #define CHECK_QUERY(source_id, lon, lat, expected)                                                 \
     BOOST_CHECK_EQUAL(                                                                             \
-        sources.getRasterDataFromSource(source_id, normalize(lon), normalize(lat)).datum,          \
+        sources.getRasterDataFromSource(source_id, lon, lat).datum,          \
         expected)
 
 #define CHECK_INTERPOLATE(source_id, lon, lat, expected)                                           \
     BOOST_CHECK_EQUAL(                                                                             \
-        sources.getRasterInterpolateFromSource(source_id, normalize(lon), normalize(lat)).datum,   \
+        sources.getRasterInterpolateFromSource(source_id, lon, lat).datum,   \
         expected)
 
 BOOST_AUTO_TEST_CASE(raster_test)


### PR DESCRIPTION
* scripting_environment now casts coordinates' `lat` and `lon` properties to doubles, so this modifies the function signature for query functions called from lua profiles
* adds forward_ and backward_mode to raster test profiles (required to return a valid edge)
* URLs were being called "malformed" with hyphens in them, so I had to rename `rasterbot-interp.lua` to `rasterbotinterp.lua`

@TheMarex — :eyes: & :+1: ?