### PR TITLE
Fix/incorrect merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
    - Guidance:
      - improved handling of sliproads (emit turns instead of 'take the ramp')
+     - improved collapsing of instructions. Some 'new name' instructions will be suppressed if they are without alternative and the segment is short
      - BREAKING: modifies the file format with new internal identifiers
 
    - API:

--- a/features/bicycle/oneway.feature
+++ b/features/bicycle/oneway.feature
@@ -115,7 +115,7 @@ Feature: Bike - Oneway streets
 
     Scenario: Bike - Two consecutive oneways
         Given the node map
-            | a | b | c |
+            | a | b |   | c |
 
         And the ways
             | nodes | oneway |

--- a/features/car/oneway.feature
+++ b/features/car/oneway.feature
@@ -68,7 +68,7 @@ Feature: Car - Oneway streets
 
     Scenario: Car - Two consecutive oneways
         Given the node map
-            | a | b | c |
+            | a | b |   | c |
 
         And the ways
             | nodes | oneway |

--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -5,6 +5,7 @@ Feature: Car - Turn restrictions
 
     Background: Use car routing
         Given the profile "car"
+        Given a grid size of 200 meters
 
     @no_turning
     Scenario: Car - No left turn

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -12,19 +12,17 @@ Feature: Traffic - turn penalties
             | nodes | highway |
             | ad    | primary |
             | cd    | primary |
-            | de    | primary |
+            | def   | primary |
             | dhk   | primary |
 
             | bf    | primary |
-            | ef    | primary |
             | fg    | primary |
             | fim   | primary |
 
             | jk    | primary |
-            | kl    | primary |
+            | klm   | primary |
             | ko    | primary |
 
-            | lm    | primary |
             | mn    | primary |
             | mp    | primary |
         And the profile "car"
@@ -32,22 +30,22 @@ Feature: Traffic - turn penalties
 
     Scenario: Weighting not based on turn penalty file
         When I route I should get
-            | from | to | route          | speed   | time      |
-            | a    | h  | ad,dhk,dhk     | 63 km/h | 11.5s +-1 |
+            | from | to | route           | speed   | time      |
+            | a    | h  | ad,dhk,dhk      | 63 km/h | 11.5s +-1 |
                                                                   # straight
-            | i    | g  | fim,fg,fg      | 59 km/h | 12s  +-1  |
+            | i    | g  | fim,fg,fg       | 59 km/h | 12s  +-1  |
                                                                   # right
-            | a    | e  | ad,de,de       | 57 km/h | 12.5s +-1 |
+            | a    | e  | ad,def,def      | 57 km/h | 12.5s +-1 |
                                                                   # left
-            | c    | g  | cd,de,ef,fg,fg | 63 km/h | 23s +-1   |
+            | c    | g  | cd,def,fg,fg    | 63 km/h | 23s +-1   |
                                                                   # double straight
-            | p    | g  | mp,fim,fg,fg   | 61 km/h | 23.5s +-1 |
+            | p    | g  | mp,fim,fg,fg    | 61 km/h | 23.5s +-1 |
                                                                   # straight-right
-            | a    | l  | ad,dhk,kl,kl   | 60 km/h | 24s +-1   |
+            | a    | l  | ad,dhk,klm,klm  | 60 km/h | 24s +-1   |
                                                                   # straight-left
-            | l    | e  | kl,dhk,de,de   | 59 km/h | 24.5s +-1 |
+            | l    | e  | klm,dhk,def,def | 59 km/h | 24.5s +-1 |
                                                                   # double right
-            | g    | n  | fg,fim,mn,mn   | 57 km/h | 25s +-1   |
+            | g    | n  | fg,fim,mn,mn    | 57 km/h | 25s +-1   |
                                                                   # double left
 
     Scenario: Weighting based on turn penalty file
