### PR TITLE
Refine Roundabout Handling: Turbo-Roundabouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Changes from 5.5.0
     - Bugfixes
       - Fix #3418 and ensure we only return bearings in the range 0-359 in API responses
+      - Fixed a bug that could lead to emitting false instructions for staying on a roundabout
 
 # 5.5.0
   - Changes from 5.4.0

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -535,3 +535,149 @@ Feature: Basic Roundabout
             | i,n       | Petersburger Strasse,Petersburger Strasse,Petersburger Strasse | depart,Bersarinplatz-exit-2,arrive |
             | i,d       | Petersburger Strasse,Weidenweg,Weidenweg                       | depart,Bersarinplatz-exit-3,arrive |
             | i,g       | Petersburger Strasse,Petersburger Strasse,Petersburger Strasse | depart,Bersarinplatz-exit-4,arrive |
+
+    @turboroundabout
+    # http://www.openstreetmap.org/?mlat=48.782118&mlon=8.194456&zoom=16#map=19/48.78216/8.19457
+    Scenario: Turboroundabout, Baden-Baden
+        Given the node map
+            """
+                a p
+                b o
+            d c     m n
+            f e     k l
+                g i
+                h j
+            """
+
+       And the ways
+            | nodes | highway     | oneway | junction   | name          | turn:lanes                             |
+            | ab    | trunk_link  | yes    |            |               |                                        |
+            | bc    | trunk       | yes    | roundabout | Europaplatz   | slight_left;slight_right\|slight_right |
+            | cd    | trunk       | yes    |            | Europastrasse |                                        |
+            | ce    | trunk       | yes    | roundabout | Europaplatz   |                                        |
+            | fe    | trunk       | yes    |            | Europastrasse |                                        |
+            | eg    | trunk       | yes    | roundabout | Europaplatz   |                                        |
+            | gh    | residential | yes    |            | Allee Cite    |                                        |
+            | gi    | trunk       | yes    | roundabout | Europaplatz   |                                        |
+            | ji    | residential | yes    |            | Allee Cite    |                                        |
+            | ik    | trunk       | yes    | roundabout | Europaplatz   | slight_left;slight_right\|slight_right |
+            | kl    | trunk       | yes    |            | Europastrasse |                                        |
+            | km    | trunk       | yes    | roundabout | Europaplatz   |                                        |
+            | nm    | trunk       | yes    |            | Europastrasse |                                        |
+            | mo    | trunk       | yes    | rounadbout | Europaplatz   |                                        |
+            | op    | trunk_link  | yes    |            |               |                                        |
+            | ob    | trunk       | yes    | roundabout | Europaplatz   |                                        |
+
+       When I route I should get
+           | waypoints | route                                    | turns                           | lanes |
+           | a,d       | ,Europaplatz,Europastrasse,Europastrasse | depart,roundabout-exit-1,arrive | ,,    |
+           | a,h       | ,Europaplatz,Allee Cite,Allee Cite       | depart,roundabout-exit-2,arrive | ,,    |
+           | a,l       | ,Europaplatz,Europastrasse,Europastrasse | depart,roundabout-exit-3,arrive | ,,    |
+           | a,p       | ,Europaplatz,,                           | depart,roundabout-exit-4,arrive | ,,    |
+
+    @turboroundabout
+    # http://www.openstreetmap.org/?mlat=50.180039&mlon=8.474939&zoom=16#map=19/50.17999/8.47506
+    Scenario: Turboroundabout, Königstein im Taunus
+        Given the node map
+            """
+                a
+                b   w t   v
+              c         s u
+              d           r
+            f e         q
+              g         p
+            h   i     n
+              j   k m
+                    l o
+            """
+
+       And the ways
+            | nodes | highway      | oneway | junction   | name                         | turn:lanes                         |
+            | ab    | primary      | yes    |            | Le-Cannet-Rocheville-Strasse |                                    |
+            | wa    | primary      | yes    |            | Le-Cannet-Rocheville-Strasse |                                    |
+            | bc    | primary      | yes    | roundabout |                              | through\|through;right             |
+            | cd    | primary      | yes    | roundabout |                              | through\|through\|right;through    |
+            | df    | tertiary     | yes    |            | Frankfurter Strasse          |                                    |
+            | de    | primary      | yes    | roundabout |                              | through\|through\|right;through    |
+            | fe    | tertiary     | yes    |            | Frankfurter Strasse          |                                    |
+            | eg    | primary      | yes    | roundabout |                              | through\|through\|right;through    |
+            | gh    | primary      | yes    |            | Bischof-Kaller-Strasse       |                                    |
+            | gi    | primary      | yes    | roundabout |                              | left\|through;slight_left\|through |
+            | ji    | primary      | yes    |            | Bischof-Kaller-Strasse       |                                    |
+            | ik    | primary      | yes    | roundabout |                              | left\|through;slight_left\|through |
+            | km    | primary      | yes    | roundabout |                              |                                    |
+            | kl    | primary      | yes    |            | Sodener Strasse              |                                    |
+            | mn    | primary      | yes    | roundabout |                              | through\|through;right             |
+            | on    | primary      | yes    |            | Sodener Strasse              |                                    |
+            | np    | primary      | yes    | roundabout |                              | through\|through;right             |
+            | pq    | primary      | yes    | roundabout |                              | through\|through\|right;through    |
+            | qr    | primary      | yes    |            |                              |                                    |
+            | qs    | primary      | yes    | roundabout |                              |                                    |
+            | us    | primary_link | yes    |            |                              |                                    |
+            | st    | primary      | yes    | roundabout |                              |                                    |
+            | vt    | primary      | yes    |            |                              |                                    |
+            | tw    | primary      | yes    | roundabout |                              | left\|left\|right\|right           |
+            | wa    | primary      | yes    |            | Le-Cannet-Rocheville-Strasse |                                    |
+            | wb    | primary      | yes    | roundabout |                              | through\|through;right             |
+
+       When I route I should get
+           | waypoints | route                                                                      | turns                                   | lanes |
+           | a,w       | Le-Cannet-Rocheville-Strasse,,                                             | depart,roundabout-exit-undefined,arrive | ,,    |
+           | a,r       | Le-Cannet-Rocheville-Strasse,,                                             | depart,roundabout-exit-4,arrive         | ,,    |
+           | a,f       | Le-Cannet-Rocheville-Strasse,Frankfurter Strasse,Frankfurter Strasse       | depart,roundabout-exit-1,arrive         | ,,    |
+           | a,h       | Le-Cannet-Rocheville-Strasse,Bischof-Kaller-Strasse,Bischof-Kaller-Strasse | depart,roundabout-exit-2,arrive         | ,,    |
+           | u,r       | ,,                                                                         | depart,roundabout-exit-5,arrive         | ,,    |
+           | j,h       | Bischof-Kaller-Strasse,Bischof-Kaller-Strasse,Bischof-Kaller-Strasse       | depart,roundabout-exit-5,arrive         | ,,    |
+           | n,m       | ,                                                                          | depart,arrive                           | ,     |
+
+    @turboroundabout
+    # http://www.openstreetmap.org/?mlat=47.57723&mlon=7.796765&zoom=16#map=19/47.57720/7.79711
+    Scenario: Turboroundabout, Rheinfelden (Baden)
+        Given the node map
+            """
+            r             w
+                a   l k
+              b         j
+              c
+              d         i
+            s   e f g h   v
+
+                  t u
+            """
+
+       And the ways
+            | nodes | highway      | oneway | junction   |
+            | ar    | secondary    | yes    |            |
+            | ab    | primary      | yes    | roundabout |
+            | rb    | secondary    | yes    |            |
+            | bc    | primary      | yes    | roundabout |
+            | cd    | primary      | yes    | roundabout |
+            | ds    | primary      | yes    |            |
+            | se    | primary      | yes    |            |
+            | de    | primary      | yes    | roundabout |
+            | ef    | primary      | yes    | roundabout |
+            | ft    | unclassified | yes    |            |
+            | fg    | primary      | yes    | roundabout |
+            | ug    | unclassified | yes    |            |
+            | gh    | primary      | yes    | roundabout |
+            | hv    | primary      | yes    |            |
+            | hi    | primary      | yes    | roundabout |
+            | vi    | primary      | yes    |            |
+            | ij    | primary      | yes    | roundabout |
+            | jw    | tertiary     | yes    |            |
+            | jk    | primary      | yes    | roundabout |
+            | wk    | tertiary     | yes    |            |
+            | kl    | primary      | yes    | roundabout |
+            | la    | primary      | yes    | roundabout |
+
+       When I route I should get
+           | waypoints | route    | turns                           |
+           | w,r       | wk,ar,ar | depart,roundabout-exit-1,arrive |
+           | w,s       | wk,ds,ds | depart,roundabout-exit-2,arrive |
+           | w,t       | wk,ft,ft | depart,roundabout-exit-3,arrive |
+           | w,v       | wk,hv,hv | depart,roundabout-exit-4,arrive |
+           | u,v       | ug,hv,hv | depart,roundabout-exit-1,arrive |
+           | u,w       | ug,jw,jw | depart,roundabout-exit-2,arrive |
+           | u,r       | ug,ar,ar | depart,roundabout-exit-3,arrive |
+           | u,s       | ug,ds,ds | depart,roundabout-exit-4,arrive |
+           | u,t       | ug,ft,ft | depart,roundabout-exit-5,arrive |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -564,16 +564,16 @@ Feature: Basic Roundabout
             | kl    | trunk       | yes    |            | Europastrasse |                                        |
             | km    | trunk       | yes    | roundabout | Europaplatz   |                                        |
             | nm    | trunk       | yes    |            | Europastrasse |                                        |
