### PR TITLE
[ready] Improve/sliproads

### DIFF
--- a/features/guidance/dedicated-turn-roads.feature
+++ b/features/guidance/dedicated-turn-roads.feature
@@ -167,3 +167,34 @@ Feature: Slipways and Dedicated Turn Lanes
         When I route I should get
             | waypoints | route                                                     | turns                    |
             | a,o       | Schwarzwaldstrasse (L561),Ettlinger Allee,Ettlinger Allee | depart,turn right,arrive |
+
+    Scenario: Traffic Lights everywhere
+        #http://map.project-osrm.org/?z=18&center=48.995336%2C8.383813&loc=48.995467%2C8.384548&loc=48.995115%2C8.382761&hl=en&alt=0
+        Given the node map
+            | a |   |   | k | l |   |   | j |   |
+            |   |   |   |   |   | d | b | c | i |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   | e | g |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   | h |   |
+            |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   | f |   |
+
+        And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+            | e    | traffic_signals |
+            | g    | traffic_signals |
+
+        And the ways
+            | nodes  | highway        | name          | oneway |
+            | aklbci | secondary      | Ebertstrasse  | yes    |
+            | kdeh   | secondary_link |               | yes    |
+            | jcghf  | primary        | Brauerstrasse | yes    |
+
+        When I route I should get
+            | waypoints | route                                    | turns                    |
+            | a,i       | Ebertstrasse,Ebertstrasse                | depart,arrive            |
+            | a,l       | Ebertstrasse,Ebertstrasse                | depart,arrive            |
+            | a,f       | Ebertstrasse,Brauerstrasse,Brauerstrasse | depart,turn right,arrive |

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -29,7 +29,8 @@ class IntersectionHandler
                         const std::vector<QueryNode> &node_info_list,
                         const util::NameTable &name_table,
                         const SuffixTable &street_name_suffix_table);
-    virtual ~IntersectionHandler();
+
+    virtual ~IntersectionHandler() = default;
 
     // check whether the handler can actually handle the intersection
     virtual bool
@@ -50,6 +51,9 @@ class IntersectionHandler
 
     // Decide on a basic turn types
     TurnType::Enum findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;
