### PR TITLE
introduce exit_ramps into the set of instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 5.1.0
    - API:
-     - added roundabout-turn instruction. The instruction indicates a small roundabout that is treated as an intersection
+     - added StepManeuver type `roundabout turn`. The type indicates a small roundabout that is treated as an intersection
         (turn right at the roundabout for first exit, go straight at the roundabout...)
+     - added StepManeuver type `on ramp` and `off ramp` to distinguish between ramps that enter and exit a highway.
      - reduced new name instructions for trivial changes
      - combined multiple turns into a single instruction at segregated roads`
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -430,13 +430,15 @@ step.
   | depart            | indicates the departure of the leg                           |
   | arrive            | indicates the destination of the leg                         |
   | merge             | merge onto a street (e.g. getting on the highway from a ramp, the `modifier specifies the direction of the merge`) |
-  | ramp              | take a ramp to enter/exit a highway (direction given my `modifier`)                          |
+  | ramp              | **Deprecated**. Replaced by `on_ramp` and `off_ramp`.        |
+  | on ramp           | take a ramp to enter a highway (direction given my `modifier`) |
+  | off ramp          | take a ramp to exit a highway (direction given my `modifier`)  |
   | fork              | take the left/right side at a fork depending on `modifier`   |
   | end of road       | road ends in a T intersection turn in direction of `modifier`|
   | continue          | Turn in direction of `modifier` to stay on the same road     |
   | roundabout        | traverse roundabout, has additional field `exit` with NR if the roundabout is left. `the modifier specifies the direction of entering the roundabout` |
   | rotary            | a larger version of a roundabout, can offer `rotary_name` in addition to the `exit` parameter.  |
-  | roundabout_turn | A `roundabout_turn` describes a turn at a small intersection that is modelled as a roundabout. The intersection itself is small and can be overseen as a whole. The `direction modifier` indicates the normal turn direction as we would expect at an intersection. A possible announcement would be: `At the roundabout turn left`. |
+  | roundabout turn   | Describes a turn at a small roundabout that should be treated as normal turn. The `modifier` indicates the turn direciton. Example instruction: `At the roundabout turn left`. |
   | notification      | not an actual turn but a change in the driving conditions. For example the travel mode.  If the road takes a turn itself, the `modifier` describes the direction |
 
   Please note that even though there are `new name` and `notification` instructions, the `mode` and `name` can change

--- a/features/guidance/end-of-road.feature
+++ b/features/guidance/end-of-road.feature
@@ -117,7 +117,7 @@ Feature: End Of Road Instructions
             | bd     | motorway_link |
 
        When I route I should get
-            | waypoints | route    | turns                    |
-            | a,c       | ab,bc,bc | depart,ramp left,arrive  |
-            | a,d       | ab,bd,bd | depart,ramp right,arrive |
+            | waypoints | route    | turns                       |
+            | a,c       | ab,bc,bc | depart,on ramp left,arrive  |
+            | a,d       | ab,bd,bd | depart,on ramp right,arrive |
 

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -16,9 +16,9 @@ Feature: Motorway Guidance
             | bfg    | motorway_link |
 
        When I route I should get
-            | waypoints | route         | turns                           |
-            | a,e       | abcde,abcde   | depart,arrive                   |
-            | a,g       | abcde,bfg,bfg | depart,ramp slight right,arrive |
+            | waypoints | route         | turns                                |
+            | a,e       | abcde,abcde   | depart,arrive                        |
+            | a,g       | abcde,bfg,bfg | depart,off ramp slight right,arrive |
 
     Scenario: Ramp Exit Right Curved Right
         Given the node map
@@ -32,9 +32,9 @@ Feature: Motorway Guidance
             | bfg    | motorway_link |
 
        When I route I should get
-            | waypoints | route         | turns                    |
-            | a,e       | abcde,abcde   | depart,arrive            |
-            | a,g       | abcde,bfg,bfg | depart,ramp right,arrive |
+            | waypoints | route         | turns                         |
+            | a,e       | abcde,abcde   | depart,arrive                 |
+            | a,g       | abcde,bfg,bfg | depart,off ramp right,arrive |
 
     Scenario: Ramp Exit Right Curved Left
         Given the node map
@@ -49,9 +49,9 @@ Feature: Motorway Guidance
             | cfg    | motorway_link |
 
        When I route I should get
-            | waypoints | route         | turns                           |
-            | a,e       | abcde,abcde   | depart,arrive                   |
-            | a,g       | abcde,cfg,cfg | depart,ramp slight right,arrive |
+            | waypoints | route         | turns                                |
+            | a,e       | abcde,abcde   | depart,arrive                        |
+            | a,g       | abcde,cfg,cfg | depart,off ramp slight right,arrive |
 
 
     Scenario: Ramp Exit Left
@@ -65,9 +65,9 @@ Feature: Motorway Guidance
             | bfg    | motorway_link |
 
        When I route I should get
-            | waypoints | route         | turns                          |
-            | a,e       | abcde,abcde   | depart,arrive                  |
-            | a,g       | abcde,bfg,bfg | depart,ramp slight left,arrive |
+            | waypoints | route         | turns                               |
+            | a,e       | abcde,abcde   | depart,arrive                       |
+            | a,g       | abcde,bfg,bfg | depart,off ramp slight left,arrive |
 
     Scenario: Ramp Exit Left Curved Left
         Given the node map
@@ -81,9 +81,9 @@ Feature: Motorway Guidance
             | bfg    | motorway_link |
 
        When I route I should get
-            | waypoints | route         | turns                   |
-            | a,e       | abcde,abcde   | depart,arrive           |
-            | a,g       | abcde,bfg,bfg | depart,ramp left,arrive |
+            | waypoints | route         | turns                        |
+            | a,e       | abcde,abcde   | depart,arrive                |
+            | a,g       | abcde,bfg,bfg | depart,off ramp left,arrive |
 
     Scenario: Ramp Exit Left Curved Right
         Given the node map
@@ -97,9 +97,9 @@ Feature: Motorway Guidance
             | cfg    | motorway_link |
 
        When I route I should get
-            | waypoints | route         | turns                          |
-            | a,e       | abcde,abcde   | depart,arrive                  |
-            | a,g       | abcde,cfg,cfg | depart,ramp slight left,arrive |
+            | waypoints | route         | turns                               |
+            | a,e       | abcde,abcde   | depart,arrive                       |
+            | a,g       | abcde,cfg,cfg | depart,off ramp slight left,arrive |
 
     Scenario: On Ramp Right
         Given the node map
@@ -176,11 +176,11 @@ Feature: Motorway Guidance
             | chi    | motorway_link |
 
        When I route I should get
-            | waypoints | route           | turns                           |
-            | a,e       | abcde,abcde     | depart,arrive                   |
-            | f,e       | fgc,abcde,abcde | depart,merge slight left,arrive |
-            | a,i       | abcde,chi,chi   | depart,ramp slight right,arrive |
-            | f,i       | fgc,chi,chi     | depart,ramp right,arrive        |
+            | waypoints | route           | turns                                |
+            | a,e       | abcde,abcde     | depart,arrive                        |
+            | f,e       | fgc,abcde,abcde | depart,merge slight left,arrive      |
+            | a,i       | abcde,chi,chi   | depart,off ramp slight right,arrive |
+            | f,i       | fgc,chi,chi     | depart,off ramp right,arrive        |
 
     Scenario: On And Off Ramp Left
        Given the node map
@@ -194,11 +194,11 @@ Feature: Motorway Guidance
             | chi    | motorway_link |
 
        When I route I should get
-            | waypoints | route           | turns                            |
-            | a,e       | abcde,abcde     | depart,arrive                    |
-            | f,e       | fgc,abcde,abcde | depart,merge slight right,arrive |
-            | a,i       | abcde,chi,chi   | depart,ramp slight left,arrive   |
-            | f,i       | fgc,chi,chi     | depart,ramp left,arrive          |
+            | waypoints | route           | turns                               |
+            | a,e       | abcde,abcde     | depart,arrive                       |
+            | f,e       | fgc,abcde,abcde | depart,merge slight right,arrive    |
+            | a,i       | abcde,chi,chi   | depart,off ramp slight left,arrive |
+            | f,i       | fgc,chi,chi     | depart,off ramp left,arrive        |
 
     Scenario: Merging Motorways
         Given the node map

--- a/features/guidance/ramp.feature
+++ b/features/guidance/ramp.feature
@@ -16,8 +16,8 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route     | turns                    |
-            | a,d       | abc,bd,bd | depart,ramp right,arrive |
+            | waypoints | route     | turns                          |
+            | a,d       | abc,bd,bd | depart,on ramp right,arrive |
 
     Scenario: Ramp On Through Street Left
         Given the node map
@@ -30,8 +30,8 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route     | turns                   |
-            | a,d       | abc,bd,bd | depart,ramp left,arrive |
+            | waypoints | route     | turns                         |
+            | a,d       | abc,bd,bd | depart,on ramp left,arrive |
 
     Scenario: Ramp On Through Street Left and Right
         Given the node map
@@ -46,9 +46,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route     | turns                    |
-            | a,d       | abc,bd,bd | depart,ramp right,arrive |
-            | a,e       | abc,be,be | depart,ramp left,arrive  |
+            | waypoints | route     | turns                          |
+            | a,d       | abc,bd,bd | depart,on ramp right,arrive |
+            | a,e       | abc,be,be | depart,on ramp left,arrive  |
 
     Scenario: Ramp On Three Way Intersection Right
         Given the node map
@@ -62,8 +62,8 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route    | turns                    |
-            | a,d       | ab,bd,bd | depart,ramp right,arrive |
+            | waypoints | route    | turns                          |
+            | a,d       | ab,bd,bd | depart,on ramp right,arrive |
 
     Scenario: Ramp On Three Way Intersection Right
         Given the node map
@@ -78,8 +78,8 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route    | turns                    |
-            | a,d       | ab,bd,bd | depart,ramp right,arrive |
+            | waypoints | route    | turns                          |
+            | a,d       | ab,bd,bd | depart,on ramp right,arrive |
 
     Scenario: Ramp Off Though Street
         Given the node map
@@ -93,9 +93,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route     | turns                    |
-            | a,d       | abc,bd,bd | depart,ramp right,arrive |
-            | a,c       | abc,abc   | depart,arrive            |
+            | waypoints | route     | turns                          |
+            | a,d       | abc,bd,bd | depart,on ramp right,arrive |
+            | a,c       | abc,abc   | depart,arrive                  |
 
     Scenario: Straight Ramp Off Turning Though Street
         Given the node map
@@ -108,9 +108,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route       | turns                       |
-            | a,d       | abc,bd,bd   | depart,ramp straight,arrive |
-            | a,c       | abc,abc,abc | depart,continue left,arrive |
+            | waypoints | route       | turns                             |
+            | a,d       | abc,bd,bd   | depart,on ramp straight,arrive |
+            | a,c       | abc,abc,abc | depart,continue left,arrive       |
 
     Scenario: Fork Ramp Off Turning Though Street
         Given the node map
@@ -124,9 +124,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route       | turns                       |
-            | a,d       | abc,bd,bd   | depart,ramp right,arrive    |
-            | a,c       | abc,abc,abc | depart,continue left,arrive |
+            | waypoints | route       | turns                             |
+            | a,d       | abc,bd,bd   | depart,on ramp right,arrive    |
+            | a,c       | abc,abc,abc | depart,continue left,arrive       |
 
     Scenario: Fork Ramp
         Given the node map
@@ -141,9 +141,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route    | turns                    |
-            | a,d       | ab,bd,bd | depart,ramp right,arrive |
-            | a,c       | ab,bc,bc | depart,turn left,arrive  |
+            | waypoints | route    | turns                          |
+            | a,d       | ab,bd,bd | depart,on ramp right,arrive |
+            | a,c       | ab,bc,bc | depart,turn left,arrive        |
 
     Scenario: Fork Slight Ramp
         Given the node map
@@ -158,9 +158,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,d       | ab,bd,bd | depart,ramp slight right,arrive |
-            | a,c       | ab,bc,bc | depart,turn slight left,arrive  |
+            | waypoints | route    | turns                                 |
+            | a,d       | ab,bd,bd | depart,on ramp slight right,arrive |
+            | a,c       | ab,bc,bc | depart,turn slight left,arrive        |
 
     Scenario: Fork Slight Ramp on Through Street
         Given the node map
@@ -174,9 +174,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route       | turns                              |
-            | a,d       | abc,bd,bd   | depart,ramp slight right,arrive    |
-            | a,c       | abc,abc,abc | depart,continue slight left,arrive |
+            | waypoints | route       | turns                                    |
+            | a,d       | abc,bd,bd   | depart,on ramp slight right,arrive    |
+            | a,c       | abc,abc,abc | depart,continue slight left,arrive       |
 
     Scenario: Fork Slight Ramp on Obvious Through Street
         Given the node map
@@ -190,9 +190,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route     | turns                           |
-            | a,d       | abc,bd,bd | depart,ramp slight right,arrive |
-            | a,c       | abc,abc   | depart,arrive                   |
+            | waypoints | route     | turns                                 |
+            | a,d       | abc,bd,bd | depart,on ramp slight right,arrive |
+            | a,c       | abc,abc   | depart,arrive                         |
 
     Scenario: Two Ramps Joining into common Motorway
         Given the node map

--- a/features/guidance/roundabout-turn.feature
+++ b/features/guidance/roundabout-turn.feature
@@ -23,18 +23,18 @@ Feature: Basic Roundabout
 
        When I route I should get
            | waypoints | route    | turns                                         |
-           | a,d       | ab,cd,cd | depart,roundabout_turn left exit-3,arrive     |
-           | a,f       | ab,ef,ef | depart,roundabout_turn straight exit-2,arrive |
-           | a,h       | ab,gh,gh | depart,roundabout_turn right exit-1,arrive    |
-           | d,f       | cd,ef,ef | depart,roundabout_turn left exit-3,arrive     |
-           | d,h       | cd,gh,gh | depart,roundabout_turn straight exit-2,arrive |
-           | d,a       | cd,ab,ab | depart,roundabout_turn right exit-1,arrive    |
-           | f,h       | ef,gh,gh | depart,roundabout_turn left exit-3,arrive     |
-           | f,a       | ef,ab,ab | depart,roundabout_turn straight exit-2,arrive |
-           | f,d       | ef,cd,cd | depart,roundabout_turn right exit-1,arrive    |
-           | h,a       | gh,ab,ab | depart,roundabout_turn left exit-3,arrive     |
-           | h,d       | gh,cd,cd | depart,roundabout_turn straight exit-2,arrive |
-           | h,f       | gh,ef,ef | depart,roundabout_turn right exit-1,arrive    |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-3,arrive     |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-1,arrive    |
+           | d,f       | cd,ef,ef | depart,roundabout turn left exit-3,arrive     |
+           | d,h       | cd,gh,gh | depart,roundabout turn straight exit-2,arrive |
+           | d,a       | cd,ab,ab | depart,roundabout turn right exit-1,arrive    |
+           | f,h       | ef,gh,gh | depart,roundabout turn left exit-3,arrive     |
+           | f,a       | ef,ab,ab | depart,roundabout turn straight exit-2,arrive |
+           | f,d       | ef,cd,cd | depart,roundabout turn right exit-1,arrive    |
+           | h,a       | gh,ab,ab | depart,roundabout turn left exit-3,arrive     |
+           | h,d       | gh,cd,cd | depart,roundabout turn straight exit-2,arrive |
+           | h,f       | gh,ef,ef | depart,roundabout turn right exit-1,arrive    |
 
     Scenario: Enter and Exit - Rotated
         Given the node map
@@ -53,18 +53,18 @@ Feature: Basic Roundabout
 
        When I route I should get
            | waypoints | route    | turns                                         |
-           | a,d       | ab,cd,cd | depart,roundabout_turn left exit-3,arrive     |
-           | a,f       | ab,ef,ef | depart,roundabout_turn straight exit-2,arrive |
-           | a,h       | ab,gh,gh | depart,roundabout_turn right exit-1,arrive    |
-           | d,f       | cd,ef,ef | depart,roundabout_turn left exit-3,arrive     |
-           | d,h       | cd,gh,gh | depart,roundabout_turn straight exit-2,arrive |
-           | d,a       | cd,ab,ab | depart,roundabout_turn right exit-1,arrive    |
-           | f,h       | ef,gh,gh | depart,roundabout_turn left exit-3,arrive     |
-           | f,a       | ef,ab,ab | depart,roundabout_turn straight exit-2,arrive |
-           | f,d       | ef,cd,cd | depart,roundabout_turn right exit-1,arrive    |
-           | h,a       | gh,ab,ab | depart,roundabout_turn left exit-3,arrive     |
-           | h,d       | gh,cd,cd | depart,roundabout_turn straight exit-2,arrive |
-           | h,f       | gh,ef,ef | depart,roundabout_turn right exit-1,arrive    |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-3,arrive     |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-1,arrive    |
+           | d,f       | cd,ef,ef | depart,roundabout turn left exit-3,arrive     |
+           | d,h       | cd,gh,gh | depart,roundabout turn straight exit-2,arrive |
+           | d,a       | cd,ab,ab | depart,roundabout turn right exit-1,arrive    |
+           | f,h       | ef,gh,gh | depart,roundabout turn left exit-3,arrive     |
+           | f,a       | ef,ab,ab | depart,roundabout turn straight exit-2,arrive |
+           | f,d       | ef,cd,cd | depart,roundabout turn right exit-1,arrive    |
+           | h,a       | gh,ab,ab | depart,roundabout turn left exit-3,arrive     |
+           | h,d       | gh,cd,cd | depart,roundabout turn straight exit-2,arrive |
+           | h,f       | gh,ef,ef | depart,roundabout turn right exit-1,arrive    |
 
     Scenario: Only Enter
         Given the node map
@@ -263,8 +263,8 @@ Feature: Basic Roundabout
 
         When I route I should get
             | waypoints | route    | turns                                         |
-            | a,e       | ab,ce,ce | depart,roundabout_turn straight exit-1,arrive |
-            | a,f       | ab,df,df | depart,roundabout_turn left exit-2,arrive     |
+            | a,e       | ab,ce,ce | depart,roundabout turn straight exit-1,arrive |
+            | a,f       | ab,df,df | depart,roundabout turn left exit-2,arrive     |
 
        Scenario: Collinear in X,Y
         Given the node map
@@ -282,8 +282,8 @@ Feature: Basic Roundabout
 
         When I route I should get
             | waypoints | route    | turns                                         |
-            | a,e       | ad,be,be | depart,roundabout_turn straight exit-1,arrive |
-            | a,f       | ad,cf,cf | depart,roundabout_turn left exit-2,arrive     |
+            | a,e       | ad,be,be | depart,roundabout turn straight exit-1,arrive |
+            | a,f       | ad,cf,cf | depart,roundabout turn left exit-2,arrive     |
 
        Scenario: Collinear in X,Y
         Given the node map
@@ -301,8 +301,8 @@ Feature: Basic Roundabout
 
         When I route I should get
             | waypoints | route    | turns                                         |
-            | a,e       | ac,de,de | depart,roundabout_turn straight exit-1,arrive |
-            | a,f       | ac,bf,bf | depart,roundabout_turn left exit-2,arrive     |
+            | a,e       | ac,de,de | depart,roundabout turn straight exit-1,arrive |
+            | a,f       | ac,bf,bf | depart,roundabout turn left exit-2,arrive     |
 
     Scenario: Enter and Exit -- too complex
         Given the node map

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -142,6 +142,9 @@ module.exports = function () {
                 case 'depart':
                 case 'arrive':
                     return v.maneuver.type;
+                case 'on ramp':
+                case 'off ramp':
+                    return v.maneuver.type + ' ' + v.maneuver.modifier;
                 case 'roundabout':
                     return 'roundabout-exit-' + v.maneuver.exit;
                 case 'rotary':
@@ -149,7 +152,7 @@ module.exports = function () {
                         return v.rotary_name + '-exit-' + v.maneuver.exit;
                     else
                         return 'rotary-exit-' + v.maneuver.exit;
-                case 'roundabout_turn':
+                case 'roundabout turn':
                     return v.maneuver.type + ' ' + v.maneuver.modifier + ' exit-' + v.maneuver.exit;
                 // FIXME this is a little bit over-simplistic for merge/fork instructions
                 default:

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -43,7 +43,8 @@ enum TurnType // at the moment we can support 32 turn types, without increasing 
     Continue,                           // remain on a street
     Turn,                               // basic turn
     Merge,                              // merge onto a street
-    Ramp,                               // special turn (highway ramp exits)
+    OnRamp,                             // special turn (highway ramp on-ramps)
+    OffRamp,                            // special turn, highway exit
     Fork,                               // fork road splitting up
     EndOfRoad,                          // T intersection
     Notification,                       // Travel Mode Changes, Restrictions apply...

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -33,11 +33,31 @@ const constexpr char *modifier_names[] = {"uturn",    "sharp right", "right", "s
 
 // translations of TurnTypes. Not all types are exposed to the outside world.
 // invalid types should never be returned as part of the API
-const constexpr char *turn_type_names[] = {
-    "invalid", "new name",        "continue",        "turn",       "merge",      "ramp",
-    "fork",    "end of road",     "notification",    "roundabout", "roundabout", "rotary",
-    "rotary",  "roundabout_turn", "roundabout_turn", "invalid",    "invalid",    "invalid",
-    "invalid", "invalid",         "invalid",         "invalid",    "invalid",    "invalid"};
+const constexpr char *turn_type_names[] = {"invalid",
+                                           "new name",
+                                           "continue",
+                                           "turn",
+                                           "merge",
+                                           "on ramp",
+                                           "off ramp",
+                                           "fork",
+                                           "end of road",
+                                           "notification",
+                                           "roundabout",
+                                           "roundabout",
+                                           "rotary",
+                                           "rotary",
+                                           "roundabout turn",
+                                           "roundabout turn",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid",
+                                           "invalid"};
 
 const constexpr char *waypoint_type_names[] = {"invalid", "arrive", "depart"};
 
@@ -128,7 +148,9 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
 {
     util::json::Object step_maneuver;
     if (maneuver.waypoint_type == guidance::WaypointType::None)
+    {
         step_maneuver.values["type"] = detail::instructionTypeToString(maneuver.instruction.type);
+    }
     else
         step_maneuver.values["type"] = detail::waypointTypeToString(maneuver.waypoint_type);
 

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -54,7 +54,7 @@ TurnType IntersectionHandler::findBasicTurnType(const EdgeID via_edge,
     bool onto_ramp = isRampClass(out_data.road_classification.road_class);
 
     if (!on_ramp && onto_ramp)
-        return TurnType::Ramp;
+        return TurnType::OnRamp;
 
     if (in_data.name_id == out_data.name_id && in_data.name_id != INVALID_NAME_ID)
     {
@@ -73,9 +73,9 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
     // handle travel modes:
     const auto in_mode = node_based_graph.GetEdgeData(via_edge).travel_mode;
     const auto out_mode = node_based_graph.GetEdgeData(road.turn.eid).travel_mode;
-    if (type == TurnType::Ramp)
+    if (type == TurnType::OnRamp)
     {
-        return {TurnType::Ramp, getTurnDirection(road.turn.angle)};
+        return {TurnType::OnRamp, getTurnDirection(road.turn.angle)};
     }
 
     if (angularDeviation(road.turn.angle, 0) < 0.01)

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -177,18 +177,18 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
     {
         if (intersection[1].entry_allowed)
         {
-            if (TurnType::Ramp != findBasicTurnType(via_edge, intersection[1]))
+            if (TurnType::OnRamp != findBasicTurnType(via_edge, intersection[1]))
                 intersection[1].turn.instruction = {TurnType::EndOfRoad, DirectionModifier::Right};
             else
-                intersection[1].turn.instruction = {TurnType::Ramp, DirectionModifier::Right};
+                intersection[1].turn.instruction = {TurnType::OnRamp, DirectionModifier::Right};
         }
         if (intersection[2].entry_allowed)
         {
-            if (TurnType::Ramp != findBasicTurnType(via_edge, intersection[2]))
+            if (TurnType::OnRamp != findBasicTurnType(via_edge, intersection[2]))
 
                 intersection[2].turn.instruction = {TurnType::EndOfRoad, DirectionModifier::Left};
             else
-                intersection[2].turn.instruction = {TurnType::Ramp, DirectionModifier::Left};
+                intersection[2].turn.instruction = {TurnType::OnRamp, DirectionModifier::Left};
         }
     }
     else
@@ -220,7 +220,6 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
 
 Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection intersection) const
 {
-    static int fallback_count = 0;
     const std::size_t obvious_index = findObviousTurn(via_edge, intersection);
     const auto fork_range = findFork(intersection);
     std::size_t straightmost_turn = 0;


### PR DESCRIPTION
Currently we emit only a single ramp type. Off-ramps are conceived differently than on-ramps.
While an on-ramp is essentially a normal turn with the additional information of a ramp,

e.g. 
<img width="444" alt="screen shot 2016-05-03 at 11 12 30" src="https://cloud.githubusercontent.com/assets/12932279/14982152/9ed3821a-1134-11e6-9cd1-d115ff259988.png">

For which we would expect something like `Go straight onto the ramp towards *destination*`,

or 
<img width="609" alt="screen shot 2016-05-03 at 13 41 59" src="https://cloud.githubusercontent.com/assets/12932279/14982190/dc9e3acc-1134-11e6-8dd4-0167c2757d41.png">

For which I would expect an instruction like `Turn left/right onto the ramp towards *destination*`

Off ramps are essentially only required for their side of the highway.

<img width="360" alt="screen shot 2016-05-03 at 13 44 18" src="https://cloud.githubusercontent.com/assets/12932279/14982228/30276254-1135-11e6-9ae3-aea04d696f6f.png">

Here I would expect `Take exit NR towards *destination*` if the exit is on the normal side (probably hard to do right now) or `Take exit NR on the left towards *destination*`, in case of an unusual exit that is located on the left.
<img width="204" alt="screen shot 2016-05-03 at 13 47 10" src="https://cloud.githubusercontent.com/assets/12932279/14982284/989f1804-1135-11e6-8fa9-072f7dcb0e1a.png">

- [x] update readme

- [ ] integrate downstream ( @karenzshea , new instruction coming down )