### PR TITLE
Basic destination sign handling.

### DIFF
--- a/features/guidance/destination-signs.feature
+++ b/features/guidance/destination-signs.feature
@@ -15,19 +15,21 @@ Feature: Destination Signs
           | m | n |
 
         And the ways
-          | nodes | name | ref | destination | destination:ref |
-          | ab    | AB   | E1  |             |                 |
-          | cd    | CD   |     | Berlin      |                 |
-          | ef    | EF   |     | Berlin      | A1              |
-          | gh    |      |     | Berlin      | A1              |
-          | ij    |      |     | Berlin      |                 |
-          | kl    | KL   | E1  | Berlin      | A1              |
+          | nodes | name | ref | destination    | destination:ref |
+          | ab    | AB   | E1  |                |                 |
+          | cd    | CD   |     | Berlin         |                 |
+          | ef    | EF   |     | Berlin         | A1              |
+          | gh    |      |     | Berlin         | A1              |
+          | ij    |      |     | Berlin         |                 |
+          | kl    | KL   | E1  | Berlin         | A1              |
+          | mn    | MN   |     | Berlin;Hamburg | A1;A2           |
 
         When I route I should get
-          | from | to | route                           |
-          | a    | b  | AB (E1),AB (E1)                 |
-          | c    | d  | CD (Berlin),CD (Berlin)         |
-          | e    | f  | EF (A1: Berlin),EF (A1: Berlin) |
-          | g    | h  | ,                               |
-          | i    | j  | ,                               |
-          | k    | l  | KL (E1),KL (E1)                 |
+          | from | to | route                                                     |
+          | a    | b  | AB (E1),AB (E1)                                           |
+          | c    | d  | CD (Berlin),CD (Berlin)                                   |
+          | e    | f  | EF (A1: Berlin),EF (A1: Berlin)                           |
+          | g    | h  | ,                                                         |
+          | i    | j  | ,                                                         |
+          | k    | l  | KL (E1),KL (E1)                                           |
+          | m    | n  | MN (A1, A2: Berlin, Hamburg),MN (A1, A2: Berlin, Hamburg) |

--- a/features/guidance/destination-signs.feature
+++ b/features/guidance/destination-signs.feature
@@ -14,6 +14,7 @@ Feature: Destination Signs
           | k | l |
           | m | n |
           | o | p |
+          | q | r |
 
         And the ways
           | nodes | name | ref | destination    | destination:ref | oneway | #                                    |
@@ -25,6 +26,7 @@ Feature: Destination Signs
           | kl    | KL   | E1  | Berlin         | A1              | yes    |                                      |
           | mn    | MN   |     | Berlin;Hamburg | A1;A2           | yes    |                                      |
           | op    | OP   |     | Berlin;Hamburg | A1;A2           | no     | mis-tagged destination: not a oneway |
+          | qr    | QR   |     |                | A1;A2           | yes    |                                      |
 
         When I route I should get
           | from | to | route                                                     | #                         |
@@ -36,3 +38,4 @@ Feature: Destination Signs
           | k    | l  | KL (E1),KL (E1)                                           |                           |
           | m    | n  | MN (A1, A2: Berlin, Hamburg),MN (A1, A2: Berlin, Hamburg) |                           |
           | o    | p  | OP,OP                                                     | guard against mis-tagging |
+          | q    | r  | QR (A1, A2),QR (A1, A2)                                   |                           |

--- a/features/guidance/destination-signs.feature
+++ b/features/guidance/destination-signs.feature
@@ -1,0 +1,33 @@
+@routing @guidance
+Feature: Destination Signs
+
+    Background:
+        Given the profile "car"
+
+    Scenario: Car - route name assembly with destination signs
+        Given the node map
+          | a | b |
+          | c | d |
+          | e | f |
+          | g | h |
+          | i | j |
+          | k | l |
+          | m | n |
+
+        And the ways
+          | nodes | name | ref | destination | destination:ref |
+          | ab    | AB   | E1  |             |                 |
+          | cd    | CD   |     | Berlin      |                 |
+          | ef    | EF   |     | Berlin      | A1              |
+          | gh    |      |     | Berlin      | A1              |
+          | ij    |      |     | Berlin      |                 |
+          | kl    | KL   | E1  | Berlin      | A1              |
+
+        When I route I should get
+          | from | to | route                           |
+          | a    | b  | AB (E1),AB (E1)                 |
+          | c    | d  | CD (Berlin),CD (Berlin)         |
+          | e    | f  | EF (A1: Berlin),EF (A1: Berlin) |
+          | g    | h  | ,                               |
+          | i    | j  | ,                               |
+          | k    | l  | KL (E1),KL (E1)                 |

--- a/features/guidance/destination-signs.feature
+++ b/features/guidance/destination-signs.feature
@@ -13,23 +13,26 @@ Feature: Destination Signs
           | i | j |
           | k | l |
           | m | n |
