### PR TITLE
reduce number of end-of-road instructions in unnecessary cases

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -525,9 +525,9 @@ Feature: Collapse
             | cf    | secondary | bottom |
 
         When I route I should get
-            | waypoints | turns                                          | route               |
-            | a,d       | depart,continue right,end of road right,arrive | road,road,road,road |
-            | d,a       | depart,continue left,end of road left,arrive   | road,road,road,road |
+            | waypoints | turns                                   | route               |
+            | a,d       | depart,continue right,turn right,arrive | road,road,road,road |
+            | d,a       | depart,continue left,turn left,arrive   | road,road,road,road |
 
     Scenario: Forking before a turn
         Given the node map

--- a/features/guidance/end-of-road.feature
+++ b/features/guidance/end-of-road.feature
@@ -8,116 +8,123 @@ Feature: End Of Road Instructions
     Scenario: End of Road with through street
         Given the node map
             |   |   | c |
-            | a |   | b |
-            |   |   | d |
+            | a | e | b |
+            |   | f | d |
 
         And the ways
             | nodes  | highway |
-            | ab     | primary |
+            | aeb    | primary |
             | cbd    | primary |
+            | ef     | primary |
 
        When I route I should get
-            | waypoints | route      | turns                           |
-            | a,c       | ab,cbd,cbd | depart,end of road left,arrive  |
-            | a,d       | ab,cbd,cbd | depart,end of road right,arrive |
+            | waypoints | route       | turns                           |
+            | a,c       | aeb,cbd,cbd | depart,end of road left,arrive  |
+            | a,d       | aeb,cbd,cbd | depart,end of road right,arrive |
 
     Scenario: End of Road with three streets
         Given the node map
             |   |   | c |
-            | a |   | b |
-            |   |   | d |
+            | a | e | b |
+            |   | f | d |
 
         And the ways
             | nodes  | highway |
-            | ab     | primary |
+            | aeb    | primary |
             | cb     | primary |
             | bd     | primary |
+            | ef     | primary |
 
        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,c       | ab,cb,cb | depart,end of road left,arrive  |
-            | a,d       | ab,bd,bd | depart,end of road right,arrive |
+            | waypoints | route     | turns                           |
+            | a,c       | aeb,cb,cb | depart,end of road left,arrive  |
+            | a,d       | aeb,bd,bd | depart,end of road right,arrive |
 
     Scenario: End of Road with three streets, slightly angled
         Given the node map
-            | a |   |   |   |   | c |
-            |   |   |   |   |   | b |
+            | a | e |   |   |   | c |
+            |   | f |   |   |   | b |
             |   |   |   |   |   | d |
 
         And the ways
             | nodes  | highway |
-            | ab     | primary |
+            | aeb    | primary |
             | cb     | primary |
             | bd     | primary |
+            | ef     | primary |
 
        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,c       | ab,cb,cb | depart,end of road left,arrive  |
-            | a,d       | ab,bd,bd | depart,end of road right,arrive |
+            | waypoints | route     | turns                           |
+            | a,c       | aeb,cb,cb | depart,end of road left,arrive  |
+            | a,d       | aeb,bd,bd | depart,end of road right,arrive |
 
     Scenario: End of Road with three streets, slightly angled
         Given the node map
             |   |   |   |   |   | c |
-            |   |   |   |   |   | b |
-            | a |   |   |   |   | d |
+            |   | f |   |   |   | b |
+            | a | e |   |   |   | d |
 
         And the ways
             | nodes  | highway |
-            | ab     | primary |
+            | aeb    | primary |
+            | ef     | primary |
             | cb     | primary |
             | bd     | primary |
 
        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,c       | ab,cb,cb | depart,end of road left,arrive  |
-            | a,d       | ab,bd,bd | depart,end of road right,arrive |
+            | waypoints | route     | turns                           |
+            | a,c       | aeb,cb,cb | depart,end of road left,arrive  |
+            | a,d       | aeb,bd,bd | depart,end of road right,arrive |
 
     Scenario: End of Road with through street, slightly angled
         Given the node map
-            | a |   |   |   |   | c |
-            |   |   |   |   |   | b |
+            | a | e |   |   |   | c |
+            |   | f |   |   |   | b |
             |   |   |   |   |   | d |
 
         And the ways
             | nodes  | highway |
-            | ab     | primary |
+            | aeb    | primary |
+            | ef     | primary |
             | cbd    | primary |
 
        When I route I should get
-            | waypoints | route      | turns                           |
-            | a,c       | ab,cbd,cbd | depart,end of road left,arrive  |
-            | a,d       | ab,cbd,cbd | depart,end of road right,arrive |
+            | waypoints | route       | turns                           |
+            | a,c       | aeb,cbd,cbd | depart,end of road left,arrive  |
+            | a,d       | aeb,cbd,cbd | depart,end of road right,arrive |
 
     Scenario: End of Road with through street, slightly angled
         Given the node map
             |   |   |   |   |   | c |
