### PR TITLE
Fix segfault when route includes very short segments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.2.5
+  - Bugfixes
+    - Fixes a segfault caused by incorrect trimming logic for very short steps.
+
 # 5.2.4
   - Bugfixes:
     - Fixed in issue that arised on roundabouts in combination with intermediate intersections and sliproads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 project(OSRM C CXX)
 set(OSRM_VERSION_MAJOR 5)
 set(OSRM_VERSION_MINOR 2)
-set(OSRM_VERSION_PATCH 4)
+set(OSRM_VERSION_PATCH 5)
 
 # these two functions build up custom variables:
 #   OSRM_INCLUDE_PATHS and OSRM_DEFINES

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -17,7 +17,7 @@ module.exports = function () {
         this.setContractArgs(args, callback);
     });
 
-    this.Given(/^a grid size of (\d+) meters$/, (meters, callback) => {
+    this.Given(/^a grid size of ([0-9.]+) meters$/, (meters, callback) => {
         this.setGridSize(meters);
         callback();
     });

--- a/features/testbot/fixed.feature
+++ b/features/testbot/fixed.feature
@@ -24,3 +24,18 @@ Feature: Fixed bugs, kept to check for regressions
         When I route I should get
             | from | to | route   |
             | x    | y  | abc,abc |
+
+    Scenario: Step trimming with very short segments
+        Given a grid size of 0.1 meters
+        Given the node map
+            | a | 1 | b | c | d | 2 | e |
+
+        Given the ways
+            | nodes | oneway |
+            | ab    | yes    |
+            | bcd   | yes    |
+            | de    | yes    |
+
+        When I route I should get
+            | from | to | route     |
+            | 1    | 2  | bcd,bcd   |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -894,13 +894,13 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
     auto &next_to_last_step = *(steps.end() - 2);
     // in the end, the situation with the roundabout cannot occur. As a result, we can remove
     // all zero-length instructions
-    if (next_to_last_step.distance <= 1)
+    if (next_to_last_step.distance <= 1 && steps.size() > 2)
     {
         geometry.locations.pop_back();
         geometry.annotations.pop_back();
         geometry.osm_node_ids.pop_back();
         geometry.segment_offsets.pop_back();
-        BOOST_ASSERT(geometry.segment_distances.back() < 1);
+        BOOST_ASSERT(geometry.segment_distances.back() <= 1);
         geometry.segment_distances.pop_back();
 
         next_to_last_step.maneuver.waypoint_type = WaypointType::Arrive;


### PR DESCRIPTION
When trimming very short segments, there was some bad logic that lead to array-out-of-bounds access and segfaults.

Thanks to @MoKob for the assist on this one