### PR TITLE
Remove latitude rounding in yToLat

### DIFF
--- a/features/testbot/compression.feature
+++ b/features/testbot/compression.feature
@@ -18,5 +18,5 @@ Feature: Geometry Compression
 
         When I route I should get
             | from | to | route         | distance | speed   |
-            | b    | e  | abcdef,abcdef | 589m     | 36 km/h |
-            | e    | b  | abcdef,abcdef | 589m     | 36 km/h |
+            | b    | e  | abcdef,abcdef | 588.8m   | 36 km/h |
+            | e    | b  | abcdef,abcdef | 588.8m   | 36 km/h |

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -118,4 +118,4 @@ Feature: Basic Map Matching
         When I match I should get
             | trace | matchings | annotation                                                                     |
             | abeh  | abcedgh   | 1:9.897633,0:0,1:10.008842,1:10.008842,1:10.008842,0:0,2:20.017685,1:10.008842 |
-            | abci  | abc,ci    | 1:9.897633,0:0,1:10.008842,0:0.111209,1:10.121593                              |
+            | abci  | abc,ci    | 1:9.897633,0:0,1:10.008842,0:0.111209,1:10.010367                              |

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -35,7 +35,7 @@ inline FloatLatitude yToLat(const double y)
     const double normalized_lat =
         detail::RAD_TO_DEGREE * 2. * std::atan(std::exp(clamped_y * detail::DEGREE_TO_RAD));
 
-    return FloatLatitude(std::round(normalized_lat * COORDINATE_PRECISION) / COORDINATE_PRECISION - 90.);
+    return FloatLatitude(normalized_lat - 90.);
 }
 
 inline double latToY(const FloatLatitude latitude)


### PR DESCRIPTION
Hi, please check a revert of the latitude rounding introduced in 24a75d3 as a possible fix of #2398.
The change incorrectly makes too earlier rounding of float latitudes and could introduce an error into distance calculations.

Expectations in two tests must be adjusted, where the round-off error is amplified in haversineDistance function. For dlon = 0 the round-off error in dlat could lead to a difference in the result that is up to 2*6372797*1e-6*0.01745 = 0.22 meters.
