### PR TITLE
Use mmap instead of read during edge weight updates.

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -40,8 +40,8 @@ int main(int argc, const char *argv[]) try
     RouteParameters params;
 
     // Route in monaco
-    params.coordinates.push_back({util::FloatLongitude(7.419758), util::FloatLatitude(43.731142)});
-    params.coordinates.push_back({util::FloatLongitude(7.419505), util::FloatLatitude(43.736825)});
+    params.coordinates.push_back({util::FloatLongitude{7.419758}, util::FloatLatitude{43.731142}});
+    params.coordinates.push_back({util::FloatLongitude{7.419505}, util::FloatLatitude{43.736825}});
 
     // Response is in JSON format
     json::Object result;

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -43,6 +43,34 @@ namespace osrm
 namespace extractor
 {
 
+namespace lookup
+{
+// Set to 1 byte alignment
+struct SegmentHeaderBlock
+{
+    std::uint32_t num_osm_nodes;
+    OSMNodeID previous_osm_node_id;
+} __attribute ((packed));
+static_assert(sizeof(SegmentHeaderBlock) == 12, "SegmentHeaderBlock is not packed correctly");
+
+struct SegmentBlock
+{
+    OSMNodeID this_osm_node_id;
+    double segment_length;
+    std::int32_t segment_weight;
+} __attribute ((packed));
+static_assert(sizeof(SegmentBlock) == 20, "SegmentBlock is not packed correctly");
+
+struct PenaltyBlock
+{
+    std::uint32_t fixed_penalty;
+    OSMNodeID from_id;
+    OSMNodeID via_id;
+    OSMNodeID to_id;
+} __attribute ((packed));
+static_assert(sizeof(PenaltyBlock) == 28, "PenaltyBlock is not packed correctly");
+}
+
 class EdgeBasedGraphFactory
 {
   public:

--- a/include/extractor/external_memory_node.hpp
+++ b/include/extractor/external_memory_node.hpp
@@ -5,6 +5,8 @@
 
 #include "util/typedefs.hpp"
 
+#include <cstdint>
+
 namespace osrm
 {
 namespace extractor
@@ -26,13 +28,13 @@ struct ExternalMemoryNode : QueryNode
     static ExternalMemoryNode min_value()
     {
         return ExternalMemoryNode(
-            util::FixedLongitude(0), util::FixedLatitude(0), MIN_OSM_NODEID, false, false);
+            util::FixedLongitude{0}, util::FixedLatitude{0}, MIN_OSM_NODEID, false, false);
     }
 
     static ExternalMemoryNode max_value()
     {
-        return ExternalMemoryNode(util::FixedLongitude(std::numeric_limits<int>::max()),
-                                  util::FixedLatitude(std::numeric_limits<int>::max()),
+        return ExternalMemoryNode(util::FixedLongitude{std::numeric_limits<std::int32_t>::max()},
+                                  util::FixedLatitude{std::numeric_limits<std::int32_t>::max()},
                                   MAX_OSM_NODEID,
                                   false,
                                   false);

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -68,8 +68,8 @@ struct InternalExtractorEdge
                                    bool is_split,
                                    LaneDescriptionID lane_description,
                                    guidance::RoadClassificationData road_classification)
-        : result(OSMNodeID(source),
-                 OSMNodeID(target),
+        : result(source,
+                 target,
                  name_id,
                  0,
                  forward,

--- a/include/extractor/query_node.hpp
+++ b/include/extractor/query_node.hpp
@@ -6,6 +6,7 @@
 #include "util/coordinate.hpp"
 
 #include <limits>
+#include <cstdint>
 
 namespace osrm
 {
@@ -15,16 +16,16 @@ namespace extractor
 struct QueryNode
 {
     using key_type = OSMNodeID; // type of NodeID
-    using value_type = int;     // type of lat,lons
+    using value_type = std::int32_t;     // type of lat,lons
 
     explicit QueryNode(const util::FixedLongitude lon_,
                        const util::FixedLatitude lat_,
-                       key_type node_id)
-        : lon(lon_), lat(lat_), node_id(std::move(node_id))
+                       const key_type node_id_)
+        : lon(lon_), lat(lat_), node_id(node_id_)
     {
     }
     QueryNode()
-        : lon(std::numeric_limits<int>::max()), lat(std::numeric_limits<int>::max()),
+        : lon{std::numeric_limits<value_type>::max()}, lat{std::numeric_limits<value_type>::max()},
           node_id(SPECIAL_OSM_NODEID)
     {
     }
@@ -35,15 +36,15 @@ struct QueryNode
 
     static QueryNode min_value()
     {
-        return QueryNode(util::FixedLongitude(-180 * COORDINATE_PRECISION),
-                         util::FixedLatitude(-90 * COORDINATE_PRECISION),
+        return QueryNode(util::FixedLongitude{static_cast<value_type>(-180 * COORDINATE_PRECISION)},
+                         util::FixedLatitude{static_cast<value_type>(-90 * COORDINATE_PRECISION)},
                          MIN_OSM_NODEID);
     }
 
     static QueryNode max_value()
     {
-        return QueryNode(util::FixedLongitude(180 * COORDINATE_PRECISION),
-                         util::FixedLatitude(90 * COORDINATE_PRECISION),
+        return QueryNode(util::FixedLongitude{static_cast<value_type>(180 * COORDINATE_PRECISION)},
+                         util::FixedLatitude{static_cast<value_type>(90 * COORDINATE_PRECISION)},
                          MAX_OSM_NODEID);
     }
 };

--- a/include/server/api/base_parameters_grammar.hpp
+++ b/include/server/api/base_parameters_grammar.hpp
@@ -115,8 +115,8 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
             (double_ > qi::lit(',') >
              double_)[qi::_val = ph::bind(
                           [](double lon, double lat) {
-                              return util::Coordinate(util::toFixed(util::FloatLongitude(lon)),
-                                                      util::toFixed(util::FloatLatitude(lat)));
+                              return util::Coordinate(util::toFixed(util::FloatLongitude{lon}),
+                                                      util::toFixed(util::FloatLatitude{lat}));
                           },
                           qi::_1,
                           qi::_2)];

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -61,7 +61,7 @@ inline FixedLatitude toFixed(const FloatLatitude floating)
 {
     const auto latitude = static_cast<double>(floating);
     const auto fixed = boost::numeric_cast<std::int32_t>(latitude * COORDINATE_PRECISION);
-    return FixedLatitude(fixed);
+    return FixedLatitude{fixed};
 }
 
 /**
@@ -75,7 +75,7 @@ inline FixedLongitude toFixed(const FloatLongitude floating)
 {
     const auto longitude = static_cast<double>(floating);
     const auto fixed = boost::numeric_cast<std::int32_t>(longitude * COORDINATE_PRECISION);
-    return FixedLongitude(fixed);
+    return FixedLongitude{fixed};
 }
 
 /**
@@ -89,7 +89,7 @@ inline FloatLatitude toFloating(const FixedLatitude fixed)
 {
     const auto latitude = static_cast<std::int32_t>(fixed);
     const auto floating = boost::numeric_cast<double>(latitude / COORDINATE_PRECISION);
-    return FloatLatitude(floating);
+    return FloatLatitude{floating};
 }
 
 /**
@@ -103,7 +103,7 @@ inline FloatLongitude toFloating(const FixedLongitude fixed)
 {
     const auto longitude = static_cast<std::int32_t>(fixed);
     const auto floating = boost::numeric_cast<double>(longitude / COORDINATE_PRECISION);
-    return FloatLongitude(floating);
+    return FloatLongitude{floating};
 }
 
 // fwd. decl.
@@ -127,7 +127,7 @@ struct Coordinate
     FixedLongitude lon;
     FixedLatitude lat;
 
-    Coordinate() : lon(std::numeric_limits<int>::min()), lat(std::numeric_limits<int>::min()) {}
+    Coordinate() : lon{std::numeric_limits<int>::min()}, lat{std::numeric_limits<int>::min()} {}
 
     Coordinate(const FloatCoordinate &other);
 
@@ -173,7 +173,7 @@ struct FloatCoordinate
     FloatLatitude lat;
 
     FloatCoordinate()
-        : lon(std::numeric_limits<double>::min()), lat(std::numeric_limits<double>::min())
+        : lon{std::numeric_limits<double>::min()}, lat{std::numeric_limits<double>::min()}
     {
     }
 

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -61,10 +61,10 @@ inline std::pair<double, FloatCoordinate> projectPointOnSegment(const FloatCoord
 
     return {clamped_ratio,
             {
-                FloatLongitude(1.0 - clamped_ratio) * source.lon +
-                    target.lon * FloatLongitude(clamped_ratio),
-                FloatLatitude(1.0 - clamped_ratio) * source.lat +
-                    target.lat * FloatLatitude(clamped_ratio),
+                FloatLongitude{1.0 - clamped_ratio} * source.lon +
+                    target.lon * FloatLongitude{clamped_ratio},
+                FloatLatitude{1.0 - clamped_ratio} * source.lat +
+                    target.lat * FloatLatitude{clamped_ratio},
             }};
 }
 

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -95,14 +95,14 @@ template <typename T, bool UseSharedMemory = false> class PackedVector
         if (left_index == 0)
         {
             // ID is at the far left side of this element
-            return static_cast<T>(elem >> (ELEMSIZE - BITSIZE));
+            return T{elem >> (ELEMSIZE - BITSIZE)};
         }
         else if (left_index >= BITSIZE)
         {
             // ID is entirely contained within this element
             const std::uint64_t at_right = elem >> (left_index - BITSIZE);
             const std::uint64_t left_mask = static_cast<std::uint64_t>(pow(2, BITSIZE)) - 1;
-            return static_cast<T>(at_right & left_mask);
+            return T{at_right & left_mask};
         }
         else
         {
@@ -114,7 +114,7 @@ template <typename T, bool UseSharedMemory = false> class PackedVector
             const std::uint64_t next_elem = static_cast<std::uint64_t>(vec.at(index + 1));
 
             const std::uint64_t right_side = next_elem >> (ELEMSIZE - (BITSIZE - left_index));
-            return static_cast<T>(left_side | right_side);
+            return T{left_side | right_side};
         }
     }
 

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -23,10 +23,10 @@ namespace util
 struct RectangleInt2D
 {
     RectangleInt2D()
-        : min_lon(std::numeric_limits<std::int32_t>::max()),
-          max_lon(std::numeric_limits<std::int32_t>::min()),
-          min_lat(std::numeric_limits<std::int32_t>::max()),
-          max_lat(std::numeric_limits<std::int32_t>::min())
+        : min_lon{std::numeric_limits<std::int32_t>::max()},
+          max_lon{std::numeric_limits<std::int32_t>::min()},
+          min_lat{std::numeric_limits<std::int32_t>::max()},
+          max_lat{std::numeric_limits<std::int32_t>::min()}
     {
     }
 
@@ -56,10 +56,10 @@ struct RectangleInt2D
         max_lon = std::max(max_lon, other.max_lon);
         min_lat = std::min(min_lat, other.min_lat);
         max_lat = std::max(max_lat, other.max_lat);
-        BOOST_ASSERT(min_lon != FixedLongitude(std::numeric_limits<std::int32_t>::min()));
-        BOOST_ASSERT(min_lat != FixedLatitude(std::numeric_limits<std::int32_t>::min()));
-        BOOST_ASSERT(max_lon != FixedLongitude(std::numeric_limits<std::int32_t>::min()));
-        BOOST_ASSERT(max_lat != FixedLatitude(std::numeric_limits<std::int32_t>::min()));
+        BOOST_ASSERT(min_lon != FixedLongitude{std::numeric_limits<std::int32_t>::min()});
+        BOOST_ASSERT(min_lat != FixedLatitude{std::numeric_limits<std::int32_t>::min()});
+        BOOST_ASSERT(max_lon != FixedLongitude{std::numeric_limits<std::int32_t>::min()});
+        BOOST_ASSERT(max_lat != FixedLatitude{std::numeric_limits<std::int32_t>::min()});
     }
 
     Coordinate Centroid() const
@@ -67,8 +67,8 @@ struct RectangleInt2D
         Coordinate centroid;
         // The coordinates of the midpoints are given by:
         // x = (x1 + x2) /2 and y = (y1 + y2) /2.
-        centroid.lon = (min_lon + max_lon) / FixedLongitude(2);
-        centroid.lat = (min_lat + max_lat) / FixedLatitude(2);
+        centroid.lon = (min_lon + max_lon) / FixedLongitude{2};
+        centroid.lat = (min_lat + max_lat) / FixedLatitude{2};
         return centroid;
     }
 
@@ -169,10 +169,10 @@ struct RectangleInt2D
 
     bool IsValid() const
     {
-        return min_lon != FixedLongitude(std::numeric_limits<std::int32_t>::max()) &&
-               max_lon != FixedLongitude(std::numeric_limits<std::int32_t>::min()) &&
-               min_lat != FixedLatitude(std::numeric_limits<std::int32_t>::max()) &&
-               max_lat != FixedLatitude(std::numeric_limits<std::int32_t>::min());
+        return min_lon != FixedLongitude{std::numeric_limits<std::int32_t>::max()} &&
+               max_lon != FixedLongitude{std::numeric_limits<std::int32_t>::min()} &&
+               min_lat != FixedLatitude{std::numeric_limits<std::int32_t>::max()} &&
+               max_lat != FixedLatitude{std::numeric_limits<std::int32_t>::min()};
     }
 
     friend std::ostream &operator<<(std::ostream &out, const RectangleInt2D &rect);

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -193,8 +193,8 @@ class StaticRTree
                     Coordinate current_centroid = coordinate_calculation::centroid(
                         m_coordinate_list[current_element.u], m_coordinate_list[current_element.v]);
                     current_centroid.lat =
-                        FixedLatitude(COORDINATE_PRECISION *
-                                      web_mercator::latToY(toFloating(current_centroid.lat)));
+                        FixedLatitude{static_cast<std::int32_t>(COORDINATE_PRECISION *
+                                      web_mercator::latToY(toFloating(current_centroid.lat)))};
 
                     current_wrapper.m_hilbert_value = hilbertCode(current_centroid);
                 }

--- a/include/util/strong_typedef.hpp
+++ b/include/util/strong_typedef.hpp
@@ -40,32 +40,32 @@ namespace osrm
  * etc.  Also clarifies what this random "int" value is
  * being used for.
  */
-#define OSRM_STRONG_TYPEDEF(From, To)                                                              \
-    class To final                                                                                 \
-    {                                                                                              \
-        static_assert(std::is_arithmetic<From>(), "");                                             \
-        From x;                                                                                    \
-        friend std::ostream &operator<<(std::ostream &stream, const To &inst);                     \
-                                                                                                   \
-      public:                                                                                      \
-        To() = default;                                                                            \
-        explicit To(const From x_) : x(x_) {}                                                      \
-        explicit operator From &() { return x; }                                                   \
-        explicit operator From() const { return x; }                                               \
-        To operator+(const To rhs_) const { return To(x + static_cast<const From>(rhs_)); }        \
-        To operator-(const To rhs_) const { return To(x - static_cast<const From>(rhs_)); }        \
-        To operator*(const To rhs_) const { return To(x * static_cast<const From>(rhs_)); }        \
-        To operator/(const To rhs_) const { return To(x / static_cast<const From>(rhs_)); }        \
-        bool operator<(const To z_) const { return x < static_cast<const From>(z_); }              \
-        bool operator>(const To z_) const { return x > static_cast<const From>(z_); }              \
-        bool operator<=(const To z_) const { return x <= static_cast<const From>(z_); }            \
-        bool operator>=(const To z_) const { return x >= static_cast<const From>(z_); }            \
-        bool operator==(const To z_) const { return x == static_cast<const From>(z_); }            \
-        bool operator!=(const To z_) const { return x != static_cast<const From>(z_); }            \
-    };                                                                                             \
-    inline std::ostream &operator<<(std::ostream &stream, const To &inst)                          \
-    {                                                                                              \
-        return stream << inst.x;                                                                   \
+#define OSRM_STRONG_TYPEDEF(From, To)                                                                    \
+    struct To final                                                                                      \
+    {                                                                                                    \
+        static_assert(std::is_arithmetic<From>(), "");                                                   \
+        From __value;                                                                                    \
+        friend std::ostream &operator<<(std::ostream &stream, const To &inst);                           \
+                                                                                                         \
+        explicit operator From &() { return __value; }                                                   \
+        explicit operator From() const { return __value; }                                               \
+        To operator+(const To rhs_) const { return To{__value + static_cast<const From>(rhs_)}; }        \
+        To operator-(const To rhs_) const { return To{__value - static_cast<const From>(rhs_)}; }        \
+        To operator*(const To rhs_) const { return To{__value * static_cast<const From>(rhs_)}; }        \
+        To operator/(const To rhs_) const { return To{__value / static_cast<const From>(rhs_)}; }        \
+        bool operator<(const To z_) const { return __value < static_cast<const From>(z_); }              \
+        bool operator>(const To z_) const { return __value > static_cast<const From>(z_); }              \
+        bool operator<=(const To z_) const { return __value <= static_cast<const From>(z_); }            \
+        bool operator>=(const To z_) const { return __value >= static_cast<const From>(z_); }            \
+        bool operator==(const To z_) const { return __value == static_cast<const From>(z_); }            \
+        bool operator!=(const To z_) const { return __value != static_cast<const From>(z_); }            \
+    };                                                                                                   \
+    static_assert(std::is_trivial<To>(), #To " is not a trivial type");                                \
+    static_assert(std::is_standard_layout<To>(), #To " is not a standart layout");                     \
+    static_assert(std::is_pod<To>(), #To " is not a POD layout");                                      \
+    inline std::ostream &operator<<(std::ostream &stream, const To &inst)                                \
+    {                                                                                                    \
+        return stream << inst.__value;                                                                   \
     }
 
 #define OSRM_STRONG_TYPEDEF_HASHABLE(From, To)                                                     \

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -43,13 +43,13 @@ OSRM_STRONG_TYPEDEF_HASHABLE(std::uint64_t, OSMNodeID)
 OSRM_STRONG_TYPEDEF(std::uint32_t, OSMWayID)
 OSRM_STRONG_TYPEDEF_HASHABLE(std::uint32_t, OSMWayID)
 
-static const OSMNodeID SPECIAL_OSM_NODEID = OSMNodeID(std::numeric_limits<std::uint64_t>::max());
-static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID(std::numeric_limits<std::uint32_t>::max());
+static const OSMNodeID SPECIAL_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
+static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::max()};
 
-static const OSMNodeID MAX_OSM_NODEID = OSMNodeID(std::numeric_limits<std::uint64_t>::max());
-static const OSMNodeID MIN_OSM_NODEID = OSMNodeID(std::numeric_limits<std::uint64_t>::min());
-static const OSMWayID MAX_OSM_WAYID = OSMWayID(std::numeric_limits<std::uint32_t>::max());
-static const OSMWayID MIN_OSM_WAYID = OSMWayID(std::numeric_limits<std::uint32_t>::min());
+static const OSMNodeID MAX_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
+static const OSMNodeID MIN_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::min()};
+static const OSMWayID MAX_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::max()};
+static const OSMWayID MIN_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::min()};
 
 using OSMNodeID_weak = std::uint64_t;
 using OSMEdgeID_weak = std::uint64_t;

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -35,7 +35,7 @@ inline FloatLatitude yToLat(const double y)
     const double normalized_lat =
         detail::RAD_TO_DEGREE * 2. * std::atan(std::exp(clamped_y * detail::DEGREE_TO_RAD));
 
-    return FloatLatitude(normalized_lat - 90.);
+    return FloatLatitude{normalized_lat - 90.};
 }
 
 inline double latToY(const FloatLatitude latitude)
@@ -56,7 +56,7 @@ template <typename T, typename... U> constexpr double horner(double x, T an, U..
 
 inline double latToYapprox(const FloatLatitude latitude)
 {
-    if (latitude < FloatLatitude(-70.) || latitude > FloatLatitude(70.))
+    if (latitude < FloatLatitude{-70.} || latitude > FloatLatitude{70.})
         return latToY(latitude);
 
     // Approximate the inverse Gudermannian function with the Padé approximant [11/11]: deg → deg
@@ -93,14 +93,14 @@ inline double latToYapprox(const FloatLatitude latitude)
 
 inline FloatLatitude clamp(const FloatLatitude lat)
 {
-    return std::max(std::min(lat, FloatLatitude(detail::MAX_LATITUDE)),
-                    FloatLatitude(-detail::MAX_LATITUDE));
+    return std::max(std::min(lat, FloatLatitude{detail::MAX_LATITUDE}),
+                    FloatLatitude{-detail::MAX_LATITUDE});
 }
 
 inline FloatLongitude clamp(const FloatLongitude lon)
 {
-    return std::max(std::min(lon, FloatLongitude(detail::MAX_LONGITUDE)),
-                    FloatLongitude(-detail::MAX_LONGITUDE));
+    return std::max(std::min(lon, FloatLongitude{detail::MAX_LONGITUDE}),
+                    FloatLongitude{-detail::MAX_LONGITUDE});
 }
 
 inline void pixelToDegree(const double shift, double &x, double &y)
@@ -159,10 +159,10 @@ inline void xyzToMercator(
 {
     xyzToWGS84(x, y, z, minx, miny, maxx, maxy);
 
-    minx = static_cast<double>(clamp(util::FloatLongitude(minx))) * DEGREE_TO_PX;
-    miny = latToY(clamp(util::FloatLatitude(miny))) * DEGREE_TO_PX;
-    maxx = static_cast<double>(clamp(util::FloatLongitude(maxx))) * DEGREE_TO_PX;
-    maxy = latToY(clamp(util::FloatLatitude(maxy))) * DEGREE_TO_PX;
+    minx = static_cast<double>(clamp(util::FloatLongitude{minx})) * DEGREE_TO_PX;
+    miny = latToY(clamp(util::FloatLatitude{miny})) * DEGREE_TO_PX;
+    maxx = static_cast<double>(clamp(util::FloatLongitude{maxx})) * DEGREE_TO_PX;
+    maxy = latToY(clamp(util::FloatLatitude{maxy})) * DEGREE_TO_PX;
 }
 }
 }

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -3,6 +3,7 @@
 #include "contractor/graph_contractor.hpp"
 
 #include "extractor/compressed_edge_container.hpp"
+#include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/node_based_edge.hpp"
 
 #include "util/exception.hpp"
@@ -252,7 +253,7 @@ parse_segment_lookup_from_csv_files(const std::vector<std::string> &segment_spee
                 throw util::exception{"Segment speed file " + filename + " malformed"};
 
             SegmentSpeedSource val{
-                {static_cast<OSMNodeID>(from_node_id), static_cast<OSMNodeID>(to_node_id)},
+                {OSMNodeID{from_node_id}, OSMNodeID{to_node_id}},
                 {speed, static_cast<std::uint8_t>(file_id)}};
 
             local.push_back(std::move(val));
@@ -338,7 +339,7 @@ parse_turn_penalty_lookup_from_csv_files(const std::vector<std::string> &turn_pe
                 throw util::exception{"Turn penalty file " + filename + " malformed"};
 
             map[std::make_tuple(
-                OSMNodeID(from_node_id), OSMNodeID(via_node_id), OSMNodeID(to_node_id))] =
+                OSMNodeID{from_node_id}, OSMNodeID{via_node_id}, OSMNodeID{to_node_id})] =
                 std::make_pair(penalty, file_id);
         }
     };
@@ -366,39 +367,58 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
         throw util::exception("Limit of 255 segment speed and turn penalty files each reached");
 
     util::SimpleLogger().Write() << "Opening " << edge_based_graph_filename;
-    boost::filesystem::ifstream input_stream(edge_based_graph_filename, std::ios::binary);
-    if (!input_stream)
-        throw util::exception("Could not load edge based graph file");
+
+    auto mmap_file = [](const std::string &filename) {
+        using boost::interprocess::file_mapping;
+        using boost::interprocess::mapped_region;
+        using boost::interprocess::read_only;
+
+        const file_mapping mapping{ filename.c_str(), read_only };
+        mapped_region region{mapping, read_only};
+        region.advise(mapped_region::advice_sequential);
+        return region;
+    };
+
+    const auto edge_based_graph_region = mmap_file(edge_based_graph_filename);
 
     const bool update_edge_weights = !segment_speed_filenames.empty();
     const bool update_turn_penalties = !turn_penalty_filenames.empty();
 
-    boost::filesystem::ifstream edge_segment_input_stream;
-    boost::filesystem::ifstream edge_fixed_penalties_input_stream;
-
-    if (update_edge_weights || update_turn_penalties)
-    {
-        edge_segment_input_stream.open(edge_segment_lookup_filename, std::ios::binary);
-        edge_fixed_penalties_input_stream.open(edge_penalty_filename, std::ios::binary);
-        if (!edge_segment_input_stream || !edge_fixed_penalties_input_stream)
+    const auto edge_penalty_region = [&] {
+        if (update_edge_weights || update_turn_penalties)
         {
-            throw util::exception("Could not load .edge_segment_lookup or .edge_penalties, did you "
-                                  "run osrm-extract with '--generate-edge-lookup'?");
+            return mmap_file(edge_penalty_filename);
         }
-    }
+        return boost::interprocess::mapped_region();
+    }();
+
+    const auto edge_segment_region = [&] {
+        if (update_edge_weights || update_turn_penalties)
+        {
+            return mmap_file(edge_segment_lookup_filename);
+        }
+        return boost::interprocess::mapped_region();
+    }();
+
+    // Set the struct packing to 1 byte word sizes.  This prevents any padding.  We only use
+    // this struct once, so any alignment penalty is trivial.  If this is *not* done, then
+    // the struct will be padded out by an extra 4 bytes, and sizeof() will mean we read
+    // too much data from the original file.
+    #pragma pack(push, r1, 1)
+    struct EdgeBasedGraphHeader {
+        util::FingerPrint fingerprint;
+        std::uint64_t number_of_edges;
+        EdgeID max_edge_id;
+    };
+    #pragma pack(pop, r1)
+
+    const EdgeBasedGraphHeader graph_header = *(reinterpret_cast<const EdgeBasedGraphHeader *>(edge_based_graph_region.get_address()));
 
     const util::FingerPrint fingerprint_valid = util::FingerPrint::GetValid();
-    util::FingerPrint fingerprint_loaded;
-    input_stream.read((char *)&fingerprint_loaded, sizeof(util::FingerPrint));
-    fingerprint_loaded.TestContractor(fingerprint_valid);
+    graph_header.fingerprint.TestContractor(fingerprint_valid);
 
-    std::uint64_t number_of_edges = 0;
-    EdgeID max_edge_id = SPECIAL_EDGEID;
-    input_stream.read((char *)&number_of_edges, sizeof(number_of_edges));
-    input_stream.read((char *)&max_edge_id, sizeof(max_edge_id));
-
-    edge_based_edge_list.resize(number_of_edges);
-    util::SimpleLogger().Write() << "Reading " << number_of_edges
+    edge_based_edge_list.resize(graph_header.number_of_edges);
+    util::SimpleLogger().Write() << "Reading " << graph_header.number_of_edges
                                  << " edges from the edge based graph";
 
     SegmentSpeedSourceFlatMap segment_speed_lookup;
@@ -500,12 +520,9 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
         // update the RTree itself, we just use the leaf nodes to iterate over all segments)
         using LeafNode = util::StaticRTree<extractor::EdgeBasedNode>::LeafNode;
 
-        using boost::interprocess::file_mapping;
         using boost::interprocess::mapped_region;
-        using boost::interprocess::read_only;
 
-        const file_mapping mapping{rtree_leaf_filename.c_str(), read_only};
-        mapped_region region{mapping, read_only};
+        auto region = mmap_file(rtree_leaf_filename.c_str());
         region.advise(mapped_region::advice_willneed);
 
         const auto bytes = region.get_size();
@@ -713,43 +730,43 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
 
     tbb::parallel_invoke(maybe_save_geometries, save_datasource_indexes, save_datastore_names);
 
-    // TODO: can we read this in bulk?  util::DeallocatingVector isn't necessarily
-    // all stored contiguously
-    for (; number_of_edges > 0; --number_of_edges)
+    auto penaltyblock =
+        reinterpret_cast<const extractor::lookup::PenaltyBlock *>(edge_penalty_region.get_address());
+    auto edge_segment_byte_ptr = reinterpret_cast<const char *>(edge_segment_region.get_address());
+    auto edge_based_edge_ptr = reinterpret_cast<extractor::EdgeBasedEdge *>(
+        reinterpret_cast<char *>(edge_based_graph_region.get_address()) + sizeof(EdgeBasedGraphHeader));
+
+    const auto edge_based_edge_last = reinterpret_cast<extractor::EdgeBasedEdge *>(
+        reinterpret_cast<char *>(edge_based_graph_region.get_address()) + sizeof(EdgeBasedGraphHeader) + sizeof(extractor::EdgeBasedEdge) * graph_header.number_of_edges);
+
+    while (edge_based_edge_ptr != edge_based_edge_last)
     {
-        extractor::EdgeBasedEdge inbuffer;
-        input_stream.read((char *)&inbuffer, sizeof(extractor::EdgeBasedEdge));
+        // Make a copy of the data from the memory map
+        extractor::EdgeBasedEdge inbuffer = *edge_based_edge_ptr;
+        edge_based_edge_ptr++;
+
         if (update_edge_weights || update_turn_penalties)
         {
-            // Processing-time edge updates
-            unsigned fixed_penalty;
-            edge_fixed_penalties_input_stream.read(reinterpret_cast<char *>(&fixed_penalty),
-                                                   sizeof(fixed_penalty));
+            auto header = reinterpret_cast<const extractor::lookup::SegmentHeaderBlock *>(
+                edge_segment_byte_ptr);
+            edge_segment_byte_ptr += sizeof(extractor::lookup::SegmentHeaderBlock);
 
+            auto previous_osm_node_id = header->previous_osm_node_id;
             int new_weight = 0;
+            int compressed_edge_nodes = static_cast<int>(header->num_osm_nodes);
 
-            unsigned num_osm_nodes = 0;
-            edge_segment_input_stream.read(reinterpret_cast<char *>(&num_osm_nodes),
-                                           sizeof(num_osm_nodes));
-            OSMNodeID previous_osm_node_id;
-            edge_segment_input_stream.read(reinterpret_cast<char *>(&previous_osm_node_id),
-                                           sizeof(previous_osm_node_id));
-            OSMNodeID this_osm_node_id;
-            double segment_length;
-            int segment_weight;
-            int compressed_edge_nodes = static_cast<int>(num_osm_nodes);
-            --num_osm_nodes;
-            for (; num_osm_nodes != 0; --num_osm_nodes)
+            auto segmentblocks =
+                reinterpret_cast<const extractor::lookup::SegmentBlock *>(edge_segment_byte_ptr);
+            edge_segment_byte_ptr +=
+                sizeof(extractor::lookup::SegmentBlock) * (header->num_osm_nodes - 1);
+
+            const auto num_segments = header->num_osm_nodes - 1;
+            for (auto i : util::irange<std::size_t>(0, num_segments))
             {
-                edge_segment_input_stream.read(reinterpret_cast<char *>(&this_osm_node_id),
-                                               sizeof(this_osm_node_id));
-                edge_segment_input_stream.read(reinterpret_cast<char *>(&segment_length),
-                                               sizeof(segment_length));
-                edge_segment_input_stream.read(reinterpret_cast<char *>(&segment_weight),
-                                               sizeof(segment_weight));
 
                 auto speed_iter =
-                    find(segment_speed_lookup, Segment{previous_osm_node_id, this_osm_node_id});
+                    find(segment_speed_lookup,
+                         Segment{previous_osm_node_id, segmentblocks[i].this_osm_node_id});
                 if (speed_iter != segment_speed_lookup.end())
                 {
                     // This sets the segment weight using the same formula as the
@@ -757,30 +774,22 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
                     // is lost in the annals of time.
                     int new_segment_weight = std::max(
                         1,
-                        static_cast<int>(std::floor(
-                            (segment_length * 10.) / (speed_iter->speed_source.speed / 3.6) + .5)));
+                        static_cast<int>(std::floor((segmentblocks[i].segment_length * 10.) /
+                                                        (speed_iter->speed_source.speed / 3.6) +
+                                                    .5)));
                     new_weight += new_segment_weight;
                 }
                 else
                 {
                     // If no lookup found, use the original weight value for this segment
-                    new_weight += segment_weight;
+                    new_weight += segmentblocks[i].segment_weight;
                 }
 
-                previous_osm_node_id = this_osm_node_id;
+                previous_osm_node_id = segmentblocks[i].this_osm_node_id;
             }
 
-            OSMNodeID from_id;
-            OSMNodeID via_id;
-            OSMNodeID to_id;
-            edge_fixed_penalties_input_stream.read(reinterpret_cast<char *>(&from_id),
-                                                   sizeof(from_id));
-            edge_fixed_penalties_input_stream.read(reinterpret_cast<char *>(&via_id),
-                                                   sizeof(via_id));
-            edge_fixed_penalties_input_stream.read(reinterpret_cast<char *>(&to_id), sizeof(to_id));
-
-            const auto turn_iter =
-                turn_penalty_lookup.find(std::make_tuple(from_id, via_id, to_id));
+            const auto turn_iter = turn_penalty_lookup.find(
+                std::make_tuple(penaltyblock->from_id, penaltyblock->via_id, penaltyblock->to_id));
             if (turn_iter != turn_penalty_lookup.end())
             {
                 int new_turn_weight = static_cast<int>(turn_iter->second.first * 10);
@@ -788,24 +797,28 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
                 if (new_turn_weight + new_weight < compressed_edge_nodes)
                 {
                     util::SimpleLogger().Write(logWARNING)
-                        << "turn penalty " << turn_iter->second.first << " for turn " << from_id
-                        << ", " << via_id << ", " << to_id
-                        << " is too negative: clamping turn weight to " << compressed_edge_nodes;
+                        << "turn penalty " << turn_iter->second.first << " for turn "
+                        << penaltyblock->from_id << ", " << penaltyblock->via_id << ", "
+                        << penaltyblock->to_id << " is too negative: clamping turn weight to "
+                        << compressed_edge_nodes;
                 }
 
                 inbuffer.weight = std::max(new_turn_weight + new_weight, compressed_edge_nodes);
             }
             else
             {
-                inbuffer.weight = fixed_penalty + new_weight;
+                inbuffer.weight = penaltyblock->fixed_penalty + new_weight;
             }
+
+            // Increment the pointer
+            penaltyblock++;
         }
 
         edge_based_edge_list.emplace_back(std::move(inbuffer));
     }
 
     util::SimpleLogger().Write() << "Done reading edges";
-    return max_edge_id;
+    return graph_header.max_edge_id;
 }
 
 void Contractor::ReadNodeLevels(std::vector<float> &node_levels) const

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -128,7 +128,7 @@ FixedLine coordinatesToTileLine(const util::Coordinate start,
     for (auto const &pt : geo_line)
     {
         double px_merc = pt.x * util::web_mercator::DEGREE_TO_PX;
-        double py_merc = util::web_mercator::latToY(util::FloatLatitude(pt.y)) *
+        double py_merc = util::web_mercator::latToY(util::FloatLatitude{pt.y}) *
                          util::web_mercator::DEGREE_TO_PX;
         // convert lon/lat to tile coordinates
         const auto px = std::round(
@@ -174,8 +174,8 @@ Status TilePlugin::HandleRequest(const api::TileParameters &parameters, std::str
     util::web_mercator::xyzToWGS84(
         parameters.x, parameters.y, parameters.z, min_lon, min_lat, max_lon, max_lat);
 
-    util::Coordinate southwest{util::FloatLongitude(min_lon), util::FloatLatitude(min_lat)};
-    util::Coordinate northeast{util::FloatLongitude(max_lon), util::FloatLatitude(max_lat)};
+    util::Coordinate southwest{util::FloatLongitude{min_lon}, util::FloatLatitude{min_lat}};
+    util::Coordinate northeast{util::FloatLongitude{max_lon}, util::FloatLatitude{max_lat}};
 
     // Fetch all the segments that are in our bounding box.
     // This hits the OSRM StaticRTree

--- a/src/engine/polyline_compressor.cpp
+++ b/src/engine/polyline_compressor.cpp
@@ -116,8 +116,8 @@ std::vector<util::Coordinate> decodePolyline(const std::string &geometry_string)
         lng += dlng;
 
         util::Coordinate p;
-        p.lat = util::FixedLatitude(lat * detail::POLYLINE_TO_COORDINATE);
-        p.lon = util::FixedLongitude(lng * detail::POLYLINE_TO_COORDINATE);
+        p.lat = util::FixedLatitude{static_cast<std::int32_t>(lat * detail::POLYLINE_TO_COORDINATE)};
+        p.lon = util::FixedLongitude{static_cast<std::int32_t>(lng * detail::POLYLINE_TO_COORDINATE)};
         new_coordinates.push_back(p);
     }
 

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -344,9 +344,9 @@ void ExtractionContainers::PrepareEdges(lua_State *segment_state)
         BOOST_ASSERT(edge_iterator->result.osm_target_id == node_iterator->node_id);
         BOOST_ASSERT(edge_iterator->weight_data.speed >= 0);
         BOOST_ASSERT(edge_iterator->source_coordinate.lat !=
-                     util::FixedLatitude(std::numeric_limits<int>::min()));
+                     util::FixedLatitude{std::numeric_limits<std::int32_t>::min()});
         BOOST_ASSERT(edge_iterator->source_coordinate.lon !=
-                     util::FixedLongitude(std::numeric_limits<int>::min()));
+                     util::FixedLongitude{std::numeric_limits<std::int32_t>::min()});
 
         const double distance = util::coordinate_calculation::greatCircleDistance(
             edge_iterator->source_coordinate,
@@ -652,14 +652,14 @@ void ExtractionContainers::PrepareRestrictions()
            restrictions_iterator != restrictions_list_end)
     {
         if (way_start_and_end_iterator->way_id <
-            OSMWayID(restrictions_iterator->restriction.from.way))
+            OSMWayID{static_cast<std::uint32_t>(restrictions_iterator->restriction.from.way)})
         {
             ++way_start_and_end_iterator;
             continue;
         }
 
         if (way_start_and_end_iterator->way_id >
-            OSMWayID(restrictions_iterator->restriction.from.way))
+            OSMWayID{static_cast<std::uint32_t>(restrictions_iterator->restriction.from.way)})
         {
             util::SimpleLogger().Write(LogLevel::logWARNING)
                 << "Restriction references invalid way: "
@@ -670,9 +670,9 @@ void ExtractionContainers::PrepareRestrictions()
         }
 
         BOOST_ASSERT(way_start_and_end_iterator->way_id ==
-                     OSMWayID(restrictions_iterator->restriction.from.way));
+                     OSMWayID{static_cast<std::uint32_t>(restrictions_iterator->restriction.from.way)});
         // we do not remap the via id yet, since we will need it for the to node as well
-        const OSMNodeID via_node_id = OSMNodeID(restrictions_iterator->restriction.via.node);
+        const OSMNodeID via_node_id = OSMNodeID{restrictions_iterator->restriction.via.node};
 
         // check if via is actually valid, if not invalidate
         auto via_id_iter = external_to_internal_node_id_map.find(via_node_id);
@@ -686,11 +686,11 @@ void ExtractionContainers::PrepareRestrictions()
             continue;
         }
 
-        if (OSMNodeID(way_start_and_end_iterator->first_segment_source_id) == via_node_id)
+        if (way_start_and_end_iterator->first_segment_source_id == via_node_id)
         {
             // assign new from node id
             auto id_iter = external_to_internal_node_id_map.find(
-                OSMNodeID(way_start_and_end_iterator->first_segment_target_id));
+                way_start_and_end_iterator->first_segment_target_id);
             if (id_iter == external_to_internal_node_id_map.end())
             {
                 util::SimpleLogger().Write(LogLevel::logWARNING)
@@ -703,11 +703,11 @@ void ExtractionContainers::PrepareRestrictions()
             }
             restrictions_iterator->restriction.from.node = id_iter->second;
         }
