### PR TITLE
[ready] Include datasources in route annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # 5.4.0
+  Changes from 5.3.0
     - Profiles
       - includes library guidance.lua that offers preliminary configuration on guidance.
     - Guidance
       - Handle Access tags for lanes, only considering valid lanes in lane-guidance (think car | car | bike | car)
+    - API:
+      - `annotations=true` now returns the data source id for each segment as `datasources`
 
 # 5.3.0
   Changes from 5.3.0-rc.3

--- a/docs/http.md
+++ b/docs/http.md
@@ -414,10 +414,22 @@ With `steps=false` and `annotations=true`:
   "annotation": {
     "distance": [5,5,10,5,5],
     "duration": [15,15,40,15,15],
+    "datasources": [1,0,0,0,1],
     "nodes": [49772551,49772552,49786799,49786800,49786801,49786802]
   }
 }
 ```
+
+#### Annotation data
+
+Several fields are available as annotations.  They are:
+
+   | field       | description                                                                                             |
+   |-------------|---------------------------------------------------------------------------------------------------------|
+   | distance    | the distance, in metres, between each pair of coordinates                                               |
+   | duration    | the duration between each pair of coordinates, in seconds                                               |
+   | datasources | the index of the datasource for the speed between each pair of coordinates. `0` is the default profile, other values are supplied via `--segment-speed-file` to `osrm-contract`                                 |
+   | nodes       | the OSM node ID for each coordinate along the route, excluding the first/last user-supplied coordinates |
 
 ### RouteStep
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -399,8 +399,8 @@ Represents a route between two waypoints.
 
    | annotations  |                                                                       |
    |--------------|-----------------------------------------------------------------------|
-   | true         | returns distance and durations of each coordinate along the route     |
-   | false        | will not exist                                                        |
+   | true         | An `Annotation` object containing node ids, durations and distances   |
+   | false        | `undefined`                                                           |
 
 #### Example
 
@@ -420,16 +420,28 @@ With `steps=false` and `annotations=true`:
 }
 ```
 
-#### Annotation data
+### Annotation
 
-Several fields are available as annotations.  They are:
+Annotation of the whole route leg with fine-grained information about each segment or node id.
 
