### PR TITLE
Fix BOOST_FUSION_ADAPT_STRUCT parameters for ParsedURL

### DIFF
--- a/include/server/api/parsed_url.hpp
+++ b/include/server/api/parsed_url.hpp
@@ -28,9 +28,9 @@ struct ParsedURL final
 } // osrm
 
 BOOST_FUSION_ADAPT_STRUCT(osrm::server::api::ParsedURL,
-    (std::string, service),
-    (unsigned, version),
-    (std::string, profile),
+    (std::string, service)
+    (unsigned, version)
+    (std::string, profile)
     (std::string, query)
 )
 


### PR DESCRIPTION
Sorry, i have introduced  a build regression https://travis-ci.org/Project-OSRM/osrm-backend/jobs/121406445
...
/home/travis/build/Project-OSRM/osrm-backend/include/server/api/parsed_url.hpp:35:1: error: macro "BOOST_FUSION_ADAPT_STRUCT" passed 5 arguments, but takes just 2

 )

BOOST_FUSION_ADAPT_STRUCT description  http://www.boost.org/doc/libs/1_60_0/libs/fusion/doc/html/fusion/adapted/adapt_struct.html
