### PR TITLE
[Not Ready] Expose Full Turn Lane Information in API

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -25,9 +25,9 @@ Feature: Turn Lane Guidance
             | de    |                            |
 
        When I route I should get
-            | waypoints | route          | turns                                         | lanes     | #      |
-            | a,d       | ab,bc,cd,cd    | depart,turn right,turn left,arrive            | ,1 2,1 2, | 2 hops |
-            | a,e       | ab,bc,cd,de,de | depart,turn right,turn left,turn right,arrive | ,1,1,0,   | 3 hops |
+            | waypoints | route          | turns                                         | lanes                                                                                                          | #      |
+            | a,d       | ab,bc,cd,cd    | depart,turn right,turn left,arrive            | ,through:false right:true right:true right:false,left:true left:true through:false,                            | 2 hops |
+            | a,e       | ab,bc,cd,de,de | depart,turn right,turn left,turn right,arrive | ,through:false right:false right:true right:false,left:false left:true through:false,through:false right:true, | 3 hops |
 
     @anticipate
     Scenario: Anticipate Lane Change for quick same direction turns, staying on the same street
@@ -48,9 +48,9 @@ Feature: Turn Lane Guidance
             | dy    |                      |                     | YSt  |
 
        When I route I should get
-            | waypoints | route               | turns                                          | lanes  |
-            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,end of road right,arrive | ,0,0,  |
-            | e,a       | MySt,MySt,MySt,MySt | depart,continue left,end of road left,arrive   | ,2,1,  |
+            | waypoints | route               | turns                                          | lanes                                                        |
+            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,end of road right,arrive | ,through:false right:false right:true,left:false right:true, |
+            | e,a       | MySt,MySt,MySt,MySt | depart,continue left,end of road left,arrive   | ,left:true left:false through:false,left:true right:false,   |
 
     @anticipate
     Scenario: Anticipate Lane Change for quick same direction turns, changing between streets
@@ -71,9 +71,9 @@ Feature: Turn Lane Guidance
             | dy    |                      |                     | EYSt |
 
        When I route I should get
-            | waypoints | route               | turns                                      | lanes  |
-            | a,e       | AXSt,BDSt,EYSt,EYSt | depart,turn right,end of road right,arrive | ,0,0,  |
-            | e,a       | EYSt,BDSt,AXSt,AXSt | depart,turn left,end of road left,arrive   | ,2,1,  |
+            | waypoints | route               | turns                                      | lanes                                                        |
+            | a,e       | AXSt,BDSt,EYSt,EYSt | depart,turn right,end of road right,arrive | ,through:false right:false right:true,left:false right:true, |
+            | e,a       | EYSt,BDSt,AXSt,AXSt | depart,turn left,end of road left,arrive   | ,left:true left:false through:false,left:true right:false,   |
 
 
     @anticipate
@@ -92,8 +92,8 @@ Feature: Turn Lane Guidance
             | cy    |                          | Hwy  | motorway      |        |
 
        When I route I should get
-            | waypoints | route          | turns                                           | lanes |
-            | a,d       | On,Hwy,Off,Off | depart,merge slight right,off ramp right,arrive | ,0,0, |
+            | waypoints | route          | turns                                           | lanes                                                                |
+            | a,d       | On,Hwy,Off,Off | depart,merge slight right,off ramp right,arrive | ,slight_left:false slight_left:true,through:false slight_right:true, |
 
 
     @anticipate
@@ -114,9 +114,9 @@ Feature: Turn Lane Guidance
             | dj    |                                                    |   2   | motorway_link | yes    | dj   |
 
        When I route I should get
-            | waypoints | route         | turns                                          | lanes     |
-            | a,i       | abx,bcd,di,di | depart,off ramp right,fork slight left,arrive  | ,0 1,1 2, |
-            | a,j       | abx,bcd,dj,dj | depart,off ramp right,fork slight right,arrive | ,0 1,0 1, |
+            | waypoints | route         | turns                                          | lanes                                                                                                                                    |
+            | a,i       | abx,bcd,di,di | depart,off ramp right,fork slight left,arrive  | ,none:false none:false none:false slight_right:true slight_right:true,slight_left:true slight_left;slight_right:true slight_right:false, |
+            | a,j       | abx,bcd,dj,dj | depart,off ramp right,fork slight right,arrive | ,none:false none:false none:false slight_right:true slight_right:true,slight_left:false slight_left;slight_right:true slight_right:true, |
 
 
     @anticipate
@@ -135,9 +135,9 @@ Feature: Turn Lane Guidance
             | cj    |                    | 1     | motorway_link | yes    | xbcj |
 
        When I route I should get
-            | waypoints | route             | turns                                             | lanes |
-            | a,i       | ab,xbcj,ci,ci     | depart,merge slight left,turn slight right,arrive | ,,0,  |
-            | a,j       | ab,xbcj,xbcj,xbcj | depart,merge slight left,use lane straight,arrive | ,,1,  |
+            | waypoints | route             | turns                                             | lanes                           |
+            | a,i       | ab,xbcj,ci,ci     | depart,merge slight left,turn slight right,arrive | ,,none:false slight_right:true, |
+            | a,j       | ab,xbcj,xbcj,xbcj | depart,merge slight left,use lane straight,arrive | ,,none:true slight_right:false, |
 
 
     @anticipate
@@ -160,9 +160,8 @@ Feature: Turn Lane Guidance
             | de    |                            | de   |
 
        When I route I should get
-            | waypoints | route             | turns                                         | lanes   |
-            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,1,1,0, |
-
+            | waypoints | route             | turns                                         | lanes                                                                                                          |
+            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,through:false right:false right:true right:false,left:false left:true through:false,through:false right:true, |
 
     @anticipate
     Scenario: Lane anticipation for fan-out
@@ -184,9 +183,8 @@ Feature: Turn Lane Guidance
             | de    |                            | de   |
 
        When I route I should get
-            | waypoints | route             | turns                                         | lanes         |
-            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,0,1 2,0 1 2, |
-
+            | waypoints | route             | turns                                         | lanes                                                                                                       |
+            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,through:false right:true,left:true left:true through:false,through:false right:true right:true right:true, |
 
     @anticipate
     Scenario: Lane anticipation for fan-in followed by fan-out
@@ -208,9 +206,8 @@ Feature: Turn Lane Guidance
             | de    |                            | de   |
 
        When I route I should get
-            | waypoints | route             | turns                                         | lanes           |
-            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,1 2,1 2,0 1 2, |
-
+            | waypoints | route             | turns                                         | lanes                                                                                                                              |
+            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,through:false right:true right:true right:false,left:true left:true through:false,through:false right:true right:true right:true, |
 
     @anticipate
     Scenario: Lane anticipation for fan-out followed by fan-in
@@ -232,9 +229,8 @@ Feature: Turn Lane Guidance
             | de    |                            | de   |
 
        When I route I should get
-            | waypoints | route             | turns                                         | lanes   |
-            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,0,1,0, |
-
+            | waypoints | route             | turns                                         | lanes                                                                                  |
+            | a,e       | abx,bcy,cdz,de,de | depart,turn right,turn left,turn right,arrive | ,through:false right:true,left:false left:true through:false,through:false right:true, |
 
     @anticipate
     Scenario: Lane anticipation for multiple hops with same number of lanes
@@ -260,8 +256,8 @@ Feature: Turn Lane Guidance
             | ef    |                            | ef   |
 
        When I route I should get
-            | waypoints | route                 | turns                                                   | lanes     |
-            | a,f       | abx,bcy,cdz,dew,ef,ef | depart,turn right,turn left,turn right,turn left,arrive | ,1,1,1,1, |
+            | waypoints | route                 | turns                                                   | lanes                                                                                                                                              |
+            | a,f       | abx,bcy,cdz,dew,ef,ef | depart,turn right,turn left,turn right,turn left,arrive | ,through:false right:false right:true right:false,left:false left:true through:false,through:false right:true right:false,left:true through:false, |
 
     @anticipate @bug @todo
     Scenario: Tripple Right keeping Left
@@ -284,9 +280,9 @@ Feature: Turn Lane Guidance
             | feg   |                    | tertiary  | fourth |
 
         When I route I should get
-            | waypoints | route                                  | turns                                                            | lanes             |
-            | a,f       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,end of road left,arrive  | ,2,2,2,2,         |
-            | a,g       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,end of road right,arrive | ,0 1,0 1,0 1,0 1, |
+            | waypoints | route                                  | turns                                                            | lanes                                                                                                                                                                      |
+            | a,f       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,end of road left,arrive  | ,none:false none:true right:false right:false,none:false none:true right:false right:false,none:false none:true right:false right:false,left:true right:false right:false, |
+            | a,g       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,end of road right,arrive | ,none:false none:false right:true right:true,none:false none:false right:true right:true,none:false none:false right:true right:true,left:false right:true right:true,     |
 
     @anticipate @bug @todo
     Scenario: Tripple Left keeping Right
@@ -309,6 +305,6 @@ Feature: Turn Lane Guidance
             | feg   |                    | tertiary  | fourth |
 
         When I route I should get
-            | waypoints | route                                  | turns                                                         | lanes             |
-            | a,f       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,end of road right,arrive | ,2,2,2,2,         |
-            | a,g       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,end of road left,arrive  | ,0 1,0 1,0 1,0 1, |
+            | waypoints | route                                  | turns                                                         | lanes                                                                                                                                                               |
+            | a,f       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,end of road right,arrive | ,left:false left:false none:true none:false,left:false left:false none:true none:false,left:false left:false none:true none:false,left:false left:false right:true, |
+            | a,g       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,end of road left,arrive  | ,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true right:false,     |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -20,11 +20,11 @@ Feature: Turn Lane Guidance
             | bd     |                |                    | left\|right         | right    |
 
        When I route I should get
-            | waypoints | route                | turns                           | lanes   |
-            | a,c       | in,straight,straight | depart,new name straight,arrive | ,1,     |
-            | a,d       | in,right,right       | depart,turn right,arrive        | ,0,     |
-            | c,a       | straight,in,in       | depart,new name straight,arrive | ,0 1 2, |
-            | c,d       | straight,right,right | depart,turn left,arrive         | ,3,     |
+            | waypoints | route                | turns                           | lanes                                           |
+            | a,c       | in,straight,straight | depart,new name straight,arrive | ,through:true right:false,                      |
+            | a,d       | in,right,right       | depart,turn right,arrive        | ,through:false right:true,                      |
+            | c,a       | straight,in,in       | depart,new name straight,arrive | ,left:false through:true none:true none:true,   |
+            | c,d       | straight,right,right | depart,turn left,arrive         | ,left:true through:false none:false none:false, |
 
     Scenario: Basic Turn Lane 4-Way Turn
         Given the node map
@@ -40,13 +40,13 @@ Feature: Turn Lane Guidance
             | be     |                |                    |                     | left     |
 
        When I route I should get
-            | waypoints | route                   | turns                           | lanes |
-            | a,c       | in,straight,straight    | depart,new name straight,arrive | ,1,   |
-            | a,d       | in,right,right          | depart,turn right,arrive        | ,0,   |
-            | a,e       | in,left,left            | depart,turn left,arrive         | ,1,   |
-            | d,a       | right,in,in             | depart,turn left,arrive         | ,1,   |
-            | d,e       | right,left,left         | depart,new name straight,arrive | ,0,   |
-            | d,c       | right,straight,straight | depart,turn right,arrive        | ,0,   |
+            | waypoints | route                   | turns                           | lanes                   |
+            | a,c       | in,straight,straight    | depart,new name straight,arrive | ,none:true right:false, |
+            | a,d       | in,right,right          | depart,turn right,arrive        | ,none:false right:true, |
+            | a,e       | in,left,left            | depart,turn left,arrive         | ,none:true right:false, |
+            | d,a       | right,in,in             | depart,turn left,arrive         | ,left:true none:false,  |
+            | d,e       | right,left,left         | depart,new name straight,arrive | ,left:false none:true,  |
+            | d,c       | right,straight,straight | depart,turn right,arrive        | ,left:false none:true,  |
 
     Scenario: Basic Turn Lane 4-Way Turn using none
         Given the node map
@@ -62,10 +62,10 @@ Feature: Turn Lane Guidance
             | be     |                |                    |                     | left     |
 
        When I route I should get
