### PR TITLE
On successful travis build, trigger node-osrm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,17 @@ matrix:
 
   include:
 
+    # Release / Triggered build
+    # This is listed first so it runs first to enable
+    # quickly knowing if downstream apps are broken
+    - os: linux
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
+      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Release' TRIGGER=true
+
     # Debug Builds
     - os: linux
       compiler: gcc
@@ -55,14 +66,6 @@ matrix:
       env: CCOMPILER='clang' CXXCOMPILER='clang++' BUILD_TYPE='Debug'
 
     # Release Builds
-    - os: linux
-      compiler: gcc
-      addons: &gcc5
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Release' TRIGGER=true
-
     - os: linux
       compiler: gcc
       addons: &gcc48

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ branches:
     - master
     - develop
 
+env:
+  global:
+   - secure: hWsZLHs4YIPQVDOEnEP7zIvjSe/CS8vWUEWJwU8FP61h7sGb0Hbi2/MUW0u+KuBsiPfhcPP7E9mWt3trYirQdmZkuSU11qZsq9rdrFZCh/ykP/GBNTfZSDJos713yMV4KivLfjF7VlitkzsDXND489v3RQxQGAkKaytfDGpxc5c=
+
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,6 @@ matrix:
 
   include:
 
-    # Release / Triggered build
-    # This is listed first so it runs first to enable
-    # quickly knowing if downstream apps are broken
-    - os: linux
-      compiler: gcc
-      addons: &gcc5
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Release' TRIGGER=true
-
     # Debug Builds
     - os: linux
       compiler: gcc
@@ -42,7 +31,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-5', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'pip']
-      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Debug' COVERAGE=ON
+      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Debug' COVERAGE=ON TRIGGER_DOWNSTREAM=ON
 
     - os: linux
       compiler: gcc
@@ -66,6 +55,14 @@ matrix:
       env: CCOMPILER='clang' CXXCOMPILER='clang++' BUILD_TYPE='Debug'
 
     # Release Builds
+    - os: linux
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
+      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Release'
+
     - os: linux
       compiler: gcc
       addons: &gcc48
@@ -167,8 +164,11 @@ script:
 
 after_success:
   - |
-    if [ -n "$RUN_CLANG_FORMAT" ]; then
+    if [ -n "${RUN_CLANG_FORMAT}" ]; then
       ./scripts/format.sh || true # we don't want to fail just yet
     fi
-  - if [[ ${TRIGGER:-false} == true ]]; then ./scripts/trigger-downstream.sh; fi
-  - coveralls --build-root build --exclude unit_tests --exclude third_party --exclude node_modules --gcov-options '\-lp'
+  - |
+    if [[ -n "${COVERAGE}" ]]; then
+       coveralls --build-root build --exclude unit_tests --exclude third_party --exclude node_modules --gcov-options '\-lp'
+    fi
+  - if [[ -n "${TRIGGER_DOWNSTREAM}" ]]; then ./scripts/trigger-downstream.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-5', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Release'
+      env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5' BUILD_TYPE='Release' TRIGGER=true
 
     - os: linux
       compiler: gcc
@@ -163,4 +163,5 @@ after_success:
     if [ -n "$RUN_CLANG_FORMAT" ]; then
       ./scripts/format.sh || true # we don't want to fail just yet
     fi
+  - if [[ ${TRIGGER:-false} == true ]] then ./scripts/trigger-downstream.sh; fi
   - coveralls --build-root build --exclude unit_tests --exclude third_party --exclude node_modules --gcov-options '\-lp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,5 +167,5 @@ after_success:
     if [ -n "$RUN_CLANG_FORMAT" ]; then
       ./scripts/format.sh || true # we don't want to fail just yet
     fi
-  - if [[ ${TRIGGER:-false} == true ]] then ./scripts/trigger-downstream.sh; fi
+  - if [[ ${TRIGGER:-false} == true ]]; then ./scripts/trigger-downstream.sh; fi
   - coveralls --build-root build --exclude unit_tests --exclude third_party --exclude node_modules --gcov-options '\-lp'

--- a/scripts/trigger-config.json
+++ b/scripts/trigger-config.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "message": "Triggered build: osrm-backend develop branch commit <TRAVIS_COMMIT>",
+    "branch": "develop",
+    "config": {
+      "matrix": {
+        "include": [{
+          "os": "linux",
+          "compiler": ": clang-release-node-v0.10",
+          "env": "NODE='0.10' CC='clang-3.5' CXX='clang++-3.5' JOBS=6 PUBLISHABLE=false",
+          "sudo": false,
+          "addons": {
+            "apt": {
+              "sources": ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.5"],
+              "packages": ["clang-3.5"]
+            }
+          }
+        }]
+      }
+    }
+  }
+}

--- a/scripts/trigger-config.json
+++ b/scripts/trigger-config.json
@@ -6,13 +6,13 @@
       "matrix": {
         "include": [{
           "os": "linux",
-          "compiler": ": clang-release-node-v0.10",
-          "env": "NODE='0.10' CC='clang-3.5' CXX='clang++-3.5' JOBS=6 PUBLISHABLE=false",
+          "compiler": ": gcc-debug-node-v4",
+          "env": "NODE='4' TARGET=Debug CC='gcc-4.8' CXX='clang++-4.8' JOBS=6 PUBLISHABLE=false",
           "sudo": false,
           "addons": {
             "apt": {
-              "sources": ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.5"],
-              "packages": ["clang-3.5"]
+              "sources": [ "ubuntu-toolchain-r-test" ],
+              "packages": [ "g++-4.8" ]
             }
           }
         }]

--- a/scripts/trigger-downstream.sh
+++ b/scripts/trigger-downstream.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+TRAVIS_COMMIT=${TRAVIS_COMMIT:-$(git log --format=%H --no-merges -n 1 | tr -d '\n')}
+
+trigger_downstream() {
+    curl -s -X POST \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -H "Travis-API-Version: 3" \
+      -H "Authorization: token ${TRAVIS_TOKEN}" \
+      -d "$(python -c "import json;print open('./scripts/trigger-config.json').read().replace('<TRAVIS_COMMIT>','$TRAVIS_COMMIT')")" \
+      https://api.travis-ci.org/repo/Project-OSRM%2Fnode-osrm/requests
+}
+
+trigger_downstream


### PR DESCRIPTION
This triggers a travis build of `node-osrm` when `osrm-backend` builds and runs successfully.


 - I've chosen one `osrm-backend` job to be the triggering job (the g++-5 release build seemed like a good one but it could be anything)
 - The triggered builds overrides the `.travis.yml` matrix for `node-osrm` to only run one job: a `clang release` job. The idea here is to be as fast as possible and not to overload travis.

TODO before merging:

  - [x] Need to add a secure variable to encode `$TRAVIS_TOKEN`


Note: anyone with `$TRAVIS_TOKEN` defined can also run this locally to trigger `node-osrm` builds easily.:

```bash
./scripts/trigger-downstream.sh
```