### PR TITLE
fixes 2219

### DIFF
--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -85,3 +85,22 @@ Feature: Basic Map Matching
             | trace | matchings |
             | dcba  | hgfe      |
 
+    Scenario: Testbot - Matching with oneway streets
+        Given a grid size of 10 meters
+        Given the node map
+            | a | b | c | d |
+            | e | f | g | h |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | yes    |
+            | bc    | yes    |
+            | cd    | yes    |
+            | hg    | yes    |
+            | gf    | yes    |
+            | fe    | yes    |
+
+        When I match I should get
+            | trace | matchings |
+            | dcba  | hg,gf,fe  |
+            | efgh  | ab,bc,cd  |

--- a/include/engine/routing_algorithms/shortest_path.hpp
+++ b/include/engine/routing_algorithms/shortest_path.hpp
@@ -309,7 +309,7 @@ class ShortestPathRouting final
                                     new_total_distance_to_forward, packed_leg_to_forward);
                     // if only the reverse node is valid (e.g. when using the match plugin) we
                     // actually need to move
-                    if (target_phantom.forward_segment_id.enabled)
+                    if (!target_phantom.forward_segment_id.enabled)
                     {
                         BOOST_ASSERT(target_phantom.reverse_segment_id.enabled);
                         new_total_distance_to_reverse = new_total_distance_to_forward;

--- a/include/extractor/restriction_parser.hpp
+++ b/include/extractor/restriction_parser.hpp
@@ -19,7 +19,7 @@ namespace osrm
 namespace extractor
 {
 
-class ProfileProperties;
+struct ProfileProperties;
 
 /**
  * Parses the relations that represents turn restrictions.


### PR DESCRIPTION
Reverts Error introduced in 

https://github.com/Project-OSRM/osrm-backend/commit/991a0b38c5ac78793e50dfffa3e191bc39f1baba#diff-982a4e4e47e7de8db207d7f0723c6346R313

Resulting in https://github.com/Project-OSRM/osrm-backend/issues/2219

In addition, I also fixed a compiler warning

```
/Users/mokob/git/engine/project-osrm/osrm-backend/include/extractor/profile_properties.hpp:11:1: warning: 'ProfileProperties' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct ProfileProperties
^
/Users/mokob/git/engine/project-osrm/osrm-backend/include/extractor/restriction_parser.hpp:22:1: note: did you mean struct here?
class ProfileProperties;
^~~~~
struct
```