### PR TITLE
Merge compressed geometries

### DIFF
--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -8,6 +8,7 @@
 #include "extractor/external_memory_node.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
 #include "extractor/guidance/turn_lane_types.hpp"
+#include "extractor/original_edge_data.hpp"
 #include "engine/phantom_node.hpp"
 #include "util/exception.hpp"
 #include "util/guidance/bearing_class.hpp"
@@ -74,20 +75,22 @@ class BaseDataFacade
     virtual util::Coordinate GetCoordinateOfNode(const unsigned id) const = 0;
     virtual OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const = 0;
 
-    virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const = 0;
+    virtual GeometryID GetGeometryIndexForEdgeID(const unsigned id) const = 0;
 
-    virtual void GetUncompressedGeometry(const EdgeID id,
-                                         std::vector<NodeID> &result_nodes) const = 0;
+    virtual std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID id) const = 0;
+
+    virtual std::vector<NodeID> GetUncompressedReverseGeometry(const EdgeID id) const = 0;
 
     // Gets the weight values for each segment in an uncompressed geometry.
     // Should always be 1 shorter than GetUncompressedGeometry
-    virtual void GetUncompressedWeights(const EdgeID id,
-                                        std::vector<EdgeWeight> &result_weights) const = 0;
+    virtual std::vector<EdgeWeight> GetUncompressedForwardWeights(const EdgeID id) const = 0;
+
+    virtual std::vector<EdgeWeight> GetUncompressedReverseWeights(const EdgeID id) const = 0;
 
     // Returns the data source ids that were used to supply the edge
     // weights.  Will return an empty array when only the base profile is used.
-    virtual void GetUncompressedDatasources(const EdgeID id,
-                                            std::vector<uint8_t> &data_sources) const = 0;
+    virtual std::vector<uint8_t> GetUncompressedForwardDatasources(const EdgeID id) const = 0;
+    virtual std::vector<uint8_t> GetUncompressedReverseDatasources(const EdgeID id) const = 0;
 
     // Gets the name of a datasource
     virtual std::string GetDatasourceName(const uint8_t datasource_name_id) const = 0;

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -76,7 +76,7 @@ class InternalDataFacade final : public BaseDataFacade
 
     util::ShM<util::Coordinate, false>::vector m_coordinate_list;
     util::PackedVector<OSMNodeID, false> m_osmnodeid_list;
-    util::ShM<NodeID, false>::vector m_via_node_list;
+    util::ShM<GeometryID, false>::vector m_via_geometry_list;
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;
     util::ShM<LaneDataID, false>::vector m_lane_data_id;
@@ -189,7 +189,7 @@ class InternalDataFacade final : public BaseDataFacade
         boost::filesystem::ifstream edges_input_stream(edges_file, std::ios::binary);
         unsigned number_of_edges = 0;
         edges_input_stream.read((char *)&number_of_edges, sizeof(unsigned));
-        m_via_node_list.resize(number_of_edges);
+        m_via_geometry_list.resize(number_of_edges);
         m_name_ID_list.resize(number_of_edges);
         m_turn_instruction_list.resize(number_of_edges);
         m_lane_data_id.resize(number_of_edges);
@@ -201,7 +201,7 @@ class InternalDataFacade final : public BaseDataFacade
         {
             edges_input_stream.read((char *)&(current_edge_data),
                                     sizeof(extractor::OriginalEdgeData));
-            m_via_node_list[i] = current_edge_data.via_node;
+            m_via_geometry_list[i] = current_edge_data.via_geometry;
             m_name_ID_list[i] = current_edge_data.name_id;
             m_turn_instruction_list[i] = current_edge_data.turn_instruction;
             m_lane_data_id[i] = current_edge_data.lane_data_id;
@@ -670,9 +670,9 @@ class InternalDataFacade final : public BaseDataFacade
         return GetNameForID(name_id + 1);
     }
 
-    virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const override final
+    virtual GeometryID GetGeometryIndexForEdgeID(const unsigned id) const override final
     {
-        return m_via_node_list.at(id);
+        return m_via_geometry_list.at(id);
     }
 
     virtual std::size_t GetCoreSize() const override final { return m_is_core_node.size(); }
@@ -689,47 +689,128 @@ class InternalDataFacade final : public BaseDataFacade
         }
     }
 
-    virtual void GetUncompressedGeometry(const EdgeID id,
-                                         std::vector<NodeID> &result_nodes) const override final
+    virtual std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID id) const override final
     {
+        /*
+         * NodeID's for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector.
+         * */
         const unsigned begin = m_geometry_indices.at(id);
         const unsigned end = m_geometry_indices.at(id + 1);
 
-        result_nodes.clear();
+        std::vector<NodeID> result_nodes;
+
         result_nodes.reserve(end - begin);
+
         std::for_each(m_geometry_list.begin() + begin,
                       m_geometry_list.begin() + end,
                       [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
                           result_nodes.emplace_back(edge.node_id);
                       });
+
+        return result_nodes;
     }
 
-    virtual void
-    GetUncompressedWeights(const EdgeID id,
-                           std::vector<EdgeWeight> &result_weights) const override final
+    virtual std::vector<NodeID> GetUncompressedReverseGeometry(const EdgeID id) const override final
     {
+        /*
+         * NodeID's for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector.
+         * */
         const unsigned begin = m_geometry_indices.at(id);
         const unsigned end = m_geometry_indices.at(id + 1);
 
-        result_weights.clear();
+        std::vector<NodeID> result_nodes;
+
+        result_nodes.reserve(end - begin);
+
+        std::for_each(m_geometry_list.rbegin() + (m_geometry_list.size() - end),
+                      m_geometry_list.rbegin() + (m_geometry_list.size() - begin),
+                      [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
+                          result_nodes.emplace_back(edge.node_id);
+                      });
+
+        return result_nodes;
+    }
+
+    virtual std::vector<EdgeWeight>
+    GetUncompressedForwardWeights(const EdgeID id) const override final
+    {
+        /*
+         * EdgeWeights's for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * forward weights of bi-directional edges, edges 2 to
+         * n of that edge need to be read.
+         */
+        const unsigned begin = m_geometry_indices.at(id) + 1;
+        const unsigned end = m_geometry_indices.at(id + 1);
+
+        std::vector<EdgeWeight> result_weights;
         result_weights.reserve(end - begin);
+
         std::for_each(m_geometry_list.begin() + begin,
                       m_geometry_list.begin() + end,
                       [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
-                          result_weights.emplace_back(edge.weight);
+                          result_weights.emplace_back(edge.forward_weight);
                       });
+
+        return result_weights;
+    }
+
+    virtual std::vector<EdgeWeight>
+    GetUncompressedReverseWeights(const EdgeID id) const override final
+    {
+        /*
+         * EdgeWeights for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * reverse weights of bi-directional edges, edges 1 to
+         * n-1 of that edge need to be read in reverse.
+         */
+        const unsigned begin = m_geometry_indices.at(id);
+        const unsigned end = m_geometry_indices.at(id + 1) - 1;
+
+        std::vector<EdgeWeight> result_weights;
+        result_weights.reserve(end - begin);
+
+        std::for_each(m_geometry_list.rbegin() + (m_geometry_list.size() - end),
+                      m_geometry_list.rbegin() + (m_geometry_list.size() - begin),
+                      [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
+                          result_weights.emplace_back(edge.reverse_weight);
+                      });
+
+        return result_weights;
     }
 
     // Returns the data source ids that were used to supply the edge
     // weights.