-            |   |   |   |   |   | b |
-            | a |   |   |   |   | d |
+            |   | f |   |   |   | b |
+            | a | e |   |   |   | d |
 
         And the ways
             | nodes  | highway |
-            | ab     | primary |
+            | aeb    | primary |
+            | ef     | primary |
             | cbd    | primary |
 
        When I route I should get
-            | waypoints | route      | turns                           |
-            | a,c       | ab,cbd,cbd | depart,end of road left,arrive  |
-            | a,d       | ab,cbd,cbd | depart,end of road right,arrive |
+            | waypoints | route       | turns                           |
+            | a,c       | aeb,cbd,cbd | depart,end of road left,arrive  |
+            | a,d       | aeb,cbd,cbd | depart,end of road right,arrive |
 
     Scenario: End of Road with two ramps - prefer ramp over end of road
         Given the node map
             |   |   | c |
-            | a |   | b |
-            |   |   | d |
+            | a | e | b |
+            |   | f | d |
 
         And the ways
             | nodes  | highway       |
-            | ab     | primary       |
+            | aeb    | primary       |
+            | ef     | primary       |
             | bc     | motorway_link |
             | bd     | motorway_link |
 
        When I route I should get
-            | waypoints | route    | turns                       |
-            | a,c       | ab,bc,bc | depart,on ramp left,arrive  |
-            | a,d       | ab,bd,bd | depart,on ramp right,arrive |
+            | waypoints | route     | turns                       |
+            | a,c       | aeb,bc,bc | depart,on ramp left,arrive  |
+            | a,d       | aeb,bd,bd | depart,on ramp right,arrive |
 

--- a/features/guidance/intersections.feature
+++ b/features/guidance/intersections.feature
@@ -17,8 +17,8 @@ Feature: Intersections Data
             | bd     | corner  |
 
        When I route I should get
-            | waypoints | route           | turns         | intersections                               |
-            | a,c       | through,through | depart,arrive | true:90,true:90 true:180 false:270;true:270 |
+            | waypoints | route           | intersections                               |
+            | a,c       | through,through | true:90,true:90 true:180 false:270;true:270 |
 
     Scenario: Passing Three Way North
         Given the node map
@@ -32,8 +32,8 @@ Feature: Intersections Data
             | bd     | corner  |
 
        When I route I should get
-            | waypoints | route           | turns         | intersections                             |
-            | a,c       | through,through | depart,arrive | true:90,true:0 true:90 false:270;true:270 |
+            | waypoints | route           | intersections                             |
+            | a,c       | through,through | true:90,true:0 true:90 false:270;true:270 |
 
     Scenario: Passing Oneway Street In
         Given the node map
@@ -47,8 +47,8 @@ Feature: Intersections Data
             | db     | corner  | yes    |
 
        When I route I should get
-            | waypoints | route           | turns         | intersections                              |
-            | a,c       | through,through | depart,arrive | true:90,false:0 true:90 false:270;true:270 |
+            | waypoints | route           | intersections                              |
+            | a,c       | through,through | true:90,false:0 true:90 false:270;true:270 |
 
     Scenario: Passing Oneway Street Out
         Given the node map
@@ -62,8 +62,8 @@ Feature: Intersections Data
             | bd     | corner  | yes    |
 
        When I route I should get
-            | waypoints | route           | turns         | intersections                             |
-            | a,c       | through,through | depart,arrive | true:90,true:0 true:90 false:270;true:270 |
+            | waypoints | route           | intersections                             |
+            | a,c       | through,through | true:90,true:0 true:90 false:270;true:270 |
 
     Scenario: Passing Two Intersections
         Given the node map
@@ -80,27 +80,8 @@ Feature: Intersections Data
             | cf     | corner  |
 
        When I route I should get
-            | waypoints | route           | turns         | intersections                                                        |
-            | a,d       | through,through | depart,arrive | true:90,true:0 true:90 false:270,true:90 true:180 false:270;true:270 |
-
-    Scenario: Regression test #2424
-        Given the node map
-            |   |   | e |   |   |   |   |   | i |   |   |   |   |
-            | a |   | b |   | c |   | d |   | h |   | k |   | m |
-            |   |   |   |   | f |   |   |   |   |   | l |   |   |
-
-        And the ways
-            | nodes  | name    |
-            | abcd   | Fritz-Elsas-Straße |
-            | hkm    | Fritz-Elsas-Straße |
-            | dhi    | Martin-Luther-Straße |
-            | be     | corner  |
-            | kl     | corner  |
-            | cf     | corner  |
-
-       When I route I should get
-            | waypoints | route | turns         |
-            | a,m       | Fritz-Elsas-Straße,Fritz-Elsas-Straße| depart,arrive |
+            | waypoints | route           | intersections                                                        |
+            | a,d       | through,through | true:90,true:0 true:90 false:270,true:90 true:180 false:270;true:270 |
 
     Scenario: Passing Two Intersections, Collapsing
         Given the node map
