### PR TITLE
highway=motorway_link does not imply oneway, fixes #1662

### DIFF
--- a/features/bicycle/oneway.feature
+++ b/features/bicycle/oneway.feature
@@ -48,14 +48,14 @@ Feature: Bike - Oneway streets
 
     Scenario: Bike - Implied oneways
         Then routability should be
-            | highway         | foot | bicycle | junction   | forw | backw |
-            |                 | no   |         |            | x    | x     |
-            |                 | no   |         | roundabout | x    |       |
-            | motorway        | no   | yes     |            | x    |       |
-            | motorway_link   | no   | yes     |            | x    |       |
-            | motorway        | no   | yes     | roundabout | x    |       |
-            | motorway_link   | no   | yes     | roundabout | x    |       |
-            | mini_roundabout | no   | yes     |            | x    |       |
+            | highway         | foot | bicycle | junction   | forw | backw | #                     |
+            |                 | no   |         |            | x    | x     |                       |
+            |                 | no   |         | roundabout | x    |       |                       |
+            | motorway        | no   | yes     |            | x    |       |                       |
+            | motorway_link   | no   | yes     |            | x    | x     | does not imply oneway |
+            | motorway        | no   | yes     | roundabout | x    |       |                       |
+            | motorway_link   | no   | yes     | roundabout | x    |       |                       |
+            | mini_roundabout | no   | yes     |            | x    |       |                       |
 
     Scenario: Bike - Overriding implied oneways
         Then routability should be

--- a/features/car/oneway.feature
+++ b/features/car/oneway.feature
@@ -17,20 +17,22 @@ Feature: Car - Oneway streets
 
     Scenario: Car - Implied oneways
         Then routability should be
-            | highway         | junction   | forw | backw |
-            | motorway        |            | x    |       |
-            | motorway_link   |            | x    |       |
-            | primary         |            | x    | x     |
-            | motorway        | roundabout | x    |       |
-            | motorway_link   | roundabout | x    |       |
-            | primary         | roundabout | x    |       |
-            | mini_roundabout |            | x    |       |
+            | highway         | junction   | forw | backw | #                     |
+            | motorway        |            | x    |       |                       |
+            | motorway_link   |            | x    | x     | does not imply oneway |
+            | primary         |            | x    | x     |                       |
+            | motorway        | roundabout | x    |       |                       |
+            | motorway_link   | roundabout | x    |       |                       |
+            | primary         | roundabout | x    |       |                       |
+            | mini_roundabout |            | x    |       |                       |
 
     Scenario: Car - Overrule implied oneway
         Then routability should be
-            | highway       | oneway | forw | backw |
-            | motorway      | no     | x    | x     |
-            | motorway_link | no     | x    | x     |
+            | highway       | oneway | forw | backw | #                    |
+            | motorway      | no     | x    | x     |                      |
+            | motorway_link | no     | x    | x     |                      |
+            | motorway_link | yes    | x    |       |                      |
+            | motorway_link |        | x    | x     | does not imply onway |
 
     Scenario: Car - Around the Block
         Given the node map

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -11,9 +11,9 @@ Feature: Motorway Guidance
             |   |   |   | f | g |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | bfg    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | bfg   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route         | turns                                |
@@ -27,9 +27,9 @@ Feature: Motorway Guidance
             |   |   |   | g | e |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | bfg    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | bfg   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route         | turns                         |
@@ -44,9 +44,9 @@ Feature: Motorway Guidance
 
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | cfg    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | cfg   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route         | turns                                |
@@ -60,9 +60,9 @@ Feature: Motorway Guidance
             | a | b | c | d | e |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | bfg    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | bfg   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route         | turns                               |
@@ -76,9 +76,9 @@ Feature: Motorway Guidance
             | a | b | c |   |   |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | bfg    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | bfg   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route         | turns                        |
