### PR TITLE
Trim datasource names before writing to datafile.

### DIFF
--- a/features/options/contract/datasources.feature
+++ b/features/options/contract/datasources.feature
@@ -1,0 +1,30 @@
+@prepare @options @files
+Feature: osrm-contract command line options: datasources
+# expansions:
+# {extracted_base} => path to current extracted input file
+# {profile} => path to current profile script
+
+    Background:
+        Given the profile "testbot"
+        Given the extract extra arguments "--generate-edge-lookup"
+        And the node map
+            | a | b |
+        And the ways
+            | nodes |
+            | ab    |
+        And the speed file
+        """
+        1,2,27
+        2,1,27
+        2,3,27
+        3,2,27
+        1,4,27
+        4,1,27
+        """
+        And the data has been extracted
+
+    Scenario: osrm-contract - Passing base file
+        When I run "osrm-contract --segment-speed-file speeds.csv {extracted_base}.osrm"
+        Then stderr should be empty
+        And datasource names should contain "lua profile,speeds"
+        And it should exit with code 0

--- a/features/step_definitions/options.js
+++ b/features/step_definitions/options.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var fs = require('fs');
 
 module.exports = function () {
     this.When(/^I run "osrm\-routed\s?(.*?)"$/, { timeout: this.TIMEOUT }, (options, callback) => {
@@ -57,6 +58,11 @@ module.exports = function () {
 
     this.Then(/^stdout should contain (\d+) lines?$/, (lines) => {
         assert.equal(this.stdout.split('\n').length - 1, parseInt(lines));
+    });
+
+    this.Then(/^datasource names should contain "(.+)"$/, (expectedData) => {
+        var actualData = fs.readFileSync(this.osmData.extractedFile+'.osrm.datasource_names',{encoding:'UTF-8'}).trim().split("\n").join(",");
+        assert.equal(actualData, expectedData);
     });
 
     this.Given(/^the query options$/, (table, callback) => {

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -624,7 +624,11 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
         datasource_stream << "lua profile" << std::endl;
         for (auto const &name : segment_speed_filenames)
         {
-            datasource_stream << name << std::endl;
+            // Only write the filename, without path or extension.
+            // This prevents information leakage, and keeps names short
+            // for rendering in the debug tiles.
+            const boost::filesystem::path p(name);
+            datasource_stream << p.stem().string() << std::endl;
         }
     };
 


### PR DESCRIPTION
This change strips the full pathname and file extension from the values given `--segment-speed-file` when written to the `.datasource_names` file.

This prevents information leakage in the `tile` plugin, and makes labels more likely to render on maps where label-collision logic is in place.