### PR TITLE
Install clang-3.8 via mason binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,16 +49,13 @@ matrix:
           packages: ['g++-4.8', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
       env: CCOMPILER='gcc-4.8' CXXCOMPILER='g++-4.8' BUILD_TYPE='Debug'
 
-  # LLVM APT servers switched off, commenting Clang builds out as they will always fail now
-  # http://lists.llvm.org/pipermail/llvm-foundation/2016-June/000025.html
-  #
-  #    - os: linux
-  #      compiler: "clang-3.8-debug"
-  #      addons: &clang38
-  #        apt:
-  #          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
-  #          packages: ['clang-3.8', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
-  #      env: CCOMPILER='clang-3.8' CXXCOMPILER='clang++-3.8' BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON
+    - os: linux
+      compiler: "clang-3.8-debug"
+      addons: &clang38
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['libstdc++-5-dev', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
+      env: CLANG_VERSION='3.8.0' BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON
 
     - os: osx
       osx_image: xcode7.3
@@ -124,6 +121,13 @@ before_install:
   - export PATH=${DEPS_DIR}/bin:${PATH} && mkdir -p ${DEPS_DIR}
   - CMAKE_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/cmake/3.5.2.tar.gz"
   - travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}
+  - |
+    if [[ ${CLANG_VERSION:-false} != false ]]; then
+      export CCOMPILER='clang'
+      export CXXCOMPILER='clang++'
+      CLANG_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/clang/${CLANG_VERSION}.tar.gz"
+      travis_retry wget --quiet -O - ${CLANG_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}
+    fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       # implicit deps, but seem to be installed by default with recent images: libxml2 GDAL boost


### PR DESCRIPTION
We needed to disable clang-3.8 builds in https://github.com/Project-OSRM/osrm-backend/commit/e7159adf59dde64a8e10a330595c7ef76224122e due to LLVM apt servers going offline (http://lists.llvm.org/pipermail/llvm-foundation/2016-June/000025.html).

This brings back testing of clang-3.8 via a mason package downloaded from s3, which should be fast and stable.

Bonus: this package supports `-fsanitize=<things>` like `address` and `integer`.