### PR TITLE
[ready] compress use lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 5.3.0
   Changes from 5.3.0-rc.3
+    - Guidance
+      - Only announce `use lane` on required turns (not using all lanes to go straight)
     - Bugfixes
       - Fix BREAKING: bug that could result in failure to load 'osrm.icd' files. This breaks the dataformat
 
@@ -8,7 +10,6 @@
     - Guidance
       - Improved detection of obvious turns
       - Improved turn lane detection
-      - Improved lane anticipation for roundabouts
     - Bugfixes
       - Fix bug that didn't chose minimal weights on overlapping edges
 

--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -135,9 +135,9 @@ Feature: Turn Lane Guidance
             | cj    |                    | 1     | motorway_link | yes    | xbcj |
 
        When I route I should get
-            | waypoints | route             | turns                                             | lanes                           |
-            | a,i       | ab,xbcj,ci,ci     | depart,merge slight left,turn slight right,arrive | ,,none:false slight right:true, |
-            | a,j       | ab,xbcj,xbcj,xbcj | depart,merge slight left,use lane straight,arrive | ,,none:true slight right:false, |
+            | waypoints | route         | turns                                             | lanes                           |
+            | a,i       | ab,xbcj,ci,ci | depart,merge slight left,turn slight right,arrive | ,,none:false slight right:true, |
+            | a,j       | ab,xbcj,xbcj  | depart,merge slight left,arrive                   | ,,                              |
 
 
     @anticipate

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -87,7 +87,6 @@ Feature: Turn Lane Guidance
 
 
     #this next test requires decision on how to announce lanes for going straight if there is no turn
-    @TODO
     Scenario: Turn with Bus-Lane
         Given the node map
             | a |   | b |   | c |
@@ -101,9 +100,9 @@ Feature: Turn Lane Guidance
             | bd    | turn |                    |                   |
 
         When I route I should get
-            | waypoints | route          | turns                           | lanes                       |
-            | a,d       | road,turn,turn | depart,turn right,arrive        | ,straight:false right:true, |
-            | a,c       | road,road,road | depart,use lane straight,arrive | ,straight:true right:false, |
+            | waypoints | route          | turns                    | lanes                       |
+            | a,d       | road,turn,turn | depart,turn right,arrive | ,straight:false right:true, |
+            | a,c       | road,road      | depart,arrive            | ,                           |
 
     @PROFILE @LANES
     Scenario: Turn with Bus-Lane but without lanes
@@ -194,13 +193,13 @@ Feature: Turn Lane Guidance
             | fl    | cross |                          | yes    |
 
         When I route I should get
-            | waypoints | route             | turns                           | lanes                                           |
-            | a,j       | road,cross,cross  | depart,turn right,arrive        | ,left:false straight:false right:true,          |
-            | k,d       | cross,road,road   | depart,turn right,arrive        | ,left:false straight;right:true,                |
-            | e,l       | road,cross,cross  | depart,turn right,arrive        | ,none:false straight:false straight;right:true, |
-            | i,h       | cross,road,road   | depart,turn right,arrive        | ,,                                              |
-            | i,j       | cross,cross,cross | depart,use lane straight,arrive | ,left:false straight:true,                      |
-            | i,l       | cross,cross,cross | depart,continue uturn,arrive    | ,left:true straight:false,                      |
+            | waypoints | route             | turns                        | lanes                                           |
+            | a,j       | road,cross,cross  | depart,turn right,arrive     | ,left:false straight:false right:true,          |
+            | k,d       | cross,road,road   | depart,turn right,arrive     | ,left:false straight;right:true,                |
+            | e,l       | road,cross,cross  | depart,turn right,arrive     | ,none:false straight:false straight;right:true, |
+            | i,h       | cross,road,road   | depart,turn right,arrive     | ,,                                              |
+            | i,j       | cross,cross       | depart,arrive                | ,                                               |
+            | i,l       | cross,cross,cross | depart,continue uturn,arrive | ,left:true straight:false,                      |
 
     Scenario: Turn Lanes at Segregated Road
         Given the node map
@@ -238,9 +237,9 @@ Feature: Turn Lane Guidance
             | ce    | turn |                    |
 
         When I route I should get
-            | waypoints | route          | turns                           | lanes                   |
-            | a,e       | road,turn,turn | depart,turn right,arrive        | ,none:false right:true, |
-            | a,d       | road,road,road | depart,use lane straight,arrive | ,none:true right:false, |
+            | waypoints | route          | turns                    | lanes                   |
+            | a,e       | road,turn,turn | depart,turn right,arrive | ,none:false right:true, |
+            | a,d       | road,road      | depart,arrive            | ,                       |
 
     Scenario: Turn Lanes Given earlier than actual turn
         Given the node map
