### PR TITLE
Add maxspeed=none tag to car profile.

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -124,7 +124,8 @@ maxspeed_table = {
   ["gb:motorway"] = (70*1609)/1000,
   ["uk:nsl_single"] = (60*1609)/1000,
   ["uk:nsl_dual"] = (70*1609)/1000,
-  ["uk:motorway"] = (70*1609)/1000
+  ["uk:motorway"] = (70*1609)/1000,
+  ["none"] = 140
 }
 
 -- set profile properties

--- a/taginfo.json
+++ b/taginfo.json
@@ -77,6 +77,7 @@
         {"key": "access", "value": "emergency"},
         {"key": "access", "value": "psv"},
         {"key": "access", "value": "delivery"},
+        {"key": "maxspeed", "value": "none"},
         {"key": "maxspeed", "value": "urban"},
         {"key": "maxspeed", "value": "rural"},
         {"key": "maxspeed", "value": "trunk"},


### PR DESCRIPTION
Pull request to keep discussion from https://github.com/Project-OSRM/osrm-backend/issues/2145 moving. /cc @utack @TheMarex @danpat 

maxspeed=none means there is no explicit maxspeed limit. Set to
guestimate for driving on the Autobahn.

References:

 - https://github.com/Project-OSRM/osrm-backend/issues/2145
 - http://wiki.openstreetmap.org/wiki/Key:maxspeed
 - http://taginfo.openstreetmap.org/tags/maxspeed=none
 - http://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed