### PR TITLE
Faster rtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
    - Infrastructure
     - BREAKING: reordered internal instruction types. This breaks the **data format**
+    - BREAKING: Changed the on-disk encoding of the StaticRTree for better performance. This breaks the **data format**
 
    - Fixes:
     - Issue #2310: post-processing for local paths, fixes #2310

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -90,47 +90,47 @@ class BaseDataFacade
     virtual extractor::TravelMode GetTravelModeForEdgeID(const unsigned id) const = 0;
 
     virtual std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate south_west,
-                                                 const util::Coordinate north_east) = 0;
+                                                 const util::Coordinate north_east) const = 0;
 
     virtual std::vector<PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
                                const float max_distance,
                                const int bearing,
-                               const int bearing_range) = 0;
+                               const int bearing_range) const = 0;
     virtual std::vector<PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
-                               const float max_distance) = 0;
+                               const float max_distance) const = 0;
 
     virtual std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
                         const double max_distance,
                         const int bearing,
-                        const int bearing_range) = 0;
+                        const int bearing_range) const = 0;
     virtual std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
                         const int bearing,
-                        const int bearing_range) = 0;
+                        const int bearing_range) const = 0;
     virtual std::vector<PhantomNodeWithDistance>
-    NearestPhantomNodes(const util::Coordinate input_coordinate, const unsigned max_results) = 0;
+    NearestPhantomNodes(const util::Coordinate input_coordinate, const unsigned max_results) const = 0;
     virtual std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
-                        const double max_distance) = 0;
+                        const double max_distance) const = 0;
 
     virtual std::pair<PhantomNode, PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate) = 0;
+    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate) const = 0;
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const double max_distance) = 0;
+                                                      const double max_distance) const = 0;
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
                                                       const int bearing,
-                                                      const int bearing_range) = 0;
+                                                      const int bearing_range) const = 0;
     virtual std::pair<PhantomNode, PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate input_coordinate, const int bearing, const int bearing_range) = 0;
+        const util::Coordinate input_coordinate, const int bearing, const int bearing_range) const = 0;
 
     virtual unsigned GetCheckSum() const = 0;
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -69,7 +69,7 @@ class InternalDataFacade final : public BaseDataFacade
     std::unique_ptr<QueryGraph> m_query_graph;
     std::string m_timestamp;
 
-    std::shared_ptr<util::ShM<util::Coordinate, false>::vector> m_coordinate_list;
+    util::ShM<util::Coordinate, false>::vector m_coordinate_list;
     util::ShM<NodeID, false>::vector m_via_node_list;
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;
@@ -139,12 +139,12 @@ class InternalDataFacade final : public BaseDataFacade
         extractor::QueryNode current_node;
         unsigned number_of_coordinates = 0;
         nodes_input_stream.read((char *)&number_of_coordinates, sizeof(unsigned));
-        m_coordinate_list = std::make_shared<std::vector<util::Coordinate>>(number_of_coordinates);
+        m_coordinate_list.resize(number_of_coordinates);
         for (unsigned i = 0; i < number_of_coordinates; ++i)
         {
             nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
-            m_coordinate_list->at(i) = util::Coordinate(current_node.lon, current_node.lat);
-            BOOST_ASSERT(m_coordinate_list->at(i).IsValid());
+            m_coordinate_list[i] = util::Coordinate(current_node.lon, current_node.lat);
+            BOOST_ASSERT(m_coordinate_list[i].IsValid());
         }
 
         boost::filesystem::ifstream edges_input_stream(edges_file, std::ios::binary);