-            | waypoints | route                | turns                           | lanes |
-            | a,c       | in,straight,straight | depart,new name straight,arrive | ,1,   |
-            | a,d       | in,right,right       | depart,turn right,arrive        | ,0,   |
-            | a,e       | in,left,left         | depart,turn left,arrive         | ,1,   |
+            | waypoints | route                | turns                           | lanes                   |
+            | a,c       | in,straight,straight | depart,new name straight,arrive | ,none:true right:false, |
+            | a,d       | in,right,right       | depart,turn right,arrive        | ,none:false right:true, |
+            | a,e       | in,left,left         | depart,turn left,arrive         | ,none:true right:false, |
 
     Scenario: Basic Turn Lane 4-Way With U-Turn Lane
         Given the node map
@@ -81,11 +81,11 @@ Feature: Turn Lane Guidance
             | be     |                |                             | left     |
 
        When I route I should get
-            | from | to | bearings        | route                | turns                           | lanes |
-            | a    | c  | 180,180 180,180 | in,straight,straight | depart,new name straight,arrive | ,0,   |
-            | a    | d  | 180,180 180,180 | in,right,right       | depart,turn right,arrive        | ,0,   |
-            | a    | e  | 180,180 180,180 | in,left,left         | depart,turn left,arrive         | ,1,   |
-            | 1    | a  | 90,2 270,2      | in,in,in             | depart,turn uturn,arrive        | ,1,   |
+            | from | to | bearings        | route                | turns                           | lanes                                   |
+            | a    | c  | 180,180 180,180 | in,straight,straight | depart,new name straight,arrive | ,reverse;left:false through;right:true, |
+            | a    | d  | 180,180 180,180 | in,right,right       | depart,turn right,arrive        | ,reverse;left:false through;right:true, |
+            | a    | e  | 180,180 180,180 | in,left,left         | depart,turn left,arrive         | ,reverse;left:true through;right:false, |
+            | 1    | a  | 90,2 270,2      | in,in,in             | depart,turn uturn,arrive        | ,reverse;left:true through;right:false, |
 
 
     #this next test requires decision on how to announce lanes for going straight if there is no turn
@@ -103,9 +103,9 @@ Feature: Turn Lane Guidance
             | bd    | turn |                    |                   |
 
         When I route I should get
-            | waypoints | route          | turns                           | lanes |
-            | a,d       | road,turn,turn | depart,turn right,arrive        | ,0,   |
-            | a,c       | road,road,road | depart,use lane straight,arrive | ,1,   |
+            | waypoints | route          | turns                           | lanes                      |
+            | a,d       | road,turn,turn | depart,turn right,arrive        | ,through:false right:true, |
+            | a,c       | road,road,road | depart,use lane straight,arrive | ,through:true right:false, |
 
     #turn lanes are often drawn at the incoming road, even though the actual turn requires crossing the intersection first
     @todo @WORKAROUND-FIXME @bug
@@ -134,23 +134,23 @@ Feature: Turn Lane Guidance
             | fl    | cross |                         | yes    |
 
         When I route I should get
-            | waypoints | route             | turns                           | lanes | #                          |
-            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,0,   |                            |
-            | a,d       | road,road,road    | depart,use lane straight,arrive | ,1,   | #post-processing reduction |
-            | a,l       | road,cross,cross  | depart,turn left,arrive         | ,2,   |                            |
-            | a,h       | road,road,road    | depart,continue uturn,arrive    | ,2,   |                            |
-            | k,d       | cross,road,road   | depart,turn right,arrive        | ,0,   |                            |
-            | k,l       | cross,cross,cross | depart,use lane straight,arrive | ,0,   |                            |
-            | k,h       | cross,road,road   | depart,turn left,arrive         | ,1,   |                            |
-            | k,j       | cross,cross,cross | depart,continue uturn,arrive    | ,1,   |                            |
-            | e,l       | road,cross,cross  | depart,turn right,arrive        | ,0,   |                            |
-            | e,h       | road,road         | depart,arrive                   | ,     |                            |
-            | e,j       | road,cross,cross  | depart,turn left,arrive         | ,2,   |                            |
-            | e,d       | road,road,road    | depart,continue uturn,arrive    | ,2,   |                            |
-            | i,h       | cross,road,road   | depart,turn right,arrive        | ,,    |                            |
-            | i,j       | cross,cross,cross | depart,use lane straight,arrive | ,0,   |                            |
-            | i,d       | cross,road,road   | depart,turn left,arrive         | ,1,   |                            |
-            | i,l       | cross,cross,cross | depart,continue uturn,arrive    | ,1,   |                            |
+            | waypoints | route             | turns                           | lanes                                         |
+            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,left:false through:false right:true          |
+            | a,d       | road,road,road    | depart,use lane straight,arrive | ,left:false through:true right:false,         |
+            | a,l       | road,cross,cross  | depart,turn left,arrive         | ,left:true through:false right:false,         |
+            | a,h       | road,road,road    | depart,continue uturn,arrive    | ,left:true through:false right:false,         |
+            | k,d       | cross,road,road   | depart,turn right,arrive        | ,left:false through;right:true,               |
+            | k,l       | cross,cross,cross | depart,use lane straight,arrive | ,left:false through;right:true,               |
+            | k,h       | cross,road,road   | depart,turn left,arrive         | ,left:true through;right:false,               |
+            | k,j       | cross,cross,cross | depart,continue uturn,arrive    | ,left:true through;right:false,               |
+            | e,l       | road,cross,cross  | depart,turn right,arrive        | ,none:false through:false through;right:true, |
+            | e,h       | road,road         | depart,arrive                   | ,none:false through:true through;right:true   |
+            | e,j       | road,cross,cross  | depart,turn left,arrive         | ,none:true through:false through;right:false, |
+            | e,d       | road,road,road    | depart,continue uturn,arrive    | ,none:true through:false through;right:false, |
+            | i,h       | cross,road,road   | depart,turn right,arrive        | ,,                                            |
+            | i,j       | cross,cross,cross | depart,use lane straight,arrive | ,left:false through:true,                     |
+            | i,d       | cross,road,road   | depart,turn left,arrive         | ,left:true through:false,                     |
+            | i,l       | cross,cross,cross | depart,continue uturn,arrive    | ,left:true through:false,                     |
 
     #copy of former case to prevent further regression
     Scenario: Turn Lanes at Segregated Road
@@ -178,15 +178,13 @@ Feature: Turn Lane Guidance
             | fl    | cross |                         | yes    |
 
         When I route I should get
-            | waypoints | route             | turns                           | lanes | #                          |
-            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,0,   |                            |
-            | k,d       | cross,road,road   | depart,turn right,arrive        | ,0,   |                            |
-            | k,l       | cross,cross,cross | depart,use lane straight,arrive | ,0,   |                            |
-            | e,l       | road,cross,cross  | depart,turn right,arrive        | ,0,   |                            |
-            | e,d       | road,road,road    | depart,continue uturn,arrive    | ,2,   |                            |
-            | i,h       | cross,road,road   | depart,turn right,arrive        | ,,    |                            |
-            | i,j       | cross,cross,cross | depart,use lane straight,arrive | ,0,   |                            |
-            | i,l       | cross,cross,cross | depart,continue uturn,arrive    | ,1,   |                            |
+            | waypoints | route             | turns                           | lanes                                         |
+            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,left:false through:false right:true,         |
+            | k,d       | cross,road,road   | depart,turn right,arrive        | ,left:false through;right:true,               |
+            | e,l       | road,cross,cross  | depart,turn right,arrive        | ,none:false through:false through;right:true, |
+            | i,h       | cross,road,road   | depart,turn right,arrive        | ,,                                            |
+            | i,j       | cross,cross,cross | depart,use lane straight,arrive | ,left:false through:true,                     |
+            | i,l       | cross,cross,cross | depart,continue uturn,arrive    | ,left:true through:false,                     |
 
     Scenario: Turn Lanes at Segregated Road
         Given the node map
@@ -206,8 +204,8 @@ Feature: Turn Lane Guidance
             | cf    | cross |                         | yes    |
 
         When I route I should get
-            | waypoints | route             | turns                           | lanes |
-            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,0,   |
+            | waypoints | route             | turns                           | lanes                                 |
+            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,left:false through:false right:true, |
 
     #this can happen due to traffic lights / lanes not drawn up to the intersection itself
     Scenario: Turn Lanes Given earlier than actual turn
@@ -224,9 +222,9 @@ Feature: Turn Lane Guidance
             | ce    | turn |                    |
 
         When I route I should get
-            | waypoints | route          | turns                           | lanes |
-            | a,e       | road,turn,turn | depart,turn right,arrive        | ,0,   |
-            | a,d       | road,road,road | depart,use lane straight,arrive | ,1,   |
+            | waypoints | route          | turns                           | lanes                   |
+            | a,e       | road,turn,turn | depart,turn right,arrive        | ,none:false right:true, |
+            | a,d       | road,road,road | depart,use lane straight,arrive | ,none:true right:false, |
 
     Scenario: Turn Lanes Given earlier than actual turn
         Given the node map
@@ -244,11 +242,11 @@ Feature: Turn Lane Guidance
             | hk    | second-turn |                    |                     |
 
         When I route I should get
-            | waypoints | route                        | turns                           | lanes |
-            | a,k       | road,second-turn,second-turn | depart,turn right,arrive        | ,0,   |
-            | a,i       | road,road,road               | depart,use lane straight,arrive | ,1,   |
-            | i,j       | road,first-turn,first-turn   | depart,turn left,arrive         | ,1,   |
-            | i,a       | road,road,road               | depart,use lane straight,arrive | ,0,   |
+            | waypoints | route                        | turns                           | lanes                   |
+            | a,k       | road,second-turn,second-turn | depart,turn right,arrive        | ,none:false right:true, |
+            | a,i       | road,road,road               | depart,use lane straight,arrive | ,none:true right:false, |
+            | i,j       | road,first-turn,first-turn   | depart,turn left,arrive         | ,left:true none:false,  |
+            | i,a       | road,road,road               | depart,use lane straight,arrive | ,left:false none:true,  |
 
     Scenario: Passing a one-way street
         Given the node map
@@ -263,8 +261,8 @@ Feature: Turn Lane Guidance
             | cf    | turn |                    |        |
 
         When I route I should get
-            | waypoints | route          | turns                   | lanes |
-            | a,f       | road,turn,turn | depart,turn left,arrive | ,1,   |
+            | waypoints | route          | turns                   | lanes                     |
+            | a,f       | road,turn,turn | depart,turn left,arrive | ,left:true through:false, |
 
     Scenario: Passing a one-way street, partly pulled back lanes
         Given the node map
@@ -281,9 +279,9 @@ Feature: Turn Lane Guidance
             | bg    | right |                     | no     |
 
         When I route I should get
-            | waypoints | route            | turns                    | lanes |
-            | a,f       | road,turn,turn   | depart,turn left,arrive  | ,1,   |
-            | a,g       | road,right,right | depart,turn right,arrive | ,0,   |
+            | waypoints | route            | turns                    | lanes                           |
+            | a,f       | road,turn,turn   | depart,turn left,arrive  | ,left:true through;right:false, |
+            | a,g       | road,right,right | depart,turn right,arrive | ,left:false through;right:true, |
 
     Scenario: Passing a one-way street, partly pulled back lanes, no through
         Given the node map
@@ -300,9 +298,9 @@ Feature: Turn Lane Guidance
             | bg    | right |                     | no     |
 
         When I route I should get
-            | waypoints | route            | turns                    | lanes |
-            | a,f       | road,turn,turn   | depart,turn left,arrive  | ,1,   |
-            | a,g       | road,right,right | depart,turn right,arrive | ,0,   |
+            | waypoints | route            | turns                    | lanes                   |
+            | a,f       | road,turn,turn   | depart,turn left,arrive  | ,left:true right:false, |
+            | a,g       | road,right,right | depart,turn right,arrive | ,left:false right:true, |
 
     @todo @bug
     Scenario: Narrowing Turn Lanes
@@ -322,10 +320,10 @@ Feature: Turn Lane Guidance
             | cf    | right   |                     |
 
         When I route I should get
-            | waypoints | route                | turns                           | lanes |
-            | a,g       | road,left,left       | depart,turn left,arrive         | ,2,   |
-            | a,e       | road,through,through | depart,new name straight,arrive | ,1,   |
-            | a,f       | road,right,right     | depart,turn right,arrive        | ,0,   |
+            | waypoints | route                | turns                           | lanes                                 |
+            | a,g       | road,left,left       | depart,turn left,arrive         | ,left:true through:false right:false, |
+            | a,e       | road,through,through | depart,new name straight,arrive | ,left:false through:true right:false, |
+            | a,f       | road,right,right     | depart,turn right,arrive        | ,left:false through:false right:true, |
 
     Scenario: Turn at a traffic light
         Given the node map
@@ -344,9 +342,9 @@ Feature: Turn Lane Guidance
             | ce    | turn |                    |
 
         When I route I should get