@@ -62,24 +60,24 @@ Feature: Traffic - turn penalties
             """
         And the contract extra arguments "--turn-penalty-file penalties.csv"
         When I route I should get
-            | from | to | route                    | speed   | time      |
-            | a    | h  | ad,dhk,dhk               | 63 km/h | 11.5s +-1 |
+            | from | to | route                 | speed   | time      |
+            | a    | h  | ad,dhk,dhk            | 63 km/h | 11.5s +-1 |
                                                                               # straight
-            | i    | g  | fim,fg,fg                | 55 km/h | 13s +-1   |
+            | i    | g  | fim,fg,fg             | 55 km/h | 13s +-1   |
                                                                               # right - ifg penalty
-            | a    | e  | ad,de,de                 | 64 km/h | 11s +-1   |
+            | a    | e  | ad,def,def            | 64 km/h | 11s +-1   |
                                                                               # left - faster because of negative ade penalty
-            | c    | g  | cd,de,ef,fg,fg           | 63 km/h | 23s +-1   |
+            | c    | g  | cd,def,fg,fg          | 63 km/h | 23s +-1   |
                                                                               # double straight
-            | p    | g  | mp,fim,fg,fg             | 59 km/h | 24.5s +-1 |
+            | p    | g  | mp,fim,fg,fg          | 59 km/h | 24.5s +-1 |
                                                                               # straight-right - ifg penalty
-            | a    | l  | ad,de,ef,fim,lm,lm       | 61 km/h | 35.5s +-1 |
+            | a    | l  | ad,def,fim,klm,klm    | 61 km/h | 35.5s +-1 |
                                                                               # was straight-left - forced around by hkl penalty
-            | l    | e  | lm,fim,ef,ef             | 57 km/h | 25s +-1   |
+            | l    | e  | klm,fim,def,def       | 57 km/h | 25s +-1   |
                                                                               # double right - forced left by lkh penalty
-            | g    | n  | fg,fim,mn,mn             | 30 km/h | 47.5s +-1   |
+            | g    | n  | fg,fim,mn,mn          | 30 km/h | 47.5s +-1 |
                                                                               # double left - imn penalty
-            | j    | c  | jk,kl,lm,fim,ef,de,cd,cd | 60 km/h | 48s +-1   |
+            | j    | c  | jk,klm,fim,def,cd,cd  | 60 km/h | 48s +-1   |
                                                                               # double left - hdc penalty ever so slightly higher than imn; forces all the way around
 
     Scenario: Too-negative penalty clamps, but does not fail
@@ -90,8 +88,8 @@ Feature: Traffic - turn penalties
             1,4,5,-10
             """
         When I route I should get
-            | from | to | route    | time    |
-            | a    | d  | ad,ad    | 10s +-1 |
-            | a    | e  | ad,de,de | 10s +-1 |
-            | b    | f  | bf,bf    | 10s +-1 |
-            | b    | g  | bf,fg,fg | 20s +-1 |
+            | from | to | route      | time    |
+            | a    | d  | ad,ad      | 10s +-1 |
+            | a    | e  | ad,def,def | 10s +-1 |
+            | b    | f  | bf,bf      | 10s +-1 |
+            | b    | g  | bf,fg,fg   | 20s +-1 |

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -345,3 +345,143 @@ Feature: Collapse
             | a,d       | first,first,first,first | depart,continue left,continue right,arrive |
             | a,e       | first,second,second     | depart,turn left,arrive                    |
             | a,f       | first,third,third       | depart,turn straight,arrive                |
