### PR TITLE
Add support for building on circleci

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+function dep() {
+    ./.mason/mason install $1 $2
+    # the rm here is to workaround https://github.com/mapbox/mason/issues/230
+    rm -f ./mason_packages/.link/mason.ini
+    ./.mason/mason link $1 $2
+}
+
+function all_deps() {
+    FAIL=0
+    dep lua 5.3.0 &
+    dep luabind e414c57bcb687bb3091b7c55bbff6947f052e46b &
+    dep boost 1.61.0 &
+    dep boost_libatomic 1.61.0 &
+    dep boost_libchrono 1.61.0 &
+    dep boost_libsystem 1.61.0 &
+    dep boost_libthread 1.61.0 &
+    dep boost_libfilesystem 1.61.0 &
+    dep boost_libprogram_options 1.61.0 &
+    dep boost_libregex 1.61.0 &
+    dep boost_libiostreams 1.61.0 &
+    dep boost_libtest 1.61.0 &
+    dep boost_libdate_time 1.61.0 &
+    dep expat 2.1.1 &
+    dep stxxl 1.4.1 &
+    dep bzip2 1.0.6 &
+    dep zlib system &
+    dep tbb 43_20150316 &
+    for job in $(jobs -p)
+    do
+        wait $job || let "FAIL+=1"
+    done
+    if [[ "$FAIL" != "0" ]]; then
+        exit ${FAIL}
+    fi
+}
+
+function main() {
+    # setup mason and deps
+    ./scripts/setup_mason.sh
+    all_deps
+}
+
+main
+
+set +eu
+set +o pipefail

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,32 +11,24 @@ function dep() {
 }
 
 function all_deps() {
-    FAIL=0
-    dep lua 5.3.0 &
-    dep luabind e414c57bcb687bb3091b7c55bbff6947f052e46b &
-    dep boost 1.61.0 &
-    dep boost_libatomic 1.61.0 &
-    dep boost_libchrono 1.61.0 &
-    dep boost_libsystem 1.61.0 &
-    dep boost_libthread 1.61.0 &
-    dep boost_libfilesystem 1.61.0 &
-    dep boost_libprogram_options 1.61.0 &
-    dep boost_libregex 1.61.0 &
-    dep boost_libiostreams 1.61.0 &
-    dep boost_libtest 1.61.0 &
-    dep boost_libdate_time 1.61.0 &
-    dep expat 2.1.1 &
-    dep stxxl 1.4.1 &
-    dep bzip2 1.0.6 &
-    dep zlib system &
-    dep tbb 43_20150316 &
-    for job in $(jobs -p)
-    do
-        wait $job || let "FAIL+=1"
-    done
-    if [[ "$FAIL" != "0" ]]; then
-        exit ${FAIL}
-    fi
+    dep lua 5.3.0
+    dep luabind e414c57bcb687bb3091b7c55bbff6947f052e46b
+    dep boost 1.61.0
+    dep boost_libatomic 1.61.0
+    dep boost_libchrono 1.61.0
+    dep boost_libsystem 1.61.0
+    dep boost_libthread 1.61.0
+    dep boost_libfilesystem 1.61.0
+    dep boost_libprogram_options 1.61.0
+    dep boost_libregex 1.61.0
+    dep boost_libiostreams 1.61.0
+    dep boost_libtest 1.61.0
+    dep boost_libdate_time 1.61.0
+    dep expat 2.1.1
+    dep stxxl 1.4.1
+    dep bzip2 1.0.6
+    dep zlib system
+    dep tbb 43_20150316
 }
 
 function main() {

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,41 @@
+machine:
+  xcode:
+    version: 7.3
+  environment:
+    XCODE_SCHEME: "no"
+    XCODE_WORKSPACE: "no"
+    CCACHE_COMPRESS: 1
+    CCACHE_TEMPDIR: /tmp/.ccache-temp
+
+dependencies:
+  cache_directories:
+    - '~/.ccache'
+    - '~/.apt-cache'
+    - 'test/data'
+  pre:
+    - |
+      if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "Setting up apt-cache on linux"
+        # https://discuss.circleci.com/t/add-ability-to-cache-apt-get-programs/598/3
+        sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get update -y
+        echo "Installing apt deps"
+        sudo apt-get install -y libstdc++-5-dev pkg-config wget
+      else
+        brew install pkg-config wget || true
+      fi
+
+  override:
+    - which ccache
+    - ccache -s
+    - |
+      if [[ "$(uname -s)" == "Linux" ]]; then
+        JOBS=2 ./scripts/ci-build.sh $(pwd)/local-install
+      else
+        JOBS=4 ./scripts/ci-build.sh $(pwd)/local-install
+      fi
+
+test:
+  override:
+    - echo "success"

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+if [[ ${1:-false} == false ]]; then
+    echo "please provide install prefix as first arg"
+    exit 1
+fi
+
+INSTALL_PREFIX=$(realpath $1)
+
+export CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# ensure we start inside the osrm-backend directory (one level up)
+cd ${CURRENT_DIR}/../
+
+if [[ `which pkg-config` ]]; then
+    echo "Success: Found pkg-config";
+else
+    echo "echo you need pkg-config installed";
+    exit 1;
+fi;
+
+export MASON_HOME=$(pwd)/mason_packages/.link
+
+function install_build_deps() {
+    export CCACHE_VERSION="3.2.4"
+    export CMAKE_VERSION="3.5.2"
+    export CLANG_VERSION="3.8.0"
+    ./.mason/mason install ccache ${CCACHE_VERSION}
+    ./.mason/mason install cmake ${CMAKE_VERSION}
+    ./.mason/mason install clang ${CLANG_VERSION}
+    export PATH=$(./.mason/mason prefix ccache ${CCACHE_VERSION})/bin:${PATH}
+    export CMAKE_PATH=$(./.mason/mason prefix cmake ${CMAKE_VERSION})/bin
+    export PATH=$(./.mason/mason prefix clang ${CLANG_VERSION})/bin:${PATH}
+    export CC=clang-3.8
+    export CXX=clang++-3.8
+}
+
+function main() {
+    export BUILD_DIR="$(pwd)/build"
+    if [[ -d "${BUILD_DIR}" ]]; then
+        echo "${BUILD_DIR} already exists, please delete before re-running"
+        exit 1
+    fi
+    # setup mason and deps
+    ./bootstrap.sh
+    source ./scripts/install_node.sh 4
+    npm install
+    install_build_deps
+    export CMAKE_EXTRA_ARGS=""
+    if [[ ${AR:-false} != false ]]; then
+        export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_AR=${AR}"
+    fi
+    if [[ ${RANLIB:-false} != false ]]; then
+        export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_RANLIB=${RANLIB}"
+    fi
+    if [[ ${NM:-false} != false ]]; then
+        export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_NM=${NM}"
+    fi
+    mkdir ${BUILD_DIR} && cd ${BUILD_DIR}
+    ${CMAKE_PATH}/cmake ../ -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+      -DCMAKE_CXX_COMPILER="${CXX}" \
+      -DBoost_NO_SYSTEM_PATHS=ON \
+      -DTBB_INSTALL_DIR=${MASON_HOME} \
+      -DCMAKE_INCLUDE_PATH=${MASON_HOME}/include \
+      -DCMAKE_LIBRARY_PATH=${MASON_HOME}/lib \
+      -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+      -DBoost_USE_STATIC_LIBS=ON \
+      -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
+      -DBUILD_TOOLS=1 \
+      -DENABLE_CCACHE=ON \
+      -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} \
+      -DCOVERAGE=${COVERAGE:-OFF} \
+      ${CMAKE_EXTRA_ARGS}
+
+    make --jobs=${JOBS} VERBOSE=1
+    make tests --jobs=${JOBS} VERBOSE=1
+    make benchmarks --jobs=${JOBS} VERBOSE=1
+    if [[ $(uname -s) == 'Linux' ]]; then
+        # make it possible to find libtbb shared libs at custom location
+        export LD_LIBRARY_PATH=${MASON_HOME}/lib:${LD_LIBRARY_PATH}
+    fi
+    # before installing, lets fix the tools and (if it exists) the libosrm shared lib
+    # for OS X so they can find the shared libtbb libs
+    # on OSX DYLD_LIBRARY_PATH does not work well (not inherited in shells)
+    # so to support libraries on custom paths we fix linking using install_name_tool
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        for tool in $(ls ${BUILD_DIR}/osrm-*); do
+          install_name_tool -change libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib ${tool}
+          install_name_tool -change libtbbmalloc.dylib ${MASON_HOME}/lib/libtbbmalloc.dylib ${tool}
+        done
+        if [[ -f ${BUILD_DIR}/libosrm.dylib ]]; then
+          install_name_tool -change libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib ${BUILD_DIR}/libosrm.dylib
+          install_name_tool -change libtbbmalloc.dylib ${MASON_HOME}/lib/libtbbmalloc.dylib ${BUILD_DIR}/libosrm.dylib
+        fi
+
+        # fix the local/non-installed unit tests
+        for tool in $(ls ${BUILD_DIR}/unit_tests/*-tests); do
+          install_name_tool -change libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib ${tool}
+          install_name_tool -change libtbbmalloc.dylib ${MASON_HOME}/lib/libtbbmalloc.dylib ${tool}
+        done
+    fi
+
+    make install
+    export PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib/pkgconfig
+    cd ../
+    rm -rf example/build
+    mkdir -p example/build
+    cd example/build
+    ${CMAKE_PATH}/cmake ../ -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+    make
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        # fix the example links
+        install_name_tool -change libosrm.dylib ${BUILD_DIR}/libosrm.dylib ./osrm-example
+        install_name_tool -change libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib ./osrm-example
+        install_name_tool -change libtbbmalloc.dylib ${MASON_HOME}/lib/libtbbmalloc.dylib ./osrm-example
+    fi
+    cd ../../
+    make -C test/data clean || true
+    make -C test/data
+    make -C test/data benchmark
+    ./example/build/osrm-example test/data/monaco.osrm
+    cd ${BUILD_DIR}
+    ./unit_tests/library-tests ../test/data/monaco.osrm
+    ./unit_tests/extractor-tests
+    ./unit_tests/engine-tests
+    ./unit_tests/util-tests
+    ./unit_tests/server-tests
+    cd ../
+    echo Y | ${BUILD_DIR}/osrm-springclean
+    npm test
+}
+
+main
+
+set +eu
+set +o pipefail

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -11,6 +11,8 @@ fi
 INSTALL_PREFIX=$(realpath $1)
 
 export CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export BUILD_TYPE=${BUILD_TYPE:-Debug}
+export JOBS=${JOBS:-2}
 
 # ensure we start inside the osrm-backend directory (one level up)
 cd ${CURRENT_DIR}/../

--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -1,9 +1,30 @@
-# here we set up the node version on the fly. currently only node 4, but can be used for more values if need be
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+if [[ ${1:-false} == 'false' ]]; then
+    echo "Error: pass node version as first argument"
+    exit 1
+fi
+
+NODE_VERSION=$1
+
+# if an existing nvm is already installed we need to unload it
+nvm unload || true
+
+# here we set up the node version on the fly based on the matrix value.
 # This is done manually so that the build works the same on OS X
-rm -rf ~/.nvm/ && git clone --depth 1 --branch v0.30.1 https://github.com/creationix/nvm.git ~/.nvm
-source ~/.nvm/nvm.sh
-nvm install $1
-nvm use $1
+rm -rf ./__nvm/ && git clone --depth 1 https://github.com/creationix/nvm.git ./__nvm
+# note: we must temporarily disable throwing on unbound
+# variables because nvm has them
+set +eu
+source ./__nvm/nvm.sh
+nvm install ${NODE_VERSION}
+nvm use ${NODE_VERSION}
+set -eu
 node --version
 npm --version
 which node
+set +eu
+set +o pipefail

--- a/scripts/setup_mason.sh
+++ b/scripts/setup_mason.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+# we pin the mason version to avoid changes in mason breaking builds
+MASON_VERSION="ecee686"
+
+function main() {
+    if [[ ! -d ./.mason ]]; then
+        echo "Cloning mason at https://github.com/mapbox/mason/commit/${MASON_VERSION}"
+        git clone https://github.com/mapbox/mason.git ./.mason
+        (cd ./.mason && git checkout ${MASON_VERSION})
+    else
+        echo "Updating to mason at https://github.com/mapbox/mason/commit/${MASON_VERSION}"
+        (cd ./.mason && git fetch && git pull || true && git checkout ${MASON_VERSION})
+    fi
+}
+
+main
+
+set +eu
+set +o pipefail


### PR DESCRIPTION
This adds a circle.yml and script to build osrm-backend on ubuntu with clang-3.8.

This is an experiment to enable us to ask questions like:
- How fast do builds run on circleci vs travis?
- Will we hit the circleci limits of the free account?
- How much might it cost to enable circle CI OS X builds?

Next actions:
- [ ] @TheMarex: Enable circleci to see if this passes (it should and if not, it should be very close to working as I verified a passing build under my personal account: https://circleci.com/gh/springmeyer/osrm-backend/11)
- [ ] After working, then we could try to get OS X working (should require very minimal changes)
