### PR TITLE
Fix omitting the last point's coordinates in the geometry field

### DIFF
--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var d3 = require('d3-queue');
+var polyline = require('polyline');
 
 module.exports = function () {
     this.When(/^I match I should get$/, (table, callback) => {
@@ -35,6 +36,7 @@ module.exports = function () {
                         route = '',
                         duration = '',
                         annotation = '',
+                        geometry = '',
                         OSMIDs = '';
 
 
@@ -63,6 +65,11 @@ module.exports = function () {
                             annotation = this.annotationList(json.matchings[0]);
                         }
 
+                        if (headers.has('geometry')) {
+                            if (json.matchings.length != 1) throw new Error('*** Checking geometry only supported for matchings with one subtrace');
+                            geometry = json.matchings[0].geometry;
+                        }
+
                         if (headers.has('OSM IDs')) {
                             if (json.matchings.length != 1) throw new Error('*** CHecking annotation only supported for matchings with one subtrace');
                             OSMIDs = this.OSMIDList(json.matchings[0]);
@@ -83,6 +90,13 @@ module.exports = function () {
 
                     if (headers.has('annotation')) {
                         got.annotation = annotation.toString();
+                    }
+
+                    if (headers.has('geometry')) {
+                        if (this.queryParams['geometries'] === 'polyline')
+                            got.geometry = polyline.decode(geometry).toString();
+                        else
+                            got.geometry = geometry;
                     }
 
                     if (headers.has('OSM IDs')) {

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -128,3 +128,21 @@ Feature: Basic Map Matching
             | trace | matchings | OSM IDs               |
             | abeh  | abcedgh   | 1,2,3,2,3,4,5,4,5,6,7 |
             | abci  | abc,ci    | 1,2,3,2,3,8,3,8       |
+
+    Scenario: Testbot - Geometry details
+        Given the query options
+            | overview   | full     |
+            | geometries | polyline |
+
+        Given the node map
+            | a | b | c |
+            |   | d |   |
+
+        And the ways
+            | nodes | oneway |
+            | abc   | no     |
+            | bd    | no     |
+
+        When I match I should get
+            | trace | matchings | geometry                                |
+            | abd   | abd       | 1,1,1,1.00009,1,1.00009,0.99991,1.00009 |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node-timeout": "0.0.4",
     "request": "^2.69.0",
     "xmlbuilder": "^4.2.1",
-    "chalk": "^1.1.3"
+    "chalk": "^1.1.3",
+    "polyline": "^0.2.0"
   },
   "bin": {
     "cucumber": "./node_modules/cucumber/bin/cucumber.js"

--- a/src/engine/guidance/assemble_overview.cpp
+++ b/src/engine/guidance/assemble_overview.cpp
@@ -85,12 +85,12 @@ std::vector<util::Coordinate> assembleOverview(const std::vector<LegGeometry> &l
     std::vector<util::Coordinate> overview_geometry;
     overview_geometry.reserve(overview_size);
 
-    auto leg_index = 0UL;
+    auto leg_reverse_index = leg_geometries.size();
     for (const auto &geometry : leg_geometries)
     {
         auto begin = geometry.locations.begin();
         auto end = geometry.locations.end();
-        if (leg_index < leg_geometries.size() - 1)
+        if (--leg_reverse_index > 0)
         {
             end = std::prev(end);
         }


### PR DESCRIPTION
#2546 leg_index is not incremented, so the last point of the last leg was always missing if number of legs > 1 