### PR TITLE
[ready] Improve Tests for Guidance

### DIFF
--- a/features/guidance/fork.feature
+++ b/features/guidance/fork.feature
@@ -245,7 +245,6 @@ Feature: Fork Instructions
             | a,c       | abd,bc,bc | depart,turn slight left,arrive |
             | a,d       | abd,abd   | depart,arrive                  |
 
-    @pr2275 @bug
     Scenario: Tripple fork
         Given the node map
             |   |   |   |   |   |   |   |   | c |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -726,7 +726,6 @@ Feature: Simple Turns
             | a,e       | abc,eb,eb | depart,turn right,arrive        |
             | a,f       | abc,fb,fb | depart,turn slight right,arrive |
 
-     @bug @pr2275
      Scenario: Right Turn Assignment Three Conflicting Turns with invalid - 2
         Given the node map
             |   |   | g |   |   |
@@ -787,7 +786,6 @@ Feature: Simple Turns
             | a,e       | abc,be,be | depart,turn right,arrive        |
             | a,f       | abc,bf,bf | depart,turn sharp right,arrive  |
 
-    @bug @pr2275
     Scenario: Conflicting Turns with well distinguished turn (back)
         Given the node map
             | a |   |   | b |   |   | c |

--- a/include/extractor/guidance/constants.hpp
+++ b/include/extractor/guidance/constants.hpp
@@ -16,9 +16,9 @@ const double constexpr STRAIGHT_ANGLE = 180.;
 const double constexpr MAXIMAL_ALLOWED_NO_TURN_DEVIATION = 3.;
 // angle that lies between two nearly indistinguishable roads
 const double constexpr NARROW_TURN_ANGLE = 40.;
-const double constexpr GROUP_ANGLE = 90;
+const double constexpr GROUP_ANGLE = 60;
 // angle difference that can be classified as straight, if its the only narrow turn
-const double constexpr FUZZY_ANGLE_DIFFERENCE = 15.;
+const double constexpr FUZZY_ANGLE_DIFFERENCE = 20.;
 const double constexpr DISTINCTION_RATIO = 2;
 const unsigned constexpr INVALID_NAME_ID = 0;
 


### PR DESCRIPTION
This PR adds a few tests to the guidance framework.

Furthermore, it fixes a few issues in guidance and re-enables the respective tests:

It enables the tests currently disabled in `features/guidance/turn.feature` as well as `features/guidance/fork.feature`.

- [x] merge https://github.com/Project-OSRM/osrm-backend/pull/2297 first