### PR TITLE
bike: surface should never increase speed

### DIFF
--- a/features/bicycle/surface.feature
+++ b/features/bicycle/surface.feature
@@ -38,3 +38,20 @@ Feature: Bike - Surfaces
         | cycleway |         | 48s   |
         | nosense  |         |       |
         | nosense  | asphalt |       |
+
+    Scenario: Bicycle - Surfaces should not increase speed when pushing bikes
+      Given the node map
+         | a | b |
+         | c | d |
+
+      And the ways
+        | nodes | highway | oneway | surface |
+        | ab    | primary | yes    | asphalt |
+        | cd    | footway |        | asphalt |
+
+      When I route I should get
+        | from | to | route | modes                     | speed   |
+        | a    | b  | ab,ab | cycling,cycling           | 15 km/h |
+        | b    | a  | ab,ab | pushing bike,pushing bike | 6 km/h  |
+        | c    | d  | cd,cd | pushing bike,pushing bike | 6 km/h  |
+        | d    | c  | cd,cd | pushing bike,pushing bike | 6 km/h  |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -207,7 +207,6 @@ function way_function (way, result)
   local foot = way:get_value_by_key("foot")
   local foot_forward = way:get_value_by_key("foot:forward")
   local foot_backward = way:get_value_by_key("foot:backward")
-  local surface = way:get_value_by_key("surface")
   local bicycle = way:get_value_by_key("bicycle")
 
   -- name
@@ -385,17 +384,12 @@ function way_function (way, result)
     result.backward_speed = walking_speed
   end
 
-  -- surfaces
-  if surface then
-    surface_speed = surface_speeds[surface]
-    if surface_speed then
-      if result.forward_speed > 0 then
-        result.forward_speed = surface_speed
-      end
-      if result.backward_speed > 0 then
-        result.backward_speed  = surface_speed
-      end
-    end
+  -- reduce speed on bad surfaces
+  local surface = way:get_value_by_key("surface")
+
+  if surface and surface_speeds[surface] then
+    result.forward_speed = math.min(surface_speeds[surface], result.forward_speed)
+    result.backward_speed = math.min(surface_speeds[surface], result.backward_speed)
   end
 
   -- maxspeed


### PR DESCRIPTION
The bike profile sets the speed according to the surface tag, even if the speed is faster than what's already determined by the way type.

This cause incorrect behaviour where you push the bike (like footways and oneways and surface=asphalt, since the speed will end up being full bike speed. This again to incorrect routing in a lot cases.

This PR fixes the problem and adds a cucumber test (which fails without the fix).

The updated behaviour mirrors the car profile.
