### PR TITLE
[Ready] Be more aggressive classifying Roundabout Intersections

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -477,7 +477,7 @@ Feature: Turn Lane Guidance
             | gh    |                                                    | primary |            | gh    |
 
         When I route I should get
-            | waypoints | route           | turns                                            | lanes                                                                                                                                    |
+            | waypoints | route           | turns                                            | lanes                                                                                      |
             | a,h       | abx,bc,fg,gh,gh | depart,turn right,cdefc-exit-2,turn right,arrive | ,straight:false right:false right:false right:false right:true,,straight:false right:true, |
 
     @anticipate @bug @todo

--- a/features/guidance/roundabout-bike.feature
+++ b/features/guidance/roundabout-bike.feature
@@ -5,37 +5,6 @@ Feature: Basic Roundabout
         Given the profile "bicycle"
         Given a grid size of 10 meters
 
-    Scenario: Enter and Exit
-        Given the node map
-            |   |   | a |   |   |
-            |   |   | b |   |   |
-            | h | g |   | c | d |
-            |   |   | e |   |   |
-            |   |   | f |   |   |
-
-       And the ways
-            | nodes  | junction   |
-            | ab     |            |
-            | cd     |            |
-            | ef     |            |
-            | gh     |            |
-            | bgecb  | roundabout |
-
-       When I route I should get
-           | waypoints | route    | turns                           |
-           | a,d       | ab,cd,cd | depart,roundabout-exit-3,arrive |
-           | a,f       | ab,ef,ef | depart,roundabout-exit-2,arrive |
-           | a,h       | ab,gh,gh | depart,roundabout-exit-1,arrive |
-           | d,f       | cd,ef,ef | depart,roundabout-exit-3,arrive |
-           | d,h       | cd,gh,gh | depart,roundabout-exit-2,arrive |
-           | d,a       | cd,ab,ab | depart,roundabout-exit-1,arrive |
-           | f,h       | ef,gh,gh | depart,roundabout-exit-3,arrive |
-           | f,a       | ef,ab,ab | depart,roundabout-exit-2,arrive |
-           | f,d       | ef,cd,cd | depart,roundabout-exit-1,arrive |
-           | h,a       | gh,ab,ab | depart,roundabout-exit-3,arrive |
-           | h,d       | gh,cd,cd | depart,roundabout-exit-2,arrive |
-           | h,f       | gh,ef,ef | depart,roundabout-exit-1,arrive |
-
     Scenario: Only Enter
         Given the node map
             |   |   | a |   |   |

--- a/features/guidance/roundabout-turn-bike.feature
+++ b/features/guidance/roundabout-turn-bike.feature
@@ -1,0 +1,37 @@
+@routing  @guidance
+Feature: Basic Roundabout
+
+    Background:
+        Given the profile "bicycle"
+        Given a grid size of 10 meters
+
+    Scenario: Enter and Exit
+        Given the node map
+            |   |   | a |   |   |
+            |   |   | b |   |   |
+            | h | g |   | c | d |
+            |   |   | e |   |   |
+            |   |   | f |   |   |
+
+       And the ways
+            | nodes  | junction   |
+            | ab     |            |
+            | cd     |            |
+            | ef     |            |
+            | gh     |            |
+            | bgecb  | roundabout |
+
+       When I route I should get
+           | waypoints | route    | turns                                         |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-3,arrive     |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-1,arrive    |
+           | d,f       | cd,ef,ef | depart,roundabout turn left exit-3,arrive     |
+           | d,h       | cd,gh,gh | depart,roundabout turn straight exit-2,arrive |
+           | d,a       | cd,ab,ab | depart,roundabout turn right exit-1,arrive    |
+           | f,h       | ef,gh,gh | depart,roundabout turn left exit-3,arrive     |
+           | f,a       | ef,ab,ab | depart,roundabout turn straight exit-2,arrive |
+           | f,d       | ef,cd,cd | depart,roundabout turn right exit-1,arrive    |
+           | h,a       | gh,ab,ab | depart,roundabout turn left exit-3,arrive     |
+           | h,d       | gh,cd,cd | depart,roundabout turn straight exit-2,arrive |
+           | h,f       | gh,ef,ef | depart,roundabout turn right exit-1,arrive    |

--- a/features/guidance/roundabout-turn.feature
+++ b/features/guidance/roundabout-turn.feature
@@ -389,3 +389,105 @@ Feature: Basic Roundabout
            | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive | 0->180,180->224,180->0 |
            | a,h       | ab,gh,gh | depart,roundabout turn right exit-1,arrive    | 0->180,180->224,270->0 |
 
