### PR TITLE
Fix #2706 by using correct fallback u-turn

### DIFF
--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -143,7 +143,20 @@ Intersection IntersectionGenerator::getConnectedRoads(const NodeID from_node,
     const auto valid_count =
         boost::count_if(intersection, [](const ConnectedRoad &road) { return road.entry_allowed; });
     if (0 == valid_count && uturn_could_be_valid)
-        intersection[0].entry_allowed = true;
+    {
+        // after intersections sorting by angles, find the u-turn with (from_node == to_node)
+        // that was inserted together with setting uturn_could_be_valid flag
+        std::size_t self_u_turn = 0;
+        while (self_u_turn < intersection.size()
+               && intersection[self_u_turn].turn.angle < std::numeric_limits<double>::epsilon()
+               && from_node != node_based_graph.GetTarget(intersection[self_u_turn].turn.eid))
+        {
+            ++self_u_turn;
+        }
+
+        BOOST_ASSERT(from_node == node_based_graph.GetTarget(intersection[self_u_turn].turn.eid));
+        intersection[self_u_turn].entry_allowed = true;
+    }
 
     return mergeSegregatedRoads(std::move(intersection));
 }


### PR DESCRIPTION
Regression #2706  is due to a combination of 08248e38534eec1c4df629d5f12505d168297fde
and http://www.openstreetmap.org/changeset/40938983
where in ways http://www.openstreetmap.org/way/27292481
and http://www.openstreetmap.org/way/432488408
nodes
4315134884 (part of way 432488408)
4315134891 (part of way 432488408)
4315134886 (part of way 432488408)
form a u-turn that has index 0 after sorting and used as an allowed one
with a reversed edge.
A u-turn that corresponds to the condition uturn_could_be_valid == true has index 1
and ignored.

If the fix is ok, i will add a features test.
At the moment i tested only with `osmosis --read-pbf egypt-latest.osm.pbf --bounding-box left=29.775009 bottom=31.038227 right=29.921951 top=31.17991 --write-pbf egypt0.osm.pbf`