### PR TITLE
Makes bicycle and foot profile's name and ref tag handling consistent with car profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
    - Profile Changes:
     - introduced a suffix_list / get_name_suffix_list to specify name suffices to be suppressed in name change announcements
+    - street names are now consistently assembled for the car, bike and walk profile as: "Name (Ref)" as in "Berlin (A5)"
 
    - Infrastructure
     - BREAKING: reordered internal instruction types. This breaks the data format

--- a/features/bicycle/names.feature
+++ b/features/bicycle/names.feature
@@ -10,13 +10,13 @@ Feature: Bike - Street names in instructions
             |   | c |
 
         And the ways
-            | nodes | name     |
-            | ab    | My Way   |
-            | bc    | Your Way |
+            | nodes | name     | ref |
+            | ab    | My Way   | A6  |
+            | bc    | Your Way | A7  |
 
         When I route I should get
-            | from | to | route                    |
-            | a    | c  | My Way,Your Way,Your Way |
+            | from | to | route                                   |
+            | a    | c  | My Way (A6),Your Way (A7),Your Way (A7) |
 
     @unnamed
     Scenario: Bike - Use way type to describe unnamed ways

--- a/features/bicycle/ref.feature
+++ b/features/bicycle/ref.feature
@@ -14,7 +14,7 @@ Feature: Bike - Way ref
 
         When I route I should get
             | from | to | route                               |
-            | a    | b  | Utopia Drive / E7,Utopia Drive / E7 |
+            | a    | b  | Utopia Drive (E7),Utopia Drive (E7) |
 
     Scenario: Bike - Way with only ref
         Given the node map

--- a/features/foot/names.feature
+++ b/features/foot/names.feature
@@ -10,13 +10,13 @@ Feature: Foot - Street names in instructions
             |   | c |
 
         And the ways
-            | nodes | name     |
-            | ab    | My Way   |
-            | bc    | Your Way |
+            | nodes | name     | ref |
+            | ab    | My Way   | A6  |
+            | bc    | Your Way | B7  |
 
         When I route I should get
-            | from | to | route                    |
-            | a    | c  | My Way,Your Way,Your Way |
+            | from | to | route                                   |
+            | a    | c  | My Way (A6),Your Way (B7),Your Way (B7) |
 
     @unnamed
     Scenario: Foot - Use way type to describe unnamed ways

--- a/features/foot/ref.feature
+++ b/features/foot/ref.feature
@@ -14,7 +14,7 @@ Feature: Foot - Way ref
 
         When I route I should get
             | from | to | route                               |
-            | a    | b  | Utopia Drive / E7,Utopia Drive / E7 |
+            | a    | b  | Utopia Drive (E7),Utopia Drive (E7) |
 
     Scenario: Foot - Way with only ref
         Given the node map

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -210,7 +210,7 @@ function way_function (way, result)
 
   -- name
   if ref and "" ~= ref and name and "" ~= name then
-    result.name = name .. ' / ' .. ref
+    result.name = name .. " (" .. ref .. ")"
   elseif ref and "" ~= ref then
     result.name = ref
   elseif name and "" ~= name then

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -151,7 +151,7 @@ function way_function (way, result)
 
    -- name
   if ref and "" ~= ref and name and "" ~= name then
-    result.name = name .. ' / ' .. ref
+    result.name = name .. " (" .. ref .. ")"
     elseif ref and "" ~= ref then
       result.name = ref
   elseif name and "" ~= name then


### PR DESCRIPTION
In light of https://github.com/Project-OSRM/osrm-backend/pull/2328 I found the bicycle and foot profile to be inconsistent with how name and ref tags are assembled for a way's name.

Changing to

    Name (Ref)

for consistency.

/cc @systemed for visible changes in bicycle profile responses