### PR TITLE
turn link handling

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -528,3 +528,103 @@ Feature: Collapse
             | waypoints | turns                                          | route               |
             | a,d       | depart,continue right,end of road right,arrive | road,road,road,road |
             | d,a       | depart,continue left,end of road left,arrive   | road,road,road,road |
+
+    Scenario: Forking before a turn
+        Given the node map
+            |   |   |   | g |   |
+            |   |   |   |   |   |
+            |   |   |   | c |   |
+            | a |   | b | d | e |
+            |   |   |   |   |   |
+            |   |   |   | f |   |
+
+        And the ways
+            | nodes | name  | oneway | highway   |
+            | ab    | road  | yes    | primary   |
+            | bd    | road  | yes    | primary   |
+            | bc    | road  | yes    | primary   |
+            | de    | road  | yes    | primary   |
+            | fdcg  | cross | no     | secondary |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | fdcg   | d        | no_left_turn  |
+            | restriction | bc       | fdcg   | c        | no_right_turn |
+
+        When I route I should get
+          | waypoints | route            | turns                   |
+          | a,g       | road,cross,cross | depart,turn left,arrive |
+          | a,e       | road,road        | depart,arrive           |
+
+    Scenario: Forking before a turn (narrow)
+        Given the node map
+            |   |   |   | g |   |
+            |   |   |   |   |   |
+            |   |   |   | c |   |
+            | a | b |   | d | e |
+            |   |   |   |   |   |
+            |   |   |   | f |   |
+
+        And the ways
+            | nodes | name  | oneway | highway   |
+            | ab    | road  | yes    | primary   |
+            | bd    | road  | yes    | primary   |
+            | bc    | road  | yes    | primary   |
+            | de    | road  | yes    | primary   |
+            | fdcg  | cross | no     | secondary |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | fdcg   | d        | no_left_turn  |
+            | restriction | bc       | fdcg   | c        | no_right_turn |
+
+        When I route I should get
+          | waypoints | route            | turns                   |
+          | a,g       | road,cross,cross | depart,turn left,arrive |
+          | a,e       | road,road        | depart,arrive           |
+
+    Scenario: Forking before a turn (forky)
+        Given the node map
+            |   |   |   | g |   |   |
+            |   |   |   |   |   |   |
+            |   |   |   | c |   |   |
+            | a | b |   |   |   |   |
+            |   |   |   |   | d |   |
+            |   |   |   |   | f | e |
+
+        And the ways
+            | nodes | name  | oneway | highway   |
+            | ab    | road  | yes    | primary   |
+            | bd    | road  | yes    | primary   |
+            | bc    | road  | yes    | primary   |
+            | de    | road  | yes    | primary   |
+            | fdcg  | cross | no     | secondary |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | fdcg   | d        | no_left_turn  |
+            | restriction | bc       | fdcg   | c        | no_right_turn |
+
+        When I route I should get
+          | waypoints | route            | turns                               |
+          | a,g       | road,cross,cross | depart,turn left,arrive             |
+          | a,e       | road,road,road   | depart,continue slight right,arrive |
+
+     Scenario: On-Off on Highway
+        Given the node map
+            | f |   |   |   |
+            | a | b | c | d |
+            |   |   |   | e |
+
+        And the ways
+            | nodes | name | highway       | oneway |
+            | abcd  | Hwy  | motorway      | yes    |
+            | fb    | on   | motorway_link | yes    |
+            | ce    | off  | motorway_link | yes    |
+
+        When I route I should get
+            | waypoints | route          | turns                                           |
+            | a,d       | Hwy,Hwy        | depart,arrive                                   |
+            | f,d       | on,Hwy,Hwy     | depart,merge slight right,arrive                |
+            | f,e       | on,Hwy,off,off | depart,merge slight right,off ramp right,arrive |
+            | a,e       | Hwy,off,off    | depart,off ramp right,arrive                    |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -805,3 +805,31 @@ Feature: Simple Turns
             | a,d       | abc,bd,bd | depart,turn sharp right,arrive  |
             | a,e       | abc,be,be | depart,turn right,arrive        |
             | a,f       | abc,bf,bf | depart,turn slight right,arrive |