@@ -253,7 +253,7 @@ class InternalDataFacade final : public BaseDataFacade
 
     void LoadRTree()
     {
-        BOOST_ASSERT_MSG(!m_coordinate_list->empty(), "coordinates must be loaded before r-tree");
+        BOOST_ASSERT_MSG(!m_coordinate_list.empty(), "coordinates must be loaded before r-tree");
 
         m_static_rtree.reset(new InternalRTree(ram_index_path, file_index_path, m_coordinate_list));
         m_geospatial_query.reset(
@@ -364,7 +364,7 @@ class InternalDataFacade final : public BaseDataFacade
     // node and edge information access
     util::Coordinate GetCoordinateOfNode(const unsigned id) const override final
     {
-        return m_coordinate_list->at(id);
+        return m_coordinate_list[id];
     }
 
     extractor::guidance::TurnInstruction

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -379,7 +379,7 @@ class InternalDataFacade final : public BaseDataFacade
     }
 
     std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate south_west,
-                                         const util::Coordinate north_east) override final
+                                         const util::Coordinate north_east) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
         const util::RectangleInt2D bbox{south_west.lon, north_east.lon, south_west.lat,
@@ -389,7 +389,7 @@ class InternalDataFacade final : public BaseDataFacade
 
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
-                               const float max_distance) override final
+                               const float max_distance) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -400,7 +400,7 @@ class InternalDataFacade final : public BaseDataFacade
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
                                const float max_distance,
                                const int bearing,
-                               const int bearing_range) override final
+                               const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -410,7 +410,7 @@ class InternalDataFacade final : public BaseDataFacade
 
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
-                        const unsigned max_results) override final
+                        const unsigned max_results) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -420,7 +420,7 @@ class InternalDataFacade final : public BaseDataFacade
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
-                        const double max_distance) override final
+                        const double max_distance) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -431,7 +431,7 @@ class InternalDataFacade final : public BaseDataFacade
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
                         const int bearing,
-                        const int bearing_range) override final
+                        const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -444,7 +444,7 @@ class InternalDataFacade final : public BaseDataFacade
                         const unsigned max_results,
                         const double max_distance,
                         const int bearing,
-                        const int bearing_range) override final
+                        const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -454,7 +454,7 @@ class InternalDataFacade final : public BaseDataFacade
 
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const double max_distance) override final
+                                                      const double max_distance) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -463,7 +463,7 @@ class InternalDataFacade final : public BaseDataFacade
     }
 
     std::pair<PhantomNode, PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate input_coordinate) override final
+        const util::Coordinate input_coordinate) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -475,7 +475,7 @@ class InternalDataFacade final : public BaseDataFacade
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
                                                       const int bearing,
-                                                      const int bearing_range) override final
+                                                      const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -486,7 +486,7 @@ class InternalDataFacade final : public BaseDataFacade
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const int bearing,
-                                                      const int bearing_range) override final
+                                                      const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -459,7 +459,7 @@ class SharedDataFacade final : public BaseDataFacade
     }
 
     std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate south_west,
-                                         const util::Coordinate north_east) override final
+                                         const util::Coordinate north_east) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
         const util::RectangleInt2D bbox{south_west.lon, north_east.lon, south_west.lat,
@@ -469,7 +469,7 @@ class SharedDataFacade final : public BaseDataFacade
 
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
-                               const float max_distance) override final
+                               const float max_distance) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -480,7 +480,7 @@ class SharedDataFacade final : public BaseDataFacade
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
                                const float max_distance,
                                const int bearing,
-                               const int bearing_range) override final
+                               const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -490,7 +490,7 @@ class SharedDataFacade final : public BaseDataFacade
 
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
-                        const unsigned max_results) override final
+                        const unsigned max_results) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -500,7 +500,7 @@ class SharedDataFacade final : public BaseDataFacade
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
-                        const double max_distance) override final
+                        const double max_distance) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -511,7 +511,7 @@ class SharedDataFacade final : public BaseDataFacade
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
                         const int bearing,
-                        const int bearing_range) override final
+                        const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -524,7 +524,7 @@ class SharedDataFacade final : public BaseDataFacade
                         const unsigned max_results,
                         const double max_distance,
                         const int bearing,
-                        const int bearing_range) override final
+                        const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -533,7 +533,7 @@ class SharedDataFacade final : public BaseDataFacade
     }
 
     std::pair<PhantomNode, PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate input_coordinate) override final
+        const util::Coordinate input_coordinate) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -543,7 +543,7 @@ class SharedDataFacade final : public BaseDataFacade
 
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const double max_distance) override final
+                                                      const double max_distance) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -555,7 +555,7 @@ class SharedDataFacade final : public BaseDataFacade
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
                                                       const int bearing,
