### PR TITLE
Removes summary from legs property

### DIFF
--- a/features/step_definitions/requests.js
+++ b/features/step_definitions/requests.js
@@ -44,12 +44,9 @@ module.exports = function () {
 
     this.Then(/^response should be a well-formed route$/, () => {
         this.ShouldBeWellFormed();
-        assert.equal(typeof this.json.status_message, 'string');
-        assert.equal(typeof this.json.route_summary, 'object');
-        assert.equal(typeof this.json.route_geometry, 'string');
-        assert.ok(Array.isArray(this.json.route_instructions));
-        assert.ok(Array.isArray(this.json.via_points));
-        assert.ok(Array.isArray(this.json.via_indices));
+        assert.equal(this.json.code, 'ok');
+        assert.ok(Array.isArray(this.json.routes));
+        assert.ok(Array.isArray(this.json.waypoints));
     });
 
     this.Then(/^"([^"]*)" should return code (\d+)$/, (binary, code) => {

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -59,14 +59,6 @@ module.exports = function () {
                             got['#'] = row['#'];
                         }
 
-                        if (headers.has('start')) {
-                            got.start = instructions ? json.route_summary.start_point : null;
-                        }
-
-                        if (headers.has('end')) {
-                            got.end = instructions ? json.route_summary.end_point : null;
-                        }
-
                         if (headers.has('geometry')) {
                             got.geometry = json.routes[0].geometry;
                         }

--- a/features/testbot/uturn.feature
+++ b/features/testbot/uturn.feature
@@ -78,16 +78,16 @@ Feature: U-turns at via points
             | uturns | true |
 
         And the ways
-            | nodes |
-            | ab    |
-            | bc    |
-            | cd    |
-            | be    |
-            | dg    |
-            | ef    |
-            | fg    |
+            | nodes | oneway |
+            | ab    | no     |
+            | bc    | no     |
+            | cd    | no     |
+            | be    | yes    |
+            | dg    | no     |
+            | ef    | no     |
+            | fg    | no     |
 
         When I route I should get
-            | waypoints | route                                        |
-            | 1,2,3,4,5 | ab,be,be,be,bc,bc,bc,be,ef,fg,dg,dg,dg,cd,cd |
+            | waypoints | route                                           |
+            | 1,2,3,4,5 | ab,be,be,be,ef,fg,dg,cd,bc,bc,bc,cd,dg,dg,dg,cd,cd |
 

--- a/include/engine/guidance/route_leg.hpp
+++ b/include/engine/guidance/route_leg.hpp
@@ -3,9 +3,6 @@
 
 #include "engine/guidance/route_step.hpp"
 
-#include <boost/optional.hpp>
-
-#include <string>
 #include <vector>
 
 namespace osrm
@@ -19,7 +16,6 @@ struct RouteLeg
 {
     double duration;
     double distance;
-    std::string summary;
     std::vector<RouteStep> steps;
 };
 }

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -199,7 +199,6 @@ util::json::Object makeRouteLeg(guidance::RouteLeg leg, util::json::Array steps)
     util::json::Object route_leg;
     route_leg.values["distance"] = std::round(leg.distance * 10) / 10.;
     route_leg.values["duration"] = std::round(leg.duration * 10) / 10.;
-    route_leg.values["summary"] = std::move(leg.summary);
     route_leg.values["steps"] = std::move(steps);
     return route_leg;
 }

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -44,7 +44,6 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
                          {"legs", json::Array{{json::Object{
                                       {{"distance", 0.},
                                        {"duration", 0.},
-                                       {"summary", ""},
                                        {"steps", json::Array{{json::Object{
                                                      {{"duration", 0.},
                                                       {"distance", 0.},
@@ -133,10 +132,6 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates)
 
             const auto duration = leg_object.values.at("duration").get<json::Number>().value;
             BOOST_CHECK_EQUAL(duration, 0);
-
-            // nothing can be said about summary, empty or contains human readable summary
-            const auto summary = leg_object.values.at("summary").get<json::String>().value;
-            BOOST_CHECK(((void)summary, true));
 
             const auto &steps = leg_object.values.at("steps").get<json::Array>().values;
             BOOST_CHECK(!steps.empty());


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/2214.

Can you quickly take a look @lbud if this affects the cucumber tests, I found specifically:
- https://github.com/Project-OSRM/osrm-backend/blob/rewrite/new-api/features/step_definitions/requests.js#L48
- https://github.com/Project-OSRM/osrm-backend/blob/rewrite/new-api/features/support/shared_steps.js#L62-L68

as I can not find a call site for "well-formed" and I'm not sure if that's the leg's summary.