+
+    Scenario: Turn Lane on Splitting up Road
+        Given the node map
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            | g |   |   |   | f |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   | h |   |   | e |   |   | c |   |   | d |
+            | a |   |   | b |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   | i |   |   |   |   |   |   |   |   |   |   |   |
+
+        And the ways
+            | nodes | highway        | oneway | name  |
+            | ab    | secondary      | yes    | road  |
+            | be    | secondary      | yes    | road  |
+            | ecd   | secondary      | no     | road  |
+            | efg   | secondary      | yes    | road  |
+            | ehb   | secondary_link | yes    | road  |
+            | bi    | tertiary       | no     | cross |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction  |
+            | restriction | ehb      | be     | b        | no_left_turn |
+
+        When I route I should get
+            | waypoints | route            | turns                   |
+            | a,d       | road,road        | depart,arrive           |
+            | d,i       | road,cross,cross | depart,turn left,arrive |
+            | d,g       | road,road        | depart,arrive           |

--- a/features/testbot/bearing_param.feature
+++ b/features/testbot/bearing_param.feature
@@ -85,31 +85,31 @@ Feature: Bearing parameter
             | f |  |   | e |   |  | d |
 
         And the ways
-            | nodes | oneway |
-            | ia    | yes    |
-            | jb    | yes    |
-            | kc    | yes    |
-            | ld    | yes    |
-            | me    | yes    |
-            | nf    | yes    |
-            | og    | yes    |
-            | ph    | yes    |
-            | ab    | yes    |
-            | bc    | yes    |
-            | cd    | yes    |
-            | de    | yes    |
-            | ef    | yes    |
-            | fg    | yes    |
-            | gh    | yes    |
-            | ha    | yes    |
+            | nodes | oneway | name |
+            | ia    | yes    | ia   |
+            | jb    | yes    | jb   |
+            | kc    | yes    | kc   |
+            | ld    | yes    | ld   |
+            | me    | yes    | me   |
+            | nf    | yes    | nf   |
+            | og    | yes    | og   |
+            | ph    | yes    | ph   |
+            | ab    | yes    | ring |
+            | bc    | yes    | ring |
+            | cd    | yes    | ring |
+            | de    | yes    | ring |
+            | ef    | yes    | ring |
+            | fg    | yes    | ring |
+            | gh    | yes    | ring |
+            | ha    | yes    | ring |
 
         When I route I should get
