### PR TITLE
Start modularizing the CMake buildsystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,10 +161,10 @@ script:
       sudo ldconfig
     fi
   - echo "travis_fold:start:UNIT_TESTS"
-  - ./extractor-tests
-  - ./engine-tests
-  - ./util-tests
-  - ./server-tests
+  - ./unit_tests/extractor-tests
+  - ./unit_tests/engine-tests
+  - ./unit_tests/util-tests
+  - ./unit_tests/server-tests
   - echo "travis_fold:end:UNIT_TESTS"
   - popd
   - echo "travis_fold:start:CUCUMBER"
@@ -173,7 +173,7 @@ script:
   - echo "travis_fold:start:BENCHMARK"
   - make -C test/data benchmark
   - echo "travis_fold:end:BENCHMARK"
-  - ./build/library-tests test/data/monaco.osrm
+  - ./build/unit_tests/library-tests test/data/monaco.osrm
   - mkdir example/build && pushd example/build
   - cmake ..
   - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,6 @@ add_custom_target(FingerPrintConfigure ALL ${CMAKE_COMMAND}
   COMMENT "Configuring revision fingerprint"
   VERBATIM)
 
-add_custom_target(benchmarks DEPENDS rtree-bench)
-
 set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread)
 
 configure_file(
@@ -79,9 +77,6 @@ add_library(osrm src/osrm/osrm.cpp $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:UTI
 add_library(osrm_extract $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_contract $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
-
-# Benchmarks
-add_executable(rtree-bench EXCLUDE_FROM_ALL src/benchmarks/static_rtree.cpp $<TARGET_OBJECTS:UTIL>)
 
 # Check the release mode
 if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
@@ -317,8 +312,6 @@ target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES})
 target_link_libraries(osrm_extract ${EXTRACTOR_LIBRARIES})
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
-# Benchmarks
-target_link_libraries(rtree-bench ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${TBB_LIBRARIES})
 
 if(BUILD_COMPONENTS)
   find_package(GDAL)
@@ -439,3 +432,4 @@ add_custom_target(uninstall
 
 # Modular build system: each directory registered here provides its own CMakeLists.txt
 add_subdirectory(unit_tests)
+add_subdirectory(src/benchmarks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,9 @@ add_custom_target(FingerPrintConfigure ALL ${CMAKE_COMMAND}
   COMMENT "Configuring revision fingerprint"
   VERBATIM)
 
-add_custom_target(tests DEPENDS engine-tests extractor-tests util-tests server-tests library-tests)
 add_custom_target(benchmarks DEPENDS rtree-bench)
 
-set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread unit_test_framework)
+set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/util/version.hpp.in
@@ -61,12 +60,6 @@ file(GLOB ContractorGlob src/contractor/*.cpp)
 file(GLOB StorageGlob src/storage/*.cpp)
 file(GLOB ServerGlob src/server/*.cpp src/server/**/*.cpp)
 file(GLOB EngineGlob src/engine/*.cpp src/engine/**/*.cpp)
-file(GLOB ExtractorTestsGlob unit_tests/extractor/*.cpp)
-file(GLOB EngineTestsGlob unit_tests/engine/*.cpp)
-file(GLOB UtilTestsGlob unit_tests/util/*.cpp)
-file(GLOB ServerTestsGlob unit_tests/server/*.cpp)
-file(GLOB LibraryTestsGlob unit_tests/library/*.cpp)
-file(GLOB IOTestsGlob unit_tests/io/*.cpp)
 
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})
@@ -87,20 +80,8 @@ add_library(osrm_extract $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_contract $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
 
-# Unit tests
-add_executable(engine-tests EXCLUDE_FROM_ALL unit_tests/engine_tests.cpp ${EngineTestsGlob} $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
-add_executable(extractor-tests EXCLUDE_FROM_ALL unit_tests/extractor_tests.cpp ${ExtractorTestsGlob} $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
-add_executable(util-tests EXCLUDE_FROM_ALL unit_tests/util_tests.cpp ${UtilTestsGlob} $<TARGET_OBJECTS:UTIL>)
-add_executable(server-tests EXCLUDE_FROM_ALL unit_tests/server_tests.cpp ${ServerTestsGlob} $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:SERVER>)
-add_executable(library-tests EXCLUDE_FROM_ALL unit_tests/library_tests.cpp ${LibraryTestsGlob})
-
 # Benchmarks
 add_executable(rtree-bench EXCLUDE_FROM_ALL src/benchmarks/static_rtree.cpp $<TARGET_OBJECTS:UTIL>)
-
-target_include_directories(engine-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
-target_include_directories(util-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
-target_include_directories(library-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/)
-target_include_directories(rtree-bench PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
 
 # Check the release mode
 if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
@@ -155,10 +136,6 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
       set(CMAKE_CXX_FLAGS "${OLD_CXX_FLAGS}")
     endif()
   endif()
-endif()
-
-if(NOT WIN32)
-  add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 
 # Configuring compilers
@@ -242,11 +219,14 @@ find_package(Osmium REQUIRED COMPONENTS io)
 include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
 
 
-find_package(Boost 1.49.0 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.49.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 if(NOT WIN32)
   add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
-add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3 -DBOOST_RESULT_OF_USE_DECLTYPE)
+add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
+add_definitions(-DBOOST_RESULT_OF_USE_DECLTYPE)
+# XXX: activate when we're clean of deprecated Boost.FS features
+# add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)
@@ -257,7 +237,7 @@ if(WIN32 AND CMAKE_BUILD_TYPE MATCHES Debug)
   set(TBB_LIBRARIES ${TBB_DEBUG_LIBRARIES})
 endif()
 
-find_package( Luabind REQUIRED )
+find_package(Luabind REQUIRED)
 include(check_luabind)
 include_directories(SYSTEM ${LUABIND_INCLUDE_DIR})
 
@@ -337,13 +317,8 @@ target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES})
 target_link_libraries(osrm_extract ${EXTRACTOR_LIBRARIES})
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
-# Tests
-target_link_libraries(engine-tests ${ENGINE_LIBRARIES})
-target_link_libraries(server-tests osrm ${Boost_LIBRARIES})
-target_link_libraries(extractor-tests ${EXTRACTOR_LIBRARIES})
+# Benchmarks
 target_link_libraries(rtree-bench ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${TBB_LIBRARIES})
-target_link_libraries(util-tests ${UTIL_LIBRARIES})
-target_link_libraries(library-tests osrm ${Boost_LIBRARIES})
 
 if(BUILD_COMPONENTS)
   find_package(GDAL)
@@ -460,3 +435,7 @@ configure_file(
 
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake)
+
+
+# Modular build system: each directory registered here provides its own CMakeLists.txt
+add_subdirectory(unit_tests)

--- a/appveyor-build.bat
+++ b/appveyor-build.bat
@@ -117,13 +117,13 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 SET PATH=%PROJECT_DIR%\osrm-deps\libs\bin;%PATH%
 
 ECHO running engine-tests.exe ...
-%Configuration%\engine-tests.exe
+%Configuration%\unit_tests\engine-tests.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO running extractor-tests.exe ...
-%Configuration%\extractor-tests.exe
+%Configuration%\unit_tests\extractor-tests.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO running util-tests.exe ...
-%Configuration%\util-tests.exe
+%Configuration%\unit_tests\util-tests.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 IF NOT "%APPVEYOR_REPO_BRANCH%"=="develop" GOTO DONE

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -1,0 +1,20 @@
+file(GLOB RTreeBenchmarkSources
+    *.cpp)
+
+add_executable(rtree-bench
+	EXCLUDE_FROM_ALL
+	${RTreeBenchmarkSources}
+	$<TARGET_OBJECTS:UTIL>)
+
+target_include_directories(rtree-bench
+	PUBLIC
+	${PROJECT_SOURCE_DIR}/unit_tests)
+
+target_link_libraries(rtree-bench
+	${Boost_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
+	${TBB_LIBRARIES})
+
+add_custom_target(benchmarks
+	DEPENDS
+	rtree-bench)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,0 +1,76 @@
+file(GLOB EngineTestsSources
+    engine_tests.cpp
+    engine/*.cpp)
+
+file(GLOB ExtractorTestsSources
+    extractor_tests.cpp
+    extractor/*.cpp)
+
+file(GLOB LibraryTestsSources
+    library_tests.cpp
+    library/*.cpp)
+
+file(GLOB ServerTestsSources
+    server_tests.cpp
+    server/*.cpp)
+
+file(GLOB UtilTestsSources
+    util_tests.cpp
+    util/*.cpp)
+
+
+add_executable(engine-tests
+	EXCLUDE_FROM_ALL
+	${EngineTestsSources}
+	$<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
+
+add_executable(extractor-tests
+	EXCLUDE_FROM_ALL
+	${ExtractorTestsSources}
+	$<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
+
+add_executable(library-tests
+	EXCLUDE_FROM_ALL
+	${LibraryTestsSources})
+
+add_executable(server-tests
+	EXCLUDE_FROM_ALL
+	${ServerTestsSources}
+	$<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:SERVER>)
+
+add_executable(util-tests
+	EXCLUDE_FROM_ALL
+	${UtilTestsSources}
+	$<TARGET_OBJECTS:UTIL>)
+
+
+# FindPackage below overwrites Boost_LIBRARIES
+set(AllBoostLibrariesExceptUnitTest ${Boost_LIBRARIES})
+
+find_package(Boost 1.49.0 REQUIRED COMPONENTS unit_test_framework)
+
+if(NOT WIN32)
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
+
+# After the find_package call we got only the unit test library
+set(BoostUnitTestLibrary ${Boost_LIBRARIES})
+
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+
+
+target_include_directories(engine-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(library-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(util-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+
+target_link_libraries(engine-tests ${ENGINE_LIBRARIES} ${BoostUnitTestLibrary})
+target_link_libraries(extractor-tests ${EXTRACTOR_LIBRARIES} ${BoostUnitTestLibrary})
+target_link_libraries(library-tests osrm ${Boost_LIBRARIES} ${BoostUnitTestLibrary})
+target_link_libraries(server-tests osrm ${Boost_LIBRARIES} ${BoostUnitTestLibrary})
+target_link_libraries(util-tests ${UTIL_LIBRARIES} ${BoostUnitTestLibrary})
+
+
+add_custom_target(tests
+	DEPENDS
+	engine-tests extractor-tests library-tests server-tests util-tests)


### PR DESCRIPTION
The main reason for modularizing the unit tests was to split off
libboost_unit_test_framework from the osrm toolchain binaries.

Now only the unit test binaries link against it, unblocking
binary distribution without unit test library dependencies.

I started this on v4 a couple of weeks ago and hit a -llua5 issue on
Travis. By now v5 diverged quite a bit (especially in the code that I
have to stare at for debugging the issues).

https://github.com/Project-OSRM/osrm-backend/pull/2073

Let's bring this to v5+ only.

This is blocking:

- https://github.com/Project-OSRM/osrm-backend/issues/2065
- https://github.com/Project-OSRM/osrm-backend/issues/2197#issuecomment-204864938