+
+    // Find the most obvious turn to follow
+    std::size_t findObviousTurn(const EdgeID via_edge, const Intersection &intersection) const;
 
     // Get the Instruction for an obvious turn
     TurnInstruction getInstructionForObvious(const std::size_t number_of_candidates,

--- a/include/extractor/guidance/intersection_scenario_three_way.hpp
+++ b/include/extractor/guidance/intersection_scenario_three_way.hpp
@@ -10,11 +10,6 @@ namespace extractor
 namespace guidance
 {
 
-// possible fork
-bool isFork(const ConnectedRoad &uturn,
-            const ConnectedRoad &possible_right_fork,
-            const ConnectedRoad &possible_left_fork);
-
 // Ending in a T-Intersection
 bool isEndOfRoad(const ConnectedRoad &uturn,
                  const ConnectedRoad &possible_right_turn,

--- a/include/extractor/guidance/roundabout_handler.hpp
+++ b/include/extractor/guidance/roundabout_handler.hpp
@@ -44,7 +44,7 @@ class RoundaboutHandler : public IntersectionHandler
                       const util::NameTable &name_table,
                       const SuffixTable &street_name_suffix_table);
 
-    ~RoundaboutHandler() override final;
+    ~RoundaboutHandler() override final = default;
 
     // check whether the handler can actually handle the intersection
     bool canProcess(const NodeID from_nid,

--- a/include/extractor/guidance/sliproad_handler.hpp
+++ b/include/extractor/guidance/sliproad_handler.hpp
@@ -1,13 +1,16 @@
-#ifndef OSRM_EXTRACTOR_GUIDANCE_MOTORWAY_HANDLER_HPP_
-#define OSRM_EXTRACTOR_GUIDANCE_MOTORWAY_HANDLER_HPP_
+#ifndef OSRM_EXTRACTOR_GUIDANCE_SLIPROAD_HANDLER_HPP_
+#define OSRM_EXTRACTOR_GUIDANCE_SLIPROAD_HANDLER_HPP_
 
 #include "extractor/guidance/intersection.hpp"
 #include "extractor/guidance/intersection_handler.hpp"
+#include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/query_node.hpp"
 
 #include "util/name_table.hpp"
 #include "util/node_based_graph.hpp"
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 namespace osrm
@@ -19,37 +22,32 @@ namespace guidance
 
 // Intersection handlers deal with all issues related to intersections.
 // They assign appropriate turn operations to the TurnOperations.
-class MotorwayHandler : public IntersectionHandler
+class SliproadHandler : public IntersectionHandler
 {
   public:
-    MotorwayHandler(const util::NodeBasedDynamicGraph &node_based_graph,
+    SliproadHandler(const IntersectionGenerator &intersection_generator,
+                    const util::NodeBasedDynamicGraph &node_based_graph,
                     const std::vector<QueryNode> &node_info_list,
                     const util::NameTable &name_table,
                     const SuffixTable &street_name_suffix_table);
 
-    ~MotorwayHandler() override final = default;
+    ~SliproadHandler() override final = default;
 
     // check whether the handler can actually handle the intersection
-    bool canProcess(const NodeID nid,
-                    const EdgeID via_eid,
-                    const Intersection &intersection) const override final;
+    bool canProcess(const NodeID /*nid*/,
+                    const EdgeID /*via_eid*/,
+                    const Intersection & /*intersection*/) const override final;
 
     // process the intersection
     Intersection operator()(const NodeID nid,
                             const EdgeID via_eid,
                             Intersection intersection) const override final;
-
   private:
-    Intersection handleSliproads(const NodeID intersection_node_id,
-                                 Intersection intersection) const;
-    Intersection fromMotorway(const EdgeID via_edge, Intersection intersection) const;
-    Intersection fromRamp(const EdgeID via_edge, Intersection intersection) const;
-
-    Intersection fallback(Intersection intersection) const;
+    const IntersectionGenerator &intersection_generator;
 };
 
 } // namespace guidance
 } // namespace extractor
 } // namespace osrm
 
-#endif /*OSRM_EXTRACTOR_GUIDANCE_MOTORWAY_HANDLER_HPP_*/
+#endif /*OSRM_EXTRACTOR_GUIDANCE_SLIPROAD_HANDLER_HPP_*/

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -428,7 +428,7 @@ inline int getPriority(const FunctionalRoadClass road_class)
     // They are used in Fork-Discovery. Possibly should be moved to profiles post v5?
     // A fork can happen between road types that are at most 1 priority apart from each other
     const constexpr int road_priority[] = {
-        10, 0, 10, 2, 10, 4, 10, 6, 10, 8, 10, 11, 10, 12, 10, 14};
+        14, 0, 14, 2, 14, 4, 14, 6, 14, 8, 10, 11, 10, 12, 10, 14};
     return road_priority[static_cast<int>(road_class)];
 }
 

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -6,6 +6,7 @@
 #include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/guidance/motorway_handler.hpp"
 #include "extractor/guidance/roundabout_handler.hpp"
+#include "extractor/guidance/sliproad_handler.hpp"
 #include "extractor/guidance/toolkit.hpp"
 #include "extractor/guidance/turn_classification.hpp"
 #include "extractor/guidance/turn_handler.hpp"
@@ -59,13 +60,11 @@ class TurnAnalysis
     const RoundaboutHandler roundabout_handler;
     const MotorwayHandler motorway_handler;
     const TurnHandler turn_handler;
+    const SliproadHandler sliproad_handler;
 
     // Utility function, setting basic turn types. Prepares for normal turn handling.
     Intersection
     setTurnTypes(const NodeID from, const EdgeID via_edge, Intersection intersection) const;
-
-    Intersection handleSliproads(const NodeID intersection_node_id,
-                                 Intersection intersection) const;
 }; // class TurnAnalysis
 
 } // namespace guidance

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -28,7 +28,8 @@ class TurnHandler : public IntersectionHandler
                 const std::vector<QueryNode> &node_info_list,
                 const util::NameTable &name_table,
                 const SuffixTable &street_name_suffix_table);
-    ~TurnHandler() override final;
+
+    ~TurnHandler() override final = default;
 
     // check whether the handler can actually handle the intersection
     bool canProcess(const NodeID nid,
@@ -41,6 +42,9 @@ class TurnHandler : public IntersectionHandler
                             Intersection intersection) const override final;
 
   private:
+    bool isObviousOfTwo(const EdgeID via_edge,
+                        const ConnectedRoad &road,
+                        const ConnectedRoad &other) const;
     // Dead end.
     Intersection handleOneWayTurn(Intersection intersection) const;
 
