### PR TITLE
Make LeafNode aligned to memory pages.

### DIFF
--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -201,6 +201,8 @@ class StaticRTree
             leaf_node_file.write((char *)&current_leaf, sizeof(current_leaf));
             processed_objects_count += current_leaf.object_count;
         }
+        leaf_node_file.flush();
+        leaf_node_file.close();
 
         std::uint32_t processing_level = 0;
         while (1 < tree_nodes_in_level.size())

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -44,8 +44,7 @@ template <class EdgeDataT,
           class CoordinateListT = std::vector<Coordinate>,
           bool UseSharedMemory = false,
           std::uint32_t BRANCHING_FACTOR = 128,
-          std::uint32_t LEAF_NODE_SIZE = 128,
-          std::uint32_t MAX_NUM_CANDIDATES = LEAF_NODE_SIZE * 10>
+          std::uint32_t LEAF_NODE_SIZE = 128>
 class StaticRTree
 {
   public:
@@ -96,7 +95,7 @@ class StaticRTree
     };
 
     struct TreeIndex { std::uint32_t index; };
-    struct SegmentIndex { std::uint32_t index; };
+    struct SegmentIndex { std::uint32_t index; std::uint32_t object; Coordinate fixed_projected_coordinate; };
     using QueryNodeType = mapbox::util::variant<TreeIndex, SegmentIndex>;
     struct QueryCandidate
     {
@@ -434,11 +433,6 @@ class StaticRTree
         std::priority_queue<QueryCandidate> traversal_queue;
         traversal_queue.push(QueryCandidate{0, TreeIndex{0}});
 
-        // we need to limit the size of this vector to MAX_NUM_CANDIDATES
-        // otherwise this could fill up
-        std::vector<CandidateSegment> candidate_cache;
-        candidate_cache.reserve(LEAF_NODE_SIZE);
-
         while (!traversal_queue.empty())
         {
             QueryCandidate current_query_node = traversal_queue.top();
@@ -451,7 +445,7 @@ class StaticRTree
                 if (current_tree_node.child_is_on_disk)
                 {
                     ExploreLeafNode(current_tree_node.children[0], fixed_projected_coordinate,
-                                    projected_coordinate, traversal_queue, candidate_cache);
+                                    projected_coordinate, traversal_queue);
                 }
                 else
                 {
@@ -461,7 +455,9 @@ class StaticRTree
             else
             {
                 // inspecting an actual road segment
-                auto &current_candidate = candidate_cache[current_query_node.node.template get<SegmentIndex>().index];
+                const auto &segment_index = current_query_node.node.template get<SegmentIndex>();
+                auto edge_data = m_leaves[segment_index.index].objects[segment_index.object];
+                const auto &current_candidate = CandidateSegment{segment_index.fixed_projected_coordinate, edge_data};
 
                 // to allow returns of no-results if too restrictive filtering, this needs to be done here
                 // even though performance would indicate that we want to stop after adding the first candidate
@@ -476,11 +472,11 @@ class StaticRTree
                 {
                     continue;
                 }
-                current_candidate.data.forward_segment_id.enabled &= use_segment.first;
-                current_candidate.data.reverse_segment_id.enabled &= use_segment.second;
+                edge_data.forward_segment_id.enabled &= use_segment.first;
+                edge_data.reverse_segment_id.enabled &= use_segment.second;
 
                 // store phantom node in result vector
-                results.push_back(std::move(current_candidate.data));
+                results.push_back(std::move(edge_data));
             }
         }
 
@@ -492,16 +488,8 @@ class StaticRTree
     void ExploreLeafNode(const std::uint32_t leaf_id,
                          const Coordinate projected_input_coordinate_fixed,
                          const FloatCoordinate &projected_input_coordinate,
-                         QueueT &traversal_queue,
-                         std::vector<CandidateSegment> &candidate_cache)
+                         QueueT &traversal_queue)
     {
-        // we are not going to load any more elements, because the cache would
-        // fill up
-        if (candidate_cache.size() > MAX_NUM_CANDIDATES)
-        {
-            return;
-        }
-
         const LeafNode& current_leaf_node = m_leaves[leaf_id];
 
         // current object represents a block on disk
@@ -520,8 +508,7 @@ class StaticRTree
                 projected_input_coordinate_fixed, projected_nearest);
             // distance must be non-negative
             BOOST_ASSERT(0. <= squared_distance);
-            traversal_queue.push(QueryCandidate{squared_distance, SegmentIndex {static_cast<std::uint32_t>(candidate_cache.size())}});
-            candidate_cache.push_back(CandidateSegment{Coordinate{projected_nearest}, std::move(current_edge)});
+            traversal_queue.push(QueryCandidate{squared_distance, SegmentIndex{leaf_id, i, Coordinate{projected_nearest}}});
         }
     }
 

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -330,16 +330,16 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
 
             using LeafNode = util::StaticRTree<extractor::EdgeBasedNode>::LeafNode;
 
-            std::ifstream leaf_node_file(rtree_leaf_filename, std::ios::binary | std::ios::in);
+            std::ifstream leaf_node_file(rtree_leaf_filename, std::ios::binary | std::ios::in | std::ios::ate);
             if (!leaf_node_file)
             {
                 throw util::exception("Failed to open " + rtree_leaf_filename);
             }
-            uint64_t m_element_count;
-            leaf_node_file.read((char *)&m_element_count, sizeof(uint64_t));
+            std::size_t leaf_nodes_count = leaf_node_file.tellg() / sizeof(LeafNode);
+            leaf_node_file.seekg(0, std::ios::beg);
 
             LeafNode current_node;
-            while (m_element_count > 0)
+            while (leaf_nodes_count > 0)
             {
                 leaf_node_file.read(reinterpret_cast<char *>(&current_node), sizeof(current_node));
 
@@ -435,7 +435,7 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
                         }
                     }
                 }
-                m_element_count -= current_node.object_count;
+                --leaf_nodes_count;
             }
         }
 

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -40,7 +40,7 @@ using TestStaticRTree = StaticRTree<TestData,
                                     false,
                                     TEST_BRANCHING_FACTOR,
                                     TEST_LEAF_NODE_SIZE>;
-using MiniStaticRTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 3>;
+using MiniStaticRTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 128>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 42;
@@ -266,7 +266,7 @@ void construction_test(const std::string &prefix, FixtureT *fixture)
 
 BOOST_FIXTURE_TEST_CASE(construct_tiny, TestRandomGraphFixture_10_30)
 {
-    using TinyTestTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 1>;
+    using TinyTestTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 64>;
     construction_test<TinyTestTree>("test_tiny", this);
 }
 


### PR DESCRIPTION
Hi, i would like to propose the following PR
* LeafNode is aligned to LEAF_PAGE_SIZE.
  Alignment brings 24 bytes memory overhead for 4096, but reduces
  cache misses rate. It will not be seen on small benchmarks, but for large memory consumptions it will be require less systems works to drop least recently used pages.
* Removed unused m_element_count from leaf nodes file.
  The size is computed as m_leaves_region.size() / LEAF_PAGE_SIZE.
* Added try/catch for mmap exceptions messages.
Exceptions will cover non-existing and empty files, but also permissions, memory errors etc