### PR TITLE
Fix shared memory encoding for node-ids

### DIFF
--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -171,13 +171,13 @@ class SharedDataFacade final : public BaseDataFacade
             coordinate_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::COORDINATE_LIST]);
 
-        auto osmnodeid_list_ptr = data_layout->GetBlockPtr<OSMNodeID>(
+        auto osmnodeid_list_ptr = data_layout->GetBlockPtr<std::uint64_t>(
             shared_memory, storage::SharedDataLayout::OSM_NODE_ID_LIST);
         m_osmnodeid_list.reset(
             osmnodeid_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
-        m_osmnodeid_list.set_number_of_entries(util::PackedVectorCapacity(
-            data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]));
+        // We (ab)use the number of coordinates here because we know we have the same amount of ids
+        m_osmnodeid_list.set_number_of_entries(data_layout->num_entries[storage::SharedDataLayout::COORDINATE_LIST]);
 
         auto travel_mode_list_ptr = data_layout->GetBlockPtr<extractor::TravelMode>(
             shared_memory, storage::SharedDataLayout::TRAVEL_MODE);

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -12,26 +12,6 @@ namespace osrm
 namespace util
 {
 
-const constexpr std::size_t BITSIZE = 33;
-const constexpr std::size_t ELEMSIZE = 64;
-const constexpr std::size_t PACKSIZE = BITSIZE * ELEMSIZE;
-
-/**
- * Returns the size of the packed vector datastructure with `elements` packed elements (the size of
- * its underlying vector)
- */
-inline std::size_t PackedVectorSize(std::size_t elements)
-{
-    return ceil(float(elements) / ELEMSIZE) * BITSIZE;
-};
-
-/**
- * Returns the capacity of a packed vector with underlying vector size `vec_size`
- */
-inline std::size_t PackedVectorCapacity(std::size_t vec_size)
-{
-    return floor(float(vec_size) / BITSIZE) * ELEMSIZE;
-}
 
 /**
  * Since OSM node IDs are (at the time of writing) not quite yet overflowing 32 bits, and
@@ -41,9 +21,23 @@ inline std::size_t PackedVectorCapacity(std::size_t vec_size)
  * NOTE: this type is templated for future use, but will require a slight refactor to
  * configure BITSIZE and ELEMSIZE
  */
-template <typename T, bool UseSharedMemory> class PackedVector
+template <typename T, bool UseSharedMemory=false> class PackedVector
 {
+    static const constexpr std::size_t BITSIZE = 33;
+    static const constexpr std::size_t ELEMSIZE = 64;
+    static const constexpr std::size_t PACKSIZE = BITSIZE * ELEMSIZE;
+
   public:
+
+    /**
+     * Returns the size of the packed vector datastructure with `elements` packed elements (the size of
+     * its underlying uint64 vector)
+     */
+    inline static std::size_t elements_to_blocks(std::size_t elements)
+    {
+        return std::ceil(static_cast<double>(elements) * BITSIZE / ELEMSIZE);
+    }
+
     void push_back(T incoming_node_id)
     {
         std::uint64_t node_id = static_cast<std::uint64_t>(incoming_node_id);
@@ -130,14 +124,14 @@ template <typename T, bool UseSharedMemory> class PackedVector
     template <bool enabled = UseSharedMemory>
     void reserve(typename std::enable_if<!enabled, std::size_t>::type capacity)
     {
-        vec.reserve(PackedVectorSize(capacity));
+        vec.reserve(elements_to_blocks(capacity));
     }
 
     template <bool enabled = UseSharedMemory>
-    void reset(typename std::enable_if<enabled, T>::type *ptr,
+    void reset(typename std::enable_if<enabled, std::uint64_t>::type *ptr,
                typename std::enable_if<enabled, std::size_t>::type size)
     {
-        vec.reset(reinterpret_cast<std::uint64_t *>(ptr), size);
+        vec.reset(ptr, size);
     }
 
     template <bool enabled = UseSharedMemory>
@@ -146,7 +140,10 @@ template <typename T, bool UseSharedMemory> class PackedVector
         num_elements = count;
     }
 
-    std::size_t capacity() const { return PackedVectorCapacity(vec.capacity()); }
+    std::size_t capacity() const
+    {
+        return std::floor(static_cast<double>(vec.capacity()) * ELEMSIZE / BITSIZE);
+    }
 
   private:
     typename util::ShM<std::uint64_t, UseSharedMemory>::vector vec;

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -247,8 +247,8 @@ int Storage::Run()
                                                       coordinate_list_size);
     // we'll read a list of OSM node IDs from the same data, so set the block size for the same
     // number of items:
-    shared_layout_ptr->SetBlockSize<OSMNodeID>(SharedDataLayout::OSM_NODE_ID_LIST,
-                                               util::PackedVectorSize(coordinate_list_size));
+    shared_layout_ptr->SetBlockSize<std::uint64_t>(SharedDataLayout::OSM_NODE_ID_LIST,
+                                                   util::PackedVector<OSMNodeID>::elements_to_blocks(coordinate_list_size));
 
     // load geometries sizes
     boost::filesystem::ifstream geometry_input_stream(config.geometries_path, std::ios::binary);
@@ -540,7 +540,7 @@ int Storage::Run()
     // Loading list of coordinates
     util::Coordinate *coordinates_ptr = shared_layout_ptr->GetBlockPtr<util::Coordinate, true>(
         shared_memory_ptr, SharedDataLayout::COORDINATE_LIST);
-    OSMNodeID *osmnodeid_ptr = shared_layout_ptr->GetBlockPtr<OSMNodeID, true>(
+    std::uint64_t *osmnodeid_ptr = shared_layout_ptr->GetBlockPtr<std::uint64_t, true>(
         shared_memory_ptr, SharedDataLayout::OSM_NODE_ID_LIST);
     util::PackedVector<OSMNodeID, true> osmnodeid_list;
     osmnodeid_list.reset(


### PR DESCRIPTION
This PR aims at addressing a shared-memory corruption in RC2 that make loading the planet fail.

- [x] Confirm on global dataset