### PR TITLE
advanced lanes

### DIFF
--- a/features/guidance/advanced-lanes.feature
+++ b/features/guidance/advanced-lanes.feature
@@ -1,0 +1,186 @@
+@routing @guidance @turn-lanes
+Feature: Turn Lane Guidance
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 3 meters
+
+    #requires https://github.com/cucumber/cucumber-js/issues/417
+    #Due to this, we use & as a pipe character. Switch them out for \| when 417 is fixed
+    @bug @WORKAROUND-FIXME
+    Scenario: Separate Turn Lanes
+        Given the node map
+            |   |   |   |   |   |   |   | e |   |
+            | a |   |   | b |   |   |   | c | g |
+            |   |   |   |   |   |   |   | d |   |
+            |   |   |   |   |   |   |   | f |   |
+
+        And the ways
+            | nodes | turn:lanes:forward | name     | oneway |
+            | ab    |                    | in       | yes    |
+            | bc    | left\|through      | in       | yes    |
+            | bd    | right              | in       | yes    |
+            | ec    |                    | cross    | no     |
+            | cd    |                    | cross    | no     |
+            | df    |                    | cross    | no     |
+            | cg    |                    | straight | no     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | cd     | d        | no_left_turn  |
+            | restriction | bc       | cd     | c        | no_right_turn |
+
+       When I route I should get
+            | waypoints | route                | turns                           | lanes                                  |
+            | a,e       | in,cross,cross       | depart,turn left,arrive         | ,left:true straight:false right:false, |
+            | a,g       | in,straight,straight | depart,new name straight,arrive | ,left:false straight:true right:false, |
+            | a,f       | in,cross,cross       | depart,turn right,arrive        | ,left:false straight:false right:true, |
+
+    @TODO @2650 @bug
+    Scenario: Sliproad with through lane
+        Given the node map
+            |   |   |   |   |   |   |   |   |   | f |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   | g |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   | e |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   | d |   |   |   |
+            | a |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   | b |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   | c |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   | h |   |   |   |   | i |   |   |   |
+
+        And the ways
+            | nodes | name   | oneway | turn:lanes:forward |
+            | ab    | ghough | yes    |                    |
+            | bc    | ghough | yes    | through\|none      |
+            | bd    | ghough | yes    | none\|through      |
+            | de    | ghough | yes    |                    |
+            | fgb   | haight | yes    |                    |
+            | bh    | haight | yes    | left\|none         |
+            | fd    | market | yes    |                    |
+            | dc    | market | yes    |                    |
+            | ci    | market | yes    |                    |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | fgb      | bd     | b        | no_left_turn  |
+            | restriction | fgb      | bc     | b        | no_left_turn  |
+
+        When I route I should get
+            | waypoints | route                | turns                              | lanes |
+            | a,h       | ghough,haight,haight | depart,turn right,arrive           |       |
+            | a,i       | ghough,market,market | depart,turn right,arrive           |       |
+            | a,e       | ghough,ghough,ghough | depart,continue slight left,arrive |       |
+
+    @TODO @2650 @bug
+    Scenario: Sliproad with through lane
+        Given the node map
+            |   |   |   |   |   |   |   | f |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   | g |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   | e |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   | d |   |   |
+            | a |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   | b |   |   |   |   |   |
+            |   |   |   |   |   |   |   | c |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   | h |   |   |   | i |   |   |
+
+        And the ways
+            | nodes | name   | oneway | turn:lanes:forward |
+            | ab    | ghough | yes    |                    |
+            | bc    | ghough | yes    | through\|none      |
+            | bd    | ghough | yes    | none\|through      |
+            | fgb   | haight | yes    |                    |
+            | bh    | haight | yes    | left\|none         |
+            | fd    | market | yes    |                    |
+            | dc    | market | yes    |                    |
+            | ci    | market | yes    |                    |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | dc     | d        | no_right_turn |
+            | restriction | fgb      | bd     | b        | no_left_turn  |
+            | restriction | fgb      | bc     | b        | no_left_turn  |
+
+        When I route I should get
+            | waypoints | route                | turns                              | lanes |
+            | a,h       | ghough,haight,haight | depart,turn right,arrive           |       |
+            | a,i       | ghough,market,market | depart,turn right,arrive           |       |
+            | a,e       | ghough,ghough,ghough | depart,continue slight left,arrive |       |
+
+    Scenario: Separate Turn Lanes
+        Given the node map
+            |   |   |   |   |   |   |   | e |   |
+            | a |   |   | b |   |   |   | c | g |
+            |   |   |   |   |   |   |   | d |   |
+            |   |   |   |   |   |   |   | f |   |
+
+        And the ways
+            | nodes | turn:lanes:forward | name     | oneway |
+            | ab    |                    | in       | yes    |
+            | bc    | left\|through      | in       | yes    |
+            | bd    | right              | in       | yes    |
+            | ec    |                    | cross    | no     |
+            | cd    |                    | cross    | no     |
+            | df    |                    | cross    | no     |
+            | cg    |                    | straight | no     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | cd     | d        | no_left_turn  |
+            | restriction | bc       | cd     | c        | no_right_turn |
+
+       When I route I should get
+            | waypoints | route                | turns                           | lanes                                  |
+            | a,e       | in,cross,cross       | depart,turn left,arrive         | ,left:true straight:false right:false, |
+            | a,g       | in,straight,straight | depart,new name straight,arrive | ,left:false straight:true right:false, |
+            | a,f       | in,cross,cross       | depart,turn right,arrive        | ,left:false straight:false right:true, |
+
+    @guidance @lanes @sliproads
+    Scenario: Separate Turn Lanes Next to other turns
+        Given the node map
+            |   |   |   |   |   |   |   | e |   |
+            | a |   |   | b |   |   |   | c | g |
+            |   |   |   |   |   |   |   | d |   |
+            |   |   |   |   |   |   |   | f |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |
+            | i |   |   | h |   |   |   | j |   |
+
+        And the ways
+            | nodes | turn:lanes:forward | name     | oneway |
+            | ab    |                    | in       | yes    |
+            | bc    | left\|through      | in       | yes    |
+            | bd    | right              | in       | yes    |
+            | ec    |                    | cross    | no     |
+            | cd    |                    | cross    | no     |
+            | df    |                    | cross    | no     |
+            | cg    |                    | straight | no     |
+            | bh    | left\|right        | turn     | yes    |
+            | ihj   |                    | other    | no     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bd       | cd     | d        | no_left_turn  |
+            | restriction | bc       | cd     | c        | no_right_turn |
+
+       When I route I should get
+            | waypoints | route                | turns                               | lanes                                  |
+            | a,e       | in,cross,cross       | depart,turn left,arrive             | ,left:true straight:false right:false, |
+            | a,g       | in,straight,straight | depart,new name straight,arrive     | ,left:false straight:true right:false, |
+            | a,f       | in,cross,cross       | depart,turn right,arrive            | ,left:false straight:false right:true, |
+            | a,j       | in,turn,other,other  | depart,turn right,turn left,arrive  | ,,left:true right:false,               |
+            | a,i       | in,turn,other,other  | depart,turn right,turn right,arrive | ,,left:false right:true,               |
+

--- a/features/guidance/advanced-lanes.feature
+++ b/features/guidance/advanced-lanes.feature
@@ -132,55 +132,7 @@ Feature: Turn Lane Guidance
             | a,i       | ,ksd,ksd | depart,turn right,arrive | ,left:false none:true right:true, |
 
     @todo @bug @2650 @sliproads
-    #market and haight in SF
-    #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
-    Scenario: Through Street Crossing Mid-Turn
-        Given the node map
-            |   |   |   |   |   |   |   | g | j |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   | k |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   | f |
-            |   |   |   |   |   |   |   |   | e |   |
-            |   |   |   |   |   |   |   | d |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            | a |   |   | b |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   | c |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   | l |   |   |   |   | h | i |   |
-
-        And the ways
-            | nodes | name   | highway     | oneway | turn:lanes:forward |
-            | ab    | ghough | secondary   | yes    |                    |
-            | bc    | ghough | secondary   | yes    | through\|through   |
-            | bd    | ghough | secondary   | yes    | none\|through      |
-            | def   | ghough | secondary   | yes    |                    |
-            | gd    | market | primary     | yes    |                    |
-            |  dc   | market | primary     | yes    |                    |
-            |   ch  | market | primary     | yes    |                    |
-            | iej   | market | primary     | yes    |                    |
-            | gkb   | haight | residential | yes    |                    |
-            | bl    | haight | residential | yes    | left\|none         |
-
-        And the relations
-            | type        | way:from | way:to | node:via | restriction   |
-            | relation    | bd       | dc     | d        | no_right_turn |
-
-        When I route I should get
-            | waypoints | route                | turns                              | lanes                                                    |
-            | a,l       | ghough,haight,haight | depart,turn right,arrive           | ,none:false straight:false straight:false straight:true, |
-            | a,h       | ghough,market,market | depart,turn slight right,arrive    | ,none:false straight:false straight:true straight:true,  |
-            | a,j       | ghough,market,market | depart,turn left,arrive            | ,none:true straight:false straight:false straight:false, |
-            | a,f       | ghough,ghough,ghough | depart,continue slight left,arrive | ,none:true straight:true straight:false straight:false,  |
-
-    @todo @bug @2650 @sliproads
-    #market and haight in SF
+    #market and haight in SF, restricted turn
     #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
     Scenario: Market/Haight without Through Street
         Given the node map
@@ -209,8 +161,8 @@ Feature: Turn Lane Guidance
             | bd    | ghough | secondary   | yes    | none\|through      |
             | def   | ghough | secondary   | yes    |                    |
             | gd    | market | primary     | yes    |                    |
-            |  dc   | market | primary     | yes    |                    |
-            |   ch  | market | primary     | yes    |                    |
+            | dc    | market | primary     | yes    |                    |
+            | ch    | market | primary     | yes    |                    |
             | iej   | market | primary     | yes    |                    |
             | bl    | haight | residential | yes    | left\|none         |
 
@@ -226,7 +178,7 @@ Feature: Turn Lane Guidance
             | a,f       | ghough,ghough,ghough | depart,continue slight left,arrive | ,none:true straight:true straight:false straight:false,  |
 
     @todo @2650 @bug @sliproads
-    #market and haight in SF
+    #market and haight in SF, unrestricted
     #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
     Scenario: Market/Haight without Through Street
         Given the node map
@@ -255,8 +207,8 @@ Feature: Turn Lane Guidance
             | bd    | ghough | secondary   | yes    | none\|through      |
             | def   | ghough | secondary   | yes    |                    |
             | gd    | market | primary     | yes    |                    |
-            |  dc   | market | primary     | yes    |                    |
-            |   ch  | market | primary     | yes    |                    |
+            | dc    | market | primary     | yes    |                    |
+            | ch    | market | primary     | yes    |                    |
             | iej   | market | primary     | yes    |                    |
             | bl    | haight | residential | yes    | left\|none         |
 

--- a/features/guidance/advanced-lanes.feature
+++ b/features/guidance/advanced-lanes.feature
@@ -5,9 +5,7 @@ Feature: Turn Lane Guidance
         Given the profile "car"
         Given a grid size of 3 meters
 
-    #requires https://github.com/cucumber/cucumber-js/issues/417
-    #Due to this, we use & as a pipe character. Switch them out for \| when 417 is fixed
-    @bug @WORKAROUND-FIXME
+    @sliproads
     Scenario: Separate Turn Lanes
         Given the node map
             |   |   |   |   |   |   |   | e |   |
@@ -36,86 +34,7 @@ Feature: Turn Lane Guidance
             | a,g       | in,straight,straight | depart,new name straight,arrive | ,left:false straight:true right:false, |
             | a,f       | in,cross,cross       | depart,turn right,arrive        | ,left:false straight:false right:true, |
 
-    @TODO @2650 @bug
-    Scenario: Sliproad with through lane
-        Given the node map
-            |   |   |   |   |   |   |   |   |   | f |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   | g |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   | e |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   | d |   |   |   |
-            | a |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   | b |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   | c |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   | h |   |   |   |   | i |   |   |   |
-
-        And the ways
-            | nodes | name   | oneway | turn:lanes:forward |
-            | ab    | ghough | yes    |                    |
-            | bc    | ghough | yes    | through\|none      |
-            | bd    | ghough | yes    | none\|through      |
-            | de    | ghough | yes    |                    |
-            | fgb   | haight | yes    |                    |
-            | bh    | haight | yes    | left\|none         |
-            | fd    | market | yes    |                    |
-            | dc    | market | yes    |                    |
-            | ci    | market | yes    |                    |
-
-        And the relations
-            | type        | way:from | way:to | node:via | restriction   |
-            | restriction | fgb      | bd     | b        | no_left_turn  |
-            | restriction | fgb      | bc     | b        | no_left_turn  |
-
-        When I route I should get
-            | waypoints | route                | turns                              | lanes |
-            | a,h       | ghough,haight,haight | depart,turn right,arrive           |       |
-            | a,i       | ghough,market,market | depart,turn right,arrive           |       |
-            | a,e       | ghough,ghough,ghough | depart,continue slight left,arrive |       |
-
-    @TODO @2650 @bug
-    Scenario: Sliproad with through lane
-        Given the node map
-            |   |   |   |   |   |   |   | f |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   | g |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   | e |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   | d |   |   |
-            | a |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   | b |   |   |   |   |   |
-            |   |   |   |   |   |   |   | c |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   | h |   |   |   | i |   |   |
-
-        And the ways
-            | nodes | name   | oneway | turn:lanes:forward |
-            | ab    | ghough | yes    |                    |
-            | bc    | ghough | yes    | through\|none      |
-            | bd    | ghough | yes    | none\|through      |
-            | fgb   | haight | yes    |                    |
-            | bh    | haight | yes    | left\|none         |
-            | fd    | market | yes    |                    |
-            | dc    | market | yes    |                    |
-            | ci    | market | yes    |                    |
-
-        And the relations
-            | type        | way:from | way:to | node:via | restriction   |
-            | restriction | bd       | dc     | d        | no_right_turn |
-            | restriction | fgb      | bd     | b        | no_left_turn  |
-            | restriction | fgb      | bc     | b        | no_left_turn  |
-
-        When I route I should get
-            | waypoints | route                | turns                              | lanes |
-            | a,h       | ghough,haight,haight | depart,turn right,arrive           |       |
-            | a,i       | ghough,market,market | depart,turn right,arrive           |       |
-            | a,e       | ghough,ghough,ghough | depart,continue slight left,arrive |       |
-
+    @sliproads
     Scenario: Separate Turn Lanes
         Given the node map
             |   |   |   |   |   |   |   | e |   |
@@ -144,7 +63,7 @@ Feature: Turn Lane Guidance
             | a,g       | in,straight,straight | depart,new name straight,arrive | ,left:false straight:true right:false, |
             | a,f       | in,cross,cross       | depart,turn right,arrive        | ,left:false straight:false right:true, |
 
-    @guidance @lanes @sliproads
+    @sliproads
     Scenario: Separate Turn Lanes Next to other turns
         Given the node map
             |   |   |   |   |   |   |   | e |   |
@@ -184,3 +103,166 @@ Feature: Turn Lane Guidance
             | a,j       | in,turn,other,other  | depart,turn right,turn left,arrive  | ,,left:true right:false,               |
             | a,i       | in,turn,other,other  | depart,turn right,turn right,arrive | ,,left:false right:true,               |
 
+    @todo @bug @2654 @none
+    #https://github.com/Project-OSRM/osrm-backend/issues/2645
+    #http://www.openstreetmap.org/export#map=19/52.56054/13.32152
+    Scenario: Kurt-Schuhmacher-Damm
+        Given the node map
+            |   |   |   | g |   | f |
+            |   |   |   |   |   |   |
+            | j |   |   | h |   | e |
+            |   |   |   |   |   |   |
+            | a |   |   | b |   | c |
+            |   |   |   | i |   | d |
+
+        And the ways
+            | nodes | name | highway        | oneway | turn:lanes        |
+            | ab    |      | motorway_link  | yes    | left\|none\|right |
+            | bc    |      | primary_link   | yes    |                   |
+            | cd    | ksd  | secondary      | yes    |                   |
+            | cef   | ksd  | primary        | yes    |                   |
+            | hj    |      | motorway_link  | yes    |                   |
+            | eh    |      | secondary_link | yes    |                   |
+            | gh    | ksd  | primary        | yes    |                   |
+            | hbi   | ksd  | secondary      | yes    |                   |
+
+        When I route I should get
+            | waypoints | route    | turns                    | lanes                             |
+            | a,f       | ,ksd,ksd | depart,turn left,arrive  | ,left:true none:true right:false, |
+            | a,i       | ,ksd,ksd | depart,turn right,arrive | ,left:false none:true right:true, |
+
+    @todo @bug @2650 @sliproads
+    #market and haight in SF
+    #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
+    Scenario: Through Street Crossing Mid-Turn
+        Given the node map
+            |   |   |   |   |   |   |   | g | j |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   | k |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   | f |
+            |   |   |   |   |   |   |   |   | e |   |
+            |   |   |   |   |   |   |   | d |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            | a |   |   | b |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   | c |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   | l |   |   |   |   | h | i |   |
+
+        And the ways
+            | nodes | name   | highway     | oneway | turn:lanes:forward |
+            | ab    | ghough | secondary   | yes    |                    |
+            | bc    | ghough | secondary   | yes    | through\|through   |
+            | bd    | ghough | secondary   | yes    | none\|through      |
+            | def   | ghough | secondary   | yes    |                    |
+            | gd    | market | primary     | yes    |                    |
+            |  dc   | market | primary     | yes    |                    |
+            |   ch  | market | primary     | yes    |                    |
+            | iej   | market | primary     | yes    |                    |
+            | gkb   | haight | residential | yes    |                    |
+            | bl    | haight | residential | yes    | left\|none         |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | relation    | bd       | dc     | d        | no_right_turn |
+
+        When I route I should get
+            | waypoints | route                | turns                              | lanes                                                    |
+            | a,l       | ghough,haight,haight | depart,turn right,arrive           | ,none:false straight:false straight:false straight:true, |
+            | a,h       | ghough,market,market | depart,turn slight right,arrive    | ,none:false straight:false straight:true straight:true,  |
+            | a,j       | ghough,market,market | depart,turn left,arrive            | ,none:true straight:false straight:false straight:false, |
+            | a,f       | ghough,ghough,ghough | depart,continue slight left,arrive | ,none:true straight:true straight:false straight:false,  |
+
+    @todo @bug @2650 @sliproads
+    #market and haight in SF
+    #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
+    Scenario: Market/Haight without Through Street
+        Given the node map
+            |   |   |   |   |   |   |   | g | j |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   | f |
+            |   |   |   |   |   |   |   |   | e |   |
+            |   |   |   |   |   |   |   | d |   |   |
+            | a |   |   |   |   |   | b | c |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   | l |   |   | h | i |   |
+
+        And the ways
+            | nodes | name   | highway     | oneway | turn:lanes:forward |
+            | ab    | ghough | secondary   | yes    |                    |
+            | bc    | ghough | secondary   | yes    | through\|through   |
+            | bd    | ghough | secondary   | yes    | none\|through      |
+            | def   | ghough | secondary   | yes    |                    |
+            | gd    | market | primary     | yes    |                    |
+            |  dc   | market | primary     | yes    |                    |
+            |   ch  | market | primary     | yes    |                    |
+            | iej   | market | primary     | yes    |                    |
+            | bl    | haight | residential | yes    | left\|none         |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | relation    | bd       | dc     | d        | no_right_turn |
+
+        When I route I should get
+            | waypoints | route                | turns                              | lanes                                                    |
+            | a,l       | ghough,haight,haight | depart,turn right,arrive           | ,none:false straight:false straight:false straight:true, |
+            | a,h       | ghough,market,market | depart,turn slight right,arrive    | ,none:false straight:false straight:true straight:true,  |
+            | a,j       | ghough,market,market | depart,turn left,arrive            | ,none:true straight:false straight:false straight:false, |
+            | a,f       | ghough,ghough,ghough | depart,continue slight left,arrive | ,none:true straight:true straight:false straight:false,  |
+
+    @todo @2650 @bug @sliproads
+    #market and haight in SF
+    #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
+    Scenario: Market/Haight without Through Street
+        Given the node map
+            |   |   |   |   |   |   |   | g | j |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   | f |
+            |   |   |   |   |   |   |   |   | e |   |
+            |   |   |   |   |   |   |   | d |   |   |
+            | a |   |   |   |   |   | b | c |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   | l |   |   | h | i |   |
+
+        And the ways
+            | nodes | name   | highway     | oneway | turn:lanes:forward |
+            | ab    | ghough | secondary   | yes    |                    |
+            | bc    | ghough | secondary   | yes    | through\|through   |
+            | bd    | ghough | secondary   | yes    | none\|through      |
+            | def   | ghough | secondary   | yes    |                    |
+            | gd    | market | primary     | yes    |                    |
+            |  dc   | market | primary     | yes    |                    |
+            |   ch  | market | primary     | yes    |                    |
+            | iej   | market | primary     | yes    |                    |
+            | bl    | haight | residential | yes    | left\|none         |
+
+        When I route I should get
+            | waypoints | route                | turns                              | lanes                                                    |
+            | a,l       | ghough,haight,haight | depart,turn right,arrive           | ,none:false straight:false straight:false straight:true, |
+            | a,h       | ghough,market,market | depart,turn slight right,arrive    | ,none:false straight:false straight:true straight:true,  |
+            | a,j       | ghough,market,market | depart,turn left,arrive            | ,none:true straight:false straight:false straight:false, |
+            | a,f       | ghough,ghough,ghough | depart,continue slight left,arrive | ,none:true straight:true straight:false straight:false,  |

