### PR TITLE
Remove movable bridge travel mode

### DIFF
--- a/features/bicycle/bridge.feature
+++ b/features/bicycle/bridge.feature
@@ -1,5 +1,5 @@
 @routing @bicycle @bridge
-Feature: Bicycle - Handle movable bridge
+Feature: Bicycle - Handle cycling
 
     Background:
         Given the profile "bicycle"
@@ -18,14 +18,14 @@ Feature: Bicycle - Handle movable bridge
 
         When I route I should get
             | from | to | route           | modes                                  |
-            | a    | g  | abc,cde,efg,efg | cycling,movable bridge,cycling,cycling |
-            | b    | f  | abc,cde,efg,efg | cycling,movable bridge,cycling,cycling |
-            | e    | c  | cde,cde         | movable bridge,movable bridge          |
-            | e    | b  | cde,abc,abc     | movable bridge,cycling,cycling         |
-            | e    | a  | cde,abc,abc     | movable bridge,cycling,cycling         |
-            | c    | e  | cde,cde         | movable bridge,movable bridge          |
-            | c    | f  | cde,efg,efg     | movable bridge,cycling,cycling         |
-            | c    | g  | cde,efg,efg     | movable bridge,cycling,cycling         |
+            | a    | g  | abc,cde,efg,efg | cycling,cycling,cycling,cycling |
+            | b    | f  | abc,cde,efg,efg | cycling,cycling,cycling,cycling |
+            | e    | c  | cde,cde         | cycling,cycling          |
+            | e    | b  | cde,abc,abc     | cycling,cycling,cycling         |
+            | e    | a  | cde,abc,abc     | cycling,cycling,cycling         |
+            | c    | e  | cde,cde         | cycling,cycling          |
+            | c    | f  | cde,efg,efg     | cycling,cycling,cycling         |
+            | c    | g  | cde,efg,efg     | cycling,cycling,cycling         |
 
     Scenario: Bicycle - Properly handle durations
         Given the node map
@@ -41,7 +41,7 @@ Feature: Bicycle - Handle movable bridge
 
         When I route I should get
             | from | to | route           | modes                                  | speed  |
-            | a    | g  | abc,cde,efg,efg | cycling,movable bridge,cycling,cycling | 5 km/h |
-            | b    | f  | abc,cde,efg,efg | cycling,movable bridge,cycling,cycling | 4 km/h |
-            | c    | e  | cde,cde         | movable bridge,movable bridge          | 2 km/h |
-            | e    | c  | cde,cde         | movable bridge,movable bridge          | 2 km/h |
+            | a    | g  | abc,cde,efg,efg | cycling,cycling,cycling,cycling | 5 km/h |
+            | b    | f  | abc,cde,efg,efg | cycling,cycling,cycling,cycling | 4 km/h |
+            | c    | e  | cde,cde         | cycling,cycling          | 2 km/h |
+            | e    | c  | cde,cde         | cycling,cycling          | 2 km/h |

--- a/features/car/bridge.feature
+++ b/features/car/bridge.feature
@@ -1,5 +1,5 @@
 @routing @car @bridge
-Feature: Car - Handle movable bridge
+Feature: Car - Handle driving
 
     Background:
         Given the profile "car"
@@ -18,14 +18,14 @@ Feature: Car - Handle movable bridge
 
         When I route I should get
             | from | to | route           | modes                                  |
-            | a    | g  | abc,cde,efg,efg | driving,movable bridge,driving,driving |
-            | b    | f  | abc,cde,efg,efg | driving,movable bridge,driving,driving |
-            | e    | c  | cde,cde         | movable bridge,movable bridge          |
-            | e    | b  | cde,abc,abc     | movable bridge,driving,driving         |
-            | e    | a  | cde,abc,abc     | movable bridge,driving,driving         |
-            | c    | e  | cde,cde         | movable bridge,movable bridge          |
-            | c    | f  | cde,efg,efg     | movable bridge,driving,driving         |
-            | c    | g  | cde,efg,efg     | movable bridge,driving,driving         |
+            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving |
+            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving |
+            | e    | c  | cde,cde         | driving,driving          |
+            | e    | b  | cde,abc,abc     | driving,driving,driving         |
+            | e    | a  | cde,abc,abc     | driving,driving,driving         |
+            | c    | e  | cde,cde         | driving,driving          |
+            | c    | f  | cde,efg,efg     | driving,driving,driving         |
+            | c    | g  | cde,efg,efg     | driving,driving,driving         |
 
     Scenario: Car - Properly handle durations
         Given the node map