-    virtual void
-    GetUncompressedDatasources(const EdgeID id,
-                               std::vector<uint8_t> &result_datasources) const override final
+    virtual std::vector<uint8_t>
+    GetUncompressedForwardDatasources(const EdgeID id) const override final
     {
-        const unsigned begin = m_geometry_indices.at(id);
+        /*
+         * Data sources for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * forward datasources of bi-directional edges, edges 2 to
+         * n of that edge need to be read.
+         */
+        const unsigned begin = m_geometry_indices.at(id) + 1;
         const unsigned end = m_geometry_indices.at(id + 1);
 
-        result_datasources.clear();
+        std::vector<uint8_t> result_datasources;
         result_datasources.reserve(end - begin);
 
         // If there was no datasource info, return an array of 0's.
@@ -747,6 +828,47 @@ class InternalDataFacade final : public BaseDataFacade
                 m_datasource_list.begin() + end,
                 [&](const uint8_t &datasource_id) { result_datasources.push_back(datasource_id); });
         }
+
+        return result_datasources;
+    }
+
+    // Returns the data source ids that were used to supply the edge
+    // weights.
+    virtual std::vector<uint8_t>
+    GetUncompressedReverseDatasources(const EdgeID id) const override final
+    {
+        /*
+         * Datasources for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * reverse datasources of bi-directional edges, edges 1 to
+         * n-1 of that edge need to be read in reverse.
+         */
+        const unsigned begin = m_geometry_indices.at(id);
+        const unsigned end = m_geometry_indices.at(id + 1) - 1;
+
+        std::vector<uint8_t> result_datasources;
+        result_datasources.reserve(end - begin);
+
+        // If there was no datasource info, return an array of 0's.
+        if (m_datasource_list.empty())
+        {
+            for (unsigned i = 0; i < end - begin; ++i)
+            {
+                result_datasources.push_back(0);
+            }
+        }
+        else
+        {
+            std::for_each(
+                m_datasource_list.rbegin() + (m_datasource_list.size() - end),
+                m_datasource_list.rbegin() + (m_datasource_list.size() - begin),
+                [&](const uint8_t &datasource_id) { result_datasources.push_back(datasource_id); });
+        }
+
+        return result_datasources;
     }
 
     virtual std::string GetDatasourceName(const uint8_t datasource_name_id) const override final

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -79,7 +79,7 @@ class SharedDataFacade final : public BaseDataFacade
 
     util::ShM<util::Coordinate, true>::vector m_coordinate_list;
     util::PackedVector<OSMNodeID, true> m_osmnodeid_list;
-    util::ShM<NodeID, true>::vector m_via_node_list;
+    util::ShM<GeometryID, true>::vector m_via_geometry_list;
     util::ShM<unsigned, true>::vector m_name_ID_list;
     util::ShM<LaneDataID, true>::vector m_lane_data_id;
     util::ShM<extractor::guidance::TurnInstruction, true>::vector m_turn_instruction_list;
@@ -229,11 +229,12 @@ class SharedDataFacade final : public BaseDataFacade
 
     void LoadViaNodeList()
     {
-        auto via_node_list_ptr = data_layout->GetBlockPtr<NodeID>(
+        auto via_geometry_list_ptr = data_layout->GetBlockPtr<GeometryID>(
             shared_memory, storage::SharedDataLayout::VIA_NODE_LIST);
-        util::ShM<NodeID, true>::vector via_node_list(
-            via_node_list_ptr, data_layout->num_entries[storage::SharedDataLayout::VIA_NODE_LIST]);
-        m_via_node_list = std::move(via_node_list);
+        util::ShM<GeometryID, true>::vector via_geometry_list(
+            via_geometry_list_ptr,
+            data_layout->num_entries[storage::SharedDataLayout::VIA_NODE_LIST]);
+        m_via_geometry_list = std::move(via_geometry_list);
     }
 
     void LoadNames()
@@ -525,40 +526,113 @@ class SharedDataFacade final : public BaseDataFacade
         return m_osmnodeid_list.at(id);
     }
 
-    virtual void GetUncompressedGeometry(const EdgeID id,
-                                         std::vector<NodeID> &result_nodes) const override final
+    virtual std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID id) const override final
     {
+        /*
+         * NodeID's for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * forward geometries of bi-directional edges, edges 2 to
+         * n of that edge need to be read.
+         */
         const unsigned begin = m_geometry_indices.at(id);
         const unsigned end = m_geometry_indices.at(id + 1);
 
-        result_nodes.clear();
+        std::vector<NodeID> result_nodes;
+
         result_nodes.reserve(end - begin);
+
         std::for_each(m_geometry_list.begin() + begin,
                       m_geometry_list.begin() + end,
                       [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
                           result_nodes.emplace_back(edge.node_id);
                       });
+
+        return result_nodes;
     }
 
-    virtual void
-    GetUncompressedWeights(const EdgeID id,
-                           std::vector<EdgeWeight> &result_weights) const override final
+    virtual std::vector<NodeID> GetUncompressedReverseGeometry(const EdgeID id) const override final
     {
-        const unsigned begin = m_geometry_indices.at(id);
+        /*
+         * NodeID's for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector.
+         * */
+        const signed begin = m_geometry_indices.at(id);
+        const signed end = m_geometry_indices.at(id + 1);
+
+        std::vector<NodeID> result_nodes;
+
+        result_nodes.reserve(end - begin);
+
+        std::for_each(m_geometry_list.rbegin() + (m_geometry_list.size() - end),
+                      m_geometry_list.rbegin() + (m_geometry_list.size() - begin),
+                      [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
+                          result_nodes.emplace_back(edge.node_id);
+                      });
+
+        return result_nodes;
+    }
+
+    virtual std::vector<EdgeWeight>
+    GetUncompressedForwardWeights(const EdgeID id) const override final
+    {
+        /*
+         * EdgeWeights's for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector.
+         * */
+        const unsigned begin = m_geometry_indices.at(id) + 1;
         const unsigned end = m_geometry_indices.at(id + 1);
 
-        result_weights.clear();
+        std::vector<EdgeWeight> result_weights;
         result_weights.reserve(end - begin);
+
         std::for_each(m_geometry_list.begin() + begin,
                       m_geometry_list.begin() + end,
                       [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
-                          result_weights.emplace_back(edge.weight);
+                          result_weights.emplace_back(edge.forward_weight);
                       });
+
+        return result_weights;
     }
 
-    virtual unsigned GetGeometryIndexForEdgeID(const unsigned id) const override final
+    virtual std::vector<EdgeWeight>
+    GetUncompressedReverseWeights(const EdgeID id) const override final
     {
-        return m_via_node_list.at(id);
+        /*
+         * EdgeWeights for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * reverse weights of bi-directional edges, edges 1 to
+         * n-1 of that edge need to be read in reverse.
+         */
+        const signed begin = m_geometry_indices.at(id);
+        const signed end = m_geometry_indices.at(id + 1) - 1;
+
+        std::vector<EdgeWeight> result_weights;
+        result_weights.reserve(end - begin);
+
+        std::for_each(m_geometry_list.rbegin() + (m_geometry_list.size() - end),
+                      m_geometry_list.rbegin() + (m_geometry_list.size() - begin),
+                      [&](const osrm::extractor::CompressedEdgeContainer::CompressedEdge &edge) {
+                          result_weights.emplace_back(edge.reverse_weight);
+                      });
+
+        return result_weights;
+    }
+
+    virtual GeometryID GetGeometryIndexForEdgeID(const unsigned id) const override final
+    {
+        return m_via_geometry_list.at(id);
     }
 
     extractor::guidance::TurnInstruction