@@ -57,8 +61,7 @@ class TurnHandler : public IntersectionHandler
     handleDistinctConflict(const EdgeID via_edge, ConnectedRoad &left, ConnectedRoad &right) const;
 
     // Classification
-    std::size_t findObviousTurn(const EdgeID via_edge, const Intersection &intersection) const;
-    std::pair<std::size_t, std::size_t> findFork(const Intersection &intersection) const;
+    std::pair<std::size_t, std::size_t> findFork(const EdgeID via_edge, const Intersection &intersection) const;
 
     Intersection assignLeftTurns(const EdgeID via_edge,
                                  Intersection intersection,

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -720,34 +720,45 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
         // TurnType::Sliproad != TurnType::NoTurn
         if (one_back_step.maneuver.instruction.type == TurnType::Sliproad)
         {
-            // Handle possible u-turns between highways that look like slip-roads
-            if (steps[getPreviousIndex(one_back_index)].name_id == steps[step_index].name_id &&
-                steps[step_index].name_id != EMPTY_NAMEID)
+            if (current_step.maneuver.instruction.type == TurnType::Suppressed &&
+                compatible(one_back_step, current_step))
             {
-                steps[one_back_index].maneuver.instruction.type = TurnType::Continue;
+                // Traffic light on the sliproad
+                steps[one_back_index] =
+                    elongate(std::move(steps[one_back_index]), steps[step_index]);
+                invalidateStep(steps[step_index]);
             }
             else
             {
-                steps[one_back_index].maneuver.instruction.type = TurnType::Turn;
-            }
-            if (compatible(one_back_step, current_step))
-            {
-                steps[one_back_index] =
-                    elongate(std::move(steps[one_back_index]), steps[step_index]);
-                steps[one_back_index].name_id = steps[step_index].name_id;
-                steps[one_back_index].name = steps[step_index].name;
+                // Handle possible u-turns between highways that look like slip-roads
+                if (steps[getPreviousIndex(one_back_index)].name_id == steps[step_index].name_id &&
+                    steps[step_index].name_id != EMPTY_NAMEID)
+                {
+                    steps[one_back_index].maneuver.instruction.type = TurnType::Continue;
+                }
+                else
+                {
+                    steps[one_back_index].maneuver.instruction.type = TurnType::Turn;
+                }
+                if (compatible(one_back_step, current_step))
+                {
+                    steps[one_back_index] =
+                        elongate(std::move(steps[one_back_index]), steps[step_index]);
+                    steps[one_back_index].name_id = steps[step_index].name_id;
+                    steps[one_back_index].name = steps[step_index].name;
 
-                const auto exit_intersection = steps[step_index].intersections.front();
-                const auto exit_bearing = exit_intersection.bearings[exit_intersection.out];
+                    const auto exit_intersection = steps[step_index].intersections.front();
+                    const auto exit_bearing = exit_intersection.bearings[exit_intersection.out];
 
-                const auto entry_intersection = steps[one_back_index].intersections.front();
-                const auto entry_bearing = entry_intersection.bearings[entry_intersection.in];
+                    const auto entry_intersection = steps[one_back_index].intersections.front();
+                    const auto entry_bearing = entry_intersection.bearings[entry_intersection.in];
 
-                const double angle =
-                    turn_angle(util::bearing::reverseBearing(entry_bearing), exit_bearing);
-                steps[one_back_index].maneuver.instruction.direction_modifier =
-                    ::osrm::util::guidance::getTurnDirection(angle);
-                invalidateStep(steps[step_index]);
+                    const double angle =
+                        turn_angle(util::bearing::reverseBearing(entry_bearing), exit_bearing);
+                    steps[one_back_index].maneuver.instruction.direction_modifier =
+                        ::osrm::util::guidance::getTurnDirection(angle);
+                    invalidateStep(steps[step_index]);
+                }
             }
         }
         // Due to empty segments, we can get name-changes from A->A

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/constants.hpp"
+#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include "util/guidance/toolkit.hpp"
@@ -33,8 +33,6 @@ IntersectionHandler::IntersectionHandler(const util::NodeBasedDynamicGraph &node
       street_name_suffix_table(street_name_suffix_table)
 {
 }
-
-IntersectionHandler::~IntersectionHandler() = default;
 
 std::size_t IntersectionHandler::countValid(const Intersection &intersection) const
 {
@@ -320,6 +318,115 @@ bool IntersectionHandler::isThroughStreet(const std::size_t index,
             return true;
     }
     return false;
+}
+
+std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
+                                                 const Intersection &intersection) const
+{
+    // no obvious road
+    if (intersection.size() == 1)
+        return 0;
+
+    // a single non u-turn is obvious
+    if (intersection.size() == 2)
+        return 1;
+
+    // at least three roads
+    std::size_t best = 0;
+    double best_deviation = 180;
+
+    std::size_t best_continue = 0;
+    double best_continue_deviation = 180;
+
+    const EdgeData &in_data = node_based_graph.GetEdgeData(via_edge);
+    for (std::size_t i = 1; i < intersection.size(); ++i)
+    {
+        const double deviation = angularDeviation(intersection[i].turn.angle, STRAIGHT_ANGLE);
+        if (intersection[i].entry_allowed && deviation < best_deviation)
+        {
+            best_deviation = deviation;
+            best = i;
+        }
+
+        const auto out_data = node_based_graph.GetEdgeData(intersection[i].turn.eid);
+        auto continue_class = node_based_graph.GetEdgeData(intersection[best_continue].turn.eid)
+                                  .road_classification.road_class;
+        if (intersection[i].entry_allowed && out_data.name_id == in_data.name_id &&
+            (best_continue == 0 || continue_class > out_data.road_classification.road_class ||
+             (deviation < best_continue_deviation &&
+              out_data.road_classification.road_class == continue_class)))
+        {
+            best_continue_deviation = deviation;
+            best_continue = i;
+        }
+    }
+
+    if (best == 0)
+        return 0;
+
+    if (best_deviation >= 2 * NARROW_TURN_ANGLE)
+        return 0;
+    // has no obvious continued road
+    if (best_continue == 0 || best_continue_deviation >= 2 * NARROW_TURN_ANGLE ||
+        (node_based_graph.GetEdgeData(intersection[best_continue].turn.eid)
+                 .road_classification.road_class ==
+             node_based_graph.GetEdgeData(intersection[best].turn.eid)
+                 .road_classification.road_class &&
+         std::abs(best_continue_deviation) > 1 && best_deviation / best_continue_deviation < 0.75))
+    {
+        // Find left/right deviation
+        const double left_deviation = angularDeviation(
+            intersection[(best + 1) % intersection.size()].turn.angle, STRAIGHT_ANGLE);
+        const double right_deviation =
+            angularDeviation(intersection[best - 1].turn.angle, STRAIGHT_ANGLE);
+
+        if (best_deviation < MAXIMAL_ALLOWED_NO_TURN_DEVIATION &&
+            std::min(left_deviation, right_deviation) > FUZZY_ANGLE_DIFFERENCE)
+            return best;
+
+        // other narrow turns?
+        if (angularDeviation(intersection[best - 1].turn.angle, STRAIGHT_ANGLE) <=
+            FUZZY_ANGLE_DIFFERENCE)
+            return 0;
+        if (angularDeviation(intersection[(best + 1) % intersection.size()].turn.angle,
+                             STRAIGHT_ANGLE) <= FUZZY_ANGLE_DIFFERENCE)
+            return 0;
+
+        // Well distinct turn that is nearly straight
+        if ((left_deviation / best_deviation >= DISTINCTION_RATIO ||
+             (left_deviation > best_deviation &&
+              !intersection[(best + 1) % intersection.size()].entry_allowed)) &&
+            (right_deviation / best_deviation >= DISTINCTION_RATIO ||
+             (right_deviation > best_deviation && !intersection[best - 1].entry_allowed)))
+        {
+            return best;
+        }
+    }
+    else
+    {
+        const double deviation =
+            angularDeviation(intersection[best_continue].turn.angle, STRAIGHT_ANGLE);
+        const auto &continue_data =
+            node_based_graph.GetEdgeData(intersection[best_continue].turn.eid);
+        if (std::abs(deviation) < 1)
+            return best_continue;
+
+        // check if any other similar best continues exist
+        for (std::size_t i = 1; i < intersection.size(); ++i)
+        {
+            if (i == best_continue || !intersection[i].entry_allowed)
+                continue;
+
+            if (angularDeviation(intersection[i].turn.angle, STRAIGHT_ANGLE) / deviation < 1.1 &&
+                continue_data.road_classification.road_class ==
+                    node_based_graph.GetEdgeData(intersection[i].turn.eid)
+                        .road_classification.road_class)
+                return 0;
+        }
+        return best_continue; // no obvious turn
+    }
+
+    return 0;
 }
 
 } // namespace guidance