+
+     Scenario: Bridge on unnamed road
+        Given the node map
+            | a | b |   |   |   | c | d |
+
+        And the ways
+            | nodes | highway | name   |
+            | ab    | primary |        |
+            | bc    | primary | Bridge |
+            | cd    | primary |        |
+
+        When I route I should get
+            | waypoints | route | turns         |
+            | a,d       | ,     | depart,arrive |
+
+     Scenario: Crossing Bridge into Segregated Turn
+        Given the node map
+            |   |   |   |   |   | f |
+            | i | h |   |   | g | e |
+            | a | b |   |   | c | d |
+
+        And the ways
+            | nodes | highway | oneway | name        |
+            | ab    | primary | yes    | to_bridge   |
+            | bc    | primary | yes    | bridge      |
+            | cd    | primary | yes    | off_bridge  |
+            | de    | primary | yes    |             |
+            | ef    | primary | no     | target_road |
+            | eg    | primary | yes    | off_bridge  |
+            | gh    | primary | yes    | bridge      |
+            | hi    | primary | yes    | to_bridge   |
+
+        When I route I should get
+            | waypoints | route                             | turns                   |
+            | a,f       | to_bridge,target_road,target_road | depart,turn left,arrive |
+
+    Scenario: Pankenbruecke
+        Given the node map
+            | h |   |   |   |   |   | i |   |   |   |   |   |   |
+            |   |   | b | c | d | e | f |   |   |   |   |   | g |
+            | a |   |   |   |   |   |   |   |   |   |   |   |   |
+
+        And the ways
+            | nodes | highway | name    | oneway |
+            | abh   | primary | inroad  | yes    |
+            | bc    | primary | inroad  | no     |
+            | cd    | primary | bridge  | no     |
+            | defg  | primary | outroad | no     |
+            | fi    | primary | cross   | no     |
+
+       When I route I should get
+            | waypoints | route                  | turns                           |
+            | a,g       | inroad,outroad,outroad | depart,new name straight,arrive |
+            | a,i       | inroad,cross,cross     | depart,turn left,arrive         |
+
+     Scenario: Close Turns - Don't Collapse
+        Given the node map
+            |   | g | d |   |
+            |   |   |   |   |
+            | e | b | c | f |
+            |   |   |   |   |
+            |   | a | h |   |
+
+        And the ways
+            | nodes | highway | name     |
+            | ab    | primary | in       |
+            | ebcf  | primary | cross    |
+            | cd    | primary | out      |
+            | bg    | primary | straight |
+            | ch    | primary | reverse  |
+
+        When I route I should get
+            | waypoints | route                    | turns                               |
+            | a,d       | in,cross,out,out         | depart,turn right,turn left,arrive  |
+            | a,h       | in,cross,reverse,reverse | depart,turn right,turn right,arrive |
+            | g,d       | straight,cross,out,out   | depart,turn left,turn left,arrive   |
+
+     Scenario: No Name During Turns
+        Given the node map
+            | a | b |   |
+            |   | c | d |
+
+        And the ways
+            | nodes | highway  | name |
+            | ab    | tertiary | road |
+            | bc    | tertiary |      |
+            | cd    | tertiary | road |
+
+        When I route I should get
+            | waypoints | route     | turns         |
+            | a,d       | road,road | depart,arrive |
+
+    Scenario: No Name During Turns, Random Oneway
+        Given the node map
+            | a | b |   |
+            |   | c | d |
+
+        And the ways
+            | nodes | highway  | name | oneway |
+            | ab    | tertiary | road | no     |
+            | bc    | tertiary |      | yes    |
+            | cd    | tertiary | road | no     |
+
+        When I route I should get
+            | waypoints | route     | turns         |
+            | a,d       | road,road | depart,arrive |
+
+    Scenario: Pulled Back Turn
+        Given the node map
+            |   |   | d |
+            | a | b | c |
+            |   | e |   |
+
+        And the ways
+            | nodes | highway  | name  |
+            | abc   | tertiary | road  |
+            | cd    | tertiary | left  |
+            | be    | tertiary | right |
+
+        When I route I should get
+            | waypoints | route            | turns                    |
+            | a,d       | road,left,left   | depart,turn left,arrive  |
+            | a,e       | road,right,right | depart,turn right,arrive |
+
+    Scenario: No Name During Turns, keep important turns
+        Given the node map
+            | a | b | e |
+            |   | c | d |
+
+        And the ways
+            | nodes | highway  | name  |
+            | ab    | tertiary | road  |
+            | bc    | tertiary |       |
+            | cd    | tertiary | road  |
+            | be    | tertiary | other |
+
+        When I route I should get
+            | waypoints | route          | turns                        |
+            | a,d       | road,road,road | depart,continue right,arrive |
+

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -485,3 +485,29 @@ Feature: Collapse
             | waypoints | route          | turns                        |
             | a,d       | road,road,road | depart,continue right,arrive |
 
