### PR TITLE
Fix compile against boost 1.61

### DIFF
--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -1,4 +1,3 @@
-#include "extractor/extractor_callbacks.hpp"
 #include "extractor/extraction_containers.hpp"
 #include "extractor/extraction_node.hpp"
 #include "extractor/extraction_way.hpp"
@@ -9,6 +8,7 @@
 #include "util/for_each_pair.hpp"
 
 #include <boost/optional/optional.hpp>
+#include "extractor/extractor_callbacks.hpp"
 
 #include <osmium/osm.hpp>
 


### PR DESCRIPTION
This gets osrm-backend compiling against the latest Boost 1.61.0 release. It is a workaround  for boostorg/numeric_conversion#4. 

Hopefully nothing else will be needed, but in case other things arise what was needed in mapnik was https://github.com/mapnik/mapnik/pull/3429/commits/7b3f607a01f62ae8e173e778ac0d7267e7507a56 -refs https://github.com/mapnik/mapnik/issues/3421