### PR TITLE
[NOT READY] Feature/expose node ids

### DIFF
--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -77,7 +77,8 @@ util::json::Object makeRouteStep(guidance::RouteStep step,
 
 util::json::Object makeRoute(const guidance::Route &route,
                              util::json::Array legs,
-                             boost::optional<util::json::Value> geometry);
+                             boost::optional<util::json::Value> geometry,
+                             util::json::Array nodes);
 
 util::json::Object
 makeWaypoint(const util::Coordinate location, std::string name, const Hint &hint);

--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -73,12 +73,12 @@ util::json::Object makeGeoJSONGeometry(ForwardIter begin, ForwardIter end)
 util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver);
 
 util::json::Object makeRouteStep(guidance::RouteStep step,
-                                 boost::optional<util::json::Value> geometry);
+                                 util::json::Value geometry,
+                                 util::json::Value nodes);
 
 util::json::Object makeRoute(const guidance::Route &route,
                              util::json::Array legs,
-                             boost::optional<util::json::Value> geometry,
-                             util::json::Array nodes);
+                             boost::optional<util::json::Value> geometry);
 
 util::json::Object
 makeWaypoint(const util::Coordinate location, std::string name, const Hint &hint);
@@ -86,7 +86,8 @@ makeWaypoint(const util::Coordinate location, std::string name, const Hint &hint
 util::json::Object makeRouteLeg(guidance::RouteLeg leg, util::json::Array steps);
 
 util::json::Array makeRouteLegs(std::vector<guidance::RouteLeg> legs,
-                                std::vector<util::json::Value> step_geometries);
+                                std::vector<util::json::Value> step_geometries,
+                                std::vector<util::json::Value> step_nodelists);
 }
 }
 } // namespace engine

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -83,6 +83,8 @@ class RouteAPI : public BaseAPI
         legs.reserve(number_of_legs);
         leg_geometries.reserve(number_of_legs);
 
+        util::json::Array route_nodes;
+
         for (auto idx : util::irange<std::size_t>(0UL, number_of_legs))
         {
             const auto &phantoms = segment_end_coordinates[idx];
@@ -95,6 +97,12 @@ class RouteAPI : public BaseAPI
                 BaseAPI::facade, path_data, phantoms.source_phantom, phantoms.target_phantom);
             auto leg = guidance::assembleLeg(facade, path_data, leg_geometry, phantoms.source_phantom,
                                              phantoms.target_phantom, reversed_target, parameters.steps);
+
+            std::transform(leg_geometry.osm_node_ids.begin(), leg_geometry.osm_node_ids.end(),
+                    std::back_inserter(route_nodes.values),
+                    [](const OSMNodeID &osm_node) {
+                        return static_cast<util::json::Value>(static_cast<uint64_t>(osm_node));
+                    });
 
             if (parameters.steps)
             {
@@ -178,7 +186,8 @@ class RouteAPI : public BaseAPI
 
         return json::makeRoute(route,
                                json::makeRouteLegs(std::move(legs), std::move(step_geometries)),
-                               std::move(json_overview));
+                               std::move(json_overview),
+                               route_nodes);
     }
 
     const RouteParameters &parameters;

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -65,6 +65,7 @@ class BaseDataFacade
 
     // node and edge information access
     virtual util::Coordinate GetCoordinateOfNode(const unsigned id) const = 0;
+    virtual OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const = 0;
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const = 0;
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -69,6 +69,7 @@ class InternalDataFacade final : public BaseDataFacade
     std::string m_timestamp;
 
     std::shared_ptr<util::ShM<util::Coordinate, false>::vector> m_coordinate_list;
+    std::shared_ptr<util::ShM<OSMNodeID, false>::vector> m_osmnodeid_list;
     util::ShM<NodeID, false>::vector m_via_node_list;
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;
@@ -139,10 +140,12 @@ class InternalDataFacade final : public BaseDataFacade
         unsigned number_of_coordinates = 0;
         nodes_input_stream.read((char *)&number_of_coordinates, sizeof(unsigned));
         m_coordinate_list = std::make_shared<std::vector<util::Coordinate>>(number_of_coordinates);
+        m_osmnodeid_list = std::make_shared<std::vector<OSMNodeID>>(number_of_coordinates);
         for (unsigned i = 0; i < number_of_coordinates; ++i)
         {
             nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
             m_coordinate_list->at(i) = util::Coordinate(current_node.lon, current_node.lat);
+            m_osmnodeid_list->at(i) = current_node.node_id;
             BOOST_ASSERT(m_coordinate_list->at(i).IsValid());
         }
 
@@ -361,6 +364,11 @@ class InternalDataFacade final : public BaseDataFacade
     util::Coordinate GetCoordinateOfNode(const unsigned id) const override final
     {
         return m_coordinate_list->at(id);
+    }
+
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const override final
+    {
+        return m_osmnodeid_list->at(id);
     }
 
     extractor::guidance::TurnInstruction

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -73,6 +73,7 @@ class SharedDataFacade final : public BaseDataFacade
     extractor::ProfileProperties* m_profile_properties;
 
     std::shared_ptr<util::ShM<util::Coordinate, true>::vector> m_coordinate_list;
+    std::shared_ptr<util::ShM<OSMNodeID, true>::vector> m_osmnodeid_list;
     util::ShM<NodeID, true>::vector m_via_node_list;
     util::ShM<unsigned, true>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, true>::vector m_turn_instruction_list;
@@ -416,6 +417,12 @@ class SharedDataFacade final : public BaseDataFacade
     {
         return m_coordinate_list->at(id);
     }
