### PR TITLE
improve slipway handling to allow multiple styles of turn lanes

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -511,3 +511,120 @@ Feature: Collapse
             | i,h       | in,road,road | depart,turn slight left,arrive  |
             | a,d       | road,road    | depart,arrive                   |
             | a,j       | road,out,out | depart,turn slight right,arrive |
+
+    Scenario: Don't collapse everything to u-turn / too wide
+        Given the node map
+            | a |   | b |   | e |
+            |   |   |   |   |   |
+            | d |   | c |   | f |
+
+        And the ways
+            | nodes | highway   | name   |
+            | abcd  | primary   | road   |
+            | be    | secondary | top    |
+            | cf    | secondary | bottom |
+
+        When I route I should get
+            | waypoints | turns                                          | route               |
+            | a,d       | depart,continue right,end of road right,arrive | road,road,road,road |
+            | d,a       | depart,continue left,end of road left,arrive   | road,road,road,road |
+
+    Scenario: Forking before a turn
+        Given the node map
+            |   |   |   | g |   |
+            |   |   |   |   |   |
+            |   |   |   | c |   |
+            | a |   | b | d | e |
+            |   |   |   |   |   |
+            |   |   |   | f |   |
+
+        And the ways
+            | nodes | name  | oneway | highway   |
+            | ab    | road  | yes    | primary   |
+            | bd    | road  | yes    | primary   |
+            | bc    | road  | yes    | primary   |
+            | de    | road  | yes    | primary   |
+            | fdcg  | cross | no     | secondary |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | fdcg   | d        | no_left_turn  |
+            | restriction | bc       | fdcg   | c        | no_right_turn |
+
+        When I route I should get
+          | waypoints | route            | turns                   |
+          | a,g       | road,cross,cross | depart,turn left,arrive |
+          | a,e       | road,road        | depart,arrive           |
+
+    Scenario: Forking before a turn (narrow)
+        Given the node map
+            |   |   |   | g |   |
+            |   |   |   |   |   |
+            |   |   |   | c |   |
+            | a | b |   | d | e |
+            |   |   |   |   |   |
+            |   |   |   | f |   |
+
+        And the ways
+            | nodes | name  | oneway | highway   |
+            | ab    | road  | yes    | primary   |
+            | bd    | road  | yes    | primary   |
+            | bc    | road  | yes    | primary   |
+            | de    | road  | yes    | primary   |
+            | fdcg  | cross | no     | secondary |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | fdcg   | d        | no_left_turn  |
+            | restriction | bc       | fdcg   | c        | no_right_turn |
+
+        When I route I should get
+          | waypoints | route            | turns                   |
+          | a,g       | road,cross,cross | depart,turn left,arrive |
+          | a,e       | road,road        | depart,arrive           |
+
+    Scenario: Forking before a turn (forky)
+        Given the node map
+            |   |   |   | g |   |   |
+            |   |   |   |   |   |   |
+            |   |   |   | c |   |   |
+            | a | b |   |   |   |   |
+            |   |   |   |   | d |   |
+            |   |   |   |   | f | e |
+
+        And the ways
+            | nodes | name  | oneway | highway   |
+            | ab    | road  | yes    | primary   |
+            | bd    | road  | yes    | primary   |
+            | bc    | road  | yes    | primary   |
+            | de    | road  | yes    | primary   |
+            | fdcg  | cross | no     | secondary |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | fdcg   | d        | no_left_turn  |
+            | restriction | bc       | fdcg   | c        | no_right_turn |
+
+        When I route I should get
+          | waypoints | route            | turns                               |
+          | a,g       | road,cross,cross | depart,turn left,arrive             |
+          | a,e       | road,road,road   | depart,continue slight right,arrive |
+
+     Scenario: On-Off on Highway
+        Given the node map
+            | f |   |   |   |
+            | a | b | c | d |
+            |   |   |   | e |
+
+        And the ways
+            | nodes | name | highway       | oneway |
+            | abcd  | Hwy  | motorway      | yes    |
+            | fb    | on   | motorway_link | yes    |
+            | ce    | off  | motorway_link | yes    |
+
+        When I route I should get
+            | waypoints | route          | turns                                           |
+            | a,d       | Hwy,Hwy        | depart,arrive                                   |
+            | f,d       | on,Hwy,Hwy     | depart,merge slight right,arrive                |
+            | f,e       | on,Hwy,off,off | depart,merge slight right,off ramp right,arrive |
+            | a,e       | Hwy,off,off    | depart,off ramp right,arrive                    |

--- a/src/extractor/guidance/motorway_handler.cpp
+++ b/src/extractor/guidance/motorway_handler.cpp
@@ -385,7 +385,7 @@ Intersection MotorwayHandler::fromRamp(const EdgeID via_eid, Intersection inters
                 {
                     // circular order indicates a merge to the left (0-3 onto 4
                     if (angularDeviation(intersection[1].turn.angle, STRAIGHT_ANGLE) <
-                        NARROW_TURN_ANGLE)
+                        2*NARROW_TURN_ANGLE)
                         intersection[1].turn.instruction = {TurnType::Merge,
                                                             DirectionModifier::SlightLeft};
                     else // fallback
@@ -407,12 +407,12 @@ Intersection MotorwayHandler::fromRamp(const EdgeID via_eid, Intersection inters
                 if (detail::isMotorwayClass(intersection[2].turn.eid, node_based_graph) &&
                     node_based_graph.GetEdgeData(intersection[1].turn.eid).name_id !=
                         EMPTY_NAMEID &&
-                    node_based_graph.GetEdgeData(intersection[1].turn.eid).name_id ==
-                        node_based_graph.GetEdgeData(intersection[0].turn.eid).name_id)
+                    node_based_graph.GetEdgeData(intersection[2].turn.eid).name_id ==
+                        node_based_graph.GetEdgeData(intersection[1].turn.eid).name_id)
                 {
                     // circular order (5-0) onto 4
                     if (angularDeviation(intersection[2].turn.angle, STRAIGHT_ANGLE) <
-                        NARROW_TURN_ANGLE)
+                        2 * NARROW_TURN_ANGLE)
                         intersection[2].turn.instruction = {TurnType::Merge,
                                                             DirectionModifier::SlightRight};
                     else // fallback


### PR DESCRIPTION
Sliproads can occur in multiple styles.

This PR adjusts their treatment to be able to handle them in more cases and makes the check for their existence more reliable.

See the cucumber tests for updated behaviour.
All cases listed previously returned two instructions instead of one.