### PR TITLE
[ready] make roundabout maneuvers continuous with respect to lane changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Guidance
       - Improved detection of obvious turns
       - Improved turn lane detection
+      - Improved lane anticipation for roundabouts
     - Bugfixes
       - Fix bug that didn't chose minimal weights on overlapping edges
 

--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -366,6 +366,62 @@ Feature: Turn Lane Guidance
             | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
 
     @anticipate
+    Scenario: Departing or arriving inside a roundabout does not yet anticipate lanes (BIG version)
+        Given the node map
+            |   |   | a |   |   |
+            | x | b |   | d | y |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   | c |   |   |
+
+        And the ways
+            | nodes | turn:lanes:forward         | highway | junction   | name       |
+            | xb    | slight_right\|slight_right | primary |            | xb         |
+            | dy    |                            | primary |            | dy         |
+            | ab    |                            | primary | roundabout | roundabout |
+            | bc    |                            | primary | roundabout | roundabout |
+            | cd    | left\|slight_right         | primary | roundabout | roundabout |
+            | da    |                            | primary | roundabout | roundabout |
+
+        When I route I should get
+            | waypoints | route                    | turns                                   | lanes                                  |
+            | x,y       | xb,dy,dy                 | depart,roundabout-exit-1,arrive         | ,slight right:false slight right:true, |
+            | x,c       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
+            | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
+
+    @anticipate
     Scenario: Anticipate Lanes for turns before and / or after roundabout
         Given the node map
             | a | b |   |   | x |

--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -259,8 +259,8 @@ Feature: Turn Lane Guidance
             | waypoints | route                 | turns                                                   | lanes                                                                                                                                                  |
             | a,f       | abx,bcy,cdz,dew,ef,ef | depart,turn right,turn left,turn right,turn left,arrive | ,straight:false right:false right:true right:false,left:false left:true straight:false,straight:false right:true right:false,left:true straight:false, |
 
-    @anticipate
-        Scenario: Anticipate with lanes in roundabout: roundabouts as the unit of anticipation
+    @anticipate @todo @bug @2661
+    Scenario: Anticipate with lanes in roundabout: roundabouts as the unit of anticipation
         Given the node map
             |   |   | e |   |   |
             | a | b |   | d | f |

--- a/include/engine/guidance/lane_processing.hpp
+++ b/include/engine/guidance/lane_processing.hpp
@@ -15,7 +15,10 @@ namespace guidance
 // Constrains lanes for multi-hop situations where lane changes depend on earlier ones.
 // Instead of forcing users to change lanes rapidly in a short amount of time,
 // we anticipate lane changes emitting only matching lanes early on.
-std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps);
+// the second parameter describes the duration that we feel two segments need to be apart to count
+// as separate maneuvers.
+std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
+                                            const double min_duration_needed_for_lane_change = 15);
 
 } // namespace guidance
 } // namespace engine

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -1,3 +1,4 @@
+#include "util/debug.hpp"
 #include "util/for_each_pair.hpp"
 #include "util/group_by.hpp"
 #include "util/guidance/toolkit.hpp"
@@ -20,18 +21,17 @@ namespace engine
 namespace guidance
 {
 
-std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps)
+std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
+                                            const double min_duration_needed_for_lane_change)
 {
-    const constexpr auto MIN_DURATION_NEEDED_FOR_LANE_CHANGE = 15.;
-
     // Postprocessing does not strictly guarantee for only turns
     const auto is_turn = [](const RouteStep &step) {
         return step.maneuver.instruction.type != TurnType::NewName &&
                step.maneuver.instruction.type != TurnType::Notification;
     };
 
-    const auto is_quick = [MIN_DURATION_NEEDED_FOR_LANE_CHANGE](const RouteStep &step) {
-        return step.duration < MIN_DURATION_NEEDED_FOR_LANE_CHANGE;
+    const auto is_quick = [min_duration_needed_for_lane_change](const RouteStep &step) {
+        return step.duration < min_duration_needed_for_lane_change;
     };
 
     const auto is_quick_turn = [&](const RouteStep &step) {

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -1,4 +1,3 @@
-#include "util/debug.hpp"
 #include "util/for_each_pair.hpp"
 #include "util/group_by.hpp"
 #include "util/guidance/toolkit.hpp"

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -524,7 +524,10 @@ std::vector<RouteStep> anticipateLaneChangeForRoundabouts(std::vector<RouteStep>
             enter.maneuver.instruction.direction_modifier =
                 mirrorDirectionModifier(enter_direction);
 
-        auto enterAndLeave = anticipateLaneChange({enter, leave});
+        // a roundabout is a continuous maneuver. We don't switch lanes within a roundabout, as long
+        // as it can be avoided.
+        auto enterAndLeave =
+            anticipateLaneChange({enter, leave}, std::numeric_limits<double>::max());
 
         // Undo flipping direction on a right turn in a right-sided counter-clockwise roundabout.
         // FIXME: assumes right-side driving (counter-clockwise roundabout flow)


### PR DESCRIPTION
In anticipating lanes over multiple turns, we consider different segments of the route.
If two turns are far enough apart, we assume a lane change to be possible. This is, of course, only an initial heuristic and should be improved upon.

For roundabouts we are in one of these cases that are suffering from the basic structure of a fixed constant that we currently apply. Roundabouts are essentially one continuous turn. As a result, we need to -- at least -- consider longer times.

This PR adjusts the fixed constant to be a parameter as a first improvement. We probably want to be able to supply heuristic functions later on, even further moving away from the current situation.