### PR TITLE
Resolves issues with multiple includedirs in pkg-config file; closes #2195.

### DIFF
--- a/cmake/pkgconfig.in
+++ b/cmake/pkgconfig.in
@@ -1,5 +1,5 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-includedir=${prefix}/include ${prefix}/include/osrm
+includedir=${prefix}/include
 libdir=${prefix}/lib
 
 Name: libOSRM
@@ -8,4 +8,4 @@ Version: v@OSRM_VERSION_MAJOR@.@OSRM_VERSION_MINOR@.@OSRM_VERSION_PATCH@
 Requires:
 Libs: -L${libdir} -losrm
 Libs.private: @ENGINE_LIBRARY_LISTING@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/osrm


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/2195.

Resolved.

```
daniel@x1c /t/o/build> env PKG_CONFIG_PATH=. pkg-config --cflags --libs libosrm
-I/usr/local/include -I/usr/local/include/osrm -L/usr/local/lib -losrm
```