+    Scenario: Enter and Exit - Bearings
+        Given the node map
+            |   |   |   | a |   |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   | i | b | l |   |   |
+            | h |   | g |   | c |   | d |
+            |   |   | j | e | k |   |   |
+            |   |   |   |   |   |   |   |
+            |   |   |   | f |   |   |   |
+
+       And the ways
+            | nodes      | junction   |
+            | ab         |            |
+            | cd         |            |
+            | ef         |            |
+            | gh         |            |
+            | bigjekclb  | roundabout |
+
+       When I route I should get
+           | waypoints | route    | turns                                         | bearing                |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-3,arrive     | 0->180,180->270,90->0  |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive | 0->180,180->270,180->0 |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-1,arrive    | 0->180,180->270,270->0 |
+
+    Scenario: Large radius Roundabout Intersection and ways modelled out: East Mission St, North 7th St
+    # http://www.openstreetmap.org/way/348812150
+    # Note: grid size is 3 meter, this roundabout is more like 5-10 meters in radius
+        Given the node map
+           |   |   |   | a |   |   |   |   |   |
+           |   |   |   |   |   |   |   |   |   |
+           |   |   |   | b |   | n |   |   |   |
+           |   |   |   |   |   |   |   |   |   |
+           |   |   | c |   |   |   | m |   |   |
+           |   |   |   |   |   |   |   |   |   |
+           | e |   | d |   |   |   | k |   | l |
+           |   |   |   |   |   |   |   |   |   |
+           |   |   | f |   |   |   | j |   |   |
+           |   |   |   |   |   |   |   |   |   |
+           |   |   |   | g |   | i |   |   |   |
+           |   |   |   |   |   |   |   |   |   |
+           |   |   |   | h |   |   |   |   |   |
+
+       And the ways
+            | nodes       | junction   | highway  | name            |
+            | ab          |            | tertiary | North 7th St    |
+            | ed          |            | tertiary | East Mission St |
+            | hg          |            | tertiary | North 7th St    |
+            | lk          |            | tertiary | East Mission St |
+            | bcdfgijkmnb | roundabout | tertiary | Roundabout      |
+
+       When I route I should get
+           | waypoints | route                                           | turns                                         |
+           | a,e       | North 7th St,East Mission St,East Mission St    | depart,roundabout turn right exit-1,arrive    |
+           | a,h       | North 7th St,North 7th St,North 7th St          | depart,roundabout turn straight exit-2,arrive |
+           | a,l       | North 7th St,East Mission St,East Mission St    | depart,roundabout turn left exit-3,arrive     |
+           | h,l       | North 7th St,East Mission St,East Mission St    | depart,roundabout turn right exit-1,arrive    |
+           | h,a       | North 7th St,North 7th St,North 7th St          | depart,roundabout turn straight exit-2,arrive |
+           | h,e       | North 7th St,East Mission St,East Mission St    | depart,roundabout turn left exit-3,arrive     |
+           | e,h       | East Mission St,North 7th St,North 7th St       | depart,roundabout turn right exit-1,arrive    |
+           | e,l       | East Mission St,East Mission St,East Mission St | depart,roundabout turn straight exit-2,arrive |
+           | e,a       | East Mission St,North 7th St,North 7th St       | depart,roundabout turn left exit-3,arrive     |
+           | l,a       | East Mission St,North 7th St,North 7th St       | depart,roundabout turn right exit-1,arrive    |
+           | l,e       | East Mission St,East Mission St,East Mission St | depart,roundabout turn straight exit-2,arrive |
+           | l,h       | East Mission St,North 7th St,North 7th St       | depart,roundabout turn left exit-3,arrive     |
+
+    Scenario: Enter and Exit - Traffic Signals
+        Given the node map
+            |   |   | a |   |   |
+            |   | i | b | l |   |
+            | h | g |   | c | d |
+            |   | j | e | k |   |
+            |   |   | f |   |   |
+
+       And the nodes
+            | node | highway         |
+            | i    | traffic_signals |
+            | j    | traffic_signals |
+            | k    | traffic_signals |
+            | l    | traffic_signals |
+
+       And the ways
+            | nodes     | junction   |
+            | ab        |            |
+            | cd        |            |
+            | ef        |            |
+            | gh        |            |
+            | bigjekclb | roundabout |
+
+       When I route I should get
+           | waypoints | route    | turns                                         |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-3,arrive     |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-1,arrive    |
+           | d,f       | cd,ef,ef | depart,roundabout turn left exit-3,arrive     |
+           | d,h       | cd,gh,gh | depart,roundabout turn straight exit-2,arrive |
+           | d,a       | cd,ab,ab | depart,roundabout turn right exit-1,arrive    |
+           | f,h       | ef,gh,gh | depart,roundabout turn left exit-3,arrive     |
+           | f,a       | ef,ab,ab | depart,roundabout turn straight exit-2,arrive |
+           | f,d       | ef,cd,cd | depart,roundabout turn right exit-1,arrive    |
+           | h,a       | gh,ab,ab | depart,roundabout turn left exit-3,arrive     |
+           | h,d       | gh,cd,cd | depart,roundabout turn straight exit-2,arrive |
+           | h,f       | gh,ef,ef | depart,roundabout turn right exit-1,arrive    |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -5,37 +5,6 @@ Feature: Basic Roundabout
         Given the profile "car"
         Given a grid size of 10 meters
 