@@ -755,14 +829,22 @@ class SharedDataFacade final : public BaseDataFacade
 
     // Returns the data source ids that were used to supply the edge
     // weights.
-    virtual void
-    GetUncompressedDatasources(const EdgeID id,
-                               std::vector<uint8_t> &result_datasources) const override final
+    virtual std::vector<uint8_t>
+    GetUncompressedForwardDatasources(const EdgeID id) const override final
     {
-        const unsigned begin = m_geometry_indices.at(id);
+        /*
+         * Data sources for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * forward datasources of bi-directional edges, edges 2 to
+         * n of that edge need to be read.
+         */
+        const unsigned begin = m_geometry_indices.at(id) + 1;
         const unsigned end = m_geometry_indices.at(id + 1);
 
-        result_datasources.clear();
+        std::vector<uint8_t> result_datasources;
         result_datasources.reserve(end - begin);
 
         // If there was no datasource info, return an array of 0's.
@@ -780,6 +862,47 @@ class SharedDataFacade final : public BaseDataFacade
                 m_datasource_list.begin() + end,
                 [&](const uint8_t &datasource_id) { result_datasources.push_back(datasource_id); });
         }
+
+        return result_datasources;
+    }
+
+    // Returns the data source ids that were used to supply the edge
+    // weights.
+    virtual std::vector<uint8_t>
+    GetUncompressedReverseDatasources(const EdgeID id) const override final
+    {
+        /*
+         * Datasources for geometries are stored in one place for
+         * both forward and reverse segments along the same bi-
+         * directional edge. The m_geometry_indices stores
+         * refences to where to find the beginning of the bi-
+         * directional edge in the m_geometry_list vector. For
+         * reverse datasources of bi-directional edges, edges 1 to
+         * n-1 of that edge need to be read in reverse.
+         */
+        const unsigned begin = m_geometry_indices.at(id);
+        const unsigned end = m_geometry_indices.at(id + 1) - 1;
+
+        std::vector<uint8_t> result_datasources;
+        result_datasources.reserve(end - begin);
+
+        // If there was no datasource info, return an array of 0's.
+        if (m_datasource_list.empty())
+        {
+            for (unsigned i = 0; i < end - begin; ++i)
+            {
+                result_datasources.push_back(0);
+            }
+        }
+        else
+        {
+            std::for_each(
+                m_datasource_list.rbegin() + (m_datasource_list.size() - end),
+                m_datasource_list.rbegin() + (m_datasource_list.size() - begin),
+                [&](const uint8_t &datasource_id) { result_datasources.push_back(datasource_id); });
+        }
+
+        return result_datasources;
     }
 
     virtual std::string GetDatasourceName(const uint8_t datasource_name_id) const override final

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -372,35 +372,25 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         int forward_offset = 0, forward_weight = 0;
         int reverse_offset = 0, reverse_weight = 0;
 
-        if (data.forward_packed_geometry_id != SPECIAL_EDGEID)
+        const std::vector<EdgeWeight> forward_weight_vector = datafacade.GetUncompressedForwardWeights(data.packed_geometry_id);
+        const std::vector<EdgeWeight> reverse_weight_vector = datafacade.GetUncompressedReverseWeights(data.packed_geometry_id);
+
+        for (std::size_t i = 0; i < data.fwd_segment_position; i++)
         {
-            std::vector<EdgeWeight> forward_weight_vector;
-            datafacade.GetUncompressedWeights(data.forward_packed_geometry_id,
-                                              forward_weight_vector);
-            for (std::size_t i = 0; i < data.fwd_segment_position; i++)
-            {
-                forward_offset += forward_weight_vector[i];
-            }
-            forward_weight = forward_weight_vector[data.fwd_segment_position];
+            forward_offset += forward_weight_vector[i];
         }
+        forward_weight = forward_weight_vector[data.fwd_segment_position];
 
-        if (data.reverse_packed_geometry_id != SPECIAL_EDGEID)
+        BOOST_ASSERT(data.fwd_segment_position < reverse_weight_vector.size());
+
+        for (std::size_t i = 0;
+             i < reverse_weight_vector.size() - data.fwd_segment_position - 1;
+             i++)
         {
-            std::vector<EdgeWeight> reverse_weight_vector;
-            datafacade.GetUncompressedWeights(data.reverse_packed_geometry_id,
-                                              reverse_weight_vector);
-
-            BOOST_ASSERT(data.fwd_segment_position < reverse_weight_vector.size());
-
-            for (std::size_t i = 0;
-                 i < reverse_weight_vector.size() - data.fwd_segment_position - 1;
-                 i++)
-            {
-                reverse_offset += reverse_weight_vector[i];
-            }
-            reverse_weight =
-                reverse_weight_vector[reverse_weight_vector.size() - data.fwd_segment_position - 1];
+            reverse_offset += reverse_weight_vector[i];
         }
+        reverse_weight =
+            reverse_weight_vector[reverse_weight_vector.size() - data.fwd_segment_position - 1];
 
         ratio = std::min(1.0, std::max(0.0, ratio));
         if (data.forward_segment_id.id != SPECIAL_SEGMENTID)
@@ -479,31 +469,18 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         bool forward_edge_valid = false;
         bool reverse_edge_valid = false;
 
-        if (segment.data.forward_packed_geometry_id != SPECIAL_EDGEID)
-        {
-            std::vector<EdgeWeight> forward_weight_vector;
-            datafacade.GetUncompressedWeights(segment.data.forward_packed_geometry_id,
-                                              forward_weight_vector);
+        const std::vector<EdgeWeight> forward_weight_vector = datafacade.GetUncompressedForwardWeights(segment.data.packed_geometry_id);
 
-            if (forward_weight_vector[segment.data.fwd_segment_position] != INVALID_EDGE_WEIGHT)
-            {
-                forward_edge_valid = segment.data.forward_segment_id.enabled;
-            }
+        if (forward_weight_vector[segment.data.fwd_segment_position] != INVALID_EDGE_WEIGHT)
+        {
+            forward_edge_valid = segment.data.forward_segment_id.enabled;
         }
 
-        if (segment.data.reverse_packed_geometry_id != SPECIAL_EDGEID)
+        const std::vector<EdgeWeight> reverse_weight_vector = datafacade.GetUncompressedReverseWeights(segment.data.packed_geometry_id);
+        if (reverse_weight_vector[reverse_weight_vector.size() -
+                                  segment.data.fwd_segment_position - 1] != INVALID_EDGE_WEIGHT)
         {
-            std::vector<EdgeWeight> reverse_weight_vector;
-            datafacade.GetUncompressedWeights(segment.data.reverse_packed_geometry_id,
-                                              reverse_weight_vector);
-
-            BOOST_ASSERT(segment.data.fwd_segment_position < reverse_weight_vector.size());
-
-            if (reverse_weight_vector[reverse_weight_vector.size() -
-                                      segment.data.fwd_segment_position - 1] != INVALID_EDGE_WEIGHT)
-            {
-                reverse_edge_valid = segment.data.reverse_segment_id.enabled;
-            }
+            reverse_edge_valid = segment.data.reverse_segment_id.enabled;
         }
 
         return std::make_pair(forward_edge_valid, reverse_edge_valid);

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -45,14 +45,10 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
 
     // Need to get the node ID preceding the source phantom node
     // TODO: check if this was traversed in reverse?
-    std::vector<NodeID> reverse_geometry;
-    facade.GetUncompressedGeometry(source_node.reverse_packed_geometry_id, reverse_geometry);
+    const std::vector<NodeID> source_geometry =
+        facade.GetUncompressedForwardGeometry(source_node.packed_geometry_id);
     geometry.osm_node_ids.push_back(facade.GetOSMNodeIDOfNode(
-        reverse_geometry[reverse_geometry.size() - source_node.fwd_segment_position - 1]));
-
-    std::vector<uint8_t> forward_datasource_vector;
-    facade.GetUncompressedDatasources(source_node.forward_packed_geometry_id,
-                                      forward_datasource_vector);
+        source_geometry[source_node.fwd_segment_position]));
 
     auto cumulative_distance = 0.;
     auto current_distance = 0.;
