### PR TITLE
[approved-by-daniel-j-h] handle access flags for lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 5.4.0
     - Profiles
       - includes library guidance.lua that offers preliminary configuration on guidance.
+    - Guidance
+      - Handle Access tags for lanes, only considering valid lanes in lane-guidance (think car | car | bike | car)
 
 # 5.3.0
   Changes from 5.3.0-rc.3

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -24,6 +24,22 @@ Feature: Turn Lane Guidance
             | c,a       | straight,in,in       | depart,new name straight,arrive | ,left:false straight:true none:true none:true,   |
             | c,d       | straight,right,right | depart,turn left,arrive         | ,left:true straight:false none:false none:false, |
 
+    Scenario: Basic Turn Lane 3-way Turn with designated lane
+        Given the node map
+            | a |   | b |   | c |
+            |   |   | d |   |   |
+
+        And the ways
+            | nodes  | turn:lanes     | turn:lanes:forward      | name     | vehicle:lanes:forward |
+            | ab     |                | through\|through\|right | in       | yes\|no\|yes          |
+            | bc     |                |                         | straight |                       |
+            | bd     |                |                         | right    |                       |
+
+       When I route I should get
+            | waypoints | route                | turns                           | lanes                       |
+            | a,c       | in,straight,straight | depart,new name straight,arrive | ,straight:true right:false, |
+            | a,d       | in,right,right       | depart,turn right,arrive        | ,straight:false right:true, |
+
     Scenario: Basic Turn Lane 4-Way Turn
         Given the node map
             |   |   | e |   |   |

--- a/include/extractor/extraction_helper_functions.hpp
+++ b/include/extractor/extraction_helper_functions.hpp
@@ -106,6 +106,13 @@ trimLaneString(std::string lane_string, std::int32_t count_left, std::int32_t co
 {
     return extractor::guidance::trimLaneString(std::move(lane_string), count_left, count_right);
 }
+
+inline std::string
+applyAccessTokens(const std::string &lane_string, const std::string &access_tokens)
+{
+    return extractor::guidance::trimLaneString(lane_string,access_tokens);
+}
+
 }
 }
 

--- a/include/extractor/extraction_helper_functions.hpp
+++ b/include/extractor/extraction_helper_functions.hpp
@@ -110,7 +110,7 @@ trimLaneString(std::string lane_string, std::int32_t count_left, std::int32_t co
 inline std::string
 applyAccessTokens(const std::string &lane_string, const std::string &access_tokens)
 {
-    return extractor::guidance::trimLaneString(lane_string,access_tokens);
+    return extractor::guidance::applyAccessTokens(lane_string, access_tokens);
 }
 
 }

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -357,8 +357,7 @@ trimLaneString(std::string lane_string, std::int32_t count_left, std::int32_t co
 // turn:lanes=left|through|through|right
 // vehicle:lanes=yes|yes|no|yes
 // bicycle:lanes=yes|no|designated|yes
-
-inline std::string trimLaneString(std::string lane_string, const std::string &access_tokens)
+inline std::string applyAccessTokens(std::string lane_string, const std::string &access_tokens)
 {
     typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
     boost::char_separator<char> sep("|", "", boost::keep_empty_tokens);

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -82,6 +82,7 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
         [luabind::def("durationIsValid", durationIsValid),
          luabind::def("parseDuration", parseDuration),
          luabind::def("trimLaneString", trimLaneString),
+         luabind::def("applyAccessTokens", applyAccessTokens),
          luabind::class_<TravelMode>("mode").enum_(
              "enums")[luabind::value("inaccessible", TRAVEL_MODE_INACCESSIBLE),
                       luabind::value("driving", TRAVEL_MODE_DRIVING),

--- a/taginfo.json
+++ b/taginfo.json
@@ -206,16 +206,31 @@
             "description": "Turn Lanes for lane guidance."
         },
         {
+            "key": "vehicle:lanes",
+            "object_types": [ "way" ],
+            "description": "Access tags for turn lanes."
+        },
+        {
             "key": "turn:lanes:forward",
             "object_types": [ "way" ],
             "description": "Turn Lanes for lane guidance."
+        },
+        {
+            "key": "vehicle:lanes:forward",
+            "object_types": [ "way" ],
+            "description": "Access tags for turn lanes."
         },
         {
             "key": "turn:lanes:backward",
             "object_types": [ "way" ],
             "description": "Turn Lanes for lane guidance."
         },
-         {
+        {
+            "key": "vehicle:lanes:backward",
+            "object_types": [ "way" ],
+            "description": "Access tags for turn lanes."
+        },
+        {
             "key": "lanes:psv",
             "object_types": [ "way" ],
             "description": "Turn Lanes for lane guidance."


### PR DESCRIPTION
Addresses https://github.com/Project-OSRM/osrm-backend/issues/2638.

When merged, https://github.com/Project-OSRM/osrm-backend/pull/2586 needs to be adjusted to move the handling into the guidance lib.

Needs to be adjusted when adding: https://github.com/Project-OSRM/osrm-backend/pull/2635 to remove '&' hack from `extractor/guidance/toolkit.hpp` and `features/guidance/turn-lanes.feature:29`