-                                                      const int bearing_range) override final
+                                                      const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
@@ -566,7 +566,7 @@ class SharedDataFacade final : public BaseDataFacade
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const int bearing,
-                                                      const int bearing_range) override final
+                                                      const int bearing_range) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -45,7 +45,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     // Returns nearest PhantomNodes in the given bearing range within max_distance.
     // Does not filter by small/big component!
     std::vector<PhantomNodeWithDistance>
-    NearestPhantomNodesInRange(const util::Coordinate input_coordinate, const double max_distance)
+    NearestPhantomNodesInRange(const util::Coordinate input_coordinate, const double max_distance) const
     {
         auto results =
             rtree.Nearest(input_coordinate,
@@ -68,7 +68,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,
                                const double max_distance,
                                const int bearing,
-                               const int bearing_range)
+                               const int bearing_range) const
     {
         auto results = rtree.Nearest(
             input_coordinate,
@@ -91,7 +91,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
                         const int bearing,
-                        const int bearing_range)
+                        const int bearing_range) const
     {
         auto results =
             rtree.Nearest(input_coordinate,
@@ -115,7 +115,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                         const unsigned max_results,
                         const double max_distance,
                         const int bearing,
-                        const int bearing_range)
+                        const int bearing_range) const
     {
         auto results =
             rtree.Nearest(input_coordinate,
@@ -136,7 +136,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     // Returns max_results nearest PhantomNodes.
     // Does not filter by small/big component!
     std::vector<PhantomNodeWithDistance>
-    NearestPhantomNodes(const util::Coordinate input_coordinate, const unsigned max_results)
+    NearestPhantomNodes(const util::Coordinate input_coordinate, const unsigned max_results) const
     {
         auto results =
             rtree.Nearest(input_coordinate,
@@ -157,7 +157,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const unsigned max_results,
-                        const double max_distance)
+                        const double max_distance) const
     {
         auto results =
             rtree.Nearest(input_coordinate,
@@ -179,7 +179,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     // a second phantom node is return that is the nearest coordinate in a big component.
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const double max_distance)
+                                                      const double max_distance) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
@@ -216,7 +216,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     // Returns the nearest phantom node. If this phantom node is not from a big component
     // a second phantom node is return that is the nearest coordinate in a big component.
     std::pair<PhantomNode, PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate)
+    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
@@ -251,7 +251,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     // Returns the nearest phantom node. If this phantom node is not from a big component
     // a second phantom node is return that is the nearest coordinate in a big component.
     std::pair<PhantomNode, PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate input_coordinate, const int bearing, const int bearing_range)
+        const util::Coordinate input_coordinate, const int bearing, const int bearing_range) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
@@ -297,7 +297,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
                                                       const int bearing,
-                                                      const int bearing_range)
+                                                      const int bearing_range) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
@@ -418,7 +418,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
     bool CheckSegmentDistance(const Coordinate input_coordinate,
                               const CandidateSegment &segment,
-                              const double max_distance)
+                              const double max_distance) const
     {
         BOOST_ASSERT(segment.data.forward_segment_id.id != SPECIAL_SEGMENTID ||
                      !segment.data.forward_segment_id.enabled);
@@ -434,7 +434,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
     std::pair<bool, bool> CheckSegmentBearing(const CandidateSegment &segment,
                                               const int filter_bearing,
-                                              const int filter_bearing_range)
+                                              const int filter_bearing_range) const
     {
         BOOST_ASSERT(segment.data.forward_segment_id.id != SPECIAL_SEGMENTID ||
                      !segment.data.forward_segment_id.enabled);
@@ -459,7 +459,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         return std::make_pair(forward_bearing_valid, backward_bearing_valid);
     }
 
-    RTreeT &rtree;
+    const RTreeT &rtree;
     const CoordinateList &coordinates;
     DataFacadeT &datafacade;
 };

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -22,7 +22,7 @@ namespace engine
 
 // Implements complex queries on top of an RTree and builds PhantomNodes from it.
 //