@@ -84,8 +80,8 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     // segment leading to the target node
     geometry.segment_distances.push_back(cumulative_distance);
 
-    std::vector<DatasourceID> forward_datasources;
-    facade.GetUncompressedDatasources(target_node.forward_packed_geometry_id, forward_datasources);
+    const std::vector<DatasourceID> forward_datasources =
+        facade.GetUncompressedForwardDatasources(target_node.packed_geometry_id);
 
     geometry.annotations.emplace_back(
         LegGeometry::Annotation{current_distance,
@@ -96,10 +92,10 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
 
     // Need to get the node ID following the destination phantom node
     // TODO: check if this was traversed in reverse??
-    std::vector<NodeID> forward_geometry;
-    facade.GetUncompressedGeometry(target_node.forward_packed_geometry_id, forward_geometry);
+    const std::vector<NodeID> target_geometry =
+        facade.GetUncompressedForwardGeometry(target_node.packed_geometry_id);
     geometry.osm_node_ids.push_back(
-        facade.GetOSMNodeIDOfNode(forward_geometry[target_node.fwd_segment_position]));
+        facade.GetOSMNodeIDOfNode(target_geometry[target_node.fwd_segment_position + 1]));
 
     BOOST_ASSERT(geometry.segment_distances.size() == geometry.segment_offsets.size() - 1);
     BOOST_ASSERT(geometry.locations.size() > geometry.segment_distances.size());

--- a/include/engine/hint.hpp
+++ b/include/engine/hint.hpp
@@ -63,8 +63,8 @@ struct Hint
     friend std::ostream &operator<<(std::ostream &, const Hint &);
 };
 
-static_assert(sizeof(Hint) == 60 + 4, "Hint is bigger than expected");
-constexpr std::size_t ENCODED_HINT_SIZE = 88;
+static_assert(sizeof(Hint) == 56 + 4, "Hint is bigger than expected");
+constexpr std::size_t ENCODED_HINT_SIZE = 80;
 static_assert(ENCODED_HINT_SIZE / 4 * 3 >= sizeof(Hint),
               "ENCODED_HINT_SIZE does not match size of Hint");
 }

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -53,8 +53,7 @@ struct PhantomNode
                 int reverse_weight,
                 int forward_offset,
                 int reverse_offset,
-                unsigned forward_packed_geometry_id_,
-                unsigned reverse_packed_geometry_id_,
+                unsigned packed_geometry_id_,
                 bool is_tiny_component,
                 unsigned component_id,
                 util::Coordinate location,
@@ -65,8 +64,7 @@ struct PhantomNode
         : forward_segment_id(forward_segment_id), reverse_segment_id(reverse_segment_id),
           name_id(name_id), forward_weight(forward_weight), reverse_weight(reverse_weight),
           forward_offset(forward_offset), reverse_offset(reverse_offset),
-          forward_packed_geometry_id(forward_packed_geometry_id_),
-          reverse_packed_geometry_id(reverse_packed_geometry_id_),
+          packed_geometry_id(packed_geometry_id_),
           component{component_id, is_tiny_component}, location(std::move(location)),
           input_location(std::move(input_location)), fwd_segment_position(fwd_segment_position),
           forward_travel_mode(forward_travel_mode), backward_travel_mode(backward_travel_mode)
@@ -78,7 +76,7 @@ struct PhantomNode
           reverse_segment_id{SPECIAL_SEGMENTID, false},
           name_id(std::numeric_limits<unsigned>::max()), forward_weight(INVALID_EDGE_WEIGHT),
           reverse_weight(INVALID_EDGE_WEIGHT), forward_offset(0), reverse_offset(0),
-          forward_packed_geometry_id(SPECIAL_EDGEID), reverse_packed_geometry_id(SPECIAL_EDGEID),
+          packed_geometry_id(SPECIAL_GEOMETRYID),
           component{INVALID_COMPONENTID, false}, fwd_segment_position(0),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
@@ -129,8 +127,7 @@ struct PhantomNode
           reverse_segment_id{other.reverse_segment_id}, name_id{other.name_id},
           forward_weight{forward_weight_}, reverse_weight{reverse_weight_},
           forward_offset{forward_offset_}, reverse_offset{reverse_offset_},
-          forward_packed_geometry_id{other.forward_packed_geometry_id},
-          reverse_packed_geometry_id{other.reverse_packed_geometry_id},
+          packed_geometry_id{other.packed_geometry_id},
           component{other.component.id, other.component.is_tiny}, location{location_},
           input_location{input_location_}, fwd_segment_position{other.fwd_segment_position},
           forward_travel_mode{other.forward_travel_mode},
@@ -145,8 +142,7 @@ struct PhantomNode
     int reverse_weight;
     int forward_offset;
     int reverse_offset;
-    unsigned forward_packed_geometry_id;
-    unsigned reverse_packed_geometry_id;
+    unsigned packed_geometry_id;
     struct ComponentType
     {
         std::uint32_t id : 31;
@@ -163,7 +159,7 @@ struct PhantomNode
     extractor::TravelMode backward_travel_mode;
 };
 
-static_assert(sizeof(PhantomNode) == 60, "PhantomNode has more padding then expected");
+static_assert(sizeof(PhantomNode) == 56, "PhantomNode has more padding then expected");
 
 using PhantomNodePair = std::pair<PhantomNode, PhantomNode>;
 
@@ -195,8 +191,7 @@ inline std::ostream &operator<<(std::ostream &out, const PhantomNode &pn)
         << "rev-w: " << pn.reverse_weight << ", "
         << "fwd-o: " << pn.forward_offset << ", "
         << "rev-o: " << pn.reverse_offset << ", "
-        << "fwd_geom: " << pn.forward_packed_geometry_id << ", "
-        << "rev_geom: " << pn.reverse_packed_geometry_id << ", "
+        << "geom: " << pn.packed_geometry_id << ", "
         << "comp: " << pn.component.is_tiny << " / " << pn.component.id << ", "
         << "pos: " << pn.fwd_segment_position << ", "
         << "loc: " << pn.location;

