### PR TITLE
Fixes Undefined Behavior in LaneTupel (Strict Aliasing)

### DIFF
--- a/include/util/guidance/turn_lanes.hpp
+++ b/include/util/guidance/turn_lanes.hpp
@@ -60,7 +60,6 @@ class LaneTupel
 
     bool operator==(const LaneTupel other) const;
     bool operator!=(const LaneTupel other) const;
-    bool operator<(const LaneTupel other) const;
 
     LaneID lanes_in_turn;
     LaneID first_lane_from_the_right;

--- a/src/util/guidance/turn_lanes.cpp
+++ b/src/util/guidance/turn_lanes.cpp
@@ -31,13 +31,6 @@ bool LaneTupel::operator==(const LaneTupel other) const
 
 bool LaneTupel::operator!=(const LaneTupel other) const { return !(*this == other); }
 
-// comparation based on interpretation as unsigned 32bit integer
-bool LaneTupel::operator<(const LaneTupel other) const
-{
-    return std::tie(lanes_in_turn, first_lane_from_the_right) <
-           std::tie(other.lanes_in_turn, other.first_lane_from_the_right);
-}
-
 } // namespace guidance
 } // namespace util
 } // namespace osrm

--- a/src/util/guidance/turn_lanes.cpp
+++ b/src/util/guidance/turn_lanes.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <tuple>
 
 #include <boost/assert.hpp>
 
@@ -24,10 +25,8 @@ LaneTupel::LaneTupel(const LaneID lanes_in_turn, const LaneID first_lane_from_th
 // comparation based on interpretation as unsigned 32bit integer
 bool LaneTupel::operator==(const LaneTupel other) const
 {
-    static_assert(sizeof(LaneTupel) == sizeof(std::uint16_t),
-                  "Comparation requires LaneTupel to be the of size 16Bit");
-    return *reinterpret_cast<const std::uint16_t *>(this) ==
-           *reinterpret_cast<const std::uint16_t *>(&other);
+    return std::tie(lanes_in_turn, first_lane_from_the_right) ==
+           std::tie(other.lanes_in_turn, other.first_lane_from_the_right);
 }
 
 bool LaneTupel::operator!=(const LaneTupel other) const { return !(*this == other); }
@@ -35,10 +34,8 @@ bool LaneTupel::operator!=(const LaneTupel other) const { return !(*this == othe
 // comparation based on interpretation as unsigned 32bit integer
 bool LaneTupel::operator<(const LaneTupel other) const
 {
-    static_assert(sizeof(LaneTupel) == sizeof(std::uint16_t),
-                  "Comparation requires LaneTupel to be the of size 16Bit");
-    return *reinterpret_cast<const std::uint16_t *>(this) <
-           *reinterpret_cast<const std::uint16_t *>(&other);
+    return std::tie(lanes_in_turn, first_lane_from_the_right) <
+           std::tie(other.lanes_in_turn, other.first_lane_from_the_right);
 }
 
 } // namespace guidance


### PR DESCRIPTION
Here's the best explanation for the strict aliasing rules I could find. Please read it.
http://dbp-consulting.com/tutorials/StrictAliasing.html

tl;dr: has to go through a memcpy (in C++) as in:
https://github.com/WebAssembly/binaryen/blob/184cc11cee2a65d30c7696eb3284e132099e4acb/src/support/utilities.h#L29-L40

This changeset just compares attributes memberwise.