--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -463,18 +463,18 @@ Feature: Turn Lane Guidance
             |   | y |   |   |   |
 
         And the ways
-            | nodes | turn:lanes:forward                                 | highway | junction   | name  |
-            | ab    | through\|right\|right\|right\|right                | primary |            | abx   |
-            | bx    |                                                    | primary |            | abx   |
-            | bc    | right\|right\|right\|right                         | primary |            | bc    |
-            | cd    |                                                    | primary | roundabout | cdefc |
-            | de    | slight_left\|slight_left&slight_left\|slight_right | primary | roundabout | cdefc |
-            | ef    | left\|slight_right\|slight_right                   | primary | roundabout | cdefc |
-            | fc    |                                                    | primary | roundabout | cdefc |
-            | ey    |                                                    | primary |            | ey    |
-            | fg    | through\|right                                     | primary |            | fg    |
-            | gz    |                                                    | primary |            | gz    |
-            | gh    |                                                    | primary |            | gh    |
+            | nodes | turn:lanes:forward                                  | highway | junction   | name  |
+            | ab    | through\|right\|right\|right\|right                 | primary |            | abx   |
+            | bx    |                                                     | primary |            | abx   |
+            | bc    | right\|right\|right\|right                          | primary |            | bc    |
+            | cd    |                                                     | primary | roundabout | cdefc |
+            | de    | slight_left\|slight_left\|slight_left\|slight_right | primary | roundabout | cdefc |
+            | ef    | left\|slight_right\|slight_right                    | primary | roundabout | cdefc |
+            | fc    |                                                     | primary | roundabout | cdefc |
+            | ey    |                                                     | primary |            | ey    |
+            | fg    | through\|right                                      | primary |            | fg    |
+            | gz    |                                                     | primary |            | gz    |
+            | gh    |                                                     | primary |            | gh    |
 
         When I route I should get
             | waypoints | route           | turns                                            | lanes                                                                                      |

--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -257,7 +257,170 @@ Feature: Turn Lane Guidance
 
        When I route I should get
             | waypoints | route                 | turns                                                   | lanes                                                                                                                                                  |
-            | a,f       | abx,bcy,cdz,dew,ef,ef | depart,turn right,turn left,turn right,turn left,arrive | ,straight:false right:false right:true right:false,left:false left:true straight:false,straight:false right:true right:false,left:true straight:false, |
+            | a,f       | abx,bcy,cdz,dew,ef,ef | depart,turn right,turn left,turn right,turn left,arrive | ,straight:false right:true right:false right:false,left:true left:false straight:false,straight:false right:true right:false,left:true straight:false, |
+
+       @anticipate
+       Scenario: Anticipate Lanes for through, through with lanes
+           Given the node map
+               |   |   |   | f | g |   |
+               |   |   |   |   |   |   |
+               | a | b | c | d |   | e |
+               |   |   |   |   |   |   |
+               |   |   |   | h | i |   |
+
+           And the ways
+               | nodes | turn:lanes:forward                     | name |
+               | ab    |                                        | main |
+               | bc    | left\|through\|through\|through\|right | main |
+               | cd    | left\|through\|right                   | main |
+               | de    |                                        | main |
+               | cf    |                                        | off  |
+               | ch    |                                        | off  |
+               | dg    |                                        | off  |
+               | di    |                                        | off  |
+
+          When I route I should get
+               | waypoints | route               | turns                                             | lanes                                                                                                     |
+               | a,e       | main,main,main,main | depart,use lane straight,use lane straight,arrive | ,left:false straight:false straight:true straight:false right:false,left:false straight:true right:false, |
+
+       @anticipate
+       Scenario: Anticipate Lanes for through and collapse multiple use lanes
+           Given the node map
+               |   |   | e | f | g |
+               |   |   |   |   |   |
+               | a | b | c | d |   |
+               |   |   |   |   |   |
+               |   |   | h | i | j |
+
+           And the ways
+               | nodes | turn:lanes:forward                     | name |
+               | ab    | left\|through\|through\|right          | main |
+               | bc    | left\|through\|through\|right          | main |
+               | cd    | left\|through\|through\|through\|right | main |
+               | be    |                                        | off  |
+               | bh    |                                        | off  |
+               | cf    |                                        | off  |
+               | ci    |                                        | off  |
+               | dg    |                                        | off  |
+               | dj    |                                        | off  |
+
+          When I route I should get
+               | waypoints | route          | turns                           | lanes                                                                |
+               | a,c       | main,main,main | depart,use lane straight,arrive | ,left:false straight:true straight:true right:false,                 |
+               | a,d       | main,main,main | depart,use lane straight,arrive | ,left:false straight:true straight:true right:false,                 |
+
+       @anticipate
+       Scenario: Anticipate Lanes for through followed by left/right
+           Given the node map
+               |   |   | f | g |   |
+               |   |   |   |   | d |
+               | a | b | c | x |   |
+               |   |   |   |   | e |
+               |   |   | h | i |   |
+
+           And the ways
+               | nodes | turn:lanes:forward                              | name  |
+               | ab    | left\|through\|through\|through\|through\|right | main  |
+               | bc    | left\|through\|through\|right                   | main  |
+               | cx    | left\|right                                     | main  |
+               | xd    |                                                 | left  |
+               | xe    |                                                 | right |
+               | bf    |                                                 | off   |
+               | bh    |                                                 | off   |
+               | cg    |                                                 | off   |
+               | ci    |                                                 | off   |
+
+          When I route I should get
+               | waypoints | route                      | turns                                                        | lanes                                                                                                                                                         |
+               | a,d       | main,main,main,left,left   | depart,use lane straight,use lane straight,turn left,arrive  | ,left:false straight:false straight:true straight:false straight:false right:false,left:false straight:true straight:false right:false,left:true right:false, |
+               | a,e       | main,main,main,right,right | depart,use lane straight,use lane straight,turn right,arrive | ,left:false straight:false straight:false straight:true straight:false right:false,left:false straight:false straight:true right:false,left:false right:true, |
+
+       @anticipate
+       Scenario: Anticipate Lanes for through with turn before / after
+           Given the node map
+               | a | b | c |
+               |   | d |   |
+               | f | e | g |
+               |   | h |   |
+               | j | i | l |
+
+           And the ways
+               | nodes | turn:lanes:forward                                           | name  | oneway |
+               | ab    | right\|right\|right\|right                                   | ab    | yes    |
+               | cb    | left\|left\|left\|left                                       | cb    | yes    |
+               | bd    |                                                              | bdehi |        |
+               | de    | left\|left\|through\|through\|through\|through\|right\|right | bdehi |        |
+               | ef    |                                                              | ef    |        |
+               | eg    |                                                              | eg    |        |
+               | eh    |                                                              | bdehi |        |
+               | hi    | left\|left\|right\|right                                     | bdehi |        |
+               | ij    |                                                              | ij    |        |
+               | il    |                                                              | il    |        |
+
+          When I route I should get
+               | waypoints | route                | turns                                                 | lanes                                                                                                                                                                                               | #           |
+               | a,f       | ab,bdehi,ef,ef       | depart,turn right,turn right,arrive                   | ,right:false right:false right:true right:true,left:false left:false straight:false straight:false straight:false straight:false right:true right:true,                                             |             |
+               | a,g       | ab,bdehi,eg,eg       | depart,turn right,turn left,arrive                    | ,right:true right:true right:false right:false,left:true left:true straight:false straight:false straight:false straight:false right:false right:false,                                             |             |
+               | a,j       | ab,bdehi,bdehi,ij,ij | depart,turn right,use lane straight,turn right,arrive | ,right:true right:true right:false right:false,left:false left:false straight:false straight:false straight:true straight:true right:false right:false,left:false left:false right:true right:true, |             |
+               | a,l       | ab,bdehi,bdehi,il,il | depart,turn right,use lane straight,turn left,arrive  | ,right:false right:false right:true right:true,left:false left:false straight:true straight:true straight:false straight:false right:false right:false,left:true left:true right:false right:false, | not perfect |
+               | c,g       | cb,bdehi,eg,eg       | depart,turn left,turn left,arrive                     | ,left:true left:true left:false left:false,left:true left:true straight:false straight:false straight:false straight:false right:false right:false,                                                 |             |
+               | c,f       | cb,bdehi,ef,ef       | depart,turn left,turn right,arrive                    | ,left:false left:false left:true left:true,left:false left:false straight:false straight:false straight:false straight:false right:true right:true,                                                 |             |
+               | c,l       | cb,bdehi,bdehi,il,il | depart,turn left,use lane straight,turn left,arrive   | ,left:false left:false left:true left:true,left:false left:false straight:true straight:true straight:false straight:false right:false right:false,left:true left:true right:false right:false,     |             |
+               | c,j       | cb,bdehi,bdehi,ij,ij | depart,turn left,use lane straight,turn right,arrive  | ,left:true left:true left:false left:false,left:false left:false straight:false straight:false straight:true straight:true right:false right:false,left:false left:false right:true right:true,     | not perfect |
+
+       @anticipate
+       Scenario: Anticipate Lanes for turns with through before and after
+           Given the node map
+               | a | b | q |   | s | h | i |
+               |   |   | e | f | g |   |   |
+               | c | d | r |   | t | j | k |
+
+           And the ways
+               | nodes | turn:lanes:forward                              | name |
+               | ab    | through\|right\|right\|right                    | top  |
+               | be    |                                                 | top  |
+               | bq    |                                                 | off  |
+               | ef    | left\|through\|through\|through\|through\|right | main |
+               | fg    | left\|left\|right\|right                        | main |
+               | fs    |                                                 | off  |
+               | ft    |                                                 | off  |
+               | gh    |                                                 | top  |
+               | hi    |                                                 | top  |
+               | cd    | left\|left\|left\|through                       | bot  |
+               | de    |                                                 | bot  |
+               | dr    |                                                 | off  |
+               | gj    |                                                 | bot  |
+               | jk    |                                                 | bot  |
+
+          When I route I should get
+               | waypoints | route                 | turns                                                  | lanes                                                                                                                                                                           |
+               | a,i       | top,main,main,top,top | depart,turn right,use lane straight,turn left,arrive   | ,straight:false right:false right:true right:true,left:false straight:true straight:true straight:false straight:false right:false,left:true left:true right:false right:false, |
+               | a,k       | top,main,main,bot,bot | depart,turn right,use lane straight,turn right,arrive  | ,straight:false right:true right:true right:false,left:false straight:false straight:false straight:true straight:true right:false,left:false left:false right:true right:true, |
+               | c,i       | bot,main,main,top,top | depart,turn left,use lane straight,turn left,arrive    | ,left:false left:true left:true straight:false,left:false straight:true straight:true straight:false straight:false right:false,left:true left:true right:false right:false,    |
+               | c,k       | bot,main,main,bot,bot | depart,turn left,use lane straight,turn right,arrive   | ,left:true left:true left:false straight:false,left:false straight:false straight:false straight:true straight:true right:false,left:false left:false right:true right:true,    |
+
+       @anticipate
+       Scenario: Anticipate Lanes for turn between throughs
+           Given the node map
+               |   | q |   |   |
+               | a | b | c | s |
+               |   | r | d | t |
+               |   |   | e |   |
+
+           And the ways
+               | nodes | turn:lanes:forward                                       | name |
+               | ab    | left\|through\|through\|through\|through\|through\|right | main |
+               | bq    |                                                          | off  |
+               | br    |                                                          | off  |
+               | bc    | through\|through\|right\|right\|right                    | main |
+               | cs    |                                                          | off  |
+               | cd    | left\|through\|through                                   | main |
+               | de    |                                                          | main |
+               | dt    |                                                          | off  |
+
+          When I route I should get
+               | waypoints | route                    | turns                                                            | lanes                                                                                                                                                                                                    |
+               | a,e       | main,main,main,main,main | depart,use lane straight,continue right,use lane straight,arrive | ,left:false straight:false straight:false straight:false straight:true straight:true right:false,straight:false straight:false right:false right:true right:true,left:false straight:true straight:true, |
 
     @anticipate @todo @bug @2661
     Scenario: Anticipate with lanes in roundabout: roundabouts as the unit of anticipation
@@ -331,7 +494,7 @@ Feature: Turn Lane Guidance
             | cd    |                            | primary | roundabout |
             | de    |                            | primary | roundabout |
             | ef    |                            | primary | roundabout |
-            | fg    | slight_right               | primary | roundabout |
+            | fg    | through\|slight_right      | primary | roundabout |
             | gb    |                            | primary | roundabout |
             | gh    |                            | primary |            |
             | cx    |                            | primary |            |
@@ -480,7 +643,30 @@ Feature: Turn Lane Guidance
             | waypoints | route           | turns                                            | lanes                                                                                      |
             | a,h       | abx,bc,fg,gh,gh | depart,turn right,cdefc-exit-2,turn right,arrive | ,straight:false right:false right:false right:false right:true,,straight:false right:true, |
 
-    @anticipate @bug @todo
+    @anticipate
+    Scenario: Anticipate none tags
+        Given the node map
+            | a | b | c |
+            |   | d |   |
+            | f | e | g |
+            |   | h |   |
+
+        And the ways
+            | nodes | turn:lanes:forward       | highway   | name |
+            | ab    | none\|none\|right\|right | primary   | abc  |
+            | bc    |                          | primary   | abc  |
+            | bd    |                          | primary   | bdeh |
+            | de    | left\|none\|none\|right  | primary   | bdeh |
+            | eh    |                          | primary   | bdeh |
+            | ef    |                          | primary   | feg  |
+            | eg    |                          | primary   | feg  |
+
+        When I route I should get
+            | waypoints | route            | turns                               | lanes                                                                                      |
+            | a,g       | abc,bdeh,feg,feg | depart,turn right,turn left,arrive  | ,none:false none:false right:true right:false,left:true none:false none:false right:false, |
+            | a,f       | abc,bdeh,feg,feg | depart,turn right,turn right,arrive | ,none:false none:false right:false right:true,left:false none:false none:false right:true, |
+
+    @anticipate
     Scenario: Tripple Right keeping Left
         Given the node map
             | a |   |   |   | b |   | i |
@@ -501,11 +687,11 @@ Feature: Turn Lane Guidance
             | feg   |                    | tertiary  | fourth |
 
         When I route I should get
-            | waypoints | route                                  | turns                                                            | lanes                                                                                                                                                                      |
-            | a,f       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,end of road left,arrive  | ,none:false none:true right:false right:false,none:false none:true right:false right:false,none:false none:true right:false right:false,left:true right:false right:false, |
-            | a,g       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,end of road right,arrive | ,none:false none:false right:true right:true,none:false none:false right:true right:true,none:false none:false right:true right:true,left:false right:true right:true,     |
+            | waypoints | route                                  | turns                                                     | lanes                                                                                                                                                                      |
+            | a,f       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,turn left,arrive  | ,none:false none:false right:true right:false,none:false none:false right:true right:false,none:false none:false right:true right:false,left:true right:false right:false, |
+            | a,g       | start,first,second,third,fourth,fourth | depart,turn right,turn right,turn right,turn right,arrive | ,none:false none:false right:true right:true,none:false none:false right:true right:true,none:false none:false right:true right:true,left:false right:true right:true,     |
 
-    @anticipate @bug @todo
+    @anticipate
     Scenario: Tripple Left keeping Right
         Given the node map
             | i |   | b |   |   |   | a |
@@ -526,6 +712,6 @@ Feature: Turn Lane Guidance
             | feg   |                    | tertiary  | fourth |
 
         When I route I should get
-            | waypoints | route                                  | turns                                                         | lanes                                                                                                                                                               |
-            | a,f       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,end of road right,arrive | ,left:false left:false none:true none:false,left:false left:false none:true none:false,left:false left:false none:true none:false,left:false left:false right:true, |
-            | a,g       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,end of road left,arrive  | ,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true right:false,     |
+            | waypoints | route                                  | turns                                                  | lanes                                                                                                                                                               |
+            | a,f       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,turn right,arrive | ,left:false left:true none:false none:false,left:false left:true none:false none:false,left:false left:true none:false none:false,left:false left:false right:true, |
+            | a,g       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,turn left,arrive  | ,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true right:false,     |

--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -280,8 +280,8 @@ Feature: Turn Lane Guidance
                | di    |                                        | off  |
 
           When I route I should get
-               | waypoints | route               | turns                                             | lanes                                                                                                     |
-               | a,e       | main,main,main,main | depart,use lane straight,use lane straight,arrive | ,left:false straight:false straight:true straight:false right:false,left:false straight:true right:false, |
+               | waypoints | route          | turns                           | lanes                                                                |
+               | a,e       | main,main,main | depart,use lane straight,arrive | ,left:false straight:false straight:true straight:false right:false, |
 
        @anticipate
        Scenario: Anticipate Lanes for through and collapse multiple use lanes
@@ -305,9 +305,9 @@ Feature: Turn Lane Guidance
                | dj    |                                        | off  |
 
           When I route I should get
-               | waypoints | route          | turns                           | lanes                                                                |
-               | a,c       | main,main,main | depart,use lane straight,arrive | ,left:false straight:true straight:true right:false,                 |
-               | a,d       | main,main,main | depart,use lane straight,arrive | ,left:false straight:true straight:true right:false,                 |
+               | waypoints | route     | turns         | lanes |
+               | a,c       | main,main | depart,arrive | ,     |
+               | a,d       | main,main | depart,arrive | ,     |
 
        @anticipate
        Scenario: Anticipate Lanes for through followed by left/right
@@ -419,8 +419,8 @@ Feature: Turn Lane Guidance
                | dt    |                                                          | off  |
 
           When I route I should get
-               | waypoints | route                    | turns                                                            | lanes                                                                                                                                                                                                    |
-               | a,e       | main,main,main,main,main | depart,use lane straight,continue right,use lane straight,arrive | ,left:false straight:false straight:false straight:false straight:true straight:true right:false,straight:false straight:false right:false right:true right:true,left:false straight:true straight:true, |
+               | waypoints | route               | turns                                          | lanes                                                                                                                                                             |
+               | a,e       | main,main,main,main | depart,use lane straight,continue right,arrive | ,left:false straight:false straight:false straight:false straight:true straight:true right:false,straight:false straight:false right:false right:true right:true, |
 
     @anticipate @todo @bug @2661
     Scenario: Anticipate with lanes in roundabout: roundabouts as the unit of anticipation
@@ -615,7 +615,7 @@ Feature: Turn Lane Guidance
             | x,c       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,,    |
             | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,,    |
 
-    @anticipate
+    @anticipate @todo @2032
     Scenario: No Lanes for Roundabouts, see #2626
         Given the node map
             | a | b |   |   | x |

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -756,15 +756,15 @@ Feature: Collapse
             |   |   |   | h | i |   |
 
         And the ways
-            | nodes | turn:lanes:forward                  | name |
-            | ab    |                                     | main |
-            | bc    | left\|through&through&through&right | main |
-            | cd    | left\|through&right                 | main |
-            | de    |                                     | main |
-            | cf    |                                     | off  |
-            | ch    |                                     | off  |
-            | dg    |                                     | off  |
-            | di    |                                     | off  |
+            | nodes | turn:lanes:forward                     | name |
+            | ab    |                                        | main |
+            | bc    | left\|through\|through\|through\|right | main |
+            | cd    | left\|through\|right                   | main |
+            | de    |                                        | main |
+            | cf    |                                        | off  |
+            | ch    |                                        | off  |
+            | dg    |                                        | off  |
+            | di    |                                        | off  |
 
        When I route I should get
             | waypoints | route               | turns                                             |
@@ -779,15 +779,15 @@ Feature: Collapse
             |   |   |   | h | i |   |
 
         And the ways
