### PR TITLE
fix local path loos

### DIFF
--- a/features/bicycle/area.feature
+++ b/features/bicycle/area.feature
@@ -4,7 +4,7 @@ Feature: Bike - Squares and other areas
     Background:
         Given the profile "bicycle"
 
-    @square @mokob @2154
+    @square
     Scenario: Bike - Route along edge of a squares
         Given the node map
             | x |   |
@@ -50,7 +50,7 @@ Feature: Bike - Squares and other areas
             | d    | a  | xa,xa |
             | a    | d  | xa,xa |
 
-    @parking @mokob @2154
+    @parking
     Scenario: Bike - parking areas
         Given the node map
             | e |   |   | f |
@@ -78,7 +78,7 @@ Feature: Bike - Squares and other areas
             | a    | d  | abcda,abcda    |
 
 
-    @train @platform @mokob @2154
+    @train @platform
     Scenario: Bike - railway platforms
         Given the node map
             | x | a | b | y |

--- a/features/car/advisory.feature
+++ b/features/car/advisory.feature
@@ -34,7 +34,6 @@ OSRM will use 4/5 of the projected free-flow speed.
             | a    | b  | ab,ab | 47 km/h +- 1 |
             | b    | c  | bc,bc | 47 km/h +- 1 |
 
-    @mokob @2162
     Scenario: Car - Advisory speed overwrites backwards maxspeed
         Given the node map
             | a | b | c |
@@ -49,7 +48,6 @@ OSRM will use 4/5 of the projected free-flow speed.
             | b    | a  | ab,ab | 47 km/h +- 1 |
             | c    | b  | bc,bc | 47 km/h +- 1 |
 
-    @mokob @2162 @deleteme
     Scenario: Car - Advisory speed overwrites backwards maxspeed
         Given the node map
             | a | b | c | d |
@@ -65,7 +63,6 @@ OSRM will use 4/5 of the projected free-flow speed.
             | c    | b  | bc,bc | 47 km/h +- 1 |
             | d    | c  | cd,cd | 47 km/h +- 1 |
 
-    @mokob @2162
     Scenario: Car - Directional advisory speeds play nice with eachother
         Given the node map
             | a | b | c |

--- a/features/testbot/mode.feature
+++ b/features/testbot/mode.feature
@@ -12,7 +12,6 @@ Feature: Testbot - Travel mode
     Background:
        Given the profile "testbot"
 
-    @mokob @2166
     Scenario: Testbot - Always announce mode change
         Given the node map
             | a | b | c | d |
@@ -28,7 +27,6 @@ Feature: Testbot - Travel mode
             | a    | d  | foo,foo,foo,foo | driving,river downstream,driving,driving |
             | b    | d  | foo,foo,foo     | river downstream,driving,driving         |
 
-    @mokob @2166
     Scenario: Testbot - Compressed Modes
         Given the node map
             | a | b | c | d | e | f | g |
@@ -44,7 +42,6 @@ Feature: Testbot - Travel mode
             | a    | g  | road,liquid,solid,solid  | driving,river downstream,driving,driving |
             | c    | g  | liquid,solid,solid       | river downstream,driving,driving         |
 
-    @mokob @2166
     Scenario: Testbot - Modes in each direction, different forward/backward speeds
         Given the node map
             |   | 0 | 1 |   |
@@ -79,7 +76,7 @@ Feature: Testbot - Travel mode
             | 0    | 1  | ab,ab | steps down,steps down | 60s +-1 |
             | 1    | 0  | ab,ab | steps up,steps up     | 60s +-1 |
 
-    @oneway @mokob @2166
+    @oneway
     Scenario: Testbot - Modes for oneway, different forward/backward speeds
         Given the node map
             | a | b |
@@ -107,7 +104,7 @@ Feature: Testbot - Travel mode
             | a    | b  | ab,ab | steps down,steps down |
             | b    | a  |       |                       |
 
-    @oneway @mokob @2166
+    @oneway
     Scenario: Testbot - Modes for reverse oneway, different forward/backward speeds
         Given the node map
             | a | b |
@@ -135,7 +132,7 @@ Feature: Testbot - Travel mode
             | a    | b  |       |                   |
             | b    | a  | ab,ab | steps up,steps up |
 
-    @via @mokob @2166
+    @via
     Scenario: Testbot - Mode should be set at via points
         Given the node map
             | a | 1 | b |
@@ -149,7 +146,6 @@ Feature: Testbot - Travel mode
             | a,1,b     | ab,ab,ab,ab | river downstream,river downstream,river downstream,river downstream |
             | b,1,a     | ab,ab,ab,ab | river upstream,river upstream,river upstream,river upstream         |
 
-    @mokob @2166
     Scenario: Testbot - Starting at a tricky node
        Given the node map
             |  | a |  |   |   |
@@ -164,7 +160,6 @@ Feature: Testbot - Travel mode
             | from | to | route | modes                         |
             | b    | a  | ab,ab | river upstream,river upstream |
 
-    @mokob @2166
     Scenario: Testbot - Mode changes on straight way without name change
        Given the node map
             | a | 1 | b | 2 | c |
@@ -204,7 +199,6 @@ Feature: Testbot - Travel mode
             | b    | d  | bc,cd,cd          | route,driving,driving                         |
             | a    | f  | ab,bc,cd,de,ef,ef | driving,route,driving,driving,driving,driving |
 
-    @mokob @2166
     Scenario: Testbot - Modes, triangle map
         Given the node map
             |   |   |   |   |   |   | d |
@@ -239,7 +233,6 @@ Feature: Testbot - Travel mode
             | a    | d  | abc,cd,cd        | driving,driving,driving                        |
             | d    | a  | de,ce,abc,abc    | driving,river upstream,driving,driving         |
 
-    @mokob @2166
     Scenario: Testbot - River in the middle
         Given the node map
             | a | b | c |   |   |

--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -46,7 +46,6 @@ Feature: Via points
             | a,d,c     | abc,bd,bd,bd,abc,abc |
             | c,d,a     | abc,bd,bd,bd,abc,abc |
 
-    @mokob
     Scenario: Multiple via points
         Given the node map
             | a |   |   |   | e | f | g |   |

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -373,8 +373,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         // t: fwd_segment 3
         // -> (U, v), (v, w), (w, x)
         // note that (x, t) is _not_ included but needs to be added later.
-        BOOST_ASSERT(start_index <= end_index);
-        for (std::size_t i = start_index; i != end_index; ++i)
+        for (std::size_t i = start_index; i != end_index; (start_index < end_index ? ++i : --i))
         {
             BOOST_ASSERT(i < id_vector.size());
             BOOST_ASSERT(phantom_node_pair.target_phantom.forward_travel_mode > 0);


### PR DESCRIPTION
Addressing https://github.com/Project-OSRM/osrm-backend/issues/2309.

I reverted the change to the loop. It seems to be a border case that I sadly cannot reproduce in cucumber. Nevertheless, the function should work fine this way. Even if its only necessary for looking up a single coordinate.