-            | waypoints | route          | turns                           | lanes |
-            | a,d       | road,road,road | depart,use lane straight,arrive | ,1,   |
-            | a,e       | road,turn,turn | depart,turn right,arrive        | ,0,   |
+            | waypoints | route          | turns                           | lanes                      |
+            | a,d       | road,road,road | depart,use lane straight,arrive | ,through:true right:false, |
+            | a,e       | road,turn,turn | depart,turn right,arrive        | ,through:false right:true, |
 
     @bug @todo
     Scenario: Theodor Heuss Platz
@@ -380,10 +378,10 @@ Feature: Turn Lane Guidance
             | hl            | top-right-out |                                                                 |            | yes    | secondary |
 
         When I route I should get
-            | waypoints | route                           | turns                           | lanes   |
-            | i,m       | top,top-right,top-right         | depart,roundabout-exit-4,arrive | ,0 1 2, |
-            | i,l       | top,top-right-out,top-right-out | depart,roundabout-exit-4,arrive | ,2 3,   |
-            | i,o       | top,top,top                     | depart,roundabout-exit-5,arrive | ,,      |
+            | waypoints | route                           | turns                           | lanes                                                                                  |
+            | i,m       | top,top-right,top-right         | depart,roundabout-exit-4,arrive | ,slight_left:false slight_left;slight_right:true slight_right:true slight_right:true,  |
+            | i,l       | top,top-right-out,top-right-out | depart,roundabout-exit-4,arrive | ,slight_left:true slight_left;slight_right:true slight_right:false slight_right:false, |
+            | i,o       | top,top,top                     | depart,roundabout-exit-5,arrive | ,,                                                                                     |
 
     Scenario: Turn Lanes Breaking up
         Given the node map
@@ -408,9 +406,9 @@ Feature: Turn Lane Guidance
             | restriction | bc       | fdcg   | c        | no_right_turn |
 
         When I route I should get
-            | waypoints | route            | turns                           | lanes |
-            | a,g       | road,cross,cross | depart,turn left,arrive         | ,2 3, |
-            | a,e       | road,road,road   | depart,use lane straight,arrive | ,0 1, |
+            | waypoints | route            | turns                           | lanes                                             |
+            | a,g       | road,cross,cross | depart,turn left,arrive         | ,left:true left:true through:false through:false, |
+            | a,e       | road,road,road   | depart,use lane straight,arrive | ,left:false left:false through:true through:true, |
 
     Scenario: U-Turn Road at Intersection
         Given the node map
@@ -431,11 +429,11 @@ Feature: Turn Lane Guidance
             | gdeh  | cross |                    | no     | primary  |
 
        When I route I should get
-            | from | to | bearings        | route            | turns                           | lanes |
-            | a    | g  | 180,180 180,180 | road,cross,cross | depart,turn right,arrive        | ,0,   |
-            | a    | h  | 180,180 180,180 | road,cross,cross | depart,turn left,arrive         | ,2,   |
-            | a    | i  | 180,180 180,180 | road,road,road   | depart,use lane straight,arrive | ,1 2, |
-            | b    | a  | 90,2 270,2      | road,road,road   | depart,continue uturn,arrive    | ,2,   |
+            | from | to | bearings        | route            | turns                           | lanes                                 |
+            | a    | g  | 180,180 180,180 | road,cross,cross | depart,turn right,arrive        | ,none:false through:false right:true, |
+            | a    | h  | 180,180 180,180 | road,cross,cross | depart,turn left,arrive         | ,none:true through:false right:false, |
+            | a    | i  | 180,180 180,180 | road,road,road   | depart,use lane straight,arrive | ,none:true through:true right:false,  |
+            | b    | a  | 90,2 270,2      | road,road,road   | depart,continue uturn,arrive    | ,none:true through:false right:false, |
 
     Scenario: Segregated Intersection Merges With Lanes
         Given the node map
@@ -456,10 +454,10 @@ Feature: Turn Lane Guidance
             | cf    | left     |                                 | yes    | primary   |
 
         When I route I should get
-            | waypoints | route                  | turns                           | lanes   |
-            | a,f       | road,left,left         | depart,turn left,arrive         | ,2 3 4, |
-            | a,e       | road,road,road         | depart,turn uturn,arrive        | ,4,     |
-            | a,g       | road,straight,straight | depart,new name straight,arrive | ,0 1,   |
+            | waypoints | route                  | turns                           | lanes                                                         |
+            | a,f       | road,left,left         | depart,turn left,arrive         | ,left:true left:true left:true through:false through:false,   |
+            | a,e       | road,road,road         | depart,turn uturn,arrive        | ,left:true left:false left:false through:false through:false, |
+            | a,g       | road,straight,straight | depart,new name straight,arrive | ,left:false left:false left:false through:true through:true,  |
 
     @bug @todo
     Scenario: Passing Through a Roundabout
@@ -504,9 +502,9 @@ Feature: Turn Lane Guidance
             | ce    | cross |                                                    | primary |
 
         When I route I should get
-            | waypoints | route            | turns                           | lanes   |
-            | a,d       | road,road,road   | depart,use lane straight,arrive | ,1 2 3, |
-            | a,e       | road,cross,cross | depart,turn slight right,arrive | ,0 1,   |
+            | waypoints | route            | turns                           | lanes                                                                     |
+            | a,d       | road,road,road   | depart,use lane straight,arrive | ,through:true through:true through;slight_right:true slight_right:false,  |
+            | a,e       | road,cross,cross | depart,turn slight right,arrive | ,through:false through:false through;slight_right:true slight_right:true, |
 
     Scenario: Highway Ramp
         Given the node map
@@ -520,9 +518,9 @@ Feature: Turn Lane Guidance
             | ce    | ramp |                                                    | motorway_link |
 
         When I route I should get
-            | waypoints | route         | turns                               | lanes   |
-            | a,d       | hwy,hwy,hwy   | depart,use lane straight,arrive     | ,1 2 3, |
-            | a,e       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,0 1,   |
+            | waypoints | route         | turns                               | lanes                                                                     |
+            | a,d       | hwy,hwy,hwy   | depart,use lane straight,arrive     | ,through:true through:true through;slight_right:true slight_right:false,  |
+            | a,e       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,through:false through:false through;slight_right:true slight_right:true, |
 
     @bug @todo
     Scenario: Turning Off Ramp
@@ -541,10 +539,10 @@ Feature: Turn Lane Guidance
             | fh    | on   |                    | motorway_link | yes    |
 
         When I route I should get
-            | waypoints | route         | turns                    | lanes |
-            | a,d       | off,road,road | depart,turn_right,arrive | ,0,   |
-            | a,g       | off,road,road | depart,turn_left,arrive  | ,1,   |
-            | a,h       |               |                          |       |
+            | waypoints | route         | turns                    | lanes                   |
+            | a,d       | off,road,road | depart,turn_right,arrive | ,left:false right:true, |
+            | a,g       | off,road,road | depart,turn_left,arrive  | ,left:true right:false, |
+            | a,h       |               |                          |                         |
 
     Scenario: Off Ramp In a Turn
         Given the node map
@@ -560,9 +558,9 @@ Feature: Turn Lane Guidance
             | bd    | ramp |                               | motorway_link | yes    |
 
         When I route I should get
-            | waypoints | route         | turns                               | lanes |
-            | a,c       | hwy,hwy,hwy   | depart,use lane slight left,arrive  | ,1 2, |
-            | a,d       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,0,   |
+            | waypoints | route         | turns                               | lanes                                           |
+            | a,c       | hwy,hwy,hwy   | depart,use lane slight left,arrive  | ,through:true through:true slight_right:false,  |
+            | a,d       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,through:false through:false slight_right:true, |
 
     Scenario: Reverse Lane in Segregated Road
         Given the node map
@@ -579,8 +577,8 @@ Feature: Turn Lane Guidance
             | fgh   | road |                          | primary      | yes    |
 
         When I route I should get
-            | waypoints | route          | turns                        | lanes |
-            | a,h       | road,road,road | depart,continue uturn,arrive | ,2,   |
+            | waypoints | route          | turns                        | lanes                                     |
+            | a,h       | road,road,road | depart,continue uturn,arrive | ,reverse:true through:false through:false,|
 
     Scenario: Reverse Lane in Segregated Road with none
         Given the node map
@@ -597,8 +595,8 @@ Feature: Turn Lane Guidance
             | fgh   | road |                       | primary      | yes    |
 
         When I route I should get
-            | waypoints | route          | turns                        | lanes |
-            | a,h       | road,road,road | depart,continue uturn,arrive | ,2,   |
+            | waypoints | route          | turns                        | lanes                                   |
+            | a,h       | road,road,road | depart,continue uturn,arrive | ,reverse:true through:false none:false, |
 
     Scenario: Reverse Lane in Segregated Road with none, Service Turn Prior
         Given the node map
@@ -617,8 +615,8 @@ Feature: Turn Lane Guidance
             | ji    | park |                       | service      | no     |
 
         When I route I should get
-            | waypoints | route          | turns                        | lanes |
-            | a,h       | road,road,road | depart,continue uturn,arrive | ,2,   |
+            | waypoints | route          | turns                        | lanes                                   |
+            | a,h       | road,road,road | depart,continue uturn,arrive | ,reverse:true through:false none:false, |
 
     Scenario: Don't collapse everything to u-turn / too wide
         Given the node map
@@ -635,9 +633,9 @@ Feature: Turn Lane Guidance
             | cf    | secondary | bottom |                    |
 
         When I route I should get
-            | waypoints | turns                                          | route               | lanes |
-            | a,d       | depart,continue right,end of road right,arrive | road,road,road,road | ,0,,  |
-            | d,a       | depart,continue left,end of road left,arrive   | road,road,road,road | ,1,,  |
+            | waypoints | turns                                          | route               | lanes                       |
+            | a,d       | depart,continue right,end of road right,arrive | road,road,road,road | ,through:false right:true,, |
+            | d,a       | depart,continue left,end of road left,arrive   | road,road,road,road | ,left:true through:false,,  |
 
     Scenario: Merge Lanes Onto Freeway
         Given the node map
@@ -650,8 +648,8 @@ Feature: Turn Lane Guidance
             | db    | motorway_link | ramp | slight_right\|slight_right |
 
         When I route I should get
-            | waypoints | turns                           | route        | lanes |
-            | d,c       | depart,merge slight left,arrive | ramp,Hwy,Hwy | ,0 1, |
+            | waypoints | turns                           | route        | lanes                                 |
+            | d,c       | depart,merge slight left,arrive | ramp,Hwy,Hwy | ,slight_right:true slight_right:true, |
 
     Scenario: Fork on motorway links - don't fork on through but use lane
         Given the node map
@@ -667,6 +665,6 @@ Feature: Turn Lane Guidance
             | ab    | on   | motorway_link |                    |
 
         When I route I should get
