### PR TITLE
Removes server-side support for POST requests on v5

### DIFF
--- a/include/server/request_parser.hpp
+++ b/include/server/request_parser.hpp
@@ -64,17 +64,11 @@ class RequestParser
         space_before_header_value,
         header_value,
         expecting_newline_2,
-        expecting_newline_3,
-        post_O,
-        post_S,
-        post_T,
-        post_request
+        expecting_newline_3
     } state;
 
     http::header current_header;
     http::compression_type selected_compression;
-    bool is_post_header;
-    int content_length;
 };
 }
 }


### PR DESCRIPTION
Resolves https://github.com/Project-OSRM/osrm-backend/issues/2163.

@TheMarex we seriously need to talk about routed. I just took a deeper look at the request parser and we have a freaking character-level state machine in there. :wat:

I can totally see this coming from the [Boost.ASIO examples](http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/examples/cpp11_examples.html).

Just compare the following two files with ours:

- http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/example/cpp11/http/server/request_parser.hpp
- http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/example/cpp11/http/server/request_parser.cpp

This is not a priority with v5 or any release in particular but we need a clear upgrade path. And I'm fine with removing our hand-written C++ code e.g. with a node-using routed (or anything more serious, heck look at [how beautiful it could be](https://nghttp2.org/documentation/libnghttp2_asio.html#server-api)).