### PR TITLE
[Travis] Disable spotlight indexing on osx to speed up 'npm test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,7 @@ matrix:
       #- env: CCOMPILER='clang-3.8' CXXCOMPILER='clang++-3.8' BUILD_TYPE='Release' BUILD_SHARED_LIBS=ON
 
 before_install:
+  - if [[ $(uname -s) == 'Darwin' ]]; then sudo mdutil -i off /; fi;
   - source ./scripts/install_node.sh 4
   - npm install
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"


### PR DESCRIPTION
I noticed that OS X spotlight indexing is on by default on travis. And due to the large number of files that `npm test` creates it keeps spotlight indexing quite busy. This leads to more CPU being used by spotlight that by osrm-backend during the tests.

This PR disables spotlight indexing. This speeds up the `npm test` on OSX Debug builds from 13 minutes to 9 minutes.