-            | mo    | trunk       | yes    | rounadbout | Europaplatz   |                                        |
+            | mo    | trunk       | yes    | roundabout | Europaplatz   |                                        |
             | op    | trunk_link  | yes    |            |               |                                        |
             | ob    | trunk       | yes    | roundabout | Europaplatz   |                                        |
 
        When I route I should get
-           | waypoints | route                                    | turns                           | lanes |
-           | a,d       | ,Europaplatz,Europastrasse,Europastrasse | depart,roundabout-exit-1,arrive | ,,    |
-           | a,h       | ,Europaplatz,Allee Cite,Allee Cite       | depart,roundabout-exit-2,arrive | ,,    |
-           | a,l       | ,Europaplatz,Europastrasse,Europastrasse | depart,roundabout-exit-3,arrive | ,,    |
-           | a,p       | ,Europaplatz,,                           | depart,roundabout-exit-4,arrive | ,,    |
+           | waypoints | route                        | turns                            | lanes |
+           | a,d       | ,Europastrasse,Europastrasse | depart,Europaplatz-exit-1,arrive | ,,    |
+           | a,h       | ,Allee Cite,Allee Cite       | depart,Europaplatz-exit-2,arrive | ,,    |
+           | a,l       | ,Europastrasse,Europastrasse | depart,Europaplatz-exit-3,arrive | ,,    |
+           | a,p       | ,,                           | depart,Europaplatz-exit-4,arrive | ,,    |
 
     @turboroundabout
     # http://www.openstreetmap.org/?mlat=50.180039&mlon=8.474939&zoom=16#map=19/50.17999/8.47506

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -159,7 +159,6 @@ class RouteAPI : public BaseAPI
                                                               leg_geometry,
                                                               phantoms.source_phantom,
                                                               phantoms.target_phantom);
