### PR TITLE
Add search_radius_multiplier param to /match endpoint

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -259,14 +259,15 @@ http://{server}/match/v1/{profile}/{coordinates}?steps={true|false}&geometries={
 In addition to the [general options](#general-options) the following options are supported for this service:
 
 
-|Option      |Values                                          |Description                                                                               |
-|------------|------------------------------------------------|------------------------------------------------------------------------------------------|
-|steps       |`true`, `false` (default)                       |Return route steps for each route                                                         |
-|geometries  |`polyline` (default), `geojson`                 |Returned route geometry format (influences overview and per step)                        |
-|annotations |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.                |
-|overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
-|timestamps  |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamp of the input location.                                                          |
-|radiuses    |`{radius};{radius}[;{radius} ...]`              |Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy.|
+|Option                   |Values                                          |Description                                                                               |
+|-------------------------|------------------------------------------------|------------------------------------------------------------------------------------------|
+|steps                    |`true`, `false` (default)                       |Return route steps for each route                                                         |
+|geometries               |`polyline` (default), `geojson`                 |Returned route geometry format (influences overview and per step)                        |
+|annotations              |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.                |
+|overview                 |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
+|timestamps               |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamp of the input location.                                                          |
+|radiuses                 |`{radius};{radius}[;{radius} ...]`              |Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy.|
+|search_radius_multiplier |`double > 0` (default 3)                        |Multiplied by `radius` for each point to get search radius for candidate segments. Has a quartic (O(n^4)) effect on running time, use with care!|
 
 |Parameter   |Values                        |
 |------------|------------------------------|

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -67,10 +67,13 @@ struct MatchParameters : public RouteParameters
     }
 
     std::vector<unsigned> timestamps;
+    double search_radius_multiplier = 3;
+
     bool IsValid() const
     {
         return RouteParameters::IsValid() &&
-               (timestamps.empty() || timestamps.size() == coordinates.size());
+               (timestamps.empty() || timestamps.size() == coordinates.size()) &&
+               search_radius_multiplier > 0;
     }
 };
 }

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -25,7 +25,6 @@ class MatchPlugin : public BasePlugin
     using SubMatchingList = routing_algorithms::SubMatchingList;
     using CandidateLists = routing_algorithms::CandidateLists;
     static const constexpr double DEFAULT_GPS_PRECISION = 5;
-    static const constexpr double RADIUS_MULTIPLIER = 3;
 
     MatchPlugin(datafacade::BaseDataFacade &facade_, const int max_locations_map_matching)
         : BasePlugin(facade_), map_matching(&facade_, heaps, DEFAULT_GPS_PRECISION),

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -33,13 +33,21 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
             (qi::uint_ %
              ';')[ph::bind(&engine::api::MatchParameters::timestamps, qi::_r1) = qi::_1];
 
+        search_radius_multiplier_rule =
+            qi::lit("search_radius_multiplier=") > qi::double_[
+                ph::bind(&engine::api::MatchParameters::search_radius_multiplier, qi::_r1) = qi::_1];
+
         root_rule = BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
-                    -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1)) % '&');
+                    -('?' > (timestamps_rule(qi::_r1) |
+                             search_radius_multiplier_rule(qi::_r1) |
+                             BaseGrammar::base_rule(qi::_r1))
+                            % '&');
     }
 
   private:
     qi::rule<Iterator, Signature> root_rule;
     qi::rule<Iterator, Signature> timestamps_rule;
+    qi::rule<Iterator, Signature> search_radius_multiplier_rule;
 };
 }
 }

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -130,7 +130,7 @@ Status MatchPlugin::HandleRequest(const api::MatchParameters &parameters,
     if (parameters.radiuses.empty())
     {
         search_radiuses.resize(parameters.coordinates.size(),
-                               DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER);
+                               DEFAULT_GPS_PRECISION * parameters.search_radius_multiplier);
     }
     else
     {
@@ -138,14 +138,14 @@ Status MatchPlugin::HandleRequest(const api::MatchParameters &parameters,
         std::transform(parameters.radiuses.begin(),
                        parameters.radiuses.end(),
                        search_radiuses.begin(),
-                       [](const boost::optional<double> &maybe_radius) {
+                       [&](const boost::optional<double> &maybe_radius) {
                            if (maybe_radius)
                            {
-                               return *maybe_radius * RADIUS_MULTIPLIER;
+                               return *maybe_radius * parameters.search_radius_multiplier;
                            }
                            else
                            {
-                               return DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER;
+                               return DEFAULT_GPS_PRECISION * parameters.search_radius_multiplier;
                            }
 
                        });


### PR DESCRIPTION
By default, OSRM /match considers a radius of 3 * gps_precision
around the input point when looking for candidate segments. Oftentimes
the 3x multiplier is too small and results in an incorrect match or an
error. Allow the multiplier to be passed in the URL.

N.B. if you double the value of this multiplier, it will make /match
 _16x_ slower. This is because doubling the query radius means there are
4x as many candidate segments (on average), and the Viterbi algorithm
is N^2 in the average number of hidden states per observation. Use with
care!
