### PR TITLE
Filter out edges that have any speed=0 segments.

### DIFF
--- a/features/car/traffic_speeds.feature
+++ b/features/car/traffic_speeds.feature
@@ -23,8 +23,8 @@ Feature: Traffic - speeds
             | fb    | primary |
         And the speed file
         """
-        1,2,27
-        2,1,27
+        1,2,0
+        2,1,0
         2,3,27
         3,2,27
         1,4,27
@@ -36,12 +36,58 @@ Feature: Traffic - speeds
         Given the extract extra arguments "--generate-edge-lookup"
         Given the contract extra arguments "--segment-speed-file speeds.csv"
         And I route I should get
-            | from | to | route    | speed   |
-            | a    | b  | ab,ab    | 27 km/h |
-            | a    | c  | ab,bc,bc | 27 km/h |
-            | b    | c  | bc,bc    | 27 km/h |
-            | a    | d  | ad,ad    | 27 km/h |
-            | d    | c  | dc,dc    | 36 km/h |
-            | g    | b  | ab,ab    | 27 km/h |
-            | a    | g  | ab,ab    | 27 km/h |
+            | from | to | route          | speed   |
+            | a    | b  | ad,de,eb,eb    | 30 km/h |
+            | a    | c  | ad,dc,dc       | 31 km/h |
+            | b    | c  | bc,bc          | 27 km/h |
+            | a    | d  | ad,ad          | 27 km/h |
+            | d    | c  | dc,dc          | 36 km/h |
+            | g    | b  | fb,fb          | 36 km/h |
+            | a    | g  | ad,df,fb,fb    | 30 km/h |
 
+
+    Scenario: Speeds that isolate a single node (a)
+        Given the profile "testbot"
+        Given the extract extra arguments "--generate-edge-lookup"
+        Given the contract extra arguments "--segment-speed-file speeds.csv"
+        Given the speed file
+        """
+        1,2,0
+        2,1,0
+        2,3,27
+        3,2,27
+        1,4,0
+        4,1,0
+        """
+        And I route I should get
+            | from | to | route          | speed   |
+            | a    | b  | fb,fb          | 36 km/h |
+            | a    | c  | fb,bc,bc       | 30 km/h |
+            | b    | c  | bc,bc          | 27 km/h |
+            | a    | d  | fb,df,df       | 36 km/h |
+            | d    | c  | dc,dc          | 36 km/h |
+            | g    | b  | fb,fb          | 36 km/h |
+            | a    | g  | fb,fb          | 36 km/h |
+
+    Scenario: Verify that negative values are treated like 0
+        Given the profile "testbot"
+        Given the extract extra arguments "--generate-edge-lookup"
+        Given the contract extra arguments "--segment-speed-file speeds.csv"
+        Given the speed file
+        """
+        1,2,-10
+        2,1,-20
+        2,3,27
+        3,2,27
+        1,4,-3
+        4,1,-5
+        """
+        And I route I should get
+            | from | to | route          | speed   |
+            | a    | b  | fb,fb          | 36 km/h |
+            | a    | c  | fb,bc,bc       | 30 km/h |
+            | b    | c  | bc,bc          | 27 km/h |
+            | a    | d  | fb,df,df       | 36 km/h |
+            | d    | c  | dc,dc          | 36 km/h |
+            | g    | b  | fb,fb          | 36 km/h |
+            | a    | g  | fb,fb          | 36 km/h |

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -215,14 +215,14 @@ class RouteAPI : public BaseAPI
                 nodes.values.reserve(leg_geometry.osm_node_ids.size());
                 datasources.values.reserve(leg_geometry.annotations.size());
 
-                std::for_each(
-                    leg_geometry.annotations.begin(),
-                    leg_geometry.annotations.end(),
-                    [this, &durations, &distances, &datasources](const guidance::LegGeometry::Annotation &step) {
-                        durations.values.push_back(step.duration);
-                        distances.values.push_back(step.distance);
-                        datasources.values.push_back(step.datasource);
-                    });
+                std::for_each(leg_geometry.annotations.begin(),
+                              leg_geometry.annotations.end(),
+                              [this, &durations, &distances, &datasources](
+                                  const guidance::LegGeometry::Annotation &step) {
+                                  durations.values.push_back(step.duration);
+                                  distances.values.push_back(step.distance);
+                                  datasources.values.push_back(step.datasource);
+                              });
                 std::for_each(leg_geometry.osm_node_ids.begin(),
                               leg_geometry.osm_node_ids.end(),
                               [this, &nodes](const OSMNodeID &node_id) {

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -20,6 +20,11 @@ namespace osrm
 namespace engine
 {
 
+inline std::pair<bool, bool> boolPairAnd(const std::pair<bool, bool> &A, const std::pair<bool, bool> &B)
+{
+    return std::make_pair(A.first && B.first, A.second && B.second);
+}
+
 // Implements complex queries on top of an RTree and builds PhantomNodes from it.
 //
 // Only holds a weak reference on the RTree and coordinates!
@@ -48,7 +53,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     {
         auto results =
             rtree.Nearest(input_coordinate,
-                          [](const CandidateSegment &) { return std::make_pair(true, true); },
+                          [this](const CandidateSegment &segment) { return HasValidEdge(segment); },
                           [this, max_distance, input_coordinate](const std::size_t,
                                                                  const CandidateSegment &segment) {
                               return CheckSegmentDistance(input_coordinate, segment, max_distance);
@@ -68,7 +73,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         auto results = rtree.Nearest(
             input_coordinate,
             [this, bearing, bearing_range, max_distance](const CandidateSegment &segment) {
-                return CheckSegmentBearing(segment, bearing, bearing_range);
+                return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),HasValidEdge(segment));
             },
             [this, max_distance, input_coordinate](const std::size_t,
                                                    const CandidateSegment &segment) {
@@ -89,7 +94,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         auto results =
             rtree.Nearest(input_coordinate,
                           [this, bearing, bearing_range](const CandidateSegment &segment) {
-                              return CheckSegmentBearing(segment, bearing, bearing_range);
+                              return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
                           },
                           [max_results](const std::size_t num_results, const CandidateSegment &) {
                               return num_results >= max_results;
@@ -111,7 +116,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         auto results =
             rtree.Nearest(input_coordinate,
                           [this, bearing, bearing_range](const CandidateSegment &segment) {
-                              return CheckSegmentBearing(segment, bearing, bearing_range);
+                              return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
                           },
                           [this, max_distance, max_results, input_coordinate](
                               const std::size_t num_results, const CandidateSegment &segment) {
@@ -129,7 +134,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     {
         auto results =
             rtree.Nearest(input_coordinate,
-                          [](const CandidateSegment &) { return std::make_pair(true, true); },
+                          [this](const CandidateSegment &segment) { return HasValidEdge(segment); },
                           [max_results](const std::size_t num_results, const CandidateSegment &) {
                               return num_results >= max_results;
                           });
@@ -146,7 +151,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     {
         auto results =
             rtree.Nearest(input_coordinate,
-                          [](const CandidateSegment &) { return std::make_pair(true, true); },
+                          [this](const CandidateSegment &segment) { return HasValidEdge(segment); },
                           [this, max_distance, max_results, input_coordinate](
                               const std::size_t num_results, const CandidateSegment &segment) {
                               return num_results >= max_results ||
@@ -166,14 +171,18 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         bool has_big_component = false;
         auto results = rtree.Nearest(
             input_coordinate,
-            [&has_big_component, &has_small_component](const CandidateSegment &segment) {
+            [this, &has_big_component, &has_small_component](const CandidateSegment &segment) {
                 auto use_segment = (!has_small_component ||
                                     (!has_big_component && !segment.data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
+                const auto valid_edges = HasValidEdge(segment);
 
-                has_big_component = has_big_component || !segment.data.component.is_tiny;
-                has_small_component = has_small_component || segment.data.component.is_tiny;
-
+                if (valid_edges.first || valid_edges.second)
+                {
+                    has_big_component = has_big_component || !segment.data.component.is_tiny;
+                    has_small_component = has_small_component || segment.data.component.is_tiny;
+                }
+                use_directions = boolPairAnd(use_directions, valid_edges);
                 return use_directions;
             },
             [this, &has_big_component, max_distance, input_coordinate](
@@ -201,14 +210,21 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         bool has_big_component = false;
         auto results = rtree.Nearest(
             input_coordinate,
-            [&has_big_component, &has_small_component](const CandidateSegment &segment) {
+            [this, &has_big_component, &has_small_component](const CandidateSegment &segment) {
                 auto use_segment = (!has_small_component ||
                                     (!has_big_component && !segment.data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
+                if (!use_directions.first && !use_directions.second) return use_directions;
+                const auto valid_edges = HasValidEdge(segment);
 
-                has_big_component = has_big_component || !segment.data.component.is_tiny;
-                has_small_component = has_small_component || segment.data.component.is_tiny;
+                if (valid_edges.first || valid_edges.second)
+                {
 
+                    has_big_component = has_big_component || !segment.data.component.is_tiny;
+                    has_small_component = has_small_component || segment.data.component.is_tiny;
+                }
+
+                use_directions = boolPairAnd(use_directions, valid_edges);
                 return use_directions;
             },
             [&has_big_component](const std::size_t num_results, const CandidateSegment &) {
@@ -239,10 +255,11 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 auto use_segment = (!has_small_component ||
                                     (!has_big_component && !segment.data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
+                use_directions = boolPairAnd(use_directions, HasValidEdge(segment));
 
                 if (use_segment)
                 {
-                    use_directions = CheckSegmentBearing(segment, bearing, bearing_range);
+                    use_directions = boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
                     if (use_directions.first || use_directions.second)
                     {
                         has_big_component = has_big_component || !segment.data.component.is_tiny;
@@ -283,10 +300,11 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 auto use_segment = (!has_small_component ||
                                     (!has_big_component && !segment.data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
+                use_directions = boolPairAnd(use_directions, HasValidEdge(segment));
 
                 if (use_segment)
                 {
-                    use_directions = CheckSegmentBearing(segment, bearing, bearing_range);
+                    use_directions = boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
                     if (use_directions.first || use_directions.second)
                     {
                         has_big_component = has_big_component || !segment.data.component.is_tiny;
@@ -438,6 +456,47 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 std::round(backward_edge_bearing), filter_bearing, filter_bearing_range) &&
             segment.data.reverse_segment_id.enabled;
         return std::make_pair(forward_bearing_valid, backward_bearing_valid);
+    }
+
+    /**
+     * Checks to see if the edge weights are valid.  We might have an edge,
+     * but a traffic update might set the speed to 0 (weight == INVALID_EDGE_WEIGHT).
+     * which means that this edge is not currently traversible.  If this is the case,
+     * then we shouldn't snap to this edge.
+     */
+    std::pair<bool, bool> HasValidEdge(const CandidateSegment &segment) const
+    {
+
+        bool forward_edge_valid = false;
+        bool reverse_edge_valid = false;
+
+        if (segment.data.forward_packed_geometry_id != SPECIAL_EDGEID)
+        {
+            std::vector<EdgeWeight> forward_weight_vector;
+            datafacade.GetUncompressedWeights(segment.data.forward_packed_geometry_id,
+                                              forward_weight_vector);
+
+            if (forward_weight_vector[segment.data.fwd_segment_position] != INVALID_EDGE_WEIGHT)
+            {
+                forward_edge_valid = segment.data.forward_segment_id.enabled;
+            }
+        }
+
+        if (segment.data.reverse_packed_geometry_id != SPECIAL_EDGEID)
+        {
+            std::vector<EdgeWeight> reverse_weight_vector;
+            datafacade.GetUncompressedWeights(segment.data.reverse_packed_geometry_id,
+                                              reverse_weight_vector);
+
+            BOOST_ASSERT(segment.data.fwd_segment_position < reverse_weight_vector.size());
+
+            if (reverse_weight_vector[reverse_weight_vector.size() - segment.data.fwd_segment_position - 1] != INVALID_EDGE_WEIGHT)
+            {
+                reverse_edge_valid = segment.data.reverse_segment_id.enabled;
+            }
+        }
+
+        return std::make_pair(forward_edge_valid, reverse_edge_valid);
     }
 
     const RTreeT &rtree;

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -73,7 +73,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         auto results = rtree.Nearest(
             input_coordinate,
             [this, bearing, bearing_range, max_distance](const CandidateSegment &segment) {
-                return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),HasValidEdge(segment));
+                return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
+                                   HasValidEdge(segment));
             },
             [this, max_distance, input_coordinate](const std::size_t,
                                                    const CandidateSegment &segment) {
@@ -91,14 +92,15 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                         const int bearing,
                         const int bearing_range) const
     {
-        auto results =
-            rtree.Nearest(input_coordinate,
-                          [this, bearing, bearing_range](const CandidateSegment &segment) {
-                              return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
-                          },
-                          [max_results](const std::size_t num_results, const CandidateSegment &) {
-                              return num_results >= max_results;
-                          });
+        auto results = rtree.Nearest(
+            input_coordinate,
+            [this, bearing, bearing_range](const CandidateSegment &segment) {
+                return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
+                                   HasValidEdge(segment));
+            },
+            [max_results](const std::size_t num_results, const CandidateSegment &) {
+                return num_results >= max_results;
+            });
 
         return MakePhantomNodes(input_coordinate, results);
     }
@@ -113,16 +115,17 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                         const int bearing,
                         const int bearing_range) const
     {
-        auto results =
-            rtree.Nearest(input_coordinate,
-                          [this, bearing, bearing_range](const CandidateSegment &segment) {
-                              return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
-                          },
-                          [this, max_distance, max_results, input_coordinate](
-                              const std::size_t num_results, const CandidateSegment &segment) {
-                              return num_results >= max_results ||
-                                     CheckSegmentDistance(input_coordinate, segment, max_distance);
-                          });
+        auto results = rtree.Nearest(
+            input_coordinate,
+            [this, bearing, bearing_range](const CandidateSegment &segment) {
+                return boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
+                                   HasValidEdge(segment));
+            },
+            [this, max_distance, max_results, input_coordinate](const std::size_t num_results,
+                                                                const CandidateSegment &segment) {
+                return num_results >= max_results ||
+                       CheckSegmentDistance(input_coordinate, segment, max_distance);
+            });
 
         return MakePhantomNodes(input_coordinate, results);
     }
@@ -214,7 +217,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 auto use_segment = (!has_small_component ||
                                     (!has_big_component && !segment.data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
-                if (!use_directions.first && !use_directions.second) return use_directions;
+                if (!use_directions.first && !use_directions.second)
+                    return use_directions;
                 const auto valid_edges = HasValidEdge(segment);
 
                 if (valid_edges.first || valid_edges.second)
@@ -259,7 +263,9 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
                 if (use_segment)
                 {
-                    use_directions = boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
+                    use_directions =
+                        boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
+                                    HasValidEdge(segment));
                     if (use_directions.first || use_directions.second)
                     {
                         has_big_component = has_big_component || !segment.data.component.is_tiny;
@@ -304,7 +310,9 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
                 if (use_segment)
                 {
-                    use_directions = boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range), HasValidEdge(segment));
+                    use_directions =
+                        boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
+                                    HasValidEdge(segment));
                     if (use_directions.first || use_directions.second)
                     {
                         has_big_component = has_big_component || !segment.data.component.is_tiny;
@@ -490,7 +498,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
             BOOST_ASSERT(segment.data.fwd_segment_position < reverse_weight_vector.size());
 
-            if (reverse_weight_vector[reverse_weight_vector.size() - segment.data.fwd_segment_position - 1] != INVALID_EDGE_WEIGHT)
+            if (reverse_weight_vector[reverse_weight_vector.size() -
+                                      segment.data.fwd_segment_position - 1] != INVALID_EDGE_WEIGHT)
             {
                 reverse_edge_valid = segment.data.reverse_segment_id.enabled;
             }

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -51,8 +51,8 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         reverse_geometry[reverse_geometry.size() - source_node.fwd_segment_position - 1]));
 
     std::vector<uint8_t> forward_datasource_vector;
-    facade.GetUncompressedDatasources(source_node.forward_packed_geometry_id, forward_datasource_vector);
-
+    facade.GetUncompressedDatasources(source_node.forward_packed_geometry_id,
+                                      forward_datasource_vector);
 
     auto cumulative_distance = 0.;
     auto current_distance = 0.;
@@ -73,8 +73,8 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         }
 
         prev_coordinate = coordinate;
-        geometry.annotations.emplace_back(
-            LegGeometry::Annotation{current_distance, path_point.duration_until_turn / 10., path_point.datasource_id});
+        geometry.annotations.emplace_back(LegGeometry::Annotation{
+            current_distance, path_point.duration_until_turn / 10., path_point.datasource_id});
         geometry.locations.push_back(std::move(coordinate));
         geometry.osm_node_ids.push_back(facade.GetOSMNodeIDOfNode(path_point.turn_via_node));
     }
@@ -88,7 +88,9 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     facade.GetUncompressedDatasources(target_node.forward_packed_geometry_id, forward_datasources);
 
     geometry.annotations.emplace_back(
-        LegGeometry::Annotation{current_distance, target_node.forward_weight / 10., forward_datasources[target_node.fwd_segment_position]});
+        LegGeometry::Annotation{current_distance,
+                                target_node.forward_weight / 10.,
+                                forward_datasources[target_node.fwd_segment_position]});
     geometry.segment_offsets.push_back(geometry.locations.size());
     geometry.locations.push_back(target_node.location);
 
@@ -98,7 +100,6 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     facade.GetUncompressedGeometry(target_node.forward_packed_geometry_id, forward_geometry);
     geometry.osm_node_ids.push_back(
         facade.GetOSMNodeIDOfNode(forward_geometry[target_node.fwd_segment_position]));
-
 
     BOOST_ASSERT(geometry.segment_distances.size() == geometry.segment_offsets.size() - 1);
     BOOST_ASSERT(geometry.locations.size() > geometry.segment_distances.size());

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -62,8 +62,10 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     {
     }
     void GetUncompressedWeights(const EdgeID /* id */,
-                                std::vector<EdgeWeight> & /* result_weights */) const override
+                                std::vector<EdgeWeight> &result_weights) const override
     {
+        result_weights.resize(1);
+        result_weights[0] = 1;
     }
     void GetUncompressedDatasources(const EdgeID /*id*/,
                                     std::vector<uint8_t> & /*data_sources*/) const override

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -165,6 +165,9 @@ struct GraphFixture
             // to examine during tests.
             d.forward_segment_id = {pair.second, true};
             d.reverse_segment_id = {pair.first, true};
+            d.fwd_segment_position = 0;
+            d.forward_packed_geometry_id = 0;
+            d.reverse_packed_geometry_id = 0;
             edges.emplace_back(d);
         }
     }


### PR DESCRIPTION
Fixes #2713

:flameretardantpants: are on, I'm ready for the use-of-`goto` abuse.  I think this is the perfect situation for it.

TODO:
  - [x] don't snap to edges that are zero'd
  - [x] verify contraction on nodes that become isolated because of edge filtering

Notes: 
  - debug tiles will show edges with zero speeds, even though we won't route on them.
  - in a perfect world, setting a single segment to 0 would bisect a road, leading to two cul-de-sac like streets.  Without re-writing/recompressing geometries, we can't do that, so instead we're setting the whole edge to unroutable.  For a long road with a single 0-speed segment in the middle, this makes the whole road effectively unreachable, which is the best we can do for now I think.