### PR TITLE
fix invalid circle centers

### DIFF
--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -258,7 +258,10 @@ circleCenter(const Coordinate C1, const Coordinate C2, const Coordinate C3)
                             C2C1_slope * (C2_x + C3_x)) /
                            (2 * (C3C2_slope - C2C1_slope));
         const double lat = (0.5 * (C1_x + C2_x) - lon) / C2C1_slope + 0.5 * (C1_y + C2_y);
-        return Coordinate(FloatLongitude(lon), FloatLatitude(lat));
+        if (lon < -180.0 || lon > 180.0 || lat < -90.0 || lat > 90.0)
+            return boost::none;
+        else
+            return Coordinate(FloatLongitude(lon), FloatLatitude(lat));
     }
 }
 

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -302,6 +302,13 @@ BOOST_AUTO_TEST_CASE(circleCenter)
     c = Coordinate(FloatLongitude(-112.096419), FloatLatitude(41.147259));
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
+
+    // Out of bounds
+    a = Coordinate(FloatLongitude(-112.096234), FloatLatitude(41.147258));
+    b = Coordinate(FloatLongitude(-112.106606), FloatLatitude(41.147259));
+    c = Coordinate(FloatLongitude(-113.096419), FloatLatitude(41.147258));
+    result = coordinate_calculation::circleCenter(a, b, c);
+    BOOST_CHECK(!result);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Even though the math works out fine, some circles can end up producing invalid circle centres in respect to lon/lat values. A valid circle through three points does not necessarily end up located on the planet, if the points follow a very strange setting.

This PR corrects this behaviour by only returning valid circle-centres.