@@ -258,11 +257,11 @@ Feature: Turn Lane Guidance
             | hk    | second-turn |                    |                     |
 
         When I route I should get
-            | waypoints | route                        | turns                           | lanes                   |
-            | a,k       | road,second-turn,second-turn | depart,turn right,arrive        | ,none:false right:true, |
-            | a,i       | road,road,road               | depart,use lane straight,arrive | ,none:true right:false, |
-            | i,j       | road,first-turn,first-turn   | depart,turn left,arrive         | ,left:true none:false,  |
-            | i,a       | road,road,road               | depart,use lane straight,arrive | ,left:false none:true,  |
+            | waypoints | route                        | turns                    | lanes                   |
+            | a,k       | road,second-turn,second-turn | depart,turn right,arrive | ,none:false right:true, |
+            | a,i       | road,road                    | depart,arrive            | ,                       |
+            | i,j       | road,first-turn,first-turn   | depart,turn left,arrive  | ,left:true none:false,  |
+            | i,a       | road,road                    | depart,arrive            | ,                       |
 
     Scenario: Passing a one-way street
         Given the node map
@@ -358,9 +357,9 @@ Feature: Turn Lane Guidance
             | ce    | turn |                    |
 
         When I route I should get
-            | waypoints | route          | turns                           | lanes                       |
-            | a,d       | road,road,road | depart,use lane straight,arrive | ,straight:true right:false, |
-            | a,e       | road,turn,turn | depart,turn right,arrive        | ,straight:false right:true, |
+            | waypoints | route          | turns                    | lanes                       |
+            | a,d       | road,road      | depart,arrive            | ,                           |
+            | a,e       | road,turn,turn | depart,turn right,arrive | ,straight:false right:true, |
 
     @bug @todo
     Scenario: Theodor Heuss Platz
@@ -422,9 +421,9 @@ Feature: Turn Lane Guidance
             | restriction | bc       | fdcg   | c        | no_right_turn |
 
         When I route I should get
-            | waypoints | route            | turns                           | lanes                                               |
-            | a,g       | road,cross,cross | depart,turn left,arrive         | ,left:true left:true straight:false straight:false, |
-            | a,e       | road,road,road   | depart,use lane straight,arrive | ,left:false left:false straight:true straight:true, |
+            | waypoints | route            | turns                   | lanes                                               |
+            | a,g       | road,cross,cross | depart,turn left,arrive | ,left:true left:true straight:false straight:false, |
+            | a,e       | road,road        | depart,arrive           | ,                                                   |
 
     Scenario: U-Turn Road at Intersection
         Given the node map
@@ -445,11 +444,11 @@ Feature: Turn Lane Guidance
             | gdeh  | cross |                    | no     | primary  |
 
        When I route I should get
-            | from | to | bearings        | route            | turns                           | lanes                                  |
-            | a    | g  | 180,180 180,180 | road,cross,cross | depart,turn right,arrive        | ,none:false straight:false right:true, |
-            | a    | h  | 180,180 180,180 | road,cross,cross | depart,turn left,arrive         | ,none:true straight:false right:false, |
-            | a    | i  | 180,180 180,180 | road,road,road   | depart,use lane straight,arrive | ,none:true straight:true right:false,  |
-            | b    | a  | 90,2 270,2      | road,road,road   | depart,continue uturn,arrive    | ,none:true straight:false right:false, |
+            | from | to | bearings        | route            | turns                        | lanes                                  |
+            | a    | g  | 180,180 180,180 | road,cross,cross | depart,turn right,arrive     | ,none:false straight:false right:true, |
+            | a    | h  | 180,180 180,180 | road,cross,cross | depart,turn left,arrive      | ,none:true straight:false right:false, |
+            | a    | i  | 180,180 180,180 | road,road        | depart,arrive                | ,                                      |
+            | b    | a  | 90,2 270,2      | road,road,road   | depart,continue uturn,arrive | ,none:true straight:false right:false, |
 
     Scenario: Segregated Intersection Merges With Lanes
         Given the node map
@@ -519,7 +518,7 @@ Feature: Turn Lane Guidance
 
         When I route I should get
             | waypoints | route            | turns                           | lanes                                                                        |