-            | nodes | turn:lanes:forward                  | name |
-            | ab    |                                     | main |
-            | bc    | left\|through&through&through&right | main |
-            | cd    | left\|through&through&through&right | main |
-            | de    |                                     | main |
-            | cf    |                                     | off  |
-            | ch    |                                     | off  |
-            | dg    |                                     | off  |
-            | di    |                                     | off  |
+            | nodes | turn:lanes:forward                     | name |
+            | ab    |                                        | main |
+            | bc    | left\|through\|through\|through\|right | main |
+            | cd    | left\|through\|through\|through\|right | main |
+            | de    |                                        | main |
+            | cf    |                                        | off  |
+            | ch    |                                        | off  |
+            | dg    |                                        | off  |
+            | di    |                                        | off  |
 
        When I route I should get
             | waypoints | route          | turns                           |

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -746,3 +746,49 @@ Feature: Collapse
         When I route I should get
             | waypoints | route               | turns                          |
             | d,c       | first,first,first   | depart,continue uturn,arrive   |
+
+    Scenario: Do not collapse UseLane step when lanes change
+        Given the node map
+            |   |   |   | f | g |   |
+            |   |   |   |   |   |   |
+            | a | b | c | d |   | e |
+            |   |   |   |   |   |   |
+            |   |   |   | h | i |   |
+
+        And the ways
+            | nodes | turn:lanes:forward                  | name |
+            | ab    |                                     | main |
+            | bc    | left\|through&through&through&right | main |
+            | cd    | left\|through&right                 | main |
+            | de    |                                     | main |
+            | cf    |                                     | off  |
+            | ch    |                                     | off  |
+            | dg    |                                     | off  |
+            | di    |                                     | off  |
+
+       When I route I should get
+            | waypoints | route               | turns                                             |
+            | a,e       | main,main,main,main | depart,use lane straight,use lane straight,arrive |
+
+    Scenario: But _do_ collapse UseLane step when lanes stay the same
+        Given the node map
+            |   |   |   | f | g |   |
+            |   |   |   |   |   |   |
+            | a | b | c | d |   | e |
+            |   |   |   |   |   |   |
+            |   |   |   | h | i |   |
+
+        And the ways
+            | nodes | turn:lanes:forward                  | name |
+            | ab    |                                     | main |
+            | bc    | left\|through&through&through&right | main |
+            | cd    | left\|through&through&through&right | main |
+            | de    |                                     | main |
+            | cf    |                                     | off  |
+            | ch    |                                     | off  |
+            | dg    |                                     | off  |
+            | di    |                                     | off  |
+
+       When I route I should get
+            | waypoints | route          | turns                           |
+            | a,e       | main,main,main | depart,use lane straight,arrive |

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -767,8 +767,8 @@ Feature: Collapse
             | di    |                                        | off  |
 
        When I route I should get
-            | waypoints | route               | turns                                             |
-            | a,e       | main,main,main,main | depart,use lane straight,use lane straight,arrive |
+            | waypoints | route          | turns                           |
+            | a,e       | main,main,main | depart,use lane straight,arrive |
 
     Scenario: But _do_ collapse UseLane step when lanes stay the same
         Given the node map
@@ -790,5 +790,5 @@ Feature: Collapse
             | di    |                                        | off  |
 
        When I route I should get
-            | waypoints | route          | turns                           |
-            | a,e       | main,main,main | depart,use lane straight,arrive |
+            | waypoints | route     | turns         |
+            | a,e       | main,main | depart,arrive |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -358,10 +358,10 @@ Feature: Turn Lane Guidance
             | bg    | right |                     | no     |
 
         When I route I should get
-            | waypoints | route            | turns                           | lanes                            |
-            | a,f       | road,turn,turn   | depart,turn left,arrive         | ,left:true straight;right:false, |
-            | a,d       | road,road,road   | depart,use lane straight,arrive | ,left:false straight;right:true, |
-            | a,g       | road,right,right | depart,turn right,arrive        | ,left:false straight;right:true, |
+            | waypoints | route            | turns                    | lanes                            |
+            | a,f       | road,turn,turn   | depart,turn left,arrive  | ,left:true straight;right:false, |
+            | a,d       | road,road        | depart,arrive            | ,                                |
+            | a,g       | road,right,right | depart,turn right,arrive | ,left:false straight;right:true, |
 
     @partition-lanes @previous-lanes
     Scenario: Passing a one-way street, partly pulled back lanes, no through
@@ -491,9 +491,9 @@ Feature: Turn Lane Guidance
             | restriction | bc       | dc     | c        | no_right_turn |
 
         When I route I should get
-            | waypoints | route            | turns                   | lanes                                               |
-            | a,g       | road,cross,cross | depart,turn left,arrive | ,left:true left:true straight:false straight:false, |
-            | a,e       | road,road        | depart,arrive           | ,                                                   |
+            | waypoints | route            | turns                   | lanes                                                           |
+            | a,g       | road,cross,cross | depart,turn left,arrive | ,left:true left:true straight:false straight:false right:false, |
+            | a,e       | road,road        | depart,arrive           | ,                                                               |
 
     #NEEDS TO BE INVESTIGATED. Turn restriction shouldn't be here. See #2867
     @reverse @previous-lanes

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -499,11 +499,11 @@ Feature: Turn Lane Guidance
     @reverse @previous-lanes
     Scenario: U-Turn Road at Intersection
         Given the node map
-            |   |   |   |   |   | h |   |
-            |   |   |   |   | f | e | j |
-            | a | b |   |   |   |   |   |
-            |   |   |   |   | c | d | i |
-            |   |   |   |   |   | g |   |
+            |   |   |   |   |   |   | h |   |
+            |   |   |   |   | f |   | e | j |
+            | a | b |   |   |   |   |   |   |
+            |   |   |   |   | c |   | d | i |
+            |   |   |   |   |   |   | g |   |
 
         And the ways
             | nodes | name  | turn:lanes:forward | oneway | highway  |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -5,7 +5,7 @@ Feature: Turn Lane Guidance
         Given the profile "car"
         Given a grid size of 20 meters
 
-    @bug
+    @simple
     Scenario: Basic Turn Lane 3-way Turn with empty lanes
         Given the node map
             | a |   | b |   | c |
@@ -40,6 +40,7 @@ Feature: Turn Lane Guidance
             | a,c       | in,straight,straight | depart,new name straight,arrive | ,straight:true right:false, |
             | a,d       | in,right,right       | depart,turn right,arrive        | ,straight:false right:true, |
 
+    @simple
     Scenario: Basic Turn Lane 4-Way Turn
         Given the node map
             |   |   | e |   |   |
@@ -62,6 +63,7 @@ Feature: Turn Lane Guidance
             | d,e       | right,left,left         | depart,new name straight,arrive | ,left:false none:true,  |
             | d,c       | right,straight,straight | depart,turn right,arrive        | ,left:false none:true,  |
 
+    @simple @none
     Scenario: Basic Turn Lane 4-Way Turn using none
         Given the node map
             |   |   | e |   |   |
@@ -81,6 +83,7 @@ Feature: Turn Lane Guidance
             | a,d       | in,right,right       | depart,turn right,arrive        | ,none:false right:true, |
             | a,e       | in,left,left         | depart,turn left,arrive         | ,none:true right:false, |
 
+    @simple @reverse
     Scenario: Basic Turn Lane 4-Way With U-Turn Lane
         Given the node map
             |   |   | e |   |   |
@@ -103,6 +106,7 @@ Feature: Turn Lane Guidance
 
 
     #this next test requires decision on how to announce lanes for going straight if there is no turn
+    @simple @psv @none
     Scenario: Turn with Bus-Lane
         Given the node map
             | a |   | b |   | c |
@@ -158,7 +162,7 @@ Feature: Turn Lane Guidance
             | waypoints | route          | turns                    | lanes                       |
             | a,d       | road,turn,turn | depart,turn right,arrive | ,straight:false right:true, |
 
-    @PROFILE @LANES
+    @simple @psv
     Scenario: Turn with Bus-Lane but without lanes
         Given the node map
             | a |   | b |   | c |
@@ -177,7 +181,7 @@ Feature: Turn Lane Guidance
             | a,c       | road,road      | depart,arrive            |
 
     #turn lanes are often drawn at the incoming road, even though the actual turn requires crossing the intersection first
-    @todo @bug
+    @todo @bug @collapse @partition-lanes
     Scenario: Turn Lanes at Segregated Road
         Given the node map
             |   |   | i | l |   |   |
@@ -222,6 +226,7 @@ Feature: Turn Lane Guidance
             | i,l       | cross,cross,cross | depart,continue uturn,arrive    | ,left:true straight:false,                      |
 
     #copy of former case to prevent further regression
+    @collapse @partition-lanes
     Scenario: Turn Lanes at Segregated Road
         Given the node map
             |   |   | i | l |   |   |
@@ -255,6 +260,7 @@ Feature: Turn Lane Guidance
             | i,j       | cross,cross       | depart,arrive                | ,                                               |
             | i,l       | cross,cross,cross | depart,continue uturn,arrive | ,left:true straight:false,                      |
 
+    @partition-lanes
     Scenario: Turn Lanes at Segregated Road
         Given the node map
             |   |   | g | f |   |   |
@@ -277,7 +283,7 @@ Feature: Turn Lane Guidance
             | a,j       | road,cross,cross  | depart,turn right,arrive        | ,left:false straight:false right:true, |
 
     #this can happen due to traffic lights / lanes not drawn up to the intersection itself
-    @2654
+    @2654 @previous-lanes
     Scenario: Turn Lanes Given earlier than actual turn
         Given the node map
             | a |   | b | c |   | d |
@@ -296,7 +302,7 @@ Feature: Turn Lane Guidance
             | a,e       | road,turn,turn | depart,turn right,arrive | ,none:false right:true, |
             | a,d       | road,road      | depart,arrive            | ,                       |
 
-    @2654
+    @2654 @previous-lanes
     Scenario: Turn Lanes Given earlier than actual turn
         Given the node map
             | a |   | b | c | d |   | e |   | f | g | h |   | i |
@@ -319,6 +325,7 @@ Feature: Turn Lane Guidance
             | i,j       | road,first-turn,first-turn   | depart,turn left,arrive  | ,left:true none:false,  |
             | i,a       | road,road                    | depart,arrive            | ,                       |
 
+    @previous-lanes
     Scenario: Passing a one-way street
         Given the node map
             | e |   |   | f |   |
@@ -335,6 +342,7 @@ Feature: Turn Lane Guidance
             | waypoints | route          | turns                   | lanes                      |
             | a,f       | road,turn,turn | depart,turn left,arrive | ,left:true straight:false, |
 
+    @partition-lanes
     Scenario: Passing a one-way street, partly pulled back lanes
         Given the node map
             | e |   |   | f |   |
@@ -350,10 +358,12 @@ Feature: Turn Lane Guidance
             | bg    | right |                     | no     |
 
         When I route I should get
-            | waypoints | route            | turns                    | lanes                            |
-            | a,f       | road,turn,turn   | depart,turn left,arrive  | ,left:true straight;right:false, |
-            | a,g       | road,right,right | depart,turn right,arrive | ,left:false straight;right:true, |
+            | waypoints | route            | turns                           | lanes                            |
+            | a,f       | road,turn,turn   | depart,turn left,arrive         | ,left:true straight;right:false, |
+            | a,d       | road,road,road   | depart,use lane straight,arrive | ,left:false straight;right:true, |
+            | a,g       | road,right,right | depart,turn right,arrive        | ,left:false straight;right:true, |
 
+    @partition-lanes @previous-lanes
     Scenario: Passing a one-way street, partly pulled back lanes, no through
         Given the node map
             | e |   |   | f |
@@ -373,7 +383,7 @@ Feature: Turn Lane Guidance
             | a,f       | road,turn,turn   | depart,turn left,arrive  | ,left:true right:false, |
             | a,g       | road,right,right | depart,turn right,arrive | ,left:false right:true, |
 
-    @todo @bug
+    @todo @bug @partition-lanes @previous-lanes
     Scenario: Narrowing Turn Lanes
         Given the node map
             |   |   |   |   | g |   |
@@ -396,6 +406,7 @@ Feature: Turn Lane Guidance
             | a,e       | road,through,through | depart,new name straight,arrive | ,left:false straight:true right:false, |
             | a,f       | road,right,right     | depart,turn right,arrive        | ,left:false straight:false right:true, |
 
+    @previous-lanes
     Scenario: Turn at a traffic light
         Given the node map
             | a | b | c | d |
@@ -417,7 +428,7 @@ Feature: Turn Lane Guidance
             | a,d       | road,road      | depart,arrive            | ,                           |
             | a,e       | road,turn,turn | depart,turn right,arrive | ,straight:false right:true, |
 
-    @bug @todo
+    @bug @todo @roundabout
     Scenario: Theodor Heuss Platz
         Given the node map
             |   |   |   | i | o |   |   | l |   |
@@ -454,6 +465,7 @@ Feature: Turn Lane Guidance
             | i,l       | top,top-right-out,top-right-out | depart,roundabout-exit-4,arrive | ,slight left:true slight left;slight right:true slight right:false slight right:false, |
             | i,o       | top,top,top                     | depart,roundabout-exit-5,arrive | ,,                                                                                     |
 
+    @sliproads
     Scenario: Turn Lanes Breaking up
         Given the node map
             |   |   |   | g |   |
@@ -466,12 +478,12 @@ Feature: Turn Lane Guidance
         And the ways
             | nodes | name  | turn:lanes:forward                  | oneway | highway   |
             | ab    | road  | left\|left\|through\|through\|right | yes    | primary   |
-            | bd    | road  | through\|through                    | yes    | primary   |
+            | bd    | road  | through\|through\|right             | yes    | primary   |
             | bc    | road  | left\|left                          | yes    | primary   |
             | de    | road  |                                     | yes    | primary   |
-            | fd    | cross |                                  |        | secondary |
-            |  dc   | cross |                                  |        | secondary |
-            |   cg  | cross |                                  |        | secondary |
+            | fd    | cross |                                     |        | secondary |
+            |  dc   | cross |                                     |        | secondary |
+            |   cg  | cross |                                     |        | secondary |
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |
@@ -484,6 +496,7 @@ Feature: Turn Lane Guidance
             | a,e       | road,road        | depart,arrive           | ,                                                   |
 
     #NEEDS TO BE INVESTIGATED. Turn restriction shouldn't be here. See #2867
+    @reverse @previous-lanes
     Scenario: U-Turn Road at Intersection
         Given the node map
             |   |   |   |   |   | h |   |
@@ -517,6 +530,7 @@ Feature: Turn Lane Guidance
             | a    | i  | 180,180 180,180 | road,road        | depart,arrive                | ,                                      |
             | b    | a  | 90,2 270,2      | road,road,road   | depart,continue uturn,arrive | ,none:true straight:false right:false, |
 
+    @reverse
     Scenario: Segregated Intersection Merges With Lanes
         Given the node map
             |   |   |   |   |   |   | f |
@@ -541,7 +555,7 @@ Feature: Turn Lane Guidance
             | a,e       | road,road,road         | depart,turn uturn,arrive        | ,left:true left:false left:false straight:false straight:false, |
             | a,g       | road,straight,straight | depart,new name straight,arrive | ,left:false left:false left:false straight:true straight:true,  |
 
-    @bug @todo
+    @bug @todo @roundabout
     Scenario: Passing Through a Roundabout
         Given the node map
             |   |   | h |   | g |   |   |
@@ -568,6 +582,7 @@ Feature: Turn Lane Guidance
             | i,j       | left,bottom,bottom | depart,round-exit-1,arrive | ,0,   |
             | i,k       | left,right,right   | depart,round-exit-2,arrive | ,1,   |
 
+    @previous-lanes
     Scenario: Crossing Traffic Light
         Given the node map
             | a |   | b |   | c |   | d |
@@ -588,6 +603,7 @@ Feature: Turn Lane Guidance
             | a,d       | road,road        | depart,arrive                   | ,                                                                            |
             | a,e       | road,cross,cross | depart,turn slight right,arrive | ,straight:false straight:false straight;slight right:true slight right:true, |
 
+    @ramp
     Scenario: Highway Ramp
         Given the node map
             | a |   | b |   | c |   | d |
@@ -626,6 +642,7 @@ Feature: Turn Lane Guidance
             | a,g       | off,road,road | depart,turn_left,arrive  | ,left:true right:false, |
             | a,h       |               |                          |                         |
 
+    @ramp
     Scenario: Off Ramp In a Turn
         Given the node map
             | a |   |   |   |   |   |   |   |   |   |   |   |
@@ -644,6 +661,7 @@ Feature: Turn Lane Guidance
             | a,c       | hwy,hwy       | depart,arrive                       | ,                                                 |
             | a,d       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,straight:false straight:false slight right:true, |
 
+    @reverse
     Scenario: Reverse Lane in Segregated Road
         Given the node map
             | h |   |   |   |   | g |   |   |   |   |   | f |
@@ -662,6 +680,7 @@ Feature: Turn Lane Guidance
             | waypoints | route          | turns                        | lanes                                     |
             | a,h       | road,road,road | depart,continue uturn,arrive | ,uturn:true straight:false straight:false,|
 
+    @reverse
     Scenario: Reverse Lane in Segregated Road with none
         Given the node map
             | h |   |   |   |   | g |   |   |   |   |   | f |
@@ -680,6 +699,7 @@ Feature: Turn Lane Guidance
             | waypoints | route          | turns                        | lanes                                  |
             | a,h       | road,road,road | depart,continue uturn,arrive | ,uturn:true straight:false none:false, |
 
+    @reverse
     Scenario: Reverse Lane in Segregated Road with none, Service Turn Prior
         Given the node map
             | h |   |   |   |   | g |   |   |   |   |   | f |
@@ -700,6 +720,7 @@ Feature: Turn Lane Guidance
             | waypoints | route          | turns                        | lanes                                  |
             | a,h       | road,road,road | depart,continue uturn,arrive | ,uturn:true straight:false none:false, |
 
+    @simple
     Scenario: Don't collapse everything to u-turn / too wide
         Given the node map
             | a |   | b |   | e |
@@ -719,6 +740,7 @@ Feature: Turn Lane Guidance
             | a,d       | depart,continue right,turn right,arrive | road,road,road,road | ,straight:false right:true,, |
             | d,a       | depart,continue left,turn left,arrive   | road,road,road,road | ,left:true straight:false,,  |
 
+    @simple
     Scenario: Merge Lanes Onto Freeway
         Given the node map
             | a |   |   | b | c |
@@ -733,7 +755,7 @@ Feature: Turn Lane Guidance
             | waypoints | turns                           | route        | lanes                                 |
             | d,c       | depart,merge slight left,arrive | ramp,Hwy,Hwy | ,slight right:true slight right:true, |
 
-    @2654
+    @2654 @simple
     Scenario: Fork on motorway links - don't fork on through but use lane
         Given the node map
             | i |   |   |   |   | a |
@@ -803,7 +825,7 @@ Feature: Turn Lane Guidance
             | waypoints | route     | turns         | lanes |
             | x,d       | road,road | depart,arrive | ,     |
 
-    @partition
+    @partition-lanes
     Scenario: Partitioned turn, Slight Curve
         Given the node map
             |   |   | f |   | e |

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -20,7 +20,8 @@ namespace osrm
 namespace engine
 {
 
-inline std::pair<bool, bool> boolPairAnd(const std::pair<bool, bool> &A, const std::pair<bool, bool> &B)
+inline std::pair<bool, bool> boolPairAnd(const std::pair<bool, bool> &A,
+                                         const std::pair<bool, bool> &B)
 {
     return std::make_pair(A.first && B.first, A.second && B.second);
 }

--- a/include/engine/guidance/post_processing.hpp
+++ b/include/engine/guidance/post_processing.hpp
@@ -15,7 +15,6 @@ namespace engine
 {
 namespace guidance
 {
-
 // passed as none-reference to modify in-place and move out again
 OSRM_ATTR_WARN_UNUSED
 std::vector<RouteStep> postProcess(std::vector<RouteStep> steps);
@@ -27,6 +26,14 @@ std::vector<RouteStep> postProcess(std::vector<RouteStep> steps);
 // set of instructionst that is not cluttered by unnecessary turns/name changes.
 OSRM_ATTR_WARN_UNUSED
 std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps);
+
+// A check whether two instructions can be treated as one. This is only the case for very short
+// maneuvers that can, in some form, be seen as one. Lookahead of one step.
+bool collapsable(const RouteStep &step, const RouteStep &next);
+
+// Elongate a step by another. the data is added either at the front, or the back
+OSRM_ATTR_WARN_UNUSED
+RouteStep elongate(RouteStep step, const RouteStep &by_step);
 
 // trim initial/final segment of very short length.
 // This function uses in/out parameter passing to modify both steps and geometry in place.

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -702,15 +702,15 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
             }
         }
 
-        const auto insertInCoreHeap =
-            [](const CoreEntryPoint &p, SearchEngineData::QueryHeap &core_heap) {
-                NodeID id;
-                EdgeWeight weight;
-                NodeID parent;
-                // TODO this should use std::apply when we get c++17 support
-                std::tie(id, weight, parent) = p;
-                core_heap.Insert(id, weight, parent);
-            };
+        const auto insertInCoreHeap = [](const CoreEntryPoint &p,
+                                         SearchEngineData::QueryHeap &core_heap) {
+            NodeID id;
+            EdgeWeight weight;
+            NodeID parent;
+            // TODO this should use std::apply when we get c++17 support
+            std::tie(id, weight, parent) = p;
+            core_heap.Insert(id, weight, parent);
+        };
 
         forward_core_heap.Clear();
         for (const auto &p : forward_entry_points)

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -92,8 +92,9 @@ class EdgeBasedGraphFactory
         const std::vector<QueryNode> &node_info_list,
         ProfileProperties profile_properties,
         const util::NameTable &name_table,
