### PR TITLE
Add cmake option to disable -DBOOST_TEST_DYN_LINK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
 
 
 find_package(Boost 1.49.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
-if(NOT WIN32)
+if(NOT WIN32 AND NOT Boost_USE_STATIC_LIBS)
   add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -49,7 +49,7 @@ set(AllBoostLibrariesExceptUnitTest ${Boost_LIBRARIES})
 
 find_package(Boost 1.49.0 REQUIRED COMPONENTS unit_test_framework)
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT Boost_USE_STATIC_LIBS)
   add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 


### PR DESCRIPTION
This is needed when building the unit tests against a static `libboost_unit_test_framework` otherwise you will hit a linking error like:

```
undef: __ZN5boost9unit_test14unit_test_mainEPFbvEiPPc
Undefined symbols for architecture x86_64:
  "boost::unit_test::unit_test_main(bool (*)(), int, char**)", referenced from:
      _main in engine_tests.cpp.o
ld: symbol(s) not found for architecture x86_64
```