--- a/include/extractor/compressed_edge_container.hpp
+++ b/include/extractor/compressed_edge_container.hpp
@@ -16,12 +16,22 @@ namespace extractor
 class CompressedEdgeContainer
 {
   public:
-    struct CompressedEdge
+    struct OnewayCompressedEdge
     {
       public:
         NodeID node_id;    // refers to an internal node-based-node
         EdgeWeight weight; // the weight of the edge leading to this node
     };
+
+    struct CompressedEdge
+    {
+      public:
+        NodeID node_id;
+        EdgeWeight forward_weight;
+        EdgeWeight reverse_weight;
+    };
+
+    using OnewayEdgeBucket = std::vector<OnewayCompressedEdge>;
     using EdgeBucket = std::vector<CompressedEdge>;
 
     CompressedEdgeContainer();
@@ -35,11 +45,18 @@ class CompressedEdgeContainer
     void
     AddUncompressedEdge(const EdgeID edge_id, const NodeID target_node, const EdgeWeight weight);
 
+    void InitializeBothwayVector();
+    unsigned ZipEdges(const unsigned f_edge_pos, const unsigned r_edge_pos);
+
     bool HasEntryForID(const EdgeID edge_id) const;
+    bool HasZippedEntryForForwardID(const EdgeID edge_id) const;
+    bool HasZippedEntryForReverseID(const EdgeID edge_id) const;
     void PrintStatistics() const;
     void SerializeInternalVector(const std::string &path) const;
     unsigned GetPositionForID(const EdgeID edge_id) const;
-    const EdgeBucket &GetBucketReference(const EdgeID edge_id) const;
+    unsigned GetZippedPositionForForwardID(const EdgeID edge_id) const;
+    unsigned GetZippedPositionForReverseID(const EdgeID edge_id) const;
+    const OnewayEdgeBucket &GetBucketReference(const EdgeID edge_id) const;
     bool IsTrivial(const EdgeID edge_id) const;
     NodeID GetFirstEdgeTargetID(const EdgeID edge_id) const;
     NodeID GetLastEdgeTargetID(const EdgeID edge_id) const;
@@ -49,9 +66,12 @@ class CompressedEdgeContainer
     int free_list_maximum = 0;
 
     void IncreaseFreeList();
+    std::vector<OnewayEdgeBucket> m_compressed_oneway_geometries;
     std::vector<EdgeBucket> m_compressed_geometries;
     std::vector<unsigned> m_free_list;
     std::unordered_map<EdgeID, unsigned> m_edge_id_to_list_index_map;
+    std::unordered_map<EdgeID, unsigned> m_forward_edge_id_to_zipped_index_map;
+    std::unordered_map<EdgeID, unsigned> m_reverse_edge_id_to_zipped_index_map;
 };
 }
 }

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -84,7 +84,7 @@ class EdgeBasedGraphFactory
     EdgeBasedGraphFactory &operator=(const EdgeBasedGraphFactory &) = delete;
 
     explicit EdgeBasedGraphFactory(std::shared_ptr<util::NodeBasedDynamicGraph> node_based_graph,
-                                   const CompressedEdgeContainer &compressed_edge_container,
+                                   CompressedEdgeContainer &compressed_edge_container,
                                    const std::unordered_set<NodeID> &barrier_nodes,
                                    const std::unordered_set<NodeID> &traffic_lights,
                                    std::shared_ptr<const RestrictionMap> restriction_map,
@@ -149,7 +149,7 @@ class EdgeBasedGraphFactory
 
     const std::unordered_set<NodeID> &m_barrier_nodes;
     const std::unordered_set<NodeID> &m_traffic_lights;
-    const CompressedEdgeContainer &m_compressed_edge_container;
+    CompressedEdgeContainer &m_compressed_edge_container;
 
     ProfileProperties profile_properties;
 

--- a/include/extractor/edge_based_node.hpp
+++ b/include/extractor/edge_based_node.hpp
@@ -22,8 +22,8 @@ struct EdgeBasedNode
     EdgeBasedNode()
         : forward_segment_id{SPECIAL_SEGMENTID, false},
           reverse_segment_id{SPECIAL_SEGMENTID, false}, u(SPECIAL_NODEID), v(SPECIAL_NODEID),
-          name_id(0), forward_packed_geometry_id(SPECIAL_EDGEID),
-          reverse_packed_geometry_id(SPECIAL_EDGEID), component{INVALID_COMPONENTID, false},
+          name_id(0), packed_geometry_id(SPECIAL_GEOMETRYID),
+          component{INVALID_COMPONENTID, false},
           fwd_segment_position(std::numeric_limits<unsigned short>::max()),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
@@ -35,16 +35,14 @@ struct EdgeBasedNode
                            NodeID u,
                            NodeID v,
                            unsigned name_id,
-                           unsigned forward_geometry_id_,
-                           unsigned reverse_geometry_id_,
+                           unsigned packed_geometry_id_,
                            bool is_tiny_component,
                            unsigned component_id,
                            unsigned short fwd_segment_position,
                            TravelMode forward_travel_mode,
                            TravelMode backward_travel_mode)
         : forward_segment_id(forward_segment_id_), reverse_segment_id(reverse_segment_id_), u(u),