-            | from | to | bearings | route                         | bearing                       |
-            | 0    | q  | 0 90     | ia,ab,bc,cd,de,ef,fg,gh,ha,ha | 0->0,0->90,90->180,180->180,180->270,270->270,270->0,0->0,0->90,90->0 |
-            | 0    | a  | 45 90    | jb,bc,cd,de,ef,fg,gh,ha,ha    | 0->45,45->180,180->180,180->270,270->270,270->0,0->0,0->90,90->0   |
-            | 0    | q  | 90 90    | kc,cd,de,ef,fg,gh,ha,ha       | 0->90,90->180,180->270,270->270,270->0,0->0,0->90,90->0       |
-            | 0    | a  | 135 90   | ld,de,ef,fg,gh,ha,ha          | 0->135,135->270,270->270,270->0,0->0,0->90,90->0          |
-            | 0    | a  | 180 90   | me,ef,fg,gh,ha,ha             | 0->180,180->270,270->0,0->0,0->90,90->0              |
-            | 0    | a  | 225 90   | nf,fg,gh,ha,ha                | 0->225,225->0,0->0,0->90,90->0                  |
-            | 0    | a  | 270 90   | og,gh,ha,ha                   | 0->270,270->0,0->90,90->0                    |
-            | 0    | a  | 315 90   | ph,ha,ha                      | 0->315,315->90,90->0                      |
+            | from | to | bearings | route                       | bearing                                   |
+            | 0    | q  | 0 90     | ia,ring,ring,ring,ring,ring | 0->0,0->90,180->270,270->0,0->90,90->0    |
+            | 0    | a  | 45 90    | jb,ring,ring,ring,ring,ring | 0->45,45->180,180->270,270->0,0->90,90->0 |
+            | 0    | q  | 90 90    | kc,ring,ring,ring,ring      | 0->90,90->180,270->0,0->90,90->0          |
+            | 0    | a  | 135 90   | ld,ring,ring,ring,ring      | 0->135,135->270,270->0,0->90,90->0        |
+            | 0    | a  | 180 90   | me,ring,ring,ring           | 0->180,180->270,0->90,90->0               |
+            | 0    | a  | 225 90   | nf,ring,ring,ring           | 0->225,225->0,0->90,90->0                 |
+            | 0    | a  | 270 90   | og,ring,ring                | 0->270,270->0,90->0                       |
+            | 0    | a  | 315 90   | ph,ring,ring                | 0->315,315->90,90->0                      |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -33,6 +33,16 @@ namespace
 {
 const constexpr double MAX_COLLAPSE_DISTANCE = 25;
 
+inline bool choiceless(const RouteStep &step, const RouteStep &previous)
+{
+    // if the next turn is choiceless, we consider longer turn roads collapsable than usually
+    // accepted. We might need to improve this to find out whether we merge onto a through-street.
+    return previous.distance < 3 * MAX_COLLAPSE_DISTANCE &&
+           1 >= std::count(step.intersections.front().entry.begin(),
+                           step.intersections.front().entry.end(),
+                           true);
+}
+
 // List of types that can be collapsed, if all other restrictions pass
 bool isCollapsableInstruction(const TurnInstruction instruction)
 {
@@ -40,6 +50,8 @@ bool isCollapsableInstruction(const TurnInstruction instruction)
            (instruction.type == TurnType::Suppressed &&
             instruction.direction_modifier == DirectionModifier::Straight) ||
            (instruction.type == TurnType::Turn &&
+            instruction.direction_modifier == DirectionModifier::Straight) ||
+           (instruction.type == TurnType::Continue &&
             instruction.direction_modifier == DirectionModifier::Straight) ||
            (instruction.type == TurnType::Merge);
 }
@@ -387,7 +399,11 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
 
     BOOST_ASSERT(!one_back_step.intersections.empty() && !current_step.intersections.empty());
     // Very Short New Name
-    if (collapsable(one_back_step))
+    if (((collapsable(one_back_step) ||
+          (isCollapsableInstruction(one_back_step.maneuver.instruction) &&
+           choiceless(current_step, one_back_step))) &&
+         !(one_back_step.maneuver.instruction.type == TurnType::Merge)))
+    // the check against merge is a workaround for motorways
     {
         BOOST_ASSERT(two_back_index < steps.size());
         if (compatible(one_back_step, steps[two_back_index]))
@@ -433,7 +449,11 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
             {
                 steps[one_back_index].maneuver.instruction.type = TurnType::Continue;
             }
-            else if (TurnType::Merge == one_back_step.maneuver.instruction.type)
+            else if (TurnType::Merge == one_back_step.maneuver.instruction.type &&
+                     current_step.maneuver.instruction.type !=
+                         TurnType::Suppressed) // This suppressed is a check for highways. We might
+                                               // need a highway-suppressed to get the turn onto a
+                                               // highway...
             {
                 steps[one_back_index].maneuver.instruction.direction_modifier =
                     util::guidance::mirrorDirectionModifier(
@@ -445,7 +465,8 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
         }
     }
     // Potential U-Turn
-    else if (one_back_step.distance <= MAX_COLLAPSE_DISTANCE &&
+    else if ((one_back_step.distance <= MAX_COLLAPSE_DISTANCE ||
+              choiceless(current_step, one_back_step)) &&
              bearingsAreReversed(util::bearing::reverseBearing(
                                      one_back_step.intersections.front()
                                          .bearings[one_back_step.intersections.front().in]),
@@ -529,6 +550,7 @@ std::vector<RouteStep> removeNoTurnInstructions(std::vector<RouteStep> steps)
 // that we come across.
 std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
 {
+    print(steps);
     // the steps should always include the first/last step in form of a location
     BOOST_ASSERT(steps.size() >= 2);
     if (steps.size() == 2)
@@ -542,14 +564,12 @@ std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
     // required. We might end up with only one of them (e.g. starting within a roundabout)
     // or having a via-point in the roundabout.
     // In this case, exits are numbered from the start of the lag.
-    std::size_t last_valid_instruction = 0;
     for (std::size_t step_index = 0; step_index < steps.size(); ++step_index)
     {
         auto &step = steps[step_index];
         const auto instruction = step.maneuver.instruction;
         if (entersRoundabout(instruction))
         {
-            last_valid_instruction = step_index;
             has_entered_roundabout = setUpRoundabout(step);
 
             if (has_entered_roundabout && step_index + 1 < steps.size())
@@ -570,16 +590,10 @@ std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
                 // in case the we are not on a roundabout, the very first instruction
                 // after the depart will be transformed into a roundabout and become
                 // the first valid instruction
-                last_valid_instruction = 1;
             }
             closeOffRoundabout(has_entered_roundabout, steps, step_index);
             has_entered_roundabout = false;
             on_roundabout = false;
-        }
-        else if (!isSilent(instruction))
-        {
-            // Remember the last non silent instruction
-            last_valid_instruction = step_index;
         }
     }
 
@@ -648,6 +662,8 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
     for (std::size_t step_index = 1; step_index + 1 < steps.size(); ++step_index)
     {
         const auto &current_step = steps[step_index];
+        if( current_step.maneuver.instruction.type == TurnType::NoTurn )
+            continue;
         const auto one_back_index = getPreviousIndex(step_index);
         BOOST_ASSERT(one_back_index < steps.size());
 
@@ -748,7 +764,8 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
                     invalidateStep(steps[step_index]);
                 }
             }
-            else if (one_back_step.distance <= MAX_COLLAPSE_DISTANCE)
+            else if (choiceless(current_step, one_back_step) ||
+                     one_back_step.distance <= MAX_COLLAPSE_DISTANCE)
             {
                 // check for one of the multiple collapse scenarios and, if possible, collapse the
                 // turn
@@ -757,7 +774,8 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
                 collapseTurnAt(steps, two_back_index, one_back_index, step_index);
             }
         }
-        else if (one_back_index > 0 && one_back_step.distance <= MAX_COLLAPSE_DISTANCE)
+        else if (one_back_index > 0 && (one_back_step.distance <= MAX_COLLAPSE_DISTANCE ||
+                                        choiceless(current_step, one_back_step)))
         {
             // check for one of the multiple collapse scenarios and, if possible, collapse the turn
             const auto two_back_index = getPreviousIndex(one_back_index);

--- a/src/extractor/guidance/motorway_handler.cpp
+++ b/src/extractor/guidance/motorway_handler.cpp
@@ -385,7 +385,7 @@ Intersection MotorwayHandler::fromRamp(const EdgeID via_eid, Intersection inters
                 {
                     // circular order indicates a merge to the left (0-3 onto 4
                     if (angularDeviation(intersection[1].turn.angle, STRAIGHT_ANGLE) <
-                        NARROW_TURN_ANGLE)
+                        2*NARROW_TURN_ANGLE)
                         intersection[1].turn.instruction = {TurnType::Merge,
                                                             DirectionModifier::SlightLeft};
                     else // fallback
@@ -407,12 +407,12 @@ Intersection MotorwayHandler::fromRamp(const EdgeID via_eid, Intersection inters
                 if (detail::isMotorwayClass(intersection[2].turn.eid, node_based_graph) &&
                     node_based_graph.GetEdgeData(intersection[1].turn.eid).name_id !=
                         EMPTY_NAMEID &&
-                    node_based_graph.GetEdgeData(intersection[1].turn.eid).name_id ==
-                        node_based_graph.GetEdgeData(intersection[0].turn.eid).name_id)
+                    node_based_graph.GetEdgeData(intersection[2].turn.eid).name_id ==
+                        node_based_graph.GetEdgeData(intersection[1].turn.eid).name_id)
                 {
                     // circular order (5-0) onto 4
                     if (angularDeviation(intersection[2].turn.angle, STRAIGHT_ANGLE) <
-                        NARROW_TURN_ANGLE)
+                        2 * NARROW_TURN_ANGLE)
                         intersection[2].turn.instruction = {TurnType::Merge,
                                                             DirectionModifier::SlightRight};
                     else // fallback


### PR DESCRIPTION
Some turn links are longer than a normal intersection. This PR augments what is called a obvious turn based on road classes for same-name turns and introduces handling of link-roads that offer no choice at the next turn.

See modified turn.feature for an example.

Previous outputs (in order):

`depart,continue slight right,arrive`
`depart,continue straight,turn left,arrive`
`depart,arrive`

Also Includes:
Sliproads can occur in multiple styles.

This PR adjusts their treatment to be able to handle them in more cases and makes the check for their existence more reliable.

See the cucumber tests for updated behaviour.
All cases listed previously returned two instructions instead of one.