### PR TITLE
No longer hard crash datastore on unrecognised options

### DIFF
--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -85,7 +85,7 @@ return_code parseArguments(int argc, char *argv[], contractor::ContractorConfig 
                                           .run(),
                                       option_variables);
     }
-    catch (boost::program_options::error &e)
+    catch (const boost::program_options::error &e)
     {
         util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
         return return_code::fail;

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -82,7 +82,7 @@ return_code parseArguments(int argc, char *argv[], extractor::ExtractorConfig &e
                                           .run(),
                                       option_variables);
     }
-    catch (boost::program_options::error &e)
+    catch (const boost::program_options::error &e)
     {
         util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
         return return_code::fail;

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -130,7 +130,7 @@ inline unsigned generateServerProgramOptions(const int argc,
                                           .run(),
                                       option_variables);
     }
-    catch (boost::program_options::error &e)
+    catch (const boost::program_options::error &e)
     {
         util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
         return INIT_FAILED;

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -50,11 +50,20 @@ bool generateDataStoreOptions(const int argc,
 
     // parse command line options
     boost::program_options::variables_map option_variables;
-    boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
-                                      .options(cmdline_options)
-                                      .positional(positional_options)
-                                      .run(),
-                                  option_variables);
+
+    try
+    {
+        boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
+                                          .options(cmdline_options)
+                                          .positional(positional_options)
+                                          .run(),
+                                      option_variables);
+    }
+    catch (const boost::program_options::error &e)
+    {
+        util::SimpleLogger().Write(logWARNING) << "[error] " << e.what();
+        return false;
+    }
 
     if (option_variables.count("version"))
     {


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/pull/2674#issuecomment-235240123. Datastore was missing.