+          | o | p |
 
         And the ways
-          | nodes | name | ref | destination    | destination:ref |
-          | ab    | AB   | E1  |                |                 |
-          | cd    | CD   |     | Berlin         |                 |
-          | ef    | EF   |     | Berlin         | A1              |
-          | gh    |      |     | Berlin         | A1              |
-          | ij    |      |     | Berlin         |                 |
-          | kl    | KL   | E1  | Berlin         | A1              |
-          | mn    | MN   |     | Berlin;Hamburg | A1;A2           |
+          | nodes | name | ref | destination    | destination:ref | oneway | #                                    |
+          | ab    | AB   | E1  |                |                 | yes    |                                      |
+          | cd    | CD   |     | Berlin         |                 | yes    |                                      |
+          | ef    | EF   |     | Berlin         | A1              | yes    |                                      |
+          | gh    |      |     | Berlin         | A1              | yes    |                                      |
+          | ij    |      |     | Berlin         |                 | yes    |                                      |
+          | kl    | KL   | E1  | Berlin         | A1              | yes    |                                      |
+          | mn    | MN   |     | Berlin;Hamburg | A1;A2           | yes    |                                      |
+          | op    | OP   |     | Berlin;Hamburg | A1;A2           | no     | mis-tagged destination: not a oneway |
 
         When I route I should get
-          | from | to | route                                                     |
-          | a    | b  | AB (E1),AB (E1)                                           |
-          | c    | d  | CD (Berlin),CD (Berlin)                                   |
-          | e    | f  | EF (A1: Berlin),EF (A1: Berlin)                           |
-          | g    | h  | ,                                                         |
-          | i    | j  | ,                                                         |
-          | k    | l  | KL (E1),KL (E1)                                           |
-          | m    | n  | MN (A1, A2: Berlin, Hamburg),MN (A1, A2: Berlin, Hamburg) |
+          | from | to | route                                                     | #                         |
+          | a    | b  | AB (E1),AB (E1)                                           |                           |
+          | c    | d  | CD (Berlin),CD (Berlin)                                   |                           |
+          | e    | f  | EF (A1: Berlin),EF (A1: Berlin)                           |                           |
+          | g    | h  | ,                                                         |                           |
+          | i    | j  | ,                                                         |                           |
+          | k    | l  | KL (E1),KL (E1)                                           |                           |
+          | m    | n  | MN (A1, A2: Berlin, Hamburg),MN (A1, A2: Berlin, Hamburg) |                           |
+          | o    | p  | OP,OP                                                     | guard against mis-tagging |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -1,6 +1,7 @@
 -- Car profile
 
 local find_access_tag = require("lib/access").find_access_tag
