### PR TITLE
Copy data to beginning of buffer, not end.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.2.2
+  - Bugfix
+    - buffer overrun in tile plugin response handling
+
 # 5.2.0
   Changes form 5.2.0 RC2
    - Bugfixes:

--- a/src/server/request_handler.cpp
+++ b/src/server/request_handler.cpp
@@ -105,11 +105,10 @@ void RequestHandler::HandleRequest(const http::request &current_request, http::r
         else
         {
             BOOST_ASSERT(result.is<std::string>());
-            current_reply.content.resize(current_reply.content.size() +
-                                         result.get<std::string>().size());
+            current_reply.content.resize(result.get<std::string>().size());
             std::copy(result.get<std::string>().cbegin(),
                       result.get<std::string>().cend(),
-                      current_reply.content.end());
+                      current_reply.content.begin());
 
             current_reply.headers.emplace_back("Content-Type", "application/x-protobuf");
         }


### PR DESCRIPTION
033dc0a72d9930d51fe97ec4010c7b176974631a introduced some faulty logic when copying the PBF result from the tile plugin to the HTTP response buffer.

This was causing EACCESS segfaults because we were copying data memory past the end of our buffer.