### PR TITLE
Removes unused access_tag list from car profile

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -7,7 +7,6 @@ barrier_whitelist = { ["cattle_grid"] = true, ["border_control"] = true, ["check
 access_tag_whitelist = { ["yes"] = true, ["motorcar"] = true, ["motor_vehicle"] = true, ["vehicle"] = true, ["permissive"] = true, ["designated"] = true, ["destination"] = true }
 access_tag_blacklist = { ["no"] = true, ["private"] = true, ["agricultural"] = true, ["forestry"] = true, ["emergency"] = true, ["psv"] = true }
 access_tag_restricted = { ["destination"] = true, ["delivery"] = true }
-access_tags = { "motorcar", "motor_vehicle", "vehicle" }
 access_tags_hierachy = { "motorcar", "motor_vehicle", "vehicle", "access" }
 service_tag_restricted = { ["parking_aisle"] = true }
 restriction_exception_tags = { "motorcar", "motor_vehicle", "vehicle" }


### PR DESCRIPTION
Looking into the profiles for https://github.com/Project-OSRM/osrm-backend/issues/2150#issuecomment-203595229 I found
`access_tags` being neither used in the profile, nor
through luabind. It is dead code.

Using my time machine (which sadly can only go back
in history), I found the introducing commit here:

https://github.com/Project-OSRM/osrm-backend/commit/74cc50f52b79cdb06d5c61fabc1fdc9ca5979fcc#diff-ded22cbfae0ae88f6359ccff1c3355b0R106

Seems like we no longer use it, and it was still left in the car profile.
