### PR TITLE
Fix/2311 - self loop discovery

### DIFF
--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -558,9 +558,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         // make sure to correctly unpack loops
         if (distance != forward_heap.GetKey(middle) + reverse_heap.GetKey(middle))
         {
-            // self loop
-            BOOST_ASSERT(forward_heap.GetData(middle).parent == middle &&
-                         reverse_heap.GetData(middle).parent == middle);
+            // self loop makes up the full path
             packed_leg.push_back(middle);
             packed_leg.push_back(middle);
         }


### PR DESCRIPTION
Self loop discovery is only possible on a single node. If a path leads back to a node without the self-loops (currently only due to us not adding loops for all paths - see: https://github.com/Project-OSRM/osrm-backend/issues/2016), we can end up with an unexpected input for `RoutingStep`. This PR adjusts the checks to make sure that we handle this situation correctly.

Fixes https://github.com/Project-OSRM/osrm-backend/issues/2311