### PR TITLE
Fix pkg-config usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ install:
     fi
   - popd
   - mkdir example/build && pushd example/build
-  - cmake ..
+  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
   - make
   - popd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,22 @@ set(OSRM_VERSION_MAJOR 5)
 set(OSRM_VERSION_MINOR 2)
 set(OSRM_VERSION_PATCH 0)
 
+# these two functions build up custom variables:
+#   OSRM_INCLUDE_PATHS and OSRM_DEFINES
+# These variables we want to pass to
+# include_directories and add_definitions for both
+# this build and for sharing externally via pkg-config
+
+function(add_dependency_includes includes)
+  list(APPEND OSRM_INCLUDE_PATHS "${includes}")
+  set(OSRM_INCLUDE_PATHS "${OSRM_INCLUDE_PATHS}" PARENT_SCOPE)
+endfunction(add_dependency_includes)
+
+function(add_dependency_defines defines)
+  list(APPEND OSRM_DEFINES "${defines}")
+  set(OSRM_DEFINES "${OSRM_DEFINES}" PARENT_SCOPE)
+endfunction(add_dependency_defines)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include(CheckCXXCompilerFlag)
 include(FindPackageHandleStandardArgs)
@@ -164,7 +180,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   # using GCC
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=1 -D_FORTIFY_SOURCE=2 ${COLOR_FLAG} -fPIC")
   if(WIN32) # using mingw
-    add_definitions(-DWIN32)
+    add_dependency_defines(-DWIN32)
     set(OPTIONAL_SOCKET_LIBS ws2_32 wsock32)
   endif()
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
@@ -173,12 +189,12 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   # using Visual Studio C++
   set(BOOST_COMPONENTS ${BOOST_COMPONENTS} date_time chrono zlib)
-  add_definitions(-DBOOST_LIB_DIAGNOSTIC)
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions(-DNOMINMAX) # avoid min and max macros that can break compilation
-  add_definitions(-D_USE_MATH_DEFINES) #needed for M_PI with cmath.h
-  add_definitions(-D_WIN32_WINNT=0x0501)
-  add_definitions(-DXML_STATIC)
+  add_dependency_defines(-DBOOST_LIB_DIAGNOSTIC)
+  add_dependency_defines(-D_CRT_SECURE_NO_WARNINGS)
+  add_dependency_defines(-DNOMINMAX) # avoid min and max macros that can break compilation
+  add_dependency_defines(-D_USE_MATH_DEFINES) #needed for M_PI with cmath.h
+  add_dependency_defines(-D_WIN32_WINNT=0x0501)
+  add_dependency_defines(-DXML_STATIC)
   find_library(ws2_32_LIBRARY_PATH ws2_32)
   target_link_libraries(osrm-extract wsock32 ws2_32)
 endif()
@@ -205,7 +221,7 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 
 # Activate C++11
 if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 # Configuring other platform dependencies
@@ -230,41 +246,54 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/cmake")
 set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include")
 find_package(Osmium REQUIRED COMPONENTS io)
