### PR TITLE
prefer obvious turn assignment over forks

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -606,9 +606,11 @@ Feature: Collapse
             | restriction | bc       | fdcg   | c        | no_right_turn |
 
         When I route I should get
-          | waypoints | route            | turns                               |
-          | a,g       | road,cross,cross | depart,turn left,arrive             |
-          | a,e       | road,road,road   | depart,continue slight right,arrive |
+          | waypoints | route                 | turns                                          |
+          | a,g       | road,cross,cross      | depart,turn left,arrive                        |
+          | a,e       | road,road,road        | depart,continue slight right,arrive            |
+          # We should discuss whether the next item should be collapsed to depart,turn right,arrive.
+          | a,f       | road,road,cross,cross | depart,continue slight right,turn right,arrive |
 
      Scenario: On-Off on Highway
         Given the node map

--- a/features/guidance/fork.feature
+++ b/features/guidance/fork.feature
@@ -281,3 +281,18 @@ Feature: Fork Instructions
             | a,c       | abd,bc,bc | depart,turn slight left,arrive  |
             | a,d       | abd,abd   | depart,arrive                   |
             | a,e       | abd,be,be | depart,turn slight right,arrive |
+
+    Scenario: Don't Fork when leaving Road
+        Given the node map
+            | a |   | b |   | c |
+            |   |   |   |   | d |
+
+        And the ways
+            | nodes  | highway   |
+            | abc    | secondary |
+            | bd     | secondary |
+
+       When I route I should get
+            | waypoints | route     | turns                           |
+            | a,c       | abc,abc   | depart,arrive                   |
+            | a,d       | abc,bd,bd | depart,turn slight right,arrive |

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -109,8 +109,12 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
 
         const bool is_much_narrower_than_other =
             angularDeviation(other.turn.angle, STRAIGHT_ANGLE) /
-                angularDeviation(road.turn.angle, STRAIGHT_ANGLE) >
-            INCREASES_BY_FOURTY_PERCENT;
+                    angularDeviation(road.turn.angle, STRAIGHT_ANGLE) >
+                INCREASES_BY_FOURTY_PERCENT &&
+            angularDeviation(angularDeviation(other.turn.angle, STRAIGHT_ANGLE),
+                             angularDeviation(road.turn.angle, STRAIGHT_ANGLE)) >
+                FUZZY_ANGLE_DIFFERENCE;
+
         return is_much_narrower_than_other;
     };
 
@@ -129,13 +133,9 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
                                         .road_classification.road_class;
             const auto right_class = node_based_graph.GetEdgeData(intersection[1].turn.eid)
                                          .road_classification.road_class;
-            if (canBeSeenAsFork(left_class, right_class))
-            {
-                assignFork(via_edge, intersection[2], intersection[1]);
-            }
-            else if (isObviousOfTwo(intersection[1], intersection[2]) &&
-                     (second_data.name_id != in_data.name_id ||
-                      first_data.name_id == second_data.name_id))
+            if (isObviousOfTwo(intersection[1], intersection[2]) &&
+                (second_data.name_id != in_data.name_id ||
+                 first_data.name_id == second_data.name_id))
             {
                 intersection[1].turn.instruction =
                     getInstructionForObvious(intersection.size(), via_edge, false, intersection[1]);
@@ -150,6 +150,10 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
                     getInstructionForObvious(intersection.size(), via_edge, false, intersection[2]);
                 intersection[1].turn.instruction = {findBasicTurnType(via_edge, intersection[1]),
                                                     DirectionModifier::SlightRight};
+            }
+            else if (canBeSeenAsFork(left_class, right_class))
+            {
+                assignFork(via_edge, intersection[2], intersection[1]);
             }
             else
             {


### PR DESCRIPTION
In three way turns, forks can happen if a road goes perfectly straight. This PR fixes the behaviour.

See cucumber testcase for an example. 
Don't fork when leaving road would have said `depart,fork slight right,arrive` instead of `depart,turn slight right,arrive`