-            | waypoints | route             | turns                                             | lanes |
-            | a,j       | on,xbcj,xbcj,xbcj | depart,merge slight left,use lane straight,arrive | ,,1,  |
-            | a,i       | on,xbcj,off,off   | depart,merge slight left,turn slight right,arrive | ,,0,  |
+            | waypoints | route             | turns                                             | lanes                           |
+            | a,j       | on,xbcj,xbcj,xbcj | depart,merge slight left,use lane straight,arrive | ,,none:true slight_right:false, |
+            | a,i       | on,xbcj,off,off   | depart,merge slight left,turn slight right,arrive | ,,none:false slight_right:true, |

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -223,7 +223,7 @@ module.exports = function () {
             };
 
             ['osrm', 'osrm.ebg', 'osrm.edges', 'osrm.enw', 'osrm.fileIndex', 'osrm.geometry', 'osrm.icd',
-             'osrm.names', 'osrm.nodes', 'osrm.properties', 'osrm.ramIndex', 'osrm.restrictions'].forEach(file => {
+             'osrm.names', 'osrm.nodes', 'osrm.properties', 'osrm.ramIndex', 'osrm.restrictions', 'osrm.tld', 'osrm.tls'].forEach(file => {
                  q.defer(rename, file);
              });
 
@@ -283,7 +283,7 @@ module.exports = function () {
 
             ['osrm', 'osrm.core', 'osrm.datasource_indexes', 'osrm.datasource_names', 'osrm.ebg','osrm.edges',
              'osrm.enw', 'osrm.fileIndex', 'osrm.geometry', 'osrm.hsgr', 'osrm.icd','osrm.level', 'osrm.names',
-             'osrm.nodes', 'osrm.properties', 'osrm.ramIndex', 'osrm.restrictions'].forEach((file) => {
+             'osrm.nodes', 'osrm.properties', 'osrm.ramIndex', 'osrm.restrictions', 'osrm.tld', 'osrm.tls'].forEach((file) => {
                  q.defer(rename, file);
              });
 

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -169,7 +169,14 @@ module.exports = function () {
     };
 
     this.lanesList = (instructions) => {
-        return this.extractInstructionList(instructions, instruction => ('lanes' in instruction.maneuver ? instruction.maneuver.lanes.join(' ') : ''));
+        return this.extractInstructionList(instructions, instruction => {
+                                                                          if( 'lanes' in instruction.maneuver )
+                                                                          {
+                                                                              return instruction.maneuver.lanes.map( p => { return p.marked + ':' + p.take; } ).join(' ');
+                                                                          } else
+                                                                          {
+                                                                              return '';
+                                                                          }});
     };
 
     this.turnList = (instructions) => {

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -138,6 +138,10 @@ class BaseDataFacade
                                                       const int bearing,
                                                       const int bearing_range) const = 0;
 
+    virtual bool hasLaneData(const EdgeID id) const = 0;
+    virtual util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const = 0;
+    virtual std::string GetTurnStringForID(const LaneStringID lane_string_id ) const = 0;
+
     virtual unsigned GetCheckSum() const = 0;
 
     virtual bool IsCoreNode(const NodeID id) const = 0;

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -16,6 +16,7 @@
 #include "storage/storage_config.hpp"
 #include "engine/geospatial_query.hpp"
 #include "util/graph_loader.hpp"
+#include "util/guidance/turn_lanes.hpp"
 #include "util/io.hpp"
 #include "util/packed_vector.hpp"
 #include "util/range_table.hpp"
@@ -78,8 +79,11 @@ class InternalDataFacade final : public BaseDataFacade
     util::ShM<NodeID, false>::vector m_via_node_list;
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;
+    util::ShM<LaneDataID, false>::vector m_lane_data_id;
+    util::ShM<util::guidance::LaneTupelIdPair, false>::vector m_lane_tupel_id_pairs;
     util::ShM<extractor::TravelMode, false>::vector m_travel_mode_list;
     util::ShM<char, false>::vector m_names_char_list;
+    util::ShM<char, false>::vector m_lanes_char_list;
     util::ShM<unsigned, false>::vector m_geometry_indices;
     util::ShM<extractor::CompressedEdgeContainer::CompressedEdge, false>::vector m_geometry_list;
     util::ShM<bool, false>::vector m_is_core_node;
@@ -93,6 +97,7 @@ class InternalDataFacade final : public BaseDataFacade
     boost::filesystem::path ram_index_path;
     boost::filesystem::path file_index_path;
     util::RangeTable<16, false> m_name_table;
+    util::RangeTable<16, false> m_lane_string_table;
 
     // bearing classes by node based node
     util::ShM<BearingClassID, false>::vector m_bearing_class_id_table;
@@ -116,6 +121,20 @@ class InternalDataFacade final : public BaseDataFacade
 
         in_stream.read(reinterpret_cast<char *>(&m_profile_properties),
                        sizeof(m_profile_properties));
+    }
+
+    void LoadLaneTupelIdPairs(const boost::filesystem::path &lane_data_path)
+    {
+        boost::filesystem::ifstream in_stream(lane_data_path);
+        if (!in_stream)
+        {
+            throw util::exception("Could not open " + lane_data_path.string() + " for reading.");
+        }
+        std::uint64_t size;
+        in_stream.read(reinterpret_cast<char *>(&size), sizeof(size));
+        m_lane_tupel_id_pairs.resize(size);
+        in_stream.read(reinterpret_cast<char *>(&m_lane_tupel_id_pairs[0]),
+                       sizeof(m_lane_tupel_id_pairs) * size);
     }
 
     void LoadTimestamp(const boost::filesystem::path &timestamp_path)
@@ -173,6 +192,7 @@ class InternalDataFacade final : public BaseDataFacade
         m_via_node_list.resize(number_of_edges);
         m_name_ID_list.resize(number_of_edges);
         m_turn_instruction_list.resize(number_of_edges);
+        m_lane_data_id.resize(number_of_edges);
         m_travel_mode_list.resize(number_of_edges);
         m_entry_class_id_list.resize(number_of_edges);
 
@@ -184,6 +204,7 @@ class InternalDataFacade final : public BaseDataFacade
             m_via_node_list[i] = current_edge_data.via_node;
             m_name_ID_list[i] = current_edge_data.name_id;
             m_turn_instruction_list[i] = current_edge_data.turn_instruction;
+            m_lane_data_id[i] = current_edge_data.lane_data_id;
             m_travel_mode_list[i] = current_edge_data.travel_mode;
             m_entry_class_id_list[i] = current_edge_data.entry_classid;
         }
@@ -282,6 +303,19 @@ class InternalDataFacade final : public BaseDataFacade
         m_static_rtree.reset(new InternalRTree(ram_index_path, file_index_path, m_coordinate_list));
         m_geospatial_query.reset(
             new InternalGeospatialQuery(*m_static_rtree, m_coordinate_list, *this));
+    }
+
+    void LoadLaneStrings(const boost::filesystem::path &lane_string_file)
+    {
+        boost::filesystem::ifstream lane_stream(lane_string_file, std::ios::binary);
+
+        lane_stream >> m_lane_string_table;
+
+        unsigned number_of_chars = 0;
+        lane_stream.read((char *)&number_of_chars, sizeof(unsigned));
+        BOOST_ASSERT_MSG(0 != number_of_chars, "lane file broken");
+        m_lanes_char_list.resize(number_of_chars + 1); //+1 gives sentinel element
+        lane_stream.read((char *)&m_lanes_char_list[0], number_of_chars * sizeof(char));
     }
 
     void LoadStreetNames(const boost::filesystem::path &names_file)
@@ -386,11 +420,17 @@ class InternalDataFacade final : public BaseDataFacade
         util::SimpleLogger().Write() << "loading street names";
         LoadStreetNames(config.names_data_path);
 
+        util::SimpleLogger().Write() << "loading lane tags";
+        LoadLaneStrings(config.turn_lane_string_path);
+
         util::SimpleLogger().Write() << "loading rtree";
         LoadRTree();
 
         util::SimpleLogger().Write() << "loading intersection class data";
         LoadIntersectionClasses(config.intersection_class_path);
+
+        util::SimpleLogger().Write() << "Loading Lane Data Pairs";
+        LoadLaneTupelIdPairs(config.turn_lane_data_path);
     }
 
     // search graph access
@@ -740,6 +780,37 @@ class InternalDataFacade final : public BaseDataFacade
     util::guidance::EntryClass GetEntryClass(const EntryClassID entry_class_id) const override final
     {
         return m_entry_class_table.at(entry_class_id);
+    }
+
+    bool hasLaneData(const EdgeID id) const override final
+    {
+        return m_lane_data_id[id] != INVALID_LANE_DATAID;
+    }
+
+    util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const override final
+    {
+        BOOST_ASSERT(hasLaneData(id));
+        return m_lane_tupel_id_pairs[m_lane_data_id[id]];
+    }
+
+    std::string GetTurnStringForID(const LaneStringID lane_string_id) const override final
+    {
+        if (INVALID_LANE_STRINGID == lane_string_id)
+        {
+            return "";
+        }
+        auto range = m_lane_string_table.GetRange(lane_string_id);
+
+        std::string result;
+        result.reserve(range.size());
+        if (range.begin() != range.end())
+        {
+            result.resize(range.back() - range.front() + 1);
+            std::copy(m_lanes_char_list.begin() + range.front(),
+                      m_lanes_char_list.begin() + range.back() + 1,
+                      result.begin());
+        }
+        return result;
     }
 };
 }

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -12,6 +12,7 @@
 #include "extractor/profile_properties.hpp"
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
+#include "util/guidance/turn_lanes.hpp"
 
 #include "engine/geospatial_query.hpp"
 #include "util/make_unique.hpp"
@@ -79,10 +80,14 @@ class SharedDataFacade final : public BaseDataFacade
     util::PackedVector<OSMNodeID, true> m_osmnodeid_list;
     util::ShM<NodeID, true>::vector m_via_node_list;
     util::ShM<unsigned, true>::vector m_name_ID_list;
+    util::ShM<LaneDataID, true>::vector m_lane_data_id;
     util::ShM<extractor::guidance::TurnInstruction, true>::vector m_turn_instruction_list;
     util::ShM<extractor::TravelMode, true>::vector m_travel_mode_list;
     util::ShM<char, true>::vector m_names_char_list;
+    util::ShM<char, true>::vector m_turn_string_char_list;
     util::ShM<unsigned, true>::vector m_name_begin_indices;
+    util::ShM<char, true>::vector m_lane_string_char_list;
+    util::ShM<unsigned, true>::vector m_lane_string_begin_indices;
     util::ShM<unsigned, true>::vector m_geometry_indices;
     util::ShM<extractor::CompressedEdgeContainer::CompressedEdge, true>::vector m_geometry_list;
     util::ShM<bool, true>::vector m_is_core_node;
@@ -91,12 +96,14 @@ class SharedDataFacade final : public BaseDataFacade
     util::ShM<char, true>::vector m_datasource_name_data;
     util::ShM<std::size_t, true>::vector m_datasource_name_offsets;
     util::ShM<std::size_t, true>::vector m_datasource_name_lengths;
+    util::ShM<util::guidance::LaneTupelIdPair, true>::vector m_lane_tupel_id_pairs;
 
     std::unique_ptr<SharedRTree> m_static_rtree;
     std::unique_ptr<SharedGeospatialQuery> m_geospatial_query;
     boost::filesystem::path file_index_path;
 
     std::shared_ptr<util::RangeTable<16, true>> m_name_table;
+    std::shared_ptr<util::RangeTable<16, true>> m_turn_string_table;
 
     // bearing classes by node based node
     util::ShM<BearingClassID, true>::vector m_bearing_class_id_table;
@@ -177,13 +184,27 @@ class SharedDataFacade final : public BaseDataFacade
             osmnodeid_list_ptr,
             data_layout->num_entries[storage::SharedDataLayout::OSM_NODE_ID_LIST]);
         // We (ab)use the number of coordinates here because we know we have the same amount of ids
-        m_osmnodeid_list.set_number_of_entries(data_layout->num_entries[storage::SharedDataLayout::COORDINATE_LIST]);
+        m_osmnodeid_list.set_number_of_entries(
+            data_layout->num_entries[storage::SharedDataLayout::COORDINATE_LIST]);
 
         auto travel_mode_list_ptr = data_layout->GetBlockPtr<extractor::TravelMode>(
             shared_memory, storage::SharedDataLayout::TRAVEL_MODE);
         util::ShM<extractor::TravelMode, true>::vector travel_mode_list(
             travel_mode_list_ptr, data_layout->num_entries[storage::SharedDataLayout::TRAVEL_MODE]);
         m_travel_mode_list = std::move(travel_mode_list);
+
+        auto lane_data_id_ptr = data_layout->GetBlockPtr<LaneDataID>(
+            shared_memory, storage::SharedDataLayout::LANE_DATA_ID);
+        util::ShM<LaneDataID, true>::vector lane_data_id(
+            lane_data_id_ptr, data_layout->num_entries[storage::SharedDataLayout::LANE_DATA_ID]);
+        m_lane_data_id = std::move(lane_data_id);
+
+        auto lane_tupel_id_pair_ptr = data_layout->GetBlockPtr<util::guidance::LaneTupelIdPair>(
+            shared_memory, storage::SharedDataLayout::TURN_LANE_DATA);
+        util::ShM<util::guidance::LaneTupelIdPair, true>::vector lane_tupel_id_pair(
+            lane_tupel_id_pair_ptr,
+            data_layout->num_entries[storage::SharedDataLayout::TURN_LANE_DATA]);
+        m_lane_tupel_id_pairs = std::move(lane_tupel_id_pair);
 
         auto turn_instruction_list_ptr =
             data_layout->GetBlockPtr<extractor::guidance::TurnInstruction>(
@@ -237,6 +258,29 @@ class SharedDataFacade final : public BaseDataFacade
         m_names_char_list = std::move(names_char_list);
     }
 
