### PR TITLE
fix obvious turn collapsing for straight turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.3.0
+    Changes from 5.3.0-rc.2
+        - Guidance
+            - Improved detection of obvious turns
+
 # 5.3.0 RC2
     Changes from 5.3.0-rc.1
         - Bugfixes

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -606,13 +606,13 @@ Feature: Collapse
             | restriction | bc       | fdcg   | c        | no_right_turn |
 
         When I route I should get
-          | waypoints | route                 | turns                                          |
-          | a,g       | road,cross,cross      | depart,turn left,arrive                        |
-          | a,e       | road,road,road        | depart,continue slight right,arrive            |
-          # We should discuss whether the next item should be collapsed to depart,turn right,arrive.
-          | a,f       | road,road,cross,cross | depart,continue slight right,turn right,arrive |
+            | waypoints | route                 | turns                                          |
+            | a,g       | road,cross,cross      | depart,turn left,arrive                        |
+            | a,e       | road,road,road        | depart,continue slight right,arrive            |
+            # We should discuss whether the next item should be collapsed to depart,turn right,arrive.
+            | a,f       | road,road,cross,cross | depart,continue slight right,turn right,arrive |
 
-     Scenario: On-Off on Highway
+    Scenario: On-Off on Highway
         Given the node map
             | f |   |   |   |
             | a | b | c | d |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -853,3 +853,29 @@ Feature: Simple Turns
             | a,c       | depart,arrive                   | road,road    |
             | d,a       | depart,turn left,arrive         | in,road,road |
             | d,c       | depart,new name straight,arrive | in,road,road |
+
+    Scenario: Channing Street
+        Given the node map
+            |   |   | g | f |   |
+            |   |   |   |   |   |
+            | d |   | c | b | a |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   | h | e |   |
+
+        And the nodes
+            | node | highway         |
+            | c    | traffic_signals |
+            | b    | traffic_signals |
+
+        And the ways
+            | nodes | name                           | highway     | oneway |
+            | ab    | Channing Street Northeast      | residential | no     |
+            | bcd   | Channing Street Northwest      | residential | yes    |
+            | ebf   | North Capitol Street Northeast | primary     | yes    |
+            | gch   | North Capitol Street Northeast | primary     | yes    |
+
+        When I route I should get
+            | waypoints | turns                   | route                                                                                   |
+            | a,d       | depart,arrive           | Channing Street Northeast,Channing Street Northwest                                     |
+            | a,h       | depart,turn left,arrive | Channing Street Northeast,North Capitol Street Northeast,North Capitol Street Northeast |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -385,7 +385,9 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
         {
             BOOST_ASSERT(!one_back_step.intersections.empty());
             if (TurnType::Continue == current_step.maneuver.instruction.type ||
-                TurnType::Suppressed == current_step.maneuver.instruction.type)
+                (TurnType::Suppressed == current_step.maneuver.instruction.type &&
+                 current_step.maneuver.instruction.direction_modifier !=
+                     DirectionModifier::Straight))
                 steps[step_index].maneuver.instruction.type = TurnType::Turn;
             else if (TurnType::Merge == current_step.maneuver.instruction.type)
             {
@@ -399,6 +401,7 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
                          DirectionModifier::Straight &&
                      one_back_step.intersections.front().bearings.size() > 2)
                 steps[step_index].maneuver.instruction.type = TurnType::Turn;
+
             steps[two_back_index] = elongate(std::move(steps[two_back_index]), one_back_step);
             // If the previous instruction asked to continue, the name change will have to
             // be changed into a turn
@@ -416,9 +419,7 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
             if ((TurnType::Continue == one_back_step.maneuver.instruction.type ||
                  TurnType::Suppressed == one_back_step.maneuver.instruction.type) &&
                 current_step.name_id != steps[two_back_index].name_id)
-            {
                 steps[one_back_index].maneuver.instruction.type = TurnType::Turn;
-            }
             else if (TurnType::Turn == one_back_step.maneuver.instruction.type &&
                      current_step.name_id == steps[two_back_index].name_id)
             {


### PR DESCRIPTION
Obvious turn handling did not consider the origin of the road.
In combination with turn collapsing, we could end up seeing `turn straight` where `new name` should have been emitted.

This PR fixes this behaviour (see new cucumber case).

Behaviour changes from `depart,turn straight,arrive` into `depart,arrive`.