### PR TITLE
Increase travis cacher timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   global:
    - CCACHE_TEMPDIR=/tmp/.ccache-temp
    - CCACHE_COMPRESS=1
+   - CASHER_TIME_OUT=1000
    - JOBS=4
 
 matrix:


### PR DESCRIPTION
Looking through logs of recent travis builds I've seen that:

  - Often caches fail to upload or download before timing out
  - This leads to very slow builds that do not benefit from the caching

This fixes the problem by increasing the timeout of the cacher to be able to handle the large objects produced by `ccache`.