### PR TITLE
Show user hint on wrong Node.js version, fixes #2435.

### DIFF
--- a/scripts/poly2req.js
+++ b/scripts/poly2req.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-let fs = require('fs');
+let fs = require('fs');  // Node 4.x required!
 
 let VERSION = "route_5.0";
 let SAMPLE_SIZE = 20;


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/2435.

This is more of a hack but looks like the best we can do.

The reason for this is the following:

1/ we require strict mode for our v4 script

2/ v0.10 in strict mode marks 'let' as a reserved keyword,
   aborting before execution **any** code in the script. Thus,
   we can't assert e.g. on process.versions['node'] !== '4'.