-   | field       | description                                                                                             |
-   |-------------|---------------------------------------------------------------------------------------------------------|
-   | distance    | the distance, in metres, between each pair of coordinates                                               |
-   | duration    | the duration between each pair of coordinates, in seconds                                               |
-   | datasources | the index of the datasource for the speed between each pair of coordinates. `0` is the default profile, other values are supplied via `--segment-speed-file` to `osrm-contract`                                 |
-   | nodes       | the OSM node ID for each coordinate along the route, excluding the first/last user-supplied coordinates |
+#### Properties
+
+- `distance`: The distance, in metres, between each pair of coordinates
+- `duration`: The duration between each pair of coordinates, in seconds
+- `datasources`: The index of the datasource for the speed between each pair of coordinates. `0` is the default profile, other values are supplied via `--segment-speed-file` to `osrm-contract`
+- `nodes`: The OSM node ID for each coordinate along the route, excluding the first/last user-supplied coordinates
+
+#### Example
+
+```json
+{
+  "distance": [5,5,10,5,5],
+  "duration": [15,15,40,15,15],
+  "datasources": [1,0,0,0,1],
+  "nodes": [49772551,49772552,49786799,49786800,49786801,49786802]
+}
+```
+
 
 ### RouteStep
 

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -152,15 +152,15 @@ module.exports = function () {
     };
 
     this.annotationList = (instructions) => {
-        function zip(list_1, list_2)
+        function zip(list_1, list_2, list_3)
         {
-            let pairs = [];
+            let tuples = [];
             for (let i = 0; i <  list_1.length; ++i) {
-                pairs.push([list_1[i], list_2[i]]);
+                tuples.push([list_1[i], list_2[i], list_3[i]]);
             }
-            return pairs;
+            return tuples;
         }
-        return instructions.legs.map(l => {return zip(l.annotation.duration, l.annotation.distance).map(p => { return p.join(':'); }).join(','); }).join(',');
+        return instructions.legs.map(l => {return zip(l.annotation.duration, l.annotation.distance, l.annotation.datasources).map(p => { return p.join(':'); }).join(','); }).join(',');
     };
 
     this.OSMIDList = (instructions) => {

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -4,6 +4,7 @@ Feature: Basic Map Matching
     Background:
         Given the profile "testbot"
         Given a grid size of 10 meters
+        Given the extract extra arguments "--generate-edge-lookup"
 
     Scenario: Testbot - Map matching with outlier that has no candidate
         Given a grid size of 100 meters
@@ -118,10 +119,17 @@ Feature: Basic Map Matching
             | abcdegh  | no     |
             | ci       | no     |
 
+        And the speed file
+        """
+        1,2,36
+        """
+
+        And the contract extra arguments "--segment-speed-file speeds.csv"
+
         When I match I should get
-            | trace | matchings | annotation                                                                     |
-            | abeh  | abcedgh   | 1:9.897633,0:0,1:10.008842,1:10.008842,1:10.008842,0:0,2:20.017685,1:10.008842 |
-            | abci  | abc,ci    | 1:9.897633,0:0,1:10.008842,0:0.111209,1:10.010367                              |
+            | trace | matchings | annotation                                                                                     |
+            | abeh  | abcedgh   | 1:9.897633:1,0:0:0,1:10.008842:0,1:10.008842:0,1:10.008842:0,0:0:0,2:20.017685:0,1:10.008842:0 |
+            | abci  | abc,ci    | 1:9.897633:1,0:0:0,1:10.008842:0,0:0.111209:0,1:10.010367:0                                    |
 
         # The following is the same as the above, but separated for readability (line length)
         When I match I should get

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -207,18 +207,21 @@ class RouteAPI : public BaseAPI
                 util::json::Array durations;
                 util::json::Array distances;
                 util::json::Array nodes;
+                util::json::Array datasources;
                 auto &leg_geometry = leg_geometries[idx];
 
                 durations.values.reserve(leg_geometry.annotations.size());
                 distances.values.reserve(leg_geometry.annotations.size());
                 nodes.values.reserve(leg_geometry.osm_node_ids.size());
+                datasources.values.reserve(leg_geometry.annotations.size());
 
                 std::for_each(
                     leg_geometry.annotations.begin(),
                     leg_geometry.annotations.end(),
-                    [this, &durations, &distances](const guidance::LegGeometry::Annotation &step) {
+                    [this, &durations, &distances, &datasources](const guidance::LegGeometry::Annotation &step) {
                         durations.values.push_back(step.duration);
                         distances.values.push_back(step.distance);
+                        datasources.values.push_back(step.datasource);
                     });
                 std::for_each(leg_geometry.osm_node_ids.begin(),
                               leg_geometry.osm_node_ids.end(),
@@ -229,6 +232,7 @@ class RouteAPI : public BaseAPI
                 annotation.values["distance"] = std::move(distances);
                 annotation.values["duration"] = std::move(durations);
                 annotation.values["nodes"] = std::move(nodes);
+                annotation.values["datasources"] = std::move(datasources);
                 annotations.push_back(std::move(annotation));
             }
         }

--- a/include/engine/guidance/leg_geometry.hpp
+++ b/include/engine/guidance/leg_geometry.hpp
@@ -39,6 +39,7 @@ struct LegGeometry
     {
         double distance;
         double duration;
+        DatasourceID datasource;
     };
     std::vector<Annotation> annotations;
 

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -33,6 +33,9 @@ struct PathData
     extractor::TravelMode travel_mode : 4;
     // entry class of the turn, indicating possibility of turns
     EntryClassID entry_classid;
+
+    // Source of the speed value on this road segment
+    DatasourceID datasource_id;
 };
 
 struct InternalRouteResult

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -83,6 +83,8 @@ static const NameID EMPTY_NAMEID = 0;
 static const unsigned INVALID_COMPONENTID = 0;
 static const EdgeWeight INVALID_EDGE_WEIGHT = std::numeric_limits<EdgeWeight>::max();
 
+using DatasourceID = std::uint8_t;
+
 struct SegmentID
 {
     SegmentID(const NodeID id_, const bool enabled_) : id{id_}, enabled{enabled_}

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -335,7 +335,7 @@ Status TilePlugin::HandleRequest(const api::TileParameters &parameters, std::str
                                                &used_weights](const detail::FixedLine &tile_line,
                                                               const std::uint32_t speed_kmh,
                                                               const std::size_t duration,
-                                                              const std::uint8_t datasource,
+                                                              const DatasourceID datasource,
                                                               const std::size_t name,
                                                               std::int32_t &start_x,
                                                               std::int32_t &start_y) {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -293,11 +293,12 @@ int Storage::Run()
         throw util::exception("Could not open " + config.datasource_indexes_path.string() +
                               " for reading.");
     }
-    std::size_t number_of_compressed_datasources = 0;
+    std::uint64_t number_of_compressed_datasources = 0;
     if (geometry_datasource_input_stream)
     {
         geometry_datasource_input_stream.read(
-            reinterpret_cast<char *>(&number_of_compressed_datasources), sizeof(std::size_t));
+            reinterpret_cast<char *>(&number_of_compressed_datasources),
+            sizeof(number_of_compressed_datasources));
     }
     shared_layout_ptr->SetBlockSize<uint8_t>(SharedDataLayout::DATASOURCES_LIST,
                                              number_of_compressed_datasources);


### PR DESCRIPTION
This PR adds datasource information to the route annotation.
When using multiple traffic sources, this allows you to see the makeup of discovered route.