-          v(v), name_id(name_id), forward_packed_geometry_id(forward_geometry_id_),
-          reverse_packed_geometry_id(reverse_geometry_id_),
+          v(v), name_id(name_id), packed_geometry_id(packed_geometry_id_),
           component{component_id, is_tiny_component}, fwd_segment_position(fwd_segment_position),
           forward_travel_mode(forward_travel_mode), backward_travel_mode(backward_travel_mode)
     {
@@ -57,8 +55,7 @@ struct EdgeBasedNode
     NodeID v;                     // indices into the coordinates array
     unsigned name_id;             // id of the edge name
 
-    unsigned forward_packed_geometry_id;
-    unsigned reverse_packed_geometry_id;
+    unsigned packed_geometry_id;
     struct
     {
         unsigned id : 31;

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -125,7 +125,7 @@ getRepresentativeCoordinate(const NodeID from_node,
     };
 
     // Uncompressed roads are simple, return the coordinate at the end
-    if (!compressed_geometries.HasEntryForID(via_edge_id))
+    if (!compressed_geometries.HasZippedEntryForForwardID(via_edge_id) && !compressed_geometries.HasZippedEntryForReverseID(via_edge_id))
     {
         return extractCoordinateFromNode(traverse_in_reverse ? query_nodes[from_node]
                                                              : query_nodes[to_node]);

--- a/include/extractor/original_edge_data.hpp
+++ b/include/extractor/original_edge_data.hpp
@@ -15,26 +15,26 @@ namespace extractor
 
 struct OriginalEdgeData
 {
-    explicit OriginalEdgeData(NodeID via_node,
+    explicit OriginalEdgeData(GeometryID via_geometry,
                               unsigned name_id,
                               LaneDataID lane_data_id,
                               guidance::TurnInstruction turn_instruction,
                               EntryClassID entry_classid,
                               TravelMode travel_mode)
-        : via_node(via_node), name_id(name_id), entry_classid(entry_classid),
+        : via_geometry(via_geometry), name_id(name_id), entry_classid(entry_classid),
           lane_data_id(lane_data_id), turn_instruction(turn_instruction), travel_mode(travel_mode)
     {
     }
 
     OriginalEdgeData()
-        : via_node(std::numeric_limits<unsigned>::max()),
+        : via_geometry{std::numeric_limits<unsigned>::max() >> 1, false},
           name_id(std::numeric_limits<unsigned>::max()), entry_classid(INVALID_ENTRY_CLASSID),
           lane_data_id(INVALID_LANE_DATAID), turn_instruction(guidance::TurnInstruction::INVALID()),
           travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
     }
 
-    NodeID via_node;
+    GeometryID via_geometry;
     unsigned name_id;
     EntryClassID entry_classid;
     LaneDataID lane_data_id;

--- a/include/util/shared_memory_vector_wrapper.hpp
+++ b/include/util/shared_memory_vector_wrapper.hpp
@@ -46,6 +46,34 @@ template <typename DataT> class ShMemIterator : public std::iterator<std::input_
     DataT &operator*() { return *p; }
 };
 
+template <typename DataT> class ShMemReverseIterator : public std::iterator<std::input_iterator_tag, DataT>
+{
+    DataT *p;
+
+  public:
+    explicit ShMemReverseIterator(DataT *x) : p(x) {}
+    ShMemReverseIterator(const ShMemReverseIterator &mit) : p(mit.p) {}
+    ShMemReverseIterator &operator++()
+    {
+        --p;
+        return *this;
+    }
+    ShMemReverseIterator operator++(int)
+    {
+        ShMemReverseIterator tmp(*this);
+        operator++();
+        return tmp;
+    }
+    ShMemReverseIterator operator+(std::ptrdiff_t diff)
+    {
+        ShMemReverseIterator tmp(p - diff);
+        return tmp;
+    }
+    bool operator==(const ShMemReverseIterator &rhs) { return p == rhs.p; }
+    bool operator!=(const ShMemReverseIterator &rhs) { return p != rhs.p; }
+    DataT &operator*() { return *p; }
+};
+
 template <typename DataT> class SharedMemoryWrapper
 {
   private:
@@ -70,6 +98,10 @@ template <typename DataT> class SharedMemoryWrapper
     ShMemIterator<DataT> begin() const { return ShMemIterator<DataT>(m_ptr); }
 
     ShMemIterator<DataT> end() const { return ShMemIterator<DataT>(m_ptr + m_size); }
+
+    ShMemReverseIterator<DataT> rbegin() const { return ShMemReverseIterator<DataT>(m_ptr + m_size - 1); }
+
+    ShMemReverseIterator<DataT> rend() const { return ShMemReverseIterator<DataT>(m_ptr - 1); }
 
     std::size_t size() const { return m_size; }
 

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -77,6 +77,7 @@ static const EntryClassID INVALID_ENTRY_CLASSID = std::numeric_limits<EntryClass
 
 static const NodeID SPECIAL_NODEID = std::numeric_limits<NodeID>::max();
 static const NodeID SPECIAL_SEGMENTID = std::numeric_limits<NodeID>::max() >> 1;
+static const NodeID SPECIAL_GEOMETRYID = std::numeric_limits<NodeID>::max() >> 1;
 static const EdgeID SPECIAL_EDGEID = std::numeric_limits<EdgeID>::max();
 static const NameID INVALID_NAMEID = std::numeric_limits<NameID>::max();
 static const NameID EMPTY_NAMEID = 0;
@@ -95,6 +96,22 @@ struct SegmentID
     NodeID id : 31;
     std::uint32_t enabled : 1;
 };
+
+/* We need to bit pack here because the index for the via_node
+ * is given to us without knowing whether the geometry should
+ * be read forward or in reverse. The extra field `forward`
+ * indicates that to the routing engine
+ */
+struct GeometryID
+{
+    GeometryID(const NodeID id_, const bool forward_) : id{id_}, forward{forward_} {}
+
+    GeometryID() : id(std::numeric_limits<unsigned>::max() >> 1), forward(false) {}
+
+    NodeID id : 31;
+    std::uint32_t forward : 1;
+};
+
 
 static_assert(sizeof(SegmentID) == 4, "SegmentID needs to be 4 bytes big");
 

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -593,106 +593,66 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
                 extractor::QueryNode *u;
                 extractor::QueryNode *v;
 
-                // forward_packed_geometry_id is the index id for geometry, weight and duration of
-                // the segments
-                if (leaf_object.forward_packed_geometry_id != SPECIAL_EDGEID)
+                const unsigned forward_begin =
+                    m_geometry_indices.at(leaf_object.packed_geometry_id);
+                const auto current_segment =
+                    &(m_geometry_list[forward_begin + leaf_object.fwd_segment_position]);
+
+                u = &(internal_to_external_node_map
+                          [m_geometry_list[forward_begin +
+                                           leaf_object.fwd_segment_position]
+                               .node_id]);
+                v = &(internal_to_external_node_map
+                          [m_geometry_list[forward_begin + leaf_object.fwd_segment_position + 1]
+                               .node_id]);
+
+                const double segment_length = util::coordinate_calculation::greatCircleDistance(
+                    util::Coordinate{u->lon, u->lat}, util::Coordinate{v->lon, v->lat});
+
+                auto forward_speed_iter =
+                    find(segment_speed_lookup, Segment{u->node_id, v->node_id});
+                if (forward_speed_iter != segment_speed_lookup.end())
                 {
-                    const unsigned forward_begin =
-                        m_geometry_indices.at(leaf_object.forward_packed_geometry_id);
-                    const auto current_fwd_segment =
-                        &(m_geometry_list[forward_begin + leaf_object.fwd_segment_position]);
+                    const auto new_segment_weight = getNewWeight(forward_speed_iter,
+                                                                 segment_length,
+                                                                 segment_speed_filenames,
+                                                                 current_segment->forward_weight,
+                                                                 log_edge_updates_factor);
 
-                    if (leaf_object.fwd_segment_position == 0)
-                    {
-                        u = &(internal_to_external_node_map[leaf_object.u]);
-                        v = &(
-                            internal_to_external_node_map[m_geometry_list[forward_begin].node_id]);
-                    }
-                    else
-                    {
-                        u = &(internal_to_external_node_map
-                                  [m_geometry_list[forward_begin +
-                                                   leaf_object.fwd_segment_position - 1]
-                                       .node_id]);
-                        v = &(internal_to_external_node_map[current_fwd_segment->node_id]);
-                    }
-                    const double segment_length = util::coordinate_calculation::greatCircleDistance(
-                        util::Coordinate{u->lon, u->lat}, util::Coordinate{v->lon, v->lat});
+                    m_geometry_list[forward_begin + 1 + leaf_object.fwd_segment_position].forward_weight =
+                        new_segment_weight;
+                    m_geometry_datasource[forward_begin + 1 + leaf_object.fwd_segment_position] =
+                        forward_speed_iter->speed_source.source;
 
-                    auto forward_speed_iter =
-                        find(segment_speed_lookup, Segment{u->node_id, v->node_id});
-
-                    if (forward_speed_iter != segment_speed_lookup.end())
-                    {
-                        const auto new_segment_weight = getNewWeight(forward_speed_iter,
-                                                                     segment_length,
-                                                                     segment_speed_filenames,
-                                                                     current_fwd_segment->weight,
-                                                                     log_edge_updates_factor);
-                        current_fwd_segment->weight = new_segment_weight;
-                        m_geometry_datasource[forward_begin + leaf_object.fwd_segment_position] =
-                            forward_speed_iter->speed_source.source;
-
-                        // count statistics for logging
-                        counters[forward_speed_iter->speed_source.source] += 1;
-                    }
-                    else
-                    {
-                        // count statistics for logging
-                        counters[LUA_SOURCE] += 1;
-                    }
+                    // count statistics for logging
+                    counters[forward_speed_iter->speed_source.source] += 1;
                 }
-                // reverse_packed_geometry_id is the index id for geometry, weight and duration of
-                // the segment
-                if (leaf_object.reverse_packed_geometry_id != SPECIAL_EDGEID)
+                else
                 {
-                    const unsigned reverse_begin =
-                        m_geometry_indices.at(leaf_object.reverse_packed_geometry_id);
-                    const unsigned reverse_end =
-                        m_geometry_indices.at(leaf_object.reverse_packed_geometry_id + 1);
+                    // count statistics for logging
+                    counters[LUA_SOURCE] += 1;
+                }
 
-                    int rev_segment_position =
-                        (reverse_end - reverse_begin) - leaf_object.fwd_segment_position - 1;
-                    const auto current_rev_segment =
-                        &(m_geometry_list[reverse_begin + rev_segment_position]);
-                    if (rev_segment_position == 0)
-                    {
-                        u = &(internal_to_external_node_map[leaf_object.v]);
-                        v = &(
-                            internal_to_external_node_map[m_geometry_list[reverse_begin].node_id]);
-                    }
-                    else
-                    {
-                        u = &(
-                            internal_to_external_node_map[m_geometry_list[reverse_begin +
-                                                                          rev_segment_position - 1]
-                                                              .node_id]);
-                        v = &(internal_to_external_node_map[current_rev_segment->node_id]);
-                    }
-                    const double segment_length = util::coordinate_calculation::greatCircleDistance(
-                        util::Coordinate{u->lon, u->lat}, util::Coordinate{v->lon, v->lat});
+                const auto reverse_speed_iter =
+                    find(segment_speed_lookup, Segment{v->node_id, u->node_id});
+                if (reverse_speed_iter != segment_speed_lookup.end())
+                {
+                    const auto new_segment_weight = getNewWeight(reverse_speed_iter,
+                                                                 segment_length,
+                                                                 segment_speed_filenames,
+                                                                 current_segment->reverse_weight,
+                                                                 log_edge_updates_factor);
+                    m_geometry_list[forward_begin + leaf_object.fwd_segment_position].reverse_weight =
+                        new_segment_weight;
+                    m_geometry_datasource[forward_begin + leaf_object.fwd_segment_position] =
+                        reverse_speed_iter->speed_source.source;
 
-                    auto reverse_speed_iter =
-                        find(segment_speed_lookup, Segment{u->node_id, v->node_id});
-                    if (reverse_speed_iter != segment_speed_lookup.end())
-                    {
-                        const auto new_segment_weight = getNewWeight(reverse_speed_iter,
-                                                                     segment_length,
-                                                                     segment_speed_filenames,
-                                                                     current_rev_segment->weight,
-                                                                     log_edge_updates_factor);
-                        current_rev_segment->weight = new_segment_weight;
-                        m_geometry_datasource[reverse_begin + rev_segment_position] =
-                            reverse_speed_iter->speed_source.source;
-
-                        // count statistics for logging
-                        counters[reverse_speed_iter->speed_source.source] += 1;
-                    }
-                    else
-                    {
-                        // count statistics for logging
-                        counters[LUA_SOURCE] += 1;
-                    }
+                    // count statistics for logging
+                    counters[reverse_speed_iter->speed_source.source] += 1;
+                }
+                else
+                {
+                    counters[LUA_SOURCE] += 1;
                 }
             }
         }); // parallel_for_each