+
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const override final
+    {
+        return m_osmnodeid_list->at(id);
+    }
+
 
     virtual void GetUncompressedGeometry(const EdgeID id,
                                          std::vector<NodeID> &result_nodes) const override final

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -43,6 +43,12 @@ LegGeometry assembleGeometry(const DataFacadeT &facade,
     geometry.segment_offsets.push_back(0);
     geometry.locations.push_back(source_node.location);
 
+    // Need to get the node ID preceeding the source phantom node
+    // TODO: check if this was traversed in reverse???
+    std::vector<NodeID> reverse_geometry;
+    facade.GetUncompressedGeometry(source_node.reverse_packed_geometry_id, reverse_geometry);
+    geometry.osm_node_ids.push_back(facade.GetOSMNodeIDOfNode(reverse_geometry[reverse_geometry.size() - source_node.fwd_segment_position - 1]));
+
     auto current_distance = 0.;
     auto prev_coordinate = geometry.locations.front();
     for (const auto &path_point : leg_data)
@@ -71,6 +77,13 @@ LegGeometry assembleGeometry(const DataFacadeT &facade,
     geometry.segment_distances.push_back(current_distance);
     geometry.segment_offsets.push_back(geometry.locations.size());
     geometry.locations.push_back(target_node.location);
+
+
+    // Need to get the node ID *after* the target phantom node
+    // TODO: check if this was traversed in reverse???
+    std::vector<NodeID> forward_geometry;
+    facade.GetUncompressedGeometry(target_node.forward_packed_geometry_id, forward_geometry);
+    geometry.osm_node_ids.push_back(facade.GetOSMNodeIDOfNode(forward_geometry[target_node.fwd_segment_position]));
 
     BOOST_ASSERT(geometry.segment_distances.size() == geometry.segment_offsets.size() - 1);
     BOOST_ASSERT(geometry.locations.size() > geometry.segment_distances.size());

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -61,6 +61,9 @@ LegGeometry assembleGeometry(const DataFacadeT &facade,
 
         prev_coordinate = coordinate;
         geometry.locations.push_back(std::move(coordinate));
+        // We will only have OSM nodes for the intermediate points, not the start and
+        // end, which are phantom nodes.
+        geometry.osm_node_ids.push_back(facade.GetOSMNodeIDOfNode(path_point.turn_via_node));
     }
     current_distance +=
         util::coordinate_calculation::haversineDistance(prev_coordinate, target_node.location);

--- a/include/engine/guidance/leg_geometry.hpp
+++ b/include/engine/guidance/leg_geometry.hpp
@@ -3,6 +3,7 @@
 
 #include "util/coordinate.hpp"
 #include "util/integer_range.hpp"
+#include "util/typedefs.hpp"
 
 #include <boost/assert.hpp>
 
@@ -30,6 +31,9 @@ struct LegGeometry
     std::vector<std::size_t> segment_offsets;
     // length of the segment in meters
     std::vector<double> segment_distances;
+
+    // The original OSM Node IDs for each coordinate
+    std::vector<OSMNodeID> osm_node_ids;
 
     std::size_t FrontIndex(std::size_t segment_index) const
     {

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -167,7 +167,8 @@ util::json::Object makeRouteStep(guidance::RouteStep step, util::json::Value geo
 
 util::json::Object makeRoute(const guidance::Route &route,
                              util::json::Array legs,
-                             boost::optional<util::json::Value> geometry)
+                             boost::optional<util::json::Value> geometry,
+                             util::json::Array nodes)
 {
     util::json::Object json_route;
     json_route.values["distance"] = std::round(route.distance * 10) / 10.;
@@ -176,6 +177,10 @@ util::json::Object makeRoute(const guidance::Route &route,
     if (geometry)
     {
         json_route.values["geometry"] = *std::move(geometry);
+    }
+    if (nodes.values.size() > 0)
+    {
+        json_route.values["nodes"] = std::move(nodes);
     }
     return json_route;
 }

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -611,6 +611,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
     {
         // fixup the coordinate
         geometry.locations.erase(geometry.locations.begin());
+        geometry.osm_node_ids.erase(geometry.osm_node_ids.begin());
 
         // remove the initial distance value
         geometry.segment_distances.erase(geometry.segment_distances.begin());
@@ -672,6 +673,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
     if (next_to_last_step.distance <= 1)
     {
         geometry.locations.pop_back();
+        geometry.osm_node_ids.pop_back();
         geometry.segment_offsets.pop_back();
         BOOST_ASSERT(geometry.segment_distances.back() < 1);
         geometry.segment_distances.pop_back();

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -47,6 +47,12 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     {
         return {util::FixedLongitude{0}, util::FixedLatitude{0}};
     }
+
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned /* id */) const override
+    {
+        return OSMNodeID{0};
+    }
+
     bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
     unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const override
     {


### PR DESCRIPTION
Reopening #2165 


# This is to address #2054

This change loads the original OSM node ID values into memory along with coordinates, instead of just discarding them.

They are then appended to the `route` object in `trip` and `match` responses, so that the route through the original OSM data can be followed.  These values could then be used with an offline service to get detailed metadata about the route that OSRM does not have the capacity to store/expose.

Current status: 

  - works only with the `InternalDataFacade`
  - will always be 2 nodes short - the nodes just before and just after the PhantomNodes - not sure whether to include these or not, or include a null value so that the node array aligns with the coordinate array.

Edit by @TheMarex:

Todo:
- [ ] Implement shared memory loading
- [ ] Investigate memory overhead on big datasets
- [ ] Write tests
- [ ] Write addition to API spec and discuss (API parameter? default?)
- [ ] Write changelog entry