-        else if (OSMNodeID(way_start_and_end_iterator->last_segment_target_id) == via_node_id)
+        else if (way_start_and_end_iterator->last_segment_target_id == via_node_id)
         {
             // assign new from node id
             auto id_iter = external_to_internal_node_id_map.find(
-                OSMNodeID(way_start_and_end_iterator->last_segment_source_id));
+                way_start_and_end_iterator->last_segment_source_id);
             if (id_iter == external_to_internal_node_id_map.end())
             {
                 util::SimpleLogger().Write(LogLevel::logWARNING)
@@ -746,7 +746,7 @@ void ExtractionContainers::PrepareRestrictions()
            restrictions_iterator != restrictions_list_end_)
     {
         if (way_start_and_end_iterator->way_id <
-            OSMWayID(restrictions_iterator->restriction.to.way))
+            OSMWayID{static_cast<std::uint32_t>(restrictions_iterator->restriction.to.way)})
         {
             ++way_start_and_end_iterator;
             continue;
@@ -758,7 +758,7 @@ void ExtractionContainers::PrepareRestrictions()
             continue;
         }
         if (way_start_and_end_iterator->way_id >
-            OSMWayID(restrictions_iterator->restriction.to.way))
+            OSMWayID{static_cast<std::uint32_t>(restrictions_iterator->restriction.to.way)})
         {
             util::SimpleLogger().Write(LogLevel::logDEBUG)
                 << "Restriction references invalid way: "
@@ -768,18 +768,18 @@ void ExtractionContainers::PrepareRestrictions()
             continue;
         }
         BOOST_ASSERT(way_start_and_end_iterator->way_id ==
-                     OSMWayID(restrictions_iterator->restriction.to.way));
-        const OSMNodeID via_node_id = OSMNodeID(restrictions_iterator->restriction.via.node);
+                     OSMWayID{static_cast<std::uint32_t>(restrictions_iterator->restriction.to.way)});
+        const OSMNodeID via_node_id = OSMNodeID{restrictions_iterator->restriction.via.node};
 
         // assign new via node id
         auto via_id_iter = external_to_internal_node_id_map.find(via_node_id);
         BOOST_ASSERT(via_id_iter != external_to_internal_node_id_map.end());
         restrictions_iterator->restriction.via.node = via_id_iter->second;
 
