### PR TITLE
adjust changelog (mention both files) and update a typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
     - Infrastructure
      - BREAKING: The new turn type changes the turn-type order. This breaks the **data format**.
-     - BREAKING: Turn lane data introduces a new file (osrm.tld). This breaks the fileformat for older versions.
+     - BREAKING: Turn lane data introduces two new files (osrm.tld,osrm.tls). This breaks the fileformat for older versions.
 
 # 5.2.5
   - Bugfixes

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -152,7 +152,7 @@ int Storage::Run()
     if (!util::deserializeAdjacencyArray(config.turn_lane_description_path.string(),
                                          lane_description_offsets,
                                          lane_description_masks))
-        throw util::exception("Could not open read lane descriptions from: " +
+        throw util::exception("Failed to read lane descriptions from: " +
                               config.turn_lane_description_path.string());
     shared_layout_ptr->SetBlockSize<std::uint32_t>(SharedDataLayout::LANE_DESCRIPTION_OFFSETS,
                                                    lane_description_offsets.size());


### PR DESCRIPTION
Updates the Changelog (there is a file missing in the description) and fixes a related typo.