@@ -117,9 +98,9 @@ Feature: Intersections Data
             | cf     | corner        |
 
        When I route I should get
-            | waypoints | route                  | turns                          | intersections                                                        |
-            | a,d       | through,through        | depart,arrive                  | true:90,true:0 true:90 false:270,true:90 true:180 false:270;true:270 |
-            | f,a       | corner,through,through | depart,end of road left,arrive | true:0;true:90 false:180 true:270,true:0 false:90 true:270;true:90   |
+            | waypoints | route                  | intersections                                                        |
+            | a,d       | through,through        | true:90,true:0 true:90 false:270,true:90 true:180 false:270;true:270 |
+            | f,a       | corner,through,through | true:0;true:90 false:180 true:270,true:0 false:90 true:270;true:90   |
 
     Scenario: Roundabouts
         Given the node map
@@ -144,10 +125,10 @@ Feature: Intersections Data
             | hd    |            |
 
         When I route I should get
-            | waypoints | route          | turns                              | intersections                                                                                                                 |
-            | e,f       | ea,fb,fb       | depart,abcda-exit-1,arrive         | true:180;false:0 false:150 true:210,false:30 true:150 true:270;true:90                                                        |
-            | e,g       | ea,gc,gc       | depart,abcda-exit-2,arrive         | true:180;false:0 false:150 true:210,false:30 true:150 true:270,true:30 true:180 false:330;true:0                              |
-            | e,h       | ea,hd,hd       | depart,abcda-exit-3,arrive         | true:180;false:0 false:150 true:210,false:30 true:150 true:270,true:30 true:180 false:330,true:90 false:210 true:330;true:270 |
-            | e,2       | ea,abcda,abcda | depart,abcda-exit-undefined,arrive | true:180;false:0 false:150 true:210,false:30 true:150 true:270;true:327 +-1                                                   |
-            | 1,g       | abcda,gc,gc    | depart,abcda-exit-2,arrive         | true:214;false:30 true:150 true:270,true:30 true:180 false:330;true:0                                                         |
-            | 1,3       | abcda,abcda    | depart,arrive                      | true:214,false:30 true:150 true:270,true:30 true:180 false:330;true:214                                                       |
+            | waypoints | route          | intersections                                                                                                                 |
+            | e,f       | ea,fb,fb       | true:180;false:0 false:150 true:210,false:30 true:150 true:270;true:90                                                        |
+            | e,g       | ea,gc,gc       | true:180;false:0 false:150 true:210,false:30 true:150 true:270,true:30 true:180 false:330;true:0                              |
+            | e,h       | ea,hd,hd       | true:180;false:0 false:150 true:210,false:30 true:150 true:270,true:30 true:180 false:330,true:90 false:210 true:330;true:270 |
+            | e,2       | ea,abcda,abcda | true:180;false:0 false:150 true:210,false:30 true:150 true:270;true:327 +-1                                                   |
+            | 1,g       | abcda,gc,gc    | true:214;false:30 true:150 true:270,true:30 true:180 false:330;true:0                                                         |
+            | 1,3       | abcda,abcda    | true:214,false:30 true:150 true:270,true:30 true:180 false:330;true:214                                                       |

--- a/features/guidance/post-processing.feature
+++ b/features/guidance/post-processing.feature
@@ -1,0 +1,22 @@
+@routing  @guidance @post-processing
+Feature: General Post-Processing related features
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 10 meters
+
+    # this testcase used to crash geometry generation (at that time handled during intersection generation)
+    Scenario: Regression test #2424
+        Given the node map
+            |   |   | e |   |   |   |   |   | i |   |   |   |   |
+            | a |   | b |   | c |   | d |   | h |   | k |   | m |
+            |   |   |   |   | f |   |   |   |   |   | l |   |   |
+
+        And the ways
+            | nodes  | name                 |
+            | abcd   | Fritz-Elsas-Straße   |
+            | hkm    | Fritz-Elsas-Straße   |
+            | dhi    | Martin-Luther-Straße |
+            | be     | corner               |
+            | kl     | corner               |
+            | cf     | corner               |


### PR DESCRIPTION
<img width="306" alt="screen shot 2016-05-24 at 15 40 50" src="https://cloud.githubusercontent.com/assets/12932279/15506014/1f9e12ba-21c6-11e6-882a-8a76a1685e29.png">

Sometimes, end-of-road can feel way to verbose. If there has not been at least a single intersection in between, the benefit gained from `end of road` is slim.

This PR reduces the verbosity of our current guidance output. The T-intersection itself could, if necessary, still be deduced from the by now available intersection classifications.