### PR TITLE
Fix #2413 by making enum-base explicitly unsigned char

### DIFF
--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -33,8 +33,8 @@ namespace json
 namespace detail
 {
 
-std::string instructionTypeToString(extractor::guidance::TurnType type);
-std::string instructionModifierToString(extractor::guidance::DirectionModifier modifier);
+std::string instructionTypeToString(extractor::guidance::TurnType::Enum type);
+std::string instructionModifierToString(extractor::guidance::DirectionModifier::Enum modifier);
 
 util::json::Array coordinateToLonLat(const util::Coordinate coordinate);
 

--- a/include/engine/guidance/toolkit.hpp
+++ b/include/engine/guidance/toolkit.hpp
@@ -49,7 +49,7 @@ inline bool staysOnRoundabout(const extractor::guidance::TurnInstruction instruc
     return instruction.type == extractor::guidance::TurnType::StayOnRoundabout;
 }
 
-inline extractor::guidance::DirectionModifier angleToDirectionModifier(const double bearing)
+inline extractor::guidance::DirectionModifier::Enum angleToDirectionModifier(const double bearing)
 {
     if (bearing < 135)
     {

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -49,7 +49,7 @@ class IntersectionHandler
     std::size_t countValid(const Intersection &intersection) const;
 
     // Decide on a basic turn types
-    TurnType findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;
+    TurnType::Enum findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;
 
     // Get the Instruction for an obvious turn
     TurnInstruction getInstructionForObvious(const std::size_t number_of_candidates,

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -145,13 +145,13 @@ getRepresentativeCoordinate(const NodeID from_node,
 }
 
 // shift an instruction around the degree circle in CCW order
-inline DirectionModifier forcedShiftCCW(const DirectionModifier modifier)
+inline DirectionModifier::Enum forcedShiftCCW(const DirectionModifier::Enum modifier)
 {
-    return static_cast<DirectionModifier>((static_cast<std::uint32_t>(modifier) + 1) %
-                                          detail::num_direction_modifiers);
+    return static_cast<DirectionModifier::Enum>((static_cast<std::uint32_t>(modifier) + 1) %
+                                                detail::num_direction_modifiers);
 }
 
-inline DirectionModifier shiftCCW(const DirectionModifier modifier)
+inline DirectionModifier::Enum shiftCCW(const DirectionModifier::Enum modifier)
 {
     if (detail::shiftable_ccw[static_cast<int>(modifier)])
         return forcedShiftCCW(modifier);
@@ -160,14 +160,14 @@ inline DirectionModifier shiftCCW(const DirectionModifier modifier)
 }
 
 // shift an instruction around the degree circle in CW order
-inline DirectionModifier forcedShiftCW(const DirectionModifier modifier)
+inline DirectionModifier::Enum forcedShiftCW(const DirectionModifier::Enum modifier)
 {
-    return static_cast<DirectionModifier>(
+    return static_cast<DirectionModifier::Enum>(
         (static_cast<std::uint32_t>(modifier) + detail::num_direction_modifiers - 1) %
         detail::num_direction_modifiers);
 }
 
-inline DirectionModifier shiftCW(const DirectionModifier modifier)
+inline DirectionModifier::Enum shiftCW(const DirectionModifier::Enum modifier)
 {
     if (detail::shiftable_cw[static_cast<int>(modifier)])
         return forcedShiftCW(modifier);
@@ -175,7 +175,7 @@ inline DirectionModifier shiftCW(const DirectionModifier modifier)
         return modifier;
 }
 
-inline bool isBasic(const TurnType type)
+inline bool isBasic(const TurnType::Enum type)
 {
     return type == TurnType::Turn || type == TurnType::EndOfRoad;
 }
@@ -219,7 +219,7 @@ inline bool isSlightTurn(const TurnInstruction turn)
             turn.direction_modifier == DirectionModifier::SlightLeft);
 }
 
-inline bool isSlightModifier(const DirectionModifier direction_modifier)
+inline bool isSlightModifier(const DirectionModifier::Enum direction_modifier)
 {
     return (direction_modifier == DirectionModifier::Straight ||
             direction_modifier == DirectionModifier::SlightRight ||
@@ -257,7 +257,7 @@ inline double angleFromDiscreteAngle(const DiscreteAngle angle)
            0.5 * detail::discrete_angle_step_size;
 }
 
-inline double getAngularPenalty(const double angle, DirectionModifier modifier)
+inline double getAngularPenalty(const double angle, DirectionModifier::Enum modifier)
 {
     // these are not aligned with getTurnDirection but represent an ideal center
     const double center[] = {0, 45, 90, 135, 180, 225, 270, 315};
@@ -278,16 +278,16 @@ inline double getTurnConfidence(const double angle, TurnInstruction instruction)
 }
 
 // swaps left <-> right modifier types
-inline DirectionModifier mirrorDirectionModifier(const DirectionModifier modifier)
+inline DirectionModifier::Enum mirrorDirectionModifier(const DirectionModifier::Enum modifier)
 {
-    const constexpr DirectionModifier results[] = {
+    const constexpr DirectionModifier::Enum results[] = {
         DirectionModifier::UTurn,      DirectionModifier::SharpLeft, DirectionModifier::Left,
         DirectionModifier::SlightLeft, DirectionModifier::Straight,  DirectionModifier::SlightRight,
         DirectionModifier::Right,      DirectionModifier::SharpRight};
     return results[modifier];
 }
 
-inline bool canBeSuppressed(const TurnType type)
+inline bool canBeSuppressed(const TurnType::Enum type)
 {
     if (type == TurnType::Turn)
         return true;
@@ -300,7 +300,7 @@ inline bool isLowPriorityRoadClass(const FunctionalRoadClass road_class)
            road_class == FunctionalRoadClass::SERVICE;
 }
 
-inline bool isDistinct(const DirectionModifier first, const DirectionModifier second)
+inline bool isDistinct(const DirectionModifier::Enum first, const DirectionModifier::Enum second)
 {
     if ((first + 1) % detail::num_direction_modifiers == second)
         return false;
@@ -441,7 +441,7 @@ inline bool canBeSeenAsFork(const FunctionalRoadClass first, const FunctionalRoa
 // turn and vice versa.
 inline ConnectedRoad mirror(ConnectedRoad road)
 {
-    const constexpr DirectionModifier mirrored_modifiers[] = {
+    const constexpr DirectionModifier::Enum mirrored_modifiers[] = {
         DirectionModifier::UTurn,      DirectionModifier::SharpLeft, DirectionModifier::Left,
         DirectionModifier::SlightLeft, DirectionModifier::Straight,  DirectionModifier::SlightRight,
         DirectionModifier::Right,      DirectionModifier::SharpRight};

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -20,62 +20,62 @@ namespace detail
 const constexpr uint8_t num_direction_modifiers = 8;
 } // detail
 
-// direction modifiers based on angle
-// Would be nice to have
-// enum class DirectionModifier : unsigned char
-enum DirectionModifier
-{
-    UTurn,
-    SharpRight,
-    Right,
-    SlightRight,
-    Straight,
-    SlightLeft,
-    Left,
-    SharpLeft
-};
 
-// enum class TurnType : unsigned char
-enum TurnType // at the moment we can support 32 turn types, without increasing memory consumption
+// direction modifiers based on angle
+namespace DirectionModifier
 {
-    Invalid,                            // no valid turn instruction
-    NewName,                            // no turn, but name changes
-    Continue,                           // remain on a street
-    Turn,                               // basic turn
-    Merge,                              // merge onto a street
-    OnRamp,                             // special turn (highway ramp on-ramps)
-    OffRamp,                            // special turn, highway exit
-    Fork,                               // fork road splitting up
-    EndOfRoad,                          // T intersection
-    Notification,                       // Travel Mode Changes, Restrictions apply...
-    EnterRoundabout,                    // Entering a small Roundabout
-    EnterAndExitRoundabout,             // Touching a roundabout
-    EnterRotary,                        // Enter a rotary
-    EnterAndExitRotary,                 // Touching a rotary
-    EnterRoundaboutIntersection,        // Entering a small Roundabout
-    EnterAndExitRoundaboutIntersection, // Touching a roundabout
-    NoTurn,                             // end of segment without turn/middle of a segment
-    Suppressed,                         // location that suppresses a turn
-    EnterRoundaboutAtExit,              // Entering a small Roundabout at a countable exit
-    ExitRoundabout,                     // Exiting a small Roundabout
-    EnterRotaryAtExit,                  // Enter A Rotary at a countable exit
-    ExitRotary,                         // Exit a rotary
-    EnterRoundaboutIntersectionAtExit,  // Entering a small Roundabout at a countable exit
-    ExitRoundaboutIntersection,         // Exiting a small Roundabout
-    StayOnRoundabout                    // Continue on Either a small or a large Roundabout
-};
+typedef std::uint8_t Enum;
+const constexpr Enum UTurn = 0;
+const constexpr Enum SharpRight = 1;
+const constexpr Enum Right = 2;
+const constexpr Enum SlightRight = 3;
+const constexpr Enum Straight = 4;
+const constexpr Enum SlightLeft = 5;
+const constexpr Enum Left = 6;
+const constexpr Enum SharpLeft = 7;
+}
+
+namespace TurnType
+{
+typedef std::uint8_t Enum;
+const constexpr Enum Invalid = 0;                             // no valid turn instruction
+const constexpr Enum NewName = 1;                             // no turn, but name changes
+const constexpr Enum Continue = 2;                            // remain on a street
+const constexpr Enum Turn = 3;                                // basic turn
+const constexpr Enum Merge = 4;                               // merge onto a street
+const constexpr Enum OnRamp = 5;                              // special turn (highway ramp on-ramps)
+const constexpr Enum OffRamp = 6;                             // special turn, highway exit
+const constexpr Enum Fork = 7;                                // fork road splitting up
+const constexpr Enum EndOfRoad = 8;                           // T intersection
+const constexpr Enum Notification = 9;                        // Travel Mode Changes, Restrictions apply...
+const constexpr Enum EnterRoundabout = 10;                    // Entering a small Roundabout
+const constexpr Enum EnterAndExitRoundabout = 11;             // Touching a roundabout
+const constexpr Enum EnterRotary = 12;                        // Enter a rotary
+const constexpr Enum EnterAndExitRotary = 13;                 // Touching a rotary
+const constexpr Enum EnterRoundaboutIntersection = 14;        // Entering a small Roundabout
+const constexpr Enum EnterAndExitRoundaboutIntersection = 15; // Touching a roundabout
+const constexpr Enum NoTurn = 16;                             // end of segment without turn/middle of a segment
+const constexpr Enum Suppressed = 17;                         // location that suppresses a turn
+const constexpr Enum EnterRoundaboutAtExit = 18;              // Entering a small Roundabout at a countable exit
+const constexpr Enum ExitRoundabout = 19;                     // Exiting a small Roundabout
+const constexpr Enum EnterRotaryAtExit = 20;                  // Enter A Rotary at a countable exit
+const constexpr Enum ExitRotary = 21;                         // Exit a rotary
+const constexpr Enum EnterRoundaboutIntersectionAtExit = 22;  // Entering a small Roundabout at a countable exit
+const constexpr Enum ExitRoundaboutIntersection = 23;         // Exiting a small Roundabout
+const constexpr Enum StayOnRoundabout = 24;                   // Continue on Either a small or a large Roundabout
+}
 
 // turn angle in 1.40625 degree -> 128 == 180 degree
 struct TurnInstruction
 {
-    TurnInstruction(const TurnType type = TurnType::Invalid,
-                    const DirectionModifier direction_modifier = DirectionModifier::Straight)
+    TurnInstruction(const TurnType::Enum type = TurnType::Invalid,
+                    const DirectionModifier::Enum direction_modifier = DirectionModifier::Straight)
         : type(type), direction_modifier(direction_modifier)
     {
     }
 
-    TurnType type : 5;
-    DirectionModifier direction_modifier : 3;
+    TurnType::Enum type : 5;
+    DirectionModifier::Enum direction_modifier : 3;
 
     static TurnInstruction INVALID()
     {
@@ -87,52 +87,54 @@ struct TurnInstruction
         return TurnInstruction(TurnType::NoTurn, DirectionModifier::UTurn);
     }
 
-    static TurnInstruction REMAIN_ROUNDABOUT(const RoundaboutType, const DirectionModifier modifier)
+    static TurnInstruction REMAIN_ROUNDABOUT(const RoundaboutType, const DirectionModifier::Enum modifier)
     {
         return TurnInstruction(TurnType::StayOnRoundabout, modifier);
     }
 
     static TurnInstruction ENTER_ROUNDABOUT(const RoundaboutType roundabout_type,
-                                            const DirectionModifier modifier)
+                                            const DirectionModifier::Enum modifier)
     {
-        const constexpr TurnType enter_instruction[] = {
+        const constexpr TurnType::Enum enter_instruction[] = {
             TurnType::Invalid, TurnType::EnterRoundabout, TurnType::EnterRotary,
             TurnType::EnterRoundaboutIntersection};
         return {enter_instruction[static_cast<int>(roundabout_type)], modifier};
     }
 
     static TurnInstruction EXIT_ROUNDABOUT(const RoundaboutType roundabout_type,
-                                           const DirectionModifier modifier)
+                                           const DirectionModifier::Enum modifier)
     {
-        const constexpr TurnType exit_instruction[] = {TurnType::Invalid, TurnType::ExitRoundabout,
+        const constexpr TurnType::Enum exit_instruction[] = {TurnType::Invalid, TurnType::ExitRoundabout,
                                                        TurnType::ExitRotary,
                                                        TurnType::ExitRoundaboutIntersection};
         return {exit_instruction[static_cast<int>(roundabout_type)], modifier};
     }
 
     static TurnInstruction ENTER_AND_EXIT_ROUNDABOUT(const RoundaboutType roundabout_type,
-                                                     const DirectionModifier modifier)
+                                                     const DirectionModifier::Enum modifier)
     {
-        const constexpr TurnType exit_instruction[] = {
+        const constexpr TurnType::Enum exit_instruction[] = {
             TurnType::Invalid, TurnType::EnterAndExitRoundabout, TurnType::EnterAndExitRotary,
             TurnType::EnterAndExitRoundaboutIntersection};
         return {exit_instruction[static_cast<int>(roundabout_type)], modifier};
     }
 
     static TurnInstruction ENTER_ROUNDABOUT_AT_EXIT(const RoundaboutType roundabout_type,
-                                                    const DirectionModifier modifier)
+                                                    const DirectionModifier::Enum modifier)
     {
-        const constexpr TurnType enter_instruction[] = {
+        const constexpr TurnType::Enum enter_instruction[] = {
             TurnType::Invalid, TurnType::EnterRoundaboutAtExit, TurnType::EnterRotaryAtExit,
             TurnType::EnterRoundaboutIntersectionAtExit};
         return {enter_instruction[static_cast<int>(roundabout_type)], modifier};
     }
 
-    static TurnInstruction SUPPRESSED(const DirectionModifier modifier)
+    static TurnInstruction SUPPRESSED(const DirectionModifier::Enum modifier)
     {
         return {TurnType::Suppressed, modifier};
     }
 };
+
+static_assert(sizeof(TurnInstruction) == 1, "TurnInstruction does not fit one byte");
 
 inline bool operator!=(const TurnInstruction lhs, const TurnInstruction rhs)
 {

--- a/include/extractor/original_edge_data.hpp
+++ b/include/extractor/original_edge_data.hpp
@@ -20,24 +20,24 @@ struct OriginalEdgeData
                               guidance::TurnInstruction turn_instruction,
                               EntryClassID entry_classid,
                               TravelMode travel_mode)
-        : via_node(via_node), name_id(name_id), turn_instruction(turn_instruction),
-          entry_classid(entry_classid), travel_mode(travel_mode)
+        : via_node(via_node), name_id(name_id), entry_classid(entry_classid),
+          turn_instruction(turn_instruction), travel_mode(travel_mode)
     {
     }
 
     OriginalEdgeData()
         : via_node(std::numeric_limits<unsigned>::max()),
           name_id(std::numeric_limits<unsigned>::max()),
-          turn_instruction(guidance::TurnInstruction::INVALID()),
           entry_classid(INVALID_ENTRY_CLASSID),
+          turn_instruction(guidance::TurnInstruction::INVALID()),
           travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
     }
 
     NodeID via_node;
     unsigned name_id;
-    guidance::TurnInstruction turn_instruction;
     EntryClassID entry_classid;
+    guidance::TurnInstruction turn_instruction;
     TravelMode travel_mode;
 };
 }

--- a/include/util/guidance/toolkit.hpp
+++ b/include/util/guidance/toolkit.hpp
@@ -26,7 +26,7 @@ inline double angularDeviation(const double angle, const double from)
     return std::min(360 - deviation, deviation);
 }
 
-inline extractor::guidance::DirectionModifier getTurnDirection(const double angle)
+inline extractor::guidance::DirectionModifier::Enum getTurnDirection(const double angle)
 {
     // An angle of zero is a u-turn
     // 180 goes perfectly straight

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -17,8 +17,8 @@
 #include <utility>
 #include <vector>
 
-using TurnType = osrm::extractor::guidance::TurnType;
-using DirectionModifier = osrm::extractor::guidance::DirectionModifier;
+namespace TurnType = osrm::extractor::guidance::TurnType;
+namespace DirectionModifier = osrm::extractor::guidance::DirectionModifier;
 using TurnInstruction = osrm::extractor::guidance::TurnInstruction;
 
 namespace osrm
@@ -55,12 +55,12 @@ inline bool isValidModifier(const guidance::StepManeuver maneuver)
     return true;
 }
 
-std::string instructionTypeToString(const TurnType type)
+std::string instructionTypeToString(const TurnType::Enum type)
 {
     return turn_type_names[static_cast<std::size_t>(type)];
 }
 
-std::string instructionModifierToString(const DirectionModifier modifier)
+std::string instructionModifierToString(const DirectionModifier::Enum modifier)
 {
     return modifier_names[static_cast<std::size_t>(modifier)];
 }

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -17,8 +17,8 @@
 #include <utility>
 
 using TurnInstruction = osrm::extractor::guidance::TurnInstruction;
-using TurnType = osrm::extractor::guidance::TurnType;
-using DirectionModifier = osrm::extractor::guidance::DirectionModifier;
+namespace TurnType = osrm::extractor::guidance::TurnType;
+namespace DirectionModifier = osrm::extractor::guidance::DirectionModifier;
 using osrm::util::guidance::angularDeviation;
 using osrm::util::guidance::getTurnDirection;
 
@@ -41,12 +41,8 @@ void print(const std::vector<RouteStep> &steps)
     int segment = 0;
     for (const auto &step : steps)
     {
-        const auto type =
-            static_cast<std::underlying_type<TurnType>::type>(step.maneuver.instruction.type);
-        const auto modifier = static_cast<std::underlying_type<DirectionModifier>::type>(
-            step.maneuver.instruction.direction_modifier);
-
-        std::cout << "\t[" << ++segment << "]: " << type << " " << modifier << "  " << static_cast<int>(step.maneuver.waypoint_type)
+        std::cout << "\t[" << ++segment << "]: " << step.maneuver.instruction.type
+                  << " " << step.maneuver.instruction.direction_modifier << "  " << static_cast<int>(step.maneuver.waypoint_type)
                   << " Duration: " << step.duration << " Distance: " << step.distance
                   << " Geometry: " << step.geometry_begin << " " << step.geometry_end
                   << " exit: " << step.maneuver.exit
@@ -187,7 +183,7 @@ void closeOffRoundabout(const bool on_roundabout,
         steps[1] = forwardInto(steps[1], steps[0]);
         steps[0].duration = 0;
         steps[0].distance = 0;
-        const auto exitToEnter = [](const TurnType type) {
+        const auto exitToEnter = [](const TurnType::Enum type) {
             if (TurnType::ExitRotary == type)
                 return TurnType::EnterRotary;
             // if we do not enter the roundabout Intersection, we cannot treat the full traversal as

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -42,7 +42,7 @@ std::size_t IntersectionHandler::countValid(const Intersection &intersection) co
                          [](const ConnectedRoad &road) { return road.entry_allowed; });
 }
 
-TurnType IntersectionHandler::findBasicTurnType(const EdgeID via_edge,
+TurnType::Enum IntersectionHandler::findBasicTurnType(const EdgeID via_edge,
                                                 const ConnectedRoad &road) const
 {
 


### PR DESCRIPTION
call stack at the crash point
```
osrm-routed.exe!osrm::engine::api::json::detail::instructionModifierToString(osrm::extractor::guidance::DirectionModifier modifier) Line 80    C++
     osrm-routed.exe!osrm::engine::api::json::makeStepManeuver(const osrm::engine::guidance::StepManeuver & maneuver) Line 158    C++
     osrm-routed.exe!osrm::engine::api::json::makeRouteStep(osrm::engine::guidance::RouteStep step, mapbox::util::variant<osrm::util::json::String,osrm::util::json::Number,mapbox::util::recursive_wrapper<osrm::util::json::Object>,mapbox::util::recursive_wrapper<osrm::util::json::Array>,osrm::util::json::True,osrm::util::json::False,osrm::util::json::Null> geometry) Line 185    C++
     osrm-routed.exe!osrm::engine::api::json::makeRouteLegs::__l6::<lambda>(osrm::engine::guidance::RouteStep step) Line 237    C++
...
```

where maneuver.instruction.direction_modifier = -2, but must be maneuver.instruction.direction_modifier = Left (6 '\x6')

It happens because of  enum-base type (that is 7.2/5 "if not explicitly specified, the underlying type of a scoped enumeration type is int.") sign extension. MSVC implicitly extends 1xx to 11..11xx and than at the crash point the sign-extended value is casted to size_t and used as an index.
