### PR TITLE
Increase the Cucumber timeout, as we're hitting it on Travis.

### DIFF
--- a/features/support/env.js
+++ b/features/support/env.js
@@ -7,7 +7,8 @@ var d3 = require('d3-queue');
 module.exports = function () {
     this.initializeEnv = (callback) => {
         this.DEFAULT_PORT = 5000;
-        this.DEFAULT_TIMEOUT = 2000;
+	// OSX builds on Travis hit a timeout of ~2000 from time to time
+        this.DEFAULT_TIMEOUT = 5000;
         this.setDefaultTimeout(this.DEFAULT_TIMEOUT);
         this.ROOT_FOLDER = process.cwd();
         this.OSM_USER = 'osrm';


### PR DESCRIPTION
Our OSX Travis builds seem to hit the 2s timeout from time to time,
which is really irritating.

This increases the timeout to 5s, hoping for the best.