### PR TITLE
Expose node IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
      - paramater `annotate` was renamed to `annotations`.
      - `annotation` as accidentally placed in `Route` instead of `RouteLeg`
      - Support for destination signs. New member `destinations` in `RouteStep`, based on `destination` and `destination:ref`.
+     - Add `nodes` property to `annotation` in `RouteLeg` containing the ids of nodes covered by the route
 
    - Profile changes:
      - `result.destinations` allows you to set a way's destinations

--- a/docs/http.md
+++ b/docs/http.md
@@ -413,7 +413,8 @@ With `steps=false` and `annotations=true`:
   "steps": []
   "annotation": {
     "distance": [5,5,10,5,5],
-    "duration": [15,15,40,15,15]
+    "duration": [15,15,40,15,15],
+    "nodes": [49772551,49772552,49786799,49786800,49786801,49786802]
   }
 }
 ```

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -34,7 +34,8 @@ module.exports = function () {
                         turns = '',
                         route = '',
                         duration = '',
-                        annotation = '';
+                        annotation = '',
+                        OSMIDs = '';
 
 
                     if (res.statusCode === 200) {
@@ -61,6 +62,11 @@ module.exports = function () {
                             if (json.matchings.length != 1) throw new Error('*** Checking annotation only supported for matchings with one subtrace');
                             annotation = this.annotationList(json.matchings[0]);
                         }
+
+                        if (headers.has('OSM IDs')) {
+                            if (json.matchings.length != 1) throw new Error('*** CHecking annotation only supported for matchings with one subtrace');
+                            OSMIDs = this.OSMIDList(json.matchings[0]);
+                        }
                     }
 
                     if (headers.has('turns')) {
@@ -77,6 +83,10 @@ module.exports = function () {
 
                     if (headers.has('annotation')) {
                         got.annotation = annotation.toString();
+                    }
+
+                    if (headers.has('OSM IDs')) {
+                        got['OSM IDs'] = OSMIDs;
                     }
 
                     var ok = true;

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -166,7 +166,7 @@ module.exports = function () {
     this.OSMIDList = (instructions) => {
         // OSM node IDs also come from the annotation list
         return instructions.legs.map(l => l.annotation.nodes.map(n => n.toString()).join(',')).join(',');
-    }
+    };
 
     this.turnList = (instructions) => {
         return instructions.legs.reduce((m, v) => m.concat(v.steps), [])

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -163,6 +163,11 @@ module.exports = function () {
         return matching.legs.map(l => {return zip(l.annotation.duration, l.annotation.distance).map(p => { return p.join(':'); }).join(','); }).join(',');
     };
 
+    this.OSMIDList = (instructions) => {
+        // OSM node IDs also come from the annotation list
+        return instructions.annotation.nodes.map(x => x.toString()).join(',');
+    }
+
     this.turnList = (instructions) => {
         return instructions.legs.reduce((m, v) => m.concat(v.steps), [])
             .map(v => {

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -151,7 +151,7 @@ module.exports = function () {
         return this.extractInstructionList(instructions, s => s.maneuver.bearing_before + '->' + s.maneuver.bearing_after);
     };
 
-    this.annotationList = (matching) => {
+    this.annotationList = (instructions) => {
         function zip(list_1, list_2)
         {
             let pairs = [];
@@ -160,12 +160,12 @@ module.exports = function () {
             }
             return pairs;
         }
-        return matching.legs.map(l => {return zip(l.annotation.duration, l.annotation.distance).map(p => { return p.join(':'); }).join(','); }).join(',');
+        return instructions.legs.map(l => {return zip(l.annotation.duration, l.annotation.distance).map(p => { return p.join(':'); }).join(','); }).join(',');
     };
 
     this.OSMIDList = (instructions) => {
         // OSM node IDs also come from the annotation list
-        return instructions.annotation.nodes.map(x => x.toString()).join(',');
+        return instructions.legs.map(l => l.annotation.nodes.map(n => n.toString()).join(',')).join(',');
     }
 
     this.turnList = (instructions) => {

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -122,3 +122,9 @@ Feature: Basic Map Matching
             | trace | matchings | annotation                                                                     |
             | abeh  | abcedgh   | 1:9.897633,0:0,1:10.008842,1:10.008842,1:10.008842,0:0,2:20.017685,1:10.008842 |
             | abci  | abc,ci    | 1:9.897633,0:0,1:10.008842,0:0.111209,1:10.010367                              |
+
+        # The following is the same as the above, but separated for readability (line length)
+        When I match I should get
+            | trace | matchings | OSM IDs               |
+            | abeh  | abcedgh   | 1,2,3,2,3,4,5,4,5,6,7 |
+            | abci  | abc,ci    | 1,2,3,2,3,8,3,8       |

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -198,6 +198,7 @@ class RouteAPI : public BaseAPI
             {
                 util::json::Array durations;
                 util::json::Array distances;
+                util::json::Array nodes;
                 auto &leg_geometry = leg_geometries[idx];
                 std::for_each(
                     leg_geometry.annotations.begin(),
@@ -206,9 +207,16 @@ class RouteAPI : public BaseAPI
                         durations.values.push_back(step.duration);
                         distances.values.push_back(step.distance);
                     });
+                std::for_each(
+                    leg_geometry.osm_node_ids.begin(),
+                    leg_geometry.osm_node_ids.end(),
+                    [this, &nodes](const OSMNodeID &node_id) {
+                        nodes.values.push_back(static_cast<std::uint64_t>(node_id));
+                    });
                 util::json::Object annotation;
                 annotation.values["distance"] = std::move(distances);
                 annotation.values["duration"] = std::move(durations);
+                annotation.values["nodes"] = std::move(nodes);
                 annotations.push_back(std::move(annotation));
             }
         }

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -207,12 +207,11 @@ class RouteAPI : public BaseAPI
                         durations.values.push_back(step.duration);
                         distances.values.push_back(step.distance);
                     });
-                std::for_each(
-                    leg_geometry.osm_node_ids.begin(),
-                    leg_geometry.osm_node_ids.end(),
-                    [this, &nodes](const OSMNodeID &node_id) {
-                        nodes.values.push_back(static_cast<std::uint64_t>(node_id));
-                    });
+                std::for_each(leg_geometry.osm_node_ids.begin(),
+                              leg_geometry.osm_node_ids.end(),
+                              [this, &nodes](const OSMNodeID &node_id) {
+                                  nodes.values.push_back(static_cast<std::uint64_t>(node_id));
+                              });
                 util::json::Object annotation;
                 annotation.values["distance"] = std::move(distances);
                 annotation.values["duration"] = std::move(durations);

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -67,6 +67,7 @@ class BaseDataFacade
 
     // node and edge information access
     virtual util::Coordinate GetCoordinateOfNode(const unsigned id) const = 0;
+    virtual OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const = 0;
 
     virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const = 0;
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -17,6 +17,7 @@
 #include "engine/geospatial_query.hpp"
 #include "util/graph_loader.hpp"
 #include "util/io.hpp"
+#include "util/packed_vector.hpp"
 #include "util/range_table.hpp"
 #include "util/rectangle.hpp"
 #include "util/shared_memory_vector_wrapper.hpp"
@@ -24,7 +25,6 @@
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
 #include "util/typedefs.hpp"
-#include "util/packed_vector.hpp"
 
 #include "osrm/coordinate.hpp"
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -73,6 +73,7 @@ class InternalDataFacade final : public BaseDataFacade
     std::string m_timestamp;
 
     util::ShM<util::Coordinate, false>::vector m_coordinate_list;
+    util::ShM<OSMNodeID, false>::vector m_osmnodeid_list;
     util::ShM<NodeID, false>::vector m_via_node_list;
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;
@@ -156,10 +157,12 @@ class InternalDataFacade final : public BaseDataFacade
         unsigned number_of_coordinates = 0;
         nodes_input_stream.read((char *)&number_of_coordinates, sizeof(unsigned));
         m_coordinate_list.resize(number_of_coordinates);
+        m_osmnodeid_list.resize(number_of_coordinates);
         for (unsigned i = 0; i < number_of_coordinates; ++i)
         {
             nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
             m_coordinate_list[i] = util::Coordinate(current_node.lon, current_node.lat);
+            m_osmnodeid_list[i] = current_node.node_id;
             BOOST_ASSERT(m_coordinate_list[i].IsValid());
         }
 
@@ -436,6 +439,11 @@ class InternalDataFacade final : public BaseDataFacade
     util::Coordinate GetCoordinateOfNode(const unsigned id) const override final
     {
         return m_coordinate_list[id];
+    }
+
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const override final
+    {
+        return m_osmnodeid_list[id];
     }
 
     extractor::guidance::TurnInstruction

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -74,7 +74,7 @@ class InternalDataFacade final : public BaseDataFacade
     std::string m_timestamp;
 
     util::ShM<util::Coordinate, false>::vector m_coordinate_list;
-    util::PackedVector<false> m_osmnodeid_list;
+    util::PackedVector<OSMNodeID, false> m_osmnodeid_list;
     util::ShM<NodeID, false>::vector m_via_node_list;
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -76,6 +76,7 @@ class SharedDataFacade final : public BaseDataFacade
     extractor::ProfileProperties *m_profile_properties;
 
     util::ShM<util::Coordinate, true>::vector m_coordinate_list;
+    util::ShM<OSMNodeID, true>::vector m_osmnodeid_list;
     util::ShM<NodeID, true>::vector m_via_node_list;
     util::ShM<unsigned, true>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, true>::vector m_turn_instruction_list;
@@ -169,6 +170,11 @@ class SharedDataFacade final : public BaseDataFacade
         m_coordinate_list.reset(
             coordinate_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::COORDINATE_LIST]);
+
+        auto osmnodeid_list_ptr = data_layout->GetBlockPtr<OSMNodeID>(
+            shared_memory, storage::SharedDataLayout::OSM_NODE_ID_LIST);
+        m_osmnodeid_list.reset(osmnodeid_list_ptr,
+            data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
 
         auto travel_mode_list_ptr = data_layout->GetBlockPtr<extractor::TravelMode>(
             shared_memory, storage::SharedDataLayout::TRAVEL_MODE);
@@ -469,6 +475,11 @@ class SharedDataFacade final : public BaseDataFacade
     util::Coordinate GetCoordinateOfNode(const NodeID id) const override final
     {
         return m_coordinate_list[id];
+    }
+
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const override final
+    {
+        return m_osmnodeid_list[id];
     }
 
     virtual void GetUncompressedGeometry(const EdgeID id,

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -76,7 +76,7 @@ class SharedDataFacade final : public BaseDataFacade
     extractor::ProfileProperties *m_profile_properties;
 
     util::ShM<util::Coordinate, true>::vector m_coordinate_list;
-    util::ShM<OSMNodeID, true>::vector m_osmnodeid_list;
+    util::PackedVector<true> m_osmnodeid_list;
     util::ShM<NodeID, true>::vector m_via_node_list;
     util::ShM<unsigned, true>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, true>::vector m_turn_instruction_list;
@@ -175,6 +175,7 @@ class SharedDataFacade final : public BaseDataFacade
             shared_memory, storage::SharedDataLayout::OSM_NODE_ID_LIST);
         m_osmnodeid_list.reset(osmnodeid_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
+        m_osmnodeid_list.set_number_of_entries(util::PackedVectorCapacity(data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]));
 
         auto travel_mode_list_ptr = data_layout->GetBlockPtr<extractor::TravelMode>(
             shared_memory, storage::SharedDataLayout::TRAVEL_MODE);
@@ -479,7 +480,7 @@ class SharedDataFacade final : public BaseDataFacade
 
     OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const override final
     {
-        return m_osmnodeid_list[id];
+        return m_osmnodeid_list.at(id);
     }
 
     virtual void GetUncompressedGeometry(const EdgeID id,

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -76,7 +76,7 @@ class SharedDataFacade final : public BaseDataFacade
     extractor::ProfileProperties *m_profile_properties;
 
     util::ShM<util::Coordinate, true>::vector m_coordinate_list;
-    util::PackedVector<true> m_osmnodeid_list;
+    util::PackedVector<OSMNodeID, true> m_osmnodeid_list;
     util::ShM<NodeID, true>::vector m_via_node_list;
     util::ShM<unsigned, true>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, true>::vector m_turn_instruction_list;

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -173,9 +173,11 @@ class SharedDataFacade final : public BaseDataFacade
 
         auto osmnodeid_list_ptr = data_layout->GetBlockPtr<OSMNodeID>(
             shared_memory, storage::SharedDataLayout::OSM_NODE_ID_LIST);
-        m_osmnodeid_list.reset(osmnodeid_list_ptr,
+        m_osmnodeid_list.reset(
+            osmnodeid_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
-        m_osmnodeid_list.set_number_of_entries(util::PackedVectorCapacity(data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]));
+        m_osmnodeid_list.set_number_of_entries(util::PackedVectorCapacity(
+            data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]));
 
         auto travel_mode_list_ptr = data_layout->GetBlockPtr<extractor::TravelMode>(
             shared_memory, storage::SharedDataLayout::TRAVEL_MODE);

--- a/include/engine/guidance/leg_geometry.hpp
+++ b/include/engine/guidance/leg_geometry.hpp
@@ -3,6 +3,7 @@
 
 #include "util/coordinate.hpp"
 #include "util/integer_range.hpp"
+#include "util/typedefs.hpp"
 
 #include <boost/assert.hpp>
 
@@ -30,6 +31,8 @@ struct LegGeometry
     std::vector<std::size_t> segment_offsets;
     // length of the segment in meters
     std::vector<double> segment_distances;
+    // original OSM node IDs for each coordinate
+    std::vector<OSMNodeID> osm_node_ids;
 
     // Per-coordinate metadata
     struct Annotation

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -28,6 +28,7 @@ struct SharedDataLayout
         GRAPH_NODE_LIST,
         GRAPH_EDGE_LIST,
         COORDINATE_LIST,
+        OSM_NODE_ID_LIST,
         TURN_INSTRUCTION,
         ENTRY_CLASSID,
         TRAVEL_MODE,

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -25,7 +25,7 @@ class PackedVector
   public:
     PackedVector() = default;
 
-    void insert(OSMNodeID incoming_node_id)
+    void push_back(OSMNodeID incoming_node_id)
     {
         std::uint64_t node_id = static_cast<std::uint64_t>(incoming_node_id);
         // mask incoming values, just in case they are > bitsize
@@ -61,7 +61,7 @@ class PackedVector
         num_elements++;
     }
 
-    OSMNodeID retrieve(const std::size_t &a_index) const
+    OSMNodeID at(const std::size_t &a_index) const
     {
         BOOST_ASSERT(a_index < num_elements);
 
@@ -100,6 +100,21 @@ class PackedVector
             const std::uint64_t right_side = next_elem >> (ELEMSIZE - (BITSIZE - left_index));
             return static_cast<OSMNodeID>(left_side | right_side);
         }
+    }
+
+    std::size_t size() const
+    {
+        return num_elements;
+    }
+
+    void reserve(std::size_t capacity)
+    {
+        vec.reserve(ceil(float(capacity) / ELEMSIZE) * BITSIZE);
+    }
+
+    std::size_t capacity() const
+    {
+        return floor(float(vec.capacity()) / BITSIZE) * ELEMSIZE;
     }
 
   private:

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -2,6 +2,7 @@
 #define PACKED_VECTOR_HPP
 
 #include "util/typedefs.hpp"
+#include "util/shared_memory_vector_wrapper.hpp"
 
 #include <cmath>
 #include <vector>
@@ -15,12 +16,18 @@ const constexpr std::size_t BITSIZE = 33;
 const constexpr std::size_t ELEMSIZE = 64;
 const constexpr std::size_t PACKSIZE = BITSIZE * ELEMSIZE;
 
-std::size_t PackedVectorSize(std::size_t elements)
+/**
+ * Returns the size of the packed vector datastructure with `elements` packed elements (the size of its underlying vector)
+ */
+inline std::size_t PackedVectorSize(std::size_t elements)
 {
     return ceil(float(elements) / ELEMSIZE) * BITSIZE;
 };
 
-std::size_t PackedVectorCapacity(std::size_t vec_size)
+/**
+ * Returns the capacity of a packed vector with underlying vector size `vec_size`
+ */
+inline std::size_t PackedVectorCapacity(std::size_t vec_size)
 {
     return floor(float(vec_size) / BITSIZE) * ELEMSIZE;
 }
@@ -33,11 +40,13 @@ std::size_t PackedVectorCapacity(std::size_t vec_size)
 template <bool UseSharedMemory> class PackedVector
 {
   public:
+
     PackedVector() = default;
 
     void push_back(OSMNodeID incoming_node_id)
     {
         std::uint64_t node_id = static_cast<std::uint64_t>(incoming_node_id);
+
         // mask incoming values, just in case they are > bitsize
         const std::uint64_t incoming_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
         node_id = node_id & incoming_mask;

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -1,0 +1,101 @@
+#ifndef PACKED_VECTOR_HPP
+#define PACKED_VECTOR_HPP
+
+#include "util/typedefs.hpp"
+
+#include <vector>
+
+namespace osrm
+{
+namespace util
+{
+
+const constexpr std::size_t BITSIZE = 33;
+const constexpr std::size_t ELEMSIZE = 64;
+const constexpr std::size_t PACKSIZE = BITSIZE * ELEMSIZE;
+
+class PackedVector
+{
+  public:
+    PackedVector() = default;
+
+    void insert(OSMNodeID &node_id)
+    {
+        // mask incoming values, just in case they are > bitsize
+        std::uint64_t incoming_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
+        node_id = node_id & incoming_mask;
+
+        const std::size_t available = (PACKSIZE - BITSIZE * num_elements) % ELEMSIZE;
+
+        if (available == 0)
+        {
+            // insert ID at the left side of this element
+            std::uint64_t at_left = node_id << (ELEMSIZE - BITSIZE);
+            vec.push_back(at_left);
+        }
+        else if (available >= BITSIZE)
+        {
+            // insert ID somewhere in the middle of this element; ID can be contained
+            // entirely within one element
+            std::uint64_t shifted = node_id << (available - BITSIZE);
+            vec.back() = vec.back() | shifted;
+        }
+        else
+        {
+            // ID will be split between the end of this element and the beginning
+            // of the next element
+            std::uint64_t left = node_id >> (BITSIZE - available);
+            vec.back() = vec.back() | left;
+
+            std::uint64_t right = node_id << (ELEMSIZE - (BITSIZE - available));
+            vec.push_back(right);
+        }
+
+        num_elements++;
+    }
+
+    OSMNodeID retrieve(const std::size_t &a_index) const
+    {
+        // TODO check if OOB
+
+        const std::size_t pack_group = trunc(a_index / ELEMSIZE);
+        const std::size_t pack_index = (a_index + ELEMSIZE) % ELEMSIZE;       // ?
+        const std::size_t left_index = (PACKSIZE - BITSIZE * pack_index) % ELEMSIZE;
+
+        const bool back_half = pack_index >= BITSIZE;
+        std::size_t index = pack_group * BITSIZE + trunc(pack_index / BITSIZE) + trunc((pack_index - back_half) / 2);
+
+        std::uint64_t elem = vec.at(index);
+
+        if (left_index == 0)
+        {
+            // ID is at the far left side of this element
+            return elem >> (ELEMSIZE - BITSIZE);
+        }
+        else if (left_index >= BITSIZE)
+        {
+            // ID is entirely contained within this element
+            std::uint64_t at_right = elem >> (left_index - BITSIZE);
+            std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
+            return at_right & left_mask;
+        }
+        else
+        {
+            // ID is split between this and the next element
+            std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, left_index)) - 1;
+            std::uint64_t left_side = (elem & left_mask) << (BITSIZE - left_index);
+
+            // TODO check OOB
+            std::uint64_t next_elem = vec.at(index + 1);
+
+            std::uint64_t right_side = next_elem >> (ELEMSIZE - (BITSIZE - left_index));
+            return left_side | right_side;
+        }
+    }
+
+  private:
+    std::vector<OSMNodeID> vec;
+    std::size_t num_elements = 0;
+};
+
+#endif /* PACKED_VECTOR_HPP */

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -17,7 +17,8 @@ const constexpr std::size_t ELEMSIZE = 64;
 const constexpr std::size_t PACKSIZE = BITSIZE * ELEMSIZE;
 
 /**
- * Returns the size of the packed vector datastructure with `elements` packed elements (the size of its underlying vector)
+ * Returns the size of the packed vector datastructure with `elements` packed elements (the size of
+ * its underlying vector)
  */
 inline std::size_t PackedVectorSize(std::size_t elements)
 {
@@ -40,7 +41,6 @@ inline std::size_t PackedVectorCapacity(std::size_t vec_size)
 template <bool UseSharedMemory> class PackedVector
 {
   public:
-
     PackedVector() = default;
 
     void push_back(OSMNodeID incoming_node_id)
@@ -124,10 +124,7 @@ template <bool UseSharedMemory> class PackedVector
         }
     }
 
-    std::size_t size() const
-    {
-        return num_elements;
-    }
+    std::size_t size() const { return num_elements; }
 
     template <bool enabled = UseSharedMemory>
     void reserve(typename std::enable_if<!enabled, std::size_t>::type capacity)
@@ -136,7 +133,8 @@ template <bool UseSharedMemory> class PackedVector
     }
 
     template <bool enabled = UseSharedMemory>
-    void reset(typename std::enable_if<enabled, OSMNodeID>::type *ptr, typename std::enable_if<enabled, std::size_t>::type size)
+    void reset(typename std::enable_if<enabled, OSMNodeID>::type *ptr,
+               typename std::enable_if<enabled, std::size_t>::type size)
     {
         vec.reset(reinterpret_cast<std::uint64_t *>(ptr), size);
     }
@@ -147,13 +145,9 @@ template <bool UseSharedMemory> class PackedVector
         num_elements = count;
     }
 
-    std::size_t capacity() const
-    {
-        return PackedVectorCapacity(vec.capacity());
-    }
+    std::size_t capacity() const { return PackedVectorCapacity(vec.capacity()); }
 
   private:
-
     typename util::ShM<std::uint64_t, UseSharedMemory>::vector vec;
 
     std::size_t num_elements = 0;
@@ -186,13 +180,13 @@ template <bool UseSharedMemory> class PackedVector
     }
 
     template <bool enabled = UseSharedMemory>
-    std::uint64_t vec_back(typename std::enable_if<enabled>::type* = nullptr)
+    std::uint64_t vec_back(typename std::enable_if<enabled>::type * = nullptr)
     {
         return vec[cursor];
     }
 
     template <bool enabled = UseSharedMemory>
-    std::uint64_t vec_back(typename std::enable_if<!enabled>::type* = nullptr)
+    std::uint64_t vec_back(typename std::enable_if<!enabled>::type * = nullptr)
     {
         return vec.back();
     }

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -3,6 +3,7 @@
 
 #include "util/typedefs.hpp"
 
+#include <cmath>
 #include <vector>
 
 namespace osrm
@@ -14,15 +15,21 @@ const constexpr std::size_t BITSIZE = 33;
 const constexpr std::size_t ELEMSIZE = 64;
 const constexpr std::size_t PACKSIZE = BITSIZE * ELEMSIZE;
 
+/**
+ * Since OSM node IDs are (at the time of writing) not quite yet overflowing 32 bits, and
+ * will predictably be containable within 33 bits for a long time, the following packs
+ * 64-bit OSM IDs as 33-bit numbers within a 64-bit vector.
+ */
 class PackedVector
 {
   public:
     PackedVector() = default;
 
-    void insert(OSMNodeID &node_id)
+    void insert(OSMNodeID incoming_node_id)
     {
+        std::uint64_t node_id = static_cast<std::uint64_t>(incoming_node_id);
         // mask incoming values, just in case they are > bitsize
-        std::uint64_t incoming_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
+        const std::uint64_t incoming_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
         node_id = node_id & incoming_mask;
 
         const std::size_t available = (PACKSIZE - BITSIZE * num_elements) % ELEMSIZE;
@@ -37,14 +44,14 @@ class PackedVector
         {
             // insert ID somewhere in the middle of this element; ID can be contained
             // entirely within one element
-            std::uint64_t shifted = node_id << (available - BITSIZE);
+            const std::uint64_t shifted = node_id << (available - BITSIZE);
             vec.back() = vec.back() | shifted;
         }
         else
         {
             // ID will be split between the end of this element and the beginning
             // of the next element
-            std::uint64_t left = node_id >> (BITSIZE - available);
+            const std::uint64_t left = node_id >> (BITSIZE - available);
             vec.back() = vec.back() | left;
 
             std::uint64_t right = node_id << (ELEMSIZE - (BITSIZE - available));
@@ -56,46 +63,50 @@ class PackedVector
 
     OSMNodeID retrieve(const std::size_t &a_index) const
     {
-        // TODO check if OOB
+        BOOST_ASSERT(a_index < num_elements);
 
         const std::size_t pack_group = trunc(a_index / ELEMSIZE);
-        const std::size_t pack_index = (a_index + ELEMSIZE) % ELEMSIZE;       // ?
+        const std::size_t pack_index = (a_index + ELEMSIZE) % ELEMSIZE;
         const std::size_t left_index = (PACKSIZE - BITSIZE * pack_index) % ELEMSIZE;
 
         const bool back_half = pack_index >= BITSIZE;
-        std::size_t index = pack_group * BITSIZE + trunc(pack_index / BITSIZE) + trunc((pack_index - back_half) / 2);
+        const std::size_t index = pack_group * BITSIZE + trunc(pack_index / BITSIZE) +
+                                  trunc((pack_index - back_half) / 2);
 
-        std::uint64_t elem = vec.at(index);
+        BOOST_ASSERT(index < vec.size());
+        const std::uint64_t elem = vec.at(index);
 
         if (left_index == 0)
         {
             // ID is at the far left side of this element
-            return elem >> (ELEMSIZE - BITSIZE);
+            return static_cast<OSMNodeID>(elem >> (ELEMSIZE - BITSIZE));
         }
         else if (left_index >= BITSIZE)
         {
             // ID is entirely contained within this element
-            std::uint64_t at_right = elem >> (left_index - BITSIZE);
-            std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
-            return at_right & left_mask;
+            const std::uint64_t at_right = elem >> (left_index - BITSIZE);
+            const std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
+            return static_cast<OSMNodeID>(at_right & left_mask);
         }
         else
         {
             // ID is split between this and the next element
-            std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, left_index)) - 1;
-            std::uint64_t left_side = (elem & left_mask) << (BITSIZE - left_index);
+            const std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, left_index)) - 1;
+            const std::uint64_t left_side = (elem & left_mask) << (BITSIZE - left_index);
 
-            // TODO check OOB
-            std::uint64_t next_elem = vec.at(index + 1);
+            BOOST_ASSERT(index < vec.size() - 1);
+            const std::uint64_t next_elem = vec.at(index + 1);
 
-            std::uint64_t right_side = next_elem >> (ELEMSIZE - (BITSIZE - left_index));
-            return left_side | right_side;
+            const std::uint64_t right_side = next_elem >> (ELEMSIZE - (BITSIZE - left_index));
+            return static_cast<OSMNodeID>(left_side | right_side);
         }
     }
 
   private:
-    std::vector<OSMNodeID> vec;
+    std::vector<std::uint64_t> vec;
     std::size_t num_elements = 0;
 };
+}
+}
 
 #endif /* PACKED_VECTOR_HPP */

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -1,8 +1,8 @@
 #ifndef PACKED_VECTOR_HPP
 #define PACKED_VECTOR_HPP
 
-#include "util/typedefs.hpp"
 #include "util/shared_memory_vector_wrapper.hpp"
+#include "util/typedefs.hpp"
 
 #include <cmath>
 #include <vector>

--- a/include/util/shared_memory_vector_wrapper.hpp
+++ b/include/util/shared_memory_vector_wrapper.hpp
@@ -3,6 +3,8 @@
 
 #include <boost/assert.hpp>
 
+#include "util/simple_logger.hpp"
+
 #include <cstddef>
 
 #include <algorithm>

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -729,6 +729,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
         // fixup the coordinate
         geometry.locations.erase(geometry.locations.begin());
         geometry.annotations.erase(geometry.annotations.begin());
+        geometry.osm_node_ids.erase(geometry.osm_node_ids.begin());
 
         // remove the initial distance value
         geometry.segment_distances.erase(geometry.segment_distances.begin());
@@ -818,6 +819,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
     {
         geometry.locations.pop_back();
         geometry.annotations.pop_back();
+        geometry.osm_node_ids.pop_back();
         geometry.segment_offsets.pop_back();
         BOOST_ASSERT(geometry.segment_distances.back() < 1);
         geometry.segment_distances.pop_back();

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -542,7 +542,7 @@ int Storage::Run()
         shared_memory_ptr, SharedDataLayout::COORDINATE_LIST);
     OSMNodeID *osmnodeid_ptr = shared_layout_ptr->GetBlockPtr<OSMNodeID, true>(
         shared_memory_ptr, SharedDataLayout::OSM_NODE_ID_LIST);
-    util::PackedVector<true> osmnodeid_list;
+    util::PackedVector<OSMNodeID, true> osmnodeid_list;
     osmnodeid_list.reset(
         osmnodeid_ptr, shared_layout_ptr->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -20,6 +20,7 @@
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
 #include "util/typedefs.hpp"
+#include "util/packed_vector.hpp"
 
 #ifdef __linux__
 #include <sys/mman.h>
@@ -244,9 +245,9 @@ int Storage::Run()
     nodes_input_stream.read((char *)&coordinate_list_size, sizeof(unsigned));
     shared_layout_ptr->SetBlockSize<util::Coordinate>(SharedDataLayout::COORDINATE_LIST,
                                                       coordinate_list_size);
-    // we'll read a list of OSM node IDs from the same data, so set the same block size:
+    // we'll read a list of OSM node IDs from the same data, so set the block size for the same number of items:
     shared_layout_ptr->SetBlockSize<OSMNodeID>(SharedDataLayout::OSM_NODE_ID_LIST,
-                                               coordinate_list_size);
+                                               util::PackedVectorSize(coordinate_list_size));
 
     // load geometries sizes
     boost::filesystem::ifstream geometry_input_stream(config.geometries_path, std::ios::binary);
@@ -540,13 +541,15 @@ int Storage::Run()
         shared_memory_ptr, SharedDataLayout::COORDINATE_LIST);
     OSMNodeID *osmnodeid_ptr = shared_layout_ptr->GetBlockPtr<OSMNodeID, true>(
         shared_memory_ptr, SharedDataLayout::OSM_NODE_ID_LIST);
+    util::PackedVector<true> osmnodeid_list;
+    osmnodeid_list.reset(osmnodeid_ptr, shared_layout_ptr->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
 
     extractor::QueryNode current_node;
     for (unsigned i = 0; i < coordinate_list_size; ++i)
     {
         nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
         coordinates_ptr[i] = util::Coordinate(current_node.lon, current_node.lat);
-        osmnodeid_ptr[i] = OSMNodeID(current_node.node_id);
+        osmnodeid_list.push_back(OSMNodeID(current_node.node_id));
     }
     nodes_input_stream.close();
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -14,13 +14,13 @@
 #include "util/exception.hpp"
 #include "util/fingerprint.hpp"
 #include "util/io.hpp"
+#include "util/packed_vector.hpp"
 #include "util/range_table.hpp"
 #include "util/shared_memory_vector_wrapper.hpp"
 #include "util/simple_logger.hpp"
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
 #include "util/typedefs.hpp"
-#include "util/packed_vector.hpp"
 
 #ifdef __linux__
 #include <sys/mman.h>

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -245,7 +245,8 @@ int Storage::Run()
     nodes_input_stream.read((char *)&coordinate_list_size, sizeof(unsigned));
     shared_layout_ptr->SetBlockSize<util::Coordinate>(SharedDataLayout::COORDINATE_LIST,
                                                       coordinate_list_size);
-    // we'll read a list of OSM node IDs from the same data, so set the block size for the same number of items:
+    // we'll read a list of OSM node IDs from the same data, so set the block size for the same
+    // number of items:
     shared_layout_ptr->SetBlockSize<OSMNodeID>(SharedDataLayout::OSM_NODE_ID_LIST,
                                                util::PackedVectorSize(coordinate_list_size));
 
@@ -542,7 +543,8 @@ int Storage::Run()
     OSMNodeID *osmnodeid_ptr = shared_layout_ptr->GetBlockPtr<OSMNodeID, true>(
         shared_memory_ptr, SharedDataLayout::OSM_NODE_ID_LIST);
     util::PackedVector<true> osmnodeid_list;
-    osmnodeid_list.reset(osmnodeid_ptr, shared_layout_ptr->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
+    osmnodeid_list.reset(
+        osmnodeid_ptr, shared_layout_ptr->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
 
     extractor::QueryNode current_node;
     for (unsigned i = 0; i < coordinate_list_size; ++i)

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -244,6 +244,9 @@ int Storage::Run()
     nodes_input_stream.read((char *)&coordinate_list_size, sizeof(unsigned));
     shared_layout_ptr->SetBlockSize<util::Coordinate>(SharedDataLayout::COORDINATE_LIST,
                                                       coordinate_list_size);
+    // we'll read a list of OSM node IDs from the same data, so set the same block size:
+    shared_layout_ptr->SetBlockSize<OSMNodeID>(SharedDataLayout::OSM_NODE_ID_LIST,
+                                               coordinate_list_size);
 
     // load geometries sizes
     boost::filesystem::ifstream geometry_input_stream(config.geometries_path, std::ios::binary);
@@ -535,12 +538,15 @@ int Storage::Run()
     // Loading list of coordinates
     util::Coordinate *coordinates_ptr = shared_layout_ptr->GetBlockPtr<util::Coordinate, true>(
         shared_memory_ptr, SharedDataLayout::COORDINATE_LIST);
+    OSMNodeID *osmnodeid_ptr = shared_layout_ptr->GetBlockPtr<OSMNodeID, true>(
+        shared_memory_ptr, SharedDataLayout::OSM_NODE_ID_LIST);
 
     extractor::QueryNode current_node;
     for (unsigned i = 0; i < coordinate_list_size; ++i)
     {
         nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
         coordinates_ptr[i] = util::Coordinate(current_node.lon, current_node.lat);
+        osmnodeid_ptr[i] = OSMNodeID(current_node.node_id);
     }
     nodes_input_stream.close();
 

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -50,6 +50,10 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     {
         return {util::FixedLongitude{0}, util::FixedLatitude{0}};
     }
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned /* id */) const override
+    {
+        return OSMNodeID{0};
+    }
     bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
     unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const override
     {

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -50,10 +50,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     {
         return {util::FixedLongitude{0}, util::FixedLatitude{0}};
     }
-    OSMNodeID GetOSMNodeIDOfNode(const unsigned /* id */) const override
-    {
-        return OSMNodeID{0};
-    }
+    OSMNodeID GetOSMNodeIDOfNode(const unsigned /* id */) const override { return OSMNodeID{0}; }
     bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
     unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const override
     {

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -12,7 +12,7 @@ using namespace osrm::util;
 // Verify that the packed vector behaves as expected
 BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
 {
-    PackedVector packed_ids;
+    PackedVector<false> packed_ids;
     std::vector<OSMNodeID> original_ids;
 
     const constexpr std::size_t num_test_cases = 399;
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
 
 BOOST_AUTO_TEST_CASE(packed_vector_capacity_test)
 {
-    PackedVector packed_vec;
+    PackedVector<false> packed_vec;
     const std::size_t original_size = packed_vec.capacity();
     std::vector<OSMNodeID> dummy_vec;
 

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -1,0 +1,34 @@
+#include "util/packed_vector.hpp"
+#include "util/typedefs.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_case_template.hpp>
+
+BOOST_AUTO_TEST_SUITE(packed_vector_test)
+
+using namespace osrm;
+using namespace osrm::util;
+
+// Verify that the packed vector behaves as expected
+BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
+{
+    PackedVector packed_ids;
+    std::vector<OSMNodeID> original_ids;
+
+    const constexpr std::size_t num_test_cases = 399;
+
+    for (std::size_t i = 0; i < num_test_cases; i++)
+    {
+        OSMNodeID r = static_cast<OSMNodeID>(rand() % 2147483647); // max 33-bit uint
+
+        packed_ids.insert(r);
+        original_ids.push_back(r);
+    }
+
+    for (std::size_t i = 0; i < num_test_cases; i++)
+    {
+        BOOST_CHECK_EQUAL(original_ids.at(i), packed_ids.retrieve(i));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -21,14 +21,27 @@ BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
     {
         OSMNodeID r = static_cast<OSMNodeID>(rand() % 2147483647); // max 33-bit uint
 
-        packed_ids.insert(r);
+        packed_ids.push_back(r);
         original_ids.push_back(r);
     }
 
     for (std::size_t i = 0; i < num_test_cases; i++)
     {
-        BOOST_CHECK_EQUAL(original_ids.at(i), packed_ids.retrieve(i));
+        BOOST_CHECK_EQUAL(original_ids.at(i), packed_ids.at(i));
     }
+}
+
+BOOST_AUTO_TEST_CASE(packed_vector_capacity_test)
+{
+    PackedVector packed_vec;
+    const std::size_t original_size = packed_vec.capacity();
+    std::vector<OSMNodeID> dummy_vec;
+
+    BOOST_CHECK_EQUAL(original_size, dummy_vec.capacity());
+
+    packed_vec.reserve(100);
+
+    BOOST_CHECK(packed_vec.capacity() >= 100);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -1,8 +1,8 @@
 #include "util/packed_vector.hpp"
 #include "util/typedefs.hpp"
 
-#include <boost/test/unit_test.hpp>
 #include <boost/test/test_case_template.hpp>
+#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(packed_vector_test)
 

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -12,7 +12,7 @@ using namespace osrm::util;
 // Verify that the packed vector behaves as expected
 BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
 {
-    PackedVector<false> packed_ids;
+    PackedVector<OSMNodeID, false> packed_ids;
     std::vector<OSMNodeID> original_ids;
 
     const constexpr std::size_t num_test_cases = 399;
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
 
 BOOST_AUTO_TEST_CASE(packed_vector_capacity_test)
 {
-    PackedVector<false> packed_vec;
+    PackedVector<OSMNodeID, false> packed_vec;
     const std::size_t original_size = packed_vec.capacity();
     std::vector<OSMNodeID> dummy_vec;
 


### PR DESCRIPTION
This recreates https://github.com/Project-OSRM/osrm-backend/pull/2337 against current master to address #2054. 

Cribbing the TODO list from that PR:

- [x] Implement shared memory loading

  Based on preliminary checks, it does now work with shared memory. I was a bit flying blind on shared memory knowledge, though, so although it looked straightforward to me, I definitely could have done something wonky…

- [x] Investigate memory overhead on big datasets
- [x] Write tests
- [x] Write addition to API spec and discuss (API parameter? default?)

  Rather than adding node IDs to step objects, this now adds them to the optional `annotation` object introduced as an optional (off by default) API parameter recently.

- [ ] Write changelog entry
- [x] Integrate packed vector
- [x] Tests for packed vector
- [x] Re-investigate mem usage after packed vector to confirm

@TheMarex @danpat 