@@ -41,7 +41,7 @@ Feature: Car - Handle movable bridge
 
         When I route I should get
             | from | to | route           | modes                                  | speed  |
-            | a    | g  | abc,cde,efg,efg | driving,movable bridge,driving,driving | 7 km/h |
-            | b    | f  | abc,cde,efg,efg | driving,movable bridge,driving,driving | 5 km/h |
-            | c    | e  | cde,cde         | movable bridge,movable bridge          | 2 km/h |
-            | e    | c  | cde,cde         | movable bridge,movable bridge          | 2 km/h |
+            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 7 km/h |
+            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 5 km/h |
+            | c    | e  | cde,cde         | driving,driving          | 2 km/h |
+            | e    | c  | cde,cde         | driving,driving          | 2 km/h |

--- a/include/extractor/travel_mode.hpp
+++ b/include/extractor/travel_mode.hpp
@@ -46,7 +46,6 @@ const constexpr osrm::extractor::TravelMode TRAVEL_MODE_WALKING = 3;
 const constexpr osrm::extractor::TravelMode TRAVEL_MODE_FERRY = 4;
 const constexpr osrm::extractor::TravelMode TRAVEL_MODE_TRAIN = 5;
 const constexpr osrm::extractor::TravelMode TRAVEL_MODE_PUSHING_BIKE = 6;
-const constexpr osrm::extractor::TravelMode TRAVEL_MODE_MOVABLE_BRIDGE = 7;
 // FIXME only for testbot.lua
 const constexpr osrm::extractor::TravelMode TRAVEL_MODE_STEPS_UP = 8;
 const constexpr osrm::extractor::TravelMode TRAVEL_MODE_STEPS_DOWN = 9;

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -234,8 +234,6 @@ function way_function (way, result)
     if duration and durationIsValid(duration) then
       result.duration = math.max( parseDuration(duration), 1 )
     end
-    result.forward_mode = mode.movable_bridge
-    result.backward_mode = mode.movable_bridge
     result.forward_speed = bridge_speed
     result.backward_speed = bridge_speed
   elseif route_speeds[route] then

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -270,8 +270,6 @@ function way_function (way, result)
     if duration and durationIsValid(duration) then
       result.duration = max( parseDuration(duration), 1 )
     end
-    result.forward_mode = mode.movable_bridge
-    result.backward_mode = mode.movable_bridge
     result.forward_speed = bridge_speed
     result.backward_speed = bridge_speed
   end

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -100,9 +100,6 @@ std::string modeToString(const extractor::TravelMode mode)
     case TRAVEL_MODE_PUSHING_BIKE:
         token = "pushing bike";
         break;
-    case TRAVEL_MODE_MOVABLE_BRIDGE:
-        token = "movable bridge";
-        break;
     case TRAVEL_MODE_STEPS_UP:
         token = "steps up";
         break;

--- a/src/extractor/scripting_environment.cpp
+++ b/src/extractor/scripting_environment.cpp
@@ -80,7 +80,6 @@ void ScriptingEnvironment::InitContext(ScriptingEnvironment::Context &context)
                              luabind::value("ferry", TRAVEL_MODE_FERRY),
                              luabind::value("train", TRAVEL_MODE_TRAIN),
                              luabind::value("pushing_bike", TRAVEL_MODE_PUSHING_BIKE),
-                             luabind::value("movable_bridge", TRAVEL_MODE_MOVABLE_BRIDGE),
                              luabind::value("steps_up", TRAVEL_MODE_STEPS_UP),
                              luabind::value("steps_down", TRAVEL_MODE_STEPS_DOWN),
                              luabind::value("river_up", TRAVEL_MODE_RIVER_UP),


### PR DESCRIPTION
https://github.com/Project-OSRM/osrm-backend/issues/2278

Movable bridge is no longer returned as a unique mode type. The mode change is still factored into duration calculations.

cc @bsudekum @TheMarex 