-// Only holds a weak reference on the RTree!
+// Only holds a weak reference on the RTree and coordinates!
 template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 {
     using EdgeData = typename RTreeT::EdgeData;
@@ -31,9 +31,9 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
   public:
     GeospatialQuery(RTreeT &rtree_,
-                    std::shared_ptr<CoordinateList> coordinates_,
+                    const CoordinateList &coordinates_,
                     DataFacadeT &datafacade_)
-        : rtree(rtree_), coordinates(std::move(coordinates_)), datafacade(datafacade_)
+        : rtree(rtree_), coordinates(coordinates_), datafacade(datafacade_)
     {
     }
 
@@ -360,7 +360,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         double ratio;
         const auto current_perpendicular_distance =
             util::coordinate_calculation::perpendicularDistance(
-                coordinates->at(data.u), coordinates->at(data.v), input_coordinate,
+                coordinates[data.u], coordinates[data.v], input_coordinate,
                 point_on_segment, ratio);
 
         // Find the node-based-edge that this belongs to, and directly
@@ -442,7 +442,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                      !segment.data.reverse_segment_id.enabled);
 
         const double forward_edge_bearing = util::coordinate_calculation::bearing(
-            coordinates->at(segment.data.u), coordinates->at(segment.data.v));
+            coordinates[segment.data.u], coordinates[segment.data.v]);
 
         const double backward_edge_bearing = (forward_edge_bearing + 180) > 360
                                                  ? (forward_edge_bearing - 180)
@@ -460,7 +460,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     }
 
     RTreeT &rtree;
-    const std::shared_ptr<CoordinateList> coordinates;
+    const CoordinateList &coordinates;
     DataFacadeT &datafacade;
 };
 }

--- a/include/util/shared_memory_vector_wrapper.hpp
+++ b/include/util/shared_memory_vector_wrapper.hpp
@@ -55,6 +55,12 @@ template <typename DataT> class SharedMemoryWrapper
 
     SharedMemoryWrapper(DataT *ptr, std::size_t size) : m_ptr(ptr), m_size(size) {}
 
+    void reset(DataT *ptr, std::size_t size)
+    {
+        m_ptr = ptr;
+        m_size = size;
+    }
+
     DataT &at(const std::size_t index) { return m_ptr[index]; }
 
     const DataT &at(const std::size_t index) const { return m_ptr[index]; }
@@ -99,6 +105,12 @@ template <> class SharedMemoryWrapper<bool>
         const std::size_t bucket = index / 32;
         const unsigned offset = static_cast<unsigned>(index % 32);
         return m_ptr[bucket] & (1u << offset);
+    }
+
+    void reset(unsigned *ptr, std::size_t size)
+    {
+        m_ptr = ptr;
+        m_size = size;
     }
 
     std::size_t size() const { return m_size; }

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -348,8 +348,7 @@ class StaticRTree
 
             if (current_tree_node.child_is_on_disk)
             {
-                LeafNode current_leaf_node;
-                LoadLeafFromDisk(current_tree_node.children[0], current_leaf_node);
+                LeafNode current_leaf_node = LoadLeafFromDisk(current_tree_node.children[0]);
 
                 for (const auto i : irange(0u, current_leaf_node.object_count))
                 {
@@ -488,8 +487,7 @@ class StaticRTree
             return;
         }
 
-        LeafNode current_leaf_node;
-        LoadLeafFromDisk(leaf_id, current_leaf_node);
+        LeafNode current_leaf_node = LoadLeafFromDisk(leaf_id);
 
         // current object represents a block on disk
         for (const auto i : irange(0u, current_leaf_node.object_count))
@@ -529,8 +527,9 @@ class StaticRTree
         }
     }
 
-    inline void LoadLeafFromDisk(const std::uint32_t leaf_id, LeafNode &result_node)
+    inline LeafNode LoadLeafFromDisk(const std::uint32_t leaf_id)
     {
+        LeafNode result_node;
         if (!leaves_stream.is_open())
         {
             leaves_stream.open(m_leaf_node_filename, std::ios::in | std::ios::binary);
@@ -544,6 +543,7 @@ class StaticRTree
         BOOST_ASSERT_MSG(leaves_stream.good(), "Seeking to position in leaf file failed.");
         leaves_stream.read((char *)&result_node, sizeof(LeafNode));
         BOOST_ASSERT_MSG(leaves_stream.good(), "Reading from leaf file failed.");
+        return result_node;
     }
 
     template <typename CoordinateT>

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -201,6 +201,8 @@ class StaticRTree
             leaf_node_file.write((char *)&current_leaf, sizeof(current_leaf));
             processed_objects_count += current_leaf.object_count;
         }
