### PR TITLE
Fixes using uninitialised values in extractRouteNames

### DIFF
--- a/include/engine/route_name_extraction.hpp
+++ b/include/engine/route_name_extraction.hpp
@@ -124,10 +124,6 @@ RouteNames extractRouteNames(std::vector<SegmentT> &shortest_path_segments,
     {
         std::swap(shortest_segment_1, shortest_segment_2);
     }
-    if (alternative_segment_1.position > alternative_segment_2.position)
-    {
-        std::swap(alternative_segment_1, alternative_segment_2);
-    }
 
     // fetching names for the selected segments
     route_names.shortest_path_name_1 = facade->get_name_for_id(shortest_segment_1.name_id);
@@ -135,6 +131,11 @@ RouteNames extractRouteNames(std::vector<SegmentT> &shortest_path_segments,
 
     if (!alternative_path_segments.empty())
     {
+        if (alternative_segment_1.position > alternative_segment_2.position)
+        {
+            std::swap(alternative_segment_1, alternative_segment_2);
+        }
+
         route_names.alternative_path_name_1 =
             facade->get_name_for_id(alternative_segment_1.name_id);
         route_names.alternative_path_name_2 =


### PR DESCRIPTION
Fixes an issue in valgrind ./osrm-example ../test/data/monaco.osrm

Conditional jump or move depends on uninitialised value(s)
   at 0x5FEE48: osrm::engine::RouteNames osrm::engine::extractRouteNames<osrm::engine::datafacade::BaseDataFacade<osrm::contractor::QueryEdge::EdgeData>, osrm::engine::detail::Segment>(std::vector<osrm::engine::detail::Segment, std::allocator<osrm::engine::detail::Segment> >&, std::vector<osrm::engine::detail::Segment, std::allocator<osrm::engine::detail::Segment> >&, osrm::engine::datafacade::BaseDataFacade<osrm::contractor::QueryEdge::EdgeData> const*) (route_name_extraction.hpp:127)
   by 0x61A1B2: osrm::engine::ApiResponseGenerator<osrm::engine::datafacade::BaseDataFacade<osrm::contractor::QueryEdge::EdgeData> >::DescribeRoute(osrm::engine::RouteParameters const&, osrm::engine::InternalRouteResult const&, osrm::util::json::Object&) (api_response_generator.hpp:173)
   by 0x61AF47: osrm::engine::plugins::ViaRoutePlugin<osrm::engine::datafacade::BaseDataFacade<osrm::contractor::QueryEdge::EdgeData> >::HandleRequest(osrm::engine::RouteParameters const&, osrm::util::json::Object&) (viaroute.hpp:144)
   by 0x61EEEC: osrm::engine::Engine::RunQuery(osrm::engine::RouteParameters const&, osrm::util::json::Object&) (engine.cpp:100)
   by 0x5AE585: osrm::OSRM::RunQuery(osrm::engine::RouteParameters const&, osrm::util::json::Object&) (osrm.cpp:19)
   by 0x5A8E07: main (in /home/miha/work/foss/osrm-backend/build.example/osrm-example)