-        if (OSMNodeID(way_start_and_end_iterator->first_segment_source_id) == via_node_id)
+        if (way_start_and_end_iterator->first_segment_source_id == via_node_id)
         {
             auto to_id_iter = external_to_internal_node_id_map.find(
-                OSMNodeID(way_start_and_end_iterator->first_segment_target_id));
+                way_start_and_end_iterator->first_segment_target_id);
             if (to_id_iter == external_to_internal_node_id_map.end())
             {
                 util::SimpleLogger().Write(LogLevel::logWARNING)
@@ -792,10 +792,10 @@ void ExtractionContainers::PrepareRestrictions()
             }
             restrictions_iterator->restriction.to.node = to_id_iter->second;
         }
-        else if (OSMNodeID(way_start_and_end_iterator->last_segment_target_id) == via_node_id)
+        else if (way_start_and_end_iterator->last_segment_target_id == via_node_id)
         {
             auto to_id_iter = external_to_internal_node_id_map.find(
-                OSMNodeID(way_start_and_end_iterator->last_segment_source_id));
+                way_start_and_end_iterator->last_segment_source_id);
             if (to_id_iter == external_to_internal_node_id_map.end())
             {
                 util::SimpleLogger().Write(LogLevel::logWARNING)

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -48,9 +48,9 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
                                      const ExtractionNode &result_node)
 {
     external_memory.all_nodes_list.push_back(
-        {util::toFixed(util::FloatLongitude(input_node.location().lon())),
-         util::toFixed(util::FloatLatitude(input_node.location().lat())),
-         OSMNodeID(input_node.id()),
+        {util::toFixed(util::FloatLongitude{input_node.location().lon()}),
+         util::toFixed(util::FloatLatitude{input_node.location().lat()}),
+         OSMNodeID{static_cast<std::uint64_t>(input_node.id())},
          result_node.barrier,
          result_node.traffic_lights});
 }
@@ -304,7 +304,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
     std::transform(input_way.nodes().begin(),
                    input_way.nodes().end(),
                    std::back_inserter(external_memory.used_node_id_list),
-                   [](const osmium::NodeRef &ref) { return OSMNodeID(ref.ref()); });
+                   [](const osmium::NodeRef &ref) { return OSMNodeID{static_cast<std::uint64_t>(ref.ref())}; });
 
     const bool is_opposite_way = TRAVEL_MODE_INACCESSIBLE == parsed_way.forward_travel_mode;
 
