### PR TITLE
Fix linking of osrm-example to boost_iostreams

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 add_executable(osrm-example example.cpp)
 
 find_package(LibOSRM REQUIRED)
-find_package(Boost 1.49.0 COMPONENTS filesystem system thread REQUIRED)
+find_package(Boost 1.49.0 COMPONENTS filesystem system thread iostreams REQUIRED)
 
 target_link_libraries(osrm-example ${LibOSRM_LIBRARIES} ${Boost_LIBRARIES})
 include_directories(SYSTEM ${LibOSRM_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Fixes linking error seen on OS X:

```
[ 50%] Linking CXX executable osrm-example
/Users/dane/.homebrew/Cellar/cmake/3.5.0/bin/cmake -E cmake_link_script CMakeFiles/osrm-example.dir/link.txt --verbose=1
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++    -std=c++11  -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/osrm-example.dir/example.cpp.o  -o osrm-example  /Users/dane/projects/osrm-backend/here/lib/libOSRM.a /Users/dane/.homebrew/lib/libboost_filesystem-mt.dylib /Users/dane/.homebrew/lib/libboost_system-mt.dylib /Users/dane/.homebrew/lib/libboost_thread-mt.dylib /Users/dane/.homebrew/lib/libboost_chrono-mt.dylib /Users/dane/.homebrew/lib/libboost_date_time-mt.dylib /Users/dane/.homebrew/lib/libboost_atomic-mt.dylib 
undef: __ZN5boost9iostreams18mapped_file_source9open_implERKNS0_24basic_mapped_file_paramsINS0_6detail4pathEEE
undef: __ZN5boost9iostreams18mapped_file_sourceC1Ev
undef: __ZNK5boost9iostreams18mapped_file_source4sizeEv
undef: __ZNK5boost9iostreams18mapped_file_source4dataEv
Undefined symbols for architecture x86_64:
  "boost::iostreams::mapped_file_source::open_impl(boost::iostreams::basic_mapped_file_params<boost::iostreams::detail::path> const&)", referenced from:
      void boost::iostreams::mapped_file_source::open<boost::filesystem::path>(boost::filesystem::path const&, unsigned long, long) in libOSRM.a(engine.cpp.o)
  "boost::iostreams::mapped_file_source::mapped_file_source()", referenced from:
      osrm::engine::datafacade::SharedDataFacade::CheckAndReloadFacade() in libOSRM.a(engine.cpp.o)
      osrm::engine::datafacade::InternalDataFacade::InternalDataFacade(osrm::storage::StorageConfig const&) in libOSRM.a(engine.cpp.o)
  "boost::iostreams::mapped_file_source::size() const", referenced from:
      osrm::engine::datafacade::SharedDataFacade::CheckAndReloadFacade() in libOSRM.a(engine.cpp.o)
      osrm::engine::datafacade::InternalDataFacade::InternalDataFacade(osrm::storage::StorageConfig const&) in libOSRM.a(engine.cpp.o)
  "boost::iostreams::mapped_file_source::data() const", referenced from:
      osrm::engine::datafacade::SharedDataFacade::CheckAndReloadFacade() in libOSRM.a(engine.cpp.o)
      osrm::engine::datafacade::InternalDataFacade::InternalDataFacade(osrm::storage::StorageConfig const&) in libOSRM.a(engine.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```