### PR TITLE
Correctly cache ccache directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ branches:
     - master
 
 cache:
+  ccache: true
   directories:
-    - $HOME/.ccache
     - test/cache
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ branches:
     - master
 
 cache:
-  ccache: true
-  apt: true
   directories:
+    - $HOME/.ccache
     - test/cache
 
 env:
   global:
-   - CCACHE_TEMPDIR=/tmp/.ccache-temp
    - CCACHE_COMPRESS=1
    - JOBS=4
+   - CASHER_TIME_OUT=1000
+   - CCACHE_TEMPDIR=/tmp/.ccache-temp
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ branches:
     - master
 
 cache:
-  ccache: true
   directories:
+    - $HOME/.ccache
     - test/cache
 
 env:


### PR DESCRIPTION
Looking at the logs for the latest builds indicates that only the `./test/cache` is being added to the cache and not the ccache compiler data or apt data. The logs (https://travis-ci.org/Project-OSRM/osrm-backend/jobs/144440422#L1067) show only:

```
adding /home/travis/build/Project-OSRM/osrm-backend/test/cache to cache
```

The lack of apt caching may be because travis does not support this in open source repos. The docs at https://docs.travis-ci.com/user/caching/ have no mention of the `apt` keyword.

The lack of ccache caching is because of at least two reasons:

- Combining `ccache: true` with `directories` appears not to work and `ccache: true` is ignored.
- ~~Even if `ccache: true` were not ignored then the path is incorrect because it is customized by the `CCACHE_TEMPDIR` environment setting~~ False alarm: this temp directory does not change the default data path: that is still correctly `~/.ccache`.

This PR therefore fixes this situation by:

 - Removing the unsupported `apt` keyword
 - Adding the correct, default ccache data directory to the directions being cached.
