### PR TITLE
[Ready] Remove lanes from roundabouts, closes #2626

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -314,7 +314,7 @@ Feature: Turn Lane Guidance
             | a,f       | ab,df,df | depart,roundabout-exit-1,use lane slight right,arrive | ,,slight left:false slight left:false slight right:true, |
 
     @anticipate
-    Scenario: Anticipate with lanes in roundabout where we stay on the roundabout for multiple exits
+    Scenario: No Lanes for Roundabouts, see #2626
         Given the node map
             |   |   | a |   |   |
             |   |   | b |   |   |
@@ -340,11 +340,11 @@ Feature: Turn Lane Guidance
             | fy    |                            | primary |            |
 
         When I route I should get
-            | waypoints | route    | turns                           | lanes                                  |
-            | a,h       | ab,gh,gh | depart,roundabout-exit-5,arrive | ,slight right:false slight right:true, |
+            | waypoints | route    | turns                           | lanes |
+            | a,h       | ab,gh,gh | depart,roundabout-exit-5,arrive | ,,    |
 
     @anticipate
-    Scenario: Departing or arriving inside a roundabout does not yet anticipate lanes
+    Scenario: No Lanes for Roundabouts, see #2626
         Given the node map
             |   |   | a |   |   |
             | x | b |   | d | y |
@@ -360,13 +360,13 @@ Feature: Turn Lane Guidance
             | da    |                            | primary | roundabout | roundabout |
 
         When I route I should get
-            | waypoints | route                    | turns                                   | lanes                                  |
-            | x,y       | xb,dy,dy                 | depart,roundabout-exit-1,arrive         | ,slight right:false slight right:true, |
-            | x,c       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
-            | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
+            | waypoints | route                    | turns                                   | lanes |
+            | x,y       | xb,dy,dy                 | depart,roundabout-exit-1,arrive         | ,,    |
+            | x,c       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,,    |
+            | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,,    |
 
     @anticipate
-    Scenario: Departing or arriving inside a roundabout does not yet anticipate lanes (BIG version)
+    Scenario: No Lanes for Roundabouts, see #2626
         Given the node map
             |   |   | a |   |   |
             | x | b |   | d | y |
@@ -416,13 +416,13 @@ Feature: Turn Lane Guidance
             | da    |                            | primary | roundabout | roundabout |
 
         When I route I should get
-            | waypoints | route                    | turns                                   | lanes                                  |
-            | x,y       | xb,dy,dy                 | depart,roundabout-exit-1,arrive         | ,slight right:false slight right:true, |
-            | x,c       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
-            | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,slight right:true slight right:true,  |
+            | waypoints | route                    | turns                                   | lanes |
+            | x,y       | xb,dy,dy                 | depart,roundabout-exit-1,arrive         | ,,    |
+            | x,c       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,,    |
+            | x,a       | xb,roundabout,roundabout | depart,roundabout-exit-undefined,arrive | ,,    |
 
     @anticipate
-    Scenario: Anticipate Lanes for turns before and / or after roundabout
+    Scenario: No Lanes for Roundabouts, see #2626
         Given the node map
             | a | b |   |   | x |
             |   | c |   |   |   |
@@ -447,7 +447,7 @@ Feature: Turn Lane Guidance
 
         When I route I should get
             | waypoints | route           | turns                                            | lanes                                                                                                                                    |
-            | a,h       | abx,bc,fg,gh,gh | depart,turn right,cdefc-exit-2,turn right,arrive | ,straight:false right:false right:false right:false right:true,right:false right:false right:false right:true,straight:false right:true, |
+            | a,h       | abx,bc,fg,gh,gh | depart,turn right,cdefc-exit-2,turn right,arrive | ,straight:false right:false right:false right:false right:true,,straight:false right:true, |
 
     @anticipate @bug @todo
     Scenario: Tripple Right keeping Left

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -150,6 +150,7 @@ class RouteAPI : public BaseAPI
                                                               leg_geometry,
                                                               phantoms.source_phantom,
                                                               phantoms.target_phantom);
+                leg.steps = guidance::removeLanesFromRoundabouts(std::move(leg.steps));
                 leg.steps = guidance::anticipateLaneChange(std::move(leg.steps));
                 leg.steps = guidance::collapseUseLane(std::move(leg.steps));
                 leg_geometry = guidance::resyncGeometry(std::move(leg_geometry), leg.steps);

--- a/include/engine/guidance/lane_processing.hpp
+++ b/include/engine/guidance/lane_processing.hpp
@@ -20,6 +20,9 @@ namespace guidance
 std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
                                             const double min_duration_needed_for_lane_change = 15);
 
+// Remove all lane information from roundabouts. See #2626.
+std::vector<RouteStep> removeLanesFromRoundabouts(std::vector<RouteStep> steps);
+
 } // namespace guidance
 } // namespace engine
 } // namespace osrm

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -3,6 +3,7 @@
 #include "util/guidance/toolkit.hpp"
 
 #include "extractor/guidance/turn_instruction.hpp"
+#include "engine/guidance/toolkit.hpp"
 
 #include <iterator>
 
@@ -101,6 +102,29 @@ std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
     };
 
     std::for_each(begin(subsequent_quick_turns), end(subsequent_quick_turns), constrain_lanes);
+    return steps;
+}
+
+std::vector<RouteStep> removeLanesFromRoundabouts(std::vector<RouteStep> steps)
+{
+    using namespace util::guidance;
+
+    const auto removeLanes = [](RouteStep &step) {
+        for (auto &intersection : step.intersections)
+        {
+            intersection.lane_description = {};
+            intersection.lanes = {};
+        }
+    };
+
+    for (auto &step : steps)
+    {
+        const auto inst = step.maneuver.instruction;
+
+        if (entersRoundabout(inst) || staysOnRoundabout(inst) || leavesRoundabout(inst))
+            removeLanes(step);
+    }
+
     return steps;
 }
 


### PR DESCRIPTION


After half a day of looking at the tagging and the data came to the
following conclusion:

We can't keep the user to the innermost / outermost lanes depending on
the exit the route takes: we found situations where both heuristics were
wrong.

Even on popular roundabouts the tagging is often wrong or in the best
case not present at all.

There are at least two different ways to interpret roundabout
indications: 1/ where e.g. a right arrow on the lane indicates turn
restrictions for the roundabout and the need to take this lane to exit
the roundabout to the right (possibly skipping multiple exits) and 2/
where a right arrow just means this is a lane in a immediate right turn.

Example: Australia marks lanes with arrows that seem to indicate
"angles you can exit the roundabout from", for example, these two ways:
- http://www.openstreetmap.org/way/320941710
- http://www.openstreetmap.org/way/42918021

Whereas Germany marks lanes with "directions you can travel in these
lanes immediately after entering the roundabout":
- http://www.openstreetmap.org/way/52578338

These two different interpretations of how to draw the arrows on the
roads mean we have conflicting solutions to "which lanes can you use to
take exit B from entry A" based on locality.

Continuing to tag ways based on lane markings is no problem, but
unfortunately, we can't reliably resolve good advice for navigation
system users (like "use the inside lane to take the second exit at the
roundabout"), there are too many situations that would generate bad
instructions (instructions that tell users to go into a lane they
shouldn't use).