### PR TITLE
[Ready] Makes designated HOV way's routability configurable in profiles.

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -5,7 +5,7 @@ Feature: Car - Restricted access
     Background:
         Given the profile "car"
 
-    Scenario: Car - Access tag hierarchy    on ways
+    Scenario: Car - Access tag hierarchy on ways
         Then routability should be
             | access | vehicle | motor_vehicle | motorcar | bothw |
             |        |         |               |          | x     |
@@ -148,3 +148,10 @@ Feature: Car - Restricted access
             | primary |      |         | no  |           | x     |
             | runway  |      |         |     | yes       |       |
             | primary |      |         |     | no        | x     |
+
+    Scenario: Car - only designated HOV ways are ignored by default
+        Then routability should be
+            | highway | hov        | bothw |
+            | primary | designated |       |
+            | primary | yes        | x     |
+            | primary | no         | x     |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -148,6 +148,7 @@ local turn_bias                  = 1.2
 
 local obey_oneway                = true
 local ignore_areas               = true
+local ignore_hov_ways            = true
 
 local abs = math.abs
 local min = math.min
@@ -230,6 +231,12 @@ function way_function (way, result)
   -- we dont route over areas
   local area = way:get_value_by_key("area")
   if ignore_areas and area and "yes" == area then
+    return
+  end
+
+  -- respect user-preference for HOV-only ways
+  local hov = way:get_value_by_key("hov")
+  if ignore_hov_ways and hov and "designated" == hov then
     return
   end
 

--- a/taginfo.json
+++ b/taginfo.json
@@ -47,6 +47,12 @@
             "description": "Roads with area=yes are ignored by default."
         },
         {
+            "key": "hov",
+            "value": "designated",
+            "object_types": [ "way" ],
+            "description": "Roads with hov=designated are ignored by default."
+        },
+        {
             "key": "impassable",
             "description": "This is used by HOT."
         },


### PR DESCRIPTION
Why only `hov=designated` and not all access tags, such as `hov:yes`,
`hov=no` and so on? From the Wiki:

- designated: The way is designated to high occupancy vehicles.
- yes: High occupancy vehicles are allowed. **This by itself does not imply that other vehicles are restricted from using the way.**
- no: High occupancy vehicles are not allowed on the way. **This by itself does not imply that other vehicle types are allowed to use it**.

The primary use-case is conditionally filtering ways such as:

http://www.openstreetmap.org/way/11198593#map=19/37.82571/-122.30521&layers=D

In addition there is a notion of HOV lanes for lane handling:

http://wiki.openstreetmap.org/wiki/Key:hov#hov:lanes.3D.2A

This changeset does not handle lanes at all, only designated HOV ways.
For HOV lane support, a logic similar to the lane access handling needs
to be implemented. This needs to go hand in hand with the existing lane
handling introduced in:

https://github.com/Project-OSRM/osrm-backend/commit/7d076e93445a4d016422a575f1132b267cd13c29

References:
- #2711
- http://wiki.openstreetmap.org/wiki/Key:access
- http://wiki.openstreetmap.org/wiki/Key:hov#Values

cc @willwhite @danpat