### PR TITLE
improve handling of obvious for end-of-road situations

### DIFF
--- a/features/guidance/merge.feature
+++ b/features/guidance/merge.feature
@@ -50,3 +50,27 @@ Feature: Merging
             | waypoints | route      | turns                           |
             | d,c       | db,abc,abc | depart,merge slight left,arrive |
 
+    Scenario: Merge onto a turning road
+        Given the node map
+            |   |   |   |   |   |   | e |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   | d |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   | c |   |   |
+            |   |   |   | b |   |   |   |
+            | a |   |   |   |   |   | f |
+
+        And the ways
+            | nodes | highway     | name |
+            | abcde | primary     | road |
+            | fd    | residential | in   |
+
+        When I route I should get
+            | waypoints | turns                           | route        |
+            | f,e       | depart,merge slight left,arrive | in,road,road |
+            | f,a       | depart,turn sharp left,arrive  | in,road,road |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -833,3 +833,23 @@ Feature: Simple Turns
             | a,d       | road,road        | depart,arrive           |
             | d,i       | road,cross,cross | depart,turn left,arrive |
             | d,g       | road,road        | depart,arrive           |
+
+     Scenario: Go onto turning major road
+        Given the node map
+            |   |   |   | c |
+            |   |   |   |   |
+            |   |   |   |   |
+            | a |   |   | b |
+            |   |   |   |   |
+            |   |   |   | d |
+
+        And the ways
+            | nodes | highway     | name |
+            | abc   | primary     | road |
+            | bd    | residential | in   |
+
+        When I route I should get
+            | waypoints | turns                           | route        |
+            | a,c       | depart,arrive                   | road,road    |
+            | d,a       | depart,turn left,arrive         | in,road,road |
+            | d,c       | depart,new name straight,arrive | in,road,road |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -419,6 +419,20 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
                      current_step.name_id == steps[two_back_index].name_id)
             {
                 steps[one_back_index].maneuver.instruction.type = TurnType::Continue;
+
+                const auto getBearing = [](bool in, const RouteStep &step)
+                {
+                    const auto index =
+                        in ? step.intersections.front().in : step.intersections.front().out;
+                    return step.intersections.front().bearings[index];
+                };
+
+                // If we Merge onto the same street, we end up with a u-turn in some cases
+                if (bearingsAreReversed(
+                        util::bearing::reverseBearing(getBearing(true, one_back_step)),
+                        getBearing(false, current_step)))
+                    steps[one_back_index].maneuver.instruction.direction_modifier =
+                        DirectionModifier::UTurn;
             }
             else if (TurnType::Merge == one_back_step.maneuver.instruction.type &&
                      current_step.maneuver.instruction.type !=

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -180,7 +180,9 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
                 I
                 I
      */
-    else if (isEndOfRoad(intersection[0], intersection[1], intersection[2]))
+    else if (isEndOfRoad(intersection[0], intersection[1], intersection[2]) &&
+             !isObviousOfTwo(intersection[1], intersection[2]) &&
+             !isObviousOfTwo(intersection[2], intersection[1]))
     {
         if (intersection[1].entry_allowed)
         {


### PR DESCRIPTION
Even though it turns out that https://github.com/Project-OSRM/osrm-backend/issues/2550 is a data issue that is using non-up-to-date mapping, it surfaced a problem in handling end-of-road situations.

This PR considers a situation in which a main road is turning and a small road is merging onto it.
The major road now does not print a turn-instruction to follow it.

See the testcase for the exact behaviour.