@@ -318,8 +318,8 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
             input_way.nodes().crend(),
             [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
                 external_memory.all_edges_list.push_back(
-                    InternalExtractorEdge(OSMNodeID(first_node.ref()),
-                                          OSMNodeID(last_node.ref()),
+                    InternalExtractorEdge(OSMNodeID{static_cast<std::uint64_t>(first_node.ref())},
+                                          OSMNodeID{static_cast<std::uint64_t>(last_node.ref())},
                                           name_id,
                                           backward_weight_data,
                                           true,
@@ -334,11 +334,11 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
             });
 
         external_memory.way_start_end_id_list.push_back(
-            {OSMWayID(input_way.id()),
-             OSMNodeID(input_way.nodes().back().ref()),
-             OSMNodeID(input_way.nodes()[input_way.nodes().size() - 2].ref()),
-             OSMNodeID(input_way.nodes()[1].ref()),
-             OSMNodeID(input_way.nodes()[0].ref())});
+            {OSMWayID{static_cast<std::uint32_t>(input_way.id())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes().back().ref())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[input_way.nodes().size() - 2].ref())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[1].ref())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[0].ref())}});
     }
     else
     {
@@ -349,8 +349,8 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
             input_way.nodes().cend(),
             [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
                 external_memory.all_edges_list.push_back(
-                    InternalExtractorEdge(OSMNodeID(first_node.ref()),
-                                          OSMNodeID(last_node.ref()),
+                    InternalExtractorEdge(OSMNodeID{static_cast<std::uint64_t>(first_node.ref())},
+                                          OSMNodeID{static_cast<std::uint64_t>(last_node.ref())},
                                           name_id,
                                           forward_weight_data,
                                           true,
@@ -371,8 +371,8 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                 input_way.nodes().cend(),
                 [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
                     external_memory.all_edges_list.push_back(
-                        InternalExtractorEdge(OSMNodeID(first_node.ref()),
-                                              OSMNodeID(last_node.ref()),
+                        InternalExtractorEdge(OSMNodeID{static_cast<std::uint64_t>(first_node.ref())},
+                                              OSMNodeID{static_cast<std::uint64_t>(last_node.ref())},
                                               name_id,
                                               backward_weight_data,
                                               false,
@@ -388,11 +388,11 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
         }
 
         external_memory.way_start_end_id_list.push_back(
-            {OSMWayID(input_way.id()),
-             OSMNodeID(input_way.nodes().back().ref()),
-             OSMNodeID(input_way.nodes()[input_way.nodes().size() - 2].ref()),
-             OSMNodeID(input_way.nodes()[1].ref()),
-             OSMNodeID(input_way.nodes()[0].ref())});
+            {OSMWayID{static_cast<std::uint32_t>(input_way.id())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes().back().ref())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[input_way.nodes().size() - 2].ref())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[1].ref())},
+             OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[0].ref())}});
     }
 }
 }