+        leaf_node_file.flush();
+        leaf_node_file.close();
 
         std::uint32_t processing_level = 0;
         while (1 < tree_nodes_in_level.size())

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -93,7 +93,7 @@ class StaticRTree
         }
     };
 
-    using QueryNodeType = mapbox::util::variant<TreeNode, CandidateSegment>;
+    using QueryNodeType = mapbox::util::variant<std::uint32_t, CandidateSegment>;
     struct QueryCandidate
     {
         inline bool operator<(const QueryCandidate &other) const
@@ -415,17 +415,17 @@ class StaticRTree
 
         // initialize queue with root element
         std::priority_queue<QueryCandidate> traversal_queue;
-        traversal_queue.push(QueryCandidate{0, m_search_tree[0]});
+        traversal_queue.push(QueryCandidate{0, 0});
 
         while (!traversal_queue.empty())
         {
             QueryCandidate current_query_node = traversal_queue.top();
             traversal_queue.pop();
 
-            if (current_query_node.node.template is<TreeNode>())
+            if (current_query_node.node.template is<std::uint32_t>())
             { // current object is a tree node
                 const TreeNode &current_tree_node =
-                    current_query_node.node.template get<TreeNode>();
+                    m_search_tree[current_query_node.node.template get<std::uint32_t>()];
                 if (current_tree_node.child_is_on_disk)
                 {
                     ExploreLeafNode(current_tree_node.children[0], fixed_projected_coordinate,
@@ -510,7 +510,7 @@ class StaticRTree
             const auto squared_lower_bound_to_element =
                 child_rectangle.GetMinSquaredDist(fixed_projected_input_coordinate);
             traversal_queue.push(
-                QueryCandidate{squared_lower_bound_to_element, m_search_tree[child_id]});
+                QueryCandidate{squared_lower_bound_to_element, child_id});
         }
     }
 

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -336,13 +336,12 @@ class StaticRTree
                 web_mercator::latToY(toFloating(FixedLatitude(search_rectangle.max_lat)))})};
         std::vector<EdgeDataT> results;
 
-        std::queue<TreeNode> traversal_queue;
-
-        traversal_queue.push(m_search_tree[0]);
+        std::queue<std::uint32_t> traversal_queue;
+        traversal_queue.push(0);
 
         while (!traversal_queue.empty())
         {
-            auto const current_tree_node = traversal_queue.front();
+            auto const &current_tree_node = m_search_tree[traversal_queue.front()];
             traversal_queue.pop();
 
             if (current_tree_node.child_is_on_disk)
@@ -383,7 +382,7 @@ class StaticRTree
 
                     if (child_rectangle.Intersects(projected_rectangle))
                     {
-                        traversal_queue.push(m_search_tree[child_id]);
+                        traversal_queue.push(child_id);
                     }
                 }
             }

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -326,7 +326,7 @@ class StaticRTree
 
     /* Returns all features inside the bounding box.
        Rectangle needs to be projected!*/
