### PR TITLE
Signal the parent process when we're ready to serve requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
    - Infrastructure:
      - Better support for osrm-routed binary upgrade on the fly [UNIX specific]:
-       - Open sockets with SO_REUSEPORT to allow multiple servers connecting to the same port.
+       - Open sockets with SO_REUSEPORT to allow multiple osrm-routed processes serving requests from the same port.
        - Add SIGNAL_PARENT_WHEN_READY environment variable to enable osrm-routed signal its parent with USR1 when it's running and waiting for requests.
 
 # 5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
      - duration parser now accepts P[n]DT[n]H[n]M[n]S, P[n]W, PTHHMMSS and PTHH:MM:SS ISO8601 formats.
 
    - Infrastructure:
-     - Open sockets with SO_REUSEPORT to allow multiple servers connecting to the same port
+     - Better support for osrm-routed binary upgrade on the fly [UNIX specific]:
+       - Open sockets with SO_REUSEPORT to allow multiple servers connecting to the same port.
+       - Add SIGNAL_PARENT_WHEN_READY environment variable to enable osrm-routed signal its parent with USR1 when it's running and waiting for requests.
 
 # 5.1.0
    Changes with regard to 5.0.0

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,3 +1,12 @@
+## Environent Variables
+
+### SIGNAL_PARENT_WHEN_READY
+
+If the SIGNAL_PARENT_WHEN_READY environment variable is set osrm-routed will
+send the USR1 signal to its parent when it will be running and waiting for
+requests. This could be used to upgrade osrm-routed to a new binary on the fly
+without any service downtime - no incoming requests will be lost.
+
 ## HTTP API
 
 `osrm-routed` supports only `GET` requests of the form. If you your response size

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -306,6 +306,9 @@ int main(int argc, const char *argv[]) try
         sigaddset(&wait_mask, SIGTERM);
         pthread_sigmask(SIG_BLOCK, &wait_mask, nullptr);
         util::SimpleLogger().Write() << "running and waiting for requests";
+        if(std::getenv("SIGNAL_PARENT_WHEN_READY")) {
+            kill(getppid(), SIGUSR1);
+        }
         sigwait(&wait_mask, &sig);
 #else
         // Set console control handler to allow server to be stopped.


### PR DESCRIPTION
This can be used for a hot reload of the process binary. The supervising
process can be told when the new process is ready to serve requests.