--- a/src/extractor/raster_source.cpp
+++ b/src/extractor/raster_source.cpp
@@ -84,10 +84,10 @@ int SourceContainer::LoadRasterSource(const std::string &path_string,
                                       std::size_t nrows,
                                       std::size_t ncols)
 {
-    const auto _xmin = static_cast<int>(util::toFixed(util::FloatLongitude(xmin)));
-    const auto _xmax = static_cast<int>(util::toFixed(util::FloatLongitude(xmax)));
-    const auto _ymin = static_cast<int>(util::toFixed(util::FloatLatitude(ymin)));
-    const auto _ymax = static_cast<int>(util::toFixed(util::FloatLatitude(ymax)));
+    const auto _xmin = static_cast<std::int32_t>(util::toFixed(util::FloatLongitude{xmin}));
+    const auto _xmax = static_cast<std::int32_t>(util::toFixed(util::FloatLongitude{xmax}));
+    const auto _ymin = static_cast<std::int32_t>(util::toFixed(util::FloatLatitude{ymin}));
+    const auto _ymax = static_cast<std::int32_t>(util::toFixed(util::FloatLatitude{ymax}));
 
     const auto itr = LoadedSourcePaths.find(path_string);
     if (itr != LoadedSourcePaths.end())
@@ -135,8 +135,8 @@ RasterDatum SourceContainer::GetRasterDataFromSource(unsigned int source_id, dou
     BOOST_ASSERT(lon > -180);
 
     const auto &found = LoadedSources[source_id];
-    return found.GetRasterData(static_cast<int>(util::toFixed(util::FloatLongitude(lon))),
-                               static_cast<int>(util::toFixed(util::FloatLatitude(lat))));
+    return found.GetRasterData(static_cast<std::int32_t>(util::toFixed(util::FloatLongitude{lon})),
+                               static_cast<std::int32_t>(util::toFixed(util::FloatLatitude{lat})));
 }
 
 // External function for looking up interpolated data from a specified source
@@ -154,8 +154,8 @@ SourceContainer::GetRasterInterpolateFromSource(unsigned int source_id, double l
     BOOST_ASSERT(lon > -180);
 
     const auto &found = LoadedSources[source_id];
-    return found.GetRasterInterpolate(static_cast<int>(util::toFixed(util::FloatLongitude(lon))),
-                                      static_cast<int>(util::toFixed(util::FloatLatitude(lat))));
+    return found.GetRasterInterpolate(static_cast<std::int32_t>(util::toFixed(util::FloatLongitude{lon})),
+                                      static_cast<std::int32_t>(util::toFixed(util::FloatLatitude{lat})));
 }
 }
 }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -613,7 +613,7 @@ int Storage::Run()
     {
         nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
         coordinates_ptr[i] = util::Coordinate(current_node.lon, current_node.lat);
-        osmnodeid_list.push_back(OSMNodeID(current_node.node_id));
+        osmnodeid_list.push_back(current_node.node_id);
     }
     nodes_input_stream.close();
 

--- a/src/util/coordinate.cpp
+++ b/src/util/coordinate.cpp
@@ -19,16 +19,16 @@ namespace util
 
 bool Coordinate::IsValid() const
 {
-    return !(lat > FixedLatitude(90 * COORDINATE_PRECISION) ||
-             lat < FixedLatitude(-90 * COORDINATE_PRECISION) ||
-             lon > FixedLongitude(180 * COORDINATE_PRECISION) ||
-             lon < FixedLongitude(-180 * COORDINATE_PRECISION));
+    return !(lat > FixedLatitude{static_cast<std::int32_t>(90 * COORDINATE_PRECISION)} ||
+             lat < FixedLatitude{static_cast<std::int32_t>(-90 * COORDINATE_PRECISION)} ||
+             lon > FixedLongitude{static_cast<std::int32_t>(180 * COORDINATE_PRECISION)} ||
+             lon < FixedLongitude{static_cast<std::int32_t>(-180 * COORDINATE_PRECISION)});
 }
 
 bool FloatCoordinate::IsValid() const
 {
-    return !(lat > FloatLatitude(90) || lat < FloatLatitude(-90) || lon > FloatLongitude(180) ||
-             lon < FloatLongitude(-180));
+    return !(lat > FloatLatitude{90} || lat < FloatLatitude{-90} || lon > FloatLongitude{180} ||
+             lon < FloatLongitude{-180});
 }
 
 bool operator==(const Coordinate lhs, const Coordinate rhs)

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -115,8 +115,8 @@ Coordinate centroid(const Coordinate lhs, const Coordinate rhs)
     Coordinate centroid;
     // The coordinates of the midpoints are given by:
     // x = (x1 + x2) /2 and y = (y1 + y2) /2.
-    centroid.lon = (lhs.lon + rhs.lon) / FixedLongitude(2);
-    centroid.lat = (lhs.lat + rhs.lat) / FixedLatitude(2);
+    centroid.lon = (lhs.lon + rhs.lon) / FixedLongitude{2};
+    centroid.lat = (lhs.lat + rhs.lat) / FixedLatitude{2};
     return centroid;
 }
 
@@ -261,7 +261,7 @@ circleCenter(const Coordinate C1, const Coordinate C2, const Coordinate C3)
         if (lon < -180.0 || lon > 180.0 || lat < -90.0 || lat > 90.0)
             return boost::none;
         else
-            return Coordinate(FloatLongitude(lon), FloatLatitude(lat));
+            return Coordinate(FloatLongitude{lon}, FloatLatitude{lat});
     }
 }
 
@@ -284,8 +284,8 @@ Coordinate interpolateLinear(double factor, const Coordinate from, const Coordin
     const auto to_lon = static_cast<std::int32_t>(to.lon);
     const auto to_lat = static_cast<std::int32_t>(to.lat);
 
-    FixedLongitude interpolated_lon(from_lon + factor * (to_lon - from_lon));
-    FixedLatitude interpolated_lat(from_lat + factor * (to_lat - from_lat));
+    FixedLongitude interpolated_lon{static_cast<std::int32_t>(from_lon + factor * (to_lon - from_lon))};
+    FixedLatitude interpolated_lat{static_cast<std::int32_t>(from_lat + factor * (to_lat - from_lat))};
 
     return {std::move(interpolated_lon), std::move(interpolated_lat)};
 }

--- a/unit_tests/engine/douglas_peucker.cpp
+++ b/unit_tests/engine/douglas_peucker.cpp
@@ -33,10 +33,10 @@ BOOST_AUTO_TEST_CASE(removed_middle_test)
         x       x
     */
     std::vector<util::Coordinate> coordinates = {
-        util::Coordinate(util::FloatLongitude(5), util::FloatLatitude(5)),
-        util::Coordinate(util::FloatLongitude(12.5), util::FloatLatitude(12.6096298302)),
-        util::Coordinate(util::FloatLongitude(20), util::FloatLatitude(20)),
-        util::Coordinate(util::FloatLongitude(25), util::FloatLatitude(5))};
+        util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{5}},
+        util::Coordinate{util::FloatLongitude{12.5}, util::FloatLatitude{12.6096298302}},
+        util::Coordinate{util::FloatLongitude{20}, util::FloatLatitude{20}},
+        util::Coordinate{util::FloatLongitude{25}, util::FloatLatitude{5}}};
 
     for (unsigned z = 0; z < detail::DOUGLAS_PEUCKER_THRESHOLDS_SIZE; z++)
     {
@@ -58,10 +58,10 @@ BOOST_AUTO_TEST_CASE(removed_middle_test_zoom_sensitive)
         x       x
     */
     std::vector<util::Coordinate> coordinates = {
-        util::Coordinate(util::FloatLongitude(5), util::FloatLatitude(5)),
-        util::Coordinate(util::FloatLongitude(6), util::FloatLatitude(6)),
-        util::Coordinate(util::FloatLongitude(20), util::FloatLatitude(20)),
-        util::Coordinate(util::FloatLongitude(25), util::FloatLatitude(5))};
+        util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{5}},
+        util::Coordinate{util::FloatLongitude{6}, util::FloatLatitude{6}},
+        util::Coordinate{util::FloatLongitude{20}, util::FloatLatitude{20}},
+        util::Coordinate{util::FloatLongitude{25}, util::FloatLatitude{5}}};
 
     // Coordinate 6,6 should start getting included at Z9 and higher
     // Note that 5,5->6,6->10,10 is *not* a straight line on the surface
@@ -98,13 +98,13 @@ BOOST_AUTO_TEST_CASE(remove_second_node_test)
                 x
         */
         std::vector<util::Coordinate> input = {
-            util::Coordinate(util::FloatLongitude(5), util::FloatLatitude(5)),
-            util::Coordinate(util::FloatLongitude(5 + delta_pixel_to_delta_degree(2, z)),
-                             util::FloatLatitude(5)),
-            util::Coordinate(util::FloatLongitude(10), util::FloatLatitude(10)),
-            util::Coordinate(util::FloatLongitude(5), util::FloatLatitude(15)),
-            util::Coordinate(util::FloatLongitude(5),
-                             util::FloatLatitude(15 + delta_pixel_to_delta_degree(2, z)))};
+            util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{5}},
+            util::Coordinate{util::FloatLongitude{5 + delta_pixel_to_delta_degree(2, z)},
+                             util::FloatLatitude{5}},
+            util::Coordinate{util::FloatLongitude{10}, util::FloatLatitude{10}},
+            util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{15}},
+            util::Coordinate{util::FloatLongitude{5},
+                             util::FloatLatitude{15 + delta_pixel_to_delta_degree(2, z)}}};
         BOOST_TEST_MESSAGE("Delta (" << z << "): " << delta_pixel_to_delta_degree(2, z));
         auto result = douglasPeucker(input, z);
         BOOST_CHECK_EQUAL(result.size(), 3);