@@ -92,9 +92,9 @@ Feature: Motorway Guidance
             |   |   |   |   | e |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | cfg    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | cfg   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route         | turns                               |
@@ -107,9 +107,9 @@ Feature: Motorway Guidance
             | f | g |   |   |   |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | fgd    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | fgd   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route           | turns                           |
@@ -122,9 +122,9 @@ Feature: Motorway Guidance
             | a | b | c | d | e |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | fgd    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | fgd   | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route           | turns                            |
@@ -154,10 +154,10 @@ Feature: Motorway Guidance
             |   |   |   |   | f | g |
 
         And the ways
-            | nodes  | highway       |
-            | abc    | motorway_link |
-            | cde    | motorway      |
-            | cfg    | motorway      |
+            | nodes | highway       | oneway |
+            | abc   | motorway_link | yes    |
+            | cde   | motorway      |        |
+            | cfg   | motorway      |        |
 
        When I route I should get
             | waypoints | route       | turns                           |
@@ -170,17 +170,17 @@ Feature: Motorway Guidance
             | f | g |   |   |   | h | i |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | fgc    | motorway_link |
-            | chi    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | fgc   | motorway_link | yes    |
+            | chi   | motorway_link | yes    |
 
        When I route I should get
-            | waypoints | route           | turns                                |
-            | a,e       | abcde,abcde     | depart,arrive                        |
-            | f,e       | fgc,abcde,abcde | depart,merge slight left,arrive      |
+            | waypoints | route           | turns                              |
+            | a,e       | abcde,abcde     | depart,arrive                      |
+            | f,e       | fgc,abcde,abcde | depart,merge slight left,arrive    |
             | a,i       | abcde,chi,chi   | depart,off ramp slight right,arrive |
-            | f,i       | fgc,chi,chi     | depart,off ramp right,arrive        |
+            | f,i       | fgc,chi,chi     | depart,off ramp right,arrive       |
 
     Scenario: On And Off Ramp Left
        Given the node map
@@ -188,17 +188,17 @@ Feature: Motorway Guidance
             | a | b |   | c |   | d | e |
 
         And the ways
-            | nodes  | highway       |
-            | abcde  | motorway      |
-            | fgc    | motorway_link |
-            | chi    | motorway_link |
+            | nodes | highway       | oneway |
+            | abcde | motorway      |        |
+            | fgc   | motorway_link | yes    |
+            | chi   | motorway_link | yes    |
 
        When I route I should get
-            | waypoints | route           | turns                               |
-            | a,e       | abcde,abcde     | depart,arrive                       |
-            | f,e       | fgc,abcde,abcde | depart,merge slight right,arrive    |
+            | waypoints | route           | turns                             |
+            | a,e       | abcde,abcde     | depart,arrive                     |
+            | f,e       | fgc,abcde,abcde | depart,merge slight right,arrive  |
             | a,i       | abcde,chi,chi   | depart,off ramp slight left,arrive |
-            | f,i       | fgc,chi,chi     | depart,off ramp left,arrive        |
+            | f,i       | fgc,chi,chi     | depart,off ramp left,arrive       |
 
     Scenario: Merging Motorways
         Given the node map

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -318,7 +318,7 @@ function way_function (way, result)
 
   -- direction
   local impliedOneway = false
-  if junction == "roundabout" or highway == "mini_roundabout" or highway == "motorway_link" or highway == "motorway" then
+  if junction == "roundabout" or highway == "mini_roundabout" or highway == "motorway" then
     impliedOneway = true
   end
 

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -396,7 +396,6 @@ function way_function (way, result)
     oneway == "true" or
     junction == "roundabout" or
     highway == "mini_roundabout" or
-    (highway == "motorway_link" and oneway ~="no") or
     (highway == "motorway" and oneway ~= "no") then
       result.backward_mode = mode.inaccessible
 


### PR DESCRIPTION
For #1662.

References:
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link#Tagging_oneway
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway