### PR TITLE
Refactor ramIndex #2472

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
     - paramater `annotate` was renamed to `annotations`.
     - `annotation` as accidentally placed in `Route` instead of `RouteLeg`
 
+   - Infrastructure
+    - BREAKING: Changed the on-disk encoding of the StaticRTree to reduce ramIndex file size. This breaks the **data format**
+
 # 5.2.0 RC1
    Changes from 5.1.0
 

--- a/features/support/config.js
+++ b/features/support/config.js
@@ -50,21 +50,27 @@ module.exports = function () {
         };
 
         var hashExtract = (cb) => {
-            this.hashOfFiles(util.format('%s/osrm-extract%s', this.BIN_PATH, this.EXE), (hash) => {
+            var files = [ util.format('%s/osrm-extract%s', this.BIN_PATH, this.EXE),
+                          util.format('%s/libosrm_extract%s', this.BIN_PATH, this.LIB) ];
+            this.hashOfFiles(files, (hash) => {
                 this.binExtractHash = hash;
                 cb();
             });
         };
 
         var hashContract = (cb) => {
-            this.hashOfFiles(util.format('%s/osrm-contract%s', this.BIN_PATH, this.EXE), (hash) => {
+            var files = [ util.format('%s/osrm-contract%s', this.BIN_PATH, this.EXE),
+                          util.format('%s/libosrm_contract%s', this.BIN_PATH, this.LIB) ];
+            this.hashOfFiles(files, (hash) => {
                 this.binContractHash = hash;
                 cb();
             });
         };
 
         var hashRouted = (cb) => {
-            this.hashOfFiles(util.format('%s/osrm-routed%s', this.BIN_PATH, this.EXE), (hash) => {
+            var files = [ util.format('%s/osrm-routed%s', this.BIN_PATH, this.EXE),
+                          util.format('%s/libosrm%s', this.BIN_PATH, this.LIB) ];
+            this.hashOfFiles(files, (hash) => {
                 this.binRoutedHash = hash;
                 this.fingerprintRoute = this.hashString(this.binRoutedHash);
                 cb();

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -32,10 +32,12 @@ module.exports = function () {
         if (process.platform.match(/indows.*/)) {
             this.TERMSIGNAL = 9;
             this.EXE = '.exe';
+            this.LIB = '.dll';
             this.QQ = '"';
         } else {
             this.TERMSIGNAL = 'SIGTERM';
             this.EXE = '';
+            this.LIB = '.so';
             this.QQ = '';
         }
 

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -167,6 +167,14 @@ struct RectangleInt2D
         return lons_contained && lats_contained;
     }
 
+    bool IsValid() const
+    {
+        return min_lon != FixedLongitude(std::numeric_limits<std::int32_t>::max()) &&
+               max_lon != FixedLongitude(std::numeric_limits<std::int32_t>::min()) &&
+               min_lat != FixedLatitude(std::numeric_limits<std::int32_t>::max()) &&
+               max_lat != FixedLatitude(std::numeric_limits<std::int32_t>::min());
+    }
+
     friend std::ostream &operator<<(std::ostream &out, const RectangleInt2D &rect);
 };
 inline std::ostream &operator<<(std::ostream &out, const RectangleInt2D &rect)

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -32,6 +32,16 @@
 #include <string>
 #include <vector>
 
+// An extended alignment is implementation-defined, so use compiler attributes
+// until alignas(LEAF_PAGE_SIZE) is compiler-independent.
+#if defined(_MSC_VER)
+#define ALIGNED(x) __declspec(align(x))
+#elif defined(__GNUC__)
+#define ALIGNED(x) __attribute__ ((aligned(x)))
+#else
+#define ALIGNED(x)
+#endif
+
 namespace osrm
 {
 namespace util
@@ -74,13 +84,11 @@ class StaticRTree
         std::uint32_t children[BRANCHING_FACTOR];
     };
 
-    struct LeafNode
+    struct ALIGNED(LEAF_PAGE_SIZE) LeafNode
     {
         LeafNode() : object_count(0), objects() {}
         std::uint32_t object_count;
         std::array<EdgeDataT, LEAF_NODE_SIZE> objects;
-        unsigned char leaf_page_padding[LEAF_PAGE_SIZE - sizeof(std::uint32_t) -
-                                        sizeof(std::array<EdgeDataT, LEAF_NODE_SIZE>)];
     };
     static_assert(sizeof(LeafNode) == LEAF_PAGE_SIZE, "LeafNode size does not fit the page size");
 


### PR DESCRIPTION
I have removed the last level of almost empty leaves where out of 532 bztes only 4 are used.
The size of ramIndex file must reduce by a factor ~ 128. For me
-rw-rw-r-- 1 miha miha 6859612 May 27 11:47 oberbayern-latest.osrm.ramIndex
is reduced to 
-rw-rw-r-- 1 miha miha 53736 May 27 15:13 oberbayern-latest.osrm.ramIndex
The size of fileIndex will be the same because 16 bytes out of unused 32 padding bytes now used for the leaf node minimum bounding rectangle.

Negative side of the improvement is the number of tree and leaf nodes is reduced by factor 2 to 2^31-1.