### PR TITLE
Revert "Removes summary from legs property"

### DIFF
--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -93,8 +93,8 @@ class RouteAPI : public BaseAPI
 
             auto leg_geometry = guidance::assembleGeometry(
                 BaseAPI::facade, path_data, phantoms.source_phantom, phantoms.target_phantom);
-            auto leg = guidance::assembleLeg(path_data, leg_geometry, phantoms.source_phantom,
-                                             phantoms.target_phantom, reversed_target);
+            auto leg = guidance::assembleLeg(facade, path_data, leg_geometry, phantoms.source_phantom,
+                                             phantoms.target_phantom, reversed_target, parameters.steps);
 
             if (parameters.steps)
             {

--- a/include/engine/guidance/assemble_leg.hpp
+++ b/include/engine/guidance/assemble_leg.hpp
@@ -1,6 +1,7 @@
 #ifndef ENGINE_GUIDANCE_ASSEMBLE_LEG_HPP_
 #define ENGINE_GUIDANCE_ASSEMBLE_LEG_HPP_
 
+#include "engine/datafacade/datafacade_base.hpp"
 #include "engine/guidance/leg_geometry.hpp"
 #include "engine/guidance/route_leg.hpp"
 #include "engine/guidance/route_step.hpp"
@@ -22,12 +23,86 @@ namespace engine
 {
 namespace guidance
 {
+namespace detail
+{
+const constexpr std::size_t MAX_USED_SEGMENTS = 2;
+struct NamedSegment
+{
+    EdgeWeight duration;
+    std::uint32_t position;
+    std::uint32_t name_id;
+};
 
-inline RouteLeg assembleLeg(const std::vector<PathData> &route_data,
+template <std::size_t SegmentNumber>
+std::array<std::uint32_t, SegmentNumber> summarizeRoute(const std::vector<PathData> &route_data)
+{
+    // merges segments with same name id
+    const auto collapse_segments = [](std::vector<NamedSegment> &segments)
+    {
+        auto out = segments.begin();
+        auto end = segments.end();
+        for (auto in = segments.begin(); in != end; ++in)
+        {
+            if (in->name_id == out->name_id)
+            {
+                out->duration += in->duration;
+            }
+            else
+            {
+                ++out;
+                BOOST_ASSERT(out != end);
+                *out = *in;
+            }
+        }
+        return out;
+    };
+
+    std::vector<NamedSegment> segments(route_data.size());
+    std::uint32_t index = 0;
+    std::transform(
+        route_data.begin(), route_data.end(), segments.begin(), [&index](const PathData &point)
+        {
+            return NamedSegment{point.duration_until_turn, index++, point.name_id};
+        });
+    // this makes sure that the segment with the lowest position comes first
+    std::sort(segments.begin(), segments.end(), [](const NamedSegment &lhs, const NamedSegment &rhs)
+              {
+                  return lhs.name_id < rhs.name_id ||
+                         (lhs.name_id == rhs.name_id && lhs.position < rhs.position);
+              });
+    auto new_end = collapse_segments(segments);
+    segments.resize(new_end - segments.begin());
+    // sort descending
+    std::sort(segments.begin(), segments.end(), [](const NamedSegment &lhs, const NamedSegment &rhs)
+              {
+                  return lhs.duration > rhs.duration;
+              });
+
+    // make sure the segments are sorted by position
+    segments.resize(std::min(segments.size(), SegmentNumber));
+    std::sort(segments.begin(), segments.end(), [](const NamedSegment &lhs, const NamedSegment &rhs)
+              {
+                  return lhs.position < rhs.position;
+              });
+
+    std::array<std::uint32_t, SegmentNumber> summary;
+    std::fill(summary.begin(), summary.end(), 0);
+    std::transform(segments.begin(), segments.end(), summary.begin(),
+                   [](const NamedSegment &segment)
+                   {
+                       return segment.name_id;
+                   });
+    return summary;
+}
+}
+
+inline RouteLeg assembleLeg(const datafacade::BaseDataFacade &facade,
+                            const std::vector<PathData> &route_data,
                             const LegGeometry &leg_geometry,
                             const PhantomNode &source_node,
                             const PhantomNode &target_node,
-                            const bool target_traversed_in_reverse)
+                            const bool target_traversed_in_reverse,
+                            const bool needs_summary)
 {
     const auto target_duration =
         (target_traversed_in_reverse ? target_node.reverse_weight : target_node.forward_weight) /
@@ -70,7 +145,26 @@ inline RouteLeg assembleLeg(const std::vector<PathData> &route_data,
                     10.0;
     }
 
-    return RouteLeg{duration, distance, {}};
+    std::string summary;
+    if (needs_summary)
+    {
+        auto summary_array = detail::summarizeRoute<detail::MAX_USED_SEGMENTS>(route_data);
+
+        BOOST_ASSERT(detail::MAX_USED_SEGMENTS > 0);
+        BOOST_ASSERT(summary_array.begin() != summary_array.end());
+        summary = std::accumulate(std::next(summary_array.begin()), summary_array.end(),
+                                  facade.GetNameForID(summary_array.front()),
+                                  [&facade](std::string previous, const std::uint32_t name_id)
+                                  {
+                                      if (name_id != 0)
+                                      {
+                                          previous += ", " + facade.GetNameForID(name_id);
+                                      }
+                                      return previous;
+                                  });
+    }
+
+    return RouteLeg{duration, distance, summary, {}};
 }
 
 } // namespace guidance

--- a/include/engine/guidance/route_leg.hpp
+++ b/include/engine/guidance/route_leg.hpp
@@ -3,6 +3,9 @@
 
 #include "engine/guidance/route_step.hpp"
 
+#include <boost/optional.hpp>
+
+#include <string>
 #include <vector>
 
 namespace osrm
@@ -16,6 +19,7 @@ struct RouteLeg
 {
     double duration;
     double distance;
+    std::string summary;
     std::vector<RouteStep> steps;
 };
 }

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -194,6 +194,7 @@ util::json::Object makeRouteLeg(guidance::RouteLeg leg, util::json::Array steps)
     util::json::Object route_leg;
     route_leg.values["distance"] = std::round(leg.distance * 10) / 10.;
     route_leg.values["duration"] = std::round(leg.duration * 10) / 10.;
+    route_leg.values["summary"] = std::move(leg.summary);
     route_leg.values["steps"] = std::move(steps);
     return route_leg;
 }

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -55,6 +55,7 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
                 json::Array{{json::Object{
                     {{"distance", 0.},
                      {"duration", 0.},
+                     {"summary", ""},
                      {"steps", json::Array{{json::Object{{{"duration", 0.},
                                                           {"distance", 0.},
                                                           {"geometry", "yw_jGupkl@??"},
@@ -152,6 +153,10 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates)
 
             const auto duration = leg_object.values.at("duration").get<json::Number>().value;
             BOOST_CHECK_EQUAL(duration, 0);
+
+            // nothing can be said about summary, empty or contains human readable summary
+            const auto summary = leg_object.values.at("summary").get<json::String>().value;
+            BOOST_CHECK(((void)summary, true));
 
             const auto &steps = leg_object.values.at("steps").get<json::Array>().values;
             BOOST_CHECK(!steps.empty());


### PR DESCRIPTION
This adds the summary back to the RouteLeg, it now depends on if `steps=true`.

This reverts commit eaf9993dd9b6d754e1e3fc238dc96f61007b28f6.