### PR TITLE
[ready] Remove generic std::exception handlers

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -18,7 +18,7 @@
 
 #include <cstdlib>
 
-int main(int argc, const char *argv[]) try
+int main(int argc, const char *argv[])
 {
     if (argc < 2)
     {
@@ -77,9 +77,4 @@ int main(int argc, const char *argv[]) try
         std::cout << "Message: " << code << "\n";
         return EXIT_FAILURE;
     }
-}
-catch (const std::exception &e)
-{
-    std::cerr << "Error: " << e.what() << std::endl;
-    return EXIT_FAILURE;
 }

--- a/features/options/routed/invalid.feature
+++ b/features/options/routed/invalid.feature
@@ -7,7 +7,7 @@ Feature: osrm-routed command line options: invalid options
     Scenario: osrm-routed - Non-existing option
         When I run "osrm-routed --fly-me-to-the-moon"
         Then stdout should be empty
-        And stderr should contain "exception"
+        And stderr should contain "unrecognised"
         And stderr should contain "fly-me-to-the-moon"
         And it should exit with code 1
 

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -385,7 +385,7 @@ class StaticRTree
             std::size_t num_leaves = m_leaves_region.size() / sizeof(LeafNode);
             m_leaves.reset(reinterpret_cast<const LeafNode *>(m_leaves_region.data()), num_leaves);
         }
-        catch (std::exception &exc)
+        catch (const std::exception &exc)
         {
             throw exception(boost::str(boost::format("Leaf file %1% mapping failed: %2%") %
                                        leaf_file % exc.what()));

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -140,28 +140,21 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
                                        const std::string &name_file_name,
                                        const std::string &turn_lane_file_name)
 {
-    try
-    {
-        std::ofstream file_out_stream;
-        file_out_stream.open(output_file_name.c_str(), std::ios::binary);
-        const util::FingerPrint fingerprint = util::FingerPrint::GetValid();
-        file_out_stream.write((char *)&fingerprint, sizeof(util::FingerPrint));
+    std::ofstream file_out_stream;
+    file_out_stream.open(output_file_name.c_str(), std::ios::binary);
+    const util::FingerPrint fingerprint = util::FingerPrint::GetValid();
+    file_out_stream.write((char *)&fingerprint, sizeof(util::FingerPrint));
 
-        PrepareNodes();
-        WriteNodes(file_out_stream);
-        PrepareEdges(scripting_environment);
-        WriteEdges(file_out_stream);
+    PrepareNodes();
+    WriteNodes(file_out_stream);
+    PrepareEdges(scripting_environment);
+    WriteEdges(file_out_stream);
 
-        PrepareRestrictions();
-        WriteRestrictions(restrictions_file_name);
+    PrepareRestrictions();
+    WriteRestrictions(restrictions_file_name);
 
-        WriteCharData(name_file_name);
-        WriteTurnLaneMasks(turn_lane_file_name, turn_lane_offsets, turn_lane_masks);
-    }
-    catch (const std::exception &e)
-    {
-        std::cerr << "Caught Execption:" << e.what() << std::endl;
-    }
+    WriteCharData(name_file_name);
+    WriteTurnLaneMasks(turn_lane_file_name, turn_lane_offsets, turn_lane_masks);
 }
 
 void ExtractionContainers::WriteTurnLaneMasks(

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -73,7 +73,6 @@ namespace extractor
  */
 int Extractor::run(ScriptingEnvironment &scripting_environment)
 {
-    try
     {
         util::LogPolicy::GetInstance().Unmute();
         TIMER_START(extracting);
@@ -202,14 +201,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         util::SimpleLogger().Write() << "extraction finished after " << TIMER_SEC(extracting)
                                      << "s";
     }
-    // we do this for scoping
-    // TODO move to own functions
-    catch (const std::exception &e)
-    {
-        util::SimpleLogger().Write(logWARNING) << e.what();
-        return 1;
-    }
-    try
+
     {
         // Transform the node-based graph that OSM is based on into an edge-based graph
         // that is better for routing.  Every edge becomes a node, and every valid
@@ -265,11 +257,6 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
             << " nodes/sec and " << ((max_edge_id + 1) / TIMER_SEC(expansion)) << " edges/sec";
         util::SimpleLogger().Write() << "To prepare the data for routing, run: "
                                      << "./osrm-contract " << config.output_file_name << std::endl;
-    }
-    catch (const std::exception &e)
-    {
-        util::SimpleLogger().Write(logWARNING) << e.what();
-        return 1;
     }
 
     return 0;

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -228,8 +228,3 @@ int main(int argc, char *argv[]) try
     osrm::util::SimpleLogger().Write() << "finished component analysis";
     return EXIT_SUCCESS;
 }
-catch (const std::exception &e)
-{
-    osrm::util::SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
-    return EXIT_FAILURE;
-}

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -162,8 +162,3 @@ catch (const std::bad_alloc &e)
         << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
-catch (const std::exception &e)
-{
-    util::SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
-    return EXIT_FAILURE;
-}

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -77,11 +77,19 @@ return_code parseArguments(int argc, char *argv[], contractor::ContractorConfig 
 
     // parse command line options
     boost::program_options::variables_map option_variables;
-    boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
-                                      .options(cmdline_options)
-                                      .positional(positional_options)
-                                      .run(),
-                                  option_variables);
+    try
+    {
+        boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
+                                          .options(cmdline_options)
+                                          .positional(positional_options)
+                                          .run(),
+                                      option_variables);
+    }
+    catch(boost::program_options::error& e)
+    {
+        util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
+        return return_code::fail;
+    }
 
     if (option_variables.count("version"))
     {

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -161,8 +161,3 @@ catch (const std::bad_alloc &e)
         << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
-catch (const std::exception &e)
-{
-    util::SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
-    return EXIT_FAILURE;
-}

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -73,38 +73,39 @@ return_code parseArguments(int argc, char *argv[], extractor::ExtractorConfig &e
     visible_options.add(generic_options).add(config_options);
 
     // parse command line options
+    boost::program_options::variables_map option_variables;
     try
     {
-        boost::program_options::variables_map option_variables;
         boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
                                           .options(cmdline_options)
                                           .positional(positional_options)
                                           .run(),
                                       option_variables);
-        if (option_variables.count("version"))
-        {
-            util::SimpleLogger().Write() << OSRM_VERSION;
-            return return_code::exit;
-        }
-
-        if (option_variables.count("help"))
-        {
-            util::SimpleLogger().Write() << visible_options;
-            return return_code::exit;
-        }
-
-        boost::program_options::notify(option_variables);
-
-        if (!option_variables.count("input"))
-        {
-            util::SimpleLogger().Write() << visible_options;
-            return return_code::exit;
-        }
     }
-    catch (std::exception &e)
+    catch (boost::program_options::error &e)
     {
-        util::SimpleLogger().Write(logWARNING) << e.what();
+        util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
         return return_code::fail;
+    }
+
+    if (option_variables.count("version"))
+    {
+        util::SimpleLogger().Write() << OSRM_VERSION;
+        return return_code::exit;
+    }
+
+    if (option_variables.count("help"))
+    {
+        util::SimpleLogger().Write() << visible_options;
+        return return_code::exit;
+    }
+
+    boost::program_options::notify(option_variables);
+
+    if (!option_variables.count("input"))
+    {
+        util::SimpleLogger().Write() << visible_options;
+        return return_code::exit;
     }
 
     return return_code::ok;

--- a/src/tools/io-benchmark.cpp
+++ b/src/tools/io-benchmark.cpp
@@ -49,7 +49,7 @@ void runStatistics(std::vector<double> &timings_vector, Statistics &stats)
 
 boost::filesystem::path test_path;
 
-int main(int argc, char *argv[]) try
+int main(int argc, char *argv[])
 {
 
 #ifdef __FreeBSD__
@@ -311,15 +311,4 @@ int main(int argc, char *argv[]) try
     }
     return EXIT_SUCCESS;
 #endif
-}
-catch (const std::exception &e)
-{
-    osrm::util::SimpleLogger().Write(logWARNING) << "caught exception: " << e.what();
-    osrm::util::SimpleLogger().Write(logWARNING) << "cleaning up, and exiting";
-    if (boost::filesystem::exists(test_path))
-    {
-        boost::filesystem::remove(test_path);
-        osrm::util::SimpleLogger().Write(logWARNING) << "removing temporary files";
-    }
-    return EXIT_FAILURE;
 }

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -122,11 +122,19 @@ inline unsigned generateServerProgramOptions(const int argc,
 
     // parse command line options
     boost::program_options::variables_map option_variables;
-    boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
-                                      .options(cmdline_options)
-                                      .positional(positional_options)
-                                      .run(),
-                                  option_variables);
+    try
+    {
+        boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
+                                          .options(cmdline_options)
+                                          .positional(positional_options)
+                                          .run(),
+                                      option_variables);
+    }
+    catch(boost::program_options::error& e)
+    {
+        util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
+        return INIT_FAILED;
+    }
 
     if (option_variables.count("version"))
     {

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -371,8 +371,3 @@ catch (const std::bad_alloc &e)
         << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
-catch (const std::exception &e)
-{
-    util::SimpleLogger().Write(logWARNING) << "[exception] " << e.what();
-    return EXIT_FAILURE;
-}

--- a/src/tools/springclean.cpp
+++ b/src/tools/springclean.cpp
@@ -53,7 +53,7 @@ void springclean()
 }
 }
 
