### PR TITLE
Enable Travis builds for this branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
   only:
     - master
     - develop
+    - rewrite/new-api
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Putting this in every v5 feature branch is tedious.

Let's solve this once and for all (and then remove it once we merge v5 back).