### PR TITLE
Prevent linker from discarding TBB symbols we need, fixes #2557

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ include_directories(SYSTEM ${OSRM_INCLUDE_PATHS})
 # Binaries
 target_link_libraries(osrm-datastore osrm_store ${Boost_LIBRARIES})
 target_link_libraries(osrm-extract osrm_extract ${Boost_LIBRARIES})
-target_link_libraries(osrm-contract osrm_contract ${Boost_LIBRARIES})
+target_link_libraries(osrm-contract ${Boost_LIBRARIES} ${TBB_LIBRARIES} osrm_contract)
 target_link_libraries(osrm-routed osrm ${Boost_LIBRARIES} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
 
 set(EXTRACTOR_LIBRARIES


### PR DESCRIPTION
We build `osrm_contract` (the library) linking in libtbb. We then
build `osrm-contract` (the binary) linking in `osrm_contract` (the
library).

Because we're only using TBB's `parallel_invoke` in the code for the
`osrm-contract` binary, it seems like the linker discards some symbols
in the `osrm_contract` library (since the library does not need them).

Therefore we have to link libtbb for the binary again. Even worse, the
order now matters: if we first link in `osrm_contract` and then libtbb,
we're still hitting the issue re. discarded symbols.

Therefore we first link in all dependencies (libtbb, libboost*), and
only then `osrm_contract`.

Strictly speaking, we probably have to do this for all of our binary
targets, or we will hit similar issues in the future.

-----------------------------------------------------------------------------------

I tested this in a Debian Jessie container, making sure it resolves #2557.