+local get_destination = require("lib/destination").get_destination
 
 -- Begin of globals
 barrier_whitelist = { ["cattle_grid"] = true, ["border_control"] = true, ["checkpoint"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["lift_gate"] = true, ["no"] = true, ["entrance"] = true }
@@ -352,15 +353,19 @@ function way_function (way, result)
   -- local barrier = way:get_value_by_key("barrier", "")
   -- local cycleway = way:get_value_by_key("cycleway", "")
   local service = way:get_value_by_key("service")
+  local destination = get_destination(way)
 
   -- Set the name that will be used for instructions
   local has_ref = ref and "" ~= ref
   local has_name = name and "" ~= name
+  local has_destination = destination and "" ~= destination
 
   if has_name and has_ref then
     result.name = name .. " (" .. ref .. ")"
   elseif has_ref then
     result.name = ref
+  elseif has_name and has_destination then
+    result.name = name .. " (" .. destination .. ")"
   elseif has_name then
     result.name = name
 --  else

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -353,19 +353,15 @@ function way_function (way, result)
   -- local barrier = way:get_value_by_key("barrier", "")
   -- local cycleway = way:get_value_by_key("cycleway", "")
   local service = way:get_value_by_key("service")
-  local destination = get_destination(way)
 
   -- Set the name that will be used for instructions
   local has_ref = ref and "" ~= ref
   local has_name = name and "" ~= name
-  local has_destination = destination and "" ~= destination
 
   if has_name and has_ref then
     result.name = name .. " (" .. ref .. ")"
   elseif has_ref then
     result.name = ref
-  elseif has_name and has_destination then
-    result.name = name .. " (" .. destination .. ")"
   elseif has_name then
     result.name = name
 --  else
@@ -397,6 +393,14 @@ function way_function (way, result)
     (highway == "motorway_link" and oneway ~="no") or
     (highway == "motorway" and oneway ~= "no") then
       result.backward_mode = mode.inaccessible
+
+      -- If we're on a oneway and there is no ref tag, re-use destination tag as ref.
+      local destination = get_destination(way)
+      local has_destination = destination and "" ~= destination
+
+      if has_destination and has_name and not has_ref then
+        result.name = name .. " (" .. destination .. ")"
+      end
     end
   end
 

--- a/profiles/lib/destination.lua
+++ b/profiles/lib/destination.lua
@@ -1,0 +1,27 @@
+local Destination = {}
+
+function Destination.get_destination(way)
+  local destination = way:get_value_by_key("destination")
+  local destination_ref = way:get_value_by_key("destination:ref")
+
+  -- Assemble destination as: "A59: Düsseldorf, Köln"
+  --          destination:ref  ^    ^  destination
+
+  local rv = ""
+
+  if destination_ref and destination_ref ~= "" then
+    rv = rv .. destination_ref
+  end
+
+  if destination and destination ~= "" then
+      if rv ~= "" then
+          rv = rv .. ": "
+      end
+
+      rv = rv .. string.gsub(destination, ";", ", ")
+  end
+
+  return rv
+end
+
+return Destination

--- a/profiles/lib/destination.lua
+++ b/profiles/lib/destination.lua
@@ -10,7 +10,7 @@ function Destination.get_destination(way)
   local rv = ""
 
   if destination_ref and destination_ref ~= "" then
-    rv = rv .. destination_ref
+    rv = rv .. string.gsub(destination_ref, ";", ", ")
   end
 
   if destination and destination ~= "" then

--- a/src/extractor/scripting_environment.cpp
+++ b/src/extractor/scripting_environment.cpp
@@ -14,6 +14,7 @@
 #include "util/typedefs.hpp"
 
 #include <luabind/tag_function.hpp>
+#include <luabind/iterator_policy.hpp>
 #include <luabind/operator.hpp>
 
 #include <osmium/osm.hpp>
@@ -41,6 +42,11 @@ template <class T> double latToDouble(T const &object)
 template <class T> double lonToDouble(T const &object)
 {
     return static_cast<double>(util::toFloating(object.lon));
+}
+
+// Luabind does not like memr funs: instead of casting to the function's signature (mem fun ptr) we simply wrap it
+auto get_nodes_for_way(const osmium::Way& way) -> decltype(way.nodes()) {
+  return way.nodes();
 }
 
 // Error handler
@@ -134,10 +140,19 @@ void ScriptingEnvironment::InitContext(ScriptingEnvironment::Context &context)
                        &ExtractionWay::set_forward_mode)
              .property("backward_mode", &ExtractionWay::get_backward_mode,
                        &ExtractionWay::set_backward_mode),
+         luabind::class_<osmium::WayNodeList>("WayNodeList")
+           .def(luabind::constructor<>()),
+         luabind::class_<osmium::NodeRef>("NodeRef")
+           .def(luabind::constructor<>())
+           // Dear ambitious reader: registering .location() as in:
+           // .def("location", +[](const osmium::NodeRef& nref){ return nref.location(); })
+           // will crash at runtime, since we're not (yet?) using libosnmium's NodeLocationsForWays cache
+           .def("id", &osmium::NodeRef::ref),
          luabind::class_<osmium::Way>("Way")
              .def("get_value_by_key", &osmium::Way::get_value_by_key)
              .def("get_value_by_key", &get_value_by_key<osmium::Way>)
-             .def("id", &osmium::Way::id),
+             .def("id", &osmium::Way::id)
+             .def("get_nodes", get_nodes_for_way, luabind::return_stl_iterator),
          luabind::class_<InternalExtractorEdge>("EdgeSource")
              .def_readonly("source_coordinate", &InternalExtractorEdge::source_coordinate)
              .def_readwrite("weight_data", &InternalExtractorEdge::weight_data),

--- a/taginfo.json
+++ b/taginfo.json
@@ -205,6 +205,16 @@
             "description": "Ref of road for navigation instructions, overrides name."
         },
         {
+            "key": "destination",
+            "object_types": [ "way" ],
+            "description": "Destination of road for navigation instructions, supplements name."
+        },
+        {
+            "key": "destination:ref",
+            "object_types": [ "way" ],
+            "description": "Destination of road for navigation instructions, supplements name."
+        },
+        {
             "key": "junction",
             "object_types": [ "way" ],
             "value": "roundabout"


### PR DESCRIPTION
This first part in our Exit Sign / Destination Sign quest re-wires
the `destination=` and `destination:ref=` tag to the `ref=` tag (in case
it's the highway does not already have a `ref=` tag).

Doing some analysis on both Berlin and San Francisco ([here](https://github.com/Project-OSRM/osrm-backend/issues/2267#issuecomment-215001531)) it looks like this
will add a couple of thousand `ref=` tags that we will announce in guidance.

References:
- https://github.com/Project-OSRM/osrm-backend/issues/2267#issuecomment-214771682
- http://wiki.openstreetmap.org/wiki/Key:destination
- http://wiki.openstreetmap.org/wiki/Proposed_features/Destination_details
- http://taginfo.openstreetmap.org/keys/destination
- http://taginfo.openstreetmap.org/keys/destination%3Aref
- http://taginfo.openstreetmap.org/search?q=destination