--- a/unit_tests/engine/geometry_string.cpp
+++ b/unit_tests/engine/geometry_string.cpp
@@ -22,11 +22,11 @@ BOOST_AUTO_TEST_CASE(decode)
 
     // Test coordinates; these would be the coordinates we give the loc parameter,
     // e.g. loc=10.00,10.0&loc=10.01,10.1...
-    util::Coordinate coord1(util::FloatLongitude(10.0), util::FloatLatitude(10.00));
-    util::Coordinate coord2(util::FloatLongitude(10.1), util::FloatLatitude(10.01));
-    util::Coordinate coord3(util::FloatLongitude(10.2), util::FloatLatitude(10.02));
-    util::Coordinate coord4(util::FloatLongitude(10.3), util::FloatLatitude(10.03));
-    util::Coordinate coord5(util::FloatLongitude(10.4), util::FloatLatitude(10.04));
+    util::Coordinate coord1(util::FloatLongitude{10.0}, util::FloatLatitude{10.00});
+    util::Coordinate coord2(util::FloatLongitude{10.1}, util::FloatLatitude{10.01});
+    util::Coordinate coord3(util::FloatLongitude{10.2}, util::FloatLatitude{10.02});
+    util::Coordinate coord4(util::FloatLongitude{10.3}, util::FloatLatitude{10.03});
+    util::Coordinate coord5(util::FloatLongitude{10.4}, util::FloatLatitude{10.04});
 
     // Put the test coordinates into the vector for comparison
     std::vector<util::Coordinate> cmp_coords = {coord1, coord2, coord3, coord4, coord5};

--- a/unit_tests/library/waypoint_check.hpp
+++ b/unit_tests/library/waypoint_check.hpp
@@ -15,8 +15,8 @@ inline bool waypoint_check(json::Value waypoint)
     }
     const auto waypoint_object = waypoint.get<json::Object>();
     const auto waypoint_location = waypoint_object.values.at("location").get<json::Array>().values;
-    util::FloatLongitude lon(waypoint_location[0].get<json::Number>().value);
-    util::FloatLatitude lat(waypoint_location[1].get<json::Number>().value);
+    util::FloatLongitude lon{waypoint_location[0].get<json::Number>().value};
+    util::FloatLatitude lat{waypoint_location[1].get<json::Number>().value};
     util::Coordinate location_coordinate(lon, lat);
     return location_coordinate.IsValid();
 }

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(invalid_table_urls)
 
 BOOST_AUTO_TEST_CASE(valid_route_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude(1), util::FloatLatitude(2)},
-                                              {util::FloatLongitude(3), util::FloatLatitude(4)}};
+    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
 
     RouteParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -199,9 +199,9 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     CHECK_EQUAL_RANGE(reference_5.coordinates, result_5->coordinates);
     CHECK_EQUAL_RANGE(reference_5.hints, result_5->hints);
 
-    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude(0), util::FloatLatitude(1)},
-                                              {util::FloatLongitude(2), util::FloatLatitude(3)},
-                                              {util::FloatLongitude(4), util::FloatLatitude(5)}};
+    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude{0}, util::FloatLatitude{1}},
+                                              {util::FloatLongitude{2}, util::FloatLatitude{3}},
+                                              {util::FloatLongitude{4}, util::FloatLatitude{5}}};
 
     RouteParameters reference_6{};
     reference_6.coordinates = coords_2;
@@ -250,10 +250,10 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     CHECK_EQUAL_RANGE(reference_9.radiuses, result_9->radiuses);
 
     // Some Hint's are empty
-    std::vector<util::Coordinate> coords_3 = {{util::FloatLongitude(1), util::FloatLatitude(2)},
-                                              {util::FloatLongitude(3), util::FloatLatitude(4)},
-                                              {util::FloatLongitude(5), util::FloatLatitude(6)},
-                                              {util::FloatLongitude(7), util::FloatLatitude(8)}};
+    std::vector<util::Coordinate> coords_3 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}},
+                                              {util::FloatLongitude{5}, util::FloatLatitude{6}},
+                                              {util::FloatLongitude{7}, util::FloatLatitude{8}}};
     std::vector<boost::optional<engine::Hint>> hints_10 = {
         engine::Hint::FromBase64("DAIAgP___"
                                  "38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_"
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
 
 BOOST_AUTO_TEST_CASE(valid_table_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude(1), util::FloatLatitude(2)},
-                                              {util::FloatLongitude(3), util::FloatLatitude(4)}};
+    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
 
     TableParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -329,8 +329,8 @@ BOOST_AUTO_TEST_CASE(valid_table_urls)
 
 BOOST_AUTO_TEST_CASE(valid_match_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude(1), util::FloatLatitude(2)},
-                                              {util::FloatLongitude(3), util::FloatLatitude(4)}};
+    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
 
     MatchParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(valid_match_urls)
 
 BOOST_AUTO_TEST_CASE(valid_nearest_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude(1), util::FloatLatitude(2)}};
+    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}}};
 
     NearestParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -388,8 +388,8 @@ BOOST_AUTO_TEST_CASE(valid_tile_urls)
 
 BOOST_AUTO_TEST_CASE(valid_trip_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude(1), util::FloatLatitude(2)},
-                                              {util::FloatLongitude(3), util::FloatLatitude(4)}};
+    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
 
     TripParameters reference_1{};
     reference_1.coordinates = coords_1;

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(valid_urls)
 
     // one coordinate
     std::vector<util::Coordinate> coords_3 = {
-        util::Coordinate(util::FloatLongitude(0), util::FloatLatitude(1)),
+        util::Coordinate{util::FloatLongitude{0}, util::FloatLatitude{1}},
     };
     api::ParsedURL reference_3{"route", 1, "profile", "0,1", 18UL};
     auto result_3 = api::parseURL("/route/v1/profile/0,1");

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -16,121 +16,121 @@ BOOST_AUTO_TEST_CASE(compute_angle)
 {
     // Simple cases
     // North-South straight line
-    Coordinate first(FloatLongitude(1), FloatLatitude(-1));
-    Coordinate middle(FloatLongitude(1), FloatLatitude(0));
-    Coordinate end(FloatLongitude(1), FloatLatitude(1));
+    Coordinate first(FloatLongitude{1}, FloatLatitude{-1});
+    Coordinate middle(FloatLongitude{1}, FloatLatitude{0});
+    Coordinate end(FloatLongitude{1}, FloatLatitude{1});
     auto angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // North-South-North u-turn
-    first = Coordinate(FloatLongitude(1), FloatLatitude(0));
-    middle = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    end = Coordinate(FloatLongitude(1), FloatLatitude(0));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{0});
+    middle = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    end = Coordinate(FloatLongitude{1}, FloatLatitude{0});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 0);
 
     // East-west straight lines are harder, *simple* coordinates only
     // work at the equator.  For other locations, we need to follow
     // a rhumb line.
-    first = Coordinate(FloatLongitude(1), FloatLatitude(0));
-    middle = Coordinate(FloatLongitude(2), FloatLatitude(0));
-    end = Coordinate(FloatLongitude(3), FloatLatitude(0));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{0});
+    middle = Coordinate(FloatLongitude{2}, FloatLatitude{0});
+    end = Coordinate(FloatLongitude{3}, FloatLatitude{0});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // East-West-East u-turn
-    first = Coordinate(FloatLongitude(1), FloatLatitude(0));
-    middle = Coordinate(FloatLongitude(2), FloatLatitude(0));
-    end = Coordinate(FloatLongitude(1), FloatLatitude(0));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{0});
+    middle = Coordinate(FloatLongitude{2}, FloatLatitude{0});
+    end = Coordinate(FloatLongitude{1}, FloatLatitude{0});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 0);
 
     // 90 degree left turn
-    first = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    middle = Coordinate(FloatLongitude(0), FloatLatitude(1));
-    end = Coordinate(FloatLongitude(0), FloatLatitude(2));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    middle = Coordinate(FloatLongitude{0}, FloatLatitude{1});
+    end = Coordinate(FloatLongitude{0}, FloatLatitude{2});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 90);
 
     // 90 degree right turn
-    first = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    middle = Coordinate(FloatLongitude(0), FloatLatitude(1));
-    end = Coordinate(FloatLongitude(0), FloatLatitude(0));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    middle = Coordinate(FloatLongitude{0}, FloatLatitude{1});
+    end = Coordinate(FloatLongitude{0}, FloatLatitude{0});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 270);
 
     // Weird cases
     // Crossing both the meridians
-    first = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    middle = Coordinate(FloatLongitude(0), FloatLatitude(1));
-    end = Coordinate(FloatLongitude(1), FloatLatitude(-1));
+    first = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    middle = Coordinate(FloatLongitude{0}, FloatLatitude{1});
+    end = Coordinate(FloatLongitude{1}, FloatLatitude{-1});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_CLOSE(angle, 53.1, 0.2);
 
     // All coords in the same spot
-    first = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    middle = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    end = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
+    first = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    end = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First two coords in the same spot, then heading north-east
-    first = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    middle = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    end = Coordinate(FloatLongitude(1), FloatLatitude(1));
+    first = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    end = Coordinate(FloatLongitude{1}, FloatLatitude{1});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First two coords in the same spot, then heading west
-    first = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    middle = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    end = Coordinate(FloatLongitude(2), FloatLatitude(1));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    middle = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    end = Coordinate(FloatLongitude{2}, FloatLatitude{1});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First two coords in the same spot then heading north
-    first = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    middle = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    end = Coordinate(FloatLongitude(1), FloatLatitude(2));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    middle = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    end = Coordinate(FloatLongitude{1}, FloatLatitude{2});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // Second two coords in the same spot
-    first = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    middle = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    end = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    end = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First and last coords on the same spot
-    first = Coordinate(FloatLongitude(1), FloatLatitude(1));
-    middle = Coordinate(FloatLongitude(-1), FloatLatitude(-1));
-    end = Coordinate(FloatLongitude(1), FloatLatitude(1));
+    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    end = Coordinate(FloatLongitude{1}, FloatLatitude{1});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 0);
 
     // Check the antimeridian
-    first = Coordinate(FloatLongitude(180), FloatLatitude(90));
-    middle = Coordinate(FloatLongitude(180), FloatLatitude(0));
-    end = Coordinate(FloatLongitude(180), FloatLatitude(-90));
+    first = Coordinate(FloatLongitude{180}, FloatLatitude{90});
+    middle = Coordinate(FloatLongitude{180}, FloatLatitude{0});
+    end = Coordinate(FloatLongitude{180}, FloatLatitude{-90});
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // Tiny changes below our calculation resolution
     // This should be equivalent to having two points on the same
     // spot.
