### PR TITLE
Approximation of latToY function

### DIFF
--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -74,9 +74,9 @@ class StaticRTree
     struct LeafNode
     {
         LeafNode() : object_count(0), objects() {}
-        uint32_t object_count;
+        std::uint32_t object_count;
         std::array<EdgeDataT, LEAF_NODE_SIZE> objects;
-        unsigned char leaf_page_padding[LEAF_PAGE_SIZE - sizeof(object_count) - sizeof(objects)];
+        unsigned char leaf_page_padding[LEAF_PAGE_SIZE - sizeof(std::uint32_t) - sizeof(std::array<EdgeDataT, LEAF_NODE_SIZE>)];
     };
     static_assert(sizeof(LeafNode) == LEAF_PAGE_SIZE, "LeafNode size does not fit the page size");
 

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -35,7 +35,7 @@ inline FloatLatitude yToLat(const double y)
     const double normalized_lat =
         detail::RAD_TO_DEGREE * 2. * std::atan(std::exp(clamped_y * detail::DEGREE_TO_RAD));
 
-    return FloatLatitude(normalized_lat - 90.);
+    return FloatLatitude(std::round(normalized_lat * COORDINATE_PRECISION) / COORDINATE_PRECISION - 90.);
 }
 
 inline double latToY(const FloatLatitude latitude)
@@ -45,6 +45,31 @@ inline double latToY(const FloatLatitude latitude)
     const double y = detail::RAD_TO_DEGREE * 0.5 * std::log((1 + f) / (1 - f));
     const auto clamped_y = std::max(-180., std::min(180., y));
     return clamped_y;
+}
+
+template<typename T>
+constexpr double horner(double, T an) { return an; }
+
+template<typename T, typename... U>
+constexpr double horner(double x, T an, U ...a) { return horner(x, a...) * x + an; }
+
+inline double latToYapprox(const FloatLatitude latitude)
+{
+    if (latitude < FloatLatitude(-70.) || latitude > FloatLatitude(70.))
+        return latToY(latitude);
+
+    // Approximate the inverse Gudermannian function with the Padé approximant [11/11]: deg → deg
+    // Coefficients are computed for the argument range [-70°,70°] by Remez algorithm |err|_∞=3.387e-12
+    const auto x = static_cast<double>(latitude);
+    return
+        horner(x, 0.00000000000000000000000000e+00,  1.00000000000089108431373566e+00,  2.34439410386997223035693483e-06,
+                 -3.21291701673364717170998957e-04, -6.62778508496089940141103135e-10,  3.68188055470304769936079078e-08,
+                  6.31192702320492485752941578e-14, -1.77274453235716299127325443e-12, -2.24563810831776747318521450e-18,
+                  3.13524754818073129982475171e-17,  2.09014225025314211415458228e-23, -9.82938075991732185095509716e-23) /
+        horner(x, 1.00000000000000000000000000e+00,  2.34439410398970701719081061e-06, -3.72061271627251952928813333e-04,
+                 -7.81802389685429267252612620e-10,  5.18418724186576447072888605e-08,  9.37468561198098681003717477e-14,
+                 -3.30833288607921773936702558e-12, -4.78446279888774903983338274e-18,  9.32999229169156878168234191e-17,
+                  9.17695141954265959600965170e-23, -8.72130728982012387640166055e-22, -3.23083224835967391884404730e-28);
 }
 
 inline FloatLatitude clamp(const FloatLatitude lat)
@@ -87,7 +112,7 @@ inline double degreeToPixel(FloatLatitude lat, unsigned zoom)
 
 inline FloatCoordinate fromWGS84(const FloatCoordinate &wgs84_coordinate)
 {
-    return {wgs84_coordinate.lon, FloatLatitude{latToY(wgs84_coordinate.lat)}};
+    return {wgs84_coordinate.lon, FloatLatitude{latToYapprox(wgs84_coordinate.lat)}};
 }
 
 inline FloatCoordinate toWGS84(const FloatCoordinate &mercator_coordinate)


### PR DESCRIPTION
Hello, 
i have made an approximation of the latToY function by the Pade approximation. 
The range is [-70,70] degrees, the error is bounded by 4e-12, so it almost twice coordinate precision.
The approximation order [11/11] is the most possible for double precision.
The approximation now requires 22 multiplications and additions, and one division instead of log and sin.
I also changed in  yToLat to rounding to the coordinate precision instead of truncation, this will improve average value of quadratic quantization error by factor 2.

Here is the approximation error
![pade11_deg](https://cloud.githubusercontent.com/assets/4421046/15052794/aa18e616-12ff-11e6-9899-00b84abdcc42.png)
and maxima code
```
P:[0.00000000000000000000000000e+00, 1.00000000000089108431373566e+00, 2.34439410386997223035693483e-06, -3.21291701673364717170998957e-04, -6.62778508496089940141103135e-10, 3.68188055470304769936079078e-08, 6.31192702320492485752941578e-14, -1.77274453235716299127325443e-12, -2.24563810831776747318521450e-18, 3.13524754818073129982475171e-17, 2.09014225025314211415458228e-23, -9.82938075991732185095509716e-23];
Q:[1.00000000000000000000000000e+00, 2.34439410398970701719081061e-06, -3.72061271627251952928813333e-04, -7.81802389685429267252612620e-10, 5.18418724186576447072888605e-08, 9.37468561198098681003717477e-14, -3.30833288607921773936702558e-12, -4.78446279888774903983338274e-18, 9.32999229169156878168234191e-17, 9.17695141954265959600965170e-23, -8.72130728982012387640166055e-22, -3.23083224835967391884404730e-28];

horner3(p,x):=rreduce(lambda([a,y],x*y+a),p);
r(x):=horner3(P,x)/horner3(Q,x);
f(x):= 180./%pi*log(tan(%pi / 4. + (%pi*x/180.) / 2.));
plot2d([f(x)-r(x)], [x, -70, 70])$
```

The approximation lowers  in test_benchmark part of ExploreLeafNode from 48% to 30% and in time from 490us to 311us. In pure rtree benchmark with 10000 requests time per coordinate is lowered from 320us to 55us.