-        const std::vector<std::uint32_t> &turn_lane_offsets,
-        const std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks);
+        std::vector<std::uint32_t> &turn_lane_offsets,
+        std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks,
+        guidance::LaneDescriptionMap &lane_description_map);
 
     void Run(ScriptingEnvironment &scripting_environment,
              const std::string &original_edge_data_filename,
@@ -154,8 +155,9 @@ class EdgeBasedGraphFactory
     ProfileProperties profile_properties;
 
     const util::NameTable &name_table;
-    const std::vector<std::uint32_t> &turn_lane_offsets;
-    const std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks;
+    std::vector<std::uint32_t> &turn_lane_offsets;
+    std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks;
+    guidance::LaneDescriptionMap &lane_description_map;
 
     void CompressGeometry();
     unsigned RenumberEdges();

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -83,18 +83,17 @@ class EdgeBasedGraphFactory
     EdgeBasedGraphFactory(const EdgeBasedGraphFactory &) = delete;
     EdgeBasedGraphFactory &operator=(const EdgeBasedGraphFactory &) = delete;
 
-    explicit EdgeBasedGraphFactory(
-        std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
-        const CompressedEdgeContainer &compressed_edge_container,
-        const std::unordered_set<NodeID> &barrier_nodes,
-        const std::unordered_set<NodeID> &traffic_lights,
-        std::shared_ptr<const RestrictionMap> restriction_map,
-        const std::vector<QueryNode> &node_info_list,
-        ProfileProperties profile_properties,
-        const util::NameTable &name_table,
-        std::vector<std::uint32_t> &turn_lane_offsets,
-        std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks,
-        guidance::LaneDescriptionMap &lane_description_map);
+    explicit EdgeBasedGraphFactory(std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
+                                   const CompressedEdgeContainer &compressed_edge_container,
+                                   const std::unordered_set<NodeID> &barrier_nodes,
+                                   const std::unordered_set<NodeID> &traffic_lights,
+                                   std::shared_ptr<const RestrictionMap> restriction_map,
+                                   const std::vector<QueryNode> &node_info_list,
+                                   ProfileProperties profile_properties,
+                                   const util::NameTable &name_table,
+                                   std::vector<std::uint32_t> &turn_lane_offsets,
+                                   std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks,
+                                   guidance::LaneDescriptionMap &lane_description_map);
 
     void Run(ScriptingEnvironment &scripting_environment,
              const std::string &original_edge_data_filename,

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -39,11 +39,11 @@ class ExtractionContainers
     void WriteNodes(std::ofstream &file_out_stream) const;
     void WriteRestrictions(const std::string &restrictions_file_name) const;
     void WriteEdges(std::ofstream &file_out_stream) const;
-    void WriteCharData(const std::string &file_name);
     void
     WriteTurnLaneMasks(const std::string &file_name,
                        const stxxl::vector<std::uint32_t> &turn_lane_offsets,
                        const stxxl::vector<guidance::TurnLaneType::Mask> &turn_lane_masks) const;
+    void WriteCharData(const std::string &file_name);
 
   public:
     using STXXLNodeIDVector = stxxl::vector<OSMNodeID>;
@@ -60,8 +60,6 @@ class ExtractionContainers
     STXXLNameCharData name_char_data;
     STXXLNameOffsets name_offsets;
     // an adjacency array containing all turn lane masks
-    stxxl::vector<std::uint32_t> turn_lane_offsets;
-    stxxl::vector<guidance::TurnLaneType::Mask> turn_lane_masks;
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;
@@ -72,8 +70,7 @@ class ExtractionContainers
     void PrepareData(ScriptingEnvironment &scripting_environment,
                      const std::string &output_file_name,
                      const std::string &restrictions_file_name,
-                     const std::string &names_file_name,
-                     const std::string &turn_lane_file_name);
+                     const std::string &names_file_name);
 };
 }
 }

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
+#include "util/guidance/turn_lanes.hpp"
 
 #include "util/typedefs.hpp"
 
@@ -87,6 +88,16 @@ class Extractor
         const std::vector<std::uint32_t> &node_based_intersection_classes,
         const std::vector<util::guidance::BearingClass> &bearing_classes,
         const std::vector<util::guidance::EntryClass> &entry_classes) const;
+
+    void WriteTurnLaneData(const std::string &turn_lane_file) const;
+
+    // globals persisting during the extraction process and the graph generation process
+
+    // during turn lane analysis, we might have to combine lanes for roads that are modelled as two
+    // but are more or less experienced as one. This can be due to solid lines in between lanes, for
+    // example, that genereate a small separation between them. As a result, we might have to
+    // augment the turn lane map during processing, further adding more types.
+    guidance::LaneDescriptionMap turn_lane_map;
 };
 }
 }

--- a/include/extractor/extractor_callbacks.hpp
+++ b/include/extractor/extractor_callbacks.hpp
@@ -40,14 +40,12 @@ class ExtractorCallbacks
     using MapKey = std::pair<std::string, std::string>;
     using MapVal = unsigned;
     std::unordered_map<MapKey, MapVal, boost::hash<MapKey>> string_map;
-    std::unordered_map<guidance::TurnLaneDescription,
-                       LaneDescriptionID,
-                       guidance::TurnLaneDescription_hash>
-        lane_description_map;
+    guidance::LaneDescriptionMap &lane_description_map;
     ExtractionContainers &external_memory;
 
   public:
-    explicit ExtractorCallbacks(ExtractionContainers &extraction_containers);
+    explicit ExtractorCallbacks(ExtractionContainers &extraction_containers,
+                                guidance::LaneDescriptionMap &lane_description_map);
 
     ExtractorCallbacks(const ExtractorCallbacks &) = delete;
     ExtractorCallbacks &operator=(const ExtractorCallbacks &) = delete;

--- a/include/extractor/extractor_callbacks.hpp
+++ b/include/extractor/extractor_callbacks.hpp
@@ -40,12 +40,11 @@ class ExtractorCallbacks
     using MapKey = std::pair<std::string, std::string>;
     using MapVal = unsigned;
     std::unordered_map<MapKey, MapVal, boost::hash<MapKey>> string_map;
-    guidance::LaneDescriptionMap &lane_description_map;
+    guidance::LaneDescriptionMap lane_description_map;
     ExtractionContainers &external_memory;
 
   public:
-    explicit ExtractorCallbacks(ExtractionContainers &extraction_containers,
-                                guidance::LaneDescriptionMap &lane_description_map);
+    explicit ExtractorCallbacks(ExtractionContainers &extraction_containers);
 
     ExtractorCallbacks(const ExtractorCallbacks &) = delete;
     ExtractorCallbacks &operator=(const ExtractorCallbacks &) = delete;
@@ -58,6 +57,9 @@ class ExtractorCallbacks
 
     // warning: caller needs to take care of synchronization!
     void ProcessWay(const osmium::Way &current_way, const ExtractionWay &result_way);
+
+    // destroys the internal laneDescriptionMap
+    guidance::LaneDescriptionMap &&moveOutLaneDescriptionMap();
 };
 }
 }

--- a/include/extractor/guidance/motorway_handler.hpp
+++ b/include/extractor/guidance/motorway_handler.hpp
@@ -2,8 +2,8 @@
 #define OSRM_EXTRACTOR_GUIDANCE_MOTORWAY_HANDLER_HPP_
 
 #include "extractor/guidance/intersection.hpp"
-#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/intersection_generator.hpp"
+#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/query_node.hpp"
 
 #include "util/attributes.hpp"

--- a/include/extractor/guidance/roundabout_handler.hpp
+++ b/include/extractor/guidance/roundabout_handler.hpp
@@ -3,8 +3,8 @@
 
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/guidance/intersection.hpp"
-#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/intersection_generator.hpp"
+#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/roundabout_type.hpp"
 #include "extractor/profile_properties.hpp"
 #include "extractor/query_node.hpp"

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -211,7 +211,7 @@ inline bool requiresNameAnnounced(const std::string &from,
         const auto first_prefix_and_suffixes = getPrefixAndSuffix(first);
         const auto second_prefix_and_suffixes = getPrefixAndSuffix(second);
         // reverse strings, get suffices and reverse them to get prefixes
-        const auto checkTable = [&](const std::string& str) {
+        const auto checkTable = [&](const std::string &str) {
             return str.empty() || suffix_table.isSuffix(str);
         };
 

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -307,8 +307,11 @@ inline bool hasRoundaboutType(const TurnInstruction instruction)
                                                     TurnType::EnterRoundaboutIntersectionAtExit,
                                                     TurnType::ExitRoundaboutIntersection,
                                                     TurnType::StayOnRoundabout};
-    const auto valid_end = valid_types + 13;
-    return std::find(valid_types, valid_end, instruction.type) != valid_end;
+
+    const auto *first = valid_types;
+    const auto *last = first + sizeof(valid_types) / sizeof(valid_types[0]);
+
+    return std::find(first, last, instruction.type) != last;
 }
 
 // Public service vehicle lanes and similar can introduce additional lanes into the lane string that

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -2,8 +2,8 @@
 #define OSRM_EXTRACTOR_GUIDANCE_TURN_HANDLER_HPP_
 
 #include "extractor/guidance/intersection.hpp"
-#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/intersection_generator.hpp"
+#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/query_node.hpp"
 
 #include "util/attributes.hpp"

--- a/include/extractor/guidance/turn_lane_data.hpp
+++ b/include/extractor/guidance/turn_lane_data.hpp
@@ -28,7 +28,7 @@ typedef std::vector<TurnLaneData> LaneDataVector;
 
 // convertes a string given in the OSM format into a TurnLaneData vector
 OSRM_ATTR_WARN_UNUSED
-LaneDataVector laneDataFromDescription(const TurnLaneDescription &turn_lane_description);
+LaneDataVector laneDataFromDescription(TurnLaneDescription turn_lane_description);
 
 // Locate A Tag in a lane data vector (if multiple tags are set, the first one found is returned)
 LaneDataVector::const_iterator findTag(const TurnLaneType::Mask tag, const LaneDataVector &data);
@@ -36,6 +36,9 @@ LaneDataVector::iterator findTag(const TurnLaneType::Mask tag, LaneDataVector &d
 
 // Returns true if any of the queried tags is contained
 bool hasTag(const TurnLaneType::Mask tag, const LaneDataVector &data);
+
+// Check if a set of lanes is a subset of a different set of lanes
+bool isSubsetOf(const LaneDataVector &subset_candidate, const LaneDataVector &superset_candidate);
 
 } // namespace lane_data_generation
 

--- a/include/extractor/guidance/turn_lane_data.hpp
+++ b/include/extractor/guidance/turn_lane_data.hpp
@@ -40,10 +40,6 @@ LaneDataVector::iterator findTag(const TurnLaneType::Mask tag, LaneDataVector &d
 
 // Returns true if any of the queried tags is contained
 bool hasTag(const TurnLaneType::Mask tag, const LaneDataVector &data);
-
-// Check if a set of lanes is a subset of a different set of lanes
-bool isSubsetOf(const LaneDataVector &subset_candidate, const LaneDataVector &superset_candidate);
-
 } // namespace lane_data_generation
 
 } // namespace guidance

--- a/include/extractor/guidance/turn_lane_data.hpp
+++ b/include/extractor/guidance/turn_lane_data.hpp
@@ -22,6 +22,10 @@ struct TurnLaneData
     LaneID from;
     LaneID to;
 
+    // a temporary data entry that does not need to be assigned to an entry.
+    // This is the case in situations that use partition and require the entry to perform the
+    // one-to-one mapping.
+    bool suppress_assignment;
     bool operator<(const TurnLaneData &other) const;
 };
 typedef std::vector<TurnLaneData> LaneDataVector;

--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -125,9 +125,7 @@ class TurnLaneHandler
     Intersection handleSliproadTurn(Intersection intersection,
                                     const LaneDescriptionID lane_description_id,
                                     LaneDataVector lane_data,
-                                    const Intersection &previous_intersection,
-                                    const LaneDescriptionID &previous_lane_description_id,
-                                    const LaneDataVector &previous_lane_data);
+                                    const Intersection &previous_intersection);
 
     // get the lane data for an intersection
     void extractLaneData(const EdgeID via_edge,

--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -33,27 +33,75 @@ namespace lanes
 {
 class TurnLaneHandler
 {
+    typedef enum TurnLaneScenario {
+        SIMPLE,             // a straightforward assignment
+        PARTITION_LOCAL,    // an assignment that requires partitioning, using local turns
+        SIMPLE_PREVIOUS,    // an assignemtnn using the turns specified at the previous road (e.g.
+                            // traffic light, lanes not drawn up to the intersection)
+        PARTITION_PREVIOUS, // a set of lanes on a turn with a traffic island. The lanes for the
+                            // turn end at the previous turn (parts of it remain valid without being
+                            // shown again)
+        SLIPROAD, // Sliproads are simple assignments that, for better visual representation should
+                  // include turns from other roads in their listings
+        MERGE,    // Merging Lanes
+        NONE,     // not a turn lane scenario at all
+        INVALID,  // some error might have occurred
+        UNKNOWN,  // UNKNOWN describes all cases that we are currently not able to handle
+        NUM_SCENARIOS
+    } TurnLaneScenario;
+
+    const constexpr static char *scenario_names[TurnLaneScenario::NUM_SCENARIOS] = {
+        "Simple",
+        "Partition Local",
+        "Simple Previous",
+        "Partition Previous",
+        "Sliproad",
+        "Merge",
+        "None",
+        "Invalid",
+        "Unknown"};
+
   public:
     typedef std::vector<TurnLaneData> LaneDataVector;
 
     TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
-                    const std::vector<std::uint32_t> &turn_lane_offsets,
-                    const std::vector<TurnLaneType::Mask> &turn_lane_masks,
-                    const TurnAnalysis &turn_analysis);
+                    std::vector<std::uint32_t> &turn_lane_offsets,
+                    std::vector<TurnLaneType::Mask> &turn_lane_masks,
+                    LaneDescriptionMap &lane_description_map,
+                    const std::vector<QueryNode> &node_info_list,
+                    const TurnAnalysis &turn_analysis,
+                    LaneDataIdMap &id_map);
+
+    ~TurnLaneHandler();
 
     OSRM_ATTR_WARN_UNUSED
-    Intersection assignTurnLanes(const NodeID at,
-                                 const EdgeID via_edge,
-                                 Intersection intersection,
-                                 LaneDataIdMap &id_map) const;
+    Intersection assignTurnLanes(const NodeID at, const EdgeID via_edge, Intersection intersection);
 
   private:
+    unsigned *count_handled;
+    unsigned *count_called;
     // we need to be able to look at previous intersections to, in some cases, find the correct turn
     // lanes for a turn
     const util::NodeBasedDynamicGraph &node_based_graph;
-    const std::vector<std::uint32_t> &turn_lane_offsets;
-    const std::vector<TurnLaneType::Mask> &turn_lane_masks;
+    std::vector<std::uint32_t> &turn_lane_offsets;
+    std::vector<TurnLaneType::Mask> &turn_lane_masks;
+    LaneDescriptionMap &lane_description_map;
+    const std::vector<QueryNode> &node_info_list;
     const TurnAnalysis &turn_analysis;
+    LaneDataIdMap &id_map;
+
+    // Find out which scenario we have to handle
+    TurnLaneScenario deduceScenario(const NodeID at,
+                                    const EdgeID via_edge,
+                                    const Intersection &intersection,
+                                    // Output Parameters to reduce repeated creation
+                                    LaneDescriptionID &lane_description_id,
+                                    LaneDataVector &lane_data,
+                                    NodeID &previous_node,
+                                    EdgeID &previous_id,
+                                    Intersection &previous_intersection,
+                                    LaneDataVector &previous_lane_data,
+                                    LaneDescriptionID &previous_description_id);
 
     // check whether we can handle an intersection
     bool isSimpleIntersection(const LaneDataVector &turn_lane_data,
@@ -63,21 +111,28 @@ class TurnLaneHandler
     OSRM_ATTR_WARN_UNUSED
     Intersection simpleMatchTuplesToTurns(Intersection intersection,
                                           const LaneDataVector &lane_data,
-                                          const LaneDescriptionID lane_string_id,
-                                          LaneDataIdMap &id_map) const;
+                                          const LaneDescriptionID lane_string_id);
 
     // partition lane data into lane data relevant at current turn and at next turn
     OSRM_ATTR_WARN_UNUSED
     std::pair<TurnLaneHandler::LaneDataVector, TurnLaneHandler::LaneDataVector> partitionLaneData(
         const NodeID at, LaneDataVector turn_lane_data, const Intersection &intersection) const;
 
-    // if the current intersections turn string is empty, we check whether there is an incoming
-    // intersection whose turns might be related to this current intersection
+    // Sliproad turns have a separated lane to the right/left of other depicted lanes. These lanes
+    // are not necessarily separated clearly from the rest of the way. As a result, we combine both
+    // lane entries for our output, while performing the matching with the separated lanes only.
     OSRM_ATTR_WARN_UNUSED
-    Intersection handleTurnAtPreviousIntersection(const NodeID at,
-                                                  const EdgeID via_edge,
-                                                  Intersection intersection,
-                                                  LaneDataIdMap &id_map) const;
+    Intersection handleSliproadTurn(Intersection intersection,
+                                    const LaneDescriptionID lane_description_id,
+                                    LaneDataVector lane_data,
+                                    const Intersection &previous_intersection,
+                                    const LaneDescriptionID &previous_lane_description_id,
+                                    const LaneDataVector &previous_lane_data);
+
+    // get the lane data for an intersection
+    void extractLaneData(const EdgeID via_edge,
+                         LaneDescriptionID &lane_description_id,
+                         LaneDataVector &lane_data) const;
 };
 
 } // namespace lanes

--- a/include/extractor/guidance/turn_lane_matcher.hpp
+++ b/include/extractor/guidance/turn_lane_matcher.hpp
@@ -22,16 +22,20 @@ namespace lanes
 {
 
 // Translate Turn Lane Tags into a matching modifier
-DirectionModifier::Enum getMatchingModifier(const TurnLaneType::Mask &tag);
+DirectionModifier::Enum getMatchingModifier(const TurnLaneType::Mask tag);
 
 // check whether a match of a given tag and a turn instruction can be seen as valid
-bool isValidMatch(const TurnLaneType::Mask &tag, const TurnInstruction instruction);
+bool isValidMatch(const TurnLaneType::Mask tag, const TurnInstruction instruction);
 
 // localisation of the best possible match for a tag
-typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask &tag,
+typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask tag,
                                                     const Intersection &intersection);
+
+// the quality of a matching to decide between first/second possibility on segregated intersections
+double getMatchingQuality( const TurnLaneType::Mask tag, const ConnectedRoad &road );
+
 typename Intersection::const_iterator
-findBestMatchForReverse(const TurnLaneType::Mask &leftmost_tag, const Intersection &intersection);
+findBestMatchForReverse(const TurnLaneType::Mask leftmost_tag, const Intersection &intersection);
 
 // a match is trivial if all turns can be associated with their best match in a valid way and the
 // matches occur in order

--- a/include/extractor/guidance/turn_lane_matcher.hpp
+++ b/include/extractor/guidance/turn_lane_matcher.hpp
@@ -32,10 +32,10 @@ typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask tag
                                                     const Intersection &intersection);
 
 // the quality of a matching to decide between first/second possibility on segregated intersections
-double getMatchingQuality( const TurnLaneType::Mask tag, const ConnectedRoad &road );
+double getMatchingQuality(const TurnLaneType::Mask tag, const ConnectedRoad &road);
 
-typename Intersection::const_iterator
-findBestMatchForReverse(const TurnLaneType::Mask leftmost_tag, const Intersection &intersection);
+typename Intersection::const_iterator findBestMatchForReverse(const TurnLaneType::Mask leftmost_tag,
+                                                              const Intersection &intersection);
 
 // a match is trivial if all turns can be associated with their best match in a valid way and the
 // matches occur in order

--- a/include/extractor/guidance/turn_lane_types.hpp
+++ b/include/extractor/guidance/turn_lane_types.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <boost/assert.hpp>
@@ -94,6 +95,11 @@ struct TurnLaneDescription_hash
         return seed;
     }
 };
+
+typedef std::unordered_map<guidance::TurnLaneDescription,
+                           LaneDescriptionID,
+                           guidance::TurnLaneDescription_hash>
+    LaneDescriptionMap;
 
 } // guidance
 } // extractor

