### PR TITLE
be more verbose on broken configs

### DIFF
--- a/src/storage/storage_config.cpp
+++ b/src/storage/storage_config.cpp
@@ -1,4 +1,5 @@
 #include "storage/storage_config.hpp"
+#include "util/simple_logger.hpp"
 
 #include <boost/filesystem/operations.hpp>
 
@@ -21,19 +22,24 @@ StorageConfig::StorageConfig(const boost::filesystem::path &base)
 
 bool StorageConfig::IsValid() const
 {
-    return boost::filesystem::is_regular_file(ram_index_path) &&
-           boost::filesystem::is_regular_file(file_index_path) &&
-           boost::filesystem::is_regular_file(hsgr_data_path) &&
-           boost::filesystem::is_regular_file(nodes_data_path) &&
-           boost::filesystem::is_regular_file(edges_data_path) &&
-           boost::filesystem::is_regular_file(core_data_path) &&
-           boost::filesystem::is_regular_file(geometries_path) &&
-           boost::filesystem::is_regular_file(timestamp_path) &&
-           boost::filesystem::is_regular_file(datasource_names_path) &&
-           boost::filesystem::is_regular_file(datasource_indexes_path) &&
-           boost::filesystem::is_regular_file(names_data_path) &&
-           boost::filesystem::is_regular_file(properties_path) &&
-           boost::filesystem::is_regular_file(intersection_class_path);
+    const constexpr auto num_files = 13;
+    const boost::filesystem::path paths[num_files] = {
+        ram_index_path,          file_index_path,         hsgr_data_path,  nodes_data_path,
+        edges_data_path,         core_data_path,          geometries_path, timestamp_path,
+        datasource_indexes_path, datasource_indexes_path, names_data_path, properties_path,
+        intersection_class_path};
+
+    bool success = true;
+    for (auto path = paths; path != paths + num_files; ++path)
+    {
+        if (!boost::filesystem::is_regular_file(*path))
+        {
+            util::SimpleLogger().Write(logWARNING) << "Missing/Broken File: " << path->string();
+            success = false;
+        }
+    }
+
+    return success;
 }
 }
 }

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -84,7 +84,7 @@ int main(const int argc, const char *argv[]) try
     storage::StorageConfig config(base_path);
     if (!config.IsValid())
     {
-        util::SimpleLogger().Write(logWARNING) << "Invalid file path given!";
+        util::SimpleLogger().Write(logWARNING) << "Config contains invalid file paths. Exiting!";
         return EXIT_FAILURE;
     }
     storage::Storage storage(std::move(config));


### PR DESCRIPTION
After some problems today, I think we should be more verbose on missing files.

On missing files, this will now show:

```
[warn] Missing/Broken File: data/debug.osrm.icd
[warn] Config contains invalid file paths. Exiting!
```

instead of simply `[warn] Invalid file path given!`