### PR TITLE
move guidance output into debug header

### DIFF
--- a/include/engine/guidance/debug.hpp
+++ b/include/engine/guidance/debug.hpp
@@ -1,0 +1,52 @@
+#ifndef OSRM_ENGINE_GUIDANCE_DEBUG_HPP_
+#define OSRM_ENGINE_GUIDANCE_DEBUG_HPP_
+
+#include "engine/guidance/route_step.hpp"
+
+#include <iostream>
+#include <vector>
+
+namespace osrm
+{
+namespace engine
+{
+namespace guidance
+{
+inline void print(const RouteStep &step)
+{
+    std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
+              << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
+              << static_cast<int>(step.maneuver.waypoint_type) << " Duration: " << step.duration
+              << " Distance: " << step.distance << " Geometry: " << step.geometry_begin << " "
+              << step.geometry_end << " exit: " << step.maneuver.exit
+              << " Intersections: " << step.intersections.size() << " [";
+
+    for (const auto &intersection : step.intersections)
+    {
+        std::cout << "(bearings:";
+        for (auto bearing : intersection.bearings)
+            std::cout << " " << bearing;
+        std::cout << ", entry: ";
+        for (auto entry : intersection.entry)
+            std::cout << " " << entry;
+        std::cout << ")";
+    }
+    std::cout << "] name[" << step.name_id << "]: " << step.name;
+}
+
+inline void print(const std::vector<RouteStep> &steps)
+{
+    std::cout << "Path\n";
+    int segment = 0;
+    for (const auto &step : steps)
+    {
+        std::cout << "\t[" << segment++ << "]: ";
+        print(step);
+        std::cout << std::endl;
+    }
+}
+} // namespace guidance
+} // namespace engine
+} // namespace osrm
+
+#endif /*OSRM_ENGINE_GUIDANCE_DEBUG_HPP_*/

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -83,40 +83,6 @@ double nameSegmentLength(std::size_t at, const std::vector<RouteStep> &steps)
 // invalidate a step and set its content to nothing
 void invalidateStep(RouteStep &step) { step = getInvalidRouteStep(); }
 
-void print(const RouteStep &step)
-{
-    std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
-              << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
-              << static_cast<int>(step.maneuver.waypoint_type) << " Duration: " << step.duration
-              << " Distance: " << step.distance << " Geometry: " << step.geometry_begin << " "
-              << step.geometry_end << " exit: " << step.maneuver.exit
-              << " Intersections: " << step.intersections.size() << " [";
-
-    for (const auto &intersection : step.intersections)
-    {
-        std::cout << "(bearings:";
-        for (auto bearing : intersection.bearings)
-            std::cout << " " << bearing;
-        std::cout << ", entry: ";
-        for (auto entry : intersection.entry)
-            std::cout << " " << entry;
-        std::cout << ")";
-    }
-    std::cout << "] name[" << step.name_id << "]: " << step.name;
-}
-
-void print(const std::vector<RouteStep> &steps)
-{
-    std::cout << "Path\n";
-    int segment = 0;
-    for (const auto &step : steps)
-    {
-        std::cout << "\t[" << segment++ << "]: ";
-        print(step);
-        std::cout << std::endl;
-    }
-}
-
 // Compute the angle between two bearings on a normal turn circle
 //
 //      Bearings                      Angles


### PR DESCRIPTION
moves debug output in own header to make it easier to spot.