@@ -824,7 +784,7 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
                 {
                     if (speed_iter->speed_source.speed > 0)
                     {
-                        auto new_segment_weight = distanceAndSpeedToWeight(
+                        const auto new_segment_weight = distanceAndSpeedToWeight(
                             segmentblocks[i].segment_length, speed_iter->speed_source.speed);
                         new_weight += new_segment_weight;
                     }

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -628,7 +628,6 @@ Status TilePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacad
         forward_datasource = forward_datasource_vector[edge.fwd_segment_position];
 
         reverse_datasource_vector.clear();
-        // TODO have not tested geom zipping with tiles yet
         reverse_datasource_vector =
             facade->GetUncompressedReverseDatasources(edge.packed_geometry_id);
         reverse_datasource = reverse_datasource_vector[reverse_datasource_vector.size() -

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -474,8 +474,6 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                               *node_based_graph,
                               compressed_edge_container);
 
-    compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
-
     util::NameTable name_table(config.names_file_name);
 
     // could use some additional capacity? To avoid a copy during processing, though small data so
@@ -505,6 +503,7 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                                  config.generate_edge_lookup);
 
     WriteTurnLaneData(config.turn_lane_descriptions_file_name);
+    compressed_edge_container.SerializeInternalVector(config.geometry_output_path);
 
     edge_based_graph_factory.GetEdgeBasedEdges(edge_based_edge_list);
     edge_based_graph_factory.GetEdgeBasedNodes(node_based_edge_list);

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -497,7 +497,7 @@ int Storage::Run()
     }
 
     // load original edge information
-    NodeID *via_node_ptr = shared_layout_ptr->GetBlockPtr<NodeID, true>(
+    GeometryID *via_geometry_ptr = shared_layout_ptr->GetBlockPtr<GeometryID, true>(
         shared_memory_ptr, SharedDataLayout::VIA_NODE_LIST);
 
     unsigned *name_id_ptr = shared_layout_ptr->GetBlockPtr<unsigned, true>(
@@ -521,7 +521,7 @@ int Storage::Run()
     for (unsigned i = 0; i < number_of_original_edges; ++i)
     {
         edges_input_stream.read((char *)&(current_edge_data), sizeof(extractor::OriginalEdgeData));
-        via_node_ptr[i] = current_edge_data.via_node;
+        via_geometry_ptr[i] = current_edge_data.via_geometry;
         name_id_ptr[i] = current_edge_data.name_id;
         travel_mode_ptr[i] = current_edge_data.travel_mode;
         lane_data_id_ptr[i] = current_edge_data.lane_data_id;

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -61,23 +61,39 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     }
     OSMNodeID GetOSMNodeIDOfNode(const unsigned /* id */) const override { return OSMNodeID{0}; }
     bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
-    unsigned GetGeometryIndexForEdgeID(const unsigned /* id */) const override
+    GeometryID GetGeometryIndexForEdgeID(const unsigned /* id */) const override
     {
-        return SPECIAL_NODEID;
+        return GeometryID{SPECIAL_GEOMETRYID, false};
     }
-    void GetUncompressedGeometry(const EdgeID /* id */,
-                                 std::vector<NodeID> & /* result_nodes */) const override
+    std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID /* id */) const override
     {
+        return {};
     }
-    void GetUncompressedWeights(const EdgeID /* id */,
-                                std::vector<EdgeWeight> &result_weights) const override
+    std::vector<NodeID> GetUncompressedReverseGeometry(const EdgeID /* id */) const override
     {
+        return {};
+    }
+    std::vector<EdgeWeight> GetUncompressedForwardWeights(const EdgeID /* id */) const override
+    {
+        std::vector<EdgeWeight> result_weights;
         result_weights.resize(1);
         result_weights[0] = 1;
+        return result_weights;
     }
-    void GetUncompressedDatasources(const EdgeID /*id*/,
-                                    std::vector<uint8_t> & /*data_sources*/) const override
+    std::vector<EdgeWeight> GetUncompressedReverseWeights(const EdgeID /* id */) const override
     {
+        std::vector<EdgeWeight> result_weights;
+        result_weights.resize(1);
+        result_weights[0] = 1;
+        return result_weights;
+    }
+    std::vector<uint8_t> GetUncompressedForwardDatasources(const EdgeID /*id*/) const override
+    {
+        return {};
+    }
+    std::vector<uint8_t> GetUncompressedReverseDatasources(const EdgeID /*id*/) const override
+    {
+        return {};
     }
     std::string GetDatasourceName(const uint8_t /*datasource_name_id*/) const override
     {

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -74,6 +74,15 @@ BOOST_AUTO_TEST_CASE(invalid_table_urls)
     BOOST_CHECK_EQUAL(testInvalidOptions<TableParameters>("1,2;3,4?destinations=foo"), 21UL);
 }
 
+BOOST_AUTO_TEST_CASE(valid_route_hint)
+{
+    auto hint = engine::Hint::FromBase64(
+        "XAYAgP___3-QAAAABAAAACEAAAA_AAAAHgAAAHsFAAAUAAAAaWhxALeCmwI7aHEAy4KbAgUAAQE0h8Z2");
+    BOOST_CHECK_EQUAL(
+        hint.phantom.input_location,
+        util::Coordinate(util::FloatLongitude{7.432251}, util::FloatLatitude{43.745995}));
+}
+
 BOOST_AUTO_TEST_CASE(valid_route_urls)
 {
     std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
@@ -137,15 +146,12 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     CHECK_EQUAL_RANGE(reference_3.hints, result_3->hints);
 
     std::vector<boost::optional<engine::Hint>> hints_4 = {
-        engine::Hint::FromBase64("DAIAgP___"
-                                 "38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_"
-                                 "mwIAAAEBl-Umfg=="),
-        engine::Hint::FromBase64("cgAAgP___"
-                                 "39jAAAADgAAACIAAABeAAAAkQAAANoDAABOAgAAGwAAAFVGcQCiRJsCR0VxAOZFmw"
-                                 "IFAAEBl-Umfg=="),
-        engine::Hint::FromBase64("3gAAgP___"
-                                 "39KAAAAHgAAACEAAAAAAAAAGAAAAE0BAABOAQAAGwAAAIAzcQBkUJsC1zNxAHBQmw"
-                                 "IAAAEBl-Umfg==")};
+        engine::Hint::FromBase64(
+            "XAYAgP___3-QAAAABAAAACEAAAA_AAAAHgAAAHsFAAAUAAAAaWhxALeCmwI7aHEAy4KbAgUAAQE0h8Z2"),
+        engine::Hint::FromBase64(
+            "lgQAgP___3-QAAAADwAAABMAAAAoAAAALAAAADQAAAAUAAAAmWFxAL1zmwLcYXEAu3ObAgQAAQE0h8Z2"),
+        engine::Hint::FromBase64(
+            "OAUAgMUFAIAAAAAADwAAAAIAAAAAAAAAnQAAALwEAAAUAAAAgz5xAE9WmwKIPnEAUFabAgAAAQE0h8Z2")};
     RouteParameters reference_4{false,
                                 false,
                                 false,
@@ -158,9 +164,9 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
                                 std::vector<boost::optional<engine::Bearing>>{}};
     auto result_4 = parseParameters<RouteParameters>(
         "1,2;3,4?steps=false&hints="
-        "DAIAgP___38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_mwIAAAEBl-Umfg==;"
-        "cgAAgP___39jAAAADgAAACIAAABeAAAAkQAAANoDAABOAgAAGwAAAFVGcQCiRJsCR0VxAOZFmwIFAAEBl-Umfg==;"
-        "3gAAgP___39KAAAAHgAAACEAAAAAAAAAGAAAAE0BAABOAQAAGwAAAIAzcQBkUJsC1zNxAHBQmwIAAAEBl-Umfg==");
+        "XAYAgP___3-QAAAABAAAACEAAAA_AAAAHgAAAHsFAAAUAAAAaWhxALeCmwI7aHEAy4KbAgUAAQE0h8Z2;"
+        "lgQAgP___3-QAAAADwAAABMAAAAoAAAALAAAADQAAAAUAAAAmWFxAL1zmwLcYXEAu3ObAgQAAQE0h8Z2;"
+        "OAUAgMUFAIAAAAAADwAAAAIAAAAAAAAAnQAAALwEAAAUAAAAgz5xAE9WmwKIPnEAUFabAgAAAQE0h8Z2");
     BOOST_CHECK(result_4);
     BOOST_CHECK_EQUAL(reference_4.steps, result_4->steps);
     BOOST_CHECK_EQUAL(reference_4.alternatives, result_4->alternatives);