--- a/include/extractor/guidance/turn_lane_types.hpp
+++ b/include/extractor/guidance/turn_lane_types.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include <boost/assert.hpp>
-#include <boost/functional/hash_fwd.hpp>
+#include <boost/functional/hash.hpp>
 
 #include "util/json_container.hpp"
 #include "util/simple_logger.hpp"
@@ -90,8 +90,7 @@ struct TurnLaneDescription_hash
     std::size_t operator()(const TurnLaneDescription &lane_description) const
     {
         std::size_t seed = 0;
-        for (auto val : lane_description)
-            boost::hash_combine(seed, val);
+        boost::hash_range(seed, lane_description.begin(), lane_description.end());
         return seed;
     }
 };

--- a/include/util/attributes.hpp
+++ b/include/util/attributes.hpp
@@ -1,15 +1,13 @@
 #ifndef OSRM_ATTRIBUTES_HPP_
 #define OSRM_ATTRIBUTES_HPP_
 
-
 // OSRM_ATTR_WARN_UNUSED - caller has to use function's return value
 // https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
 
 #if defined(__GNUC__) && (__GNUC__ >= 4)
-  #define OSRM_ATTR_WARN_UNUSED __attribute__ ((warn_unused_result))
+#define OSRM_ATTR_WARN_UNUSED __attribute__((warn_unused_result))
 #else
-  #define OSRM_ATTR_WARN_UNUSED
+#define OSRM_ATTR_WARN_UNUSED
 #endif
