### PR TITLE
Rename annotate to annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-# 5.2
-   Changes from 5.2.0 RC2
+# 5.2.0 RC2
+   Changes from 5.2.0 RC1
 
    - Guidance:
      - improved handling of sliproads (emit turns instead of 'take the ramp')
-       BREAKING: modifies the file format with new internal identifiers
+     - BREAKING: modifies the file format with new internal identifiers
+
+   - API:
+    - paramater `annotate` was renamed to `annotations`.
 
 # 5.2.0 RC1
    Changes from 5.1.0

--- a/docs/http.md
+++ b/docs/http.md
@@ -151,7 +151,7 @@ http://router.project-osrm.org/nearest/v1/driving/13.388860,52.517037?number=3&b
 ### Request
 
 ```
-http://{server}/route/v1/{profile}/{coordinates}?alternatives={true|false}&steps={true|false}&geometries={polyline|geojson}&overview={full|simplified|false}
+http://{server}/route/v1/{profile}/{coordinates}?alternatives={true|false}&steps={true|false}&geometries={polyline|geojson}&overview={full|simplified|false}&annotations={true|false}
 ```
 
 In addition to the [general options](#general-options) the following options are supported for this service:
@@ -160,7 +160,7 @@ In addition to the [general options](#general-options) the following options are
 |------------|------------------------------------------|-------------------------------------------------------------------------------|
 |alternatives|`true`, `false` (default)                 |Search for alternative routes and return as well.\*                            |
 |steps       |`true`, `false` (default)                 |Return route steps for each route leg                                          |
-|annotate    |`true`, `false` (default)                 |Returns additional metadata for each coordinate along the route geometry.      |
+|annotations |`true`, `false` (default)                 |Returns additional metadata for each coordinate along the route geometry.      |
 |geometries  |`polyline` (default), `geojson`           |Returned route geometry format (influences overview and per step)             |
 |overview    |`simplified` (default), `full`, `false`   |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
 |continue_straight |`default` (default), `true`, `false`|Forces the route to keep going straight at waypoints and don't do a uturn even if it would be faster. Default value depends on the profile. |
@@ -253,7 +253,7 @@ The algorithm might not be able to match all points. Outliers are removed if the
 ### Request
 
 ```
-http://{server}/match/v1/{profile}/{coordinates}?steps={true|false}&geometries={polyline|geojson}&overview={simplified|full|false}
+http://{server}/match/v1/{profile}/{coordinates}?steps={true|false}&geometries={polyline|geojson}&overview={simplified|full|false}&annotations={true|false}
 ```
 
 In addition to the [general options](#general-options) the following options are supported for this service:
@@ -263,7 +263,7 @@ In addition to the [general options](#general-options) the following options are
 |------------|------------------------------------------------|------------------------------------------------------------------------------------------|
 |steps       |`true`, `false` (default)                       |Return route steps for each route                                                         |
 |geometries  |`polyline` (default), `geojson`                 |Returned route geometry format (influences overview and per step)                        |
-|annotate    |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.                |
+|annotations |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.                |
 |overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
 |timestamps  |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamp of the input location.                                                          |
 |radiuses    |`{radius};{radius}[;{radius} ...]`              |Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy.|
@@ -301,7 +301,7 @@ multiple trips for each connected component are returned.
 ### Request
 
 ```
-http://{server}/trip/v1/{profile}/{coordinates}?steps={true|false}&geometries={polyline|geojson}&overview={simplified|full|false}
+http://{server}/trip/v1/{profile}/{coordinates}?steps={true|false}&geometries={polyline|geojson}&overview={simplified|full|false}&annotations={true|false}
 ```
 
 In addition to the [general options](#general-options) the following options are supported for this service:
@@ -309,7 +309,7 @@ In addition to the [general options](#general-options) the following options are
 |Option      |Values                                          |Description                                                                |
 |------------|------------------------------------------------|---------------------------------------------------------------------------|
 |steps       |`true`, `false` (default)                       |Return route instructions for each trip                                    |
-|annotate    |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.      |
+|annotations |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.      |
 |geometries  |`polyline` (default), `geojson`                 |Returned route geometry format (influences overview and per step)         |
 |overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
 
@@ -397,14 +397,14 @@ Represents a route between two waypoints.
 
 - `annotation`: Additional details about each coordinate along the route geometry:
 
-   | annotate     |                                                                       |
+   | annotations  |                                                                       |
    |--------------|-----------------------------------------------------------------------|
    | true         | returns distance and durations of each coordinate along the route     |
    | false        | will not exist                                                        |
 
 #### Example
 
-With `steps=false` and `annotate=true`:
+With `steps=false` and `annotations=true`:
 
 ```json
 {

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -145,7 +145,6 @@ module.exports = function () {
                     this.requestUrl(row.request, afterRequest);
                 } else {
                     var params = this.queryParams;
-                    params['annotate'] = 'true';
                     got = {};
                     for (var k in row) {
                         var match = k.match(/param:(.*)/);

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -106,6 +106,9 @@ Feature: Basic Map Matching
             | efgh  | ab,bc,cd  |
 
     Scenario: Testbot - Duration details
+        Given the query options
+            | annotations | true |
+
         Given the node map
             | a | b | c | d | e |   | g | h |
             |   |   | i |   |   |   |   |   |

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -180,7 +180,7 @@ class RouteAPI : public BaseAPI
                                json::makeRouteLegs(std::move(legs), std::move(step_geometries)),
                                std::move(json_overview));
 
-        if (parameters.annotation)
+        if (parameters.annotations)
         {
             util::json::Array durations;
             util::json::Array distances;

--- a/include/engine/api/route_parameters.hpp
+++ b/include/engine/api/route_parameters.hpp
@@ -72,20 +72,20 @@ struct RouteParameters : public BaseParameters
     template <typename... Args>
     RouteParameters(const bool steps_,
                     const bool alternatives_,
-                    const bool annotation_,
+                    const bool annotations_,
                     const GeometriesType geometries_,
                     const OverviewType overview_,
                     const boost::optional<bool> continue_straight_,
                     Args... args_)
         : BaseParameters{std::forward<Args>(args_)...}, steps{steps_}, alternatives{alternatives_},
-          annotation{annotation_}, geometries{geometries_}, overview{overview_},
+          annotations{annotations_}, geometries{geometries_}, overview{overview_},
           continue_straight{continue_straight_}
     {
     }
 
     bool steps = false;
     bool alternatives = false;
-    bool annotation = false;
+    bool annotations = false;
     GeometriesType geometries = GeometriesType::Polyline;
     OverviewType overview = OverviewType::Simplified;
     boost::optional<bool> continue_straight;

--- a/include/server/api/route_parameters_grammar.hpp
+++ b/include/server/api/route_parameters_grammar.hpp
@@ -57,7 +57,7 @@ struct RouteParametersGrammar : public BaseParametersGrammar<Iterator, Signature
         base_rule =
             BaseGrammar::base_rule(qi::_r1)
             | (qi::lit("steps=") > qi::bool_[ph::bind(&engine::api::RouteParameters::steps, qi::_r1) = qi::_1])
-            | (qi::lit("annotate=") > qi::bool_[ph::bind(&engine::api::RouteParameters::annotation, qi::_r1) = qi::_1])
+            | (qi::lit("annotations=") > qi::bool_[ph::bind(&engine::api::RouteParameters::annotations, qi::_r1) = qi::_1])
             | (qi::lit("geometries=") > geometries_type[ph::bind(&engine::api::RouteParameters::geometries, qi::_r1) = qi::_1])
             | (qi::lit("overview=") > overview_type[ph::bind(&engine::api::RouteParameters::overview, qi::_r1) = qi::_1])
             ;

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_1.steps, result_1->steps);
     BOOST_CHECK_EQUAL(reference_1.alternatives, result_1->alternatives);
     BOOST_CHECK_EQUAL(reference_1.geometries, result_1->geometries);
-    BOOST_CHECK_EQUAL(reference_1.annotation, result_1->annotation);
+    BOOST_CHECK_EQUAL(reference_1.annotations, result_1->annotations);
     BOOST_CHECK_EQUAL(reference_1.overview, result_1->overview);
     BOOST_CHECK_EQUAL(reference_1.continue_straight, result_1->continue_straight);
     CHECK_EQUAL_RANGE(reference_1.bearings, result_1->bearings);
@@ -96,15 +96,15 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     RouteParameters reference_2{};
     reference_2.alternatives = true;
     reference_2.steps = true;
-    reference_2.annotation = true;
+    reference_2.annotations = true;
     reference_2.coordinates = coords_1;
     auto result_2 = parseParameters<RouteParameters>(
-        "1,2;3,4?steps=true&alternatives=true&geometries=polyline&overview=simplified&annotate=true");
+        "1,2;3,4?steps=true&alternatives=true&geometries=polyline&overview=simplified&annotations=true");
     BOOST_CHECK(result_2);
     BOOST_CHECK_EQUAL(reference_2.steps, result_2->steps);
     BOOST_CHECK_EQUAL(reference_2.alternatives, result_2->alternatives);
     BOOST_CHECK_EQUAL(reference_2.geometries, result_2->geometries);
-    BOOST_CHECK_EQUAL(reference_2.annotation, result_2->annotation);
+    BOOST_CHECK_EQUAL(reference_2.annotations, result_2->annotations);
     BOOST_CHECK_EQUAL(reference_2.overview, result_2->overview);
     BOOST_CHECK_EQUAL(reference_2.continue_straight, result_2->continue_straight);
     CHECK_EQUAL_RANGE(reference_2.bearings, result_2->bearings);
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_3.steps, result_3->steps);
     BOOST_CHECK_EQUAL(reference_3.alternatives, result_3->alternatives);
     BOOST_CHECK_EQUAL(reference_3.geometries, result_3->geometries);
-    BOOST_CHECK_EQUAL(reference_3.annotation, result_3->annotation);
+    BOOST_CHECK_EQUAL(reference_3.annotations, result_3->annotations);
     BOOST_CHECK_EQUAL(reference_3.overview, result_3->overview);
     BOOST_CHECK_EQUAL(reference_3.continue_straight, result_3->continue_straight);
     CHECK_EQUAL_RANGE(reference_3.bearings, result_3->bearings);
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_4.steps, result_4->steps);
     BOOST_CHECK_EQUAL(reference_4.alternatives, result_4->alternatives);
     BOOST_CHECK_EQUAL(reference_4.geometries, result_4->geometries);
-    BOOST_CHECK_EQUAL(reference_4.annotation, result_4->annotation);
+    BOOST_CHECK_EQUAL(reference_4.annotations, result_4->annotations);
     BOOST_CHECK_EQUAL(reference_4.overview, result_4->overview);
     BOOST_CHECK_EQUAL(reference_4.continue_straight, result_4->continue_straight);
     CHECK_EQUAL_RANGE(reference_4.bearings, result_4->bearings);
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_5.steps, result_5->steps);
     BOOST_CHECK_EQUAL(reference_5.alternatives, result_5->alternatives);
     BOOST_CHECK_EQUAL(reference_5.geometries, result_5->geometries);
-    BOOST_CHECK_EQUAL(reference_5.annotation, result_5->annotation);
+    BOOST_CHECK_EQUAL(reference_5.annotations, result_5->annotations);
     BOOST_CHECK_EQUAL(reference_5.overview, result_5->overview);
     BOOST_CHECK_EQUAL(reference_5.continue_straight, result_5->continue_straight);
     CHECK_EQUAL_RANGE(reference_5.bearings, result_5->bearings);
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_6.steps, result_6->steps);
     BOOST_CHECK_EQUAL(reference_6.alternatives, result_6->alternatives);
     BOOST_CHECK_EQUAL(reference_6.geometries, result_6->geometries);
-    BOOST_CHECK_EQUAL(reference_6.annotation, result_6->annotation);
+    BOOST_CHECK_EQUAL(reference_6.annotations, result_6->annotations);
     BOOST_CHECK_EQUAL(reference_6.overview, result_6->overview);
     BOOST_CHECK_EQUAL(reference_6.continue_straight, result_6->continue_straight);
     CHECK_EQUAL_RANGE(reference_6.bearings, result_6->bearings);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_7.steps, result_7->steps);
     BOOST_CHECK_EQUAL(reference_7.alternatives, result_7->alternatives);
     BOOST_CHECK_EQUAL(reference_7.geometries, result_7->geometries);
-    BOOST_CHECK_EQUAL(reference_7.annotation, result_7->annotation);
+    BOOST_CHECK_EQUAL(reference_7.annotations, result_7->annotations);
     BOOST_CHECK_EQUAL(reference_7.overview, result_7->overview);
     BOOST_CHECK_EQUAL(reference_7.continue_straight, result_7->continue_straight);
     CHECK_EQUAL_RANGE(reference_7.bearings, result_7->bearings);
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK_EQUAL(reference_10.steps, result_10->steps);
     BOOST_CHECK_EQUAL(reference_10.alternatives, result_10->alternatives);
     BOOST_CHECK_EQUAL(reference_10.geometries, result_10->geometries);
-    BOOST_CHECK_EQUAL(reference_10.annotation, result_10->annotation);
+    BOOST_CHECK_EQUAL(reference_10.annotations, result_10->annotations);
     BOOST_CHECK_EQUAL(reference_10.overview, result_10->overview);
     BOOST_CHECK_EQUAL(reference_10.continue_straight, result_10->continue_straight);
     CHECK_EQUAL_RANGE(reference_10.bearings, result_10->bearings);


### PR DESCRIPTION
This makes the API more consistent with other parameter namings.