-    Scenario: Enter and Exit
-        Given the node map
-            |   |   | a |   |   |
-            |   |   | b |   |   |
-            | h | g |   | c | d |
-            |   |   | e |   |   |
-            |   |   | f |   |   |
-
-       And the ways
-            | nodes  | junction   |
-            | ab     |            |
-            | cd     |            |
-            | ef     |            |
-            | gh     |            |
-            | bgecb  | roundabout |
-
-       When I route I should get
-           | waypoints | route    | turns                           |
-           | a,d       | ab,cd,cd | depart,roundabout-exit-3,arrive |
-           | a,f       | ab,ef,ef | depart,roundabout-exit-2,arrive |
-           | a,h       | ab,gh,gh | depart,roundabout-exit-1,arrive |
-           | d,f       | cd,ef,ef | depart,roundabout-exit-3,arrive |
-           | d,h       | cd,gh,gh | depart,roundabout-exit-2,arrive |
-           | d,a       | cd,ab,ab | depart,roundabout-exit-1,arrive |
-           | f,h       | ef,gh,gh | depart,roundabout-exit-3,arrive |
-           | f,a       | ef,ab,ab | depart,roundabout-exit-2,arrive |
-           | f,d       | ef,cd,cd | depart,roundabout-exit-1,arrive |
-           | h,a       | gh,ab,ab | depart,roundabout-exit-3,arrive |
-           | h,d       | gh,cd,cd | depart,roundabout-exit-2,arrive |
-           | h,f       | gh,ef,ef | depart,roundabout-exit-1,arrive |
-
     Scenario: Only Enter
         Given the node map
             |   |   | a |   |   |
@@ -280,87 +249,6 @@ Feature: Basic Roundabout
             | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
             | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
 
-       Scenario: Collinear in X,Y
-        Given the node map
-            | a |   |   |
-            | b |   |   |
-            | c | d | f |
-            | e |   |   |
-
-        And the ways
-            | nodes | junction   |
-            | ab    |            |
-            | bcdb  | roundabout |
-            | ce    |            |
-            | df    |            |
-
-        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
-            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
-
-       Scenario: Collinear in X,Y
-        Given the node map
-            | a |   |   |
-            | d |   |   |
-            | b | c | f |
-            | e |   |   |
-
-        And the ways
-            | nodes | junction   |
-            | ad    |            |
-            | bcdb  | roundabout |
-            | be    |            |
-            | cf    |            |
-
-        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,e       | ad,be,be | depart,roundabout-exit-1,arrive |
-            | a,f       | ad,cf,cf | depart,roundabout-exit-2,arrive |
-
-       Scenario: Collinear in X,Y
-        Given the node map
-            | a |   |   |
-            | c |   |   |
-            | d | b | f |
-            | e |   |   |
-
-        And the ways
-            | nodes | junction   |
-            | ac    |            |
-            | bcdb  | roundabout |
-            | de    |            |
-            | bf    |            |
-
-        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,e       | ac,de,de | depart,roundabout-exit-1,arrive |
-            | a,f       | ac,bf,bf | depart,roundabout-exit-2,arrive |
-
-    Scenario: Enter and Exit - Bearings
-        Given the node map
-            |   |   |   | a |   |   |   |
-            |   |   |   |   |   |   |   |
-            |   |   | i | b | l |   |   |
-            | h |   | g |   | c |   | d |
-            |   |   | j | e | k |   |   |
-            |   |   |   |   |   |   |   |
-            |   |   |   | f |   |   |   |
-
-       And the ways
-            | nodes      | junction   |
-            | ab         |            |
-            | cd         |            |
-            | ef         |            |
-            | gh         |            |
-            | bigjekclb  | roundabout |
-
-       When I route I should get
-           | waypoints | route    | turns                           | bearing                |
-           | a,d       | ab,cd,cd | depart,roundabout-exit-3,arrive | 0->180,180->270,90->0  |
-           | a,f       | ab,ef,ef | depart,roundabout-exit-2,arrive | 0->180,180->270,180->0 |
-           | a,h       | ab,gh,gh | depart,roundabout-exit-1,arrive | 0->180,180->270,270->0 |
-
     Scenario: Motorway Roundabout
     #See 39.933742 -75.082345
         Given the node map
@@ -437,42 +325,3 @@ Feature: Basic Roundabout
         When I route I should get
             | waypoints | route                                                   | turns                                                     |
             | a,k       | massachusetts,massachusetts,massachusetts,massachusetts | depart,sheridan circle-exit-2,dupont circle-exit-1,arrive |
