### PR TITLE
enable reverse name IDs

### DIFF
--- a/features/testbot/parallel_edges.feature
+++ b/features/testbot/parallel_edges.feature
@@ -1,0 +1,99 @@
+@routing @testbot @parallel_arcs
+Feature: Oneway Roundabout
+
+    Background:
+        Given the profile "testbot"
+
+    Scenario: Simple Circle
+        Given the node map
+            |   |   | g |   |   |
+            | a | b |   | d | f |
+            |   |   | c |   |   |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | no     |
+            | bcd   | yes    |
+            | df    | no     |
+            | dgb   | yes    |
+
+        When I route I should get
+            | waypoints | route        |
+            | a,f       | ab,bcd,df,df |
+            | f,a       | df,dgb,ab,ab |
+            | b,d       | bcd,bcd      |
+            | d,b       | dgb,dgb      |
+
+    Scenario: Parallel Geometry
+        Given the node map
+            | a | b | c | g | d | f |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | no     |
+            | bcd   | yes    |
+            | df    | no     |
+            | dgb   | yes    |
+
+        When I route I should get
+            | waypoints | route        |
+            | a,f       | ab,bcd,df,df |
+            | f,a       | df,dgb,ab,ab |
+            | b,d       | bcd,bcd      |
+            | d,b       | dgb,dgb      |
+
+     Scenario: Parallel Geometry
+        Given the node map
+            | a | b |
+
+        And the ways
+            | nodes | oneway | highway |
+            | ab    | yes    | primary |
+            | ba    | yes    | tertiary |
+
+        When I route I should get
+            | waypoints | route   | time |
+            | a,b       | ab,ab   | 10s  |
+            | b,a       | ba,ba   | 30s  |
+
+     Scenario: Parallel Geometry
+        Given the node map
+            | a | b |
+
+        And the ways
+            | nodes | oneway | highway  |
+            | ba    | yes    | tertiary |
+            | ab    | yes    | primary  |
+
+        When I route I should get
+            | waypoints | route   | time |
+            | a,b       | ab,ab   | 10s  |
+            | b,a       | ba,ba   | 30s  |
+
+     Scenario: Parallel Geometry Contractable
+        Given the node map
+            | a | b | c | d | e | f | g |
+
+        And the ways
+            | nodes | oneway | highway  |
+            | gf    | yes    | tertiary |
+            | fe    | yes    | tertiary |
+            | ed    | yes    | tertiary |
+            | dc    | yes    | tertiary |
+            | cb    | yes    | tertiary |
+            | ba    | yes    | tertiary |
+            | ab    | yes    | primary  |
+            | bc    | yes    | primary  |
+            | cd    | yes    | primary  |
+            | de    | yes    | primary  |
+            | ef    | yes    | primary  |
+            | fg    | yes    | primary  |
+
+        When I route I should get
+            | waypoints | route                | time |
+            | a,b       | ab,ab                | 10s  |
+            | a,g       | ab,bc,cd,de,ef,fg,fg | 60s  |
+            | b,a       | ba,ba                | 30s  |
+            | g,a       | gf,fe,ed,dc,cb,ba,ba | 180s |
+            | b,f       | bc,cd,de,ef,ef       | 40s  |
+            | f,b       | fe,ed,dc,cb,cb       | 120s |

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -63,6 +63,8 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
     std::size_t segment_index = 0;
     BOOST_ASSERT(leg_geometry.locations.size() >= 2);
 
