### PR TITLE
Fix #2362 by using generic path strings

### DIFF
--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -7,7 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/interprocess/mapped_region.hpp>
-#ifndef WIN32
+#ifndef _WIN32
 #include <boost/interprocess/xsi_shared_memory.hpp>
 #else
 #include <boost/interprocess/shared_memory_object.hpp>
@@ -39,7 +39,7 @@ struct OSRMLockFile
     }
 };
 
-#ifndef WIN32
+#ifndef _WIN32
 class SharedMemory
 {
 

--- a/include/util/lua_util.hpp
+++ b/include/util/lua_util.hpp
@@ -43,8 +43,7 @@ inline bool luaFunctionExists(lua_State *lua_state, const char *name)
 inline void luaAddScriptFolderToLoadPath(lua_State *lua_state, const char *file_name)
 {
     boost::filesystem::path profile_path = boost::filesystem::canonical(file_name);
-    std::string folder = profile_path.parent_path().string();
-    // TODO: This code is most probably not Windows safe since it uses UNIX'ish path delimiters
+    std::string folder = profile_path.parent_path().generic_string();
     const std::string lua_code = "package.path = \"" + folder + "/?.lua;\" .. package.path";
     luaL_dostring(lua_state, lua_code.c_str());
 }


### PR DESCRIPTION
In windows native strings in Lua incorrectly
interpreted because native separators must be escaped.
Use of generic strings prevent use of backslashes and
"Generic paths are portable and independent of the operating system.".