### PR TITLE
Suppress pedantic ISO C++ warning about argv[0] size check

### DIFF
--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -109,8 +109,9 @@ generateServerProgramOptions(const int argc,
     boost::program_options::options_description cmdline_options;
     cmdline_options.add(generic_options).add(config_options).add(hidden_options);
 
+    const auto* executable = argv[0];
     boost::program_options::options_description visible_options(
-        boost::filesystem::path(argv[0]).stem().string() + " <base.osrm> [<options>]");
+        boost::filesystem::path(executable).stem().string() + " <base.osrm> [<options>]");
     visible_options.add(generic_options).add(config_options);
 
     // parse command line options


### PR DESCRIPTION
Boost.Filesystem immediately does a size check in the path headers, triggering this.