### PR TITLE
[ready] fix handling of segregated roundabout connections

### DIFF
--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -165,6 +165,84 @@ Feature: Basic Roundabout
            | j,f       | jkl,def,def | depart,roundabout-exit-3,arrive |
            | j,c       | jkl,abc,abc | depart,roundabout-exit-4,arrive |
 
+    Scenario: Mixed Entry and Exit - segregated roads
+        Given the node map
+           |   |   | a |   | c |   |   |
+           |   |   |   |   |   |   |   |
+           | l |   |   | b |   |   | d |
+           |   |   | k |   | e |   |   |
+           | j |   |   | h |   |   | f |
+           |   |   |   |   |   |   |   |
+           |   |   | i |   | g |   |   |
+
+        And the ways
+           | nodes | junction   | oneway |
+           | abc   |            | yes    |
+           | def   |            | yes    |
+           | ghi   |            | yes    |
+           | jkl   |            | yes    |
+           | bkheb | roundabout | yes    |
+
+        When I route I should get
+           | waypoints | route       | turns                           |
+           | a,c       | abc,abc,abc | depart,roundabout-exit-4,arrive |
+           | a,l       | abc,jkl,jkl | depart,roundabout-exit-1,arrive |
+           | a,i       | abc,ghi,ghi | depart,roundabout-exit-2,arrive |
+           | a,f       | abc,def,def | depart,roundabout-exit-3,arrive |
+           | d,f       | def,def,def | depart,roundabout-exit-4,arrive |
+           | d,c       | def,abc,abc | depart,roundabout-exit-1,arrive |
+           | d,l       | def,jkl,jkl | depart,roundabout-exit-2,arrive |
+           | d,i       | def,ghi,ghi | depart,roundabout-exit-3,arrive |
+           | g,i       | ghi,ghi,ghi | depart,roundabout-exit-4,arrive |
+           | g,f       | ghi,def,def | depart,roundabout-exit-1,arrive |
+           | g,c       | ghi,abc,abc | depart,roundabout-exit-2,arrive |
+           | g,l       | ghi,jkl,jkl | depart,roundabout-exit-3,arrive |
+           | j,l       | jkl,jkl,jkl | depart,roundabout-exit-4,arrive |
+           | j,i       | jkl,ghi,ghi | depart,roundabout-exit-1,arrive |
+           | j,f       | jkl,def,def | depart,roundabout-exit-2,arrive |
+           | j,c       | jkl,abc,abc | depart,roundabout-exit-3,arrive |
+
+    Scenario: Mixed Entry and Exit - segregated roads, different names
+        Given the node map
+           |   |   | a |   | c |   |   |
+           |   |   |   |   |   |   |   |
+           | l |   |   | b |   |   | d |
+           |   |   | k |   | e |   |   |
+           | j |   |   | h |   |   | f |
+           |   |   |   |   |   |   |   |
+           |   |   | i |   | g |   |   |
+
+        And the ways
+           | nodes | junction   | oneway |
+           | ab    |            | yes    |
+           | bc    |            | yes    |
+           | de    |            | yes    |
+           | ef    |            | yes    |
+           | gh    |            | yes    |
+           | hi    |            | yes    |
+           | jk    |            | yes    |
+           | kl    |            | yes    |
+           | bkheb | roundabout | yes    |
+
+        When I route I should get
+           | waypoints | route    | turns                           |
+           | a,c       | ab,bc,bc | depart,roundabout-exit-4,arrive |
+           | a,l       | ab,kl,kl | depart,roundabout-exit-1,arrive |
+           | a,i       | ab,hi,hi | depart,roundabout-exit-2,arrive |
+           | a,f       | ab,ef,ef | depart,roundabout-exit-3,arrive |
+           | d,f       | de,ef,ef | depart,roundabout-exit-4,arrive |
+           | d,c       | de,bc,bc | depart,roundabout-exit-1,arrive |
+           | d,l       | de,kl,kl | depart,roundabout-exit-2,arrive |
+           | d,i       | de,hi,hi | depart,roundabout-exit-3,arrive |
+           | g,i       | gh,hi,hi | depart,roundabout-exit-4,arrive |
+           | g,f       | gh,ef,ef | depart,roundabout-exit-1,arrive |
+           | g,c       | gh,bc,bc | depart,roundabout-exit-2,arrive |
+           | g,l       | gh,kl,kl | depart,roundabout-exit-3,arrive |
+           | j,l       | jk,kl,kl | depart,roundabout-exit-4,arrive |
+           | j,i       | jk,hi,hi | depart,roundabout-exit-1,arrive |
+           | j,f       | jk,ef,ef | depart,roundabout-exit-2,arrive |
+           | j,c       | jk,bc,bc | depart,roundabout-exit-3,arrive |
+
        Scenario: Collinear in X
         Given the node map
             | a | b | c | d | f |
@@ -184,11 +262,11 @@ Feature: Basic Roundabout
 
        Scenario: Collinear in Y
         Given the node map
