### PR TITLE
Fix gcc compile

### DIFF
--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -35,6 +35,7 @@
 #include <atomic>
 #include <bitset>
 #include <cstdint>
+#include <deque>
 #include <fstream>
 #include <iterator>
 #include <memory>
@@ -516,7 +517,7 @@ std::size_t Contractor::LoadEdgeExpandedGraph(
 
         // vector to count used speeds for logging
         // size offset by one since index 0 is used for speeds not from external file
-        std::vector<std::atomic<std::uint64_t>> segment_speeds_counters;
+        std::deque<std::atomic<std::uint64_t>> segment_speeds_counters;
         for (std::size_t i = 0; i < segment_speed_filenames.size() + 1; ++i)
         {
             segment_speeds_counters.emplace_back();


### PR DESCRIPTION
Addition to #82bfd4e:
- vector::emplace_back requires MoveInsertable and EmplaceConstructible types,
- deque::emplace_back requires EmplaceConstructible types.
- std::atomic is neither copyable nor movable, but
  may be instantiated with any TriviallyCopyable type.