+    void LoadTurnLaneStrings()
+    {
+        auto offsets_ptr = data_layout->GetBlockPtr<unsigned>(
+            shared_memory, storage::SharedDataLayout::TURN_STRING_OFFSETS);
+        auto blocks_ptr = data_layout->GetBlockPtr<IndexBlock>(
+            shared_memory, storage::SharedDataLayout::TURN_STRING_BLOCKS);
+        util::ShM<unsigned, true>::vector turn_string_offsets(
+            offsets_ptr, data_layout->num_entries[storage::SharedDataLayout::TURN_STRING_OFFSETS]);
+        util::ShM<IndexBlock, true>::vector turn_string_blocks(
+            blocks_ptr, data_layout->num_entries[storage::SharedDataLayout::TURN_STRING_BLOCKS]);
+
+        auto turn_strings_list_ptr = data_layout->GetBlockPtr<char>(
+            shared_memory, storage::SharedDataLayout::TURN_STRING_CHAR_LIST);
+        util::ShM<char, true>::vector turn_strings_char_list(
+            turn_strings_list_ptr,
+            data_layout->num_entries[storage::SharedDataLayout::TURN_STRING_CHAR_LIST]);
+        m_turn_string_table = util::make_unique<util::RangeTable<16, true>>(
+            turn_string_offsets,
+            turn_string_blocks,
+            static_cast<unsigned>(turn_strings_char_list.size()));
+
+        m_turn_string_char_list = std::move(turn_strings_char_list);
+    }
     void LoadCoreInformation()
     {
         if (data_layout->num_entries[storage::SharedDataLayout::CORE_MARKER] <= 0)
@@ -415,6 +459,7 @@ class SharedDataFacade final : public BaseDataFacade
                 LoadTimestamp();
                 LoadViaNodeList();
                 LoadNames();
+                LoadTurnLaneStrings();
                 LoadCoreInformation();
                 LoadProfileProperties();
                 LoadRTree();
@@ -781,6 +826,37 @@ class SharedDataFacade final : public BaseDataFacade
     util::guidance::EntryClass GetEntryClass(const EntryClassID entry_class_id) const override final
     {
         return m_entry_class_table.at(entry_class_id);
+    }
+
+    bool hasLaneData(const EdgeID id) const override final
+    {
+        return INVALID_LANE_DATAID != m_lane_data_id.at(id);
+    }
+
+    util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const override final
+    {
+        BOOST_ASSERT(hasLaneData(id));
+        return m_lane_tupel_id_pairs.at(m_lane_data_id.at(id));
+    }
+
+    std::string GetTurnStringForID(const LaneStringID lane_string_id) const override final
+    {
+        if (INVALID_LANE_STRINGID == lane_string_id)
+        {
+            return "";
+        }
+        auto range = m_turn_string_table->GetRange(lane_string_id);
+
+        std::string result;
+        result.reserve(range.size());
+        if (range.begin() != range.end())
+        {
+            result.resize(range.back() - range.front() + 1);
+            std::copy(m_turn_string_char_list.begin() + range.front(),
+                      m_turn_string_char_list.begin() + range.back() + 1,
+                      result.begin());
+        }
+        return result;
     }
 };
 }

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -14,6 +14,7 @@
 #include "util/coordinate_calculation.hpp"
 #include "util/guidance/entry_class.hpp"
 #include "util/guidance/toolkit.hpp"
+#include "util/guidance/turn_lanes.hpp"
 #include "util/typedefs.hpp"
 
 #include <boost/optional.hpp>
@@ -70,7 +71,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                           bearings.second,
                           extractor::guidance::TurnInstruction::NO_TURN(),
                           WaypointType::Depart,
-                          0};
+                          0,
+                          util::guidance::LaneTupel(),
+                          ""};
     Intersection intersection{source_node.location,
                               std::vector<short>({bearings.second}),
                               std::vector<bool>({true}),
@@ -147,7 +150,11 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                             bearings.second,
                             path_point.turn_instruction,
                             WaypointType::None,
-                            0};
+                            0,
+                            path_point.lane_data.first,
+                            (path_point.lane_data.second != INVALID_LANE_STRINGID
+                                 ? facade.GetTurnStringForID(path_point.lane_data.second)
+                                 : "")};
                 segment_index++;
                 segment_duration = 0;
             }
@@ -202,7 +209,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
                 bearings.second,
                 extractor::guidance::TurnInstruction::NO_TURN(),
                 WaypointType::Arrive,
-                0};
+                0,
+                util::guidance::LaneTupel(),
+                ""};
     intersection = {
         target_node.location,
         std::vector<short>({static_cast<short>(util::bearing::reverseBearing(bearings.first))}),
@@ -233,6 +242,9 @@ std::vector<RouteStep> assembleSteps(const DataFacadeT &facade,
     BOOST_ASSERT(steps.back().intersections.front().bearings.size() == 1);
     BOOST_ASSERT(steps.back().intersections.front().entry.size() == 1);
     BOOST_ASSERT(steps.back().maneuver.waypoint_type == WaypointType::Arrive);
+    BOOST_ASSERT(steps.back().maneuver.lanes.lanes_in_turn == 0);
+    BOOST_ASSERT(steps.back().maneuver.lanes.first_lane_from_the_right == INVALID_LANEID);
+    BOOST_ASSERT(steps.back().maneuver.turn_lane_string == "");
     return steps;
 }
 

--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -3,8 +3,10 @@
 
 #include "extractor/guidance/turn_instruction.hpp"
 #include "util/coordinate.hpp"
+#include "util/guidance/turn_lanes.hpp"
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace osrm
@@ -27,8 +29,12 @@ struct StepManeuver
     short bearing_before;
     short bearing_after;
     extractor::guidance::TurnInstruction instruction;
+
     WaypointType waypoint_type;
     unsigned exit;
+
+    util::guidance::LaneTupel lanes;
+    std::string turn_lane_string;
 };
 
 inline StepManeuver getInvalidStepManeuver()
@@ -38,7 +44,9 @@ inline StepManeuver getInvalidStepManeuver()
             0,
             extractor::guidance::TurnInstruction::NO_TURN(),
             WaypointType::None,
-            0};
+            0,
+            util::guidance::LaneTupel(),
+            ""};
 }
 
 } // namespace guidance

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -5,7 +5,7 @@
 #include "extractor/travel_mode.hpp"
 #include "engine/phantom_node.hpp"
 #include "util/typedefs.hpp"
-
+#include "util/guidance/turn_lanes.hpp"
 #include "osrm/coordinate.hpp"
 
 #include <vector>
@@ -27,6 +27,8 @@ struct PathData
     EdgeWeight duration_until_turn;
     // instruction to execute at the turn
     extractor::guidance::TurnInstruction turn_instruction;
+    // turn lane data
+    util::guidance::LaneTupelIdPair lane_data;
     // travel mode of the street that leads to the turn
     extractor::TravelMode travel_mode : 4;
     // entry class of the turn, indicating possibility of turns

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -327,10 +327,14 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                                  name_index,
                                  weight_vector[i],
                                  extractor::guidance::TurnInstruction::NO_TURN(),
+                                 {{0, INVALID_LANEID}, INVALID_LANE_STRINGID},
                                  travel_mode,
                                  INVALID_ENTRY_CLASSID});
                 }
                 BOOST_ASSERT(unpacked_path.size() > 0);
+                if( facade->hasLaneData(ed.id) )
+                    unpacked_path.back().lane_data = facade->GetLaneData(ed.id);
+
                 unpacked_path.back().entry_classid = facade->GetEntryClassID(ed.id);
                 unpacked_path.back().turn_instruction = turn_instruction;
                 unpacked_path.back().duration_until_turn += (ed.distance - total_weight);
@@ -389,6 +393,7 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
                 phantom_node_pair.target_phantom.name_id,
                 weight_vector[i],
                 extractor::guidance::TurnInstruction::NO_TURN(),
+                {{0,INVALID_LANEID},INVALID_LANE_STRINGID},
                 target_traversed_in_reverse ? phantom_node_pair.target_phantom.backward_travel_mode
                                             : phantom_node_pair.target_phantom.forward_travel_mode,
                 INVALID_ENTRY_CLASSID});

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -59,6 +59,7 @@ class EdgeBasedGraphFactory
                                    const util::NameTable &turn_lanes);
 
     void Run(const std::string &original_edge_data_filename,
+             const std::string &turn_lane_data_filename,
              lua_State *lua_state,
              const std::string &edge_segment_lookup_filename,
              const std::string &edge_penalty_filename,
@@ -124,6 +125,7 @@ class EdgeBasedGraphFactory
     unsigned RenumberEdges();
     void GenerateEdgeExpandedNodes();
     void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
+                                   const std::string &turn_lane_data_filename,
                                    lua_State *lua_state,
                                    const std::string &edge_segment_lookup_filename,
                                    const std::string &edge_fixed_penalties_filename,

--- a/include/extractor/extractor_config.hpp
+++ b/include/extractor/extractor_config.hpp
@@ -61,7 +61,8 @@ struct ExtractorConfig
         output_file_name = basepath + ".osrm";
         restriction_file_name = basepath + ".osrm.restrictions";
         names_file_name = basepath + ".osrm.names";
-        turn_lane_file_name = basepath + ".osrm.tld";
+        turn_lane_strings_file_name = basepath + ".osrm.tls";
+        turn_lane_data_file_name = basepath + ".osrm.tld";
         timestamp_file_name = basepath + ".osrm.timestamp";
         geometry_output_path = basepath + ".osrm.geometry";
         node_output_path = basepath + ".osrm.nodes";
@@ -83,7 +84,8 @@ struct ExtractorConfig
     std::string output_file_name;
     std::string restriction_file_name;
     std::string names_file_name;
-    std::string turn_lane_file_name;
+    std::string turn_lane_data_file_name;
+    std::string turn_lane_strings_file_name;
     std::string timestamp_file_name;
     std::string geometry_output_path;
     std::string edge_output_path;

--- a/include/extractor/guidance/intersection.hpp
+++ b/include/extractor/guidance/intersection.hpp
@@ -22,6 +22,7 @@ struct TurnOperation final
     EdgeID eid;
     double angle;
     TurnInstruction instruction;
+    LaneDataID lane_data_id;
 };
 
 // A Connected Road is the internal representation of a potential turn. Internally, we require

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -5,6 +5,7 @@
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/guidance/toolkit.hpp"
+#include "util/guidance/turn_lanes.hpp"
 #include "util/typedefs.hpp"
 
 #include "extractor/compressed_edge_container.hpp"
@@ -35,9 +36,8 @@ namespace extractor
 namespace guidance
 {
 
-using LaneTupelIdPair = std::pair<util::guidance::LaneTupel, LaneStringID>;
-using LaneTupelIdMap =
-    std::unordered_map<LaneTupelIdPair, std::uint16_t, boost::hash<LaneTupelIdPair>>;
+using util::guidance::LaneTupelIdPair;
+using LaneDataIdMap = std::unordered_map<LaneTupelIdPair, LaneDataID, boost::hash<LaneTupelIdPair>>;
 
 using util::guidance::angularDeviation;
 

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -5,6 +5,7 @@
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/guidance/toolkit.hpp"
+#include "util/typedefs.hpp"
 
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/query_node.hpp"
@@ -20,10 +21,12 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/functional/hash.hpp>
 
 namespace osrm
 {
@@ -31,6 +34,10 @@ namespace extractor
 {
 namespace guidance
 {
+
+using LaneTupelIdPair = std::pair<util::guidance::LaneTupel, LaneStringID>;
+using LaneTupelIdMap =
+    std::unordered_map<LaneTupelIdPair, std::uint16_t, boost::hash<LaneTupelIdPair>>;
 
 using util::guidance::angularDeviation;
 

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -88,6 +88,10 @@ struct TurnInstruction
     // the lane tupel that is used for the turn
     LaneTupel lane_tupel;
 
+    // id into the lane_tupel,lane_string_id map
+    // TODO: remove lane_tupel above and assert on size == 3 below
+    std::uint16_t lane_tupel_id;
+
     static TurnInstruction INVALID() { return {TurnType::Invalid, DirectionModifier::UTurn}; }
 
     static TurnInstruction NO_TURN() { return {TurnType::NoTurn, DirectionModifier::UTurn}; }
@@ -147,7 +151,8 @@ struct TurnInstruction
     }
 };
 
-static_assert(sizeof(TurnInstruction) == 3, "TurnInstruction does not fit three byte");
+// TODO: should be 3 after the switch to ids
+static_assert(sizeof(TurnInstruction) == 6, "TurnInstruction does not fit three bytes");
 
 inline bool operator!=(const TurnInstruction lhs, const TurnInstruction rhs)
 {

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -77,24 +77,24 @@ struct TurnInstruction
 {
     using LaneTupel = util::guidance::LaneTupel;
     TurnInstruction(const TurnType::Enum type = TurnType::Invalid,
-                    const DirectionModifier::Enum direction_modifier = DirectionModifier::Straight,
-                    const LaneTupel lane_tupel = {0, INVALID_LANEID})
-        : type(type), direction_modifier(direction_modifier), lane_tupel(lane_tupel)
+                    const DirectionModifier::Enum direction_modifier = DirectionModifier::UTurn)
+        : type(type), direction_modifier(direction_modifier)
     {
     }
 
     TurnType::Enum type : 5;
     DirectionModifier::Enum direction_modifier : 3;
     // the lane tupel that is used for the turn
-    LaneTupel lane_tupel;
 
-    // id into the lane_tupel,lane_string_id map
-    // TODO: remove lane_tupel above and assert on size == 3 below
-    std::uint16_t lane_tupel_id;
+    static TurnInstruction INVALID()
+    {
+        return {TurnType::Invalid, DirectionModifier::UTurn};
+    }
 
-    static TurnInstruction INVALID() { return {TurnType::Invalid, DirectionModifier::UTurn}; }
-
-    static TurnInstruction NO_TURN() { return {TurnType::NoTurn, DirectionModifier::UTurn}; }
+    static TurnInstruction NO_TURN()
+    {
+        return {TurnType::NoTurn, DirectionModifier::UTurn};
+    }
 
     static TurnInstruction REMAIN_ROUNDABOUT(const RoundaboutType,
                                              const DirectionModifier::Enum modifier)
@@ -110,7 +110,8 @@ struct TurnInstruction
             TurnType::EnterRoundabout,
             TurnType::EnterRotary,
             TurnType::EnterRoundaboutIntersection};
-        return {enter_instruction[static_cast<int>(roundabout_type)], modifier};
+        return {
+            enter_instruction[static_cast<int>(roundabout_type)], modifier};
     }
 
     static TurnInstruction EXIT_ROUNDABOUT(const RoundaboutType roundabout_type,
@@ -142,7 +143,8 @@ struct TurnInstruction
             TurnType::EnterRoundaboutAtExit,
             TurnType::EnterRotaryAtExit,
             TurnType::EnterRoundaboutIntersectionAtExit};
-        return {enter_instruction[static_cast<int>(roundabout_type)], modifier};
+        return {
+            enter_instruction[static_cast<int>(roundabout_type)], modifier};
     }
 
     static TurnInstruction SUPPRESSED(const DirectionModifier::Enum modifier)