-            | a |   |
-            | b |   |
-            | c | e |
-            | d |   |
-            | f |   |
+            |   | a |
+            |   | b |
+            | e | c |
+            |   | d |
+            |   | f |
 
         And the ways
             | nodes | junction   |

--- a/include/extractor/guidance/roundabout_handler.hpp
+++ b/include/extractor/guidance/roundabout_handler.hpp
@@ -56,6 +56,10 @@ class RoundaboutHandler : public IntersectionHandler
                                                const EdgeID via_eid,
                                                const Intersection &intersection) const;
 
+    void invalidateExitAgainstDirection(const NodeID from_nid,
+                                        const EdgeID via_eid,
+                                        Intersection &intersection) const;
+
     // decide whether we lookk at a roundabout or a rotary
     bool isRotary(const NodeID nid) const;
 

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -25,6 +25,28 @@ namespace engine
 namespace guidance
 {
 
+void print(const std::vector<RouteStep> &steps)
+{
+    std::cout << "Path\n";
+    int segment = 0;
+    for (const auto &step : steps)
+    {
+        const auto type = static_cast<int>(step.maneuver.instruction.type);
+        const auto modifier = static_cast<int>(step.maneuver.instruction.direction_modifier);
+
+        std::cout << "\t[" << ++segment << "]: " << type << " " << modifier
+                  << " Duration: " << step.duration << " Distance: " << step.distance
+                  << " Geometry: " << step.geometry_begin << " " << step.geometry_end
+                  << " exit: " << step.maneuver.exit
+                  << " Intersections: " << step.maneuver.intersections.size() << " [";
+
+        for (const auto &intersection : step.maneuver.intersections)
+            std::cout << "(" << intersection.duration << " " << intersection.distance << ")";
+
+        std::cout << "] name[" << step.name_id << "]: " << step.name << std::endl;
+    }
+}
+
 namespace detail
 {
 bool canMergeTrivially(const RouteStep &destination, const RouteStep &source)
@@ -175,28 +197,6 @@ void closeOffRoundabout(const bool on_roundabout,
     }
 }
 } // namespace detail
-
-void print(const std::vector<RouteStep> &steps)
-{
-    std::cout << "Path\n";
-    int segment = 0;
-    for (const auto &step : steps)
-    {
-        const auto type = static_cast<int>(step.maneuver.instruction.type);
-        const auto modifier = static_cast<int>(step.maneuver.instruction.direction_modifier);
-
-        std::cout << "\t[" << ++segment << "]: " << type << " " << modifier
-                  << " Duration: " << step.duration << " Distance: " << step.distance
-                  << " Geometry: " << step.geometry_begin << " " << step.geometry_end
-                  << " exit: " << step.maneuver.exit
-                  << " Intersections: " << step.maneuver.intersections.size() << " [";
-
-        for (auto intersection : step.maneuver.intersections)
-            std::cout << "(" << intersection.duration << " " << intersection.distance << ")";
-
-        std::cout << "] name[" << step.name_id << "]: " << step.name << std::endl;
-    }
-}
 
 // Every Step Maneuver consists of the information until the turn.
 // This list contains a set of instructions, called silent, which should

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -208,6 +208,15 @@ Intersection IntersectionGenerator::mergeSegregatedRoads(Intersection intersecti
     if (intersection.size() == 1)
         return intersection;
 
+    const bool is_connected_to_roundabout = [this,&intersection]() {
+        for (const auto &road : intersection)
+        {
+            if (node_based_graph.GetEdgeData(road.turn.eid).roundabout)
+                return true;
+        }
+        return false;
+    }();
+
     // check for merges including the basic u-turn
     // these result in an adjustment of all other angles
     if (mergable(0, intersection.size() - 1))
@@ -216,8 +225,24 @@ Intersection IntersectionGenerator::mergeSegregatedRoads(Intersection intersecti
             (360 - intersection[intersection.size() - 1].turn.angle) / 2;
         for (std::size_t i = 1; i + 1 < intersection.size(); ++i)
             intersection[i].turn.angle += correction_factor;
+
+        // FIXME if we have a left-sided country, we need to switch this off and enable it below
         intersection[0] = merge(intersection.front(), intersection.back());
         intersection[0].turn.angle = 0;
+
+        if (is_connected_to_roundabout)
+        {
+            // We are merging a u-turn against the direction of a roundabout
+            //
+            //    -----------> roundabout
+            //       /    \
+            //    out      in
+            //
+            // These cases have to be disabled, even if they are not forbidden specifically by a
+            // relation
+            intersection[0].entry_allowed = false;
+        }
+
         intersection.pop_back();
     }
 


### PR DESCRIPTION
- [x] requires merge of https://github.com/Project-OSRM/osrm-backend/pull/2297

If a roundabout is entered via a segregated road, the exit counting can be off. This PR fixes the handling of segregated roads at roundabouts.