### PR TITLE
emit turn-straight for obvious turns where the main road continues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 5.2
-   Changes from 5.1
+# 5.2.0
+   Changes from 5.1.0
 
    - API:
      - new parameter `annotate` for `route` and `match` requests.  Returns additional data about each
@@ -10,6 +10,9 @@
 
    - Infrastructure:
      - Open sockets with SO_REUSEPORT to allow multiple servers connecting to the same port
+
+   - Guidance:
+     - improved detection of turning streets, not reporting new-name in wrong situations
 
 # 5.1.0
    Changes with regard to 5.0.0

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -344,4 +344,4 @@ Feature: Collapse
             | waypoints | route                   | turns                                      |
             | a,d       | first,first,first,first | depart,continue left,continue right,arrive |
             | a,e       | first,second,second     | depart,turn left,arrive                    |
-            | a,f       | first,third,third       | depart,new name straight,arrive            |
+            | a,f       | first,third,third       | depart,turn straight,arrive                |

--- a/features/guidance/continue.feature
+++ b/features/guidance/continue.feature
@@ -16,9 +16,9 @@ Feature: Continue Instructions
             | bd     | primary |
 
        When I route I should get
-            | waypoints | route       | turns                           |
-            | a,c       | abc,abc,abc | depart,continue left,arrive     |
-            | a,d       | abc,bd,bd   | depart,new name straight,arrive |
+            | waypoints | route       | turns                       |
+            | a,c       | abc,abc,abc | depart,continue left,arrive |
+            | a,d       | abc,bd,bd   | depart,turn straight,arrive |
 
     Scenario: Road turning right
         Given the node map
@@ -31,9 +31,9 @@ Feature: Continue Instructions
             | bd     | primary |
 
        When I route I should get
-            | waypoints | route       | turns                           |
-            | a,c       | abc,abc,abc | depart,continue right,arrive    |
-            | a,d       | abc,bd,bd   | depart,new name straight,arrive |
+            | waypoints | route       | turns                        |
+            | a,c       | abc,abc,abc | depart,continue right,arrive |
+            | a,d       | abc,bd,bd   | depart,turn straight,arrive  |
 
     Scenario: Road turning slight left
         Given the node map


### PR DESCRIPTION
In deciding which turn is obvious, the current turn classification does not consider names of other roads.
In situations like this

![](https://cloud.githubusercontent.com/assets/25713/15181973/76addb3a-178a-11e6-836d-0985de25eff4.jpg)

where the main road takes a turn, this can lead to going straight being reported as a new-name. Since the main road is taking a turn, we should not announce it as a new name but rather a turn.

In the concept of OSRM turn instructions, `turn` would be the instruction to emit.

We should consider handling the case `turn straight` specifically in a frontend/client to avoid the wording `turn straight onto name`. /cc @karenzshea @bsudekum