### PR TITLE
remove unnecessary warnings, initialize correctly

### DIFF
--- a/include/engine/guidance/route_step.hpp
+++ b/include/engine/guidance/route_step.hpp
@@ -34,6 +34,11 @@ struct RouteStep
     std::size_t geometry_begin;
     std::size_t geometry_end;
 };
+
+inline RouteStep getInvalidRouteStep()
+{
+    return {0, "", "", 0, 0, TRAVEL_MODE_INACCESSIBLE, getInvalidStepManeuver(), 0, 0};
+}
 }
 }
 }

--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -1,8 +1,8 @@
 #ifndef ENGINE_GUIDANCE_STEP_MANEUVER_HPP
 #define ENGINE_GUIDANCE_STEP_MANEUVER_HPP
 
-#include "util/coordinate.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
+#include "util/coordinate.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -21,7 +21,7 @@ enum class WaypointType : std::uint8_t
     Depart,
 };
 
-//A represenetation of intermediate intersections
+// A represenetation of intermediate intersections
 struct IntermediateIntersection
 {
     double duration;
@@ -39,6 +39,18 @@ struct StepManeuver
     unsigned exit;
     std::vector<IntermediateIntersection> intersections;
 };
+
+inline StepManeuver getInvalidStepManeuver()
+{
+    return {util::Coordinate{util::FloatLongitude{0.0}, util::FloatLatitude{0.0}},
+            0,
+            0,
+            extractor::guidance::TurnInstruction::NO_TURN(),
+            WaypointType::None,
+            0,
+            {}};
+}
+
 } // namespace guidance
 } // namespace engine
 } // namespace osrmn

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -35,8 +35,7 @@ namespace
 // invalidate a step and set its content to nothing
 void invalidateStep(RouteStep &step)
 {
-    step = {};
-    step.maneuver.instruction = TurnInstruction::NO_TURN();
+    step = getInvalidRouteStep();
 }
 
 void print(const std::vector<RouteStep> &steps)

--- a/src/extractor/guidance/classification_data.cpp
+++ b/src/extractor/guidance/classification_data.cpp
@@ -42,7 +42,8 @@ FunctionalRoadClass functionalRoadClassFromTag(std::string const &value)
     }
     else
     {
-        util::SimpleLogger().Write(logDEBUG) << "Unknown road class encountered: " << value;
+        // TODO activate again, when road classes are moved to the profile
+        // util::SimpleLogger().Write(logDEBUG) << "Unknown road class encountered: " << value;
         return FunctionalRoadClass::UNKNOWN;
     }
 }

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -303,20 +303,7 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
     }
     else
     {
-        if (fallback_count++ < 10)
-        {
-            util::SimpleLogger().Write(logWARNING)
-                << "Resolved to keep fallback on complex turn assignment"
-                << "Straightmost: " << straightmost_turn;
-            ;
-            for (const auto &road : intersection)
-            {
-                const auto &out_data = node_based_graph.GetEdgeData(road.turn.eid);
-                util::SimpleLogger().Write(logWARNING)
-                    << "road: " << toString(road) << " Name: " << out_data.name_id
-                    << " Road Class: " << (int)out_data.road_classification.road_class;
-            }
-        }
+        assignTrivialTurns(via_edge,intersection,1,intersection.size());
     }
     return intersection;
 }


### PR DESCRIPTION
Breaking out from char. Route-Step wasn't initialised correctly after invalidation in guidance Post Processing.

I took the change and did some clean-up, removing some currently unnecessary warnings.