-
-    Scenario: Enter and Exit - Traffic Signals
-        Given the node map
-            |   |   | a |   |   |
-            |   | i | b | l |   |
-            | h | g |   | c | d |
-            |   | j | e | k |   |
-            |   |   | f |   |   |
-
-       And the nodes
-            | node | highway         |
-            | i    | traffic_signals |
-            | j    | traffic_signals |
-            | k    | traffic_signals |
-            | l    | traffic_signals |
-
-       And the ways
-            | nodes     | junction   |
-            | ab        |            |
-            | cd        |            |
-            | ef        |            |
-            | gh        |            |
-            | bigjekclb | roundabout |
-
-       When I route I should get
-           | waypoints | route    | turns                           |
-           | a,d       | ab,cd,cd | depart,roundabout-exit-3,arrive |
-           | a,f       | ab,ef,ef | depart,roundabout-exit-2,arrive |
-           | a,h       | ab,gh,gh | depart,roundabout-exit-1,arrive |
-           | d,f       | cd,ef,ef | depart,roundabout-exit-3,arrive |
-           | d,h       | cd,gh,gh | depart,roundabout-exit-2,arrive |
-           | d,a       | cd,ab,ab | depart,roundabout-exit-1,arrive |
-           | f,h       | ef,gh,gh | depart,roundabout-exit-3,arrive |
-           | f,a       | ef,ab,ab | depart,roundabout-exit-2,arrive |
-           | f,d       | ef,cd,cd | depart,roundabout-exit-1,arrive |
-           | h,a       | gh,ab,ab | depart,roundabout-exit-3,arrive |
-           | h,d       | gh,cd,cd | depart,roundabout-exit-2,arrive |
-           | h,f       | gh,ef,ef | depart,roundabout-exit-1,arrive |
-

--- a/features/testbot/side_bias.feature
+++ b/features/testbot/side_bias.feature
@@ -53,10 +53,10 @@ Feature: Testbot - side bias
             | bcegb  | roundabout |
 
        When I route I should get
-           | waypoints | route    | turns                           |
-           | a,d       | ab,cd,cd | depart,roundabout-exit-1,arrive |
-           | a,f       | ab,ef,ef | depart,roundabout-exit-2,arrive |
-           | a,h       | ab,gh,gh | depart,roundabout-exit-3,arrive |
+           | waypoints | route    | turns                                         |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-1,arrive     |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-3,arrive    |
 
      Scenario: Mixed Entry and Exit
         Given the profile "lhs"

--- a/include/extractor/guidance/constants.hpp
+++ b/include/extractor/guidance/constants.hpp
@@ -21,8 +21,12 @@ const double constexpr GROUP_ANGLE = 60;
 const double constexpr FUZZY_ANGLE_DIFFERENCE = 25.;
 const double constexpr DISTINCTION_RATIO = 2;
 
-const double constexpr MAX_ROUNDABOUT_INTERSECTION_RADIUS = 5;
-const double constexpr MAX_ROUNDABOUT_RADIUS = 15; // 30 m diameter as final distinction
+// Named roundabouts with radii larger then than this are seen as rotary
+const double constexpr MAX_ROUNDABOUT_RADIUS = 15;
+// Unnamed small roundabouts that look like intersections are announced as turns,
+// guard against data issues or such roundabout intersections getting too large.
+const double constexpr MAX_ROUNDABOUT_INTERSECTION_RADIUS = 25;
+
 const double constexpr INCREASES_BY_FOURTY_PERCENT = 1.4;
 
 const int constexpr MAX_SLIPROAD_THRESHOLD = 250;


### PR DESCRIPTION
Roundabout Intersections are roundabouts with up to four ways and turn
angles which makes the turns obvious, e.g. as in:

```
    *
    *
* *   * *
    *
    *
```

but not e.g.

```
     *
    *
* *   *
    * *
     * *
```

For Roundabout Intersections we issue instructions such as
"turn \<direction\>" instead of "take the \<nth\> exit".

At the moment we have a limit on the radius for these Roundabout
Intersections of 5 meters. Which fails to classify a wide range of
Roundabout Intersections in the US (with the US-wide streets).

Example: http://www.openstreetmap.org/way/348812150

This changeset removes the Roundabout Intersection radius limit:

- if the roundabout is larger than a threshold and is named we classify
  it as a rotary

- if the roundabout matches our criteria for Roundabout Intersections
  we classify it as a Roundabout Intersection (note: we no longer care
  about its radius here)

- else fall back to plain old Roundabout

Up for discussion. cc @1ec5 @MoKob @TheMarex

There is a second issue with determining a roundabout's radius.
But that's for another pull request (tracking in #2716).