-
 
 #endif

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -83,7 +83,9 @@ inline void print(const extractor::guidance::lanes::LaneDataVector &turn_lane_da
         std::cout << "\t" << entry.tag << "("
                   << extractor::guidance::TurnLaneType::toString(entry.tag)
                   << ") from: " << static_cast<int>(entry.from)
-                  << " to: " << static_cast<int>(entry.to) << "\n";
+                  << " to: " << static_cast<int>(entry.to)
+                  << " Can Be Suppresssed: " << (entry.suppress_assignment ? "true" : "false")
+                  << "\n";
     std::cout << std::flush;
 }
 

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -29,15 +29,15 @@ inline void print(const engine::guidance::RouteStep &step)
 
     for (const auto &intersection : step.intersections)
     {
-        std::cout << "(bearings:";
+        std::cout << "(Lanes: " << static_cast<int>(intersection.lanes.lanes_in_turn) << " "
+                  << static_cast<int>(intersection.lanes.first_lane_from_the_right)
+                  << " bearings:";
         for (auto bearing : intersection.bearings)
             std::cout << " " << bearing;
         std::cout << ", entry: ";
         for (auto entry : intersection.entry)
             std::cout << " " << (entry ? "true" : "false");
-        const auto lanes = intersection.lanes;
-        std::cout<< " Lanes: (" << static_cast<int>(lanes.lanes_in_turn) << ", "
-              << static_cast<int>(lanes.first_lane_from_the_right) << "))";
+        std::cout << ")";
     }
     std::cout << "] name[" << step.name_id << "]: " << step.name;
 }

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -25,8 +25,7 @@ inline void print(const engine::guidance::RouteStep &step)
               << static_cast<int>(step.maneuver.waypoint_type) << " "
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
-              << " exit: " << step.maneuver.exit << " Intersections: " << step.intersections.size()
-              << " [";
+              << "\n\tIntersections: " << step.intersections.size() << " [";
 
     for (const auto &intersection : step.intersections)
     {
@@ -36,9 +35,9 @@ inline void print(const engine::guidance::RouteStep &step)
         std::cout << ", entry: ";
         for (auto entry : intersection.entry)
             std::cout << " " << (entry ? "true" : "false");
-        std::cout << " Lanes: (" << static_cast<int>(intersection.lanes.lanes_in_turn) << ", "
-                  << static_cast<int>(intersection.lanes.first_lane_from_the_right) << ")";
-        std::cout << ")";
+        const auto lanes = intersection.lanes;
+        std::cout<< " Lanes: (" << static_cast<int>(lanes.lanes_in_turn) << ", "
+              << static_cast<int>(lanes.first_lane_from_the_right) << "))";
     }
     std::cout << "] name[" << step.name_id << "]: " << step.name;
 }

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -30,8 +30,7 @@ inline void print(const engine::guidance::RouteStep &step)
     for (const auto &intersection : step.intersections)
     {
         std::cout << "(Lanes: " << static_cast<int>(intersection.lanes.lanes_in_turn) << " "
-                  << static_cast<int>(intersection.lanes.first_lane_from_the_right)
-                  << " bearings:";
+                  << static_cast<int>(intersection.lanes.first_lane_from_the_right) << " bearings:";
         for (auto bearing : intersection.bearings)
             std::cout << " " << bearing;
         std::cout << ", entry: ";

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -53,9 +53,8 @@ struct NodeBasedEdgeData
 
     bool IsCompatibleTo(const NodeBasedEdgeData &other) const
     {
-        return (reversed == other.reversed) &&
-               (roundabout == other.roundabout) && (startpoint == other.startpoint) &&
-               (access_restricted == other.access_restricted) &&
+        return (reversed == other.reversed) && (roundabout == other.roundabout) &&
+               (startpoint == other.startpoint) && (access_restricted == other.access_restricted) &&
                (travel_mode == other.travel_mode) &&
                (road_classification == other.road_classification);
     }

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -251,12 +251,13 @@ parse_segment_lookup_from_csv_files(const std::vector<std::string> &segment_spee
             const auto last = end(line);
 
             // The ulong_long -> uint64_t will likely break on 32bit platforms
-            const auto ok = parse(it,
-                                  last,                                              //
-                                  (ulong_long >> ',' >> ulong_long >> ',' >> uint_ >> *(',' >> *char_)), //
-                                  from_node_id,
-                                  to_node_id,
-                                  speed); //
+            const auto ok =
+                parse(it,
+                      last,                                                                  //
+                      (ulong_long >> ',' >> ulong_long >> ',' >> uint_ >> *(',' >> *char_)), //
+                      from_node_id,
+                      to_node_id,
+                      speed); //
 
             if (!ok || it != last)
                 throw util::exception{"Segment speed file " + filename + " malformed"};
@@ -334,14 +335,14 @@ parse_turn_penalty_lookup_from_csv_files(const std::vector<std::string> &turn_pe
             const auto last = end(line);
 
             // The ulong_long -> uint64_t will likely break on 32bit platforms
-            const auto ok =
-                parse(it,
-                      last,                                                                     //
-                      (ulong_long >> ',' >> ulong_long >> ',' >> ulong_long >> ',' >> double_ >> *(',' >> *char_)), //
-                      from_node_id,
-                      via_node_id,
-                      to_node_id,
-                      penalty); //
+            const auto ok = parse(it,
+                                  last, //
+                                  (ulong_long >> ',' >> ulong_long >> ',' >> ulong_long >> ',' >>
+                                   double_ >> *(',' >> *char_)), //
+                                  from_node_id,
+                                  via_node_id,
+                                  to_node_id,
+                                  penalty); //
 
             if (!ok || it != last)
                 throw util::exception{"Turn penalty file " + filename + " malformed"};
@@ -807,7 +808,8 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
 
             // We found a zero-speed edge, so we'll skip this whole edge-based-edge which
             // effectively removes it from the routing network.
-            if (skip_this_edge) {
+            if (skip_this_edge)
+            {
                 penaltyblock++;
                 continue;
             }

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -68,8 +68,8 @@ inline bool hasValidLanes(const guidance::Intersection &intersection)
 
 std::string instructionTypeToString(const TurnType::Enum type)
 {
-    static_assert(sizeof(turn_type_names)/sizeof(turn_type_names[0]) >= TurnType::MaxTurnType,
-            "Some turn types has not string representation.");
+    static_assert(sizeof(turn_type_names) / sizeof(turn_type_names[0]) >= TurnType::MaxTurnType,
+                  "Some turn types has not string representation.");
     return turn_type_names[static_cast<std::size_t>(type)];
 }
 
@@ -99,15 +99,17 @@ util::json::Array lanesFromIntersection(const guidance::Intersection &intersecti
 
 std::string instructionModifierToString(const DirectionModifier::Enum modifier)
 {
-    static_assert(sizeof(modifier_names)/sizeof(modifier_names[0]) >= DirectionModifier::MaxDirectionModifier,
-            "Some direction modifiers has not string representation.");
+    static_assert(sizeof(modifier_names) / sizeof(modifier_names[0]) >=
+                      DirectionModifier::MaxDirectionModifier,
+                  "Some direction modifiers has not string representation.");
     return modifier_names[static_cast<std::size_t>(modifier)];
 }
 
 std::string waypointTypeToString(const guidance::WaypointType waypoint_type)
 {
-    static_assert(sizeof(waypoint_type_names)/sizeof(waypoint_type_names[0]) >= static_cast<size_t>(guidance::WaypointType::MaxWaypointType),
-            "Some waypoint types has not string representation.");
+    static_assert(sizeof(waypoint_type_names) / sizeof(waypoint_type_names[0]) >=
+                      static_cast<size_t>(guidance::WaypointType::MaxWaypointType),
+                  "Some waypoint types has not string representation.");
     return waypoint_type_names[static_cast<std::size_t>(waypoint_type)];
 }
 

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -3,8 +3,8 @@
 #include "util/guidance/toolkit.hpp"
 
 #include "extractor/guidance/turn_instruction.hpp"
-#include "engine/guidance/toolkit.hpp"
 #include "engine/guidance/post_processing.hpp"
+#include "engine/guidance/toolkit.hpp"
 
 #include <iterator>
 #include <unordered_set>
@@ -80,7 +80,8 @@ std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
             // where lanes in the turn fan in but for example the overall lanes at that location
             // fan out, we would have to know the asymmetric mapping of lanes. This is currently
             // not possible at the moment. In the following we implement a heuristic instead.
-            const LaneID current_num_all_lanes = current.intersections.front().lane_description.size();
+            const LaneID current_num_all_lanes =
+                current.intersections.front().lane_description.size();
             const LaneID current_num_lanes_right_of_turn = current_lanes.first_lane_from_the_right;
             const LaneID current_num_lanes_left_of_turn =
                 current_num_all_lanes -

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -4,8 +4,11 @@
 
 #include "extractor/guidance/turn_instruction.hpp"
 #include "engine/guidance/toolkit.hpp"
+#include "engine/guidance/post_processing.hpp"
 
 #include <iterator>
+#include <unordered_set>
+#include <utility>
 
 using TurnInstruction = osrm::extractor::guidance::TurnInstruction;
 namespace TurnType = osrm::extractor::guidance::TurnType;
@@ -24,47 +27,45 @@ namespace guidance
 std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
                                             const double min_duration_needed_for_lane_change)
 {
-    // Postprocessing does not strictly guarantee for only turns
-    const auto is_turn = [](const RouteStep &step) {
-        return step.maneuver.instruction.type != TurnType::NewName &&
-               step.maneuver.instruction.type != TurnType::Notification;
+    // Lane anticipation works on contiguous ranges of quick steps that have lane information
+    const auto is_quick_has_lanes = [&](const RouteStep &step) {
+        const auto is_quick = step.duration < min_duration_needed_for_lane_change;
+        const auto has_lanes = step.intersections.front().lanes.lanes_in_turn > 0;
+        return has_lanes && is_quick;
     };
 
-    const auto is_quick = [min_duration_needed_for_lane_change](const RouteStep &step) {
-        return step.duration < min_duration_needed_for_lane_change;
-    };
-
-    const auto is_quick_turn = [&](const RouteStep &step) {
-        return is_turn(step) && is_quick(step);
-    };
-
-    // Determine range of subsequent quick turns, candidates for possible lane anticipation
     using StepIter = decltype(steps)::iterator;
     using StepIterRange = std::pair<StepIter, StepIter>;
 
-    std::vector<StepIterRange> subsequent_quick_turns;
+    std::vector<StepIterRange> quick_lanes_ranges;
 
-    const auto keep_turn_range = [&](StepIterRange range) {
+    const auto range_back_inserter = [&](StepIterRange range) {
         if (std::distance(range.first, range.second) > 1)
-            subsequent_quick_turns.push_back(std::move(range));
+            quick_lanes_ranges.push_back(std::move(range));
     };
 
-    util::group_by(begin(steps), end(steps), is_quick_turn, keep_turn_range);
+    util::group_by(begin(steps), end(steps), is_quick_has_lanes, range_back_inserter);
+
+    // The lanes for a keep straight depend on the next left/right turn. Tag them in advance.
+    std::unordered_set<const RouteStep *> is_straight_left;
+    std::unordered_set<const RouteStep *> is_straight_right;
 
     // Walk backwards over all turns, constraining possible turn lanes.
     // Later turn lanes constrain earlier ones: we have to anticipate lane changes.
-    const auto constrain_lanes = [](const StepIterRange &turns) {
+    const auto constrain_lanes = [&](const StepIterRange &turns) {
         const std::reverse_iterator<StepIter> rev_first{turns.second};
         const std::reverse_iterator<StepIter> rev_last{turns.first};
 
         // We're walking backwards over all adjacent turns:
         // the current turn lanes constrain the lanes we have to take in the previous turn.
-        util::for_each_pair(rev_first, rev_last, [](RouteStep &current, RouteStep &previous) {
+        util::for_each_pair(rev_first, rev_last, [&](RouteStep &current, RouteStep &previous) {
             const auto current_inst = current.maneuver.instruction;
             const auto current_lanes = current.intersections.front().lanes;
 
             // Constrain the previous turn's lanes
             auto &previous_lanes = previous.intersections.front().lanes;
+            const auto previous_inst = previous.maneuver.instruction;
+
             // Lane mapping (N:M) from previous lanes (N) to current lanes (M), with:
             //  N > M, N > 1   fan-in situation, constrain N lanes to min(N,M) shared lanes
             //  otherwise      nothing to constrain
@@ -74,34 +75,113 @@ std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
             if (!lanes_to_constrain || !lanes_fan_in)
                 return;
 
-            // In case there is no lane information we work with one artificial lane
-            const auto current_adjusted_lanes = std::max(current_lanes.lanes_in_turn, LaneID{1});
+            // We do not have a mapping from lanes to lanes. All we have is the lanes in the turn
+            // and all the lanes at that situation. To perfectly handle lane anticipation in cases
+            // where lanes in the turn fan in but for example the overall lanes at that location
+            // fan out, we would have to know the asymmetric mapping of lanes. This is currently
+            // not possible at the moment. In the following we implement a heuristic instead.
+            const LaneID current_num_all_lanes = current.intersections.front().lane_description.size();
+            const LaneID current_num_lanes_right_of_turn = current_lanes.first_lane_from_the_right;
+            const LaneID current_num_lanes_left_of_turn =
+                current_num_all_lanes -
+                (current_lanes.lanes_in_turn + current_num_lanes_right_of_turn);
 
-            const auto num_shared_lanes = std::min(current_adjusted_lanes, //
-                                                   previous_lanes.lanes_in_turn);
+            const LaneID num_shared_lanes = std::min(current_lanes.lanes_in_turn,   //
+                                                     previous_lanes.lanes_in_turn); //
 
-            if (isRightTurn(current_inst))
+            // 0/ Tag keep straight with the next turn's direction if available
+            const auto previous_is_straight =
+                !isLeftTurn(previous_inst) && !isRightTurn(previous_inst);
+
+            if (previous_is_straight)
             {
+                if (isLeftTurn(current_inst) || is_straight_left.count(&current) > 0)
+                    is_straight_left.insert(&previous);
+                else if (isRightTurn(current_inst) || is_straight_right.count(&current) > 0)
+                    is_straight_right.insert(&previous);
+            }
+
+            // 1/ How to anticipate left, right:
+            const auto anticipate_for_left_turn = [&] {
+                // Current turn is left turn, already keep left during previous turn.
+                // This implies constraining the rightmost lanes in previous step.
+                LaneID new_first_lane_from_the_right =
+                    previous_lanes.first_lane_from_the_right // start from rightmost lane
+                    + previous_lanes.lanes_in_turn           // one past leftmost lane
+                    - num_shared_lanes;                      // back number of new lanes
+
+                // The leftmost target lanes might not be involved in the turn. Figure out
+                // how many lanes are to the left and not in the turn.
+                new_first_lane_from_the_right -=
+                    std::min(current_num_lanes_left_of_turn, num_shared_lanes);
+
+                previous_lanes = {num_shared_lanes, new_first_lane_from_the_right};
+            };
+
+            const auto anticipate_for_right_turn = [&] {
                 // Current turn is right turn, already keep right during the previous turn.
                 // This implies constraining the leftmost lanes in the previous turn step.
-                previous_lanes = {num_shared_lanes, previous_lanes.first_lane_from_the_right};
-            }
-            else if (isLeftTurn(current_inst))
-            {
-                // Current turn is left turn, already keep left during previous turn.
-                // This implies constraining the rightmost lanes in the previous turn step.
-                const LaneID shared_lane_delta = previous_lanes.lanes_in_turn - num_shared_lanes;
-                const LaneID previous_adjusted_lanes =
-                    std::min(current_adjusted_lanes, shared_lane_delta);
-                const LaneID constraint_first_lane_from_the_right =
-                    previous_lanes.first_lane_from_the_right + previous_adjusted_lanes;
+                LaneID new_first_lane_from_the_right = previous_lanes.first_lane_from_the_right;
 
-                previous_lanes = {num_shared_lanes, constraint_first_lane_from_the_right};
+                // The rightmost target lanes might not be involved in the turn. Figure out
+                // how many lanes are to the right and not in the turn.
+                new_first_lane_from_the_right +=
+                    std::min(current_num_lanes_right_of_turn, num_shared_lanes);
+
+                previous_lanes = {num_shared_lanes, new_first_lane_from_the_right};
+            };
+
+            // 2/ When to anticipate a left, right turn
+            if (isLeftTurn(current_inst))
+                anticipate_for_left_turn();
+            else if (isRightTurn(current_inst))
+                anticipate_for_right_turn();
+            else // keepStraight
+            {
+                // Heuristic: we do not have a from-lanes -> to-lanes mapping. What we use
+                // here instead in addition is the number of all lanes (not only the lanes
+                // in a turn):
+                //
+                // -v-v v-v-        straight follows
+                //  | | | |
+                // <- v v ->        keep straight here
+                //    | |
+                //  <-| |->
+                //
+                // A route from the top left to the bottom right here goes over a keep
+                // straight. If we handle all keep straights as right turns (in right-sided
+                // driving), we wrongly guide the user to the rightmost lanes in the first turn.
+                // Not only is this wrong but the opposite of what we expect.
+                //
+                // The following implements a heuristic to determine a keep straight's
+                // direction in relation to the next step. In the above example we would get:
+                //
+                // coming from right, going to left (in direction of way) -> handle as left turn
+
+                if (is_straight_left.count(&current) > 0)
+                    anticipate_for_left_turn();
+                else if (is_straight_right.count(&current) > 0)
+                    anticipate_for_right_turn();
+                else // FIXME: right-sided driving
+                    anticipate_for_right_turn();
+            }
+
+            // We might have constrained the previous step in a way that makes it compatible
+            // with the current step. If we did so we collapse it here and mark the current
+            // step as invalid, scheduled for later removal.
+            if (collapsable(previous, current))
+            {
+                previous = elongate(previous, current);
+                current.maneuver.instruction = TurnInstruction::NO_TURN();
             }
         });
     };
 
-    std::for_each(begin(subsequent_quick_turns), end(subsequent_quick_turns), constrain_lanes);
+    std::for_each(begin(quick_lanes_ranges), end(quick_lanes_ranges), constrain_lanes);
+
+    // Lane Anticipation might have collapsed steps after constraining lanes. Remove invalid steps.
+    steps = removeNoTurnInstructions(std::move(steps));
+
     return steps;
 }
 

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -77,7 +77,8 @@ bool collapsable(const RouteStep &step, const RouteStep &next)
     const auto instruction_can_be_collapsed = isCollapsableInstruction(step.maneuver.instruction);
 
     const auto is_use_lane = step.maneuver.instruction.type == TurnType::UseLane;
-    const auto lanes_dont_change = step.maneuver.lanes == next.maneuver.lanes;
+    const auto lanes_dont_change =
+        step.intersections.front().lanes == next.intersections.front().lanes;
 
     if (is_short_step && instruction_can_be_collapsed)
         return true;

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -1,5 +1,5 @@
-#include "extractor/edge_based_edge.hpp"
 #include "extractor/edge_based_graph_factory.hpp"
+#include "extractor/edge_based_edge.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/exception.hpp"

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -116,11 +116,6 @@ ExtractionContainers::ExtractionContainers()
     name_offsets.push_back(0);
     // Insert the total length sentinel (corresponds to the next name string offset)
     name_offsets.push_back(0);
-
-    // the offsets have to be initialized with two values, since we have the empty turn string for
-    // the first id
-    turn_lane_offsets.push_back(0);
-    turn_lane_offsets.push_back(0);
 }
 
 /**
@@ -136,8 +131,7 @@ ExtractionContainers::ExtractionContainers()
 void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environment,
                                        const std::string &output_file_name,
                                        const std::string &restrictions_file_name,
-                                       const std::string &name_file_name,
-                                       const std::string &turn_lane_file_name)
+                                       const std::string &name_file_name)
 {
     std::ofstream file_out_stream;
     file_out_stream.open(output_file_name.c_str(), std::ios::binary);
@@ -151,35 +145,7 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
 
     PrepareRestrictions();
     WriteRestrictions(restrictions_file_name);
-
     WriteCharData(name_file_name);
-    WriteTurnLaneMasks(turn_lane_file_name, turn_lane_offsets, turn_lane_masks);
-}
-
-void ExtractionContainers::WriteTurnLaneMasks(
-    const std::string &file_name,
-    const stxxl::vector<std::uint32_t> &offsets,
-    const stxxl::vector<guidance::TurnLaneType::Mask> &masks) const
-{
-    util::SimpleLogger().Write() << "Writing turn lane masks...";
-    TIMER_START(turn_lane_timer);
-
-    std::ofstream ofs(file_name, std::ios::binary);
-
-    if (!util::serializeVector(ofs, offsets))
-    {
-        util::SimpleLogger().Write(logWARNING) << "Error while writing.";
-        return;
-    }
-
-    if (!util::serializeVector(ofs, masks))
-    {
-        util::SimpleLogger().Write(logWARNING) << "Error while writing.";
-        return;
-    }
-
-    TIMER_STOP(turn_lane_timer);
-    util::SimpleLogger().Write() << "done (" << TIMER_SEC(turn_lane_timer) << ")";
 }
 
 void ExtractionContainers::WriteCharData(const std::string &file_name)

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -45,6 +45,7 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <numeric> //partial_sum
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -93,7 +94,8 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         util::SimpleLogger().Write() << "Threads: " << number_of_threads;
 
         ExtractionContainers extraction_containers;
-        auto extractor_callbacks = util::make_unique<ExtractorCallbacks>(extraction_containers);
+        auto extractor_callbacks =
+            util::make_unique<ExtractorCallbacks>(extraction_containers, turn_lane_map);
 
         const osmium::io::File input_file(config.input_path.string());
         osmium::io::Reader reader(input_file);
@@ -194,8 +196,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         extraction_containers.PrepareData(scripting_environment,
                                           config.output_file_name,
                                           config.restriction_file_name,
-                                          config.names_file_name,
-                                          config.turn_lane_descriptions_file_name);
+                                          config.names_file_name);
 
         WriteProfileProperties(config.profile_properties_output_path,
                                scripting_environment.GetProfileProperties());
@@ -444,13 +445,21 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
 
     util::NameTable name_table(config.names_file_name);
 
-    std::vector<std::uint32_t> turn_lane_offsets;
-    std::vector<guidance::TurnLaneType::Mask> turn_lane_masks;
-    if (!util::deserializeAdjacencyArray(
-            config.turn_lane_descriptions_file_name, turn_lane_offsets, turn_lane_masks))
-    {
-        util::SimpleLogger().Write(logWARNING) << "Reading Turn Lane Masks failed.";
-    }
+    // could use some additional capacity? To avoid a copy during processing, though small data so
+    // probably not that important.
+    std::vector<std::uint32_t> turn_lane_offsets(turn_lane_map.size() + 2); // empty ID + sentinel
+    for (auto entry = turn_lane_map.begin(); entry != turn_lane_map.end(); ++entry)
+        turn_lane_offsets[entry->second + 1] = entry->first.size();
+
+    // inplace prefix sum
+    std::partial_sum(turn_lane_offsets.begin(), turn_lane_offsets.end(), turn_lane_offsets.begin());
+
+    // allocate the current masks
+    std::vector<guidance::TurnLaneType::Mask> turn_lane_masks(turn_lane_offsets.back());
+    for (auto entry = turn_lane_map.begin(); entry != turn_lane_map.end(); ++entry)
+        std::copy(entry->first.begin(),
+                  entry->first.end(),
+                  turn_lane_masks.begin() + turn_lane_offsets[entry->second]);
 
     EdgeBasedGraphFactory edge_based_graph_factory(
         node_based_graph,
@@ -462,7 +471,8 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
         scripting_environment.GetProfileProperties(),
         name_table,
         turn_lane_offsets,
-        turn_lane_masks);
+        turn_lane_masks,
+        turn_lane_map);
 
     edge_based_graph_factory.Run(scripting_environment,
                                  config.edge_output_path,
@@ -470,6 +480,8 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                                  config.edge_segment_lookup_path,
                                  config.edge_penalty_path,
                                  config.generate_edge_lookup);
+
+    WriteTurnLaneData(config.turn_lane_descriptions_file_name);
 
     edge_based_graph_factory.GetEdgeBasedEdges(edge_based_edge_list);
     edge_based_graph_factory.GetEdgeBasedNodes(node_based_edge_list);
@@ -633,5 +645,44 @@ void Extractor::WriteIntersectionClassificationData(
                                  << entry_classes.size() << " entry classes and " << total_bearings
                                  << " bearing values." << std::endl;
 }
+
+void Extractor::WriteTurnLaneData(const std::string &turn_lane_file) const
+{
+    // Write the turn lane data to file
+    std::vector<std::uint32_t> turn_lane_offsets(turn_lane_map.size() + 2); // empty ID + sentinel
+    for (auto entry = turn_lane_map.begin(); entry != turn_lane_map.end(); ++entry)
+        turn_lane_offsets[entry->second + 1] = entry->first.size();
+
+    // inplace prefix sum
+    std::partial_sum(turn_lane_offsets.begin(), turn_lane_offsets.end(), turn_lane_offsets.begin());
+
+    // allocate the current masks
+    std::vector<guidance::TurnLaneType::Mask> turn_lane_masks(turn_lane_offsets.back());
+    for (auto entry = turn_lane_map.begin(); entry != turn_lane_map.end(); ++entry)
+        std::copy(entry->first.begin(),
+                  entry->first.end(),
+                  turn_lane_masks.begin() + turn_lane_offsets[entry->second]);
+
+    util::SimpleLogger().Write() << "Writing turn lane masks...";
+    TIMER_START(turn_lane_timer);
+
+    std::ofstream ofs(turn_lane_file, std::ios::binary);
+
+    if (!util::serializeVector(ofs, turn_lane_offsets))
+    {
+        util::SimpleLogger().Write(logWARNING) << "Error while writing.";
+        return;
+    }
+
+    if (!util::serializeVector(ofs, turn_lane_masks))
+    {
+        util::SimpleLogger().Write(logWARNING) << "Error while writing.";
+        return;
+    }
+
+    TIMER_STOP(turn_lane_timer);
+    util::SimpleLogger().Write() << "done (" << TIMER_SEC(turn_lane_timer) << ")";
 }
-}
+
+} // namespace extractor
+} // namespace osrm

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -31,15 +31,13 @@ namespace extractor
 using TurnLaneDescription = guidance::TurnLaneDescription;
 namespace TurnLaneType = guidance::TurnLaneType;
 
-ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containers,
-                                       guidance::LaneDescriptionMap &lane_description_map)
-    : lane_description_map(lane_description_map), external_memory(extraction_containers)
+ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containers)
+    : external_memory(extraction_containers)
 {
     // we reserved 0, 1, 2 for the empty case
     string_map[MapKey("", "")] = 0;
 
     // The map should be empty before we start initializing it
-    BOOST_ASSERT(lane_description_map.empty());
     lane_description_map[TurnLaneDescription()] = 0;
 }
 
@@ -395,5 +393,10 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
              OSMNodeID{static_cast<std::uint64_t>(input_way.nodes()[0].ref())}});
     }
 }
+
+guidance::LaneDescriptionMap &&ExtractorCallbacks::moveOutLaneDescriptionMap()
+{
+    return std::move(lane_description_map);
 }
-}
+} // namespace extractor
+} // namespace osrm

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -31,11 +31,15 @@ namespace extractor
 using TurnLaneDescription = guidance::TurnLaneDescription;
 namespace TurnLaneType = guidance::TurnLaneType;
 
-ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containers)
-    : external_memory(extraction_containers)
+ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containers,
+                                       guidance::LaneDescriptionMap &lane_description_map)
+    : lane_description_map(lane_description_map), external_memory(extraction_containers)
 {
     // we reserved 0, 1, 2 for the empty case
     string_map[MapKey("", "")] = 0;
+
+    // The map should be empty before we start initializing it
+    BOOST_ASSERT(lane_description_map.empty());
     lane_description_map[TurnLaneDescription()] = 0;
 }
 
@@ -165,6 +169,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                                                 "reverse",
                                                                 "merge_to_left",
                                                                 "merge_to_right"};
+
         const constexpr TurnLaneType::Mask masks_by_osm_string[num_osm_tags + 1] = {
             TurnLaneType::none,
             TurnLaneType::straight,
@@ -224,16 +229,6 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
             const LaneDescriptionID new_id =
                 boost::numeric_cast<LaneDescriptionID>(lane_description_map.size());
             lane_description_map[lane_description] = new_id;
-
-            // since we are getting a new ID, we can augment the current offsets
-
-            // and store the turn lane masks, sadly stxxl does not support insert
-            for (const auto mask : lane_description)
-                external_memory.turn_lane_masks.push_back(mask);
-
-            external_memory.turn_lane_offsets.push_back(external_memory.turn_lane_offsets.back() +
-                                                        lane_description.size());
-
             return new_id;
         }
         else

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/intersection_generator.hpp"
+#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include <algorithm>

--- a/src/extractor/guidance/motorway_handler.cpp
+++ b/src/extractor/guidance/motorway_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/motorway_handler.hpp"
+#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/road_classification.hpp"
 #include "extractor/guidance/toolkit.hpp"
 

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/roundabout_handler.hpp"
+#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include "util/coordinate_calculation.hpp"

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -1,6 +1,6 @@
+#include "extractor/guidance/sliproad_handler.hpp"
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/intersection_scenario_three_way.hpp"
-#include "extractor/guidance/sliproad_handler.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include "util/guidance/toolkit.hpp"
@@ -128,10 +128,6 @@ operator()(const NodeID, const EdgeID source_edge_id, Intersection intersection)
         return intersection;
 
     const auto source_edge_data = node_based_graph.GetEdgeData(source_edge_id);
-
-    const bool hasNext = obvious_turn_index != 0;
-    if (!hasNext)
-        return intersection;
 
     // check whether the continue road is valid
     const auto check_valid = [this, source_edge_data](const ConnectedRoad &road) {

--- a/src/extractor/guidance/turn_analysis.cpp
+++ b/src/extractor/guidance/turn_analysis.cpp
@@ -1,6 +1,6 @@
+#include "extractor/guidance/turn_analysis.hpp"
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/road_classification.hpp"
-#include "extractor/guidance/turn_analysis.hpp"
 
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"

--- a/src/extractor/guidance/turn_discovery.cpp
+++ b/src/extractor/guidance/turn_discovery.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/turn_discovery.hpp"
+#include "extractor/guidance/constants.hpp"
 
 namespace osrm
 {

--- a/src/extractor/guidance/turn_discovery.cpp
+++ b/src/extractor/guidance/turn_discovery.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/turn_discovery.hpp"
 #include "extractor/guidance/constants.hpp"
+#include "extractor/guidance/turn_discovery.hpp"
 
 namespace osrm
 {
@@ -50,8 +50,10 @@ bool findPreviousIntersection(const NodeID node_v,
     // previous intersection.
     const auto straightmost_at_v_in_reverse =
         findClosestTurn(node_v_reverse_intersection, STRAIGHT_ANGLE);
-    if (angularDeviation(straightmost_at_v_in_reverse->turn.angle, STRAIGHT_ANGLE) >
-        FUZZY_ANGLE_DIFFERENCE)
+
+    // TODO evaluate if narrow turn is the right criterion here... Might be that other angles are
+    // valid
+    if (angularDeviation(straightmost_at_v_in_reverse->turn.angle, STRAIGHT_ANGLE) > GROUP_ANGLE)
         return false;
 
     const auto node_u = node_based_graph.GetTarget(straightmost_at_v_in_reverse->turn.eid);
@@ -66,12 +68,25 @@ bool findPreviousIntersection(const NodeID node_v,
     // if the edge is not traversable, we obviously don't have a previous intersection or couldn't
     // find it.
     if (node_based_graph.GetEdgeData(result_via_edge).reversed)
+    {
+        result_via_edge = SPECIAL_EDGEID;
+        result_node = SPECIAL_NODEID;
         return false;
+    }
 
     result_intersection = turn_analysis.getIntersection(node_u, result_via_edge);
-    const auto check_via_edge = findClosestTurn(result_intersection, STRAIGHT_ANGLE)->turn.eid;
-    if (check_via_edge != via_edge)
+    const auto check_via_edge =
+        result_intersection.end() !=
+        std::find_if(result_intersection.begin(),
+                     result_intersection.end(),
+                     [via_edge](const ConnectedRoad &road) { return road.turn.eid == via_edge; });
+
+    if (!check_via_edge)
+    {
+        result_via_edge = SPECIAL_EDGEID;
+        result_node = SPECIAL_NODEID;
         return false;
+    }
 
     result_intersection =
         turn_analysis.assignTurnTypes(node_u, result_via_edge, std::move(result_intersection));

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -1,7 +1,7 @@
+#include "extractor/guidance/turn_handler.hpp"
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/intersection_scenario_three_way.hpp"
 #include "extractor/guidance/toolkit.hpp"
-#include "extractor/guidance/turn_handler.hpp"
 
 #include "util/guidance/toolkit.hpp"
 

--- a/src/extractor/guidance/turn_lane_augmentation.cpp
+++ b/src/extractor/guidance/turn_lane_augmentation.cpp
@@ -118,7 +118,8 @@ LaneDataVector augmentMultiple(const std::size_t none_index,
             lane_data.push_back({tag_by_modifier[intersection[intersection_index]
                                                      .turn.instruction.direction_modifier],
                                  lane_data[none_index].from,
-                                 lane_data[none_index].to});
+                                 lane_data[none_index].to,
+                                 false});
         }
     }
     lane_data.erase(lane_data.begin() + none_index);

--- a/src/extractor/guidance/turn_lane_augmentation.cpp
+++ b/src/extractor/guidance/turn_lane_augmentation.cpp
@@ -1,3 +1,5 @@
+#include "util/debug.hpp"
+
 #include "extractor/guidance/turn_lane_augmentation.hpp"
 #include "extractor/guidance/turn_lane_types.hpp"
 #include "util/simple_logger.hpp"
@@ -280,6 +282,13 @@ LaneDataVector handleNoneValueAtSimpleTurn(LaneDataVector lane_data,
     // we have to reduce it, assigning it to neighboring turns
     else if (connection_count < lane_data.size())
     {
+        if( connection_count+1 < lane_data.size() ){
+            std::cout << "[error] failed assignment" << std::endl;
+            util::guidance::print(lane_data);
+            std::cout << "Intersection:\n";
+            for( auto road : intersection )
+                std::cout << "\t" << toString(road) << std::endl;
+        }
         // a pgerequisite is simple turns. Larger differences should not end up here
         // an additional line at the side is only reasonable if it is targeting public
         // service vehicles. Otherwise, we should not have it

--- a/src/extractor/guidance/turn_lane_augmentation.cpp
+++ b/src/extractor/guidance/turn_lane_augmentation.cpp
@@ -283,27 +283,18 @@ LaneDataVector handleNoneValueAtSimpleTurn(LaneDataVector lane_data,
     // we have to reduce it, assigning it to neighboring turns
     else if (connection_count < lane_data.size())
     {
-        if( connection_count+1 < lane_data.size() ){
-            std::cout << "[error] failed assignment" << std::endl;
-            util::guidance::print(lane_data);
-            std::cout << "Intersection:\n";
-            for( auto road : intersection )
-                std::cout << "\t" << toString(road) << std::endl;
-        }
         // a pgerequisite is simple turns. Larger differences should not end up here
         // an additional line at the side is only reasonable if it is targeting public
         // service vehicles. Otherwise, we should not have it
-        //
-        // TODO(mokob): #2730 have a look please
-        // BOOST_ASSERT(connection_count + 1 == lane_data.size());
-        //
-        if (connection_count + 1 != lane_data.size())
+        if (connection_count + 1 == lane_data.size())
         {
-            // skip broken intersections
+            lane_data = mergeNoneTag(none_index, std::move(lane_data));
         }
         else
         {
-            lane_data = mergeNoneTag(none_index, std::move(lane_data));
+            // This represents a currently unhandled case. It should not even get here, but to be
+            // sure we return nevertheless.
+            return lane_data;
         }
     }
     // we have to rename and possibly augment existing ones. The pure count remains the

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -154,27 +154,6 @@ bool hasTag(const TurnLaneType::Mask tag, const LaneDataVector &data)
     return findTag(tag, data) != data.cend();
 }
 
-bool isSubsetOf(const LaneDataVector &subset_candidate, const LaneDataVector &superset_candidate)
-{
-    auto location = superset_candidate.begin();
-    for (const auto entry : subset_candidate)
-    {
-        location = std::find_if(
-            location, superset_candidate.end(), [entry](const TurnLaneData &lane_data) {
-                return lane_data.tag == entry.tag;
-            });
-
-        if (location == superset_candidate.end())
-            return false;
-
-        // compare the number of lanes TODO this might have be to be revisited for situations where
-        // a sliproad widens into multiple lanes
-        if ((location->to - location->from) != (entry.to - entry.from))
-            return false;
-    }
-    return true;
-}
-
 } // namespace lanes
 } // namespace guidance
 } // namespace extractor

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -30,6 +30,7 @@ bool TurnLaneData::operator<(const TurnLaneData &other) const
     if (to > other.to)
         return false;
 
+    // the suppress-assignment flag is ignored, since it does not influence the order
     const constexpr TurnLaneType::Mask tag_by_modifier[] = {TurnLaneType::sharp_right,
                                                             TurnLaneType::right,
                                                             TurnLaneType::slight_right,
@@ -67,7 +68,7 @@ bool TurnLaneData::operator<(const TurnLaneData &other) const
 LaneDataVector laneDataFromDescription(TurnLaneDescription turn_lane_description)
 {
     typedef std::unordered_map<TurnLaneType::Mask, std::pair<LaneID, LaneID>> LaneMap;
-    //TODO need to handle cases that have none-in between two identical values
+    // TODO need to handle cases that have none-in between two identical values
     const auto num_lanes = boost::numeric_cast<LaneID>(turn_lane_description.size());
 
     const auto setLaneData = [&](
@@ -106,7 +107,7 @@ LaneDataVector laneDataFromDescription(TurnLaneDescription turn_lane_description
     // transform the map into the lane data vector
     LaneDataVector lane_data;
     for (const auto tag : lane_map)
-        lane_data.push_back({tag.first, tag.second.first, tag.second.second});
+        lane_data.push_back({tag.first, tag.second.first, tag.second.second, false});
 
     std::sort(lane_data.begin(), lane_data.end());
 
@@ -158,8 +159,8 @@ bool isSubsetOf(const LaneDataVector &subset_candidate, const LaneDataVector &su
     auto location = superset_candidate.begin();
     for (const auto entry : subset_candidate)
     {
-        location =
-            std::find_if(location, superset_candidate.end(), [entry](const TurnLaneData &lane_data) {
+        location = std::find_if(
+            location, superset_candidate.end(), [entry](const TurnLaneData &lane_data) {
                 return lane_data.tag == entry.tag;
             });
 

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -8,6 +8,7 @@
 #include "util/simple_logger.hpp"
 #include "util/typedefs.hpp"
 
+#include <cstddef>
 #include <cstdint>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -106,8 +107,6 @@ TurnLaneHandler::assignTurnLanes(const NodeID at, const EdgeID via_edge, Interse
                                          previous_lane_data,
                                          previous_description_id);
 
-    std::cout << "[turn lane] " << scenario_names[scenario] << std::endl;
-
     if (scenario != TurnLaneHandler::NONE)
         (*count_called)++;
 
@@ -132,9 +131,7 @@ TurnLaneHandler::assignTurnLanes(const NodeID at, const EdgeID via_edge, Interse
         return handleSliproadTurn(std::move(intersection),
                                   lane_description_id,
                                   std::move(lane_data),
-                                  previous_intersection,
-                                  previous_description_id,
-                                  previous_lane_data);
+                                  previous_intersection);
     case TurnLaneScenario::MERGE:
         return intersection;
     default:
@@ -295,7 +292,7 @@ TurnLaneHandler::deduceScenario(const NodeID at,
     // FIXME the lane to add depends on the side of driving/u-turn rules in the country
     if (!lane_data.empty() && canMatchTrivially(intersection, lane_data) &&
         is_missing_valid_u_turn && !hasTag(TurnLaneType::none, lane_data))
-        lane_data.push_back({TurnLaneType::uturn, lane_data.back().to, lane_data.back().to});
+        lane_data.push_back({TurnLaneType::uturn, lane_data.back().to, lane_data.back().to, false});
 
     bool is_simple = isSimpleIntersection(lane_data, intersection);
 
@@ -663,6 +660,8 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
         if (lane == straightmost_tag_index)
         {
             augmentEntry(turn_lane_data[straightmost_tag_index]);
+            // disable this turn for assignment if it is a -use lane only
+            turn_lane_data[straightmost_tag_index].suppress_assignment = true;
         }
 
         if (matched_at_first[lane])
@@ -674,7 +673,7 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
             std::count(matched_at_second.begin(), matched_at_second.end(), true)) ==
             getNumberOfTurns(next_intersection))
     {
-        TurnLaneData data = {TurnLaneType::straight, 255, 0};
+        TurnLaneData data = {TurnLaneType::straight, 255, 0, true};
         augmentEntry(data);
         first.push_back(data);
         std::sort(first.begin(), first.end());
@@ -701,15 +700,12 @@ Intersection TurnLaneHandler::simpleMatchTuplesToTurns(Intersection intersection
         std::move(intersection), lane_data, node_based_graph, lane_description_id, id_map);
 }
 
-Intersection
-TurnLaneHandler::handleSliproadTurn(Intersection intersection,
-                                    const LaneDescriptionID lane_description_id,
-                                    LaneDataVector lane_data,
-                                    const Intersection &previous_intersection,
-                                    const LaneDescriptionID &previous_lane_description_id,
-                                    const LaneDataVector &previous_lane_data)
+Intersection TurnLaneHandler::handleSliproadTurn(Intersection intersection,
+                                                 const LaneDescriptionID lane_description_id,
+                                                 LaneDataVector lane_data,
+                                                 const Intersection &previous_intersection)
 {
-    const auto sliproad_index =
+    const std::size_t sliproad_index =
         std::distance(previous_intersection.begin(),
                       std::find_if(previous_intersection.begin(),
                                    previous_intersection.end(),

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -1,3 +1,5 @@
+#include "util/debug.hpp"
+
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/turn_discovery.hpp"
 #include "extractor/guidance/turn_lane_augmentation.hpp"
@@ -30,13 +32,31 @@ std::size_t getNumberOfTurns(const Intersection &intersection)
 }
 } // namespace
 
+const constexpr char *TurnLaneHandler::scenario_names[TurnLaneScenario::NUM_SCENARIOS];
+
 TurnLaneHandler::TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
-                                 const std::vector<std::uint32_t> &turn_lane_offsets,
-                                 const std::vector<TurnLaneType::Mask> &turn_lane_masks,
-                                 const TurnAnalysis &turn_analysis)
+                                 std::vector<std::uint32_t> &turn_lane_offsets,
+                                 std::vector<TurnLaneType::Mask> &turn_lane_masks,
+                                 LaneDescriptionMap &lane_description_map,
+                                 const std::vector<QueryNode> &node_info_list,
+                                 const TurnAnalysis &turn_analysis,
+                                 LaneDataIdMap &id_map)
     : node_based_graph(node_based_graph), turn_lane_offsets(turn_lane_offsets),
-      turn_lane_masks(turn_lane_masks), turn_analysis(turn_analysis)
+      turn_lane_masks(turn_lane_masks), lane_description_map(lane_description_map),
+      node_info_list(node_info_list), turn_analysis(turn_analysis), id_map(id_map)
 {
+    count_handled = new unsigned;
+    count_called = new unsigned;
+    *count_handled = *count_called = 0;
+}
+
+TurnLaneHandler::~TurnLaneHandler()
+{
+    std::cout << "Handled: " << *count_handled << " of " << *count_called
+              << " lanes: " << (double)(*count_handled * 100) / (*count_called) << " %."
+              << std::endl;
+    delete count_called;
+    delete count_handled;
 }
 
 /*
@@ -57,54 +77,199 @@ TurnLaneHandler::TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_g
     assignment onto the turns.
     For example: (130, turn slight right), (180, ramp straight), (320, turn sharp left).
  */
-Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
-                                              const EdgeID via_edge,
-                                              Intersection intersection,
-                                              LaneDataIdMap &id_map) const
+Intersection
+TurnLaneHandler::assignTurnLanes(const NodeID at, const EdgeID via_edge, Intersection intersection)
 {
     // if only a uturn exists, there is nothing we can do
     if (intersection.size() == 1)
         return intersection;
 
-    const auto &data = node_based_graph.GetEdgeData(via_edge);
-    // Extract a lane description for the ID
+    // A list of output parameters to be filled in during deduceScenario.
+    // Data for the current intersection
+    LaneDescriptionID lane_description_id = INVALID_LANE_DESCRIPTIONID;
+    LaneDataVector lane_data;
+    // Data for the previous intersection
+    NodeID previous_node = SPECIAL_NODEID;
+    EdgeID previous_via_edge = SPECIAL_EDGEID;
+    Intersection previous_intersection;
+    LaneDataVector previous_lane_data;
+    LaneDescriptionID previous_description_id = INVALID_LANE_DESCRIPTIONID;
 
-    const auto turn_lane_description =
-        data.lane_description_id != INVALID_LANE_DESCRIPTIONID
-            ? TurnLaneDescription(
-                  turn_lane_masks.begin() + turn_lane_offsets[data.lane_description_id],
-                  turn_lane_masks.begin() + turn_lane_offsets[data.lane_description_id + 1])
-            : TurnLaneDescription();
+    const auto scenario = deduceScenario(at,
+                                         via_edge,
+                                         intersection,
+                                         lane_description_id,
+                                         lane_data,
+                                         previous_node,
+                                         previous_via_edge,
+                                         previous_intersection,
+                                         previous_lane_data,
+                                         previous_description_id);
 
-    BOOST_ASSERT(turn_lane_description.empty() ||
-                 turn_lane_description.size() == (turn_lane_offsets[data.lane_description_id + 1] -
-                                                  turn_lane_offsets[data.lane_description_id]));
+    std::cout << "[turn lane] " << scenario_names[scenario] << std::endl;
 
-    // going straight, due to traffic signals, we can have uncompressed geometry
-    if (intersection.size() == 2 &&
-        ((data.lane_description_id != INVALID_LANE_DESCRIPTIONID &&
-          data.lane_description_id ==
-              node_based_graph.GetEdgeData(intersection[1].turn.eid).lane_description_id) ||
-         angularDeviation(intersection[1].turn.angle, STRAIGHT_ANGLE) < FUZZY_ANGLE_DIFFERENCE))
+    if (scenario != TurnLaneHandler::NONE)
+        (*count_called)++;
+
+    switch (scenario)
+    {
+    // A turn based on current lane data
+    case TurnLaneScenario::SIMPLE:
+    case TurnLaneScenario::PARTITION_LOCAL:
+        lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
+        return simpleMatchTuplesToTurns(std::move(intersection), lane_data, lane_description_id);
+
+    // Cases operating on data carried over from a previous lane
+    case TurnLaneScenario::SIMPLE_PREVIOUS:
+    case TurnLaneScenario::PARTITION_PREVIOUS:
+        previous_lane_data =
+            handleNoneValueAtSimpleTurn(std::move(previous_lane_data), intersection);
+        return simpleMatchTuplesToTurns(
+            std::move(intersection), previous_lane_data, previous_description_id);
+
+    // Sliproads-turns that are to be handled as a single entity
+    case TurnLaneScenario::SLIPROAD:
+        return handleSliproadTurn(std::move(intersection),
+                                  lane_description_id,
+                                  std::move(lane_data),
+                                  previous_intersection,
+                                  previous_description_id,
+                                  previous_lane_data);
+    case TurnLaneScenario::MERGE:
         return intersection;
+    default:
+        // All different values that we cannot handle. For some me might want to print debug output
+        // later on, when the handling is actually improved to work in close to all cases.
+        // case TurnLaneScenario::UNKNOWN:
+        // case TurnLaneScenario::NONE:
+        // case TurnLaneScenario::INVALID:
+        {
+            /*
+            static int print_count = 0;
+            if (TurnLaneScenario::NONE != scenario && print_count++ < 10)
+            {
+                std::cout << "[Unhandled] " << (int)lane_description_id << " -- "
+                          << (int)previous_description_id << "\n"
+                          << std::endl;
+                util::guidance::printTurnAssignmentData(
+                    at, lane_data, intersection, node_info_list);
 
-    auto lane_data = laneDataFromDescription(turn_lane_description);
+                if (previous_node != SPECIAL_NODEID)
+                    util::guidance::printTurnAssignmentData(
+                        previous_node, previous_lane_data, previous_intersection, node_info_list);
+            }
+            */
+        }
+        return intersection;
+    }
+}
+
+// Find out which scenario we have to handle
+TurnLaneHandler::TurnLaneScenario
+TurnLaneHandler::deduceScenario(const NodeID at,
+                                const EdgeID via_edge,
+                                const Intersection &intersection,
+                                // Output Variables
+                                LaneDescriptionID &lane_description_id,
+                                LaneDataVector &lane_data,
+                                NodeID &previous_node,
+                                EdgeID &previous_via_edge,
+                                Intersection &previous_intersection,
+                                LaneDataVector &previous_lane_data,
+                                LaneDescriptionID &previous_description_id)
+{
+    // if only a uturn exists, there is nothing we can do
+    if (intersection.size() == 1)
+        return TurnLaneHandler::NONE;
+
+    extractLaneData(via_edge, lane_description_id, lane_data);
+
+    // traffic lights are not compressed during our preprocessing. Due to this *shortcoming*, we can
+    // get to the following situation:
+    //
+    //         d
+    // a - b - c
+    //         e
+    //
+    // with a traffic light at b and a-b as well as b-c offering the same turn lanes.
+    // In such a situation, we don't need to handle the lanes at a-b, since we will get the same
+    // information at b-c, where the actual turns are taking place.
+    const bool is_going_straight_and_turns_continue =
+        (intersection.size() == 2 &&
+         ((lane_description_id != INVALID_LANE_DESCRIPTIONID &&
+           lane_description_id ==
+               node_based_graph.GetEdgeData(intersection[1].turn.eid).lane_description_id) ||
+          angularDeviation(intersection[1].turn.angle, STRAIGHT_ANGLE) < FUZZY_ANGLE_DIFFERENCE));
+
+    if (is_going_straight_and_turns_continue)
+        return TurnLaneHandler::NONE;
 
     // if we see an invalid conversion, we stop immediately
-    if (!turn_lane_description.empty() && lane_data.empty())
-        return intersection;
+    if (lane_description_id != INVALID_LANE_DESCRIPTIONID && lane_data.empty())
+        return TurnLaneScenario::INVALID;
 
     // might be reasonable to handle multiple turns, if we know of a sequence of lanes
     // e.g. one direction per lane, if three lanes and right, through, left available
-    if (!turn_lane_description.empty() && lane_data.size() == 1 &&
+    if (lane_description_id != INVALID_LANE_DESCRIPTIONID && lane_data.size() == 1 &&
         lane_data[0].tag == TurnLaneType::none)
-        return intersection;
+        return TurnLaneScenario::NONE;
+
+    // Due to sliproads, we might need access to the previous intersection at this point already;
+    previous_node = SPECIAL_NODEID;
+    previous_via_edge = SPECIAL_EDGEID;
+    if (findPreviousIntersection(at,
+                                 via_edge,
+                                 intersection,
+                                 turn_analysis,
+                                 node_based_graph,
+                                 previous_node,
+                                 previous_via_edge,
+                                 previous_intersection))
+    {
+        extractLaneData(previous_via_edge, previous_description_id, previous_lane_data);
+        for (std::size_t road_index = 0; road_index < previous_intersection.size(); ++road_index)
+        {
+            const auto &road = previous_intersection[road_index];
+            // in case of a sliproad that is connected to road of simlar angle, we handle the
+            // turn as a combined turn
+            if (road.turn.instruction.type == TurnType::Sliproad)
+            {
+                if (via_edge == road.turn.eid)
+                    return TurnLaneScenario::SLIPROAD;
+
+                const auto &closest_road = [&]() {
+                    if (road_index + 1 == previous_intersection.size())
+                    {
+                        BOOST_ASSERT(road_index > 1);
+                        return previous_intersection[road_index - 1];
+                    }
+                    else if (road_index == 1)
+                    {
+                        BOOST_ASSERT(road_index + 1 < previous_intersection.size());
+                        return previous_intersection[road_index + 1];
+                    }
+                    else if (angularDeviation(road.turn.angle,
+                                              previous_intersection.at(road_index - 1).turn.angle) <
+                             angularDeviation(road.turn.angle,
+                                              previous_intersection.at(road_index + 1).turn.angle))
+                        return previous_intersection[road_index - 1];
+                    else
+                        return previous_intersection[road_index + 1];
+                }();
+
+                if (via_edge == closest_road.turn.eid)
+                    return TurnLaneScenario::SLIPROAD;
+            }
+        }
+    }
 
     const std::size_t possible_entries = getNumberOfTurns(intersection);
 
     // merge does not justify an instruction
     const bool has_merge_lane =
         hasTag(TurnLaneType::merge_to_left | TurnLaneType::merge_to_right, lane_data);
+    if (has_merge_lane)
+        return TurnLaneScenario::MERGE;
 
     // Dead end streets that don't have any left-tag. This can happen due to the fallbacks for
     // broken data/barriers.
@@ -114,12 +279,13 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
                                                 lane_data) &&
                                         lane_data.size() + 1 == possible_entries);
 
-    if (has_merge_lane || has_non_usable_u_turn)
-        return intersection;
+    if (has_non_usable_u_turn)
+        return TurnLaneScenario::INVALID;
 
     // check if a u-turn is allowed (for some reason) and is missing from the list of tags (u-turn
     // is often allowed from the `left` lane without an additional indication dedicated to u-turns).
     const bool is_missing_valid_u_turn =
+        !lane_data.empty() && canMatchTrivially(intersection, lane_data) &&
         lane_data.size() !=
             static_cast<std::size_t>((
                 !hasTag(TurnLaneType::uturn, lane_data) && intersection[0].entry_allowed ? 1 : 0)) +
@@ -132,18 +298,31 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
         lane_data.push_back({TurnLaneType::uturn, lane_data.back().to, lane_data.back().to});
 
     bool is_simple = isSimpleIntersection(lane_data, intersection);
-    // simple intersections can be assigned directly
+
     if (is_simple)
-    {
-        lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-        return simpleMatchTuplesToTurns(
-            std::move(intersection), lane_data, data.lane_description_id, id_map);
-    }
-    // if the intersection is not simple but we have lane data, we check for intersections with
-    // middle islands. We have two cases. The first one is providing lane data on the current
-    // segment and we only need to consider the part of the current segment. In this case we
-    // partition the data and only consider the first part.
-    else if (!lane_data.empty())
+        return TurnLaneScenario::SIMPLE;
+
+    // In case of intersections that don't offer all turns right away, we have to account for
+    // *delayed* turns. Consider the following example:
+    //
+    //         e
+    // a - b - c - f
+    //     d
+    //
+    // With lanes on a-b indicating: | left | through | right |.
+    // While right obviously refers to a-b-d, through and left refer to a-b-c-f and a-b-c-e
+    // respectively. While we are at a-b, we have to consider the right turn only.
+    // The turn a-b-c gets assigned the lanes of both *left* and *through*.
+    // At b-c, we get access to either a new set of lanes, or -- via the previous intersection
+    // -- to
+    // the second part of | left | through | right |. Lane anticipation can then deduce which
+    // lanes
+    // correspond to what and suppress unnecessary instructions.
+    //
+    // For our initial case, we consider only the turns that are available at the current
+    // location,
+    // which are given by partitioning the lane data and selecting the first part.
+    if (!lane_data.empty())
     {
         if (lane_data.size() >= possible_entries)
         {
@@ -155,115 +334,73 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
             // check if we were successfull in trimming
             if (lane_data.size() == possible_entries &&
                 isSimpleIntersection(lane_data, intersection))
-            {
-                lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-                return simpleMatchTuplesToTurns(
-                    std::move(intersection), lane_data, data.lane_description_id, id_map);
-            }
+                return TurnLaneScenario::PARTITION_LOCAL;
         }
-    }
-    // The second part does not provide lane data on the current segment, but on the segment prior
-    // to the turn. We try to partition the data and only consider the second part.
-    else if (turn_lane_description.empty())
-    {
-        // acquire the lane data of a previous segment and, if possible, use it for the current
-        // intersection.
-        return handleTurnAtPreviousIntersection(at, via_edge, std::move(intersection), id_map);
+        // If partitioning doesn't solve the problem, we don't know how to handle it right now
+        return TurnLaneScenario::UNKNOWN;
     }
 
-    return intersection;
+    if (lane_description_id != INVALID_LANE_DESCRIPTIONID)
+        return TurnLaneScenario::UNKNOWN;
+
+    // acquire the lane data of a previous segment and, if possible, use it for the current
+    // intersection.
+    if (previous_via_edge == SPECIAL_EDGEID)
+        return TurnLaneScenario::NONE;
+
+    if (previous_lane_data.empty())
+        return TurnLaneScenario::NONE;
+
+    const bool previous_has_merge_lane =
+        hasTag(TurnLaneType::merge_to_left | TurnLaneType::merge_to_right, previous_lane_data);
+    if (previous_has_merge_lane)
+        return TurnLaneScenario::MERGE;
+
+    const auto is_simple_previous =
+        isSimpleIntersection(previous_lane_data, intersection) && previous_intersection.size() == 2;
+    if (is_simple_previous)
+        return TurnLaneScenario::SIMPLE_PREVIOUS;
+
+    // This is the second part of the previously described partitioning scenario.
+    if (previous_lane_data.size() >= getNumberOfTurns(previous_intersection) &&
+        previous_intersection.size() != 2)
+    {
+        previous_lane_data = partitionLaneData(node_based_graph.GetTarget(previous_via_edge),
+                                               std::move(previous_lane_data),
+                                               previous_intersection)
+                                 .second;
+
+        std::sort(previous_lane_data.begin(), previous_lane_data.end());
+
+        // check if we were successfull in trimming
+        if ((previous_lane_data.size() == possible_entries) &&
+            isSimpleIntersection(previous_lane_data, intersection))
+            return TurnLaneScenario::PARTITION_PREVIOUS;
+    }
+
+    return TurnLaneScenario::UNKNOWN;
 }
 
-// At segregated intersections, turn lanes will often only be specified up until the first turn. To
-// actually take the turn, we need to look back to the edge we drove onto the intersection with.
-Intersection TurnLaneHandler::handleTurnAtPreviousIntersection(const NodeID at,
-                                                               const EdgeID via_edge,
-                                                               Intersection intersection,
-                                                               LaneDataIdMap &id_map) const
+void TurnLaneHandler::extractLaneData(const EdgeID via_edge,
+                                      LaneDescriptionID &lane_description_id,
+                                      LaneDataVector &lane_data) const
 {
-    NodeID previous_node = SPECIAL_NODEID;
-    Intersection previous_intersection;
-    EdgeID previous_id = SPECIAL_EDGEID;
-    LaneDataVector lane_data;
+    const auto &edge_data = node_based_graph.GetEdgeData(via_edge);
+    // TODO access correct data
+    lane_description_id = edge_data.lane_description_id;
+    const auto lane_description =
+        lane_description_id != INVALID_LANE_DESCRIPTIONID
+            ? TurnLaneDescription(turn_lane_masks.begin() + turn_lane_offsets[lane_description_id],
+                                  turn_lane_masks.begin() +
+                                      turn_lane_offsets[lane_description_id + 1])
+            : TurnLaneDescription();
 
-    // Get the previous lane string. We only accept strings that stem from a not-simple intersection
-    // and are not empty.
-    const auto previous_lane_description = [&]() -> TurnLaneDescription {
-        if (!findPreviousIntersection(at,
-                                      via_edge,
-                                      intersection,
-                                      turn_analysis,
-                                      node_based_graph,
-                                      previous_node,
-                                      previous_id,
-                                      previous_intersection))
-            return {};
+    if (!lane_description.empty())
+        lane_data = laneDataFromDescription(lane_description);
 
-        BOOST_ASSERT(previous_id != SPECIAL_EDGEID);
-
-        const auto &previous_edge_data = node_based_graph.GetEdgeData(previous_id);
-        // TODO access correct data
-        const auto previous_description =
-            previous_edge_data.lane_description_id != INVALID_LANE_DESCRIPTIONID
-                ? TurnLaneDescription(
-                      turn_lane_masks.begin() +
-                          turn_lane_offsets[previous_edge_data.lane_description_id],
-                      turn_lane_masks.begin() +
-                          turn_lane_offsets[previous_edge_data.lane_description_id + 1])
-                : TurnLaneDescription();
-        if (previous_description.empty())
-            return previous_description;
-
-        previous_intersection = turn_analysis.assignTurnTypes(
-            previous_node, previous_id, std::move(previous_intersection));
-
-        lane_data = laneDataFromDescription(previous_description);
-
-        if (isSimpleIntersection(lane_data, previous_intersection))
-            return {};
-        else
-            return previous_description;
-    }();
-
-    // no lane string, no problems
-    if (previous_lane_description.empty())
-        return intersection;
-
-    // stop on invalid lane data conversion
-    if (lane_data.empty())
-        return intersection;
-
-    const auto &previous_data = node_based_graph.GetEdgeData(previous_id);
-    const auto is_simple = isSimpleIntersection(lane_data, intersection);
-    if (is_simple)
-    {
-        lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-        return simpleMatchTuplesToTurns(
-            std::move(intersection), lane_data, previous_data.lane_description_id, id_map);
-    }
-    else
-    {
-        if (lane_data.size() >= getNumberOfTurns(previous_intersection) &&
-            previous_intersection.size() != 2)
-        {
-            lane_data = partitionLaneData(node_based_graph.GetTarget(previous_id),
-                                          std::move(lane_data),
-                                          previous_intersection)
-                            .second;
-
-            std::sort(lane_data.begin(), lane_data.end());
-
-            // check if we were successfull in trimming
-            if (lane_data.size() == getNumberOfTurns(intersection) &&
-                isSimpleIntersection(lane_data, intersection))
-            {
-                lane_data = handleNoneValueAtSimpleTurn(std::move(lane_data), intersection);
-                return simpleMatchTuplesToTurns(
-                    std::move(intersection), lane_data, previous_data.lane_description_id, id_map);
-            }
-        }
-    }
-    return intersection;
+    BOOST_ASSERT(lane_description.empty() ||
+                 lane_description.size() == (turn_lane_offsets[lane_description_id + 1] -
+                                             turn_lane_offsets[lane_description_id]));
 }
 
 /* A simple intersection does not depend on the next intersection coming up. This is important
@@ -414,8 +551,10 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
      * case left) turn lane as if it were to continue straight onto the intersection and
      * look back between (1) and (2) to make sure we find the correct lane for the left-turn.
      *
-     * Intersections like these have two parts. Turns that can be made at the first intersection and
-     * turns that have to be made at the second. The partitioning returns the lane data split into
+     * Intersections like these have two parts. Turns that can be made at the first intersection
+     * and
+     * turns that have to be made at the second. The partitioning returns the lane data split
+     * into
      * two parts, one for the first and one for the second intersection.
      */
 
@@ -433,7 +572,8 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
     std::vector<bool> matched_at_first(turn_lane_data.size(), false);
     std::vector<bool> matched_at_second(turn_lane_data.size(), false);
 
-    // find out about the next intersection. To check for valid matches, we also need the turn types
+    // find out about the next intersection. To check for valid matches, we also need the turn
+    // types
     auto next_intersection = turn_analysis.getIntersection(at, straightmost->turn.eid);
     next_intersection =
         turn_analysis.assignTurnTypes(at, straightmost->turn.eid, std::move(next_intersection));
@@ -447,7 +587,8 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
             continue;
 
         const auto best_match = findBestMatch(turn_lane_data[lane].tag, intersection);
-        if (isValidMatch(turn_lane_data[lane].tag, best_match->turn.instruction))
+        if (best_match->entry_allowed &&
+            isValidMatch(turn_lane_data[lane].tag, best_match->turn.instruction))
         {
             matched_at_first[lane] = true;
 
@@ -457,9 +598,20 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
 
         const auto best_match_at_next_intersection =
             findBestMatch(turn_lane_data[lane].tag, next_intersection);
-        if (isValidMatch(turn_lane_data[lane].tag,
+        if (best_match_at_next_intersection->entry_allowed &&
+            isValidMatch(turn_lane_data[lane].tag,
                          best_match_at_next_intersection->turn.instruction))
-            matched_at_second[lane] = true;
+        {
+            if (!matched_at_first[lane] || turn_lane_data[lane].tag == TurnLaneType::straight ||
+                getMatchingQuality(turn_lane_data[lane].tag, *best_match) >
+                    getMatchingQuality(turn_lane_data[lane].tag, *best_match_at_next_intersection))
+            {
+                if (turn_lane_data[lane].tag != TurnLaneType::straight)
+                    matched_at_first[lane] = false;
+
+                matched_at_second[lane] = true;
+            }
+        }
 
         // we need to match all items to either the current or the next intersection
         if (!(matched_at_first[lane] || matched_at_second[lane]))
@@ -504,7 +656,6 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
     LaneDataVector first, second;
     for (std::size_t lane = 0; lane < turn_lane_data.size(); ++lane)
     {
-
         if (matched_at_second[lane])
             second.push_back(turn_lane_data[lane]);
 
@@ -535,8 +686,7 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
 
 Intersection TurnLaneHandler::simpleMatchTuplesToTurns(Intersection intersection,
                                                        const LaneDataVector &lane_data,
-                                                       const LaneDescriptionID lane_description_id,
-                                                       LaneDataIdMap &id_map) const
+                                                       const LaneDescriptionID lane_description_id)
 {
     if (lane_data.empty() || !canMatchTrivially(intersection, lane_data))
         return intersection;
@@ -545,8 +695,125 @@ Intersection TurnLaneHandler::simpleMatchTuplesToTurns(Intersection intersection
         !hasTag(TurnLaneType::none | TurnLaneType::merge_to_left | TurnLaneType::merge_to_right,
                 lane_data));
 
+    (*count_handled)++;
+
     return triviallyMatchLanesToTurns(
         std::move(intersection), lane_data, node_based_graph, lane_description_id, id_map);
+}
+
+Intersection
+TurnLaneHandler::handleSliproadTurn(Intersection intersection,
+                                    const LaneDescriptionID lane_description_id,
+                                    LaneDataVector lane_data,
+                                    const Intersection &previous_intersection,
+                                    const LaneDescriptionID &previous_lane_description_id,
+                                    const LaneDataVector &previous_lane_data)
+{
+    const auto sliproad_index =
+        std::distance(previous_intersection.begin(),
+                      std::find_if(previous_intersection.begin(),
+                                   previous_intersection.end(),
+                                   [](const ConnectedRoad &road) {
+                                       return road.turn.instruction.type == TurnType::Sliproad;
+                                   }));
+
+    BOOST_ASSERT(sliproad_index <= previous_intersection.size());
+    const auto &sliproad = previous_intersection[sliproad_index];
+
+    // code duplicatino with deduceScenario: TODO refactor
+    const auto &main_road = [&]() {
+        if (sliproad_index + 1 == previous_intersection.size())
+        {
+            BOOST_ASSERT(sliproad_index > 1);
+            return previous_intersection[sliproad_index - 1];
+        }
+        else if (sliproad_index == 1)
+        {
+            BOOST_ASSERT(sliproad_index + 1 < previous_intersection.size());
+            return previous_intersection[sliproad_index + 1];
+        }
+        else if (angularDeviation(sliproad.turn.angle,
+                                  previous_intersection.at(sliproad_index - 1).turn.angle) <
+                 angularDeviation(sliproad.turn.angle,
+                                  previous_intersection.at(sliproad_index + 1).turn.angle))
+            return previous_intersection[sliproad_index - 1];
+        else
+            return previous_intersection[sliproad_index + 1];
+    }();
+    const auto main_description_id =
+        node_based_graph.GetEdgeData(main_road.turn.eid).lane_description_id;
+    const auto sliproad_description_id =
+        node_based_graph.GetEdgeData(sliproad.turn.eid).lane_description_id;
+
+    if (main_description_id == INVALID_LANE_DESCRIPTIONID ||
+        sliproad_description_id == INVALID_LANE_DESCRIPTIONID)
+        return intersection;
+
+    TurnLaneDescription combined_description;
+    // is the sliproad going off to the right?
+    if (main_road.turn.angle > sliproad.turn.angle)
+    {
+        combined_description.insert(
+            combined_description.end(),
+            turn_lane_masks.begin() + turn_lane_offsets[main_description_id],
+            turn_lane_masks.begin() + turn_lane_offsets[main_description_id + 1]);
+
+        combined_description.insert(
+            combined_description.end(),
+            turn_lane_masks.begin() + turn_lane_offsets[sliproad_description_id],
+            turn_lane_masks.begin() + turn_lane_offsets[sliproad_description_id + 1]);
+
+        // if we handle the main road, we have to adjust the lane-data
+        if (main_description_id == lane_description_id)
+        {
+            const auto offset = turn_lane_offsets[sliproad_description_id + 1] -
+                                turn_lane_offsets[sliproad_description_id];
+            for (auto &item : lane_data)
+            {
+                item.from += offset;
+                item.to += offset;
+            }
+        }
+    }
+    // or to the left?
+    else
+    {
+        combined_description.insert(
+            combined_description.end(),
+            turn_lane_masks.begin() + turn_lane_offsets[sliproad_description_id],
+            turn_lane_masks.begin() + turn_lane_offsets[sliproad_description_id + 1]);
+        combined_description.insert(
+            combined_description.end(),
+            turn_lane_masks.begin() + turn_lane_offsets[main_description_id],
+            turn_lane_masks.begin() + turn_lane_offsets[main_description_id + 1]);
+
+        // if we are handling the sliproad, we have to adjust its lane data
+        if (sliproad_description_id == lane_description_id)
+        {
+            const auto offset =
+                turn_lane_offsets[main_description_id + 1] - turn_lane_offsets[main_description_id];
+            for (auto &item : lane_data)
+            {
+                item.from += offset;
+                item.to += offset;
+            }
+        }
+    }
+
+    const auto combined_id = [&]() {
+        auto itr = lane_description_map.find(combined_description);
+        if (lane_description_map.find(combined_description) == lane_description_map.end())
+        {
+            const auto new_id = boost::numeric_cast<LaneDescriptionID>(lane_description_map.size());
+            lane_description_map[combined_description] = new_id;
+            return new_id;
+        }
+        else
+        {
+            return itr->second;
+        }
+    }();
+    return simpleMatchTuplesToTurns(std::move(intersection), lane_data, combined_id);
 }
 
 } // namespace lanes

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/toolkit.hpp"
 #include "extractor/guidance/turn_lane_matcher.hpp"
+#include "extractor/guidance/toolkit.hpp"
 #include "util/guidance/toolkit.hpp"
 
 #include <boost/assert.hpp>
@@ -102,11 +102,11 @@ bool isValidMatch(const TurnLaneType::Mask tag, const TurnInstruction instructio
     return false;
 }
 
-double getMatchingQuality( const TurnLaneType::Mask tag, const ConnectedRoad &road)
+double getMatchingQuality(const TurnLaneType::Mask tag, const ConnectedRoad &road)
 {
     const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
     const auto idealized_angle = idealized_turn_angles[getMatchingModifier(tag)];
-    return angularDeviation(idealized_angle,road.turn.angle);
+    return angularDeviation(idealized_angle, road.turn.angle);
 }
 
 // Every tag is somewhat idealized in form of the expected angle. A through lane should go straight
@@ -116,21 +116,21 @@ double getMatchingQuality( const TurnLaneType::Mask tag, const ConnectedRoad &ro
 typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask tag,
                                                     const Intersection &intersection)
 {
-    return std::min_element(
-        intersection.begin(),
-        intersection.end(),
-        [tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
-            // prefer valid matches
-            if (isValidMatch(tag, lhs.turn.instruction) != isValidMatch(tag, rhs.turn.instruction))
-                return isValidMatch(tag, lhs.turn.instruction);
+    return std::min_element(intersection.begin(),
+                            intersection.end(),
+                            [tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
+                                // prefer valid matches
+                                if (isValidMatch(tag, lhs.turn.instruction) !=
+                                    isValidMatch(tag, rhs.turn.instruction))
+                                    return isValidMatch(tag, lhs.turn.instruction);
 
-            // if the entry allowed flags don't match, we select the one with
-            // entry allowed set to true
-            if (lhs.entry_allowed != rhs.entry_allowed)
-                return lhs.entry_allowed;
+                                // if the entry allowed flags don't match, we select the one with
+                                // entry allowed set to true
+                                if (lhs.entry_allowed != rhs.entry_allowed)
+                                    return lhs.entry_allowed;
 
-            return getMatchingQuality(tag,lhs) < getMatchingQuality(tag,rhs);
-        });
+                                return getMatchingQuality(tag, lhs) < getMatchingQuality(tag, rhs);
+                            });
 }
 
 // Reverse is a special case, because it requires access to the leftmost tag. It has its own
@@ -138,8 +138,8 @@ typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask tag
 // by default in OSRM. Therefor we cannot check whether a turn is allowed, since it could be
 // possible that it is forbidden. In addition, the best u-turn angle does not necessarily represent
 // the u-turn, since it could be a sharp-left turn instead on a road with a middle island.
-typename Intersection::const_iterator
-findBestMatchForReverse(const TurnLaneType::Mask neighbor_tag, const Intersection &intersection)
+typename Intersection::const_iterator findBestMatchForReverse(const TurnLaneType::Mask neighbor_tag,
+                                                              const Intersection &intersection)
 {
     const auto neighbor_itr = findBestMatch(neighbor_tag, intersection);
     if (neighbor_itr + 1 == intersection.cend())
@@ -159,7 +159,7 @@ findBestMatchForReverse(const TurnLaneType::Mask neighbor_tag, const Intersectio
             if (lhs.entry_allowed != rhs.entry_allowed)
                 return lhs.entry_allowed;
 
-            return getMatchingQuality(tag,lhs) < getMatchingQuality(tag,rhs);
+            return getMatchingQuality(tag, lhs) < getMatchingQuality(tag, rhs);
         });
 }
 

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -17,7 +17,7 @@ namespace lanes
 {
 
 // Translate Turn Tags into a Matching Direction Modifier
-DirectionModifier::Enum getMatchingModifier(const TurnLaneType::Mask &tag)
+DirectionModifier::Enum getMatchingModifier(const TurnLaneType::Mask tag)
 {
     const constexpr TurnLaneType::Mask tag_by_modifier[] = {TurnLaneType::uturn,
                                                             TurnLaneType::sharp_right,
@@ -51,7 +51,7 @@ DirectionModifier::Enum getMatchingModifier(const TurnLaneType::Mask &tag)
 }
 
 // check whether a match of a given tag and a turn instruction can be seen as valid
-bool isValidMatch(const TurnLaneType::Mask &tag, const TurnInstruction instruction)
+bool isValidMatch(const TurnLaneType::Mask tag, const TurnInstruction instruction)
 {
     using util::guidance::hasLeftModifier;
     using util::guidance::hasRightModifier;
@@ -102,29 +102,34 @@ bool isValidMatch(const TurnLaneType::Mask &tag, const TurnInstruction instructi
     return false;
 }
 
+double getMatchingQuality( const TurnLaneType::Mask tag, const ConnectedRoad &road)
+{
+    const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
+    const auto idealized_angle = idealized_turn_angles[getMatchingModifier(tag)];
+    return angularDeviation(idealized_angle,road.turn.angle);
+}
+
 // Every tag is somewhat idealized in form of the expected angle. A through lane should go straight
 // (or follow a 180 degree turn angle between in/out segments.) The following function tries to find
 // the best possible match for every tag in a given intersection, considering a few corner cases
 // introduced to OSRM handling u-turns
-typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask &tag,
+typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask tag,
                                                     const Intersection &intersection)
 {
-    const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
-    const auto idealized_angle = idealized_turn_angles[getMatchingModifier(tag)];
     return std::min_element(
         intersection.begin(),
         intersection.end(),
-        [idealized_angle, &tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
+        [tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
             // prefer valid matches
             if (isValidMatch(tag, lhs.turn.instruction) != isValidMatch(tag, rhs.turn.instruction))
                 return isValidMatch(tag, lhs.turn.instruction);
+
             // if the entry allowed flags don't match, we select the one with
             // entry allowed set to true
             if (lhs.entry_allowed != rhs.entry_allowed)
                 return lhs.entry_allowed;
 
-            return angularDeviation(idealized_angle, lhs.turn.angle) <
-                   angularDeviation(idealized_angle, rhs.turn.angle);
+            return getMatchingQuality(tag,lhs) < getMatchingQuality(tag,rhs);
         });
 }
 
@@ -140,23 +145,21 @@ findBestMatchForReverse(const TurnLaneType::Mask &neighbor_tag, const Intersecti
     if (neighbor_itr + 1 == intersection.cend())
         return intersection.begin();
 
-    const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
     const TurnLaneType::Mask tag = TurnLaneType::uturn;
-    const auto idealized_angle = idealized_turn_angles[getMatchingModifier(tag)];
     return std::min_element(
         intersection.begin() + std::distance(intersection.begin(), neighbor_itr),
         intersection.end(),
-        [idealized_angle, &tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
+        [tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
             // prefer valid matches
             if (isValidMatch(tag, lhs.turn.instruction) != isValidMatch(tag, rhs.turn.instruction))
                 return isValidMatch(tag, lhs.turn.instruction);
+
             // if the entry allowed flags don't match, we select the one with
             // entry allowed set to true
             if (lhs.entry_allowed != rhs.entry_allowed)
                 return lhs.entry_allowed;
 
-            return angularDeviation(idealized_angle, lhs.turn.angle) <
-                   angularDeviation(idealized_angle, rhs.turn.angle);
+            return getMatchingQuality(tag,lhs) < getMatchingQuality(tag,rhs);
         });
 }
 

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -139,7 +139,7 @@ typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask tag
 // possible that it is forbidden. In addition, the best u-turn angle does not necessarily represent
 // the u-turn, since it could be a sharp-left turn instead on a road with a middle island.
 typename Intersection::const_iterator
-findBestMatchForReverse(const TurnLaneType::Mask &neighbor_tag, const Intersection &intersection)
+findBestMatchForReverse(const TurnLaneType::Mask neighbor_tag, const Intersection &intersection)
 {
     const auto neighbor_itr = findBestMatch(neighbor_tag, intersection);
     if (neighbor_itr + 1 == intersection.cend())

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -256,7 +256,8 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
             BOOST_ASSERT(findBestMatch(lane_data[lane].tag, intersection) ==
                          intersection.begin() + road_index);
 
-            if (TurnType::Suppressed == intersection[road_index].turn.instruction.type)
+            if (TurnType::Suppressed == intersection[road_index].turn.instruction.type &&
+                !lane_data[lane].suppress_assignment)
                 intersection[road_index].turn.instruction.type = TurnType::UseLane;
 
             matchRoad(intersection[road_index], lane_data[lane]);

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -105,6 +105,9 @@ bool isValidMatch(const TurnLaneType::Mask tag, const TurnInstruction instructio
 double getMatchingQuality(const TurnLaneType::Mask tag, const ConnectedRoad &road)
 {
     const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
+    const auto modifier = getMatchingModifier(tag);
+    BOOST_ASSERT(static_cast<std::size_t>(modifier) <
+                 sizeof(idealized_turn_angles) / sizeof(*idealized_turn_angles));
     const auto idealized_angle = idealized_turn_angles[getMatchingModifier(tag)];
     return angularDeviation(idealized_angle, road.turn.angle);
 }


### PR DESCRIPTION
# TODO
- [x] fix: collapse-detail cases are omitting the wrong turn type (turn over continue) for some reason
- [x] fix: anticipate lanes (https://travis-ci.org/Project-OSRM/osrm-backend/jobs/154098554#L3978) #2626 regression

- [x] review
  subrequests by daniel-j-h have been merged into this PR have have been reviewed by me. An additional review could focus on
  - [x] https://github.com/Project-OSRM/osrm-backend/pull/2614/commits/d6aa56b9146f3d7f33e38ad2d5cfc25f8dc12c0d
  - [x] https://github.com/Project-OSRM/osrm-backend/pull/2614/commits/17e7642ad9efcb1f0d0cc735b4531e483c1c3de8
  - [x] https://github.com/Project-OSRM/osrm-backend/pull/2614/commits/268201a38b2ba30be0844bb623ca10ed3bf16a36

 - [x] final adjustments

Working on https://github.com/Project-OSRM/osrm-backend/issues/2553.

Initial goal: Slipway Turns.

A slipway is a small dedicated turn lane.

<img width="654" alt="screen shot 2016-06-29 at 15 06 18" src="https://cloud.githubusercontent.com/assets/12932279/16518240/07bbff52-3f82-11e6-9d88-6b6500150c08.png">

Even though the modelling here does not follow the slipway-paradigm, such roads can already be modelled using a separate turn way.

Usually it is larger roads, though:
<img width="635" alt="screen shot 2016-07-01 at 11 52 23" src="https://cloud.githubusercontent.com/assets/12932279/16518292/575859f2-3f82-11e6-9f85-39b541d9f0ed.png">

In such cases, the experience of the driver deviates from the model of the road. The first step here aims at creating a lane-description that includes this slipway in the reported available lanes.

In the first example, we would currently see
`left` and `straight` on the one turn, `right` on the second turn.
The aim of this PR is to expose all three lanes in the turn-lanes.