### PR TITLE
fixing luabind / CP issue in profile

### DIFF
--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -107,6 +107,24 @@ Feature: Turn Lane Guidance
             | a,d       | road,turn,turn | depart,turn right,arrive        | ,straight:false right:true, |
             | a,c       | road,road,road | depart,use lane straight,arrive | ,straight:true right:false, |
 
+    @PROFILE @LANES
+    Scenario: Turn with Bus-Lane but without lanes
+        Given the node map
+            | a |   | b |   | c |
+            |   |   |   |   |   |
+            |   |   | d |   |   |
+
+        And the ways
+            | nodes | name | lanes:psv |
+            | ab    | road | 1         |
+            | bc    | road | yes       |
+            | bd    | turn |           |
+
+        When I route I should get
+            | waypoints | route          | turns                    |
+            | a,d       | road,turn,turn | depart,turn right,arrive |
+            | a,c       | road,road      | depart,arrive            |
+
     #turn lanes are often drawn at the incoming road, even though the actual turn requires crossing the intersection first
     @todo @WORKAROUND-FIXME @bug
     Scenario: Turn Lanes at Segregated Road

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -189,7 +189,7 @@ local function getPSVCounts(way)
     if( psv_backward and psv_backward ~= "" ) then
         bw = tonumber(psv_backward);
         if( bw == nil ) then
-            fw = 0
+            bw = 0
         end
     end
     return fw, bw
@@ -206,10 +206,16 @@ local function getTurnLanes(way)
     local turn_lanes_bw = way:get_value_by_key("turn:lanes:backward")
 
     if( fw_psv ~= 0 or bw_psv ~= 0 ) then
-        turn_lanes = trimLaneString(turn_lanes, bw_psv, fw_psv )
-        turn_lanes_fw = trimLaneString(turn_lanes_fw, bw_psv, fw_psv )
+        if  turn_lanes and turn_lanes ~= "" then
+            turn_lanes = trimLaneString(turn_lanes, bw_psv, fw_psv )
+        end
+        if  turn_lanes_fw and turn_lanes_fw ~= ""  then
+            turn_lanes_fw = trimLaneString(turn_lanes_fw, bw_psv, fw_psv )
+        end
         --backwards turn lanes need to treat bw_psv as fw_psv and vice versa
-        turn_lanes_bw = trimLaneString(turn_lanes_bw, fw_psv, bw_psv )
+        if  turn_lanes_bw and turn_lanes_bw ~= ""  then
+            turn_lanes_bw = trimLaneString(turn_lanes_bw, fw_psv, bw_psv )
+        end
     end
 
     return turn_lanes, turn_lanes_fw, turn_lanes_bw
@@ -427,15 +433,15 @@ function way_function (way, result)
   local turn_lanes_backward = ""
 
   turn_lanes, turn_lanes_forward, turn_lanes_backward = getTurnLanes(way)
-  if( turn_lanes ~= "" ) then
+  if  turn_lanes and turn_lanes ~= "" then
     result.turn_lanes_forward = turn_lanes;
     result.turn_lanes_backward = turn_lanes;
   else
-    if( turn_lanes_forward ~= "" ) then
+    if turn_lanes_forward and turn_lanes_forward ~= ""  then
         result.turn_lanes_forward = turn_lanes_forward;
     end
 
-    if( turn_lanes_backward ~= "" ) then
+    if turn_lanes_backward and turn_lanes_backward ~= "" then
         result.turn_lanes_backward = turn_lanes_backward;
     end
   end


### PR DESCRIPTION
It seems that some luabind versions might return "nil" for empty strings.
These are probably the result of: https://github.com/Project-OSRM/osrm-backend/issues/2594.

By checking for the availability of the data, we make sure not to trigger the error.