-    std::vector<EdgeDataT> SearchInBox(const Rectangle &search_rectangle)
+    std::vector<EdgeDataT> SearchInBox(const Rectangle &search_rectangle) const
     {
         const Rectangle projected_rectangle{
             search_rectangle.min_lon, search_rectangle.max_lon,
@@ -392,7 +392,7 @@ class StaticRTree
     }
 
     // Override filter and terminator for the desired behaviour.
-    std::vector<EdgeDataT> Nearest(const Coordinate input_coordinate, const std::size_t max_results)
+    std::vector<EdgeDataT> Nearest(const Coordinate input_coordinate, const std::size_t max_results) const
     {
         return Nearest(input_coordinate,
                        [](const CandidateSegment &)
@@ -408,7 +408,7 @@ class StaticRTree
     // Override filter and terminator for the desired behaviour.
     template <typename FilterT, typename TerminationT>
     std::vector<EdgeDataT>
-    Nearest(const Coordinate input_coordinate, const FilterT filter, const TerminationT terminate)
+    Nearest(const Coordinate input_coordinate, const FilterT filter, const TerminationT terminate) const
     {
         std::vector<EdgeDataT> results;
         auto projected_coordinate = web_mercator::fromWGS84(input_coordinate);
@@ -473,7 +473,7 @@ class StaticRTree
     void ExploreLeafNode(const std::uint32_t leaf_id,
                          const Coordinate projected_input_coordinate_fixed,
                          const FloatCoordinate &projected_input_coordinate,
-                         QueueT &traversal_queue)
+                         QueueT &traversal_queue) const
     {
         const LeafNode& current_leaf_node = m_leaves[leaf_id];
 
@@ -500,7 +500,7 @@ class StaticRTree
     template <class QueueT>
     void ExploreTreeNode(const TreeNode &parent,
                          const Coordinate fixed_projected_input_coordinate,
-                         QueueT &traversal_queue)
+                         QueueT &traversal_queue) const
     {
         for (std::uint32_t i = 0; i < parent.child_count; ++i)
         {

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -26,22 +26,21 @@ constexpr int32_t WORLD_MIN_LON = -180 * COORDINATE_PRECISION;
 constexpr int32_t WORLD_MAX_LON = 180 * COORDINATE_PRECISION;
 
 using RTreeLeaf = extractor::EdgeBasedNode;
-using CoordinateListPtr = std::shared_ptr<std::vector<util::Coordinate>>;
 using BenchStaticRTree =
     util::StaticRTree<RTreeLeaf, util::ShM<util::Coordinate, false>::vector, false>;
 
-CoordinateListPtr loadCoordinates(const boost::filesystem::path &nodes_file)
+std::vector<util::Coordinate> loadCoordinates(const boost::filesystem::path &nodes_file)
 {
     boost::filesystem::ifstream nodes_input_stream(nodes_file, std::ios::binary);
 
     extractor::QueryNode current_node;
     unsigned coordinate_count = 0;
     nodes_input_stream.read((char *)&coordinate_count, sizeof(unsigned));
-    auto coords = std::make_shared<std::vector<Coordinate>>(coordinate_count);
+    std::vector<util::Coordinate> coords(coordinate_count);
     for (unsigned i = 0; i < coordinate_count; ++i)
     {
         nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
-        coords->at(i) = util::Coordinate(current_node.lon, current_node.lat);
+        coords[i] = util::Coordinate(current_node.lon, current_node.lat);
     }
     return coords;
 }

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -330,16 +330,16 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
 
             using LeafNode = util::StaticRTree<extractor::EdgeBasedNode>::LeafNode;
 
-            std::ifstream leaf_node_file(rtree_leaf_filename, std::ios::binary | std::ios::in);
+            std::ifstream leaf_node_file(rtree_leaf_filename, std::ios::binary | std::ios::in | std::ios::ate);
             if (!leaf_node_file)
             {
                 throw util::exception("Failed to open " + rtree_leaf_filename);
             }
-            uint64_t m_element_count;
-            leaf_node_file.read((char *)&m_element_count, sizeof(uint64_t));
+            std::size_t leaf_nodes_count = leaf_node_file.tellg() / sizeof(LeafNode);
+            leaf_node_file.seekg(0, std::ios::beg);
 
             LeafNode current_node;
-            while (m_element_count > 0)
+            while (leaf_nodes_count > 0)
             {
                 leaf_node_file.read(reinterpret_cast<char *>(&current_node), sizeof(current_node));
 
@@ -435,7 +435,7 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
                         }
                     }
                 }
-                m_element_count -= current_node.object_count;
+                --leaf_nodes_count;
             }
         }
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -563,9 +563,9 @@ void Extractor::BuildRTree(std::vector<EdgeBasedNode> node_based_edge_list,
     node_based_edge_list.resize(new_size);
 
     TIMER_START(construction);
-    util::StaticRTree<EdgeBasedNode> rtree(node_based_edge_list, config.rtree_nodes_output_path,
-                                           config.rtree_leafs_output_path,
-                                           internal_to_external_node_map);
+    util::StaticRTree<EdgeBasedNode, std::vector<QueryNode>> rtree(
+        node_based_edge_list, config.rtree_nodes_output_path, config.rtree_leafs_output_path,
+        internal_to_external_node_map);
 
     TIMER_STOP(construction);
     util::SimpleLogger().Write() << "finished r-tree construction in " << TIMER_SEC(construction)

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -78,7 +78,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
         return TRAVEL_MODE_INACCESSIBLE;
     }
     std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate /* south_west */,
-                                         const util::Coordinate /*north_east */) override
+                                         const util::Coordinate /*north_east */) const override
     {
         return {};
     }
