### PR TITLE
[ready] fix 2672

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.3.0
+  Changes from 5.3.0-rc.3
+    - Bugfixes
+      - Fix BREAKING: bug that could result in failure to load 'osrm.icd' files. This breaks the dataformat
+
 # 5.3.0 RC3
   Changes from 5.3.0-rc.2
     - Guidance

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -360,7 +360,7 @@ class InternalDataFacade final : public BaseDataFacade
             std::vector<util::guidance::BearingClass> bearing_classes;
             // and the actual bearing values
             std::uint64_t num_bearings;
-            intersection_stream >> num_bearings;
+            intersection_stream.read(reinterpret_cast<char*>(&num_bearings),sizeof(num_bearings));
             m_bearing_values_table.resize(num_bearings);
             intersection_stream.read(reinterpret_cast<char *>(&m_bearing_values_table[0]),
                                      sizeof(m_bearing_values_table[0]) * num_bearings);

--- a/include/util/guidance/entry_class.hpp
+++ b/include/util/guidance/entry_class.hpp
@@ -62,6 +62,13 @@ class EntryClass
     friend std::size_t std::hash<EntryClass>::operator()(const EntryClass &) const;
 };
 
+#if not defined __GNUC__ or __GNUC__ > 4
+static_assert(std::is_trivially_copyable<EntryClass>::value,
+              "Class is serialized trivially in "
+              "the datafacades. Bytewise writing "
+              "requires trivially copyable type");
+#endif
+
 } // namespace guidance
 } // namespace utilr
 } // namespace osrm

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -507,8 +507,8 @@ Extractor::BuildEdgeExpandedGraph(lua_State *lua_state,
 
     std::vector<std::uint32_t> turn_lane_offsets;
     std::vector<guidance::TurnLaneType::Mask> turn_lane_masks;
-    if( !util::deserializeAdjacencyArray(
-        config.turn_lane_descriptions_file_name, turn_lane_offsets, turn_lane_masks) )
+    if (!util::deserializeAdjacencyArray(
+            config.turn_lane_descriptions_file_name, turn_lane_offsets, turn_lane_masks))
     {
         util::SimpleLogger().Write(logWARNING) << "Reading Turn Lane Masks failed.";
     }
@@ -673,7 +673,7 @@ void Extractor::WriteIntersectionClassificationData(
     util::RangeTable<> bearing_class_range_table(bearing_counts);
     file_out_stream << bearing_class_range_table;
 
-    file_out_stream << total_bearings;
+    file_out_stream.write(reinterpret_cast<const char *>(&total_bearings), sizeof(total_bearings));
     for (const auto &bearing_class : bearing_classes)
     {
         const auto &bearings = bearing_class.getAvailableBearings();
@@ -681,17 +681,18 @@ void Extractor::WriteIntersectionClassificationData(
                               sizeof(bearings[0]) * bearings.size());
     }
 
-    // FIXME
-    // This should be here, but g++4.8 does not have it...
-    // static_assert(std::is_trivially_copyable<util::guidance::EntryClass>::value,
-    //              "EntryClass Serialization requires trivial copyable entry classes");
+    if (!static_cast<bool>(file_out_stream))
+    {
+        throw util::exception("Failed to write to " + output_file_name + ".");
+    }
 
     util::serializeVector(file_out_stream, entry_classes);
     TIMER_STOP(write_edges);
     util::SimpleLogger().Write() << "ok, after " << TIMER_SEC(write_edges) << "s for "
                                  << node_based_intersection_classes.size() << " Indices into "
                                  << bearing_classes.size() << " bearing classes and "
-                                 << entry_classes.size() << " entry classes";
+                                 << entry_classes.size() << " entry classes and " << total_bearings
+                                 << " bearing values." << std::endl;
 }
 }
 }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -375,7 +375,7 @@ int Storage::Run()
     }
 
     std::uint64_t num_bearings;
-    intersection_stream >> num_bearings;
+    intersection_stream.read(reinterpret_cast<char*>(&num_bearings),sizeof(num_bearings));
 
     std::vector<DiscreteBearing> bearing_class_table(num_bearings);
     intersection_stream.read(reinterpret_cast<char *>(&bearing_class_table[0]),


### PR DESCRIPTION
Even though the usage is the same for in/output, mixing streams and read/write seems to have bad interactions. Works for the overloaded table operator but apparently it messes up parsing the number of bearings for Taiwan.

This PR fixes the issue https://github.com/Project-OSRM/osrm-backend/issues/2672