-    first = Coordinate(FloatLongitude(0), FloatLatitude(0));
-    middle = Coordinate(FloatLongitude(1), FloatLatitude(0));
-    end = Coordinate(FloatLongitude(1 + std::numeric_limits<double>::epsilon()), FloatLatitude(0));
+    first = Coordinate{FloatLongitude{0}, FloatLatitude{0}};
+    middle = Coordinate{FloatLongitude{1}, FloatLatitude{0}};
+    end = Coordinate{FloatLongitude{1 + std::numeric_limits<double>::epsilon()}, FloatLatitude{0}};
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // Invalid values
     /* TODO: Enable this when I figure out how to use BOOST_CHECK_THROW
      *       and not have the whole test case fail...
-    first = Coordinate(FloatLongitude(0), FloatLatitude(0));
-    middle = Coordinate(FloatLongitude(1), FloatLatitude(0));
-    end = Coordinate(FloatLongitude(std::numeric_limits<double>::max()), FloatLatitude(0));
+    first = Coordinate(FloatLongitude{0}, FloatLatitude{0});
+    middle = Coordinate(FloatLongitude{1}, FloatLatitude{0});
+    end = Coordinate(FloatLongitude(std::numeric_limits<double>::max()), FloatLatitude{0});
     BOOST_CHECK_THROW( coordinate_calculation::computeAngle(first,middle,end),
                        boost::numeric::positive_overflow);
                        */
@@ -139,9 +139,9 @@ BOOST_AUTO_TEST_CASE(compute_angle)
 // Regression test for bug captured in #1347
 BOOST_AUTO_TEST_CASE(regression_test_1347)
 {
-    Coordinate u(FloatLongitude(-100), FloatLatitude(10));
-    Coordinate v(FloatLongitude(-100.002), FloatLatitude(10.001));
-    Coordinate q(FloatLongitude(-100.001), FloatLatitude(10.002));
+    Coordinate u(FloatLongitude{-100}, FloatLatitude{10});
+    Coordinate v(FloatLongitude{-100.002}, FloatLatitude{10.001});
+    Coordinate q(FloatLongitude{-100.001}, FloatLatitude{10.002});
 
     double d1 = coordinate_calculation::perpendicularDistance(u, v, q);
 
@@ -179,10 +179,10 @@ BOOST_AUTO_TEST_CASE(regression_point_on_segment)
 
     FloatCoordinate diff{target.lon - start.lon, target.lat - start.lat};
 
-    BOOST_CHECK_CLOSE(static_cast<double>(start.lon + FloatLongitude(ratio) * diff.lon),
+    BOOST_CHECK_CLOSE(static_cast<double>(start.lon + FloatLongitude{ratio} * diff.lon),
                       static_cast<double>(nearest.lon),
                       0.1);
-    BOOST_CHECK_CLOSE(static_cast<double>(start.lat + FloatLatitude(ratio) * diff.lat),
+    BOOST_CHECK_CLOSE(static_cast<double>(start.lat + FloatLatitude{ratio} * diff.lat),
                       static_cast<double>(nearest.lat),
                       0.1);
 }
@@ -257,56 +257,56 @@ BOOST_AUTO_TEST_CASE(point_on_segment)
 
 BOOST_AUTO_TEST_CASE(circleCenter)
 {
-    Coordinate a(FloatLongitude(-100.), FloatLatitude(10.));
-    Coordinate b(FloatLongitude(-100.002), FloatLatitude(10.001));
-    Coordinate c(FloatLongitude(-100.001), FloatLatitude(10.002));
+    Coordinate a(FloatLongitude{-100.}, FloatLatitude{10.});
+    Coordinate b(FloatLongitude{-100.002}, FloatLatitude{10.001});
+    Coordinate c(FloatLongitude{-100.001}, FloatLatitude{10.002});
 
     auto result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude(-100.000833), FloatLatitude(10.000833)));
+    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-100.000833}, FloatLatitude{10.000833}));
 
     // Co-linear longitude
-    a = Coordinate(FloatLongitude(-100.), FloatLatitude(10.));
-    b = Coordinate(FloatLongitude(-100.001), FloatLatitude(10.001));
-    c = Coordinate(FloatLongitude(-100.001), FloatLatitude(10.002));
+    a = Coordinate(FloatLongitude{-100.}, FloatLatitude{10.});
+    b = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.001});
+    c = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.002});
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude(-99.9995), FloatLatitude(10.0015)));
+    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-99.9995}, FloatLatitude{10.0015}));
 
     // Co-linear longitude, impossible to calculate
-    a = Coordinate(FloatLongitude(-100.001), FloatLatitude(10.));
-    b = Coordinate(FloatLongitude(-100.001), FloatLatitude(10.001));
-    c = Coordinate(FloatLongitude(-100.001), FloatLatitude(10.002));
+    a = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.});
+    b = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.001});
+    c = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.002});
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
 
     // Co-linear latitude, this is a real case that failed
-    a = Coordinate(FloatLongitude(-112.096234), FloatLatitude(41.147101));
-    b = Coordinate(FloatLongitude(-112.096606), FloatLatitude(41.147101));
-    c = Coordinate(FloatLongitude(-112.096419), FloatLatitude(41.147259));
+    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147101});
+    b = Coordinate(FloatLongitude{-112.096606}, FloatLatitude{41.147101});
+    c = Coordinate(FloatLongitude{-112.096419}, FloatLatitude{41.147259});
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude(-112.09642), FloatLatitude(41.14707)));
+    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-112.09642}, FloatLatitude{41.14707}));
 
     // Co-linear latitude, variation
-    a = Coordinate(FloatLongitude(-112.096234), FloatLatitude(41.147101));
-    b = Coordinate(FloatLongitude(-112.096606), FloatLatitude(41.147259));
-    c = Coordinate(FloatLongitude(-112.096419), FloatLatitude(41.147259));
+    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147101});
+    b = Coordinate(FloatLongitude{-112.096606}, FloatLatitude{41.147259});
+    c = Coordinate(FloatLongitude{-112.096419}, FloatLatitude{41.147259});
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude(-112.096512), FloatLatitude(41.146962)));
+    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-112.096512}, FloatLatitude{41.146962}));
 
     // Co-linear latitude, impossible to calculate
-    a = Coordinate(FloatLongitude(-112.096234), FloatLatitude(41.147259));
-    b = Coordinate(FloatLongitude(-112.096606), FloatLatitude(41.147259));
-    c = Coordinate(FloatLongitude(-112.096419), FloatLatitude(41.147259));
+    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147259});
+    b = Coordinate(FloatLongitude{-112.096606}, FloatLatitude{41.147259});
+    c = Coordinate(FloatLongitude{-112.096419}, FloatLatitude{41.147259});
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
 
     // Out of bounds
-    a = Coordinate(FloatLongitude(-112.096234), FloatLatitude(41.147258));
-    b = Coordinate(FloatLongitude(-112.106606), FloatLatitude(41.147259));
-    c = Coordinate(FloatLongitude(-113.096419), FloatLatitude(41.147258));
+    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147258});
+    b = Coordinate(FloatLongitude{-112.106606}, FloatLatitude{41.147259});
+    c = Coordinate(FloatLongitude{-113.096419}, FloatLatitude{41.147258});
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
 }

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
 
     for (std::size_t i = 0; i < num_test_cases; i++)
     {
-        OSMNodeID r = static_cast<OSMNodeID>(rand() % 2147483647); // max 33-bit uint
+        OSMNodeID r {static_cast<std::uint64_t>(rand() % 2147483647)}; // max 33-bit uint
 
         packed_ids.push_back(r);
         original_ids.push_back(r);

--- a/unit_tests/util/rectangle.cpp
+++ b/unit_tests/util/rectangle.cpp
@@ -27,22 +27,22 @@ BOOST_AUTO_TEST_CASE(get_min_dist_test)
     //           +- -80
     //           |
     RectangleInt2D ne{
-        FloatLongitude(10), FloatLongitude(100), FloatLatitude(10), FloatLatitude(80)};
+        FloatLongitude{10}, FloatLongitude{100}, FloatLatitude{10}, FloatLatitude{80}};
     RectangleInt2D nw{
-        FloatLongitude(-100), FloatLongitude(-10), FloatLatitude(10), FloatLatitude(80)};
+        FloatLongitude{-100}, FloatLongitude{-10}, FloatLatitude{10}, FloatLatitude{80}};
     RectangleInt2D se{
-        FloatLongitude(10), FloatLongitude(100), FloatLatitude(-80), FloatLatitude(-10)};
+        FloatLongitude{10}, FloatLongitude{100}, FloatLatitude{-80}, FloatLatitude{-10}};
     RectangleInt2D sw{
-        FloatLongitude(-100), FloatLongitude(-10), FloatLatitude(-80), FloatLatitude(-10)};
+        FloatLongitude{-100}, FloatLongitude{-10}, FloatLatitude{-80}, FloatLatitude{-10}};
 
