### PR TITLE
Register a way's .nodes() function for use in the profile's way_function

### DIFF
--- a/src/extractor/scripting_environment.cpp
+++ b/src/extractor/scripting_environment.cpp
@@ -14,6 +14,7 @@
 #include "util/typedefs.hpp"
 
 #include <luabind/tag_function.hpp>
+#include <luabind/iterator_policy.hpp>
 #include <luabind/operator.hpp>
 
 #include <osmium/osm.hpp>
@@ -41,6 +42,11 @@ template <class T> double latToDouble(T const &object)
 template <class T> double lonToDouble(T const &object)
 {
     return static_cast<double>(util::toFloating(object.lon));
+}
+
+// Luabind does not like memr funs: instead of casting to the function's signature (mem fun ptr) we simply wrap it
+auto get_nodes_for_way(const osmium::Way& way) -> decltype(way.nodes()) {
+  return way.nodes();
 }
 
 // Error handler
@@ -134,10 +140,19 @@ void ScriptingEnvironment::InitContext(ScriptingEnvironment::Context &context)
                        &ExtractionWay::set_forward_mode)
              .property("backward_mode", &ExtractionWay::get_backward_mode,
                        &ExtractionWay::set_backward_mode),
+         luabind::class_<osmium::WayNodeList>("WayNodeList")
+           .def(luabind::constructor<>()),
+         luabind::class_<osmium::NodeRef>("NodeRef")
+           .def(luabind::constructor<>())
+           // Dear ambitious reader: registering .location() as in:
+           // .def("location", +[](const osmium::NodeRef& nref){ return nref.location(); })
+           // will crash at runtime, since we're not (yet?) using libosnmium's NodeLocationsForWays cache
+           .def("id", &osmium::NodeRef::ref),
          luabind::class_<osmium::Way>("Way")
              .def("get_value_by_key", &osmium::Way::get_value_by_key)
              .def("get_value_by_key", &get_value_by_key<osmium::Way>)
-             .def("id", &osmium::Way::id),
+             .def("id", &osmium::Way::id)
+             .def("get_nodes", get_nodes_for_way, luabind::return_stl_iterator),
          luabind::class_<InternalExtractorEdge>("EdgeSource")
              .def_readonly("source_coordinate", &InternalExtractorEdge::source_coordinate)
              .def_readwrite("weight_data", &InternalExtractorEdge::weight_data),


### PR DESCRIPTION
Ripped out from: https://github.com/Project-OSRM/osrm-backend/pull/2328

Can be used as in:

    function way_function(way, result)
      for node in way:get_nodes() do
        local id = node:id()
        io.write(">>> " .. id .. "\n")
      end

      -- ...
    end

Warning: we do not use libosmium's location cache, therefore .location()
on the nodes will crash at runtime. Once we switch to using libosmium's
cache this should work. Until then, you can use the node id now.