-                leg.steps = guidance::removeLanesFromRoundabouts(std::move(leg.steps));
                 leg.steps = guidance::anticipateLaneChange(std::move(leg.steps));
                 leg.steps = guidance::collapseUseLane(std::move(leg.steps));
                 leg_geometry = guidance::resyncGeometry(std::move(leg_geometry), leg.steps);

--- a/include/engine/guidance/lane_processing.hpp
+++ b/include/engine/guidance/lane_processing.hpp
@@ -22,10 +22,6 @@ OSRM_ATTR_WARN_UNUSED
 std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
                                             const double min_duration_needed_for_lane_change = 15);
 
-// Remove all lane information from roundabouts. See #2626.
-OSRM_ATTR_WARN_UNUSED
-std::vector<RouteStep> removeLanesFromRoundabouts(std::vector<RouteStep> steps);
-
 } // namespace guidance
 } // namespace engine
 } // namespace osrm

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -180,29 +180,6 @@ std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
     return steps;
 }
 
-std::vector<RouteStep> removeLanesFromRoundabouts(std::vector<RouteStep> steps)
-{
-    using namespace util::guidance;
-
-    const auto removeLanes = [](RouteStep &step) {
-        for (auto &intersection : step.intersections)
-        {
-            intersection.lane_description = {};
-            intersection.lanes = {};
-        }
-    };
-
-    for (auto &step : steps)
-    {
-        const auto inst = step.maneuver.instruction;
-
-        if (entersRoundabout(inst) || staysOnRoundabout(inst) || leavesRoundabout(inst))
-            removeLanes(step);
-    }
-
-    return steps;
-}
-
 } // namespace guidance
 } // namespace engine
 } // namespace osrm

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1053,9 +1053,13 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
         const auto &current_step = steps[step_index];
         const auto next_step_index = step_index + 1;
         const auto one_back_index = getPreviousIndex(step_index, steps);