+    const auto target_node_name_id =
+        target_traversed_in_reverse ? target_node.reverse_name_id : target_node.name_id;
     if (leg_data.size() > 0)
     {
 
@@ -98,7 +100,7 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         const auto distance = leg_geometry.segment_distances[segment_index];
         const int duration = segment_duration + target_duration;
         BOOST_ASSERT(duration >= 0);
-        steps.push_back(RouteStep{target_node.name_id, facade.GetNameForID(target_node.name_id),
+        steps.push_back(RouteStep{target_node_name_id, facade.GetNameForID(target_node_name_id),
                                   NO_ROTARY_NAME, duration / 10., distance, target_mode, maneuver,
                                   leg_geometry.FrontIndex(segment_index),
                                   leg_geometry.BackIndex(segment_index) + 1});
@@ -117,7 +119,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         int duration = target_duration - source_duration;
         BOOST_ASSERT(duration >= 0);
 
-        steps.push_back(RouteStep{source_node.name_id, facade.GetNameForID(source_node.name_id),
+        const auto source_node_name_id =
+            source_traversed_in_reverse ? source_node.reverse_name_id : source_node.name_id;
+        steps.push_back(RouteStep{source_node_name_id, facade.GetNameForID(source_node_name_id),
                                   NO_ROTARY_NAME, duration / 10.,
                                   leg_geometry.segment_distances[segment_index], source_mode,
                                   std::move(maneuver), leg_geometry.FrontIndex(segment_index),
@@ -130,9 +134,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
         extractor::guidance::TurnInstruction::NO_TURN(), WaypointType::Arrive, leg_geometry);
 
     BOOST_ASSERT(!leg_geometry.locations.empty());
-    steps.push_back(RouteStep{target_node.name_id, facade.GetNameForID(target_node.name_id),
+    steps.push_back(RouteStep{target_node_name_id, facade.GetNameForID(target_node_name_id),
                               NO_ROTARY_NAME, ZERO_DURATION, ZERO_DISTANCE, target_mode,
-                              final_maneuver, leg_geometry.locations.size()-1,
+                              final_maneuver, leg_geometry.locations.size() - 1,
                               leg_geometry.locations.size()});
 
     return steps;

--- a/include/engine/hint.hpp
+++ b/include/engine/hint.hpp
@@ -64,14 +64,14 @@ struct Hint
 };
 
 #ifndef _MSC_VER
-static_assert(sizeof(Hint) == 60 + 4, "Hint is bigger than expected");
-constexpr std::size_t ENCODED_HINT_SIZE = 88;
+static_assert(sizeof(Hint) == 64 + 4, "Hint is bigger than expected");
+constexpr std::size_t ENCODED_HINT_SIZE = 92;
 static_assert(ENCODED_HINT_SIZE / 4 * 3 >= sizeof(Hint),
               "ENCODED_HINT_SIZE does not match size of Hint");
 #else
 // PhantomNode is bigger under windows because MSVC does not support bit packing
-static_assert(sizeof(Hint) == 72 + 4, "Hint is bigger than expected");
-constexpr std::size_t ENCODED_HINT_SIZE = 104;
+static_assert(sizeof(Hint) == 76 + 4, "Hint is bigger than expected");
+constexpr std::size_t ENCODED_HINT_SIZE = 108;
 static_assert(ENCODED_HINT_SIZE / 4 * 3 >= sizeof(Hint),
               "ENCODED_HINT_SIZE does not match size of Hint");
 #endif

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -4,12 +4,12 @@
 #include "engine/routing_algorithms/routing_base.hpp"
 
 #include "engine/map_matching/hidden_markov_model.hpp"
-#include "engine/map_matching/sub_matching.hpp"
 #include "engine/map_matching/matching_confidence.hpp"
+#include "engine/map_matching/sub_matching.hpp"
 
 #include "util/coordinate_calculation.hpp"
-#include "util/json_logger.hpp"
 #include "util/for_each_pair.hpp"
+#include "util/json_logger.hpp"
 
 #include <cstddef>
 
@@ -86,8 +86,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
 
         const bool use_timestamps = trace_timestamps.size() > 1;
 
-        const auto median_sample_time = [&]
-        {
+        const auto median_sample_time = [&] {
             if (use_timestamps)
             {
                 return std::max(1u, GetMedianSampleTime(trace_timestamps));
@@ -98,8 +97,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
             }
         }();
         const auto max_broken_time = median_sample_time * MAX_BROKEN_STATES;
-        const auto max_distance_delta = [&]
-        {
+        const auto max_distance_delta = [&] {
             if (use_timestamps)
             {
                 return median_sample_time * MAX_SPEED;
@@ -118,8 +116,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                 emission_log_probabilities[t].resize(candidates_list[t].size());
                 std::transform(candidates_list[t].begin(), candidates_list[t].end(),
                                emission_log_probabilities[t].begin(),
-                               [this](const PhantomNodeWithDistance &candidate)
-                               {
+                               [this](const PhantomNodeWithDistance &candidate) {
                                    return default_emission_log_probability(candidate.distance);
                                });
             }
@@ -136,8 +133,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                     std::transform(
                         candidates_list[t].begin(), candidates_list[t].end(),
                         emission_log_probabilities[t].begin(),
-                        [&emission_log_probability](const PhantomNodeWithDistance &candidate)
-                        {
+                        [&emission_log_probability](const PhantomNodeWithDistance &candidate) {
                             return emission_log_probability(candidate.distance);
                         });
                 }
@@ -145,8 +141,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                 {
                     std::transform(candidates_list[t].begin(), candidates_list[t].end(),
                                    emission_log_probabilities[t].begin(),
-                                   [this](const PhantomNodeWithDistance &candidate)
-                                   {
+                                   [this](const PhantomNodeWithDistance &candidate) {
                                        return default_emission_log_probability(candidate.distance);
                                    });
                 }
@@ -293,7 +288,8 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
                     const double transition_pr = transition_log_probability(d_t);
                     new_value += transition_pr;
 
-                    if (new_value > current_viterbi[s_prime])
+                    if (new_value > current_viterbi[s_prime] ||
+                        (new_value == current_viterbi[s_prime] && s == s_prime))
                     {
                         current_viterbi[s_prime] = new_value;
                         current_parents[s_prime] = std::make_pair(prev_unbroken_timestamp, s);
@@ -400,8 +396,7 @@ class MapMatching final : public BasicRoutingInterface<DataFacadeT, MapMatching<
             util::for_each_pair(
                 reconstructed_indices, [&trace_distance, &trace_coordinates](
                                            const std::pair<std::size_t, std::size_t> &prev,
-                                           const std::pair<std::size_t, std::size_t> &curr)
-                {
+                                           const std::pair<std::size_t, std::size_t> &curr) {
                     trace_distance += util::coordinate_calculation::haversineDistance(
                         trace_coordinates[prev.first], trace_coordinates[curr.first]);
                 });

--- a/include/extractor/edge_based_node.hpp
+++ b/include/extractor/edge_based_node.hpp
@@ -21,8 +21,8 @@ struct EdgeBasedNode
 {
     EdgeBasedNode()
         : forward_segment_id{SPECIAL_SEGMENTID, false},
-          reverse_segment_id{SPECIAL_SEGMENTID, false}, u(SPECIAL_NODEID),
-          v(SPECIAL_NODEID), name_id(0), forward_packed_geometry_id(SPECIAL_EDGEID),
+          reverse_segment_id{SPECIAL_SEGMENTID, false}, u(SPECIAL_NODEID), v(SPECIAL_NODEID),
+          name_id(0), reverse_name_id(0), forward_packed_geometry_id(SPECIAL_EDGEID),
           reverse_packed_geometry_id(SPECIAL_EDGEID), component{INVALID_COMPONENTID, false},
           fwd_segment_position(std::numeric_limits<unsigned short>::max()),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
@@ -35,6 +35,7 @@ struct EdgeBasedNode
                            NodeID u,
                            NodeID v,
                            unsigned name_id,
+                           unsigned reverse_name_id,
                            unsigned forward_geometry_id_,
                            unsigned reverse_geometry_id_,
                            bool is_tiny_component,
@@ -42,15 +43,14 @@ struct EdgeBasedNode
                            unsigned short fwd_segment_position,
                            TravelMode forward_travel_mode,
                            TravelMode backward_travel_mode)
-        : forward_segment_id(forward_segment_id_),
-          reverse_segment_id(reverse_segment_id_), u(u), v(v), name_id(name_id),
+        : forward_segment_id(forward_segment_id_), reverse_segment_id(reverse_segment_id_), u(u),
+          v(v), name_id(name_id), reverse_name_id(reverse_name_id),
           forward_packed_geometry_id(forward_geometry_id_),
           reverse_packed_geometry_id(reverse_geometry_id_),
           component{component_id, is_tiny_component}, fwd_segment_position(fwd_segment_position),
           forward_travel_mode(forward_travel_mode), backward_travel_mode(backward_travel_mode)
     {
-        BOOST_ASSERT(forward_segment_id.enabled ||
-                     reverse_segment_id.enabled);
+        BOOST_ASSERT(forward_segment_id.enabled || reverse_segment_id.enabled);
     }
 
     SegmentID forward_segment_id; // needed for edge-expanded graph
@@ -58,7 +58,7 @@ struct EdgeBasedNode
     NodeID u;                     // indices into the coordinates array
     NodeID v;                     // indices into the coordinates array
     unsigned name_id;             // id of the edge name
-
+    unsigned reverse_name_id;     // name of the reverse edge
     unsigned forward_packed_geometry_id;
     unsigned reverse_packed_geometry_id;
     struct

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -55,10 +55,11 @@ BOOST_AUTO_TEST_CASE(invalid_route_urls)
     BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>("1,2;3,4.json?nooptions"), 13);
     BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>("1,2;3,4..json?nooptions"), 14);
     BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>("1,2;3,4.0.json?nooptions"), 15);
-    BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>(std::string{"1,2;3,4"} + '\0' + ".json"), 7);
+    BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>(std::string{"1,2;3,4"} + '\0' + ".json"),
+                      7);
     BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>(std::string{"1,2;3,"} + '\0'), 6);
 
-    //BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>(), );
+    // BOOST_CHECK_EQUAL(testInvalidOptions<RouteParameters>(), );
 }
 
 BOOST_AUTO_TEST_CASE(invalid_table_urls)
@@ -122,29 +123,29 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     CHECK_EQUAL_RANGE(reference_3.coordinates, result_3->coordinates);
 
     std::vector<boost::optional<engine::Hint>> hints_4 = {
-        engine::Hint::FromBase64("DAIAgP___"
-                                 "38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_"
-                                 "mwIAAAEBl-Umfg=="),
-        engine::Hint::FromBase64("cgAAgP___"
-                                 "39jAAAADgAAACIAAABeAAAAkQAAANoDAABOAgAAGwAAAFVGcQCiRJsCR0VxAOZFmw"
-                                 "IFAAEBl-Umfg=="),
-        engine::Hint::FromBase64("3gAAgP___"
-                                 "39KAAAAHgAAACEAAAAAAAAAGAAAAE0BAABOAQAAGwAAAIAzcQBkUJsC1zNxAHBQmw"
-                                 "IAAAEBl-Umfg==")};
-    RouteParameters reference_4{false,
-                                false,
-                                RouteParameters::GeometriesType::Polyline,
-                                RouteParameters::OverviewType::Simplified,
-                                boost::optional<bool>{},
-                                coords_1,
-                                hints_4,
-                                std::vector<boost::optional<double>>{},
-                                std::vector<boost::optional<engine::Bearing>>{}};
-    auto result_4 = parseParameters<RouteParameters>(
+        engine::Hint::FromBase64("coQCgHOEAoDFCwAAxQsAABMAAAAAAAAAAAAAAAAAAADO2AIAzdgCAKwAAAAaXMgAg"
+                                 "UUfA6RCDwC8Pg8AAAABAQFuWV0="),
+        engine::Hint::FromBase64("1EIAgPc3AYCLEAAAixAAACAAAAAAAAAAfAAAAAAAAACVOgAAtSIBAKwAAAAia8wAr"
+                                 "cAhA5NrzABdwCEDAQABAQFuWV0="),
+        engine::Hint::FromBase64("BxcAgCn5AYCKJgAAiiYAAB4AAAAHAAAAKgAAAFAAAAD6HAAAAxEBAKwAAAA4R8wAK"
+                                 "LMhAwpJzAC5syEDAQABAQFuWV0=")};
+    engine::api::RouteParameters reference_4{false,
+                                             false,
+                                             engine::api::RouteParameters::GeometriesType::Polyline,
+                                             engine::api::RouteParameters::OverviewType::Simplified,
+                                             boost::optional<bool>{},
+                                             coords_1,
+                                             hints_4,
+                                             std::vector<boost::optional<double>>{},
+                                             std::vector<boost::optional<engine::Bearing>>{}};
+    auto result_4 = api::parseParameters<engine::api::RouteParameters>(
         "1,2;3,4?steps=false&hints="
-        "DAIAgP___38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_mwIAAAEBl-Umfg==;"
-        "cgAAgP___39jAAAADgAAACIAAABeAAAAkQAAANoDAABOAgAAGwAAAFVGcQCiRJsCR0VxAOZFmwIFAAEBl-Umfg==;"
-        "3gAAgP___39KAAAAHgAAACEAAAAAAAAAGAAAAE0BAABOAQAAGwAAAIAzcQBkUJsC1zNxAHBQmwIAAAEBl-Umfg==");
+        "coQCgHOEAoDFCwAAxQsAABMAAAAAAAAAAAAAAAAAAADO2AIAzdgCAKwAAAAaXMgAgUUfA6RCDwC8Pg8AAAABAQFuWV"
+        "0=;"
+        "1EIAgPc3AYCLEAAAixAAACAAAAAAAAAAfAAAAAAAAACVOgAAtSIBAKwAAAAia8wArcAhA5NrzABdwCEDAQABAQFuWV"
+        "0=;"
+        "BxcAgCn5AYCKJgAAiiYAAB4AAAAHAAAAKgAAAFAAAAD6HAAAAxEBAKwAAAA4R8wAKLMhAwpJzAC5syEDAQABAQFuWV"
+        "0=");
     BOOST_CHECK(result_4);
     BOOST_CHECK_EQUAL(reference_4.steps, result_4->steps);
     BOOST_CHECK_EQUAL(reference_4.alternatives, result_4->alternatives);
@@ -198,7 +199,8 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     auto result_7 = parseParameters<RouteParameters>("1,2;3,4?radiuses=;unlimited");
     RouteParameters reference_7{};
     reference_7.coordinates = coords_1;
-    reference_7.radiuses = {boost::none, boost::make_optional(std::numeric_limits<double>::infinity())};
+    reference_7.radiuses = {boost::none,
+                            boost::make_optional(std::numeric_limits<double>::infinity())};
     BOOST_CHECK(result_7);
     BOOST_CHECK_EQUAL(reference_7.steps, result_7->steps);
     BOOST_CHECK_EQUAL(reference_7.alternatives, result_7->alternatives);


### PR DESCRIPTION
It can occur that a single road can be assigned different names, based on the direction of travel.

This experimental PR is used to test the implications of enabling these reverse name ids.