@@ -87,14 +87,14 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     NearestPhantomNodesInRange(const util::Coordinate /*input_coordinate*/,
                                const float /*max_distance*/,
                                const int /*bearing*/,
-                               const int /*bearing_range*/) override
+                               const int /*bearing_range*/) const override
     {
         return {};
     }
 
     std::vector<engine::PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate /*input_coordinate*/,
-                               const float /*max_distance*/) override
+                               const float /*max_distance*/) const override
     {
         return {};
     }
@@ -104,7 +104,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
                         const unsigned /*max_results*/,
                         const double /*max_distance*/,
                         const int /*bearing*/,
-                        const int /*bearing_range*/) override
+                        const int /*bearing_range*/) const override
     {
         return {};
     }
@@ -113,14 +113,14 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     NearestPhantomNodes(const util::Coordinate /*input_coordinate*/,
                         const unsigned /*max_results*/,
                         const int /*bearing*/,
-                        const int /*bearing_range*/) override
+                        const int /*bearing_range*/) const override
     {
         return {};
     }
 
     std::vector<engine::PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate /*input_coordinate*/,
-                        const unsigned /*max_results*/) override
+                        const unsigned /*max_results*/) const override
     {
         return {};
     }
@@ -128,21 +128,21 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     std::vector<engine::PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate /*input_coordinate*/,
                         const unsigned /*max_results*/,
-                        const double /*max_distance*/) override
+                        const double /*max_distance*/) const override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate /*input_coordinate*/) override
+        const util::Coordinate /*input_coordinate*/) const override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
-                                                      const double /*max_distance*/) override
+                                                      const double /*max_distance*/) const override
     {
         return {};
     }
@@ -151,7 +151,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
                                                       const double /*max_distance*/,
                                                       const int /*bearing*/,
-                                                      const int /*bearing_range*/) override
+                                                      const int /*bearing_range*/) const override
     {
         return {};
     }
@@ -159,7 +159,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     std::pair<engine::PhantomNode, engine::PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
                                                       const int /*bearing*/,
-                                                      const int /*bearing_range*/) override
+                                                      const int /*bearing_range*/) const override
     {
         return {};
     };

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -40,7 +40,7 @@ using TestStaticRTree = StaticRTree<TestData,
                                     false,
                                     TEST_BRANCHING_FACTOR,
                                     TEST_LEAF_NODE_SIZE>;
-using MiniStaticRTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 3>;
+using MiniStaticRTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 128>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 42;
@@ -266,7 +266,7 @@ void construction_test(const std::string &prefix, FixtureT *fixture)
 
 BOOST_FIXTURE_TEST_CASE(construct_tiny, TestRandomGraphFixture_10_30)
 {
-    using TinyTestTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 1>;
+    using TinyTestTree = StaticRTree<TestData, std::vector<Coordinate>, false, 2, 64>;
     construction_test<TinyTestTree>("test_tiny", this);
 }
 


### PR DESCRIPTION
Breaks out the functional changes from #2347 to upstream them. This PR makes the StaticRTree factor 3 faster and in the process fixes some long standing issues:

- StaticRTree now uses mmap, that mean no explicit file reading
- StaticRTree now is const
- StaticRTree does not need to be thread-local. Hence its updated with every other dataset on data update
- StaticRTree is x3 faster thanks to less unnecessary copies and approximate projection by @oxidase 

This PR breaks the data format for `osrm-extract` because the leaf size changes and is now page aligned.