+
         BOOST_ASSERT(one_back_index < steps.size());
 
         const auto &one_back_step = steps[one_back_index];
+        if (hasRoundaboutType(current_step.maneuver.instruction) ||
+            hasRoundaboutType(one_back_step.maneuver.instruction))
+            continue;
 
         if (!hasManeuver(one_back_step, current_step))
             continue;

--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -146,8 +146,7 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
     // roundabouts, check early to avoid other costly checks
     if (turn_edge_data.roundabout || turn_edge_data.circular)
     {
-        const auto result = ExtractCoordinateAtLength(
-            skipping_inaccuracies_distance, coordinates);
+        const auto result = ExtractCoordinateAtLength(skipping_inaccuracies_distance, coordinates);
         BOOST_ASSERT(is_valid_result(result));
         return result;
     }
@@ -234,8 +233,7 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
         std::accumulate(segment_distances.begin(), segment_distances.end(), 0.);
 
     // if we are now left with two, well than we don't have to worry, or the segment is very small
-    if (coordinates.size() == 2 ||
-        total_distance <= skipping_inaccuracies_distance)
+    if (coordinates.size() == 2 || total_distance <= skipping_inaccuracies_distance)
     {
         BOOST_ASSERT(is_valid_result(coordinates.back()));
         return coordinates.back();
@@ -252,8 +250,8 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
         // As a back-up, we have to check for this case
         if (coordinates.front() == coordinates.back())
         {
-            const auto result = ExtractCoordinateAtLength(
-                skipping_inaccuracies_distance, coordinates);
+            const auto result =
+                ExtractCoordinateAtLength(skipping_inaccuracies_distance, coordinates);
             BOOST_ASSERT(is_valid_result(result));
             return result;
         }
@@ -373,18 +371,15 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
          * We distinguish between turns that simply model the initial way of getting onto the
          * destination lanes and the ones that performa a larger turn.
          */
-        coordinates =
-            TrimCoordinatesToLength(std::move(coordinates),
-                                    2 * skipping_inaccuracies_distance,
-                                    segment_distances);
+        coordinates = TrimCoordinatesToLength(
+            std::move(coordinates), 2 * skipping_inaccuracies_distance, segment_distances);
         BOOST_ASSERT(coordinates.size() >= 2);
         segment_distances.resize(coordinates.size());
         segment_distances.back() = util::coordinate_calculation::haversineDistance(
             *(coordinates.end() - 2), coordinates.back());
         const auto vector_head = coordinates.back();
-        coordinates = TrimCoordinatesToLength(std::move(coordinates),
-                                              skipping_inaccuracies_distance,
-                                              segment_distances);
+        coordinates = TrimCoordinatesToLength(
+            std::move(coordinates), skipping_inaccuracies_distance, segment_distances);
         BOOST_ASSERT(coordinates.size() >= 2);
         const auto result =
             GetCorrectedCoordinate(turn_coordinate, coordinates.back(), vector_head);

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -1,6 +1,7 @@
 #include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/constants.hpp"
 
+#include "util/coordinate_calculation.hpp"
 #include "util/guidance/name_announcements.hpp"
 #include "util/log.hpp"
 

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -3,8 +3,8 @@
 
 #include "util/bearing.hpp"
 #include "util/coordinate_calculation.hpp"
-#include "util/log.hpp"
 #include "util/guidance/name_announcements.hpp"
+#include "util/log.hpp"
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
## Modified

I found some errors in the tests added here and corrected the `removeLanesFromRoundabout` feature. As long as we don't support these correctly, roundabouts will no longer be assigned lanes and, as a result, we don't emit strange instructions within the roundabouts.

## Original PR Item:

These kind of roundabouts came up during Lane Handling for roundabouts (https://github.com/Project-OSRM/osrm-backend/pull/2693).

They're called Turbo-roundabouts or Turbine-roundabouts and are very
popular e.g. in Germany and the UK.

Seems like our roundabout handler sometimes is getting confused.
- https://www.mapillary.com/app/?lat=48.78199533&lon=8.194456&z=17&lng=8.1936397&pKey=ayxfZQt3BkkBi11cJZ5o9Q&focus=map
- https://www.mapillary.com/app/?lat=50.18011193834988&lon=8.194456&z=17&lng=8.4751722501247&focus=map&pKey=YJy_ZngowTLsX6sc9yTq_g
- https://www.mapillary.com/app/?lat=47.5772012447751&lon=8.194456&z=16.873861849026316&lng=7.7974465839462255&focus=map

Trying to figure out why, and codifying some scenarios for cucumber.
