### PR TITLE
Add missing -lz to fix linking of server-tests

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(util-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(engine-tests ${ENGINE_LIBRARIES} ${BoostUnitTestLibrary})
 target_link_libraries(extractor-tests ${EXTRACTOR_LIBRARIES} ${BoostUnitTestLibrary})
 target_link_libraries(library-tests osrm ${Boost_LIBRARIES} ${BoostUnitTestLibrary})
-target_link_libraries(server-tests osrm ${Boost_LIBRARIES} ${BoostUnitTestLibrary})
+target_link_libraries(server-tests osrm ${Boost_LIBRARIES} ${BoostUnitTestLibrary} ${ZLIB_LIBRARY})
 target_link_libraries(util-tests ${UTIL_LIBRARIES} ${BoostUnitTestLibrary})
 
 


### PR DESCRIPTION
Without this patch I hit:

```
/Users/dane/projects/node-osrm/mason_packages/osx-10.11/cmake/3.2.2/bin/cmake -E cmake_link_script CMakeFiles/server-tests.dir/link.txt --verbose=1
ccache /usr/bin/clang++    -flto -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=2 -D_FORTIFY_SOURCE=2 -fPIC -fcolor-diagnostics -std=c++11  -stdlib=libc++ -O3 -DNDEBUG -Wl,-search_paths_first -Wl,-headerpad_max_install_names   CMakeFiles/server-tests.dir/unit_tests/server_tests.cpp.o CMakeFiles/server-tests.dir/unit_tests/server/parameters_parser.cpp.o CMakeFiles/server-tests.dir/unit_tests/server/url_parser.cpp.o CMakeFiles/UTIL.dir/src/util/assert.cpp.o CMakeFiles/UTIL.dir/src/util/coordinate.cpp.o CMakeFiles/UTIL.dir/src/util/coordinate_calculation.cpp.o CMakeFiles/UTIL.dir/src/util/exception.cpp.o CMakeFiles/UTIL.dir/src/util/fingerprint.cpp.o CMakeFiles/UTIL.dir/src/util/hilbert_value.cpp.o CMakeFiles/UTIL.dir/src/util/name_table.cpp.o CMakeFiles/UTIL.dir/src/util/simple_logger.cpp.o CMakeFiles/SERVER.dir/src/server/connection.cpp.o CMakeFiles/SERVER.dir/src/server/request_handler.cpp.o CMakeFiles/SERVER.dir/src/server/request_parser.cpp.o CMakeFiles/SERVER.dir/src/server/service_handler.cpp.o CMakeFiles/SERVER.dir/src/server/api/parameters_parser.cpp.o CMakeFiles/SERVER.dir/src/server/api/url_parser.cpp.o CMakeFiles/SERVER.dir/src/server/http/reply.cpp.o CMakeFiles/SERVER.dir/src/server/service/match_service.cpp.o CMakeFiles/SERVER.dir/src/server/service/nearest_service.cpp.o CMakeFiles/SERVER.dir/src/server/service/route_service.cpp.o CMakeFiles/SERVER.dir/src/server/service/table_service.cpp.o CMakeFiles/SERVER.dir/src/server/service/tile_service.cpp.o CMakeFiles/SERVER.dir/src/server/service/trip_service.cpp.o  -o server-tests  libosrm.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_date_time.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_filesystem.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_iostreams.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_program_options.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_regex.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_system.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_thread.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libboost_unit_test_framework.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libstxxl.a /Users/dane/projects/node-osrm/mason_packages/.link/lib/libtbb.dylib /Users/dane/projects/node-osrm/mason_packages/.link/lib/libtbbmalloc.dylib 
undef: _deflateInit2_
undef: _inflateInit2_
undef: _deflateEnd
undef: _inflateReset
undef: _inflate
undef: _deflate
undef: _inflateEnd
undef: _crc32
undef: _deflateReset
undef: __ZN5boost9unit_test14unit_test_mainEPFbvEiPPc
Undefined symbols for architecture x86_64:
  "_deflateInit2_", referenced from:
      boost::iostreams::detail::zlib_base::do_init(boost::iostreams::zlib_params const&, bool, void* (*)(void*, unsigned int, unsigned int), void (*)(void*, void*), void*) in libboost_iostreams.a(zlib.o)
  "_inflateInit2_", referenced from:
      boost::iostreams::detail::zlib_base::do_init(boost::iostreams::zlib_params const&, bool, void* (*)(void*, unsigned int, unsigned int), void (*)(void*, void*), void*) in libboost_iostreams.a(zlib.o)
  "_deflateEnd", referenced from:
      boost::iostreams::detail::zlib_base::reset(bool, bool) in libboost_iostreams.a(zlib.o)
  "_inflateReset", referenced from:
      boost::iostreams::detail::zlib_base::reset(bool, bool) in libboost_iostreams.a(zlib.o)
  "_inflate", referenced from:
      boost::iostreams::detail::zlib_base::xinflate(int) in libboost_iostreams.a(zlib.o)
  "_deflate", referenced from:
      boost::iostreams::detail::zlib_base::xdeflate(int) in libboost_iostreams.a(zlib.o)
  "_inflateEnd", referenced from:
      boost::iostreams::detail::zlib_base::reset(bool, bool) in libboost_iostreams.a(zlib.o)
  "_crc32", referenced from:
      boost::iostreams::detail::zlib_base::after(char const*&, char*&, bool) in libboost_iostreams.a(zlib.o)
  "_deflateReset", referenced from:
      boost::iostreams::detail::zlib_base::reset(bool, bool) in libboost_iostreams.a(zlib.o)
  "boost::unit_test::unit_test_main(bool (*)(), int, char**)", referenced from:
      _main in server_tests.cpp.o
ld: symbol(s) not found for architecture x86_64
```