### PR TITLE
Support loading dynamic libraries from custom locations on OS X

### DIFF
--- a/features/support/launch_classes.js
+++ b/features/support/launch_classes.js
@@ -86,7 +86,7 @@ var OSRMDirectLoader = class extends OSRMBaseLoader {
             fs.appendFile(this.scope.OSRM_ROUTED_LOG_FILE, data, (err) => { if (err) throw err; });
         };
 
-        var child = spawn(util.format('%s%s/osrm-routed', this.scope.LOAD_LIBRARIES, this.scope.BIN_PATH), [this.inputFile, util.format('-p%d', this.scope.OSRM_PORT)]);
+        var child = spawn(util.format('%s/osrm-routed', this.scope.BIN_PATH), [this.inputFile, util.format('-p%d', this.scope.OSRM_PORT)]);
         this.scope.pid = child.pid;
         child.stdout.on('data', writeToLog);
         child.stderr.on('data', writeToLog);
@@ -122,7 +122,7 @@ var OSRMDatastoreLoader = class extends OSRMBaseLoader {
             fs.appendFile(this.scope.OSRM_ROUTED_LOG_FILE, data, (err) => { if (err) throw err; });
         };
 
-        var child = spawn(util.format('%s%s/osrm-routed', this.scope.LOAD_LIBRARIES, this.scope.BIN_PATH), ['--shared-memory=1', util.format('-p%d', this.scope.OSRM_PORT)]);
+        var child = spawn(util.format('%s/osrm-routed', this.scope.BIN_PATH), ['--shared-memory=1', util.format('-p%d', this.scope.OSRM_PORT)]);
         this.child = child;
         this.scope.pid = child.pid;
         child.stdout.on('data', writeToLog);

--- a/scripts/timer.sh
+++ b/scripts/timer.sh
@@ -4,7 +4,12 @@ TIMINGS_FILE=/tmp/osrm.timings
 NAME=$1
 CMD=${@:2}
 START=$(date "+%s.%N")
-/bin/bash -c "$CMD"
+if [[ $(uname -s) == 'Darwin' ]] && [[ ${OSRM_SHARED_LIBRARY_PATH:-false} != false ]]; then
+    /bin/bash -c "DYLD_LIBRARY_PATH=${OSRM_SHARED_LIBRARY_PATH} $CMD"
+else
+    /bin/bash -c "$CMD"
+fi
+
 END=$(date "+%s.%N")
 TIME="$(echo "$END - $START" | bc)s"
 NEW_ENTRY="$NAME\t$TIME\t$(date -Iseconds)"

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -11,6 +11,11 @@ POLY2REQ:=$(SCRIPT_ROOT)/poly2req.js
 TIMER:=$(SCRIPT_ROOT)/timer.sh
 PROFILE:=$(PROFILE_ROOT)/car.lua
 
+LOAD_LIBRARIES:=
+ifneq ($(OSRM_SHARED_LIBRARY_PATH),)
+	LOAD_LIBRARIES=DYLD_LIBRARY_PATH=$(OSRM_SHARED_LIBRARY_PATH)
+endif
+
 all: $(DATA_NAME).osrm.hsgr
 
 clean:
@@ -36,7 +41,7 @@ $(DATA_NAME).requests: $(DATA_NAME).poly
 	$(POLY2REQ) $(DATA_NAME).poly > $(DATA_NAME).requests
 
 osrm-routed.pid: $(DATA_NAME).osrm.hsgr
-	@/bin/sh -c '$(OSRM_ROUTED) $(DATA_NAME).osrm& echo "$$!" > osrm-routed.pid'
+	@/bin/sh -c '$(LOAD_LIBRARIES) $(OSRM_ROUTED) $(DATA_NAME).osrm& echo "$$!" > osrm-routed.pid'
 	sleep 1
 
 benchmark: $(DATA_NAME).requests osrm-routed.pid


### PR DESCRIPTION
This builds on #1965 which did not cover all cases where that fix is needed. This fixes the command `make -C test/data benchmark` to work on OS X when:

  - libtbb.dylib is on a custom path (not /usr/lib or /usr/local/lib) and
  - the rpath is not embedded inside the tools (with `install_name_tool`)

Because the above workarounds are not always possible or easy.
