### PR TITLE
Use JavaScript for profiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 # we depend on 2.8.11 introducing target_include_directories
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR AND NOT MSVC_IDE)
@@ -55,6 +55,16 @@ option(COVERAGE OFF)
 option(SANITIZER OFF)
 option(ENABLE_LTO "Use LTO if available" ON)
 
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/node_modules/node-cmake/FindNodeJS.cmake)
+    message(FATAL_ERROR "Can't find node-cmake")
+endif()
+
+set(NodeJS_CXX_STANDARD 14 CACHE INTERNAL "Use C++14" FORCE)
+set(NodeJS_DOWNLOAD ON CACHE INTERNAL "Download node.js sources" FORCE)
+set(NodeJS_USE_CLANG_STDLIB OFF CACHE BOOL "Don't use libc++ by default" FORCE)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/node_modules/node-cmake)
+find_package(NodeJS)
+
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include/)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/)
@@ -78,6 +88,7 @@ file(GLOB ContractorGlob src/contractor/*.cpp)
 file(GLOB StorageGlob src/storage/*.cpp)
 file(GLOB ServerGlob src/server/*.cpp src/server/**/*.cpp)
 file(GLOB EngineGlob src/engine/*.cpp src/engine/**/*.cpp)
+file(GLOB NodeGlob src/node/*.cpp src/node/**/*.cpp)
 
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})
@@ -85,6 +96,7 @@ add_library(CONTRACTOR OBJECT ${ContractorGlob})
 add_library(STORAGE OBJECT ${StorageGlob})
 add_library(ENGINE OBJECT ${EngineGlob})
 add_library(SERVER OBJECT ${ServerGlob})
+add_nodejs_module(osrm-process ${NodeGlob} $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 
 add_dependencies(UTIL FingerPrintConfigure)
 set_target_properties(UTIL PROPERTIES LINKER_LANGUAGE CXX)
@@ -98,6 +110,11 @@ add_library(osrm_extract $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_contract $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
 
+add_custom_command(
+    TARGET osrm-process
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:osrm-process> ${CMAKE_SOURCE_DIR}/lib/osrm-process.node
+)
 # Check the release mode
 if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_BUILD_TYPE Release)
@@ -368,6 +385,8 @@ target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES})
 target_link_libraries(osrm_extract ${EXTRACTOR_LIBRARIES})
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
+target_link_libraries(osrm-process ${EXTRACTOR_LIBRARIES})
+
 
 if(BUILD_COMPONENTS)
   find_package(GDAL)

--- a/bin/osrm-extract
+++ b/bin/osrm-extract
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+var osrm = require('../lib/osrm-process');
+var os = require('os');
+var path = require('path');
+var program = require('commander');
+
+const concurrency = os.cpus().length;
+
+// TODO: Use osrm version
+program.version('0.0.1')
+    .option('-p, --profile <file>', 'Path to LUA routing profile [profile.lua]', 'profile.lua')
+    .option('-t, --threads <num>', 'Number of threads to use [' + concurrency + ']', concurrency)
+    .option('-i, --input <file>', 'Input file in .osm, .osm.bz2 or .osm.pbf format')
+    .option('--generate-edge-lookup',
+            'Generate a lookup table for internal edge-expanded-edge IDs to OSM node pairs')
+    .option(
+        '--small-component-size <size>',
+        'Number of nodes required before a strongly-connected-componennt is considered big (affects nearest neighbor snapping) [1000]',
+        parseInt,
+        1000)
+    .parse(process.argv);
+
+
+var inputPath;
+
+if (program.input) {
+    inputPath = program.input;
+} else if (program.args.length == 1) {
+    inputPath = program.args[0];
+} else {
+    program.outputHelp();
+    process.exit(1);
+}
+
+var options = {
+    inputPath: inputPath,
+    numThreads: program.numThreads,
+    smallComponentSize: program.smallComponentSize,
+    generateEdgeLookup: program.generateEdgeLookup
+};
+
+const profilePath = path.resolve(program.profile);
+const profileType = path.extname(profilePath);
+var profile = {};
+
+if (profileType == '.js') {
+    profile = require(profilePath);
+} else if (profileType == '.lua') {
+    options.profilePath = profilePath;
+} else {
+    throw new Error('Profile extension mus be .lua or .js');
+}
+
+osrm.extract(options, profile, function(err) {
+    if (err) {
+        throw err;
+    }
+});

--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -57,7 +57,6 @@ struct ContractorConfig
         datasource_indexes_path = osrm_input_path.string() + ".datasource_indexes";
     }
 
-    boost::filesystem::path config_file_path;
     boost::filesystem::path osrm_input_path;
 
     std::string level_output_path;

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -36,12 +36,12 @@
 
 #include <boost/filesystem/fstream.hpp>
 