+    Scenario: Segregated Intersection into Slight Turn
+        Given the node map
+            | h |   |   |   |   |   |   |
+            | a |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   | g |   |   |   |   |
+            |   |   | b | f |   |   |   |
+            |   |   |   | c |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   | e |
+            |   |   |   |   |   |   | d |
+            |   |   | j | i |   |   |   |
+
+        And the ways
+            | nodes | highway   | name | oneway |
+            | abcd  | primary   | road | yes    |
+            | efgh  | primary   | road | yes    |
+            | icf   | secondary | in   | yes    |
+            | gbj   | secondary | out  | yes    |
+
+        When I route I should get
+            | waypoints | route        | turns                           |
+            | i,h       | in,road,road | depart,turn slight left,arrive  |
+            | a,d       | road,road    | depart,arrive                   |
+            | a,j       | road,out,out | depart,turn slight right,arrive |

--- a/features/guidance/intersections.feature
+++ b/features/guidance/intersections.feature
@@ -117,9 +117,9 @@ Feature: Intersections Data
             | cf     | corner        |
 
        When I route I should get
-            | waypoints | route                        | turns                          | intersections                                                        |
-            | a,d       | through,through              | depart,arrive                  | true:90,true:0 true:90 false:270,true:90 true:180 false:270;true:270 |
-            | f,a       | corner,throughbridge,through | depart,end of road left,arrive | true:0;true:90 false:180 true:270,true:0 false:90 true:270;true:90   |
+            | waypoints | route                  | turns                          | intersections                                                        |
+            | a,d       | through,through        | depart,arrive                  | true:90,true:0 true:90 false:270,true:90 true:180 false:270;true:270 |
+            | f,a       | corner,through,through | depart,end of road left,arrive | true:0;true:90 false:180 true:270,true:0 false:90 true:270;true:90   |
 
     Scenario: Roundabouts
         Given the node map

--- a/features/guidance/new-name.feature
+++ b/features/guidance/new-name.feature
@@ -3,7 +3,7 @@ Feature: New-Name Instructions
 
     Background:
         Given the profile "car"
-        Given a grid size of 10 meters
+        Given a grid size of 100 meters
 
     Scenario: Undisturbed name Change
         Given the node map
@@ -136,7 +136,7 @@ Feature: New-Name Instructions
 
     Scenario: Empty road names - Announce Change From, suppress Change To
         Given the node map
-            | a |  | b |  | c |  | d |
+            | a |  | b | 1 | c |  | d |
 
         And the ways
             | nodes | name |
@@ -147,7 +147,7 @@ Feature: New-Name Instructions
         When I route I should get
             | waypoints | route    | turns                           |
             | a,d       | ab,cd,cd | depart,new name straight,arrive |
-            | a,c       | ab,      | depart,arrive                   |
+            | a,1       | ab,      | depart,arrive                   |
 
     Scenario: Empty road names - Loose name shortly
         Given the node map

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -805,4 +805,3 @@ Feature: Simple Turns
             | a,d       | abc,bd,bd | depart,turn sharp right,arrive  |
             | a,e       | abc,be,be | depart,turn right,arrive        |
             | a,f       | abc,bf,bf | depart,turn slight right,arrive |
-

--- a/features/testbot/alternative.feature
+++ b/features/testbot/alternative.feature
@@ -3,6 +3,7 @@ Feature: Alternative route
 
     Background:
         Given the profile "testbot"
+        And a grid size of 200 meters
 
         And the node map
             |   | b | c | d |   |   |
@@ -17,11 +18,11 @@ Feature: Alternative route
             | dz    |
             | ag    |
             | gh    |
+            | ck    |
+            | kh    |
             | hi    |
             | ij    |
             | jz    |
-            | ck    |
-            | kh    |
 
     Scenario: Enabled alternative
         Given the query options

--- a/features/testbot/basic.feature
+++ b/features/testbot/basic.feature
@@ -56,7 +56,7 @@ Feature: Basic Routing
 
     Scenario: Two ways connected in a straight line
         Given the node map
-            | a | b | c |
+            | a |   | b |   | c |
 
         And the ways
             | nodes |

--- a/features/testbot/bearing_param.feature
+++ b/features/testbot/bearing_param.feature
@@ -43,8 +43,8 @@ Feature: Bearing parameter
 
     Scenario: Testbot - Initial bearing on split way
         Given the node map
