### PR TITLE
Handle small roundabouts, fixes #516.

### DIFF
--- a/features/bicycle/oneway.feature
+++ b/features/bicycle/oneway.feature
@@ -48,22 +48,24 @@ Feature: Bike - Oneway streets
 
     Scenario: Bike - Implied oneways
         Then routability should be
-            | highway       | foot | bicycle | junction   | forw | backw |
-            |               | no   |         |            | x    | x     |
-            |               | no   |         | roundabout | x    |       |
-            | motorway      | no   | yes     |            | x    |       |
-            | motorway_link | no   | yes     |            | x    |       |
-            | motorway      | no   | yes     | roundabout | x    |       |
-            | motorway_link | no   | yes     | roundabout | x    |       |
+            | highway         | foot | bicycle | junction   | forw | backw |
+            |                 | no   |         |            | x    | x     |
+            |                 | no   |         | roundabout | x    |       |
+            | motorway        | no   | yes     |            | x    |       |
+            | motorway_link   | no   | yes     |            | x    |       |
+            | motorway        | no   | yes     | roundabout | x    |       |
+            | motorway_link   | no   | yes     | roundabout | x    |       |
+            | mini_roundabout | no   | yes     |            | x    |       |
 
     Scenario: Bike - Overriding implied oneways
         Then routability should be
-            | highway       | foot | junction   | oneway | forw | backw |
-            | primary       | no   | roundabout | no     | x    | x     |
-            | primary       | no   | roundabout | yes    | x    |       |
-            | motorway_link | no   |            | -1     |      |       |
-            | trunk_link    | no   |            | -1     |      |       |
-            | primary       | no   | roundabout | -1     |      | x     |
+            | highway         | foot | junction   | oneway | forw | backw |
+            | primary         | no   | roundabout | no     | x    | x     |
+            | primary         | no   | roundabout | yes    | x    |       |
+            | motorway_link   | no   |            | -1     |      |       |
+            | trunk_link      | no   |            | -1     |      |       |
+            | primary         | no   | roundabout | -1     |      | x     |
+            | mini_roundabout | no   |            | -1     |      | x     |
 
     Scenario: Bike - Oneway:bicycle should override normal oneways tags
         Then routability should be

--- a/features/bicycle/pushing.feature
+++ b/features/bicycle/pushing.feature
@@ -85,6 +85,12 @@ Feature: Bike - Accessability of different way types
             | junction   | forw | backw |
             | roundabout | x    |       |
 
+    @roundabout
+    Scenario: Bike - Don't push bikes against oneway flow on mini roundabouts
+        Then routability should be
+            | highway         | forw | backw |
+            | mini_roundabout | x    |       |
+
     Scenario: Bike - Instructions when pushing bike on oneways
         Given the node map
             | a | b |   |

--- a/features/car/oneway.feature
+++ b/features/car/oneway.feature
@@ -17,13 +17,14 @@ Feature: Car - Oneway streets
 
     Scenario: Car - Implied oneways
         Then routability should be
-            | highway       | junction   | forw | backw |
-            | motorway      |            | x    |       |
-            | motorway_link |            | x    |       |
-            | primary       |            | x    | x     |
-            | motorway      | roundabout | x    |       |
-            | motorway_link | roundabout | x    |       |
-            | primary       | roundabout | x    |       |
+            | highway         | junction   | forw | backw |
+            | motorway        |            | x    |       |
+            | motorway_link   |            | x    |       |
+            | primary         |            | x    | x     |
+            | motorway        | roundabout | x    |       |
+            | motorway_link   | roundabout | x    |       |
+            | primary         | roundabout | x    |       |
+            | mini_roundabout |            | x    |       |
 
     Scenario: Car - Overrule implied oneway
         Then routability should be

--- a/features/foot/oneway.feature
+++ b/features/foot/oneway.feature
@@ -21,7 +21,7 @@ Feature: Foot - Oneway streets
     Scenario: Foot - Walking and roundabouts
         Then routability should be
             | junction   | bothw |
-            | roundarout | x     |
+            | roundabout | x     |
 
     Scenario: Foot - Oneway:foot tag should not cause walking on big roads
         Then routability should be

--- a/features/guidance/mini-roundabout.feature
+++ b/features/guidance/mini-roundabout.feature
@@ -1,0 +1,66 @@
+@routing  @guidance
+Feature: Mini Roundabout
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 10 meters
+
+    Scenario: Enter and Exit mini roundabout
+        Given the node map
+            | a | b | c | d |
+
+       And the ways
+            | nodes | highway         | name |
+            | ab    | tertiary        | MySt |
+            | bc    | mini_roundabout |      |
+            | cd    | tertiary        | MySt |
+
+       When I route I should get
+           | from | to | route     | turns         | #                                      |
+           | a    | d  | MySt,MySt | depart,arrive | # suppress enter/exit mini roundabouts |
+
+    Scenario: Enter and Exit subsequent mini roundabouts
+        Given the node map
+            | a | b | c | d | e |
+
+       And the ways
+            | nodes | highway         | name |
+            | ab    | tertiary        | MySt |
+            | bc    | mini_roundabout |      |
+            | cd    | mini_roundabout |      |
+            | de    | tertiary        | MySt |
+
+       When I route I should get
+           | from | to | route     | turns         | #                                               |
+           | a    | e  | MySt,MySt | depart,arrive | # suppress multiple enter/exit mini roundabouts |
+
+    Scenario: Enter and Exit mini roundabout with sharp angle
+        Given the node map
+            | a | b |   |
+            |   | c | d |
+
+       And the ways
+            | nodes | highway         | name |
+            | ab    | tertiary        | MySt |
+            | bc    | mini_roundabout |      |
+            | cd    | tertiary        | MySt |
+
+       When I route I should get
+           | from | to | route     | turns         | #                                               |
+           | a    | d  | MySt,MySt | depart,arrive | # suppress multiple enter/exit mini roundabouts |
+
+    Scenario: Enter and Exit mini roundabout with sharp angle
+        Given the node map
+            | a | b | e |
+            |   | c | d |
+
+       And the ways
+            | nodes | highway         | name |
+            | ab    | tertiary        | MySt |
+            | bc    | mini_roundabout |      |
+            | cd    | tertiary        | MySt |
+            | be    | tertiary        | MySt |
+
+       When I route I should get
+           | from | to | route          | turns                    | #                                               |
+           | a    | d  | MySt,MySt,MySt | depart,turn right,arrive | # suppress multiple enter/exit mini roundabouts |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -225,7 +225,7 @@ function way_function (way, result)
   end
 
   -- roundabout handling