-int main() try
+int main()
 {
     osrm::util::LogPolicy::GetInstance().Unmute();
     osrm::util::SimpleLogger().Write() << "Releasing all locks";
@@ -73,9 +73,4 @@ int main() try
     }
     osrm::tools::springclean();
     return EXIT_SUCCESS;
-}
-catch (const std::exception &e)
-{
-    osrm::util::SimpleLogger().Write(logWARNING) << "[excpetion] " << e.what();
-    return EXIT_FAILURE;
 }

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -99,8 +99,3 @@ catch (const std::bad_alloc &e)
            "address space (note: this makes OSRM swap, i.e. slow)";
     return EXIT_FAILURE;
 }
-catch (const std::exception &e)
-{
-    util::SimpleLogger().Write(logWARNING) << "caught exception: " << e.what();
-    return EXIT_FAILURE;
-}

--- a/src/tools/unlock_all_mutexes.cpp
+++ b/src/tools/unlock_all_mutexes.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-int main() try
+int main()
 {
     osrm::util::LogPolicy::GetInstance().Unmute();
     osrm::util::SimpleLogger().Write() << "Releasing all locks";
@@ -12,9 +12,4 @@ int main() try
     barrier.query_mutex.unlock();
     barrier.update_mutex.unlock();
     return 0;
-}
-catch (const std::exception &e)
-{
-    osrm::util::SimpleLogger().Write(logWARNING) << "[excpetion] " << e.what();
-    return EXIT_FAILURE;
 }


### PR DESCRIPTION
When we hit an exceptional circumstance in OSRM, we currently handle everything, print a simple warning message and `exit 1`.

This can make debugging a bit annoying.  Core dumps (if enabled) aren't triggered for many situations, and it takes extra steps to catch exceptions during debugging.

This change removes the generic `std::exception` handlers and just lets tools die a natural death.