-include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
+add_dependency_includes(${OSMIUM_INCLUDE_DIR})
 
 
 find_package(Boost 1.49.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+
+# collect a subset of the boost libraries needed
+# by libosrm
+foreach(lib ${Boost_LIBRARIES})
+  if(NOT WIN32)
+    if(lib MATCHES filesystem OR lib MATCHES thread OR lib MATCHES iostreams OR lib MATCHES system)
+       list(APPEND BOOST_ENGINE_LIBRARIES "${lib}")
+    endif()
+  else()
+    list(APPEND BOOST_ENGINE_LIBRARIES "${lib}")
+  endif()
+endforeach(lib)
+
 if(NOT WIN32 AND NOT Boost_USE_STATIC_LIBS)
-  add_definitions(-DBOOST_TEST_DYN_LINK)
+  add_dependency_defines(-DBOOST_TEST_DYN_LINK)
 endif()
-add_definitions(-DBOOST_SPIRIT_USE_PHOENIX_V3)
-add_definitions(-DBOOST_RESULT_OF_USE_DECLTYPE)
-add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+add_dependency_defines(-DBOOST_SPIRIT_USE_PHOENIX_V3)
+add_dependency_defines(-DBOOST_RESULT_OF_USE_DECLTYPE)
+add_dependency_defines(-DBOOST_FILESYSTEM_NO_DEPRECATED)
+add_dependency_includes(${Boost_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)
 
 find_package(TBB REQUIRED)
-include_directories(SYSTEM ${TBB_INCLUDE_DIR})
+add_dependency_includes(${TBB_INCLUDE_DIR})
 if(WIN32 AND CMAKE_BUILD_TYPE MATCHES Debug)
   set(TBB_LIBRARIES ${TBB_DEBUG_LIBRARIES})
 endif()
 
 find_package(Luabind REQUIRED)
 include(check_luabind)
-include_directories(SYSTEM ${LUABIND_INCLUDE_DIR})
+add_dependency_includes(${LUABIND_INCLUDE_DIR})
 
 set(USED_LUA_LIBRARIES ${LUA_LIBRARY})
 if(LUAJIT_FOUND)
   set(USED_LUA_LIBRARIES, LUAJIT_LIBRARIES)
 endif()
-include_directories(SYSTEM ${LUA_INCLUDE_DIR})
+add_dependency_includes(${LUA_INCLUDE_DIR})
 
 find_package(EXPAT REQUIRED)
-include_directories(SYSTEM ${EXPAT_INCLUDE_DIRS})
+add_dependency_includes(${EXPAT_INCLUDE_DIRS})
 
 find_package(STXXL REQUIRED)
-include_directories(SYSTEM ${STXXL_INCLUDE_DIR})
+add_dependency_includes(${STXXL_INCLUDE_DIR})
 
 set(OpenMP_FIND_QUIETLY ON)
 find_package(OpenMP)
@@ -274,15 +303,18 @@ if(OPENMP_FOUND)
 endif()
 
 find_package(BZip2 REQUIRED)
-include_directories(SYSTEM ${BZIP_INCLUDE_DIRS})
+add_dependency_includes(${BZIP2_INCLUDE_DIR})
 
 find_package(ZLIB REQUIRED)
-include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
+add_dependency_includes(${ZLIB_INCLUDE_DIRS})
 
 if (ENABLE_JSON_LOGGING)
   message(STATUS "Enabling json logging")
-  add_definitions(-DENABLE_JSON_LOGGING)
+  add_dependency_defines(-DENABLE_JSON_LOGGING)
 endif()
+
+add_definitions(${OSRM_DEFINES})
+include_directories(SYSTEM ${OSRM_INCLUDE_PATHS})
 
 # Binaries
 target_link_libraries(osrm-datastore osrm_store ${Boost_LIBRARIES})
@@ -312,9 +344,8 @@ set(CONTRACTOR_LIBRARIES
     ${MAYBE_RT_LIBRARY}
     ${MAYBE_COVERAGE_LIBRARIES})
 set(ENGINE_LIBRARIES
-    ${Boost_LIBRARIES}
+    ${BOOST_ENGINE_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${STXXL_LIBRARY}
     ${TBB_LIBRARIES}
     ${MAYBE_RT_LIBRARY}
     ${MAYBE_COVERAGE_LIBRARIES}
@@ -414,13 +445,22 @@ foreach(lib ${ENGINE_LIBRARIES})
   set(ENGINE_LIBRARY_LISTING "${ENGINE_LIBRARY_LISTING} -L${ENGINE_LIBRARY_PATH} -l${ENGINE_LIBRARY_NAME}")
 endforeach()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig.in libosrm.pc @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/libosrm.pc DESTINATION lib/pkgconfig)
-
 if(BUILD_DEBIAN_PACKAGE)
   include(CPackDebianConfig)
   include(CPack)
 endif()
+
+function(JOIN VALUES GLUE OUTPUT)
+  string (REPLACE ";" "${GLUE}" _TMP_STR "${VALUES}")
+  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+endfunction()
+
+# Set up variables, then write to pkgconfig file
+JOIN("${OSRM_DEFINES}" " " OSRM_DEFINES_STRING)
+JOIN("-I${OSRM_INCLUDE_PATHS}" " -I" OSRM_INCLUDE_PATHS_STRING)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig.in libosrm.pc @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/libosrm.pc DESTINATION lib/pkgconfig)
 
 # add a target to generate API documentation with Doxygen
 find_package(Doxygen)

--- a/cmake/pkgconfig.in
+++ b/cmake/pkgconfig.in
@@ -8,4 +8,4 @@ Version: v@OSRM_VERSION_MAJOR@.@OSRM_VERSION_MINOR@.@OSRM_VERSION_PATCH@
 Requires:
 Libs: -L${libdir} -losrm
 Libs.private: @ENGINE_LIBRARY_LISTING@
-Cflags: -I${includedir} -I${includedir}/osrm
+Cflags: -I${includedir} -I${includedir}/osrm @OSRM_INCLUDE_PATHS_STRING@ @OSRM_DEFINES_STRING@ @CMAKE_CXX_FLAGS@

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,10 +6,13 @@ Please create a directory and run cmake from there, passing the path to this sou
 This process created the file `CMakeCache.txt' and the directory `CMakeFiles'. Please delete them.")
 endif()
 
+if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 project(osrm-example C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
 
 set(bitness 32)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -23,11 +26,11 @@ if(WIN32 AND MSVC_VERSION LESS 1900)
   message(FATAL_ERROR "Building with Microsoft compiler needs Latest Visual Studio 2015 (Community or better)")
 endif()
 
+link_directories(${LibOSRM_LIBRARY_DIRS})
 add_executable(osrm-example example.cpp)
 
 find_package(LibOSRM REQUIRED)
-find_package(Boost 1.49.0 COMPONENTS filesystem system thread iostreams REQUIRED)
 
-target_link_libraries(osrm-example ${LibOSRM_LIBRARIES} ${Boost_LIBRARIES})
-include_directories(SYSTEM ${LibOSRM_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-
+target_link_libraries(osrm-example ${LibOSRM_LIBRARIES} ${LibOSRM_DEPENDENT_LIBRARIES})
+include_directories(SYSTEM ${LibOSRM_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS ${LibOSRM_CXXFLAGS})

--- a/example/cmake/FindLibOSRM.cmake
+++ b/example/cmake/FindLibOSRM.cmake
@@ -1,13 +1,24 @@
 # - Try to find LibOSRM
 # Once done this will define
 #  LibOSRM_FOUND - System has LibOSRM
-#  LibOSRM_INCLUDE_DIRS - The LibOSRM include directories
-#  LibOSRM_LIBRARIES - The libraries needed to use LibOSRM
-#  LibOSRM_DEFINITIONS - Compiler switches required for using LibOSRM
+#  LibOSRM_LIBRARIES - The libraries and ldflags needed to use LibOSRM
+#  LibOSRM_DEPENDENT_LIBRARIES - The libraries and ldflags need to link LibOSRM dependencies
+#  LibOSRM_LIBRARY_DIRS - The libraries paths needed to find LibOSRM
+#  LibOSRM_CXXFLAGS - Compiler switches required for using LibOSRM
 
 find_package(PkgConfig)
-pkg_check_modules(PC_LibOSRM QUIET libosrm)
-set(LibOSRM_DEFINITIONS ${PC_LibOSRM_CFLAGS_OTHER})
+pkg_search_module(PC_LibOSRM QUIET libosrm)
+
+function(JOIN VALUES GLUE OUTPUT)
+  string (REPLACE ";" "${GLUE}" _TMP_STR "${VALUES}")
+  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+endfunction()
+
+list(REMOVE_ITEM PC_LibOSRM_CFLAGS " ")
+JOIN("${PC_LibOSRM_CFLAGS}" " " output)
+
+set(LibOSRM_CXXFLAGS ${output})
+set(LibOSRM_LIBRARY_DIRS ${PC_LibOSRM_LIBRARY_DIRS})
 
 find_path(LibOSRM_INCLUDE_DIR osrm/osrm.hpp
   PATH_SUFFIXES osrm include/osrm include
@@ -19,8 +30,6 @@ find_path(LibOSRM_INCLUDE_DIR osrm/osrm.hpp
   /opt/local
   /opt)
 
-set(LibOSRM_INCLUDE_DIRS ${LibOSRM_INCLUDE_DIR} ${LibOSRM_INCLUDE_DIR}/osrm)
-
 find_library(TEST_LibOSRM_STATIC_LIBRARY Names osrm.lib libosrm.a
   PATH_SUFFIXES osrm lib/osrm lib
   HINTS ${PC_LibOSRM_LIBDIR} ${PC_LibOSRM_LIBRARY_DIRS}
@@ -30,7 +39,7 @@ find_library(TEST_LibOSRM_STATIC_LIBRARY Names osrm.lib libosrm.a
   /usr
   /opt/local
   /opt)
-find_library(TEST_LibOSRM_DYNAMIC_LIBRARY Names osrm.dynlib libosrm.so
+find_library(TEST_LibOSRM_DYNAMIC_LIBRARY Names libosrm.dylib libosrm.so
   PATH_SUFFIXES osrm lib/osrm lib
   HINTS ${PC_LibOSRM_LIBDIR} ${PC_LibOSRM_LIBRARY_DIRS}
   ~/Library/Frameworks
@@ -40,26 +49,15 @@ find_library(TEST_LibOSRM_DYNAMIC_LIBRARY Names osrm.dynlib libosrm.so
   /opt/local
   /opt)
 
-if (NOT ("${TEST_LibOSRM_STATIC_LIBRARY}" STREQUAL "TEST_LibOSRM_STATIC_LIBRARY-NOTFOUND"))
-  if ("${PC_LibOSRM_STATIC_LIBRARIES}" STREQUAL "")
-    set(LibOSRM_STATIC_LIBRARIES ${TEST_LibOSRM_STATIC_LIBRARY})
-  else()
-    set(LibOSRM_STATIC_LIBRARIES ${PC_LibOSRM_STATIC_LIBRARIES})
-  endif()
-  set(LibOSRM_LIBRARIES ${LibOSRM_STATIC_LIBRARIES})
-endif()
-
-if (NOT ("${TEST_LibOSRM_DYNAMIC_LIBRARY}" STREQUAL "TEST_LibOSRM_DYNAMIC_LIBRARY-NOTFOUND"))
-  if ("${PC_LibOSRM_LIBRARIES}" STREQUAL "")
-    set(LibOSRM_DYNAMIC_LIBRARIES ${TEST_LibOSRM_DYNAMIC_LIBRARY})
-  else()
-    set(LibOSRM_DYNAMIC_LIBRARIES ${PC_LibOSRM_LIBRARIES})
-  endif()
-  set(LibOSRM_LIBRARIES ${LibOSRM_DYNAMIC_LIBRARIES})
-endif()
+set(LibOSRM_DEPENDENT_LIBRARIES ${PC_LibOSRM_STATIC_LDFLAGS})
+set(LibOSRM_LIBRARIES ${PC_LibOSRM_LDFLAGS})
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBOSRM_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args(LibOSRM DEFAULT_MSG
-                                LibOSRM_LIBRARIES LibOSRM_INCLUDE_DIR)
+                                LibOSRM_LIBRARY_DIRS
+                                LibOSRM_CXXFLAGS
+                                LibOSRM_LIBRARIES
+                                LibOSRM_DEPENDENT_LIBRARIES
+                                LibOSRM_INCLUDE_DIR)


### PR DESCRIPTION
This PR supersedes https://github.com/Project-OSRM/osrm-backend/pull/2458 and https://github.com/Project-OSRM/osrm-backend/pull/2431. Basically the existing problem was that we were not adding the correct link and compile flags. Instead of adding them directly in `CMakeLists.txt` we should instead use the result of `pkg-config libosrm <variable>`. This gets that working with an eye towards supporting both dynamic and static libraries for osrm-backend deps.