-  if junction and "roundabout" == junction then
+  if junction and "roundabout" == junction or "mini_roundabout" == highway then
     result.roundabout = true
   end
 
@@ -285,7 +285,7 @@ function way_function (way, result)
   else
     -- biking not allowed, maybe we can push our bike?
     -- essentially requires pedestrian profiling, for example foot=no mean we can't push a bike
-    if foot ~= 'no' and junction ~= "roundabout" then
+    if foot ~= 'no' and junction ~= "roundabout" and highway ~= "mini_roundabout" then
       if pedestrian_speeds[highway] then
         -- pedestrian-only ways and areas
         result.forward_speed = pedestrian_speeds[highway]
@@ -317,7 +317,7 @@ function way_function (way, result)
 
   -- direction
   local impliedOneway = false
-  if junction == "roundabout" or highway == "motorway_link" or highway == "motorway" then
+  if junction == "roundabout" or highway == "mini_roundabout" or highway == "motorway_link" or highway == "motorway" then
     impliedOneway = true
   end
 
@@ -357,7 +357,7 @@ function way_function (way, result)
 
   -- pushing bikes
   if bicycle_speeds[highway] or pedestrian_speeds[highway] then
-    if foot ~= "no" and junction ~= "roundabout" then
+    if foot ~= "no" and junction ~= "roundabout" and highway ~= "mini_roundabout" then
       if result.backward_mode == mode.inaccessible then
         result.backward_speed = walking_speed
         result.backward_mode = mode.pushing_bike

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -18,6 +18,7 @@ local default_speed = 15
 local walking_speed = 6
 
 bicycle_speeds = {
+  ["mini_roundabout"] = default_speed,
   ["cycleway"] = default_speed,
   ["primary"] = default_speed,
   ["primary_link"] = default_speed,

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -16,6 +16,7 @@ restriction_exception_tags = { "motorcar", "motor_vehicle", "vehicle" }
 suffix_list = { "N", "NE", "E", "SE", "S", "SW", "W", "NW", "North", "South", "West", "East" }
 
 speed_profile = {
+  ["mini_roundabout"] = 25,
   ["motorway"] = 90,
   ["motorway_link"] = 45,
   ["trunk"] = 85,

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -368,7 +368,7 @@ function way_function (way, result)
       --    result.name = highway  -- if no name exists, use way type
   end
 
-  if junction and "roundabout" == junction then
+  if junction and ("roundabout" == junction or "mini_roundabout" == highway) then
     result.roundabout = true
   end
 
@@ -390,6 +390,7 @@ function way_function (way, result)
     oneway == "1" or
     oneway == "true" or
     junction == "roundabout" or
+    highway == "mini_roundabout" or
     (highway == "motorway_link" and oneway ~="no") or
     (highway == "motorway" and oneway ~= "no") then
       result.backward_mode = mode.inaccessible

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -162,7 +162,7 @@ function way_function (way, result)
   end
 
     -- roundabouts
-  if "roundabout" == junction then
+  if "roundabout" == junction or "mini_roundabout" == highway then
     result.roundabout = true
   end
 

--- a/profiles/testbot.lua
+++ b/profiles/testbot.lua
@@ -103,11 +103,11 @@ function way_function (way, result)
     -- nothing to do
   elseif oneway == "-1" then
     result.forward_mode = mode.inaccessible
-  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" then
+  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" or highway == "mini_roundabout" then
     result.backward_mode = mode.inaccessible
   end
 
-  if junction == 'roundabout' then
+  if junction == 'roundabout' or highway == 'mini_roundabout' then
     result.roundabout = true
   end
 end

--- a/taginfo.json
+++ b/taginfo.json
@@ -143,6 +143,7 @@
         {"key": "highway", "value": "movable"},
         {"key": "highway", "value": "shuttle_train"},
         {"key": "highway", "value": "default"},
+        {"key": "highway", "value": "mini_roundabout"},
         {"key": "width", "description": "Penalties for narrow streets"},
         {"key": "lanes", "description": "Penalties for shared single lane streets"},
         {"key": "surface", "value": "asphalt"},


### PR DESCRIPTION
This gives us ~51k additional roundabout instructions.
Guidance handes sizes internally.

Note: it is highway=mini_roundabout but junction=roundabout

References:
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dmini_roundabout
- http://wiki.openstreetmap.org/wiki/Tag:junction=roundabout
- http://taginfo.openstreetmap.org/tags/highway=mini_roundabout

@MoKob do you want me to write a test case for this? I don't think duplicating the guidance test cases 1:1 make sense.