### PR TITLE
Let Travis fail fast if CMake/Clang download fails, fixes #2433

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,13 +129,13 @@ before_install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - export PATH=${DEPS_DIR}/bin:${PATH} && mkdir -p ${DEPS_DIR}
   - CMAKE_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/cmake/3.5.2.tar.gz"
-  - travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}
+  - travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR} || exit 1
   - |
     if [[ ${CLANG_VERSION:-false} != false ]]; then
       export CCOMPILER='clang'
       export CXXCOMPILER='clang++'
       CLANG_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/clang/${CLANG_VERSION}.tar.gz"
-      travis_retry wget --quiet -O - ${CLANG_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}
+      travis_retry wget --quiet -O - ${CLANG_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR} || exit 1
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/2433.