### PR TITLE
fix use-lane handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - Only announce `use lane` on required turns (not using all lanes to go straight)
     - Bugfixes
       - Fix BREAKING: bug that could result in failure to load 'osrm.icd' files. This breaks the dataformat
+      - Fix: bug that results in segfaults when `use lane` instructions are suppressed
 
 # 5.3.0 RC3
   Changes from 5.3.0-rc.2

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -715,3 +715,25 @@ Feature: Turn Lane Guidance
             | e,i       | ,,,,         | depart,off ramp right,fork slight left,use lane straight,arrive | ,none:false none:false none:false slight right:true,,straight:false slight right:true, |
             | e,d       | ,A 100,A 100 | depart,merge slight left,arrive                                 | ,,                                                                                     |
             | e,h       | ,,,,         | depart,off ramp right,fork left,use lane straight,arrive        | ,none:false none:false none:false slight right:true,,straight:true slight right:false, |
+
+    @collapse @use-lane
+    Scenario: Collapse Multiple Use Lanes
+        Given the node map
+            | x | a |   | b |   |   | c |   |   | d |
+            |   |   |   | e |   |   | f |   |   |   |
+
+        And the ways
+            | nodes | name | highway | turn:lanes:forward |
+            | ab    | road | primary | through,right      |
+            | bc    | road | primary | through,right      |
+            | cd    | road | primary |                    |
+            | xa    | road | primary |                    |
+            | be    | turn | primary |                    |
+            | cf    | turn | primary |                    |
+
+        When I route I should get
+            | waypoints | route     | turns         | lanes |
+            | x,d       | road,road | depart,arrive | ,     |
+
+
+

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1156,6 +1156,16 @@ std::vector<RouteStep> collapseUseLane(std::vector<RouteStep> steps)
         return (mask & tag) != extractor::guidance::TurnLaneType::empty;
     };
 
+    const auto getPreviousIndex = [&steps](std::size_t index) {
+        BOOST_ASSERT(index > 0);
+        BOOST_ASSERT(index < steps.size());
+        --index;
+        while (index > 0 && steps[index].maneuver.instruction.type == TurnType::NoTurn)
+            --index;
+
+        return index;
+    };
+
     const auto canCollapeUseLane =
         [containsTag](const util::guidance::LaneTupel lanes,
                       extractor::guidance::TurnLaneDescription lane_description) {
@@ -1183,7 +1193,9 @@ std::vector<RouteStep> collapseUseLane(std::vector<RouteStep> steps)
         if (step.maneuver.instruction.type == TurnType::UseLane &&
             canCollapeUseLane(step.maneuver.lanes, step.maneuver.lane_description))
         {
-            elongate(steps[step_index - 1], steps[step_index]);
+            const auto previous = getPreviousIndex(step_index);
+            steps[previous] = elongate(steps[previous], steps[step_index]);
+            //elongate(steps[step_index-1], steps[step_index]);
             invalidateStep(steps[step_index]);
         }
     }


### PR DESCRIPTION
Collapsing of use-lane instructions is broken right now. This PR corrects the segfaulting behaviour.