### PR TITLE
Turn penalty followups

### DIFF
--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -3,11 +3,11 @@ Feature: Traffic - turn penalties
 
     Background: Evenly spaced grid with multiple intersections
         Given the node map
-            |   | a |   | b |   |
-            | c | d | e | f | g |
-            |   | h |   | i |   |
-            | j | k | l | m | n |
-            |   | o |   | p |   |
+            |      | a:1  |      | b:2  |      |
+            | c:3  | d:4  | e:5  | f:6  | g:7  |
+            |      | h:8  |      | i:9  |      |
+            | j:10 | k:11 | l:12 | m:13 | n:14 |
+            |      | o:15 |      | p:16 |      |
         And the ways
             | nodes | highway |
             | ad    | primary |

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -47,18 +47,27 @@ module.exports = function () {
 
         var addNode = (name, ri, ci, cb) => {
             if (name) {
-                if (name.length !== 1) throw new Error(util.format('*** node invalid name %s, must be single characters', name));
-                if (!name.match(/[a-z0-9]/)) throw new Error(util.format('*** invalid node name %s, must me alphanumeric', name));
-
-                var lonLat;
-                if (name.match(/[a-z]/)) {
-                    if (this.nameNodeHash[name]) throw new Error(util.format('*** duplicate node %s', name));
+                var nodeWithID = name.match(/([a-z])\:([0-9]*)/);
+                if (nodeWithID) {
+                    var nodeName = nodeWithID[1],
+                        nodeID = nodeWithID[2];
+                    if (this.nameNodeHash[nodeName]) throw new Error(util.format('*** duplicate node %s', name));
                     lonLat = this.tableCoordToLonLat(ci, ri);
-                    this.addOSMNode(name, lonLat[0], lonLat[1], null);
+                    this.addOSMNode(nodeName, lonLat[0], lonLat[1], nodeID);
                 } else {
-                    if (this.locationHash[name]) throw new Error(util.format('*** duplicate node %s'), name);
-                    lonLat = this.tableCoordToLonLat(ci, ri);
-                    this.addLocation(name, lonLat[0], lonLat[1], null);
+                    if (name.length !== 1) throw new Error(util.format('*** node invalid name %s, must be single characters', name));
+                    if (!name.match(/[a-z0-9]/)) throw new Error(util.format('*** invalid node name %s, must me alphanumeric', name));
+
+                    var lonLat;
+                    if (name.match(/[a-z]/)) {
+                        if (this.nameNodeHash[name]) throw new Error(util.format('*** duplicate node %s', name));
+                        lonLat = this.tableCoordToLonLat(ci, ri);
+                        this.addOSMNode(name, lonLat[0], lonLat[1], null);
+                    } else {
+                        if (this.locationHash[name]) throw new Error(util.format('*** duplicate node %s'), name);
+                        lonLat = this.tableCoordToLonLat(ci, ri);
+                        this.addLocation(name, lonLat[0], lonLat[1], null);
+                    }
                 }
 
                 cb();

--- a/features/testbot/traffic_turn_penalties.feature
+++ b/features/testbot/traffic_turn_penalties.feature
@@ -3,10 +3,10 @@ Feature: Traffic - turn penalties applied to turn onto which a phantom node snap
 
     Background: Simple map with phantom nodes
         Given the node map
-            |   | 1 |   | 2 |   | 3 |   |
-            | a |   | b |   | c |   | d |
-            |   |   |   |   |   |   |   |
-            |   |   | e |   | f |   | g |
+            |     | 1   |     | 2   |     | 3   |     |
+            | a:1 |     | b:2 |     | c:3 |     | d:4 |
+            |     |     |     |     |     |     |     |
+            |     |     | e:5 |     | f:6 |     | g:7 |
         And the ways
             | nodes | highway |
             | ab    | primary |

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -398,7 +398,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
 
             // Since it's possible duration_until_turn can be less than source_weight here if
             // a negative enough turn penalty is used to modify this edge weight during
-            // osrm-contract, we clamp to 1 here so as not to return a negative duration
+            // osrm-contract, we clamp to 0 here so as not to return a negative duration
             // for this segment.
 
             // TODO this creates a scenario where it's possible the duration from a phantom


### PR DESCRIPTION
Addresses @MoKob and @emiltin comments in b89164c14e0db1739a33d05e4ba96dc22668b2cd — fixes typo in comment and adds the ability to assign IDs in cucumber node maps.