--- a/src/extractor/guidance/intersection_scenario_three_way.cpp
+++ b/src/extractor/guidance/intersection_scenario_three_way.cpp
@@ -13,14 +13,6 @@ namespace extractor
 namespace guidance
 {
 
-bool isFork(const ConnectedRoad &,
-            const ConnectedRoad &possible_right_fork,
-            const ConnectedRoad &possible_left_fork)
-{
-    return angularDeviation(possible_right_fork.turn.angle, STRAIGHT_ANGLE) < NARROW_TURN_ANGLE &&
-           angularDeviation(possible_left_fork.turn.angle, STRAIGHT_ANGLE) < NARROW_TURN_ANGLE;
-}
-
 bool isEndOfRoad(const ConnectedRoad &,
                  const ConnectedRoad &possible_right_turn,
                  const ConnectedRoad &possible_left_turn)

--- a/src/extractor/guidance/motorway_handler.cpp
+++ b/src/extractor/guidance/motorway_handler.cpp
@@ -47,8 +47,6 @@ MotorwayHandler::MotorwayHandler(const util::NodeBasedDynamicGraph &node_based_g
 {
 }
 
-MotorwayHandler::~MotorwayHandler() = default;
-
 bool MotorwayHandler::canProcess(const NodeID,
                                  const EdgeID via_eid,
                                  const Intersection &intersection) const

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -31,8 +31,6 @@ RoundaboutHandler::RoundaboutHandler(const util::NodeBasedDynamicGraph &node_bas
 {
 }
 
-RoundaboutHandler::~RoundaboutHandler() = default;
-
 bool RoundaboutHandler::canProcess(const NodeID from_nid,
                                    const EdgeID via_eid,
                                    const Intersection &intersection) const

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -1,0 +1,192 @@
+#include "extractor/guidance/constants.hpp"
+#include "extractor/guidance/intersection_scenario_three_way.hpp"
+#include "extractor/guidance/sliproad_handler.hpp"
+#include "extractor/guidance/toolkit.hpp"
+
+#include "util/guidance/toolkit.hpp"
+
+#include <limits>
+#include <utility>
+
+#include <boost/assert.hpp>
+
+using EdgeData = osrm::util::NodeBasedDynamicGraph::EdgeData;
+using osrm::util::guidance::getTurnDirection;
+using osrm::util::guidance::angularDeviation;
+
+namespace osrm
+{
+namespace extractor
+{
+namespace guidance
+{
+
+SliproadHandler::SliproadHandler(const IntersectionGenerator &intersection_generator,
+                                 const util::NodeBasedDynamicGraph &node_based_graph,
+                                 const std::vector<QueryNode> &node_info_list,
+                                 const util::NameTable &name_table,
+                                 const SuffixTable &street_name_suffix_table)
+    : IntersectionHandler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
+      intersection_generator(intersection_generator)
+{
+}
+
+// included for interface reasons only
+bool SliproadHandler::canProcess(const NodeID /*nid*/,
+                                 const EdgeID /*via_eid*/,
+                                 const Intersection & /*intersection*/) const
+{
+    return true;
+}
+
+Intersection SliproadHandler::
+operator()(const NodeID, const EdgeID source_edge_id, Intersection intersection) const
+{
+    auto intersection_node_id = node_based_graph.GetTarget(source_edge_id);
+
+    // if there is no turn, there is no sliproad
+    if (intersection.size() <= 2)
+        return intersection;
+
+    const auto obvious_turn_index = findObviousTurn(source_edge_id, intersection);
+    const auto &next_road = intersection[obvious_turn_index];
+
+    const auto linkTest = [this, next_road](const ConnectedRoad &road) {
+        return !node_based_graph.GetEdgeData(road.turn.eid).roundabout && road.entry_allowed &&
+               angularDeviation(road.turn.angle, STRAIGHT_ANGLE) <= 2 * NARROW_TURN_ANGLE &&
+               !hasRoundaboutType(road.turn.instruction) &&
+               angularDeviation(next_road.turn.angle, road.turn.angle) >
+                   std::numeric_limits<double>::epsilon();
+    };
+
+    bool hasNarrow =
+        std::find_if(intersection.begin(), intersection.end(), linkTest) != intersection.end();
+    if (!hasNarrow)
+        return intersection;
+
+    const auto source_edge_data = node_based_graph.GetEdgeData(source_edge_id);
+
+    const bool hasNext = obvious_turn_index != 0;
+    if (!hasNext)
+        return intersection;
+
+    // check whether the continue road is valid
+    const auto check_valid = [this, source_edge_data](const ConnectedRoad &road) {
+        const auto road_edge_data = node_based_graph.GetEdgeData(road.turn.eid);
+        // Test to see if the source edge and the one we're looking at are the same road
+        return road_edge_data.road_classification.road_class ==
+                   source_edge_data.road_classification.road_class &&
+               road_edge_data.name_id != EMPTY_NAMEID &&
+               road_edge_data.name_id == source_edge_data.name_id && road.entry_allowed;
+    };
+
+    if (!check_valid(next_road))
+        return intersection;
+
+    // Threshold check, if the intersection is too far away, don't bother continuing
+    const auto &next_road_data = node_based_graph.GetEdgeData(next_road.turn.eid);
+    if (next_road_data.distance > MAX_SLIPROAD_THRESHOLD)
+    {
+        return intersection;
+    }
+    auto next_intersection_node = node_based_graph.GetTarget(next_road.turn.eid);
+
+    const auto next_road_next_intersection = [&]() {
+        auto intersection = intersection_generator(intersection_node_id, next_road.turn.eid);
+        auto in_edge = next_road.turn.eid;
+        // skip over traffic lights
+        if (intersection.size() == 2)
+        {
+            const auto node = node_based_graph.GetTarget(in_edge);
+            in_edge = intersection[1].turn.eid;
+            next_intersection_node = node_based_graph.GetTarget(in_edge);
+            intersection = intersection_generator(node, in_edge);
+        }
+        return intersection;
+    }();
+
+    std::unordered_set<NameID> target_road_names;
+
+    for (const auto &road : next_road_next_intersection)
+    {
+        const auto &target_data = node_based_graph.GetEdgeData(road.turn.eid);
+        target_road_names.insert(target_data.name_id);
+    }
+
+    for (auto &road : intersection)
+    {
+        if (linkTest(road))
+        {
+            EdgeID candidate_in = road.turn.eid;
+            const auto target_intersection = [&](NodeID node) {
+                auto intersection = intersection_generator(node, candidate_in);
+                // skip over traffic lights
+                if (intersection.size() == 2)
+                {
+                    node = node_based_graph.GetTarget(candidate_in);
+                    candidate_in = intersection[1].turn.eid;
+                    intersection = intersection_generator(node, candidate_in);
+                }
+                return intersection;
+            }(intersection_node_id);
+
+            for (const auto &candidate_road : target_intersection)
+            {
+                const auto &candidate_data = node_based_graph.GetEdgeData(candidate_road.turn.eid);
+                if (target_road_names.count(candidate_data.name_id) > 0)
+                {
+                    if (node_based_graph.GetTarget(candidate_road.turn.eid) ==
+                        next_intersection_node)
+                    {
+                        road.turn.instruction.type = TurnType::Sliproad;
+                        break;
+                    }
+                    else
+                    {
+                        const auto skip_traffic_light_intersection =
+                            intersection_generator(node_based_graph.GetTarget(candidate_in), candidate_road.turn.eid);
+                        if (skip_traffic_light_intersection.size() == 2 &&
+                            node_based_graph.GetTarget(
+                                skip_traffic_light_intersection[1].turn.eid) ==
+                                next_intersection_node)
+                        {
+
+                            road.turn.instruction.type = TurnType::Sliproad;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (next_road.turn.instruction.type == TurnType::Fork)
+    {
+        const auto &next_data = node_based_graph.GetEdgeData(next_road.turn.eid);
+        if (next_data.name_id == source_edge_data.name_id)
+        {
+            if (angularDeviation(next_road.turn.angle, STRAIGHT_ANGLE) < 5)
+                intersection[obvious_turn_index].turn.instruction.type = TurnType::Suppressed;
+            else
+                intersection[obvious_turn_index].turn.instruction.type = TurnType::Continue;
+            intersection[obvious_turn_index].turn.instruction.direction_modifier =
+                getTurnDirection(intersection[obvious_turn_index].turn.angle);
+        }
+        else if (next_data.name_id != EMPTY_NAMEID)
+        {
+            intersection[obvious_turn_index].turn.instruction.type = TurnType::NewName;
+            intersection[obvious_turn_index].turn.instruction.direction_modifier =
+                getTurnDirection(intersection[obvious_turn_index].turn.angle);
+        }
+        else
+        {
+            intersection[obvious_turn_index].turn.instruction.type = TurnType::Suppressed;
+        }
+    }
+
+    return intersection;
+}
+
+} // namespace guidance
+} // namespace extractor
+} // namespace osrm

--- a/src/extractor/guidance/turn_analysis.cpp
+++ b/src/extractor/guidance/turn_analysis.cpp
@@ -49,7 +49,12 @@ TurnAnalysis::TurnAnalysis(const util::NodeBasedDynamicGraph &node_based_graph,
                          name_table,
                          street_name_suffix_table),
       motorway_handler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
-      turn_handler(node_based_graph, node_info_list, name_table, street_name_suffix_table)
+      turn_handler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
+      sliproad_handler(intersection_generator,
+                       node_based_graph,
+                       node_info_list,
+                       name_table,
+                       street_name_suffix_table)
 {
 }
 
@@ -78,7 +83,7 @@ Intersection TurnAnalysis::assignTurnTypes(const NodeID from_nid,
         }
     }
     // Handle sliproads
-    intersection = handleSliproads(via_eid, std::move(intersection));
+    intersection = sliproad_handler(from_nid, via_eid, std::move(intersection));
 
     // Turn On Ramps Into Off Ramps, if we come from a motorway-like road
     if (isMotorwayClass(node_based_graph.GetEdgeData(via_eid).road_classification.road_class))
@@ -124,135 +129,6 @@ TurnAnalysis::setTurnTypes(const NodeID from_nid, const EdgeID, Intersection int
                                  (from_nid == to_nid) ? DirectionModifier::UTurn
                                                       : getTurnDirection(road.turn.angle)};
     }
-    return intersection;
-}
-
-// "Sliproads" occur when we've got a link between two roads (MOTORWAY_LINK, etc), but
-// the two roads are *also* directly connected shortly afterwards.
-// In these cases, we tag the turn-type as "sliproad", and then in post-processing
-// we emit a "turn", instead of "take the ramp"+"merge"
-Intersection TurnAnalysis::handleSliproads(const EdgeID source_edge_id,
-                                           Intersection intersection) const
-{
-    auto intersection_node_id = node_based_graph.GetTarget(source_edge_id);
-
-    const auto linkTest = [this](const ConnectedRoad &road) {
-        return !node_based_graph.GetEdgeData(road.turn.eid).roundabout && road.entry_allowed &&
-               angularDeviation(road.turn.angle, STRAIGHT_ANGLE) <= 2 * NARROW_TURN_ANGLE &&
-               !hasRoundaboutType(road.turn.instruction);
-    };
-
-    bool hasNarrow =
-        std::find_if(intersection.begin(), intersection.end(), linkTest) != intersection.end();
-    if (!hasNarrow)
-        return intersection;
-
-    const auto source_edge_data = node_based_graph.GetEdgeData(source_edge_id);
-
-    // Find the continuation of the intersection we're on
-    auto next_road = std::find_if(
-        intersection.begin(),
-        intersection.end(),
-        [this, source_edge_data](const ConnectedRoad &road) {
-            const auto road_edge_data = node_based_graph.GetEdgeData(road.turn.eid);
-            // Test to see if the source edge and the one we're looking at are the same road
-            return road_edge_data.road_classification.road_class ==
-                       source_edge_data.road_classification.road_class &&
-                   road_edge_data.name_id != EMPTY_NAMEID &&
-                   road_edge_data.name_id == source_edge_data.name_id && road.entry_allowed &&
-                   angularDeviation(road.turn.angle, STRAIGHT_ANGLE) < FUZZY_ANGLE_DIFFERENCE;
-        });
-
-    const bool hasNext = next_road != intersection.end();
-    if (!hasNext)
-    {
-        return intersection;
-    }
-
-    // Threshold check, if the intersection is too far away, don't bother continuing
-    const auto &next_road_data = node_based_graph.GetEdgeData(next_road->turn.eid);
-    if (next_road_data.distance > MAX_SLIPROAD_THRESHOLD)
-    {
-        return intersection;
-    }
-
-    auto next_intersection_node = node_based_graph.GetTarget(next_road->turn.eid);
-
-    const auto next_road_next_intersection = [&]() {
-        auto intersection = intersection_generator(intersection_node_id, next_road->turn.eid);
-        auto in_edge = next_road->turn.eid;
-        //skip over traffic lights
-        if(intersection.size() == 2)
-        {
-            const auto node = node_based_graph.GetTarget(in_edge);
-            in_edge = intersection[1].turn.eid;
-            next_intersection_node = node_based_graph.GetTarget(in_edge);
-            intersection = intersection_generator(node, in_edge);
-        }
-        return intersection;
-    }();
-
-    std::unordered_set<NameID> target_road_names;
-
-    for (const auto &road : next_road_next_intersection)
-    {
-        const auto &target_data = node_based_graph.GetEdgeData(road.turn.eid);
-        target_road_names.insert(target_data.name_id);
-    }
-
-    for (auto &road : intersection)
-    {
-        if (linkTest(road))
-        {
-            const auto target_intersection = [&](NodeID node, EdgeID eid) {
-                auto intersection = intersection_generator(node, eid);
-                //skip over traffic lights
-                if(intersection.size() == 2)
-                {
-                    node = node_based_graph.GetTarget(eid);
-                    eid = intersection[1].turn.eid;
-                    intersection = intersection_generator(node, eid);
-                }
-                return intersection;
-            }(intersection_node_id, road.turn.eid);
-
-            for (const auto &candidate_road : target_intersection)
-            {
-                const auto &candidate_data = node_based_graph.GetEdgeData(candidate_road.turn.eid);
-                if (target_road_names.count(candidate_data.name_id) > 0 &&
-                    node_based_graph.GetTarget(candidate_road.turn.eid) == next_intersection_node)
-                {
-                    road.turn.instruction.type = TurnType::Sliproad;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (next_road->turn.instruction.type == TurnType::Fork)
-    {
-        const auto &next_data = node_based_graph.GetEdgeData(next_road->turn.eid);
-        if (next_data.name_id == source_edge_data.name_id)
-        {
-            if (angularDeviation(next_road->turn.angle, STRAIGHT_ANGLE) < 5)
-                next_road->turn.instruction.type = TurnType::Suppressed;
-            else
-                next_road->turn.instruction.type = TurnType::Continue;
-            next_road->turn.instruction.direction_modifier =
-                getTurnDirection(next_road->turn.angle);
-        }
-        else if (next_data.name_id != EMPTY_NAMEID)
-        {
-            next_road->turn.instruction.type = TurnType::NewName;
-            next_road->turn.instruction.direction_modifier =
-                getTurnDirection(next_road->turn.angle);
-        }
-        else
-        {
-            next_road->turn.instruction.type = TurnType::Suppressed;
-        }
-    }
-
     return intersection;
 }
 


### PR DESCRIPTION
At the current state, some combinations of secondary roads / links and traffic lights can cause sliproad handling to fail and introduce unnecessary instructions.

An example is given here:
<img width="957" alt="screen shot 2016-07-04 at 10 31 06" src="https://cloud.githubusercontent.com/assets/12932279/16560410/865a4a26-41f3-11e6-808a-c4d49c2bbad8.png">
<img width="809" alt="screen shot 2016-07-04 at 10 31 22" src="https://cloud.githubusercontent.com/assets/12932279/16560411/87b356ce-41f3-11e6-9047-91eb3459ff4c.png">
<img width="965" alt="screen shot 2016-07-04 at 14 40 54" src="https://cloud.githubusercontent.com/assets/12932279/16560705/5c34ce22-41f5-11e6-871a-ee826d664e1c.png">

With the adjustments in this PR, we handle the sliproads at the given intersection correctly:

<img width="997" alt="screen shot 2016-07-04 at 14 35 36" src="https://cloud.githubusercontent.com/assets/12932279/16560674/2b1dbfa6-41f5-11e6-850f-812ddf6165a9.png">
<img width="848" alt="screen shot 2016-07-04 at 14 35 41" src="https://cloud.githubusercontent.com/assets/12932279/16560685/326cc84c-41f5-11e6-9f07-a6280ee3d1a9.png">


