### PR TITLE
Fix/2173/no trailing dotjson policy

### DIFF
--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -62,8 +62,7 @@ struct MatchParametersGrammar final : public BaseParametersGrammar
         timestamps_rule = qi::lit("timestamps=") >> qi::uint_ % ";";
         match_rule = steps_rule[set_steps] | geometries_rule | overview_rule |
                      timestamps_rule[set_timestamps];
-        root_rule = query_rule >> -qi::lit(".") >> -qi::lit("json") >>
-                    -(qi::lit("?") >> (match_rule | base_rule) % '&');
+        root_rule = query_rule >> -qi::lit(".json") >> -(qi::lit("?") >> (match_rule | base_rule) % '&');
     }
 
     engine::api::MatchParameters parameters;

--- a/include/server/api/nearest_parameter_grammar.hpp
+++ b/include/server/api/nearest_parameter_grammar.hpp
@@ -31,8 +31,7 @@ struct NearestParametersGrammar final : public BaseParametersGrammar
             parameters.number_of_results = number;
         };
         nearest_rule = (qi::lit("number=") >> qi::uint_)[set_number];
-        root_rule = query_rule >> -qi::lit(".") >> -qi::lit("json") >>
-                    -(qi::lit("?") >> (nearest_rule | base_rule) % '&');
+        root_rule = query_rule >> -qi::lit(".json") >> -(qi::lit("?") >> (nearest_rule | base_rule) % '&');
     }
 
     engine::api::NearestParameters parameters;

--- a/include/server/api/parsed_url.hpp
+++ b/include/server/api/parsed_url.hpp
@@ -27,6 +27,11 @@ struct ParsedURL final
 } // server
 } // osrm
 
-BOOST_FUSION_ADAPT_STRUCT(osrm::server::api::ParsedURL, service, version, profile, query)
+BOOST_FUSION_ADAPT_STRUCT(osrm::server::api::ParsedURL,
+    (std::string, service),
+    (unsigned, version),
+    (std::string, profile),
+    (std::string, query)
+)
 
 #endif

--- a/include/server/api/route_parameters_grammar.hpp
+++ b/include/server/api/route_parameters_grammar.hpp
@@ -65,8 +65,7 @@ struct RouteParametersGrammar : public BaseParametersGrammar
         route_rule = steps_rule[set_steps] | alternatives_rule[set_alternatives] | geometries_rule |
                      overview_rule | uturns_rule;
 
-        root_rule = query_rule >> -qi::lit(".") >> -qi::lit("json") >>
-                    -(qi::lit("?") >> (route_rule | base_rule) % '&');
+        root_rule = query_rule >> -qi::lit(".json") >> -(qi::lit("?") >> (route_rule | base_rule) % '&');
     }
 
     engine::api::RouteParameters parameters;

--- a/include/server/api/table_parameter_grammar.hpp
+++ b/include/server/api/table_parameter_grammar.hpp
@@ -41,8 +41,7 @@ struct TableParametersGrammar final : public BaseParametersGrammar
             (qi::lit("sources=") >> (qi::ulong_ % ";")[set_sources]) | qi::lit("sources=all");
         table_rule = destinations_rule | sources_rule;
 
-        root_rule = query_rule >> -qi::lit(".") >> -qi::lit("json") >>
-                    -(qi::lit("?") >> (table_rule | base_rule) % '&');
+        root_rule = query_rule >> -qi::lit(".json") >> -(qi::lit("?") >> (table_rule | base_rule) % '&');
     }
 
     engine::api::TableParameters parameters;

--- a/include/server/api/trip_parameter_grammar.hpp
+++ b/include/server/api/trip_parameter_grammar.hpp
@@ -57,8 +57,7 @@ struct TripParametersGrammar final : public BaseParametersGrammar
                         qi::lit("overview=false")[set_false_type];
         trip_rule = steps_rule[set_steps] | geometries_rule | overview_rule;
 
-        root_rule = query_rule >> -qi::lit(".") >> -qi::lit("json") >>
-                    -(qi::lit("?") >> (trip_rule | base_rule) % '&');
+        root_rule = query_rule >> -qi::lit(".json") >> -(qi::lit("?") >> (trip_rule | base_rule) % '&');
     }
 
     engine::api::TripParameters parameters;

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -62,7 +62,7 @@ boost::optional<ParsedURL> parseURL(std::string::iterator &iter, const std::stri
 {
     using It = std::decay<decltype(iter)>::type;
 
-    static URLParser<It, ParsedURL> const parser;
+    static URLParser<It, ParsedURL()> const parser;
     ParsedURL out;
 
     const auto ok = boost::spirit::qi::parse(iter, end, parser, out);


### PR DESCRIPTION
Hello, 
it is another type fix  for #2173 with a customized real policy: it drops real number parsing if finds ".json" and returns an integer part if got_a_number is true otherwise rule fails.  Output here:
```
http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;7.420363,43.736189;7.420363,43.736189;80,0...json'   | jq '.code'
"InvalidQuery"
http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;7.420363,43.736189;7.420363,43.736189;80,0..json'   | jq '.code'
"Ok"
http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;7.420363,43.736189;7.420363,43.736189;80,0.json'   | jq '.code'
"Ok"
http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;7.420363,43.736189;7.420363,43.736189;80,0json'   | jq '.code'
"InvalidQuery"
 http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;nan,-inf;7,.736189;1e2,2.json'   | jq '.code'
"InvalidValue"
http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;7,.736189;1e2,2.json'   | jq '.code'
"Ok"
```

But it will fail if the last entry has an exponent part
```
http 'http://localhost:5000/route/v1/driving/7.416351,43.731205;7,.736189;1e2,2e4.json'   | jq '.code'
"InvalidValue"
```