-        | d |  |  |  |  | 1 |  |  |  |  | c |
-        | a |  |  |  |  | 0 |  |  |  |  | b |
+           | g | d |  |  |  |  | 1 |  |  |  |  | c | f |
+           | h | a |  |  |  |  | 0 |  |  |  |  | b | e |
 
         And the ways
             | nodes | oneway |
@@ -52,6 +52,10 @@ Feature: Bearing parameter
             | bc    | yes    |
             | cd    | yes    |
             | da    | yes    |
+            | be    | yes    |
+            | fc    | yes    |
+            | dg    | yes    |
+            | ha    | yes    |
 
         When I route I should get
             | from | to | bearings | route       | bearing       |

--- a/features/testbot/continue_straight.feature
+++ b/features/testbot/continue_straight.feature
@@ -3,6 +3,7 @@ Feature: U-turns at via points
 
     Background:
         Given the profile "testbot"
+        Given a grid size of 100 meters
 
     Scenario: Continue straight at waypoints enabled by default
         Given the node map

--- a/features/testbot/mode.feature
+++ b/features/testbot/mode.feature
@@ -11,6 +11,7 @@ Feature: Testbot - Travel mode
 
     Background:
        Given the profile "testbot"
+       Given a grid size of 200 meters
 
     Scenario: Testbot - Always announce mode change
         Given the node map
@@ -72,9 +73,9 @@ Feature: Testbot - Travel mode
             | ab    | steps   |
 
         When I route I should get
-            | from | to | route | modes                 | time    |
-            | 0    | 1  | ab,ab | steps down,steps down | 60s +-1 |
-            | 1    | 0  | ab,ab | steps up,steps up     | 60s +-1 |
+            | from | to | route | modes                 | time     |
+            | 0    | 1  | ab,ab | steps down,steps down | 120s +-1 |
+            | 1    | 0  | ab,ab | steps up,steps up     | 120s +-1 |
 
     @oneway
     Scenario: Testbot - Modes for oneway, different forward/backward speeds

--- a/features/testbot/summary.feature
+++ b/features/testbot/summary.feature
@@ -3,9 +3,10 @@ Feature: Basic Routing
 
     Background:
         Given the profile "testbot"
+        Given a grid size of 200 meters
 
     @smallest
-    Scenario: Checking 
+    Scenario: Checking
         Given the node map
             | a | b | 1 | c | d | e |
 

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -144,6 +144,7 @@ class RouteAPI : public BaseAPI
                 guidance::trimShortSegments(steps, leg_geometry);
                 leg.steps = guidance::postProcess(std::move(steps));
                 leg.steps = guidance::collapseTurns(std::move(leg.steps));
+                leg.steps = guidance::buildIntersections(std::move(leg.steps));
                 leg.steps = guidance::assignRelativeLocations(std::move(leg.steps),
                                                               leg_geometry,
                                                               phantoms.source_phantom,

--- a/include/engine/guidance/post_processing.hpp
+++ b/include/engine/guidance/post_processing.hpp
@@ -37,6 +37,9 @@ std::vector<RouteStep> assignRelativeLocations(std::vector<RouteStep> steps,
                                                const PhantomNode &source_node,
                                                const PhantomNode &target_node);
 
+// collapse suppressed instructions remaining into intersections array
+std::vector<RouteStep> buildIntersections(std::vector<RouteStep> steps);
+
 // remove steps invalidated by post-processing
 std::vector<RouteStep> removeNoTurnInstructions(std::vector<RouteStep> steps);
 

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -280,20 +280,6 @@ inline double getTurnConfidence(const double angle, TurnInstruction instruction)
     return 1.0 - (difference / max_deviation) * (difference / max_deviation);
 }
 