@@ -151,19 +153,16 @@ struct TurnInstruction
     }
 };
 
-// TODO: should be 3 after the switch to ids
-static_assert(sizeof(TurnInstruction) == 6, "TurnInstruction does not fit three bytes");
+static_assert(sizeof(TurnInstruction) == 1, "TurnInstruction does not fit a byte");
 
 inline bool operator!=(const TurnInstruction lhs, const TurnInstruction rhs)
 {
-    return lhs.type != rhs.type || lhs.direction_modifier != rhs.direction_modifier ||
-           lhs.lane_tupel != rhs.lane_tupel;
+    return lhs.type != rhs.type || lhs.direction_modifier != rhs.direction_modifier;
 }
 
 inline bool operator==(const TurnInstruction lhs, const TurnInstruction rhs)
 {
-    return lhs.type == rhs.type && lhs.direction_modifier == rhs.direction_modifier &&
-           lhs.lane_tupel == rhs.lane_tupel;
+    return lhs.type == rhs.type && lhs.direction_modifier == rhs.direction_modifier;
 }
 
 } // namespace guidance

--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -2,6 +2,7 @@
 #define OSRM_EXTRACTOR_GUIDANCE_TURN_LANE_HANDLER_HPP_
 
 #include "extractor/guidance/intersection.hpp"
+#include "extractor/guidance/toolkit.hpp"
 #include "extractor/guidance/turn_analysis.hpp"
 #include "extractor/guidance/turn_lane_data.hpp"
 #include "extractor/query_node.hpp"
@@ -13,7 +14,6 @@
 
 #include <map>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -38,12 +38,10 @@ class TurnLaneHandler
                     const std::vector<QueryNode> &node_info_list,
                     const TurnAnalysis &turn_analysis);
 
-    Intersection
-    assignTurnLanes(const NodeID at, const EdgeID via_edge, Intersection intersection) const;
+    Intersection assignTurnLanes(const NodeID at, const EdgeID via_edge, Intersection intersection);
 
   private:
-    using LaneTupel = util::guidance::LaneTupel;
-    std::unordered_map<LaneTupel, std::uint16_t> lane_tupels;
+    LaneTupelIdMap lane_tupels;
 
     // we need to be able to look at previous intersections to, in some cases, find the correct turn
     // lanes for a turn
@@ -58,7 +56,8 @@ class TurnLaneHandler
 
     // in case of a simple intersection, assign the lane entries
     Intersection simpleMatchTuplesToTurns(Intersection intersection,
-                                          const LaneDataVector &lane_data) const;
+                                          const LaneDataVector &lane_data,
+                                          const LaneStringID lane_string_id);
 
     // partition lane data into lane data relevant at current turn and at next turn
     std::pair<TurnLaneHandler::LaneDataVector, TurnLaneHandler::LaneDataVector> partitionLaneData(
@@ -68,7 +67,7 @@ class TurnLaneHandler
     // intersection whose turns might be related to this current intersection
     Intersection handleTurnAtPreviousIntersection(const NodeID at,
                                                   const EdgeID via_edge,
-                                                  Intersection intersection) const;
+                                                  Intersection intersection);
 };
 
 } // namespace lanes

--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -38,11 +38,12 @@ class TurnLaneHandler
                     const std::vector<QueryNode> &node_info_list,
                     const TurnAnalysis &turn_analysis);
 
-    Intersection assignTurnLanes(const NodeID at, const EdgeID via_edge, Intersection intersection);
+    Intersection assignTurnLanes(const NodeID at,
+                                 const EdgeID via_edge,
+                                 Intersection intersection,
+                                 LaneDataIdMap &id_map) const;
 
   private:
-    LaneTupelIdMap lane_tupels;
-
     // we need to be able to look at previous intersections to, in some cases, find the correct turn
     // lanes for a turn
     const util::NodeBasedDynamicGraph &node_based_graph;
@@ -57,7 +58,8 @@ class TurnLaneHandler
     // in case of a simple intersection, assign the lane entries
     Intersection simpleMatchTuplesToTurns(Intersection intersection,
                                           const LaneDataVector &lane_data,
-                                          const LaneStringID lane_string_id);
+                                          const LaneStringID lane_string_id,
+                                          LaneDataIdMap &id_map) const;
 
     // partition lane data into lane data relevant at current turn and at next turn
     std::pair<TurnLaneHandler::LaneDataVector, TurnLaneHandler::LaneDataVector> partitionLaneData(
@@ -67,7 +69,8 @@ class TurnLaneHandler
     // intersection whose turns might be related to this current intersection
     Intersection handleTurnAtPreviousIntersection(const NodeID at,
                                                   const EdgeID via_edge,
-                                                  Intersection intersection);
+                                                  Intersection intersection,
+                                                  LaneDataIdMap &id_map) const;
 };
 
 } // namespace lanes

--- a/include/extractor/guidance/turn_lane_matcher.hpp
+++ b/include/extractor/guidance/turn_lane_matcher.hpp
@@ -49,7 +49,7 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
                                         const LaneDataVector &lane_data,
                                         const util::NodeBasedDynamicGraph &node_based_graph,
                                         const LaneStringID lane_string_id,
-                                        LaneTupelIdMap &lane_tupel_to_string_id);
+                                        LaneDataIdMap &lane_data_to_id);
 
 } // namespace lanes
 } // namespace guidance

--- a/include/extractor/guidance/turn_lane_matcher.hpp
+++ b/include/extractor/guidance/turn_lane_matcher.hpp
@@ -2,11 +2,14 @@
 #define OSRM_EXTRACTOR_GUIDANCE_TURN_LANE_MATCHER_HPP_
 
 #include "extractor/guidance/intersection.hpp"
+#include "extractor/guidance/toolkit.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
 #include "extractor/guidance/turn_lane_data.hpp"
 
 #include "util/guidance/turn_lanes.hpp"
 #include "util/node_based_graph.hpp"
+
+#include <unordered_map>
 
 namespace osrm
 {
@@ -44,7 +47,9 @@ bool canMatchTrivially(const Intersection &intersection, const LaneDataVector &l
 // perform a trivial match on the turn lanes
 Intersection triviallyMatchLanesToTurns(Intersection intersection,
                                         const LaneDataVector &lane_data,
-                                        const util::NodeBasedDynamicGraph &node_based_graph);
+                                        const util::NodeBasedDynamicGraph &node_based_graph,
+                                        const LaneStringID lane_string_id,
+                                        LaneTupelIdMap &lane_tupel_to_string_id);
 
 } // namespace lanes
 } // namespace guidance

--- a/include/extractor/original_edge_data.hpp
+++ b/include/extractor/original_edge_data.hpp
@@ -17,18 +17,19 @@ struct OriginalEdgeData
 {
     explicit OriginalEdgeData(NodeID via_node,
                               unsigned name_id,
+                              LaneDataID lane_data_id,
                               guidance::TurnInstruction turn_instruction,
                               EntryClassID entry_classid,
                               TravelMode travel_mode)
         : via_node(via_node), name_id(name_id), entry_classid(entry_classid),
-          turn_instruction(turn_instruction), travel_mode(travel_mode)
+          lane_data_id(lane_data_id), turn_instruction(turn_instruction), travel_mode(travel_mode)
     {
     }
 
     OriginalEdgeData()
         : via_node(std::numeric_limits<unsigned>::max()),
           name_id(std::numeric_limits<unsigned>::max()), entry_classid(INVALID_ENTRY_CLASSID),
-          turn_instruction(guidance::TurnInstruction::INVALID()),
+          lane_data_id(INVALID_LANE_DATAID), turn_instruction(guidance::TurnInstruction::INVALID()),
           travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
     }
@@ -36,9 +37,12 @@ struct OriginalEdgeData
     NodeID via_node;
     unsigned name_id;
     EntryClassID entry_classid;
+    LaneDataID lane_data_id;
     guidance::TurnInstruction turn_instruction;
     TravelMode travel_mode;
 };
+
+static_assert(sizeof(OriginalEdgeData) == 16, "Increasing the size of OriginalEdgeData increases memory consumption");
 }
 }
 

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -29,6 +29,7 @@ struct SharedDataLayout
         GRAPH_EDGE_LIST,
         COORDINATE_LIST,
         OSM_NODE_ID_LIST,
+        LANE_DATA_ID,
         TURN_INSTRUCTION,
         ENTRY_CLASSID,
         TRAVEL_MODE,
@@ -49,6 +50,10 @@ struct SharedDataLayout
         BEARING_BLOCKS,
         BEARING_VALUES,
         ENTRY_CLASS,
+        TURN_LANE_DATA,
+        TURN_STRING_OFFSETS,
+        TURN_STRING_BLOCKS,
+        TURN_STRING_CHAR_LIST,
         NUM_BLOCKS
     };
 

--- a/include/storage/storage_config.hpp
+++ b/include/storage/storage_config.hpp
@@ -65,6 +65,8 @@ struct StorageConfig final
     boost::filesystem::path names_data_path;
     boost::filesystem::path properties_path;
     boost::filesystem::path intersection_class_path;
+    boost::filesystem::path turn_lane_data_path;
+    boost::filesystem::path turn_lane_string_path;
 };
 }
 }

--- a/include/util/guidance/turn_lanes.hpp
+++ b/include/util/guidance/turn_lanes.hpp
@@ -74,6 +74,7 @@ class LaneTupel
     }
 };
 
+using LaneTupelIdPair = std::pair<util::guidance::LaneTupel, LaneStringID>;
 } // namespace guidance
 } // namespace util
 } // namespace osrm

--- a/include/util/guidance/turn_lanes.hpp
+++ b/include/util/guidance/turn_lanes.hpp
@@ -65,21 +65,17 @@ class LaneTupel
     LaneID lanes_in_turn;
     LaneID first_lane_from_the_right;
 
-    friend std::size_t std::hash<LaneTupel>::operator()(const LaneTupel &) const;
+    friend std::size_t hash_value(const LaneTupel &tup)
+    {
+        std::size_t seed{0};
+        boost::hash_combine(seed, tup.lanes_in_turn);
+        boost::hash_combine(seed, tup.first_lane_from_the_right);
+        return seed;
+    }
 };
 
 } // namespace guidance
 } // namespace util
 } // namespace osrm