-            | a,d       | road,road,road   | depart,use lane straight,arrive | ,straight:true straight:true straight;slight right:true slight right:false,  |
+            | a,d       | road,road        | depart,arrive                   | ,                                                                            |
             | a,e       | road,cross,cross | depart,turn slight right,arrive | ,straight:false straight:false straight;slight right:true slight right:true, |
 
     Scenario: Highway Ramp
@@ -535,7 +534,7 @@ Feature: Turn Lane Guidance
 
         When I route I should get
             | waypoints | route         | turns                               | lanes                                                                        |
-            | a,d       | hwy,hwy,hwy   | depart,use lane straight,arrive     | ,straight:true straight:true straight;slight right:true slight right:false,  |
+            | a,d       | hwy,hwy       | depart,arrive                       | ,                                                                            |
             | a,e       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,straight:false straight:false straight;slight right:true slight right:true, |
 
     @bug @todo
@@ -575,7 +574,7 @@ Feature: Turn Lane Guidance
 
         When I route I should get
             | waypoints | route         | turns                               | lanes                                             |
-            | a,c       | hwy,hwy,hwy   | depart,use lane slight left,arrive  | ,straight:true straight:true slight right:false,  |
+            | a,c       | hwy,hwy       | depart,arrive                       | ,                                                 |
             | a,d       | hwy,ramp,ramp | depart,off ramp slight right,arrive | ,straight:false straight:false slight right:true, |
 
     Scenario: Reverse Lane in Segregated Road
@@ -681,9 +680,9 @@ Feature: Turn Lane Guidance
             | ab    | on   | motorway_link |                    |
 
         When I route I should get
-            | waypoints | route             | turns                                             | lanes                           |
-            | a,j       | on,xbcj,xbcj,xbcj | depart,merge slight left,use lane straight,arrive | ,,none:true slight right:false, |
-            | a,i       | on,xbcj,off,off   | depart,merge slight left,turn slight right,arrive | ,,none:false slight right:true, |
+            | waypoints | route           | turns                                             | lanes                           |
+            | a,j       | on,xbcj,xbcj    | depart,merge slight left,arrive                   | ,,                              |
+            | a,i       | on,xbcj,off,off | depart,merge slight left,turn slight right,arrive | ,,none:false slight right:true, |
 
     #http://www.openstreetmap.org/#map=17/52.47414/13.35712
     @todo @ramp @2645

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -151,6 +151,7 @@ class RouteAPI : public BaseAPI
                                                               phantoms.source_phantom,
                                                               phantoms.target_phantom);
                 leg.steps = guidance::anticipateLaneChange(std::move(leg.steps));
+                leg.steps = guidance::collapseUseLane(std::move(leg.steps));
                 leg_geometry = guidance::resyncGeometry(std::move(leg_geometry), leg.steps);
             }
 

--- a/include/engine/guidance/post_processing.hpp
+++ b/include/engine/guidance/post_processing.hpp
@@ -43,6 +43,15 @@ std::vector<RouteStep> buildIntersections(std::vector<RouteStep> steps);
 // remove steps invalidated by post-processing
 std::vector<RouteStep> removeNoTurnInstructions(std::vector<RouteStep> steps);
 
+// remove use lane information that is not actually a turn. For post-processing, we need to
+// associate lanes with every turn. Some of these use-lane instructions are not required after lane
+// anticipation anymore. This function removes all use lane instructions that are not actually used
+// anymore since all lanes going straight are used anyhow.
+// FIXME this is currently only a heuristic. We need knowledge on which lanes actually might become
+// turn lanes. If a straight lane becomes a turn lane, this might be something to consider. Right
+// now we bet on lane-anticipation to catch this.
+std::vector<RouteStep> collapseUseLane(std::vector<RouteStep> steps);
+
 // postProcess will break the connection between the leg geometry
 // for which a segment is supposed to represent exactly the coordinates
 // between routing maneuvers and the route steps itself.


### PR DESCRIPTION
Turning
<img width="1261" alt="screen shot 2016-07-18 at 11 24 21" src="https://cloud.githubusercontent.com/assets/12932279/16911193/68ffd5e6-4cdd-11e6-9687-916ff30daf09.png">

into
<img width="1257" alt="screen shot 2016-07-18 at 11 24 14" src="https://cloud.githubusercontent.com/assets/12932279/16911196/70b1330c-4cdd-11e6-9a2a-280407f254ec.png">

While keeping necessary lane announcements (restriction for use-lane straight needed for further tests: https://github.com/Project-OSRM/osrm-backend/pull/2642)