-struct lua_State;
-
 namespace osrm
 {
 namespace extractor
 {
+
+struct ScriptingContext;
 
 namespace lookup
 {
@@ -89,9 +89,9 @@ class EdgeBasedGraphFactory
         const std::vector<std::uint32_t> &turn_lane_offsets,
         const std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks);
 
-    void Run(const std::string &original_edge_data_filename,
+    void Run(ScriptingContext &scripting_context,
+             const std::string &original_edge_data_filename,
              const std::string &turn_lane_data_filename,
-             lua_State *lua_state,
              const std::string &edge_segment_lookup_filename,
              const std::string &edge_penalty_filename,
              const bool generate_edge_lookup);
@@ -120,8 +120,6 @@ class EdgeBasedGraphFactory
                                           const EdgeID e2,
                                           const NodeID w,
                                           const double angle) const;
-
-    std::int32_t GetTurnPenalty(double angle, lua_State *lua_state) const;
 
   private:
     using EdgeData = util::NodeBasedDynamicGraph::EdgeData;
@@ -158,7 +156,7 @@ class EdgeBasedGraphFactory
     void GenerateEdgeExpandedNodes();
     void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
                                    const std::string &turn_lane_data_filename,
-                                   lua_State *lua_state,
+                                   ScriptingContext &scripting_context,
                                    const std::string &edge_segment_lookup_filename,
                                    const std::string &edge_fixed_penalties_filename,
                                    const bool generate_edge_lookup);

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -41,7 +41,7 @@ namespace osrm
 namespace extractor
 {
 
-struct ScriptingContext;
+class ScriptingEnvironment;
 
 namespace lookup
 {
@@ -89,7 +89,7 @@ class EdgeBasedGraphFactory
         const std::vector<std::uint32_t> &turn_lane_offsets,
         const std::vector<guidance::TurnLaneType::Mask> &turn_lane_masks);
 
-    void Run(ScriptingContext &scripting_context,
+    void Run(ScriptingEnvironment &scripting_environment,
              const std::string &original_edge_data_filename,
              const std::string &turn_lane_data_filename,
              const std::string &edge_segment_lookup_filename,
@@ -156,7 +156,7 @@ class EdgeBasedGraphFactory
     void GenerateEdgeExpandedNodes();
     void GenerateEdgeExpandedEdges(const std::string &original_edge_data_filename,
                                    const std::string &turn_lane_data_filename,
-                                   ScriptingContext &scripting_context,
+                                   ScriptingEnvironment &scripting_environment,
                                    const std::string &edge_segment_lookup_filename,
                                    const std::string &edge_fixed_penalties_filename,
                                    const bool generate_edge_lookup);

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -17,6 +17,8 @@ namespace osrm
 namespace extractor
 {
 
+struct ScriptingContext;
+
 /**
  * Uses external memory containers from stxxl to store all the data that
  * is collected by the extractor callbacks.
@@ -34,7 +36,7 @@ class ExtractionContainers
 #endif
     void PrepareNodes();
     void PrepareRestrictions();
-    void PrepareEdges(lua_State *segment_state);
+    void PrepareEdges(ScriptingContext &scripting_context);
 
     void WriteNodes(std::ofstream &file_out_stream) const;
     void WriteRestrictions(const std::string &restrictions_file_name) const;
@@ -68,11 +70,11 @@ class ExtractionContainers
 
     ExtractionContainers();
 
-    void PrepareData(const std::string &output_file_name,
+    void PrepareData(ScriptingContext &scripting_context,
+                     const std::string &output_file_name,
                      const std::string &restrictions_file_name,
                      const std::string &names_file_name,
-                     const std::string &turn_lane_file_name,
-                     lua_State *segment_state);
+                     const std::string &turn_lane_file_name);
 };
 }
 }

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -8,16 +8,14 @@
 #include "extractor/restriction.hpp"
 #include "extractor/scripting_environment.hpp"
 
+#include <cstdint>
 #include <stxxl/vector>
 #include <unordered_map>
-#include <cstdint>
 
 namespace osrm
 {
 namespace extractor
 {
-
-struct ScriptingContext;
 
 /**
  * Uses external memory containers from stxxl to store all the data that
@@ -36,7 +34,7 @@ class ExtractionContainers
 #endif
     void PrepareNodes();
     void PrepareRestrictions();
-    void PrepareEdges(ScriptingContext &scripting_context);
+    void PrepareEdges(ScriptingEnvironment &scripting_environment);
 
     void WriteNodes(std::ofstream &file_out_stream) const;
     void WriteRestrictions(const std::string &restrictions_file_name) const;
@@ -70,7 +68,7 @@ class ExtractionContainers
 
     ExtractionContainers();
 
-    void PrepareData(ScriptingContext &scripting_context,
+    void PrepareData(ScriptingEnvironment &scripting_environment,
                      const std::string &output_file_name,
                      const std::string &restrictions_file_name,
                      const std::string &names_file_name,

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -43,20 +43,21 @@ namespace osrm
 namespace extractor
 {
 
+class ScriptingEnvironment;
+struct ScriptingContext;
 struct ProfileProperties;
 
 class Extractor
 {
   public:
     Extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
-    int run();
+    int run(ScriptingEnvironment& scripting_environment);
 
   private:
     ExtractorConfig config;
 
     std::pair<std::size_t, EdgeID>
-    BuildEdgeExpandedGraph(lua_State *lua_state,
-                           const ProfileProperties &profile_properties,
+    BuildEdgeExpandedGraph(ScriptingContext &scripting_context,
                            std::vector<QueryNode> &internal_to_external_node_map,
                            std::vector<EdgeBasedNode> &node_based_edge_list,
                            std::vector<bool> &node_is_startpoint,

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -44,20 +44,19 @@ namespace extractor
 {
 
 class ScriptingEnvironment;
-struct ScriptingContext;
 struct ProfileProperties;
 
 class Extractor
 {
   public:
     Extractor(ExtractorConfig extractor_config) : config(std::move(extractor_config)) {}
-    int run(ScriptingEnvironment& scripting_environment);
+    int run(ScriptingEnvironment &scripting_environment);
 
   private:
     ExtractorConfig config;
 
     std::pair<std::size_t, EdgeID>
-    BuildEdgeExpandedGraph(ScriptingContext &scripting_context,
+    BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                            std::vector<QueryNode> &internal_to_external_node_map,
                            std::vector<EdgeBasedNode> &node_based_edge_list,
                            std::vector<bool> &node_is_startpoint,

--- a/include/extractor/extractor_config.hpp
+++ b/include/extractor/extractor_config.hpp
@@ -77,7 +77,6 @@ struct ExtractorConfig
         intersection_class_data_output_path = basepath + ".osrm.icd";
     }
 
-    boost::filesystem::path config_file_path;
     boost::filesystem::path input_path;
     boost::filesystem::path profile_path;
 

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -8,6 +8,7 @@
 #include <boost/assert.hpp>
 
 #include "extractor/guidance/classification_data.hpp"
+#include "extractor/guidance/turn_lane_types.hpp"
 #include "osrm/coordinate.hpp"
 #include <utility>
 

--- a/include/extractor/restriction_parser.hpp
+++ b/include/extractor/restriction_parser.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-struct lua_State;
 namespace osmium
 {
 class Relation;
@@ -19,7 +18,7 @@ namespace osrm
 namespace extractor
 {
 
-struct ProfileProperties;
+struct ScriptingContext;
 
 /**
  * Parses the relations that represents turn restrictions.
@@ -42,11 +41,10 @@ struct ProfileProperties;
 class RestrictionParser
 {
   public:
-    RestrictionParser(lua_State *lua_state, const ProfileProperties &properties);
+    RestrictionParser(ScriptingContext &scripting_context);
     boost::optional<InputRestrictionContainer> TryParse(const osmium::Relation &relation) const;
 
   private:
-    void ReadRestrictionExceptions(lua_State *lua_state);
     bool ShouldIgnoreRestriction(const std::string &except_tag_string) const;
 
     std::vector<std::string> restriction_exceptions;

--- a/include/extractor/restriction_parser.hpp
+++ b/include/extractor/restriction_parser.hpp
@@ -18,7 +18,7 @@ namespace osrm
 namespace extractor
 {
 
-struct ScriptingContext;
+class ScriptingEnvironment;
 
 /**
  * Parses the relations that represents turn restrictions.
@@ -41,7 +41,7 @@ struct ScriptingContext;
 class RestrictionParser
 {
   public:
-    RestrictionParser(ScriptingContext &scripting_context);
+    RestrictionParser(ScriptingEnvironment &scripting_environment);
     boost::optional<InputRestrictionContainer> TryParse(const osmium::Relation &relation) const;
 
   private:

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -1,22 +1,49 @@
 #ifndef SCRIPTING_ENVIRONMENT_HPP
 #define SCRIPTING_ENVIRONMENT_HPP
 
+#include "extractor/internal_extractor_edge.hpp"
 #include "extractor/profile_properties.hpp"
-#include "extractor/raster_source.hpp"
 
-#include "util/lua_util.hpp"
-
-#include <memory>
-#include <mutex>
 #include <string>
-#include <tbb/enumerable_thread_specific.h>
+#include <unordered_set>
+#include <vector>
 
-struct lua_State;
+namespace osmium
+{
+class Node;
+class Way;
+}
 
 namespace osrm
 {
+
+namespace util
+{
+struct Coordinate;
+}
+
 namespace extractor
 {
+
+struct ExtractionNode;
+struct ExtractionWay;
+
+struct ScriptingContext {
+    ScriptingContext() = default;
+    virtual ~ScriptingContext() = default;
+    virtual std::unordered_set<std::string> getNameSuffixList() = 0;
+    virtual std::vector<std::string> getExceptions() = 0;
+    virtual void setupSources() = 0;
+    virtual int getTurnPenalty(double /* angle */) { return 0; }
+    virtual void processNode(const osmium::Node &, ExtractionNode &result) = 0;
+    virtual void processWay(const osmium::Way &, ExtractionWay &result) = 0;
+    virtual void processSegment(const osrm::util::Coordinate &source,
+                                const osrm::util::Coordinate &target,
+                                double distance,
+                                InternalExtractorEdge::WeightData &weight) = 0;
+
+    ProfileProperties properties;
+};
 
 /**
  * Creates a lua context and binds osmium way, node and relation objects and
@@ -28,25 +55,12 @@ namespace extractor
 class ScriptingEnvironment
 {
   public:
-    struct Context
-    {
-        ProfileProperties properties;
-        SourceContainer sources;
-        util::LuaState state;
-    };
-
-    explicit ScriptingEnvironment(const std::string &file_name);
-
+    ScriptingEnvironment() = default;
     ScriptingEnvironment(const ScriptingEnvironment &) = delete;
     ScriptingEnvironment &operator=(const ScriptingEnvironment &) = delete;
+    virtual ~ScriptingEnvironment() = default;
 
-    Context &GetContex();
-
-  private:
-    void InitContext(Context &context);
-    std::mutex init_mutex;
-    std::string file_name;
-    tbb::enumerable_thread_specific<std::unique_ptr<Context>> script_contexts;
+    virtual ScriptingContext &GetContext() = 0;
 };
 }
 }

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -1,0 +1,69 @@
+#ifndef SCRIPTING_ENVIRONMENT_LUA_HPP
+#define SCRIPTING_ENVIRONMENT_LUA_HPP
+
+#include "extractor/scripting_environment.hpp"
+
+#include "extractor/raster_source.hpp"
+
+#include "util/lua_util.hpp"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <tbb/enumerable_thread_specific.h>
+
+struct lua_State;
+
+namespace osrm
+{
+namespace extractor
+{
+
+struct LuaScriptingContext final : public ScriptingContext
+{
+    LuaScriptingContext() = default;
+    ~LuaScriptingContext() override = default;
+
+    std::unordered_set<std::string> getNameSuffixList() override;
+    std::vector<std::string> getExceptions() override;
+    void setupSources() override;
+    int getTurnPenalty(double angle) override;
+    void processNode(const osmium::Node &, ExtractionNode &result) override;
+    void processWay(const osmium::Way &, ExtractionWay &result) override;
+    void processSegment(const osrm::util::Coordinate &source,
+                        const osrm::util::Coordinate &target,
+                        double distance,
+                        InternalExtractorEdge::WeightData &weight) override;
+
+    SourceContainer sources;
+    util::LuaState state;
+
+    bool has_turn_penalty_function;
+    bool has_segment_function;
+};
+
+/**
+ * Creates a lua context and binds osmium way, node and relation objects and
+ * ExtractionWay and ExtractionNode to lua objects.
+ *
+ * Each thread has its own lua state which is implemented with thread specific
+ * storage from TBB.
+ */
+class LuaScriptingEnvironment final : public ScriptingEnvironment
+{
+  public:
+    explicit LuaScriptingEnvironment(const std::string &file_name);
+    ~LuaScriptingEnvironment() override = default;
+
+    ScriptingContext &GetContext() override;
+
+  private:
+    void InitContext(LuaScriptingContext &context);
+    std::mutex init_mutex;
+    std::string file_name;
+    tbb::enumerable_thread_specific<std::unique_ptr<LuaScriptingContext>> script_contexts;
+};
+}
+}
+
+#endif /* SCRIPTING_ENVIRONMENT_LUA_HPP */

--- a/include/extractor/suffix_table.hpp
+++ b/include/extractor/suffix_table.hpp
@@ -4,19 +4,20 @@
 #include <string>
 #include <unordered_set>
 
-struct lua_State;
-
 namespace osrm
 {
 namespace extractor
 {
+
+struct ScriptingContext;
+
 // A table containing suffixes.
 // At the moment, it is only a front for an unordered set. At some point we might want to make it
 // country dependent and have it behave accordingly
 class SuffixTable final
 {
   public:
-    SuffixTable(lua_State *lua_state);
+    SuffixTable(ScriptingContext &scripting_context);
 
     // check whether a string is part of the know suffix list
     bool isSuffix(const std::string &possible_suffix) const;

--- a/include/extractor/suffix_table.hpp
+++ b/include/extractor/suffix_table.hpp
@@ -9,7 +9,7 @@ namespace osrm
 namespace extractor
 {
 
-struct ScriptingContext;
+class ScriptingEnvironment;
 
 // A table containing suffixes.
 // At the moment, it is only a front for an unordered set. At some point we might want to make it
@@ -17,7 +17,7 @@ struct ScriptingContext;
 class SuffixTable final
 {
   public:
-    SuffixTable(ScriptingContext &scripting_context);
+    SuffixTable(ScriptingEnvironment &scripting_environment);
 
     // check whether a string is part of the know suffix list
     bool isSuffix(const std::string &possible_suffix) const;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "request": "^2.69.0",
     "xmlbuilder": "^4.2.1",
     "chalk": "^1.1.3",
+    "node-cmake": "^1.2.1",
+    "tape": "^4.6.0",
+    "commander": "^2.9.0",
     "polyline": "^0.2.0"
   },
   "bin": {

--- a/profiles/car.js
+++ b/profiles/car.js
@@ -1,0 +1,566 @@
+// Car profile
+var osrm = require('../lib/osrm-process');
+const mode = osrm.mode;
+
+let find_access_tag = require("./lib/access");
+let get_destination = require("./lib/destination");
+
+// Begin of globals
+const barrier_whitelist = { 'cattle_grid': true, 'border_control': true, 'checkpoint': true, 'toll_booth': true, 'sally_port': true, 'gate': true, 'lift_gate': true, 'no': true, 'entrance': true };
+const access_tag_whitelist = { 'yes': true, 'motorcar': true, 'motor_vehicle': true, 'vehicle': true, 'permissive': true, 'designated': true, 'destination': true };
+const access_tag_blacklist = { 'no': true, 'private': true, 'agricultural': true, 'forestry': true, 'emergency': true, 'psv': true, 'delivery': true };
+const access_tag_restricted = { 'destination': true, 'delivery': true };
+const access_tags_hierarchy = [ "motorcar", "motor_vehicle", "vehicle", "access" ];
+const service_tag_restricted = { 'parking_aisle': true };
+const restriction_exception_tags = [ "motorcar", "motor_vehicle", "vehicle" ];
+
+// A list of suffixes to suppress in name change instructions
+const suffix_list = [ "N", "NE", "E", "SE", "S", "SW", "W", "NW", "North", "South", "West", "East" ];
+
+const speed_profile = {
+  'motorway': 90,
+  'motorway_link': 45,
+  'trunk': 85,
+  'trunk_link': 40,
+  'primary': 65,
+  'primary_link': 30,
+  'secondary': 55,
+  'secondary_link': 25,
+  'tertiary': 40,
+  'tertiary_link': 20,
+  'unclassified': 25,
+  'residential': 25,
+  'living_street': 10,
+  'service': 15,
+//  'track': 5,
+  'ferry': 5,
+  'movable': 5,
+  'shuttle_train': 10,
+  'default': 10
+};
+
+
+// surface/trackype/smoothness
+// values were estimated from looking at the photos at the relevant wiki pages
+
+// max speed for surfaces
+const surface_speeds = {
+  'asphalt': undefined,    // undefined mean no limit. removing the line has the same effect
+  'concrete': undefined,
+  'concrete:plates': undefined,
+  'concrete:lanes': undefined,
+  'paved': undefined,
+
+  'cement': 80,
+  'compacted': 80,
+  'fine_gravel': 80,
+
+  'paving_stones': 60,
+  'metal': 60,
+  'bricks': 60,
+
+  'grass': 40,
+  'wood': 40,
+  'sett': 40,
+  'grass_paver': 40,
+  'gravel': 40,
+  'unpaved': 40,
+  'ground': 40,
+  'dirt': 40,
+  'pebblestone': 40,
+  'tartan': 40,
+
+  'cobblestone': 30,
+  'clay': 30,
+
+  'earth': 20,
+  'stone': 20,
+  'rocky': 20,
+  'sand': 20,
+
+  'mud': 10
+};
+
+// max speed for tracktypes
+const tracktype_speeds = {
+  'grade1': 60,
+  'grade2': 40,
+  'grade3': 30,
+  'grade4': 25,
+  'grade5': 20
+};
+
+// max speed for smoothnesses
+const smoothness_speeds = {
+  'intermediate': 80,
+  'bad': 40,
+  'very_bad': 20,
+  'horrible': 10,
+  'very_horrible': 5,
+  'impassable': 0
+};
+
+// http://wiki.openstreetmap.org/wiki/Speed_limits
+const maxspeed_table_default = {
+  'urban': 50,
+  'rural': 90,
+  'trunk': 110,
+  'motorway': 130
+};
+
+// List only exceptions
+const maxspeed_table = {
+  'ch:rural': 80,
+  'ch:trunk': 100,
+  'ch:motorway': 120,
+  'de:living_street': 7,
+  'ru:living_street': 20,
+  'ru:urban': 60,
+  'ua:urban': 60,
+  'at:rural': 100,
+  'de:rural': 100,
+  'at:trunk': 100,
+  'cz:trunk': 0,
+  'ro:trunk': 100,
+  'cz:motorway': 0,
+  'de:motorway': 0,
+  'ru:motorway': 110,
+  'gb:nsl_single': (60*1609)/1000,
+  'gb:nsl_dual': (70*1609)/1000,
+  'gb:motorway': (70*1609)/1000,
+  'uk:nsl_single': (60*1609)/1000,
+  'uk:nsl_dual': (70*1609)/1000,
+  'uk:motorway': (70*1609)/1000,
+  'none': 140
+};
+
+// set profile properties
+exports.uTurnPenalty                  = 20;
+exports.trafficSignalPenalty          = 2;
+exports.useTurnRestrictions           = true;
+exports.continueStraightAtWaypoint    = true;
+
+const side_road_speed_multiplier = 0.8;
+
+const turn_penalty               = 10;
+// 'note': this biases right-side driving.  Should be
+// inverted for left-driving countries.
+const turn_bias                  = 1.2;
+
+const obey_oneway                = true;
+const ignore_areas               = true;
+
+const speed_reduction = 0.8;
+
+exports.getNameSuffixList = function() {
+  return suffix_list;
+};
+
+exports.getExceptions = function() {
+  return restriction_exception_tags;
+};
+
+// returns forward,backward psv lane count
+function getPSVCounts(way) {
+    const psv = way.tag("lanes:psv")
+    const psv_forward = way.tag("lanes:psv:forward");
+    const psv_backward = way.tag("lanes:psv:backward");
+
+    let fw = 0;
+    let bw = 0;
+    if (psv) {
+        fw = parseFloat(psv)
+        if (isNaN(fw)) {
+            fw = 0;
+        }
+    }
+    if (psv_forward) {
+        fw = parseFloat(psv_forward);
+        if (isNaN(fw)) {
+            fw = 0;
+        }
+    }
+    if (psv_backward) {
+        bw = parseFloat(psv_backward);
+        if (isNaN(bw)) {
+            bw = 0;
+        }
+    }
+    return [fw, bw];
+}
+
+// this is broken for left-sided driving. It needs to switch left && right in case of left-sided driving
+function getTurnLanes(way) {
+    let [fw_psv, bw_psv] = getPSVCounts(way);
+
+    let turn_lanes = way.tag("turn:lanes");
+    let turn_lanes_fw = way.tag("turn:lanes:forward");
+    let turn_lanes_bw = way.tag("turn:lanes:backward");
+
+    if (fw_psv || bw_psv) {
+        if (turn_lanes) {
+            turn_lanes = osrm.trimLaneString(turn_lanes, bw_psv, fw_psv);
+        }
+        if (turn_lanes_fw) {
+            turn_lanes_fw = osrm.trimLaneString(turn_lanes_fw, bw_psv, fw_psv);
+        }
+        // backwards turn lanes need to treat bw_psv as fw_psv && vice versa
+        if (turn_lanes_bw) {
+          turn_lanes_bw = osrm.trimLaneString(turn_lanes_bw, fw_psv, bw_psv);
+        }
+    }
+
+    return [turn_lanes, turn_lanes_fw, turn_lanes_bw];
+}
+
+function parse_maxspeed(source) {
+  if (!source) {
+    return 0;
+  }
+  let n = getInteger(source);
+  if (typeof n !== 'undefined') {
+    if (source.indexOf('mph') >= 0 || source.indexOf('mp/h') >= 0) {
+      n = (n*1609)/1000;
+    }
+  } else {
+    // parse maxspeed like FR:urban
+    source = source.toLowerCase();
+    n = maxspeed_table[source]
+    if (typeof n === 'undefined') {
+      let highway_type = source.substr(3);
+      n = maxspeed_table_default[highway_type];
+      if (typeof n === 'undefined') {
+        n = 0;
+      }
+    }
+  }
+  return n;
+}
+
+exports.processNode = function(node, result) {
+  // parse access && barrier tags
+  const access = find_access_tag(node, access_tags_hierarchy);
+  if (access) {
+    if (access_tag_blacklist[access]) {
+      result.barrier = true;
+    }
+  } else {
+    const barrier = node.tag("barrier");
+    if (barrier) {
+      //  make an exception for rising bollard barriers
+      const bollard = node.tag("bollard");
+      const rising_bollard = (bollard === "rising");
+
+      if (!rising_bollard && !barrier_whitelist[barrier]) {
+        result.barrier = true;
+      }
+    }
+  }
+
+  // check if node is a traffic light
+  const tag = node.tag("highway");
+  if (tag === "traffic_signals") {
+    result.trafficLights = true
+  }
+};
+
+function getInteger(str, def) {
+    var match = str.match(/\d+/);
+    if (match) {
+      return parseInt(match[0]);
+    } else {
+      return def;
+    }
+}
+
+exports.processWay = function(way, result) {
+  let highway = way.tag("highway");
+  const route = way.tag("route");
+  const bridge = way.tag("bridge");
+
+  if (!(highway || route || bridge)) {
+    return;
+  }
+
+  // we dont route over areas
+  if (ignore_areas && way.tag("area") === "yes") {
+    return;
+  }
+
+  // check if oneway tag is unsupported
+  const oneway = way.tag("oneway");
+  if (oneway === "reversible") {
+    return;
+  }
+
+  if (way.tag("impassable") === "yes") {
+    return;
+  }
+
+  if (way.tag("status") === "impassable") {
+    return;
+  }
+
+  // Check if we are allowed to access the way
+  const access = find_access_tag(way, access_tags_hierarchy);
+  if (access_tag_blacklist[access]) {
+    return;
+  }
+
+  result.forwardMode = mode.driving;
+  result.backwardMode = mode.driving;
+
+  // handling ferries && piers
+  const route_speed = speed_profile[route];
+  if (route_speed > 0) {
+    highway = route;
+    const duration = way.tag("duration");
+    if (duration && osrm.durationIsValid(duration)) {
+      result.duration = Math.max(osrm.parseDuration(duration), 1);
+    }
+    result.forwardMode = mode.ferry;
+    result.backwardMode = mode.ferry;
+    result.forwardSpeed = route_speed;
+    result.backwardSpeed = route_speed;
+  }
+
+  // handling movable bridges
+  const bridge_speed = speed_profile[bridge];
+  const capacity_car = way.tag("capacity:car")
+  if (bridge_speed > 0 && capacity_car) {
+    highway = bridge;
+    const duration = way.tag("duration")
+    if (duration && durationIsValid(duration)) {
+      result.duration = Math.max(osrm.parseDuration(duration), 1);
+    }
+    result.forwardSpeed = bridge_speed;
+    result.backwardSpeed = bridge_speed;
+  }
+
+  // leave early of this way is !accessible
+  if (highway === '') {
+    return;
+  }
+
+  if (result.forwardSpeed == -1) {
+    const highway_speed = speed_profile[highway];
+    let max_speed = parse_maxspeed(way.tag("maxspeed"));
+    // Set the avg speed on the way if it is accessible by road class
+    if (highway_speed) {
+      if (max_speed > highway_speed) {
+        result.forwardSpeed = max_speed;
+        result.backwardSpeed = max_speed;
+        // max_speed = Infinity;
+      } else {
+        result.forwardSpeed = highway_speed;
+        result.backwardSpeed = highway_speed;
+      }
+    } else {
+      // Set the avg speed on ways that are marked accessible
+      if (access_tag_whitelist[access]) {
+        result.forwardSpeed = speed_profile["default"];
+        result.backwardSpeed = speed_profile["default"];
+      }
+    }
+    if (max_speed == 0) {
+      max_speed = Infinity;
+    }
+    result.forwardSpeed = Math.min(result.forwardSpeed, max_speed);
+    result.backwardSpeed = Math.min(result.backwardSpeed, max_speed);
+  }
+
+  if (result.forwardSpeed == -1 && result.backwardSpeed == -1) {
+    return;
+  }
+
+  // reduce speed on special side roads
+  const sideway = way.tag("side_road");
+  if (sideway === "yes" || sideway === "rotary") {
+    result.forwardSpeed = result.forwardSpeed * side_road_speed_multiplier;
+    result.backwardSpeed = result.backwardSpeed * side_road_speed_multiplier;
+  }
+
+  // reduce speed on bad surfaces
+  const surface = way.tag("surface");
+  const tracktype = way.tag("tracktype");
+  const smoothness = way.tag("smoothness");
+
+  if (surface && surface_speeds[surface]) {
+    result.forwardSpeed = Math.min(surface_speeds[surface], result.forwardSpeed);
+    result.backwardSpeed = Math.min(surface_speeds[surface], result.backwardSpeed);
+  }
+  if (tracktype && tracktype_speeds[tracktype]) {
+    result.forwardSpeed = Math.min(tracktype_speeds[tracktype], result.forwardSpeed);
+    result.backwardSpeed = Math.min(tracktype_speeds[tracktype], result.backwardSpeed);
+  }
+  if (smoothness && smoothness_speeds[smoothness]) {
+    result.forwardSpeed = Math.min(smoothness_speeds[smoothness], result.forwardSpeed);
+    result.backwardSpeed = Math.min(smoothness_speeds[smoothness], result.backwardSpeed);
+  }
+
+  // parse the remaining tags
+  const name = way.tag("name");
+  const pronunciation = way.tag("name:pronunciation");
+  const ref = way.tag("ref");
+  const junction = way.tag("junction");
+  // const barrier = way.tag("barrier", "")
+  // const cycleway = way.tag("cycleway", "")
+  const service = way.tag("service");
+
+  // Set the name that will be used for instructions
+  let has_ref = ref && ref != "";
+  let has_name = name && name != "";
+  let has_pronunciation = pronunciation && pronunciation != "";
+
+  if (has_name && has_ref) {
+    result.name = name + " (" + ref + ")"
+  } else if (has_ref) {
+    result.name = ref
+  } else if (has_name) {
+    result.name = name
+  }
+
+  if (has_pronunciation) {
+    result.pronunciation = pronunciation
+  }
+
+  let turn_lanes = ""
+  let turn_lanes_forward = ""
+  let turn_lanes_backward = ""
+
+  turn_lanes, turn_lanes_forward, turn_lanes_backward = getTurnLanes(way)
+  if (turn_lanes && turn_lanes != "") {
+    result.turnLanesForward = turn_lanes;
+    result.turnLanesBackward = turn_lanes;
+  } else {
+    if (turn_lanes_forward && turn_lanes_forward != "") {
+        result.turnLanesForward = turn_lanes_forward;
+    }
+
+    if (turn_lanes_backward && turn_lanes_backward != "") {
+        result.turnLanesBackward = turn_lanes_backward;
+    }
+  }
+
+
+  if (junction && junction === "roundabout") {
+    result.roundabout = true
+  }
+
+  // Set access restriction flag if access is allowed under certain restrictions only
+  if (access != "" && access_tag_restricted[access]) {
+    result.isAccessRestriction = true
+  }
+
+  // Set access restriction flag if service is allowed under certain restrictions only
+  if (service && service != "" && service_tag_restricted[service]) {
+    result.isAccessRestriction = true
+  }
+
+  // Set direction according to tags on way
+  if (obey_oneway) {
+    if (oneway === "-1") {
+      result.forwardMode = mode.inaccessible;
+    } else if (oneway === "yes" ||
+               oneway === "1" ||
+               oneway === "true" ||
+               junction === "roundabout" ||
+               (highway === "motorway" && oneway != "no")) {
+      result.backwardMode = mode.inaccessible;
+
+      // If we're on a oneway && there is no ref tag, re-use destination tag as ref.
+      let destination = get_destination(way);
+      let has_destination = destination != "";
+
+      if (has_destination && has_name && !has_ref) {
+        result.name = name + " (" + destination + ")";
+      }
+
+      result.destinations = destination;
+    }
+  }
+
+  // Override speed settings if explicit forward/backward maxspeeds are given
+  let maxspeed_forward = parse_maxspeed(way.tag("maxspeed:forward"));
+  let maxspeed_backward = parse_maxspeed(way.tag("maxspeed:backward"));
+  if (maxspeed_forward && maxspeed_forward > 0) {
+    if (mode.inaccessible != result.forwardMode && mode.inaccessible != result.backwardMode) {
+      result.backwardSpeed = result.forwardSpeed;
+    }
+    result.forwardSpeed = maxspeed_forward;
+  }
+  if (maxspeed_backward && maxspeed_backward > 0) {
+    result.backwardSpeed = maxspeed_backward;
+  }
+
+  // Override speed settings if advisory forward/backward maxspeeds are given
+  let advisory_speed = parse_maxspeed(way.tag("maxspeed:advisory"));
+  let advisory_forward = parse_maxspeed(way.tag("maxspeed:advisory:forward"));
+  let advisory_backward = parse_maxspeed(way.tag("maxspeed:advisory:backward"));
+  // apply bi-directional advisory speed first
+  if (advisory_speed && advisory_speed > 0) {
+    if (mode.inaccessible != result.forwardMode) {
+      result.forwardSpeed = advisory_speed;
+    }
+    if (mode.inaccessible != result.backwardMode) {
+      result.backwardSpeed = advisory_speed;
+    }
+  }
+  if (advisory_forward && advisory_forward > 0) {
+    if (mode.inaccessible != result.forwardMode && mode.inaccessible != result.backwardMode) {
+      result.backwardSpeed = result.forwardSpeed;
+    }
+    result.forwardSpeed = advisory_forward;
+  }
+  if (advisory_backward && advisory_backward > 0) {
+    result.backwardSpeed = advisory_backward;
+  }
+
+  let width = Infinity;
+  let lanes = Infinity;
+  if (result.forwardSpeed > 0 || result.backwardSpeed > 0) {
+    const width_string = way.tag("width")
+    if (width_string) {
+      width = getInteger(width_string, width);
+    }
+
+    const lanes_string = way.tag("lanes")
+    if (lanes_string) {
+      lanes = getInteger(lanes_string, lanes);
+    }
+  }
+
+  let is_bidirectional = result.forwardMode != mode.inaccessible && result.backwardMode != mode.inaccessible;
+
+  // scale speeds to get better avg driving times
+  if (result.forwardSpeed > 0) {
+    let scaled_speed = result.forwardSpeed * speed_reduction + 11;
+    let penalized_speed = Infinity;
+    if (width <= 3 || (lanes <= 1 && is_bidirectional)) {
+      penalized_speed = result.forwardSpeed / 2;
+    }
+    result.forwardSpeed = Math.min(penalized_speed, scaled_speed);
+  }
+
+  if (result.backwardSpeed > 0) {
+    let scaled_speed = result.backwardSpeed * speed_reduction + 11;
+    let penalized_speed = Infinity;
+    if (width <= 3 || (lanes <= 1 && is_bidirectional)) {
+      penalized_speed = result.backwardSpeed / 2;
+    }
+    result.backwardSpeed = Math.min(penalized_speed, scaled_speed);
+  }
+
+  // only allow this road as start point if it !a ferry
+  result.isStartpoint = result.forwardMode == mode.driving || result.backwardMode == mode.driving;
+};
+
+exports.getTurnPenalty = function(angle) {
+  //-- compute turn penalty as angle^2, with a left/right bias
+  k = turn_penalty/(90.0*90.0);
+  if (angle>=0) {
+    return angle*angle*k/turn_bias;
+  } else {
+    return angle*angle*k*turn_bias;
+  }
+};

--- a/profiles/lib/access.js
+++ b/profiles/lib/access.js
@@ -1,0 +1,9 @@
+module.exports = function(source, access_tags_hierarchy) {
+    for (let v of access_tags_hierarchy) {
+        const tag = source.tag(v);
+        if (tag) {
+            return tag;
+        }
+    }
+    return '';
+};

--- a/profiles/lib/destination.js
+++ b/profiles/lib/destination.js
@@ -1,0 +1,23 @@
+module.exports = function(way) {
+  const destination = way.tag("destination");
+  const destination_ref = way.tag("destination:ref");
+
+  // Assemble destination as: "A59: Düsseldorf, Köln"
+  //          destination:ref  ^    ^  destination
+
+  let rv = "";
+
+  if (destination_ref) {
+    rv = destination_ref.replace(/;/g, ', ');
+  }
+
+  if (destination) {
+      if (rv) {
+          rv += ": "
+      }
+
+      rv += destination.replace(/;/g, ', ');
+  }
+
+  return rv;
+};

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -7,7 +7,6 @@
 #include "util/exception.hpp"
 #include "util/fingerprint.hpp"
 #include "util/io.hpp"
-#include "util/lua_util.hpp"
 #include "util/simple_logger.hpp"
 #include "util/timing_util.hpp"
 
@@ -16,8 +15,6 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/ref.hpp>
-
-#include <luabind/luabind.hpp>
 
 #include <stxxl/sort>
 
@@ -69,11 +66,11 @@ ExtractionContainers::ExtractionContainers()
  * - merge edges with nodes to include location of start/end points and serialize
  *
  */
-void ExtractionContainers::PrepareData(const std::string &output_file_name,
+void ExtractionContainers::PrepareData(ScriptingContext &scripting_context,
+                                       const std::string &output_file_name,
                                        const std::string &restrictions_file_name,
                                        const std::string &name_file_name,
-                                       const std::string &turn_lane_file_name,
-                                       lua_State *segment_state)
+                                       const std::string &turn_lane_file_name)
 {
     try
     {
@@ -84,7 +81,7 @@ void ExtractionContainers::PrepareData(const std::string &output_file_name,
 
         PrepareNodes();
         WriteNodes(file_out_stream);
-        PrepareEdges(segment_state);
+        PrepareEdges(scripting_context);
         WriteEdges(file_out_stream);
 
         PrepareRestrictions();
@@ -233,7 +230,7 @@ void ExtractionContainers::PrepareNodes()
     std::cout << "ok, after " << TIMER_SEC(id_map) << "s" << std::endl;
 }
 
-void ExtractionContainers::PrepareEdges(lua_State *segment_state)
+void ExtractionContainers::PrepareEdges(ScriptingContext &scripting_context)
 {
     // Sort edges by start.
     std::cout << "[extractor] Sorting edges by start    ... " << std::flush;
@@ -315,8 +312,6 @@ void ExtractionContainers::PrepareEdges(lua_State *segment_state)
     const auto all_edges_list_end_ = all_edges_list.end();
     const auto all_nodes_list_end_ = all_nodes_list.end();
 
-    const auto has_segment_function = util::luaFunctionExists(segment_state, "segment_function");
-
     while (edge_iterator != all_edges_list_end_ && node_iterator != all_nodes_list_end_)
     {
         // skip all invalid edges
@@ -352,15 +347,8 @@ void ExtractionContainers::PrepareEdges(lua_State *segment_state)
             edge_iterator->source_coordinate,
             util::Coordinate(node_iterator->lon, node_iterator->lat));
 
-        if (has_segment_function)
-        {
-            luabind::call_function<void>(segment_state,
-                                         "segment_function",
-                                         boost::cref(edge_iterator->source_coordinate),
-                                         boost::cref(*node_iterator),
-                                         distance,
-                                         boost::ref(edge_iterator->weight_data));
-        }
+        scripting_context.processSegment(
+            edge_iterator->source_coordinate, *node_iterator, distance, edge_iterator->weight_data);
 
         const double weight = [distance](const InternalExtractorEdge::WeightData &data) {
             switch (data.type)

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -66,7 +66,7 @@ ExtractionContainers::ExtractionContainers()
  * - merge edges with nodes to include location of start/end points and serialize
  *
  */
-void ExtractionContainers::PrepareData(ScriptingContext &scripting_context,
+void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environment,
                                        const std::string &output_file_name,
                                        const std::string &restrictions_file_name,
                                        const std::string &name_file_name,
@@ -81,7 +81,7 @@ void ExtractionContainers::PrepareData(ScriptingContext &scripting_context,
 
         PrepareNodes();
         WriteNodes(file_out_stream);
-        PrepareEdges(scripting_context);
+        PrepareEdges(scripting_environment);
         WriteEdges(file_out_stream);
 
         PrepareRestrictions();
@@ -230,7 +230,7 @@ void ExtractionContainers::PrepareNodes()
     std::cout << "ok, after " << TIMER_SEC(id_map) << "s" << std::endl;
 }
 
-void ExtractionContainers::PrepareEdges(ScriptingContext &scripting_context)
+void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environment)
 {
     // Sort edges by start.
     std::cout << "[extractor] Sorting edges by start    ... " << std::flush;
@@ -347,7 +347,7 @@ void ExtractionContainers::PrepareEdges(ScriptingContext &scripting_context)
             edge_iterator->source_coordinate,
             util::Coordinate(node_iterator->lon, node_iterator->lat));
 
-        scripting_context.processSegment(
+        scripting_environment.ProcessSegment(
             edge_iterator->source_coordinate, *node_iterator, distance, edge_iterator->weight_data);
 
         const double weight = [distance](const InternalExtractorEdge::WeightData &data) {

--- a/src/extractor/restriction_parser.cpp
+++ b/src/extractor/restriction_parser.cpp
@@ -4,6 +4,8 @@
 
 #include "extractor/external_memory_node.hpp"
 
+#include "util/simple_logger.hpp"
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/regex.hpp>
@@ -22,12 +24,26 @@ namespace osrm
 namespace extractor
 {
 
-RestrictionParser::RestrictionParser(ScriptingContext &scripting_context)
-    : use_turn_restrictions(scripting_context.properties.use_turn_restrictions)
+RestrictionParser::RestrictionParser(ScriptingEnvironment &scripting_environment)
+    : use_turn_restrictions(scripting_environment.GetProfileProperties().use_turn_restrictions)
 {
     if (use_turn_restrictions)
     {
-        restriction_exceptions = scripting_context.getExceptions();
+        restriction_exceptions = scripting_environment.GetExceptions();
+        const unsigned exception_count = restriction_exceptions.size();
+        if (exception_count)
+        {
+            util::SimpleLogger().Write() << "Found " << exception_count
+                                         << " exceptions to turn restrictions:";
+            for (const std::string &str : restriction_exceptions)
+            {
+                util::SimpleLogger().Write() << "  " << str;
+            }
+        }
+        else
+        {
+            util::SimpleLogger().Write() << "Found no exceptions to turn restrictions";
+        }
     }
 }
 

--- a/src/extractor/suffix_table.cpp
+++ b/src/extractor/suffix_table.cpp
@@ -1,41 +1,15 @@
 #include "extractor/suffix_table.hpp"
 
-#include "util/lua_util.hpp"
-#include "util/simple_logger.hpp"
-
-#include <boost/algorithm/string.hpp>
-#include <boost/assert.hpp>
-#include <boost/ref.hpp>
-
-#include <iterator>
-#include <vector>
+#include "extractor/scripting_environment.hpp"
 
 namespace osrm
 {
 namespace extractor
 {
 
-SuffixTable::SuffixTable(lua_State *lua_state)
+SuffixTable::SuffixTable(ScriptingContext &scripting_context)
+    : suffix_set(scripting_context.getNameSuffixList())
 {
-    BOOST_ASSERT(lua_state != nullptr);
-    if (!util::luaFunctionExists(lua_state, "get_name_suffix_list"))
-        return;
-
-    std::vector<std::string> suffixes_vector;
-    try
-    {
-        // call lua profile to compute turn penalty
-        luabind::call_function<void>(
-            lua_state, "get_name_suffix_list", boost::ref(suffixes_vector));
-    }
-    catch (const luabind::error &er)
-    {
-        util::SimpleLogger().Write(logWARNING) << er.what();
-    }
-
-    for (auto &suffix : suffixes_vector)
-        boost::algorithm::to_lower(suffix);
-    suffix_set.insert(std::begin(suffixes_vector), std::end(suffixes_vector));
 }
 
 bool SuffixTable::isSuffix(const std::string &possible_suffix) const

--- a/src/extractor/suffix_table.cpp
+++ b/src/extractor/suffix_table.cpp
@@ -7,8 +7,8 @@ namespace osrm
 namespace extractor
 {
 
-SuffixTable::SuffixTable(ScriptingContext &scripting_context)
-    : suffix_set(scripting_context.getNameSuffixList())
+SuffixTable::SuffixTable(ScriptingEnvironment &scripting_environment)
+    : suffix_set(scripting_environment.GetNameSuffixList())
 {
 }
 

--- a/src/node/process.cpp
+++ b/src/node/process.cpp
@@ -1,0 +1,851 @@
+#include <nan.h>
+
+#include "extractor/extraction_helper_functions.hpp"
+#include "extractor/extraction_node.hpp"
+#include "extractor/extraction_way.hpp"
+#include "extractor/extractor.hpp"
+#include "extractor/extractor_config.hpp"
+#include "extractor/restriction_parser.hpp"
+#include "extractor/scripting_environment_lua.hpp"
+#include "extractor/travel_mode.hpp"
+
+#include "util/simple_logger.hpp"
+
+#include <osmium/osm.hpp>
+
+#include <variant/variant.hpp>
+
+#include <tbb/task_scheduler_init.h>
+
+#include <future>
+
+namespace
+{
+
+std::string toString(Nan::MaybeLocal<v8::Value> value, const std::string &def = {})
+{
+    if (value.IsEmpty() || value.ToLocalChecked()->IsUndefined())
+    {
+        return def;
+    }
+    else
+    {
+        v8::String::Utf8Value utfValue(value.ToLocalChecked()->ToString());
+        return {*utfValue, static_cast<size_t>(utfValue.length())};
+    }
+}
+
+std::string
+toString(Nan::NAN_METHOD_ARGS_TYPE info, const size_t index, const std::string &def = {})
+{
+    if (info.Length() < (index + 1) || info[index]->IsUndefined())
+    {
+        return def;
+    }
+    else
+    {
+        v8::String::Utf8Value utfValue(info[index]->ToString());
+        return std::string{*utfValue, static_cast<size_t>(utfValue.length())};
+    }
+}
+
+double toNumber(Nan::MaybeLocal<v8::Value> value, double def = 0)
+{
+    if (value.IsEmpty() || value.ToLocalChecked()->IsUndefined())
+    {
+        return def;
+    }
+    else
+    {
+        return value.ToLocalChecked()->ToNumber()->Value();
+    }
+}
+
+int32_t toInteger(Nan::NAN_METHOD_ARGS_TYPE info, const size_t index, const int32_t def = 0)
+{
+    if (info.Length() < (index + 1) || info[index]->IsUndefined())
+    {
+        return def;
+    }
+    else
+    {
+        return info[index]->ToInt32()->Value();
+    }
+}
+
+bool toBoolean(Nan::MaybeLocal<v8::Value> value, bool def = 0)
+{
+    if (value.IsEmpty() || value.ToLocalChecked()->IsUndefined())
+    {
+        return def;
+    }
+    else
+    {
+        return value.ToLocalChecked()->ToBoolean()->Value();
+    }
+}
+}
+
+namespace osrm
+{
+namespace node
+{
+
+Nan::Persistent<v8::Function> osmiumNode;
+Nan::Persistent<v8::Function> osmiumWay;
+Nan::Persistent<v8::Function> extractionNode;
+Nan::Persistent<v8::Function> extractionWay;
+
+class ExtractWorker final : public Nan::AsyncWorker, public extractor::ScriptingEnvironment
+{
+  public:
+    ExtractWorker(Nan::Callback *callback, v8::Local<v8::Object> profile)
+        : Nan::AsyncWorker(callback)
+    {
+        async = new uv_async_t();
+        uv_async_init(uv_default_loop(), async, Get);
+        async->data = this;
+
+        // ProfileProperties
+        properties.SetTrafficSignalPenalty(
+            toNumber(Nan::Get(profile, Nan::New("trafficSignalPenalty").ToLocalChecked()),
+                     properties.GetTrafficSignalPenalty()));
+        properties.SetUturnPenalty(
+            toNumber(Nan::Get(profile, Nan::New("uTurnPenalty").ToLocalChecked()),
+                     properties.GetUturnPenalty()));
+        properties.continue_straight_at_waypoint =
+            toBoolean(Nan::Get(profile, Nan::New("continueStraightAtWaypoint").ToLocalChecked()),
+                      properties.continue_straight_at_waypoint);
+        properties.use_turn_restrictions =
+            toBoolean(Nan::Get(profile, Nan::New("useTurnRestrictions").ToLocalChecked()),
+                      properties.use_turn_restrictions);
+
+        // Retain the profile.
+        persistentHandle.Reset(profile);
+    }
+    ~ExtractWorker() override
+    {
+        uv_close(reinterpret_cast<uv_handle_t *>(async),
+                 [](uv_handle_t *handle) { delete reinterpret_cast<uv_async_t *>(handle); });
+    }
+
+    // Executed inside the worker-thread.
+    void Execute() override
+    {
+        util::LogPolicy::GetInstance().Unmute();
+        if (config.profile_path.empty())
+        {
+            util::SimpleLogger().Write() << "Using JavaScript profile";
+            extractor::Extractor(std::move(config)).run(*this);
+        }
+        else
+        {
+            extractor::LuaScriptingEnvironment scripting_environment(
+                config.profile_path.string().c_str());
+            extractor::Extractor(std::move(config)).run(scripting_environment);
+        }
+    }
+
+    // Executed when the async work is complete
+    void HandleOKCallback() override
+    {
+        Nan::HandleScope scope;
+
+        if (!callback->IsEmpty())
+        {
+            constexpr const int argc = 1;
+            v8::Local<v8::Value> argv[argc] = {Nan::Null()};
+            callback->Call(argc, argv);
+        }
+    }
+
+    extractor::ProfileProperties properties;
+    extractor::ExtractorConfig config;
+
+  private:
+    const extractor::ProfileProperties &GetProfileProperties() override;
+
+    struct SetupSourcesParameters
+    {
+    };
+    void SetupSources(SetupSourcesParameters &);
+    void SetupSources() override;
+
+    struct GetNameSuffixListParameters
+    {
+        std::unordered_set<std::string> result;
+    };
+    void GetNameSuffixList(GetNameSuffixListParameters &);
+    std::unordered_set<std::string> GetNameSuffixList() override;
+
+    struct GetExceptionsParameters
+    {
+        std::vector<std::string> result;
+    };
+    void GetExceptions(GetExceptionsParameters &);
+    std::vector<std::string> GetExceptions() override;
+
+    struct ProcessElementsParameters
+    {
+        const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements;
+        const extractor::RestrictionParser &restriction_parser;
+        tbb::concurrent_vector<std::pair<std::size_t, extractor::ExtractionNode>> &resulting_nodes;
+        tbb::concurrent_vector<std::pair<std::size_t, extractor::ExtractionWay>> &resulting_ways;
+        tbb::concurrent_vector<boost::optional<extractor::InputRestrictionContainer>>
+            &resulting_restrictions;
+    };
+    void ProcessElements(ProcessElementsParameters &);
+    void ProcessElements(
+        const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
+        const extractor::RestrictionParser &restriction_parser,
+        tbb::concurrent_vector<std::pair<std::size_t, extractor::ExtractionNode>> &resulting_nodes,
+        tbb::concurrent_vector<std::pair<std::size_t, extractor::ExtractionWay>> &resulting_ways,
+        tbb::concurrent_vector<boost::optional<extractor::InputRestrictionContainer>>
+            &resulting_restrictions) override;
+
+    struct ProcessTurnPenaltiesParameters
+    {
+        std::vector<float> &angles;
+    };
+    void ProcessTurnPenalties(ProcessTurnPenaltiesParameters &);
+    void ProcessTurnPenalties(std::vector<float> &angles) override;
+
+    using ParameterType = mapbox::util::variant<SetupSourcesParameters,
+                                                GetNameSuffixListParameters,
+                                                GetExceptionsParameters,
+                                                ProcessElementsParameters,
+                                                ProcessTurnPenaltiesParameters>;
+    ParameterType parameters;
+    std::promise<void> result;
+    uv_async_t *async = nullptr;
+    static NAUV_WORK_CB(Get);
+
+    void ProcessSegment(const osrm::util::Coordinate &source,
+                        const osrm::util::Coordinate &target,
+                        double distance,
+                        extractor::InternalExtractorEdge::WeightData &weight) override;
+};
+
+const extractor::ProfileProperties &ExtractWorker::GetProfileProperties() { return properties; }
+
+NAUV_WORK_CB(ExtractWorker::Get)
+{
+    Nan::HandleScope scope;
+    auto worker = static_cast<ExtractWorker *>(async->data);
+
+    if (worker->parameters.is<ProcessElementsParameters>())
+    {
+        worker->ProcessElements(worker->parameters.get<ProcessElementsParameters>());
+    }
+    else if (worker->parameters.is<ProcessTurnPenaltiesParameters>())
+    {
+        worker->ProcessTurnPenalties(worker->parameters.get<ProcessTurnPenaltiesParameters>());
+    }
+    else if (worker->parameters.is<SetupSourcesParameters>())
+    {
+        worker->SetupSources(worker->parameters.get<SetupSourcesParameters>());
+    }
+    else if (worker->parameters.is<GetNameSuffixListParameters>())
+    {
+        worker->GetNameSuffixList(worker->parameters.get<GetNameSuffixListParameters>());
+    }
+    else if (worker->parameters.is<GetExceptionsParameters>())
+    {
+        worker->GetExceptions(worker->parameters.get<GetExceptionsParameters>());
+    }
+}
+
+void ExtractWorker::SetupSources()
+{
+    parameters = SetupSourcesParameters{};
+    result = {};
+    uv_async_send(async);
+    result.get_future().get();
+}
+
+void ExtractWorker::SetupSources(SetupSourcesParameters &)
+{
+    v8::Local<v8::Value> callback = GetFromPersistent("setupSources");
+    if (callback->IsFunction())
+    {
+        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback.As<v8::Function>(), 0, {});
+    }
+
+    result.set_value();
+}
+
+std::unordered_set<std::string> ExtractWorker::GetNameSuffixList()
+{
+    parameters = GetNameSuffixListParameters{};
+    result = {};
+    uv_async_send(async);
+    result.get_future().get();
+    return parameters.get<GetNameSuffixListParameters>().result;
+}
+
+void ExtractWorker::GetNameSuffixList(GetNameSuffixListParameters &params)
+{
+    v8::Local<v8::Value> callback = GetFromPersistent("getNameSuffixList");
+    if (callback->IsFunction())
+    {
+        auto retval = Nan::MakeCallback(
+            Nan::GetCurrentContext()->Global(), callback.As<v8::Function>(), 0, {});
+
+        if (retval->IsArray())
+        {
+            auto array = retval.As<v8::Array>();
+            for (uint32_t i = 0; i < array->Length(); i++)
+            {
+                auto value = Nan::Get(array, i);
+                if (!value.IsEmpty() && !value.ToLocalChecked()->IsUndefined())
+                {
+                    v8::String::Utf8Value utfValue(value.ToLocalChecked()->ToString());
+                    std::string suffix{*utfValue, static_cast<size_t>(utfValue.length())};
+                    boost::algorithm::to_lower(suffix);
+                    params.result.emplace(std::move(suffix));
+                }
+            }
+        }
+    }
+
+    result.set_value();
+}
+
+std::vector<std::string> ExtractWorker::GetExceptions()
+{
+    parameters = GetExceptionsParameters{};
+    result = {};
+    uv_async_send(async);
+    result.get_future().get();
+    return parameters.get<GetExceptionsParameters>().result;
+}
+
+void ExtractWorker::GetExceptions(GetExceptionsParameters &params)
+{
+    v8::Local<v8::Value> callback = GetFromPersistent("getExceptions");
+    if (callback->IsFunction())
+    {
+        auto retval = Nan::MakeCallback(
+            Nan::GetCurrentContext()->Global(), callback.As<v8::Function>(), 0, {});
+
+        if (retval->IsArray())
+        {
+            auto array = retval.As<v8::Array>();
+            for (uint32_t i = 0; i < array->Length(); i++)
+            {
+                auto value = Nan::Get(array, i);
+                if (!value.IsEmpty() && !value.ToLocalChecked()->IsUndefined())
+                {
+                    v8::String::Utf8Value utfValue(value.ToLocalChecked()->ToString());
+                    params.result.emplace_back(*utfValue, static_cast<size_t>(utfValue.length()));
+                }
+            }
+        }
+    }
+
+    result.set_value();
+}
+
+void ExtractWorker::ProcessElements(
+    const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
+    const extractor::RestrictionParser &restriction_parser,
+    tbb::concurrent_vector<std::pair<std::size_t, extractor::ExtractionNode>> &resulting_nodes,
+    tbb::concurrent_vector<std::pair<std::size_t, extractor::ExtractionWay>> &resulting_ways,
+    tbb::concurrent_vector<boost::optional<extractor::InputRestrictionContainer>>
+        &resulting_restrictions)
+{
+    parameters = ProcessElementsParameters{
+        osm_elements, restriction_parser, resulting_nodes, resulting_ways, resulting_restrictions,
+    };
+    result = {};
+    uv_async_send(async);
+    result.get_future().get();
+}
+
+void ExtractWorker::ProcessElements(ProcessElementsParameters &params)
+{
+    v8::Local<v8::Value> processNode = GetFromPersistent("processNode");
+    const bool hasProcessNode = processNode->IsFunction();
+    v8::Local<v8::Value> processWay = GetFromPersistent("processWay");
+    const bool hasProcessWay = processWay->IsFunction();
+
+    extractor::ExtractionNode result_node;
+    extractor::ExtractionWay result_way;
+
+    v8::Local<v8::Function> nodeConstructor = Nan::New(osmiumNode);
+    v8::Local<v8::Function> extractionNodeConstructor = Nan::New(extractionNode);
+    v8::Local<v8::Object> resultNode = extractionNodeConstructor->NewInstance();
+    resultNode->SetInternalField(0, v8::External::New(v8::Isolate::GetCurrent(), &result_node));
+
+    v8::Local<v8::Function> wayConstructor = Nan::New(osmiumWay);
+    v8::Local<v8::Function> extractionWayConstructor = Nan::New(extractionWay);
+    v8::Local<v8::Object> resultWay = extractionWayConstructor->NewInstance();
+    resultWay->SetInternalField(0, v8::External::New(v8::Isolate::GetCurrent(), &result_way));
+
+    std::size_t x = 0;
+    for (auto it = params.osm_elements.begin(), end = params.osm_elements.end(); it != end;
+         ++it, ++x)
+    {
+        Nan::HandleScope scope;
+        const auto entity = *it;
+
+        switch (entity->type())
+        {
+        case osmium::item_type::node:
+            result_node.clear();
+
+            if (hasProcessNode)
+            {
+                v8::Local<v8::Object> node = nodeConstructor->NewInstance();
+                node->SetInternalField(
+                    0,
+                    v8::External::New(v8::Isolate::GetCurrent(),
+                                      &const_cast<osmium::OSMEntity &>(*entity)));
+                constexpr const int argc = 2;
+                v8::Local<v8::Value> argv[argc] = {node, resultNode};
+                Nan::MakeCallback(
+                    Nan::GetCurrentContext()->Global(), processNode.As<v8::Function>(), argc, argv);
+            }
+
+            params.resulting_nodes.push_back(std::make_pair(x, std::move(result_node)));
+            break;
+        case osmium::item_type::way:
+            result_way.clear();
+
+            if (hasProcessWay)
+            {
+                v8::Local<v8::Object> way = wayConstructor->NewInstance();
+                way->SetInternalField(0,
+                                      v8::External::New(v8::Isolate::GetCurrent(),
+                                                        &const_cast<osmium::OSMEntity &>(*entity)));
+                constexpr const int argc = 2;
+                v8::Local<v8::Value> argv[argc] = {way, resultWay};
+                Nan::MakeCallback(
+                    Nan::GetCurrentContext()->Global(), processWay.As<v8::Function>(), argc, argv);
+            }
+
+            params.resulting_ways.push_back(std::make_pair(x, std::move(result_way)));
+            break;
+        case osmium::item_type::relation:
+            params.resulting_restrictions.push_back(
+                params.restriction_parser.TryParse(static_cast<const osmium::Relation &>(*entity)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    result.set_value();
+}
+
+void ExtractWorker::ProcessTurnPenalties(std::vector<float> &angles)
+{
+    parameters = ProcessTurnPenaltiesParameters{angles};
+    result = {};
+    uv_async_send(async);
+    result.get_future().get();
+}
+
+void ExtractWorker::ProcessTurnPenalties(ProcessTurnPenaltiesParameters &params)
+{
+    v8::Local<v8::Value> ProcessTurnPenalties = GetFromPersistent("getTurnPenalty");
+    if (ProcessTurnPenalties->IsFunction())
+    {
+        for (auto &angle : params.angles)
+        {
+            constexpr const int argc = 1;
+            v8::Local<v8::Value> argv[argc] = {Nan::New(angle)};
+            auto retval = Nan::MakeCallback(Nan::GetCurrentContext()->Global(),
+                                            ProcessTurnPenalties.As<v8::Function>(),
+                                            argc,
+                                            argv);
+            angle = retval->ToNumber()->Value();
+        }
+    }
+    result.set_value();
+}
+
+void ExtractWorker::ProcessSegment(const osrm::util::Coordinate &source,
+                                   const osrm::util::Coordinate &target,
+                                   double distance,
+                                   extractor::InternalExtractorEdge::WeightData &weight)
+{
+    // TODO
+    (void)source;
+    (void)target;
+    (void)distance;
+    (void)weight;
+}
+
+NAN_METHOD(Extract)
+{
+    Nan::HandleScope scope;
+
+    if (info.Length() < 1 || !info[0]->IsObject())
+    {
+        Nan::ThrowTypeError("first argument must be a configuration object");
+        return;
+    }
+    if (info.Length() < 2 || !info[1]->IsObject())
+    {
+        Nan::ThrowTypeError("second argument must be a profile object");
+        return;
+    }
+
+    v8::Local<v8::Object> config = info[0].As<v8::Object>();
+    v8::Local<v8::Object> profile = info[1].As<v8::Object>();
+
+    auto callback = std::make_unique<Nan::Callback>(info[2].As<v8::Function>());
+    auto worker = std::make_unique<ExtractWorker>(callback.release(), profile);
+
+    // ExtractorConfig
+    worker->config.profile_path =
+        toString(Nan::Get(config, Nan::New("profilePath").ToLocalChecked()));
+    worker->config.input_path = toString(Nan::Get(config, Nan::New("inputPath").ToLocalChecked()));
+    worker->config.requested_num_threads =
+        toNumber(Nan::Get(config, Nan::New("numThreads").ToLocalChecked()));
+    worker->config.small_component_size =
+        toNumber(Nan::Get(config, Nan::New("smallComponentSize").ToLocalChecked()), 1000);
+    worker->config.generate_edge_lookup =
+        toBoolean(Nan::Get(config, Nan::New("generateEdgeLookup").ToLocalChecked()), false);
+
+    if (worker->config.input_path.empty())
+    {
+        Nan::ThrowTypeError("inputPath is missing from configuration object");
+        return;
+    }
+
+    // TODO: Make configurable/overrideable
+    worker->config.UseDefaultOutputNames();
+
+    if (worker->config.requested_num_threads <= 0)
+    {
+        worker->config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
+    }
+
+    Nan::AsyncQueueWorker(worker.release());
+}
+
+NAN_METHOD(DurationIsValid)
+{
+    Nan::HandleScope scope;
+    info.GetReturnValue().Set(extractor::durationIsValid(toString(info, 0)));
+}
+
+NAN_METHOD(ParseDuration)
+{
+    Nan::HandleScope scope;
+    info.GetReturnValue().Set(extractor::parseDuration(toString(info, 0)));
+}
+
+NAN_METHOD(TrimLaneString)
+{
+    Nan::HandleScope scope;
+    info.GetReturnValue().Set(
+        Nan::New(
+            extractor::trimLaneString(toString(info, 0), toInteger(info, 1), toInteger(info, 2)))
+            .ToLocalChecked());
+}
+
+template <typename T> class WrapClass
+{
+  public:
+    WrapClass(const char *name)
+    {
+        tpl = Nan::New<v8::FunctionTemplate>();
+        tpl->SetClassName(Nan::New(name).ToLocalChecked());
+        itpl = tpl->InstanceTemplate();
+        itpl->SetInternalFieldCount(1);
+    }
+
+    void method(const char *name, Nan::FunctionCallback cb)
+    {
+        Nan::SetPrototypeMethod(tpl, name, cb);
+    }
+
+    void property(const char *name, Nan::GetterCallback getter)
+    {
+        Nan::SetAccessor(itpl,
+                         Nan::New(name).ToLocalChecked(),
+                         getter,
+                         0,
+                         v8::Local<v8::Value>(),
+                         v8::AccessControl::DEFAULT,
+                         static_cast<v8::PropertyAttribute>(v8::PropertyAttribute::ReadOnly |
+                                                            v8::PropertyAttribute::DontDelete));
+    }
+
+    void property(const char *name, Nan::GetterCallback getter, Nan::SetterCallback setter)
+    {
+        Nan::SetAccessor(itpl,
+                         Nan::New(name).ToLocalChecked(),
+                         getter,
+                         setter,
+                         v8::Local<v8::Value>(),
+                         v8::AccessControl::DEFAULT,
+                         static_cast<v8::PropertyAttribute>(v8::PropertyAttribute::DontDelete));
+    }
+
+    template <typename U> static T &Unwrap(const U &info)
+    {
+        v8::Local<v8::Object> self = info.Holder();
+        v8::Local<v8::External> wrap = v8::Local<v8::External>::Cast(self->GetInternalField(0));
+        return *static_cast<T *>(wrap->Value());
+    }
+
+    v8::Local<v8::Function> get() { return tpl->GetFunction(); }
+
+  private:
+    v8::Local<v8::FunctionTemplate> tpl;
+    v8::Local<v8::ObjectTemplate> itpl;
+};
+
+void freeze(v8::Local<v8::Value> obj)
+{
+    v8::Local<v8::Object> global = Nan::GetCurrentContext()->Global();
+    v8::Local<v8::Object> object =
+        Nan::Get(global, Nan::New("Object").ToLocalChecked()).ToLocalChecked().As<v8::Object>();
+    v8::Local<v8::Value> freeze =
+        Nan::Get(object, Nan::New("freeze").ToLocalChecked()).ToLocalChecked();
+    Nan::MakeCallback(global, freeze.As<v8::Function>(), 1, &obj);
+}
+
+NAN_MODULE_INIT(Initialize)
+{
+    Nan::Export(target, "extract", Extract);
+    Nan::Export(target, "durationIsValid", DurationIsValid);
+    Nan::Export(target, "parseDuration", ParseDuration);
+    Nan::Export(target, "trimLaneString", TrimLaneString);
+
+    v8::Local<v8::Object> mode = Nan::New<v8::Object>();
+    Nan::Set(mode, Nan::New("inaccessible").ToLocalChecked(), Nan::New(TRAVEL_MODE_INACCESSIBLE));
+    Nan::Set(mode, Nan::New("driving").ToLocalChecked(), Nan::New(TRAVEL_MODE_DRIVING));
+    Nan::Set(mode, Nan::New("cycling").ToLocalChecked(), Nan::New(TRAVEL_MODE_CYCLING));
+    Nan::Set(mode, Nan::New("walking").ToLocalChecked(), Nan::New(TRAVEL_MODE_WALKING));
+    Nan::Set(mode, Nan::New("ferry").ToLocalChecked(), Nan::New(TRAVEL_MODE_FERRY));
+    Nan::Set(mode, Nan::New("train").ToLocalChecked(), Nan::New(TRAVEL_MODE_TRAIN));
+    Nan::Set(mode, Nan::New("pushingBike").ToLocalChecked(), Nan::New(TRAVEL_MODE_PUSHING_BIKE));
+    Nan::Set(mode, Nan::New("stepsUp").ToLocalChecked(), Nan::New(TRAVEL_MODE_STEPS_UP));
+    Nan::Set(mode, Nan::New("stepsDown").ToLocalChecked(), Nan::New(TRAVEL_MODE_STEPS_DOWN));
+    Nan::Set(mode, Nan::New("riverUp").ToLocalChecked(), Nan::New(TRAVEL_MODE_RIVER_UP));
+    Nan::Set(mode, Nan::New("riverDown").ToLocalChecked(), Nan::New(TRAVEL_MODE_RIVER_DOWN));
+    Nan::Set(mode, Nan::New("route").ToLocalChecked(), Nan::New(TRAVEL_MODE_ROUTE));
+    freeze(mode);
+    Nan::Set(target, Nan::New<v8::String>("mode").ToLocalChecked(), mode);
+
+    {
+        using Class = WrapClass<const osmium::Node>;
+        Class node("Node");
+
+        node.method("tag", [](const auto &info) {
+            if (info.Length() < 1)
+            {
+                Nan::ThrowTypeError("first argument must be a tag name");
+                return;
+            }
+
+            v8::String::Utf8Value utfValue(info[0]->ToString());
+            auto value = Class::Unwrap(info).get_value_by_key(*utfValue);
+            if (value)
+            {
+                info.GetReturnValue().Set(Nan::New(value).ToLocalChecked());
+            }
+        });
+
+        node.property("id", [](auto, const auto &info) {
+            info.GetReturnValue().Set(static_cast<double>(Class::Unwrap(info).id()));
+        });
+
+        node.property("lat", [](auto, const auto &info) {
+            info.GetReturnValue().Set(static_cast<double>(Class::Unwrap(info).location().lat()));
+        });
+
+        node.property("lon", [](auto, const auto &info) {
+            info.GetReturnValue().Set(static_cast<double>(Class::Unwrap(info).location().lon()));
+        });
+
+        osmiumNode.Reset(node.get());
+    }
+
+    {
+        using Class = WrapClass<const osmium::Way>;
+        Class way("Way");
+
+        way.method("tag", [](const auto &info) {
+            if (info.Length() < 1)
+            {
+                Nan::ThrowTypeError("first argument must be a tag name");
+                return;
+            }
+
+            const v8::String::Utf8Value utfValue(info[0]->ToString());
+            auto value = Class::Unwrap(info).get_value_by_key(*utfValue);
+            if (value)
+            {
+                info.GetReturnValue().Set(Nan::New(value).ToLocalChecked());
+            }
+        });
+
+        way.property("id", [](auto, const auto &info) {
+            info.GetReturnValue().Set(static_cast<double>(Class::Unwrap(info).id()));
+        });
+
+        // TODO: get_nodes_for_way
+
+        osmiumWay.Reset(way.get());
+    }
+
+    {
+        using Class = WrapClass<extractor::ExtractionNode>;
+        Class node("ResultNode");
+
+        node.property("trafficLights",
+                      [](auto, const auto &info) {
+                          info.GetReturnValue().Set(Class::Unwrap(info).traffic_lights);
+                      },
+                      [](auto, auto value, const auto &info) {
+                          Class::Unwrap(info).traffic_lights = value->ToBoolean()->Value();
+                      });
+
+        node.property(
+            "barrier",
+            [](auto, const auto &info) { info.GetReturnValue().Set(Class::Unwrap(info).barrier); },
+            [](auto, auto value, const auto &info) {
+                Class::Unwrap(info).barrier = value->ToBoolean()->Value();
+            });
+
+        extractionNode.Reset(node.get());
+    }
+
+    {
+        using Class = WrapClass<extractor::ExtractionWay>;
+        Class way("ResultWay");
+
+        way.property("forwardSpeed",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(Class::Unwrap(info).forward_speed);
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).forward_speed = value->ToNumber()->Value();
+                     });
+
+        way.property("backwardSpeed",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(Class::Unwrap(info).backward_speed);
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).backward_speed = value->ToNumber()->Value();
+                     });
+
+        way.property(
+            "duration",
+            [](auto, const auto &info) { info.GetReturnValue().Set(Class::Unwrap(info).duration); },
+            [](auto, auto value, const auto &info) {
+                Class::Unwrap(info).duration = value->ToNumber()->Value();
+            });
+
+        way.property(
+            "name",
+            [](auto, const auto &info) {
+                info.GetReturnValue().Set(Nan::New(Class::Unwrap(info).name).ToLocalChecked());
+            },
+            [](auto, auto value, const auto &info) {
+                const v8::String::Utf8Value utfValue(value->ToString());
+                Class::Unwrap(info).name = {*utfValue, static_cast<size_t>(utfValue.length())};
+            });
+
+        way.property("pronunciation",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(
+                             Nan::New(Class::Unwrap(info).pronunciation).ToLocalChecked());
+                     },
+                     [](auto, auto value, const auto &info) {
+                         const v8::String::Utf8Value utfValue(value->ToString());
+                         Class::Unwrap(info).pronunciation = {
+                             *utfValue, static_cast<size_t>(utfValue.length())};
+                     });
+
+        way.property("destinations",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(
+                             Nan::New(Class::Unwrap(info).destinations).ToLocalChecked());
+                     },
+                     [](auto, auto value, const auto &info) {
+                         const v8::String::Utf8Value utfValue(value->ToString());
+                         Class::Unwrap(info).destinations = {
+                             *utfValue, static_cast<size_t>(utfValue.length())};
+                     });
+
+        way.property("turnLanesForward",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(
+                             Nan::New(Class::Unwrap(info).turn_lanes_forward).ToLocalChecked());
+                     },
+                     [](auto, auto value, const auto &info) {
+                         const v8::String::Utf8Value utfValue(value->ToString());
+                         Class::Unwrap(info).turn_lanes_forward = {
+                             *utfValue, static_cast<size_t>(utfValue.length())};
+                     });
+
+        way.property("turnLanesBackward",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(
+                             Nan::New(Class::Unwrap(info).turn_lanes_backward).ToLocalChecked());
+                     },
+                     [](auto, auto value, const auto &info) {
+                         const v8::String::Utf8Value utfValue(value->ToString());
+                         Class::Unwrap(info).turn_lanes_backward = {
+                             *utfValue, static_cast<size_t>(utfValue.length())};
+                     });
+
+        way.property("roundabout",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(Class::Unwrap(info).roundabout);
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).roundabout = value->ToBoolean()->Value();
+                     });
+
+        way.property("isAccessRestricted",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(Class::Unwrap(info).is_access_restricted);
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).is_access_restricted = value->ToBoolean()->Value();
+                     });
+
+        way.property("isStartpoint",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(Class::Unwrap(info).is_startpoint);
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).is_startpoint = value->ToBoolean()->Value();
+                     });
+
+        way.property("forwardMode",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(
+                             static_cast<uint32_t>(Class::Unwrap(info).forward_travel_mode));
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).forward_travel_mode =
+                             static_cast<extractor::TravelMode>(value->ToUint32()->Value());
+                     });
+
+        way.property("backwardMode",
+                     [](auto, const auto &info) {
+                         info.GetReturnValue().Set(
+                             static_cast<uint32_t>(Class::Unwrap(info).backward_travel_mode));
+                     },
+                     [](auto, auto value, const auto &info) {
+                         Class::Unwrap(info).backward_travel_mode =
+                             static_cast<extractor::TravelMode>(value->ToUint32()->Value());
+                     });
+
+        extractionWay.Reset(way.get());
+    }
+}
+}
+}
+
+NODE_MODULE(osrm_process, osrm::node::Initialize)

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -1,5 +1,6 @@
 #include "extractor/extractor.hpp"
 #include "extractor/extractor_config.hpp"
+#include "extractor/scripting_environment_lua.hpp"
 #include "util/simple_logger.hpp"
 #include "util/version.hpp"
 
@@ -147,7 +148,11 @@ int main(int argc, char *argv[]) try
             << "Profile " << extractor_config.profile_path.string() << " not found!";
         return EXIT_FAILURE;
     }
-    return extractor::Extractor(extractor_config).run();
+
+    // setup scripting environment
+    extractor::LuaScriptingEnvironment scripting_environment(
+        extractor_config.profile_path.string().c_str());
+    return extractor::Extractor(extractor_config).run(scripting_environment);
 }
 catch (const std::bad_alloc &e)
 {

--- a/test/node.js
+++ b/test/node.js
@@ -1,0 +1,105 @@
+var test = require('tape');
+var osrm = require('../lib/osrm-process');
+
+test("extract: fails without configuration object", function(assert) {
+    assert.plan(6);
+    assert.throws(function() {
+        osrm.extract();
+    }, /first argument must be a configuration object/, "throws without parameter");
+    assert.throws(function() {
+        osrm.extract(4);
+    }, /first argument must be a configuration object/, "throws with number parameter");
+    assert.throws(function() {
+        osrm.extract("test");
+    }, /first argument must be a configuration object/, "throws with string parameter");
+    assert.throws(function() {
+        osrm.extract(null);
+    }, /first argument must be a configuration object/, "throws with null parameter");
+    assert.throws(function() {
+        osrm.extract(undefined);
+    }, /first argument must be a configuration object/, "throws with undefined parameter");
+    assert.throws(function() {
+        osrm.extract({}, {});
+    }, /inputPath is missing from configuration object/, "throws with missing input path");
+});
+
+test("mode: enum values", function(assert) {
+    assert.plan(12);
+    assert.equals(0, osrm.mode.inaccessible);
+    assert.equals(1, osrm.mode.driving);
+    assert.equals(2, osrm.mode.cycling);
+    assert.equals(3, osrm.mode.walking);
+    assert.equals(4, osrm.mode.ferry);
+    assert.equals(5, osrm.mode.train);
+    assert.equals(6, osrm.mode.pushingBike);
+    assert.equals(8, osrm.mode.stepsUp);
+    assert.equals(9, osrm.mode.stepsDown);
+    assert.equals(10, osrm.mode.riverUp);
+    assert.equals(11, osrm.mode.riverDown);
+    assert.equals(12, osrm.mode.route);
+});
+
+test("helper: durationIsValid", function(assert) {
+    assert.plan(16);
+
+    assert.equals(true, osrm.durationIsValid("0"));
+    assert.equals(true, osrm.durationIsValid("00:01"));
+    assert.equals(true, osrm.durationIsValid("00:01:01"));
+    assert.equals(true, osrm.durationIsValid("61"));
+    assert.equals(true, osrm.durationIsValid("24:01"));
+    assert.equals(true, osrm.durationIsValid("00:01:60"));
+    assert.equals(true, osrm.durationIsValid("PT15M"));
+
+    assert.equals(false, osrm.durationIsValid(""));
+    assert.equals(false, osrm.durationIsValid("PT15"));
+    assert.equals(false, osrm.durationIsValid("PT15A"));
+    assert.equals(false, osrm.durationIsValid("PT1H25:01"));
+    assert.equals(false, osrm.durationIsValid("PT12501"));
+    assert.equals(false, osrm.durationIsValid("PT0125:01"));
+    assert.equals(false, osrm.durationIsValid("PT016001"));
+    assert.equals(false, osrm.durationIsValid("PT240000"));
+    assert.equals(false, osrm.durationIsValid("PT24:00:00"));
+});
+
+test("helper: parseDuration", function(assert) {
+    assert.plan(24);
+
+    assert.equals(0, osrm.parseDuration("00"));
+    assert.equals(600, osrm.parseDuration("10"));
+    assert.equals(60, osrm.parseDuration("00:01"));
+    assert.equals(61, osrm.parseDuration("00:01:01"));
+    assert.equals(3660, osrm.parseDuration("01:01"));
+
+    // check all combinations of iso duration tokens
+    assert.equals(61, osrm.parseDuration("PT1M1S"));
+    assert.equals(3601, osrm.parseDuration("PT1H1S"));
+    assert.equals(900, osrm.parseDuration("PT15M"));
+    assert.equals(15, osrm.parseDuration("PT15S"));
+    assert.equals(54000, osrm.parseDuration("PT15H"));
+    assert.equals(4500, osrm.parseDuration("PT1H15M"));
+    assert.equals(4501, osrm.parseDuration("PT1H15M1S"));
+    assert.equals(8706, osrm.parseDuration("PT2H25M6S"));
+    assert.equals(94501, osrm.parseDuration("P1DT2H15M1S"));
+    assert.equals(345600, osrm.parseDuration("P4D"));
+    assert.equals(14400, osrm.parseDuration("PT4H"));
+    assert.equals(4260, osrm.parseDuration("PT71M"));
+    assert.equals(8706, osrm.parseDuration("PT022506"));
+    assert.equals(8706, osrm.parseDuration("PT02:25:06"));
+    assert.equals(1814400, osrm.parseDuration("P3W"));
+
+    assert.equals(900, osrm.parseDuration("PT15m"));
+    assert.equals(4500, osrm.parseDuration("PT1h15m"));
+    assert.equals(4542, osrm.parseDuration("PT1h15m42s"));
+    assert.equals(177342, osrm.parseDuration("P2dT1h15m42s"));
+});
+
+var profile = require('./profile.js');
+
+test("extract: use JS profile", function(assert) {
+    osrm.extract({
+        inputPath: "berlin-latest.osm.pbf"
+    }, require('./profile.js'), function(err) {
+        assert.ok(!err, "no error returned");
+        assert.end();
+    });
+});

--- a/test/profile.js
+++ b/test/profile.js
@@ -1,0 +1,107 @@
+var osrm = require('../lib/osrm-process');
+const mode = osrm.mode;
+
+// Testbot profile
+
+// Moves at fixed, well-known speeds, practical for testing speed and travel
+// times:
+
+// Primary road:  36km/h = 36000m/3600s = 100m/10s
+// Secondary road:  18km/h = 18000m/3600s = 100m/20s
+// Tertiary road:  12km/h = 12000m/3600s = 100m/30s
+
+const speedProfile = {
+  primary: 36,
+  secondary: 18,
+  tertiary: 12,
+  steps: 6,
+  default: 24
+};
+
+
+// these settings are read directly by osrm
+
+exports.continueStraightAtWaypoint = true;
+exports.useTurnRestrictions = true;
+exports.trafficSignalPenalty = 7; // seconds
+exports.uTurnPenalty = 20;
+
+exports.processNode = function(node, result) {
+  const trafficSignal = node.tag('highway');
+
+  if (trafficSignal === 'traffic_signals') {
+    result.trafficLights = true;
+    // TODO: a way to set the penalty value
+  }
+};
+
+exports.processWay = function(way, result) {
+  const highway = way.tag('highway');
+  const name = way.tag('name');
+  const oneway = way.tag('oneway');
+  const route = way.tag('route');
+  const duration = way.tag('duration');
+  const maxspeed = +(way.tag('maxspeed') || 0);
+  const maxspeedForward = +(way.tag('maxspeed:forward') || 0);
+  const maxspeedBackward = +(way.tag('maxspeed:backward') || 0);
+  const junction = way.tag('junction');
+
+  if (name) {
+    result.name = name;
+  }
+
+  result.forwardMode = mode.driving;
+  result.backwardMode = mode.driving;
+
+  if (osrm.durationIsValid(duration)) {
+    result.duration = Math.max(1, osrm.parseDuration(duration));
+    result.forwardMode = mode.route;
+    result.backwardMode = mode.route;
+  }
+  else {
+    var speedForw = speedProfile[highway] || speedProfile.default;
+    var speedBack = speedForw;
+
+    if (highway === 'river') {
+      var tempSpeed = speedForw;
+      result.forwardMode = mode.riverDown;
+      result.backwardMode = mode.riverUp;
+      speedForw = tempSpeed * 1.5;
+      speedBack = tempSpeed / 1.5;
+    }
+    else if (highway === 'steps') {
+      result.forwardMode = mode.stepsDown;
+      result.backwardMode = mode.stepsUp;
+    }
+
+    if ((typeof maxspeedForward !== 'undefined') && maxspeedForward > 0) {
+      speedForw = maxspeedForward;
+    } else if ((typeof maxspeed !== 'undefined') && maxspeed > 0 &&
+               speedForw > maxspeed) {
+      speedForw = maxspeed;
+    }
+
+    if ((typeof maxspeedBackward !== 'undefined') && maxspeedBackward > 0) {
+      speedBack = maxspeedBackward;
+    } else if ((typeof maxspeed !== 'undefined') && maxspeed > 0 &&
+               speedBack > maxspeed) {
+      speedBack = maxspeed;
+    }
+
+    result.forwardSpeed = speedForw;
+    result.backwardSpeed = speedBack;
+  }
+
+  if (oneway === 'no' || oneway === '0' || oneway === 'false') {
+    // nothing to do
+  } else if (oneway === '-1') {
+    result.forwardMode = mode.inaccessible;
+  } else if (oneway === 'yes' || oneway === '1' || oneway === 'true' ||
+             junction === 'roundabout') {
+    result.backward_mode = mode.inaccessible;
+  }
+
+  if (junction === 'roundabout') {
+    result.roundabout = true;
+  }
+};


### PR DESCRIPTION
This pull requests adds support for using Node.js/JavaScript code for profiles, eliminating the need for Lua.

It works by creating a node.js C++ module that runs the extractor, and by passing in a scripting environment. The extractor is run in a thread pool thread, and whenever any profile functions are invoked, we are dispatching to the main thread to run the assigned JS function. The C++ structures `ExtractionNode/Way` and the Osmium structures are bound to JS objects and passed as parameters.

There are a few caveats:
- Callbacks must run synchronously; there's currently no way to asynchronously process a way, node or turn penalty. This means you can't use any sort of async I/O functions, such as file operations and in particular network connections.
- JavaScript uses `camelCase` names for result properties instead of the `under_score` naming style; make sure you change the names when porting Lua profiles
- The `car.js` profile I ported takes around 28 seconds on my example OSM extract, whereas the Lua version takes only 9 seconds.
- JavaScript callbacks are only run on the main thread since Node.js is single-threaded. Lua profiles are run in their respective thread, so they run in parallel.
- Changes CMake requirement to 3.1 because it is required for `node-cmake`.
- The Node module code is a monolithic file and needs cleanup and splitting up into multiple files.

To try out the JavaScript version, run `make osrm-process`, and run `bin/osrm-extract -p profiles/car.js inputfile`

cc @daniel-j-h @TheMarex 