### PR TITLE
Fix math when we have equal latitudes.

### DIFF
--- a/features/guidance/rotary.feature
+++ b/features/guidance/rotary.feature
@@ -165,3 +165,98 @@ Feature: Rotary
            | j,i       | jkl,ghi,ghi | depart,bkheb-exit-2,arrive  |
            | j,f       | jkl,def,def | depart,bkheb-exit-3,arrive  |
            | j,c       | jkl,abc,abc | depart,bkheb-exit-4,arrive  |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | a |   |   |
+            | b |   |   |
+            | c | d | f |
+            | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                     |
+            | a,e       | ab,ce,ce | depart,bcdb-exit-1,arrive |
+            | a,f       | ab,df,df | depart,bcdb-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | a |   |   |
+            | d |   |   |
+            | b | c | f |
+            | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                     |
+            | a,e       | ab,ce,ce | depart,bcdb-exit-1,arrive |
+            | a,f       | ab,df,df | depart,bcdb-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | a |   |   |
+            | c |   |   |
+            | d | b | f |
+            | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                     |
+            | a,e       | ab,ce,ce | depart,bcdb-exit-1,arrive |
+            | a,f       | ab,df,df | depart,bcdb-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | f |   |   |
+            | d | c | e |
+            |   | b |   |
+            |   | a |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                     |
+            | a,e       | ab,ce,ce | depart,bcdb-exit-1,arrive |
+            | a,f       | ab,df,df | depart,bcdb-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | f |   |   |
+            | d | c | e |
+            | b |   |   |
+            | a |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                     |
+            | a,e       | ab,ce,ce | depart,bcdb-exit-1,arrive |
+            | a,f       | ab,df,df | depart,bcdb-exit-2,arrive |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -164,3 +164,98 @@ Feature: Basic Roundabout
            | j,i       | jkl,ghi,ghi | depart,roundabout-exit-2,arrive |
            | j,f       | jkl,def,def | depart,roundabout-exit-3,arrive |
            | j,c       | jkl,abc,abc | depart,roundabout-exit-4,arrive |
+
+       Scenario: Collinear in X
+        Given the node map
+            | a | b | c | d | f |
+            |   |   | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
+            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
+
+       Scenario: Collinear in Y
+        Given the node map
+            | a |   |
+            | b |   |
+            | c | e |
+            | d |   |
+            | f |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
+            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | a |   |   |
+            | b |   |   |
+            | c | d | f |
+            | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
+            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | a |   |   |
+            | d |   |   |
+            | b | c | f |
+            | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
+            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
+
+       Scenario: Collinear in X,Y
+        Given the node map
+            | a |   |   |
+            | c |   |   |
+            | d | b | f |
+            | e |   |   |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
+            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
+

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -56,7 +56,7 @@ getCoordinateFromCompressedRange(util::Coordinate current_coordinate,
         BOOST_ASSERT(segment_length > 0);
         BOOST_ASSERT(second_distance >= detail::DESIRED_SEGMENT_LENGTH);
         double missing_distance = detail::DESIRED_SEGMENT_LENGTH - first_distance;
-        return missing_distance / segment_length;
+        return std::max(0., std::min(missing_distance / segment_length, 1.0));
     };
 
     for (auto compressed_geometry_itr = compressed_geometry_begin;
@@ -84,7 +84,8 @@ getCoordinateFromCompressedRange(util::Coordinate current_coordinate,
         util::coordinate_calculation::haversineDistance(current_coordinate, final_coordinate);
 
     // reached point where coordinates switch between
-    if (distance_to_next_coordinate >= detail::DESIRED_SEGMENT_LENGTH)
+    if (distance_to_current_coordinate < detail::DESIRED_SEGMENT_LENGTH &&
+        distance_to_next_coordinate >= detail::DESIRED_SEGMENT_LENGTH)
         return util::coordinate_calculation::interpolateLinear(
             getFactor(distance_to_current_coordinate, distance_to_next_coordinate),
             current_coordinate, final_coordinate);

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -2,12 +2,12 @@
 #include "extractor/edge_based_graph_factory.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
-#include "util/percent.hpp"
+#include "util/exception.hpp"
 #include "util/integer_range.hpp"
 #include "util/lua_util.hpp"
+#include "util/percent.hpp"
 #include "util/simple_logger.hpp"
 #include "util/timing_util.hpp"
-#include "util/exception.hpp"
 
 #include "extractor/guidance/toolkit.hpp"
 
@@ -122,8 +122,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
 
     NodeID current_edge_source_coordinate_id = node_u;
 
-    const auto edge_id_to_segment_id = [](const NodeID edge_based_node_id)
-    {
+    const auto edge_id_to_segment_id = [](const NodeID edge_based_node_id) {
         if (edge_based_node_id == SPECIAL_NODEID)
         {
             return SegmentID{SPECIAL_SEGMENTID, false};
@@ -133,7 +132,7 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
     };
 
     // traverse arrays from start and end respectively
-    for (const auto i : util::irange(std::size_t{ 0 }, geometry_size))
+    for (const auto i : util::irange(std::size_t{0}, geometry_size))
     {
         BOOST_ASSERT(
             current_edge_source_coordinate_id ==
@@ -468,6 +467,8 @@ int EdgeBasedGraphFactory::GetTurnPenalty(double angle, lua_State *lua_state) co
     {
         // call lua profile to compute turn penalty
         double penalty = luabind::call_function<double>(lua_state, "turn_function", 180. - angle);
+        BOOST_ASSERT(penalty < std::numeric_limits<int>::max());
+        BOOST_ASSERT(penalty > std::numeric_limits<int>::min());
         return boost::numeric_cast<int>(penalty);
     }
     catch (const luabind::error &er)


### PR DESCRIPTION
In circleCenter, Don't use the slope when two coordinates are at the
same latitude.

This fixes #2243 