### PR TITLE
handle short summaries correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
    - Infrastructure
     - BREAKING: Changed the on-disk encoding of the StaticRTree to reduce ramIndex file size. This breaks the **data format**
 
+   - Bugfixes
+    - fixed broken summaries for very short routes
+
 # 5.2.0 RC1
    Changes from 5.1.0
 

--- a/features/testbot/summary.feature
+++ b/features/testbot/summary.feature
@@ -7,7 +7,7 @@ Feature: Basic Routing
     @smallest
     Scenario: Checking 
         Given the node map
-            | a | b |  | c | d | e |
+            | a | b | 1 | c | d | e |
 
         And the ways
             | nodes |
@@ -22,6 +22,7 @@ Feature: Basic Routing
             | e    | a  | de,cd,bc,ab,ab | de, bc   |
             | a    | b  | ab,ab          | ab       |
             | b    | d  | bc,cd,cd       | bc, cd   |
+            | 1    | c  | bc,bc          | bc       |
 
     @smallest
     Scenario: Check handling empty values

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
                 json::Array{{json::Object{
                     {{"distance", 0.},
                      {"duration", 0.},
-                     {"summary", ""},
+                     {"summary", "Boulevard du Larvotto"},
                      {"steps",
                       json::Array{{{json::Object{{{"duration", 0.},
                                                   {"distance", 0.},


### PR DESCRIPTION
During my test-updates for collapsed instructions I came around this problem:

If a route consists simply of the phantom node and/or the phantom node segment at the end is significant, the summary can be off, depending on phantom node snapping.

This PR fixes the problem.

Grid:
| a | b |

with waypoints:
|a,b|

Could result in an empty summary. This is no longer the case with this PR