-
-// make Bearing Class hasbable
-namespace std
-{
-inline size_t hash<::osrm::util::guidance::LaneTupel>::
-operator()(const ::osrm::util::guidance::LaneTupel &lane_tupel) const
-{
-    return boost::hash_value(*reinterpret_cast<const std::uint16_t *>(&lane_tupel));
-}
-} // namespace std
 
 #endif /* OSRM_UTIL_GUIDANCE_TURN_LANES_HPP */

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -60,9 +60,11 @@ using NameID = std::uint32_t;
 using EdgeWeight = int;
 
 using LaneStringID = std::uint16_t;
+static const LaneStringID INVALID_LANE_STRINGID = std::numeric_limits<LaneStringID>::max();
 using LaneID = std::uint8_t;
 static const LaneID INVALID_LANEID = std::numeric_limits<LaneID>::max();
-static const LaneStringID INVALID_LANE_STRINGID = std::numeric_limits<LaneStringID>::max();
+using LaneDataID = std::uint16_t;
+static const LaneDataID INVALID_LANE_DATAID = std::numeric_limits<LaneStringID>::max();
 
 using BearingClassID = std::uint32_t;
 static const BearingClassID INVALID_BEARING_CLASSID = std::numeric_limits<BearingClassID>::max();

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/optional.hpp>
+#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -63,7 +64,7 @@ inline bool isValidModifier(const guidance::StepManeuver maneuver)
 
 inline bool hasValidLanes(const guidance::StepManeuver maneuver)
 {
-    return maneuver.instruction.lane_tupel.lanes_in_turn > 0;
+    return maneuver.lanes.lanes_in_turn > 0;
 }
 
 std::string instructionTypeToString(const TurnType::Enum type)
@@ -71,12 +72,31 @@ std::string instructionTypeToString(const TurnType::Enum type)
     return turn_type_names[static_cast<std::size_t>(type)];
 }
 
-util::json::Array laneArrayFromLaneTupe(const util::guidance::LaneTupel lane_tupel)
+util::json::Array lanesFromManeuver(const guidance::StepManeuver &maneuver)
 {
-    BOOST_ASSERT(lane_tupel.lanes_in_turn >= 1);
+    BOOST_ASSERT(maneuver.lanes.lanes_in_turn >= 1);
     util::json::Array result;
-    for (LaneID i = 0; i < lane_tupel.lanes_in_turn; ++i)
-        result.values.push_back(lane_tupel.first_lane_from_the_right + i);
+    LaneID lane_id = 0;
+    typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+    boost::char_separator<char> sep("|","",boost::keep_empty_tokens);
+    tokenizer tokens(maneuver.turn_lane_string, sep);
+
+    lane_id = std::distance(tokens.begin(),tokens.end());
+
+    for (auto iter = tokens.begin(); iter != tokens.end(); ++iter)
+    {
+        --lane_id;
+        util::json::Object lane;
+        lane.values["marked"] = (iter->empty() ? "none" : *iter);
+        if (lane_id >= maneuver.lanes.first_lane_from_the_right &&
+            lane_id < maneuver.lanes.first_lane_from_the_right + maneuver.lanes.lanes_in_turn)
+            lane.values["take"] = util::json::True();
+        else
+            lane.values["take"] = util::json::False();
+
+        result.values.push_back(lane);
+    }
+
     return result;
 }
 
@@ -162,8 +182,7 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
             detail::instructionModifierToString(maneuver.instruction.direction_modifier);
 
     if (detail::hasValidLanes(maneuver))
-        step_maneuver.values["lanes"] =
-            detail::laneArrayFromLaneTupe(maneuver.instruction.lane_tupel);
+        step_maneuver.values["lanes"] = detail::lanesFromManeuver(maneuver);
 
     step_maneuver.values["location"] = detail::coordinateToLonLat(maneuver.location);
     step_maneuver.values["bearing_before"] = std::round(maneuver.bearing_before);

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -182,6 +182,7 @@ void EdgeBasedGraphFactory::FlushVectorToStream(
 }
 
 void EdgeBasedGraphFactory::Run(const std::string &original_edge_data_filename,
+                                const std::string &turn_lane_data_filename,
                                 lua_State *lua_state,
                                 const std::string &edge_segment_lookup_filename,
                                 const std::string &edge_penalty_filename,
@@ -198,6 +199,7 @@ void EdgeBasedGraphFactory::Run(const std::string &original_edge_data_filename,
 
     TIMER_START(generate_edges);
     GenerateEdgeExpandedEdges(original_edge_data_filename,
+                              turn_lane_data_filename,
                               lua_state,
                               edge_segment_lookup_filename,
                               edge_penalty_filename,
@@ -296,6 +298,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedNodes()
 /// Actually it also generates OriginalEdgeData and serializes them...
 void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     const std::string &original_edge_data_filename,
+    const std::string &turn_lane_data_filename,
     lua_State *lua_state,
     const std::string &edge_segment_lookup_filename,
     const std::string &edge_fixed_penalties_filename,
@@ -348,6 +351,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     bearing_class_by_node_based_node.resize(m_node_based_graph->GetNumberOfNodes(),
                                             std::numeric_limits<std::uint32_t>::max());
 
+    guidance::LaneDataIdMap lane_data_map;
     for (const auto node_u : util::irange(0u, m_node_based_graph->GetNumberOfNodes()))
     {
         progress.PrintStatus(node_u);
@@ -364,8 +368,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
             intersection =
                 turn_analysis.assignTurnTypes(node_u, edge_from_u, std::move(intersection));
 
-            intersection =
-                turn_lane_handler.assignTurnLanes(node_u, edge_from_u, std::move(intersection));
+            intersection = turn_lane_handler.assignTurnLanes(
+                node_u, edge_from_u, std::move(intersection), lane_data_map);
             const auto possible_turns = turn_analysis.transformIntersectionIntoTurns(intersection);
 
             // the entry class depends on the turn, so we have to classify the interesction for
@@ -437,6 +441,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                 original_edge_data_vector.emplace_back(
                     m_compressed_edge_container.GetPositionForID(edge_from_u),
                     edge_data1.name_id,
+                    turn.lane_data_id,
                     turn_instruction,
                     entry_class_id,
                     edge_data1.travel_mode);
@@ -540,6 +545,22 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
     util::SimpleLogger().Write() << "Created " << entry_class_hash.size() << " entry classes and "
                                  << bearing_class_hash.size() << " Bearing Classes";
+
+    util::SimpleLogger().Write() << "Writing Turn Lane Data to File...";
+    std::ofstream turn_lane_data_file(turn_lane_data_filename.c_str(), std::ios::binary);
+    std::vector<util::guidance::LaneTupelIdPair> lane_data(lane_data_map.size());
+    // extract lane data sorted by ID
+    for (auto itr : lane_data_map)
+        lane_data[itr.second] = itr.first;
+
+    std::uint64_t size = lane_data.size();
+    turn_lane_data_file.write(reinterpret_cast<const char*>(&size),sizeof(size));
+
+    if (!lane_data.empty())
+        turn_lane_data_file.write(reinterpret_cast<const char *>(&lane_data[0]),
+                                  sizeof(util::guidance::LaneTupelIdPair) * lane_data.size());
+
+    util::SimpleLogger().Write() << "done.";
 
     FlushVectorToStream(edge_data_file, original_edge_data_vector);
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -239,7 +239,7 @@ int Extractor::run()
         extraction_containers.PrepareData(config.output_file_name,
                                           config.restriction_file_name,
                                           config.names_file_name,
-                                          config.turn_lane_file_name,
+                                          config.turn_lane_strings_file_name,
                                           main_context.state);
 
         WriteProfileProperties(config.profile_properties_output_path, main_context.properties);
@@ -504,7 +504,7 @@ Extractor::BuildEdgeExpandedGraph(lua_State *lua_state,
     compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
 
     util::NameTable name_table(config.names_file_name);
-    util::NameTable turn_lanes(config.turn_lane_file_name);
+    util::NameTable turn_lanes(config.turn_lane_strings_file_name);
 
     EdgeBasedGraphFactory edge_based_graph_factory(
         node_based_graph,
@@ -518,6 +518,7 @@ Extractor::BuildEdgeExpandedGraph(lua_State *lua_state,
         turn_lanes);
 
     edge_based_graph_factory.Run(config.edge_output_path,
+                                 config.turn_lane_data_file_name,
                                  lua_state,
                                  config.edge_segment_lookup_path,
                                  config.edge_penalty_path,

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -149,9 +149,17 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
     // Otherwise fetches the id based on the name and returns it without insertion.
 
     const constexpr auto MAX_STRING_LENGTH = 255u;
-    const auto requestId = [this,MAX_STRING_LENGTH](const std::string turn_lane_string) {
-        if( turn_lane_string == "" )
+    const auto requestId = [this,MAX_STRING_LENGTH](const std::string &turn_lane_string_) {
+        if( turn_lane_string_ == "" )
             return INVALID_LANE_STRINGID;
+
+        //requires https://github.com/cucumber/cucumber-js/issues/417
+        //remove this handling when the issue is contained
+        std::string turn_lane_string = turn_lane_string_;
+        for( auto & val : turn_lane_string )
+            if( val == '&' )
+                val = '|';
+
         const auto &lane_map_iterator = lane_map.find(turn_lane_string);
         if (lane_map.end() == lane_map_iterator)
         {

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -25,9 +25,7 @@ std::string toString(const ConnectedRoad &road)
     result +=
         std::to_string(static_cast<std::int32_t>(road.turn.instruction.type)) + " " +
         std::to_string(static_cast<std::int32_t>(road.turn.instruction.direction_modifier)) + " " +
-        std::to_string(static_cast<std::int32_t>(road.turn.instruction.lane_tupel.lanes_in_turn)) +
-        " " + std::to_string(static_cast<std::int32_t>(
-                  road.turn.instruction.lane_tupel.first_lane_from_the_right));
+        std::to_string(static_cast<std::int32_t>(road.turn.lane_data_id));
     return result;
 }
 

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -114,9 +114,12 @@ Intersection IntersectionGenerator::getConnectedRoads(const NodeID from_node,
                 has_uturn_edge = true;
         }
 
-        intersection.push_back(ConnectedRoad(
-            TurnOperation{onto_edge, angle, {TurnType::Invalid, DirectionModifier::UTurn}},
-            turn_is_valid));
+        intersection.push_back(
+            ConnectedRoad(TurnOperation{onto_edge,
+                                        angle,
+                                        {TurnType::Invalid, DirectionModifier::UTurn},
+                                        INVALID_LANE_DATAID},
+                          turn_is_valid));
     }
 
     // We hit the case of a street leading into nothing-ness. Since the code here assumes that this
@@ -124,7 +127,9 @@ Intersection IntersectionGenerator::getConnectedRoads(const NodeID from_node,
     if (!has_uturn_edge)
     {
         intersection.push_back(
-            {TurnOperation{via_eid, 0., {TurnType::Invalid, DirectionModifier::UTurn}}, false});
+            {TurnOperation{
+                 via_eid, 0., {TurnType::Invalid, DirectionModifier::UTurn}, INVALID_LANE_DATAID},
+             false});
     }
 
     const auto ByAngle = [](const ConnectedRoad &first, const ConnectedRoad second) {

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -52,8 +52,7 @@ LaneDataVector laneDataFromString(std::string turn_lane_string)
     // count the number of lanes
     const auto num_lanes = [](const std::string &turn_lane_string) {
         return boost::numeric_cast<LaneID>(
-            std::count(turn_lane_string.begin(), turn_lane_string.end(), '|') + 1 +
-            std::count(turn_lane_string.begin(), turn_lane_string.end(), '&'));
+            std::count(turn_lane_string.begin(), turn_lane_string.end(), '|') + 1);
     }(turn_lane_string);
 
     const auto getNextTag = [](std::string &string, const char *separators) {
@@ -103,7 +102,7 @@ LaneDataVector laneDataFromString(std::string turn_lane_string)
         // FIXME this is a cucumber workaround, since escaping does not work properly in
         // cucumber.js (see https://github.com/cucumber/cucumber-js/issues/417). Needs to be
         // changed to "|" only, when the bug is fixed
-        auto lane = getNextTag(turn_lane_string, "|&");
+        auto lane = getNextTag(turn_lane_string, "|");
         setLaneData(lane_map, lane, lane_nr);
         ++lane_nr;
     } while (lane_nr < num_lanes);

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -1,7 +1,7 @@
+#include "extractor/guidance/turn_lane_handler.hpp"
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/turn_discovery.hpp"
 #include "extractor/guidance/turn_lane_augmentation.hpp"
-#include "extractor/guidance/turn_lane_handler.hpp"
 #include "extractor/guidance/turn_lane_matcher.hpp"
 #include "util/simple_logger.hpp"
 #include "util/typedefs.hpp"
@@ -56,9 +56,8 @@ TurnLaneHandler::TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_g
     with a string like  |left|through;right|right| and performs an assignment onto the turns:
     for example: (130, turn slight right), (180, ramp straight), (320, turn sharp left)
  */
-Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
-                                              const EdgeID via_edge,
-                                              Intersection intersection) const
+Intersection
+TurnLaneHandler::assignTurnLanes(const NodeID at, const EdgeID via_edge, Intersection intersection)
 {
     // initialize to invalid
     for (auto &road : intersection)
@@ -117,7 +116,7 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
     if (is_simple)
     {
         lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-        return simpleMatchTuplesToTurns(std::move(intersection), lane_data);
+        return simpleMatchTuplesToTurns(std::move(intersection), lane_data, data.lane_string_id);
     }
     // if the intersection is not simple but we have lane data, we check for intersections with
     // middle islands. We have two cases. The first one is providing lane data on the current
@@ -137,7 +136,8 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
                 isSimpleIntersection(lane_data, intersection))
             {
                 lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-                return simpleMatchTuplesToTurns(std::move(intersection), lane_data);
+                return simpleMatchTuplesToTurns(
+                    std::move(intersection), lane_data, data.lane_string_id);
             }
         }
     }
@@ -157,11 +157,13 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
 // actually take the turn, we need to look back to the edge we drove onto the intersection with.
 Intersection TurnLaneHandler::handleTurnAtPreviousIntersection(const NodeID at,
                                                                const EdgeID via_edge,
-                                                               Intersection intersection) const
+                                                               Intersection intersection)
 {
     NodeID previous_node = SPECIAL_NODEID;
     Intersection previous_intersection;
     EdgeID previous_id = SPECIAL_EDGEID;
+
+    const auto &previous_data = node_based_graph.GetEdgeData(previous_id);
 
     // Get the previous lane string. We only accept strings that stem from a not-simple intersection
     // and are not empty.
@@ -175,8 +177,6 @@ Intersection TurnLaneHandler::handleTurnAtPreviousIntersection(const NodeID at,
                                       previous_id,
                                       previous_intersection))
             return "";
-
-        const auto &previous_data = node_based_graph.GetEdgeData(previous_id);
         auto previous_string = previous_data.lane_string_id != INVALID_LANE_STRINGID
                                    ? turn_lane_strings.GetNameForID(previous_data.lane_string_id)
                                    : "";
@@ -207,7 +207,8 @@ Intersection TurnLaneHandler::handleTurnAtPreviousIntersection(const NodeID at,
     if (is_simple)
     {
         lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-        return simpleMatchTuplesToTurns(std::move(intersection), lane_data);
+        return simpleMatchTuplesToTurns(
+            std::move(intersection), lane_data, previous_data.lane_string_id);
     }
     else
     {
@@ -226,7 +227,8 @@ Intersection TurnLaneHandler::handleTurnAtPreviousIntersection(const NodeID at,
                 isSimpleIntersection(lane_data, intersection))
             {
                 lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-                return simpleMatchTuplesToTurns(std::move(intersection), lane_data);
+                return simpleMatchTuplesToTurns(
+                    std::move(intersection), lane_data, previous_data.lane_string_id);
             }
         }
     }
@@ -484,7 +486,8 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
 }
 
 Intersection TurnLaneHandler::simpleMatchTuplesToTurns(Intersection intersection,
-                                                       const LaneDataVector &lane_data) const
+                                                       const LaneDataVector &lane_data,
+                                                       const LaneStringID lane_string_id)
 {
     if (lane_data.empty() || !canMatchTrivially(intersection, lane_data))
         return std::move(intersection);
@@ -494,7 +497,8 @@ Intersection TurnLaneHandler::simpleMatchTuplesToTurns(Intersection intersection
                      return boost::starts_with(data.tag, "merge");
                  }) == 0);
 
-    return triviallyMatchLanesToTurns(std::move(intersection), lane_data, node_based_graph);
+    return triviallyMatchLanesToTurns(
+        std::move(intersection), lane_data, node_based_graph, lane_string_id, lane_tupels);
 }
 
 } // namespace lanes

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -174,7 +174,7 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
                                         const LaneDataVector &lane_data,
                                         const util::NodeBasedDynamicGraph &node_based_graph,
                                         const LaneStringID lane_string_id,