-// swaps left <-> right modifier types
-inline DirectionModifier::Enum mirrorDirectionModifier(const DirectionModifier::Enum modifier)
-{
-    const constexpr DirectionModifier::Enum results[] = {DirectionModifier::UTurn,
-                                                         DirectionModifier::SharpLeft,
-                                                         DirectionModifier::Left,
-                                                         DirectionModifier::SlightLeft,
-                                                         DirectionModifier::Straight,
-                                                         DirectionModifier::SlightRight,
-                                                         DirectionModifier::Right,
-                                                         DirectionModifier::SharpRight};
-    return results[modifier];
-}
-
 inline bool canBeSuppressed(const TurnType::Enum type)
 {
     if (type == TurnType::Turn)

--- a/include/util/guidance/toolkit.hpp
+++ b/include/util/guidance/toolkit.hpp
@@ -49,6 +49,22 @@ inline extractor::guidance::DirectionModifier::Enum getTurnDirection(const doubl
     return extractor::guidance::DirectionModifier::UTurn;
 }
 
+// swaps left <-> right modifier types
+inline extractor::guidance::DirectionModifier::Enum
+mirrorDirectionModifier(const extractor::guidance::DirectionModifier::Enum modifier)
+{
+    const constexpr extractor::guidance::DirectionModifier::Enum results[] = {
+        extractor::guidance::DirectionModifier::UTurn,
+        extractor::guidance::DirectionModifier::SharpLeft,
+        extractor::guidance::DirectionModifier::Left,
+        extractor::guidance::DirectionModifier::SlightLeft,
+        extractor::guidance::DirectionModifier::Straight,
+        extractor::guidance::DirectionModifier::SlightRight,
+        extractor::guidance::DirectionModifier::Right,
+        extractor::guidance::DirectionModifier::SharpRight};
+    return results[modifier];
+}
+
 } // namespace guidance
 } // namespace util
 } // namespace osrm

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -40,7 +40,8 @@ bool isCollapsableInstruction(const TurnInstruction instruction)
            (instruction.type == TurnType::Suppressed &&
             instruction.direction_modifier == DirectionModifier::Straight) ||
            (instruction.type == TurnType::Turn &&
-            instruction.direction_modifier == DirectionModifier::Straight);
+            instruction.direction_modifier == DirectionModifier::Straight) ||
+           (instruction.type == TurnType::Merge);
 }
 
 // A check whether two instructions can be treated as one. This is only the case for very short
@@ -395,6 +396,13 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
             if (TurnType::Continue == current_step.maneuver.instruction.type ||
                 TurnType::Suppressed == current_step.maneuver.instruction.type)
                 steps[step_index].maneuver.instruction.type = TurnType::Turn;
+            else if (TurnType::Merge == current_step.maneuver.instruction.type)
+            {
+                steps[step_index].maneuver.instruction.direction_modifier =
+                    util::guidance::mirrorDirectionModifier(
+                        steps[step_index].maneuver.instruction.direction_modifier);
+                steps[step_index].maneuver.instruction.type = TurnType::Turn;
+            }
             else if (TurnType::NewName == current_step.maneuver.instruction.type &&
                      current_step.maneuver.instruction.direction_modifier !=
                          DirectionModifier::Straight &&
@@ -424,6 +432,12 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
                      current_step.name_id == steps[two_back_index].name_id)
             {
                 steps[one_back_index].maneuver.instruction.type = TurnType::Continue;
+            }
+            else if (TurnType::Merge == one_back_step.maneuver.instruction.type)
+            {
+                steps[one_back_index].maneuver.instruction.direction_modifier =
+                    util::guidance::mirrorDirectionModifier(
+                        steps[one_back_index].maneuver.instruction.direction_modifier);
             }
             steps[one_back_index].name = current_step.name;
             steps[one_back_index].name_id = current_step.name_id;

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -69,9 +69,6 @@ Intersection TurnHandler::handleTwoWayTurn(const EdgeID via_edge, Intersection i
     intersection[1].turn.instruction =
         getInstructionForObvious(intersection.size(), via_edge, false, intersection[1]);
 
-    if (intersection[1].turn.instruction.type == TurnType::Suppressed)
-        intersection[1].turn.instruction.type = TurnType::NoTurn;
-
     return intersection;
 }
 


### PR DESCRIPTION
<img width="363" alt="screen shot 2016-06-06 at 11 06 01" src="https://cloud.githubusercontent.com/assets/12932279/15817134/c0bc3cfc-2bd6-11e6-9caf-d9f5d81691f9.png">

Based on https://github.com/Project-OSRM/osrm-backend/pull/2493, this PR considers the scenario in the above picture.
The segregated intersection emits a `suppressed turn` and a `merge`. Given this PR, the instruction is collapsed into `turn slight left` instead of `merge slight right`.