### PR TITLE
fix options in step-definitions

### DIFF
--- a/features/step_definitions/options.js
+++ b/features/step_definitions/options.js
@@ -61,7 +61,7 @@ module.exports = function () {
     });
 
     this.Then(/^datasource names should contain "(.+)"$/, (expectedData) => {
-        var actualData = fs.readFileSync(this.osmData.extractedFile+'.osrm.datasource_names',{encoding:'UTF-8'}).trim().split("\n").join(",");
+        var actualData = fs.readFileSync(this.osmData.extractedFile+'.osrm.datasource_names',{encoding:'UTF-8'}).trim().split('\n').join(',');
         assert.equal(actualData, expectedData);
     });
 


### PR DESCRIPTION
Fixes:
```
/home/travis/build/Project-OSRM/osrm-backend/features/step_definitions/options.js
  64:127  warning  Strings must use singlequote  quotes
  64:138  warning  Strings must use singlequote  quotes
```