### PR TITLE
fix new-name on empty strings

### DIFF
--- a/features/guidance/new-name.feature
+++ b/features/guidance/new-name.feature
@@ -133,3 +133,34 @@ Feature: New-Name Instructions
        When I route I should get
             | waypoints | route    | turns                               |
             | a,c       | ab,bc,bc | depart,new name slight right,arrive |
+
+    Scenario: Empty road names - Announce Change From, suppress Change To
+        Given the node map
+            | a |  | b |  | c |  | d |
+
+        And the ways
+            | nodes | name |
+            | ab    | ab   |
+            | bc    |      |
+            | cd    | cd   |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,d       | ab,cd,cd | depart,new name straight,arrive |
+            | a,c       | ab,      | depart,arrive                   |
+
+    Scenario: Empty road names - Loose name shortly
+        Given the node map
+            | a |  | b |  | c |  | d |  | e |
+
+        And the ways
+            | nodes | name      |
+            | ab    | name      |
+            | bc    | with-name |
+            | cd    |           |
+            | de    | with-name |
+
+        When I route I should get
+            | waypoints | route                    | turns                           |
+            | a,e       | name,with-name,with-name | depart,new name straight,arrive |
+            | b,e       | with-name,with-name      | depart,arrive                   |

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -325,6 +325,10 @@ inline bool requiresNameAnnounced(const std::string &from,
                                   const std::string &to,
                                   const SuffixTable &suffix_table)
 {
+    //first is empty and the second is not
+    if(from.empty() && !to.empty())
+        return true;
+
     // FIXME, handle in profile to begin with?
     // this uses the encoding of references in the profile, which is very BAD
     // Input for this function should be a struct separating streetname, suffix (e.g. road,


### PR DESCRIPTION
Handling new-name instructions for empty segments offers undesired behaviour right now.

Coming from an empty segment, the new name is not announced.

I propose the following announcements:

From `empty name` to `name`: announce new-name = name. (Even though technically most likely a data error, the announcement makes sure we can get the most out of it in post-processing).

From `name` to `empty name`: don't announce anything (instruction would be: Road looses road-name which would be a data-error anyhow).