### PR TITLE
Drop support for using DYLD_LIBRARY_PATH on OS X

### DIFF
--- a/features/support/data.js
+++ b/features/support/data.js
@@ -194,8 +194,8 @@ module.exports = function () {
     this.extractData = (callback) => {
         this.logPreprocessInfo();
         this.log(util.format('== Extracting %s.osm...', this.osmData.osmFile), 'preprocess');
-        var cmd = util.format('%s%s/osrm-extract %s.osm %s --profile %s/%s.lua >>%s 2>&1',
-            this.LOAD_LIBRARIES, this.BIN_PATH, this.osmData.osmFile, this.extractArgs || '', this.PROFILES_PATH, this.profile, this.PREPROCESS_LOG_FILE);
+        var cmd = util.format('%s/osrm-extract %s.osm %s --profile %s/%s.lua >>%s 2>&1',
+            this.BIN_PATH, this.osmData.osmFile, this.extractArgs || '', this.PROFILES_PATH, this.profile, this.PREPROCESS_LOG_FILE);
         this.log(cmd);
         process.chdir(this.TEST_FOLDER);
         exec(cmd, (err) => {
@@ -242,8 +242,8 @@ module.exports = function () {
     this.contractData = (callback) => {
         this.logPreprocessInfo();
         this.log(util.format('== Contracting %s.osm...', this.osmData.extractedFile), 'preprocess');
-        var cmd = util.format('%s%s/osrm-contract %s %s.osrm >>%s 2>&1',
-            this.LOAD_LIBRARIES, this.BIN_PATH, this.contractArgs || '', this.osmData.extractedFile, this.PREPROCESS_LOG_FILE);
+        var cmd = util.format('%s/osrm-contract %s %s.osrm >>%s 2>&1',
+            this.BIN_PATH, this.contractArgs || '', this.osmData.extractedFile, this.PREPROCESS_LOG_FILE);
         this.log(cmd);
         process.chdir(this.TEST_FOLDER);
         exec(cmd, (err) => {

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -28,11 +28,6 @@ module.exports = function () {
         this.OSRM_ROUTED_LOG_FILE = path.resolve(this.TEST_FOLDER, 'osrm-routed.log');
         this.ERROR_LOG_FILE = path.resolve(this.TEST_FOLDER, 'error.log');
 
-        // OS X shim to ensure shared libraries from custom locations can be loaded
-        // This is needed in OS X >= 10.11 because DYLD_LIBRARY_PATH is blocked
-        // https://forums.developer.apple.com/thread/9233
-        this.LOAD_LIBRARIES = process.env.OSRM_SHARED_LIBRARY_PATH ? util.format('DYLD_LIBRARY_PATH=%s ', process.env.OSRM_SHARED_LIBRARY_PATH) : '';
-
         // TODO make sure this works on win
         if (process.platform.match(/indows.*/)) {
             this.TERMSIGNAL = 9;
@@ -65,7 +60,7 @@ module.exports = function () {
             var binPath = path.resolve(util.format('%s/%s%s', this.BIN_PATH, bin, this.EXE));
             fs.exists(binPath, (exists) => {
                 if (!exists) throw new Error(util.format('%s is missing. Build failed?', binPath));
-                var helpPath = util.format('%s%s --help > /dev/null 2>&1', this.LOAD_LIBRARIES, binPath);
+                var helpPath = util.format('%s --help > /dev/null 2>&1', binPath);
                 exec(helpPath, (err) => {
                     if (err) {
                         this.log(util.format('*** Exited with code %d', err.code), 'preprocess');

--- a/features/support/launch_classes.js
+++ b/features/support/launch_classes.js
@@ -87,7 +87,7 @@ var OSRMDirectLoader = class extends OSRMBaseLoader {
             fs.appendFile(this.scope.OSRM_ROUTED_LOG_FILE, data, (err) => { if (err) throw err; });
         };
 
-        var child = spawn(util.format('%s%s/osrm-routed', this.scope.LOAD_LIBRARIES, this.scope.BIN_PATH), [this.inputFile, util.format('-p%d', this.scope.OSRM_PORT)]);
+        var child = spawn(util.format('%s/osrm-routed', this.scope.BIN_PATH), [this.inputFile, util.format('-p%d', this.scope.OSRM_PORT)]);
         this.scope.pid = child.pid;
         child.stdout.on('data', writeToLog);
         child.stderr.on('data', writeToLog);
@@ -123,7 +123,7 @@ var OSRMDatastoreLoader = class extends OSRMBaseLoader {
             fs.appendFile(this.scope.OSRM_ROUTED_LOG_FILE, data, (err) => { if (err) throw err; });
         };
 
-        var child = spawn(util.format('%s%s/osrm-routed', this.scope.LOAD_LIBRARIES, this.scope.BIN_PATH), ['--shared-memory=1', util.format('-p%d', this.scope.OSRM_PORT)]);
+        var child = spawn(util.format('%s/osrm-routed', this.scope.BIN_PATH), ['--shared-memory=1', util.format('-p%d', this.scope.OSRM_PORT)]);
         this.child = child;
         this.scope.pid = child.pid;
         child.stdout.on('data', writeToLog);

--- a/features/support/run.js
+++ b/features/support/run.js
@@ -25,7 +25,7 @@ module.exports = function () {
             opts = opts.replace('{profile}', [this.PROFILES_PATH, this.profile + '.lua'].join('/'));
         }
 
-        var cmd = util.format('%s%s%s/%s%s%s %s 2>%s', this.QQ, this.LOAD_LIBRARIES, this.BIN_PATH, bin, this.EXE, this.QQ, opts, this.ERROR_LOG_FILE);
+        var cmd = util.format('%s%s/%s%s%s %s 2>%s', this.QQ, this.BIN_PATH, bin, this.EXE, this.QQ, opts, this.ERROR_LOG_FILE);
         process.chdir(this.TEST_FOLDER);
         exec(cmd, (err, stdout, stderr) => {
             this.stdout = stdout.toString();


### PR DESCRIPTION
This removes the support for DYLD_LIBRARY_PATH on OS X added in #1965. It broke after the port to cucumber.js and the attempted fix in #2436 is not ideal.

The recommended method will be to use rpath (either via build args or after the fact with `install_name_tool`) to ensure dynamic libraries are found in custom locations on OS X.