-    Coordinate nw_sw{FloatLongitude(-100.1), FloatLatitude(9.9)};
-    Coordinate nw_se{FloatLongitude(-9.9), FloatLatitude(9.9)};
-    Coordinate nw_ne{FloatLongitude(-9.9), FloatLatitude(80.1)};
-    Coordinate nw_nw{FloatLongitude(-100.1), FloatLatitude(80.1)};
-    Coordinate nw_s{FloatLongitude(-55), FloatLatitude(9.9)};
-    Coordinate nw_e{FloatLongitude(-9.9), FloatLatitude(45.0)};
-    Coordinate nw_w{FloatLongitude(-100.1), FloatLatitude(45.0)};
-    Coordinate nw_n{FloatLongitude(-55), FloatLatitude(80.1)};
+    Coordinate nw_sw{FloatLongitude{-100.1}, FloatLatitude{9.9}};
+    Coordinate nw_se{FloatLongitude{-9.9}, FloatLatitude{9.9}};
+    Coordinate nw_ne{FloatLongitude{-9.9}, FloatLatitude{80.1}};
+    Coordinate nw_nw{FloatLongitude{-100.1}, FloatLatitude{80.1}};
+    Coordinate nw_s{FloatLongitude{-55}, FloatLatitude{9.9}};
+    Coordinate nw_e{FloatLongitude{-9.9}, FloatLatitude{45.0}};
+    Coordinate nw_w{FloatLongitude{-100.1}, FloatLatitude{45.0}};
+    Coordinate nw_n{FloatLongitude{-55}, FloatLatitude{80.1}};
     BOOST_CHECK_CLOSE(
         nw.GetMinSquaredDist(nw_sw), 0.02 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
     BOOST_CHECK_CLOSE(
@@ -60,14 +60,14 @@ BOOST_AUTO_TEST_CASE(get_min_dist_test)
     BOOST_CHECK_CLOSE(
         nw.GetMinSquaredDist(nw_n), 0.01 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
 
-    Coordinate ne_sw{FloatLongitude(9.9), FloatLatitude(9.9)};
-    Coordinate ne_se{FloatLongitude(100.1), FloatLatitude(9.9)};
-    Coordinate ne_ne{FloatLongitude(100.1), FloatLatitude(80.1)};
-    Coordinate ne_nw{FloatLongitude(9.9), FloatLatitude(80.1)};
-    Coordinate ne_s{FloatLongitude(55), FloatLatitude(9.9)};
-    Coordinate ne_e{FloatLongitude(100.1), FloatLatitude(45.0)};
-    Coordinate ne_w{FloatLongitude(9.9), FloatLatitude(45.0)};
-    Coordinate ne_n{FloatLongitude(55), FloatLatitude(80.1)};
+    Coordinate ne_sw{FloatLongitude{9.9}, FloatLatitude{9.9}};
+    Coordinate ne_se{FloatLongitude{100.1}, FloatLatitude{9.9}};
+    Coordinate ne_ne{FloatLongitude{100.1}, FloatLatitude{80.1}};
+    Coordinate ne_nw{FloatLongitude{9.9}, FloatLatitude{80.1}};
+    Coordinate ne_s{FloatLongitude{55}, FloatLatitude{9.9}};
+    Coordinate ne_e{FloatLongitude{100.1}, FloatLatitude{45.0}};
+    Coordinate ne_w{FloatLongitude{9.9}, FloatLatitude{45.0}};
+    Coordinate ne_n{FloatLongitude{55}, FloatLatitude{80.1}};
     BOOST_CHECK_CLOSE(
         ne.GetMinSquaredDist(ne_sw), 0.02 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
     BOOST_CHECK_CLOSE(
@@ -85,14 +85,14 @@ BOOST_AUTO_TEST_CASE(get_min_dist_test)
     BOOST_CHECK_CLOSE(
         ne.GetMinSquaredDist(ne_n), 0.01 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
 
-    Coordinate se_ne{FloatLongitude(100.1), FloatLatitude(-9.9)};
-    Coordinate se_nw{FloatLongitude(9.9), FloatLatitude(-9.9)};
-    Coordinate se_sw{FloatLongitude(9.9), FloatLatitude(-80.1)};
-    Coordinate se_se{FloatLongitude(100.1), FloatLatitude(-80.1)};
-    Coordinate se_n{FloatLongitude(55), FloatLatitude(-9.9)};
-    Coordinate se_w{FloatLongitude(9.9), FloatLatitude(-45.0)};
-    Coordinate se_e{FloatLongitude(100.1), FloatLatitude(-45.0)};
-    Coordinate se_s{FloatLongitude(55), FloatLatitude(-80.1)};
+    Coordinate se_ne{FloatLongitude{100.1}, FloatLatitude{-9.9}};
+    Coordinate se_nw{FloatLongitude{9.9}, FloatLatitude{-9.9}};
+    Coordinate se_sw{FloatLongitude{9.9}, FloatLatitude{-80.1}};
+    Coordinate se_se{FloatLongitude{100.1}, FloatLatitude{-80.1}};
+    Coordinate se_n{FloatLongitude{55}, FloatLatitude{-9.9}};
+    Coordinate se_w{FloatLongitude{9.9}, FloatLatitude{-45.0}};
+    Coordinate se_e{FloatLongitude{100.1}, FloatLatitude{-45.0}};
+    Coordinate se_s{FloatLongitude{55}, FloatLatitude{-80.1}};
     BOOST_CHECK_CLOSE(
         se.GetMinSquaredDist(se_sw), 0.02 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
     BOOST_CHECK_CLOSE(
@@ -110,14 +110,14 @@ BOOST_AUTO_TEST_CASE(get_min_dist_test)
     BOOST_CHECK_CLOSE(
         se.GetMinSquaredDist(se_n), 0.01 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
 
-    Coordinate sw_ne{FloatLongitude(-9.9), FloatLatitude(-9.9)};
-    Coordinate sw_nw{FloatLongitude(-100.1), FloatLatitude(-9.9)};
-    Coordinate sw_sw{FloatLongitude(-100.1), FloatLatitude(-80.1)};
-    Coordinate sw_se{FloatLongitude(-9.9), FloatLatitude(-80.1)};
-    Coordinate sw_n{FloatLongitude(-55), FloatLatitude(-9.9)};
-    Coordinate sw_w{FloatLongitude(-100.1), FloatLatitude(-45.0)};
-    Coordinate sw_e{FloatLongitude(-9.9), FloatLatitude(-45.0)};
-    Coordinate sw_s{FloatLongitude(-55), FloatLatitude(-80.1)};
+    Coordinate sw_ne{FloatLongitude{-9.9}, FloatLatitude{-9.9}};
+    Coordinate sw_nw{FloatLongitude{-100.1}, FloatLatitude{-9.9}};
+    Coordinate sw_sw{FloatLongitude{-100.1}, FloatLatitude{-80.1}};
+    Coordinate sw_se{FloatLongitude{-9.9}, FloatLatitude{-80.1}};
+    Coordinate sw_n{FloatLongitude{-55}, FloatLatitude{-9.9}};
+    Coordinate sw_w{FloatLongitude{-100.1}, FloatLatitude{-45.0}};
+    Coordinate sw_e{FloatLongitude{-9.9}, FloatLatitude{-45.0}};
+    Coordinate sw_s{FloatLongitude{-55}, FloatLatitude{-80.1}};
     BOOST_CHECK_CLOSE(
         sw.GetMinSquaredDist(sw_sw), 0.02 * COORDINATE_PRECISION * COORDINATE_PRECISION, 0.1);
     BOOST_CHECK_CLOSE(

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -117,7 +117,7 @@ template <unsigned NUM_NODES, unsigned NUM_EDGES> struct RandomGraphFixture
         {
             int lon = lon_udist(g);
             int lat = lat_udist(g);
-            coords.emplace_back(Coordinate(FixedLongitude(lon), FixedLatitude(lat)));
+            coords.emplace_back(Coordinate(FixedLongitude{lon}, FixedLatitude{lat}));
         }
 
         std::uniform_int_distribution<> edge_udist(0, coords.size() - 1);
@@ -216,7 +216,7 @@ void sampling_verify_rtree(RTreeT &rtree,
     std::vector<Coordinate> queries;
     for (unsigned i = 0; i < num_samples; i++)
     {
-        queries.emplace_back(FixedLongitude(lon_udist(g)), FixedLatitude(lat_udist(g)));
+        queries.emplace_back(FixedLongitude{lon_udist(g)}, FixedLatitude{lat_udist(g)});
     }
 
     for (const auto &q : queries)
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(regression_test)
     LinearSearchNN<TestData> lsnn(fixture.coords, fixture.edges);
 
     // query a node just right of the center of the gap
-    Coordinate input(FloatLongitude(55.1), FloatLatitude(20.0));
+    Coordinate input(FloatLongitude{55.1}, FloatLatitude{20.0});
     auto result_rtree = rtree.Nearest(input, 1);
     auto result_ls = lsnn.Nearest(input, 1);
 
@@ -342,8 +342,8 @@ BOOST_AUTO_TEST_CASE(radius_regression_test)
     using Edge = std::pair<unsigned, unsigned>;
     GraphFixture fixture(
         {
-            Coord(FloatLongitude(0.0), FloatLatitude(0.0)),
-            Coord(FloatLongitude(10.0), FloatLatitude(10.0)),
+            Coord(FloatLongitude{0.0}, FloatLatitude{0.0}),
+            Coord(FloatLongitude{10.0}, FloatLatitude{10.0}),
         },
         {Edge(0, 1), Edge(1, 0)});
 
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(radius_regression_test)
     engine::GeospatialQuery<MiniStaticRTree, MockDataFacade> query(
         rtree, fixture.coords, mockfacade);
 
-    Coordinate input(FloatLongitude(5.2), FloatLatitude(5.0));
+    Coordinate input(FloatLongitude{5.2}, FloatLatitude{5.0});
 
     {
         auto results = query.NearestPhantomNodesInRange(input, 0.01);
@@ -369,8 +369,8 @@ BOOST_AUTO_TEST_CASE(bearing_tests)
     using Edge = std::pair<unsigned, unsigned>;
     GraphFixture fixture(
         {
-            Coord(FloatLongitude(0.0), FloatLatitude(0.0)),
-            Coord(FloatLongitude(10.0), FloatLatitude(10.0)),
+            Coord(FloatLongitude{0.0}, FloatLatitude{0.0}),
+            Coord(FloatLongitude{10.0}, FloatLatitude{10.0}),
         },
         {Edge(0, 1), Edge(1, 0)});
 
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(bearing_tests)
     engine::GeospatialQuery<MiniStaticRTree, MockDataFacade> query(
         rtree, fixture.coords, mockfacade);
 
-    Coordinate input(FloatLongitude(5.1), FloatLatitude(5.0));
+    Coordinate input(FloatLongitude{5.1}, FloatLatitude{5.0});
 
     {
         auto results = query.NearestPhantomNodes(input, 5);
@@ -440,11 +440,11 @@ BOOST_AUTO_TEST_CASE(bbox_search_tests)
 
     GraphFixture fixture(
         {
-            Coord(FloatLongitude(0.0), FloatLatitude(0.0)),
-            Coord(FloatLongitude(1.0), FloatLatitude(1.0)),
-            Coord(FloatLongitude(2.0), FloatLatitude(2.0)),
-            Coord(FloatLongitude(3.0), FloatLatitude(3.0)),
-            Coord(FloatLongitude(4.0), FloatLatitude(4.0)),
+            Coord(FloatLongitude{0.0}, FloatLatitude{0.0}),
+            Coord(FloatLongitude{1.0}, FloatLatitude{1.0}),
+            Coord(FloatLongitude{2.0}, FloatLatitude{2.0}),
+            Coord(FloatLongitude{3.0}, FloatLatitude{3.0}),
+            Coord(FloatLongitude{4.0}, FloatLatitude{4.0}),
         },
         {Edge(0, 1), Edge(1, 2), Edge(2, 3), Edge(3, 4)});
 
@@ -458,14 +458,14 @@ BOOST_AUTO_TEST_CASE(bbox_search_tests)
 
     {
         RectangleInt2D bbox = {
-            FloatLongitude(0.5), FloatLongitude(1.5), FloatLatitude(0.5), FloatLatitude(1.5)};
+            FloatLongitude{0.5}, FloatLongitude{1.5}, FloatLatitude{0.5}, FloatLatitude{1.5}};
         auto results = query.Search(bbox);
         BOOST_CHECK_EQUAL(results.size(), 2);
     }
 
     {
         RectangleInt2D bbox = {
-            FloatLongitude(1.5), FloatLongitude(3.5), FloatLatitude(1.5), FloatLatitude(3.5)};
+            FloatLongitude{1.5}, FloatLongitude{3.5}, FloatLatitude{1.5}, FloatLatitude{3.5}};
         auto results = query.Search(bbox);
         BOOST_CHECK_EQUAL(results.size(), 3);
     }

--- a/unit_tests/util/web_mercator.cpp
+++ b/unit_tests/util/web_mercator.cpp
@@ -22,23 +22,23 @@ BOOST_AUTO_TEST_CASE(lon_to_pixel)
 
 BOOST_AUTO_TEST_CASE(lat_to_pixel)
 {
-    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude(43.733947)) *
+    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude{43.733947}) *
                           web_mercator::DEGREE_TO_PX,
                       5424361.75863,
                       0.1);
-    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude(43.733799)) *
+    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude{43.733799}) *
                           web_mercator::DEGREE_TO_PX,
                       5424338.95731,
                       0.1);
-    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude(43.733922)) *
+    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude{43.733922}) *
                           web_mercator::DEGREE_TO_PX,
                       5424357.90705,
                       0.1);
-    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude(43.733697)) *
+    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude{43.733697}) *
                           web_mercator::DEGREE_TO_PX,
                       5424323.24293,
                       0.1);
-    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude(43.733729)) *
+    BOOST_CHECK_CLOSE(web_mercator::latToY(util::FloatLatitude{43.733729}) *
                           web_mercator::DEGREE_TO_PX,
                       5424328.17293,
                       0.1);


### PR DESCRIPTION
This changes the edge-weight-update loop to use `mmap`-ed data instead of using `read` on `::ifstream` objects.

When processing California-sized datasets, this change reduces the edge-weight-update loop from 7 seconds to 1.4 seconds.   On larger datasets where we see 150+ second durations for this code block, this should have a decent impact on the time it takes to turn around a dataset.

The file formats *should* remain compatible between releases here, hence only the minor version bump.