@@ -255,13 +261,11 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
                                               {util::FloatLongitude{5}, util::FloatLatitude{6}},
                                               {util::FloatLongitude{7}, util::FloatLatitude{8}}};
     std::vector<boost::optional<engine::Hint>> hints_10 = {
-        engine::Hint::FromBase64("DAIAgP___"
-                                 "38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_"
-                                 "mwIAAAEBl-Umfg=="),
+        engine::Hint::FromBase64(
+            "XAYAgP___3-QAAAABAAAACEAAAA_AAAAHgAAAHsFAAAUAAAAaWhxALeCmwI7aHEAy4KbAgUAAQE0h8Z2"),
         boost::none,
-        engine::Hint::FromBase64("cgAAgP___"
-                                 "39jAAAADgAAACIAAABeAAAAkQAAANoDAABOAgAAGwAAAFVGcQCiRJsCR0VxAOZFmw"
-                                 "IFAAEBl-Umfg=="),
+        engine::Hint::FromBase64(
+            "lgQAgP___3-QAAAADwAAABMAAAAoAAAALAAAADQAAAAUAAAAmWFxAL1zmwLcYXEAu3ObAgQAAQE0h8Z2"),
         boost::none};
     RouteParameters reference_10{false,
                                  false,
@@ -275,8 +279,8 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
                                  std::vector<boost::optional<engine::Bearing>>{}};
     auto result_10 = parseParameters<RouteParameters>(
         "1,2;3,4;5,6;7,8?steps=false&hints="
-        "DAIAgP___38AAAAAAAAAAAIAAAAAAAAAEAAAAOgDAAD0AwAAGwAAAOUacQBQP5sCshpxAB0_mwIAAAEBl-Umfg==;;"
-        "cgAAgP___39jAAAADgAAACIAAABeAAAAkQAAANoDAABOAgAAGwAAAFVGcQCiRJsCR0VxAOZFmwIFAAEBl-Umfg=="
+        "XAYAgP___3-QAAAABAAAACEAAAA_AAAAHgAAAHsFAAAUAAAAaWhxALeCmwI7aHEAy4KbAgUAAQE0h8Z2;;"
+        "lgQAgP___3-QAAAADwAAABMAAAAoAAAALAAAADQAAAAUAAAAmWFxAL1zmwLcYXEAu3ObAgQAAQE0h8Z2"
         ";");
     BOOST_CHECK(result_10);
     BOOST_CHECK_EQUAL(reference_10.steps, result_10->steps);

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -166,8 +166,7 @@ struct GraphFixture
             d.forward_segment_id = {pair.second, true};
             d.reverse_segment_id = {pair.first, true};
             d.fwd_segment_position = 0;
-            d.forward_packed_geometry_id = 0;
-            d.reverse_packed_geometry_id = 0;
+            d.packed_geometry_id = 0;
             edges.emplace_back(d);
         }
     }


### PR DESCRIPTION
This is working towards https://github.com/Project-OSRM/osrm-backend/issues/2592.

At a glance/in many tests it seems to work; however, there are 79 cucumber scenarios failing ([list](https://gist.github.com/lbud/6ee79543e986f02ffd935248a48a94d1)), and a lot of them are just kind of like…dropping steps.

The approach this branch takes is
* change the current `CompressedEdge` to a `OnewayCompressedEdge`; these are still created as an intermediary step but are not serialized to disk
* in `EdgeBasedGraphFactory::InsertEdgeBasedNode`, call `CompressedEdgeContainer::ZipEdges` on each forward/reverse pair, creating a `CompressedEdge` that has both forward and reverse weights

As edges formerly looked like (n=node ID, w=weight, s=start node (not IDed))
```
       w1        w2        w3
     -->       -->       -->
  s    n1        n2        n3
``` 
they now need to look like (n=node ID, f=forward weight, r=reverse weight, I=invalid weight)
```
I        f2        f3        f4
-->      -->       -->       -->
  n1       n2        n3        n4
  <--      <--       <--       <--
    r1       r2        r3        I
``` 

* serialize the newly zipped edges to disk rather than the oneway edges
* modify all `GetUncompressedWeights` `GetUncompressedGeometries` etc to have both forward and reverse functions.

I can't figure out if maybe there's something I'm missing in routing_base.hpp that broke, or what. @TheMarex @danpat @daniel-j-h do any of my changes look suspicious or conspicuously missing anything?

\* I still haven't checked to see if anything about the tile plugin is broken — will do so after everything else works.