-                                        LaneTupelIdMap &lane_tupel_to_string_id)
+                                        LaneDataIdMap &lane_data_to_id)
 {
     std::size_t road_index = 1, lane = 0;
     for (; road_index < intersection.size() && lane < lane_data.size(); ++road_index)
@@ -194,19 +194,18 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
                 {LaneID(lane_data[lane].to - lane_data[lane].from + 1), lane_data[lane].from},
                 lane_string_id};
 
-            auto lane_tupel_id = boost::numeric_cast<std::uint16_t>(lane_tupel_to_string_id.size());
-            const auto it = lane_tupel_to_string_id.find(key);
+            auto lane_data_id = boost::numeric_cast<LaneDataID>(lane_data_to_id.size());
+            const auto it = lane_data_to_id.find(key);
 
-            if (it == lane_tupel_to_string_id.end())
-                lane_tupel_to_string_id.insert({key, lane_tupel_id});
+            if (it == lane_data_to_id.end())
+                lane_data_to_id.insert({key, lane_data_id});
             else
-                lane_tupel_id = it->second;
-
-            // TODO: remove when we're done with the switch to ids
-            intersection[road_index].turn.instruction.lane_tupel = key.first;
+                lane_data_id = it->second;
 
             // set lane id instead after the switch:
-            intersection[road_index].turn.instruction.lane_tupel_id = lane_tupel_id;
+            intersection[road_index].turn.lane_data_id = lane_data_id;
+
+            std::cout << "Hashed: " << (int)lane_data[lane].from << " " << (int)lane_data[lane].to << " " << (int)lane_string_id << " to " << (int)lane_data_id << std::endl;
 
             ++lane;
         }
@@ -236,19 +235,18 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
             {LaneID(lane_data.back().to - lane_data.back().from + 1), lane_data.back().from},
             lane_string_id};
 
-        auto lane_tupel_id = boost::numeric_cast<std::uint16_t>(lane_tupel_to_string_id.size());
-        const auto it = lane_tupel_to_string_id.find(key);
+        auto lane_data_id = boost::numeric_cast<std::uint16_t>(lane_data_to_id.size());
+        const auto it = lane_data_to_id.find(key);
 
-        if (it == lane_tupel_to_string_id.end())
-            lane_tupel_to_string_id.insert({key, lane_tupel_id});
+        if (it == lane_data_to_id.end())
+            lane_data_to_id.insert({key, lane_data_id});
         else
-            lane_tupel_id = it->second;
+            lane_data_id = it->second;
 
-        // TODO: remove when we're done with the switch to ids
-        intersection[u_turn].turn.instruction.lane_tupel = key.first;
+        std::cout << "Hashed: " << (int)lane_data[lane].from << " " << (int)lane_data[lane].to << " " << (int)lane_string_id << " to " << (int)lane_data_id << std::endl;
 
         // set lane id instead after the switch:
-        intersection[road_index].turn.instruction.lane_tupel_id = lane_tupel_id;
+        intersection[u_turn].turn.lane_data_id = lane_data_id;
     }
     return std::move(intersection);
 }

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -1,8 +1,11 @@
-#include "extractor/guidance/toolkit.hpp"
 #include "extractor/guidance/turn_lane_matcher.hpp"
+#include "extractor/guidance/toolkit.hpp"
 #include "util/guidance/toolkit.hpp"
 
 #include <boost/assert.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+
+#include <functional>
 
 namespace osrm
 {
@@ -169,7 +172,9 @@ bool canMatchTrivially(const Intersection &intersection, const LaneDataVector &l
 
 Intersection triviallyMatchLanesToTurns(Intersection intersection,
                                         const LaneDataVector &lane_data,
-                                        const util::NodeBasedDynamicGraph &node_based_graph)
+                                        const util::NodeBasedDynamicGraph &node_based_graph,
+                                        const LaneStringID lane_string_id,
+                                        LaneTupelIdMap &lane_tupel_to_string_id)
 {
     std::size_t road_index = 1, lane = 0;
     for (; road_index < intersection.size() && lane < lane_data.size(); ++road_index)
@@ -185,8 +190,24 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
             if (TurnType::Suppressed == intersection[road_index].turn.instruction.type)
                 intersection[road_index].turn.instruction.type = TurnType::UseLane;
 
-            intersection[road_index].turn.instruction.lane_tupel = {
-                LaneID(lane_data[lane].to - lane_data[lane].from + 1), lane_data[lane].from};
+            LaneTupelIdPair key{
+                {LaneID(lane_data[lane].to - lane_data[lane].from + 1), lane_data[lane].from},
+                lane_string_id};
+
+            auto lane_tupel_id = boost::numeric_cast<std::uint16_t>(lane_tupel_to_string_id.size());
+            const auto it = lane_tupel_to_string_id.find(key);
+
+            if (it == lane_tupel_to_string_id.end())
+                lane_tupel_to_string_id.insert({key, lane_tupel_id});
+            else
+                lane_tupel_id = it->second;
+
+            // TODO: remove when we're done with the switch to ids
+            intersection[road_index].turn.instruction.lane_tupel = key.first;
+
+            // set lane id instead after the switch:
+            intersection[road_index].turn.instruction.lane_tupel_id = lane_tupel_id;
+
             ++lane;
         }
     }
@@ -209,8 +230,25 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
         intersection[u_turn].entry_allowed = true;
         intersection[u_turn].turn.instruction.type = TurnType::Turn;
         intersection[u_turn].turn.instruction.direction_modifier = DirectionModifier::UTurn;
-        intersection[u_turn].turn.instruction.lane_tupel = {
-            LaneID(lane_data.back().to - lane_data.back().from + 1), lane_data.back().from};
+
+        // TODO: code dup. with above, refactor
+        LaneTupelIdPair key{
+            {LaneID(lane_data.back().to - lane_data.back().from + 1), lane_data.back().from},
+            lane_string_id};
+
+        auto lane_tupel_id = boost::numeric_cast<std::uint16_t>(lane_tupel_to_string_id.size());
+        const auto it = lane_tupel_to_string_id.find(key);
+
+        if (it == lane_tupel_to_string_id.end())
+            lane_tupel_to_string_id.insert({key, lane_tupel_id});
+        else
+            lane_tupel_id = it->second;
+
+        // TODO: remove when we're done with the switch to ids
+        intersection[u_turn].turn.instruction.lane_tupel = key.first;
+
+        // set lane id instead after the switch:
+        intersection[road_index].turn.instruction.lane_tupel_id = lane_tupel_id;
     }
     return std::move(intersection);
 }

--- a/src/storage/storage_config.cpp
+++ b/src/storage/storage_config.cpp
@@ -16,7 +16,8 @@ StorageConfig::StorageConfig(const boost::filesystem::path &base)
       datasource_names_path{base.string() + ".datasource_names"},
       datasource_indexes_path{base.string() + ".datasource_indexes"},
       names_data_path{base.string() + ".names"}, properties_path{base.string() + ".properties"},
-      intersection_class_path{base.string() + ".icd"}
+      intersection_class_path{base.string() + ".icd"}, turn_lane_data_path{base.string() + ".tld"},
+      turn_lane_string_path{base.string() + ".tls"}
 {
 }
 

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -180,6 +180,10 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     BearingClassID GetBearingClassID(const NodeID /*id*/) const override { return 0; };
     EntryClassID GetEntryClassID(const EdgeID /*id*/) const override { return 0; }
 
+    bool hasLaneData(const EdgeID id) const { return true; };
+    util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const { return {{0, 0}, 0}; }
+    std::string GetTurnStringForID(const LaneStringID lane_string_id) const { return ""; };
+
     util::guidance::BearingClass
     GetBearingClass(const BearingClassID /*bearing_class_id*/) const override
     {


### PR DESCRIPTION
At the moment we only expose lane information for lanes in turns we take.

The goal of this changeset is to extend the API in order to expose all available lane information.

This can be used to show the user both: all lanes available as well as lanes in the shortest route.

------------------------------------------------------------------------------------------------

Tasks:
- [X] deduplicate OSM lane string ids and lane tuples
- [X] introduce lane tuple id instead of storing lane tuple
- [x] serialize out this mapping in ebgf
- [x] load in datafacades and provide accessors
- [ ] expose in library API as turns attribute
- [ ] pull through routed server
- [ ] rewrite cucumber support code
- [ ] refactor