### PR TITLE
[ready - pending 2750] Properly Collapse Turns at Oneway/Bridge Scenario

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -136,6 +136,12 @@ Feature: Collapse
 
     Scenario: Partly Segregated Intersection, Two Segregated Roads
         Given the node map
+            |   | n |   | m |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
             |   | g |   | h |   |
             |   |   |   |   |   |
             |   |   |   |   |   |
@@ -144,6 +150,12 @@ Feature: Collapse
             |   |   |   |   |   |
             |   |   |   |   |   |
             |   | j |   | i |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   | k |   | l |   |
 
         And the ways
             | nodes | highway | name   | oneway |
@@ -152,8 +164,8 @@ Feature: Collapse
             | de    | primary | first  | yes    |
             | ef    | primary | first  | yes    |
             | be    | primary | first  | no     |
-            | gbh   | primary | second | yes    |
-            | iej   | primary | second | yes    |
+            | ngbhm | primary | second | yes    |
+            | liejk | primary | second | yes    |
 
        When I route I should get
             | waypoints | route                | turns                        |
@@ -176,6 +188,10 @@ Feature: Collapse
 
     Scenario: Partly Segregated Intersection, Two Segregated Roads, Intersection belongs to Second
         Given the node map
+            |   | n |   | m |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
             |   | g |   | h |   |
             |   |   |   |   |   |
             |   |   |   |   |   |
@@ -184,6 +200,10 @@ Feature: Collapse
             |   |   |   |   |   |
             |   |   |   |   |   |
             |   | j |   | i |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   | k |   | l |   |
 
         And the ways
             | nodes | highway | name   | oneway |
@@ -192,8 +212,8 @@ Feature: Collapse
             | de    | primary | first  | yes    |
             | ef    | primary | first  | yes    |
             | be    | primary | second | no     |
-            | gbh   | primary | second | yes    |
-            | iej   | primary | second | yes    |
+            | ngbhm | primary | second | yes    |
+            | liejk | primary | second | yes    |
 
        When I route I should get
             | waypoints | route                | turns                        |
@@ -382,13 +402,13 @@ Feature: Collapse
 
     Scenario: Pankenbruecke
         Given the node map
-            | h |   |   |   |   |   | i |   |   |   |   |   |   |
-            |   |   | b | c | d | e | f |   |   |   |   |   | g |
-            | a |   |   |   |   |   |   |   |   |   |   |   |   |
+            | j |   |   |   | h |   |   |   |   |   | i |   |   |   |   |   |   |
+            |   |   |   |   |   |   | b | c | d | e | f |   |   |   |   |   | g |
+            | k |   |   |   | a |   |   |   |   |   |   |   |   |   |   |   |   |
 
         And the ways
             | nodes | highway | name    | oneway |
-            | abh   | primary | inroad  | yes    |
+            | kabhj | primary | inroad  | yes    |
             | bc    | primary | inroad  | no     |
             | cd    | primary | bridge  | no     |
             | defg  | primary | outroad | no     |
@@ -686,3 +706,43 @@ Feature: Collapse
             | a,c       | main,main                 | depart,arrive                          |
             | a,e       | main,straight,straight    | depart,turn straight,arrive            |
             | a,f       | main,straight,right,right | depart,turn straight,turn right,arrive |
+
+    Scenario: Entering a segregated road
+        Given the node map
+            |   | a | f |   |   |
+            |   |   |   |   | g |
+            |   | b | e |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            | c | d |   |   |   |
+
+        And the ways
+            | nodes | highway | name   | oneway |
+            | abc   | primary | first  | yes    |
+            | def   | primary | first  | yes    |
+            | be    | primary | first  | no     |
+            | ge    | primary | second | no     |
+
+        When I route I should get
+            | waypoints | route               | turns                          |
+            | d,c       | first,first,first   | depart,continue uturn,arrive   |
+
+    Scenario: Entering a segregated road slight turn
+        Given the node map
+            |   |   | a | f |   |
+            |   |   |   |   | g |
+            |   | b | e |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            | c | d |   |   |   |
+
+        And the ways
+            | nodes | highway | name   | oneway |
+            | abc   | primary | first  | yes    |
+            | def   | primary | first  | yes    |
+            | be    | primary | first  | no     |
+            | ge    | primary | second | no     |
+
+        When I route I should get
+            | waypoints | route               | turns                          |
+            | d,c       | first,first,first   | depart,continue uturn,arrive   |

--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -1,0 +1,149 @@
+@routing  @guidance @perceived-angles
+Feature: Simple Turns
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 5 meters
+
+    Scenario: Turning into splitting road
+        Given the node map
+            |   | a |   |   |
+            |   | b |   |   |
+            |   |   |   |   |
+            |   |   |   |   |
+            | c |   | d |   |
+            |   |   |   |   |
+            |   |   |   | e |
+            |   |   |   |   |
+            |   |   | f |   |
+
+        And the ways
+            | nodes | name | highway | oneway |
+            | ab    | road | primary | no     |
+            | bc    | road | primary | yes    |
+            | fdb   | road | primary | yes    |
+            | de    | turn | primary | no     |
+
+        When I route I should get
+            | waypoints | turns                           | route          |
+            | f,a       | depart,arrive                   | road,road      |
+            | e,a       | depart,turn slight right,arrive | turn,road,road |
+
+    Scenario: Middle Island
+        Given the node map
+            |   | a |   |
+            |   |   |   |
+            |   | b |   |
+            | c |   | h |
+            |   |   |   |
+            |   |   |   |
+            |   |   |   |
+            |   |   |   |
+            | d |   | g |
+            |   | e |   |
+            |   |   |   |
+            |   | f |   |
+
+        And the ways
+            | nodes | name | oneway |
+            | ab    | road | no     |
+            | ef    | road | no     |
+            | bcde  | road | yes    |
+            | eghb  | road | yes    |
+
+        When I route I should get
+            | waypoints | turns         | route     |
+            | a,f       | depart,arrive | road,road |
+            | c,f       | depart,arrive | road,road |
+            | f,a       | depart,arrive | road,road |
+            | g,a       | depart,arrive | road,road |
+
+    Scenario: Middle Island Over Bridge
+        Given the node map
+            |   | a |   |
+            |   |   |   |
+            |   | b |   |
+            | c |   | h |
+            |   |   |   |
+            |   |   |   |
+            | 1 |   | 2 |
+            |   |   |   |
+            | d |   | g |
+            |   | e |   |
+            |   |   |   |
+            |   | f |   |
+
+        And the ways
+            | nodes | name   | oneway |
+            | ab    | road   | no     |
+            | ef    | road   | no     |
+            | bc    | road   | yes    |
+            | cd    | bridge | yes    |
+            | de    | road   | yes    |
+            | eg    | road   | yes    |
+            | gh    | bridge | yes    |
+            | hb    | road   | yes    |
+
+        When I route I should get
+            | waypoints | turns                           | route            |
+            | a,f       | depart,arrive                   | road,road        |
+            | c,f       | depart,new name straight,arrive | bridge,road,road |
+            | 1,f       | depart,new name straight,arrive | bridge,road,road |
+            | f,a       | depart,arrive                   | road,road        |
+            | g,a       | depart,new name straight,arrive | bridge,road,road |
+            | 2,a       | depart,new name straight,arrive | bridge,road,road |
+
+    @negative
+    Scenario: Don't Collapse Places:
+        Given the node map
+            |   |   |   |   |   |   | h |   |   |   |   |   |   |
+            |   |   |   |   |   |   | g |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            | a | b |   |   |   |   |   |   |   |   |   | e | f |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   | c |   |   |   |   |   |   |
+            |   |   |   |   |   |   | d |   |   |   |   |   |   |
+
+        And the ways
+            | nodes | name   | oneway |
+            | ab    | place  | no     |
+            | cd    | bottom | no     |
+            | ef    | place  | no     |
+            | gh    | top    | no     |
+            | bcegb | place  | yes    |
+
+        When I route I should get
+            | waypoints | turns                                                     | route                         |
+            | a,d       | depart,continue right,turn right,arrive                   | place,place,bottom,bottom     |
+            | a,f       | depart,continue right,continue left,continue right,arrive | place,place,place,place,place |
+            | d,f       | depart,turn right,continue right,arrive                   | bottom,place,place,place      |
+            | d,h       | depart,turn right,continue left,turn right,arrive         | bottom,place,place,top,top    |
+
+    Scenario: Don't Collapse Places:
+        Given the node map
+            |   |   |   |   |   |   | g |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   | e | f |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   | c |   |   |   |   |   |   |
+
+        And the ways
+            | nodes | name   | oneway |
+            | ef    | place  | no     |
+            |  ceg  | place  | yes    |
+
+        When I route I should get
+            | waypoints | turns                                                     | route                         |
+            | c,f       | depart,turn right,continue right,arrive                   | bottom,place,place,place      |

--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -119,31 +119,28 @@ Feature: Simple Turns
             | bcegb | place  | yes    |
 
         When I route I should get
-            | waypoints | turns                                                     | route                         |
-            | a,d       | depart,continue right,turn right,arrive                   | place,place,bottom,bottom     |
-            | a,f       | depart,continue right,continue left,continue right,arrive | place,place,place,place,place |
-            | d,f       | depart,turn right,continue right,arrive                   | bottom,place,place,place      |
-            | d,h       | depart,turn right,continue left,turn right,arrive         | bottom,place,place,top,top    |
+            | waypoints | turns                                             | route                      |
+            | a,d       | depart,turn right,arrive                          | place,bottom,bottom        |
+            | a,f       | depart,continue left,continue right,arrive        | place,place,place,place    |
+            | d,f       | depart,turn right,continue right,arrive           | bottom,place,place,place   |
+            | d,h       | depart,turn right,continue left,turn right,arrive | bottom,place,place,top,top |
 
     Scenario: Don't Collapse Places:
         Given the node map
+            |   |   |   |   |   |   | h |   |   |   |   |   |   |
             |   |   |   |   |   |   | g |   |   |   |   |   |   |
             |   |   |   |   |   |   |   |   |   |   |   |   |   |
             |   |   |   |   |   |   |   |   |   |   |   |   |   |
             |   |   |   |   |   |   |   |   |   |   |   |   |   |
             |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   | e | f |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   | c |   |   |   |   |   |   |
+            |   | b |   |   |   |   |   |   |   |   |   | e | f |
 
         And the ways
             | nodes | name   | oneway |
-            | ef    | place  | no     |
-            |  ceg  | place  | yes    |
+            | fe    | place  | yes     |
+            | gh    | top    | yes     |
+            | egb | place  | yes    |
 
         When I route I should get
-            | waypoints | turns                                                     | route                         |
-            | c,f       | depart,turn right,continue right,arrive                   | bottom,place,place,place      |
+            | waypoints | turns                                             | route                      |
+            | f,h       | depart,turn right,arrive | place,top,top |

--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -124,23 +124,3 @@ Feature: Simple Turns
             | a,f       | depart,continue left,continue right,arrive        | place,place,place,place    |
             | d,f       | depart,turn right,continue right,arrive           | bottom,place,place,place   |
             | d,h       | depart,turn right,continue left,turn right,arrive | bottom,place,place,top,top |
-
-    Scenario: Don't Collapse Places:
-        Given the node map
-            |   |   |   |   |   |   | h |   |   |   |   |   |   |
-            |   |   |   |   |   |   | g |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   |   |   |   |   |   |   |   |   |   |   |   |   |
-            |   | b |   |   |   |   |   |   |   |   |   | e | f |
-
-        And the ways
-            | nodes | name   | oneway |
-            | fe    | place  | yes     |
-            | gh    | top    | yes     |
-            | egb | place  | yes    |
-
-        When I route I should get
-            | waypoints | turns                                             | route                      |
-            | f,h       | depart,turn right,arrive | place,top,top |

--- a/features/guidance/ramp.feature
+++ b/features/guidance/ramp.feature
@@ -88,9 +88,9 @@ Feature: Ramp Guidance
             |   |   |   | d |   |
 
         And the ways
-            | nodes | highway       |
-            | abc   | tertiary      |
-            | bd    | motorway_link |
+            | nodes | highway       | oneway |
+            | abc   | tertiary      | yes    |
+            | bd    | motorway_link | yes    |
 
        When I route I should get
             | waypoints | route     | turns                          |
@@ -108,9 +108,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route       | turns                             |
-            | a,d       | abc,bd,bd   | depart,on ramp straight,arrive |
-            | a,c       | abc,abc,abc | depart,continue left,arrive       |
+            | waypoints | route     | turns                          |
+            | a,d       | abc,bd,bd | depart,on ramp straight,arrive |
+            | a,c       | abc,abc   | depart,arrive                  |
 
     Scenario: Fork Ramp Off Turning Though Street
         Given the node map
@@ -124,9 +124,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route       | turns                             |
-            | a,d       | abc,bd,bd   | depart,on ramp right,arrive    |
-            | a,c       | abc,abc,abc | depart,continue left,arrive       |
+            | waypoints | route     | turns                       |
+            | a,d       | abc,bd,bd | depart,on ramp right,arrive |
+            | a,c       | abc,abc   | depart,arrive               |
 
     Scenario: Fork Ramp
         Given the node map
@@ -174,9 +174,9 @@ Feature: Ramp Guidance
             | bd    | motorway_link |
 
        When I route I should get
-            | waypoints | route       | turns                                    |
-            | a,d       | abc,bd,bd   | depart,on ramp slight right,arrive    |
-            | a,c       | abc,abc,abc | depart,continue slight left,arrive       |
+            | waypoints | route     | turns                              |
+            | a,d       | abc,bd,bd | depart,on ramp slight right,arrive |
+            | a,c       | abc,abc   | depart,arrive                      |
 
     Scenario: Fork Slight Ramp on Obvious Through Street
         Given the node map

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -246,22 +246,28 @@ Feature: Simple Turns
 
     Scenario: Four Way Intersection Double Through Street Segregated
         Given the node map
-            |   | b |   | c |   |
-            | i |   |   |   | d |
-            |   |   | a |   |   |
-            | h |   |   |   | e |
-            |   | g |   | f |   |
+            |   |   |   |   | q |   | p |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   | b |   | c |   |   |   |   |
+            | j |   |   | i |   |   |   | d |   |   | o |
+            |   |   |   |   |   | a |   |   |   |   |   |
+            | k |   |   | h |   |   |   | e |   |   | n |
+            |   |   |   |   | g |   | f |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |   |   |   |   |
+            |   |   |   |   | l |   | m |   |   |   |   |
 
         And the ways
             | nodes  | highway | oneway | name   |
-            | ha     | primary | yes    | first  |
-            | ai     | primary | yes    | first  |
-            | ae     | primary | yes    | first  |
-            | da     | primary | yes    | first  |
-            | ba     | primary | yes    | second |
-            | ac     | primary | yes    | second |
-            | fa     | primary | yes    | second |
-            | ag     | primary | yes    | second |
+            | khaij  | primary | yes    | first  |
+            | odaen  | primary | yes    | first  |
+            | qbacp  | primary | yes    | second |
+            | mfagl  | primary | yes    | second |
 
        When I route I should get
             | waypoints | route                | turns                        |
@@ -969,12 +975,13 @@ Feature: Simple Turns
             | a,d       | depart,new name straight,arrive    | Molkenmarkt,Stralauer Str,Stralauer Str |
             | e,d       | depart,new name slight left,arrive | Molkenmarkt,Stralauer Str,Stralauer Str |
 
-    Scenario: Collapse Turn Instruction, Issue #2725
     # https://www.mapillary.com/app/?lat=52.466483333333336&lng=13.431908333333332&z=17&focus=photo&pKey=LWXnKqoGqUNLnG0lofiO0Q
     # http://www.openstreetmap.org/#map=19/52.46750/13.43171
+    Scenario: Collapse Turn Instruction, Issue #2725
         Given the node map
             |   | f |   |
             |   | e |   |
+            |   |   |   |
             |   |   |   |
             | g |   | d |
             |   |   |   |
@@ -1014,26 +1021,46 @@ Feature: Simple Turns
             | y,f       | depart,arrive | Hermannstr,Hermannstr |
             | f,y       | depart,arrive | Hermannstr,Hermannstr |
 
-    Scenario: Turning into splitting road
+    Scenario: Collapse Turn Instruction, Issue #2725 - not trivially mergable at e
+    # https://www.mapillary.com/app/?lat=52.466483333333336&lng=13.431908333333332&z=17&focus=photo&pKey=LWXnKqoGqUNLnG0lofiO0Q
+    # http://www.openstreetmap.org/#map=19/52.46750/13.43171
         Given the node map
-            |   | a |   |   |
-            |   | b |   |   |
-            |   |   |   |   |
-            |   |   |   |   |
-            | c |   | d |   |
-            |   |   |   |   |
-            |   |   |   | e |
-            |   |   |   |   |
-            |   |   | f |   |
+            |   | f |   |
+            |   | e |   |
+            | g |   | d |
+            |   |   |   |
+            |   |   |   |
+            | h |   | c |
+            |   |   |   |
+            |   |   |   |
+            |   | b |   |
+            |   | a |   |
+            |   |   |   |
+            |   |   |   |
+            | r | x | s |
+            |   | y |   |
 
         And the ways
-            | nodes | name | highway | oneway |
-            | ab    | road | primary | no     |
-            | bc    | road | primary | yes    |
-            | fdb   | road | primary | yes    |
-            | de    | turn | primary | no     |
+            | nodes | name           | highway   | oneway |
+            | ab    | Hermannstr     | secondary |        |
+            | bc    | Hermannstr     | secondary | yes    |
+            | cd    | Hermannbruecke | secondary | yes    |
+            | de    | Hermannstr     | secondary | yes    |
+            | ef    | Hermannstr     | secondary |        |
+            | eg    | Hermannstr     | secondary | yes    |
+            | gh    | Hermannbruecke | secondary | yes    |
+            | hb    | Hermannstr     | secondary | yes    |
+            | xa    | Hermannstr     | secondary |        |
+            | yx    | Hermannstr     | secondary |        |
+            | rxs   | Silbersteinstr | tertiary  |        |
+
+        And the nodes
+            | node | highway         |
+            | x    | traffic_signals |
 
         When I route I should get
-            | waypoints | turns                           | route          |
-            | f,a       | depart,arrive                   | road,road      |
-            | e,a       | depart,turn slight right,arrive | turn,road,road |
+            | waypoints | turns         | route                 |
+            | a,f       | depart,arrive | Hermannstr,Hermannstr |
+            | f,a       | depart,arrive | Hermannstr,Hermannstr |
+            | y,f       | depart,arrive | Hermannstr,Hermannstr |
+            | f,y       | depart,arrive | Hermannstr,Hermannstr |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -968,3 +968,47 @@ Feature: Simple Turns
             | waypoints | turns                              | route                                   |
             | a,d       | depart,new name straight,arrive    | Molkenmarkt,Stralauer Str,Stralauer Str |
             | e,d       | depart,new name slight left,arrive | Molkenmarkt,Stralauer Str,Stralauer Str |
+
+    Scenario: Collapse Turn Instruction, Issue #2725
+    # https://www.mapillary.com/app/?lat=52.466483333333336&lng=13.431908333333332&z=17&focus=photo&pKey=LWXnKqoGqUNLnG0lofiO0Q
+    # http://www.openstreetmap.org/#map=19/52.46750/13.43171
+        Given the node map
+            |   | f |   |
+            |   | e |   |
+            | g |   | d |
+            |   |   |   |
+            |   |   |   |
+            | h |   | c |
+            |   |   |   |
+            |   |   |   |
+            |   | b |   |
+            |   | a |   |
+            |   |   |   |
+            |   |   |   |
+            | r | x | s |
+            |   | y |   |
+
+        And the ways
+            | nodes | name           | highway   | oneway |
+            | ab    | Hermannstr     | secondary |        |
+            | bc    | Hermannstr     | secondary | yes    |
+            | cd    | Hermannbruecke | secondary | yes    |
+            | de    | Hermannstr     | secondary | yes    |
+            | ef    | Hermannstr     | secondary |        |
+            | eg    | Hermannstr     | secondary | yes    |
+            | gh    | Hermannbruecke | secondary | yes    |
+            | hb    | Hermannstr     | secondary | yes    |
+            | xa    | Hermannstr     | secondary |        |
+            | yx    | Hermannstr     | secondary |        |
+            | rxs   | Silbersteinstr | tertiary  |        |
+
+        And the nodes
+            | node | highway         |
+            | x    | traffic_signals |
+
+        When I route I should get
+            | waypoints | turns         | route                 |
+            | a,f       | depart,arrive | Hermannstr,Hermannstr |
+            | f,a       | depart,arrive | Hermannstr,Hermannstr |
+            | y,f       | depart,arrive | Hermannstr,Hermannstr |
+            | f,y       | depart,arrive | Hermannstr,Hermannstr |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -975,6 +975,7 @@ Feature: Simple Turns
         Given the node map
             |   | f |   |
             |   | e |   |
+            |   |   |   |
             | g |   | d |
             |   |   |   |
             |   |   |   |
@@ -1012,3 +1013,27 @@ Feature: Simple Turns
             | f,a       | depart,arrive | Hermannstr,Hermannstr |
             | y,f       | depart,arrive | Hermannstr,Hermannstr |
             | f,y       | depart,arrive | Hermannstr,Hermannstr |
+
+    Scenario: Turning into splitting road
+        Given the node map
+            |   | a |   |   |
+            |   | b |   |   |
+            |   |   |   |   |
+            |   |   |   |   |
+            | c |   | d |   |
+            |   |   |   |   |
+            |   |   |   | e |
+            |   |   |   |   |
+            |   |   | f |   |
+
+        And the ways
+            | nodes | name | highway | oneway |
+            | ab    | road | primary | no     |
+            | bc    | road | primary | yes    |
+            | fdb   | road | primary | yes    |
+            | de    | turn | primary | no     |
+
+        When I route I should get
+            | waypoints | turns                           | route          |
+            | f,a       | depart,arrive                   | road,road      |
+            | e,a       | depart,turn slight right,arrive | turn,road,road |

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -48,11 +48,12 @@ class IntersectionGenerator
     // from `from_node` via `via_eid`
     // The resulting candidates have to be analysed for their actual instructions later on.
     OSRM_ATTR_WARN_UNUSED
-    Intersection getConnectedRoads(const NodeID from_node, const EdgeID via_eid) const;
+    Intersection GetConnectedRoads(const NodeID from_node, const EdgeID via_eid) const;
 
     // check if two indices in an intersection can be seen as a single road in the perceived
     // intersection representation
-    bool canMerge(const Intersection &intersection,
+    bool CanMerge(const NodeID intersection_node,
+                  const Intersection &intersection,
                   std::size_t first_index,
                   std::size_t second_index) const;
 
@@ -68,7 +69,8 @@ class IntersectionGenerator
     // The treatment results in a straight turn angle of 180º rather than a turn angle of approx
     // 160
     OSRM_ATTR_WARN_UNUSED
-    Intersection mergeSegregatedRoads(Intersection intersection) const;
+    Intersection MergeSegregatedRoads(const NodeID intersection_node,
+                                      Intersection intersection) const;
 
     // The counterpiece to mergeSegregatedRoads. While we can adjust roads that split up at the
     // intersection itself, it can also happen that intersections are connected to joining roads.
@@ -81,8 +83,20 @@ class IntersectionGenerator
     //       b
     //
     // for the local view of b at a.
-    Intersection adjustForJoiningRoads(const NodeID node_at_intersection,
+    OSRM_ATTR_WARN_UNUSED
+    Intersection AdjustForJoiningRoads(const NodeID node_at_intersection,
                                        Intersection intersection) const;
+
+    // Graph Compression cannot compress every setting. For example any barrier/traffic light cannot
+    // be compressed. As a result, a simple road of the form `a ----- b` might end up as having an
+    // intermediate intersection, if there is a traffic light in between. If we want to look farther
+    // down a road, finding the next actual decision requires the look at multiple intersections.
+    // Here we follow the road until we either reach a dead end or find the next intersection with
+    // more than a single next road.
+    inline Intersection GetActualNextIntersection(const NodeID starting_node,
+                                                  const EdgeID via_edge,
+                                                  NodeID *resulting_from_node,
+                                                  EdgeID *resulting_via_edge) const;
 };
 
 } // namespace guidance

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -62,7 +62,8 @@ class IntersectionGenerator
     Intersection GetConnectedRoads(const NodeID from_node, const EdgeID via_eid) const;
 
     // check if two indices in an intersection can be seen as a single road in the perceived
-    // intersection representation
+    // intersection representation See below for an example. Utility function for
+    // MergeSegregatedRoads
     bool CanMerge(const NodeID intersection_node,
                   const Intersection &intersection,
                   std::size_t first_index,

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -35,6 +35,17 @@ class IntersectionGenerator
 
     Intersection operator()(const NodeID nid, const EdgeID via_eid) const;
 
+    // Graph Compression cannot compress every setting. For example any barrier/traffic light cannot
+    // be compressed. As a result, a simple road of the form `a ----- b` might end up as having an
+    // intermediate intersection, if there is a traffic light in between. If we want to look farther
+    // down a road, finding the next actual decision requires the look at multiple intersections.
+    // Here we follow the road until we either reach a dead end or find the next intersection with
+    // more than a single next road.
+    Intersection GetActualNextIntersection(const NodeID starting_node,
+                                           const EdgeID via_edge,
+                                           NodeID *resulting_from_node,
+                                           EdgeID *resulting_via_edge) const;
+
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;
     const RestrictionMap &restriction_map;
@@ -86,17 +97,6 @@ class IntersectionGenerator
     OSRM_ATTR_WARN_UNUSED
     Intersection AdjustForJoiningRoads(const NodeID node_at_intersection,
                                        Intersection intersection) const;
-
-    // Graph Compression cannot compress every setting. For example any barrier/traffic light cannot
-    // be compressed. As a result, a simple road of the form `a ----- b` might end up as having an
-    // intermediate intersection, if there is a traffic light in between. If we want to look farther
-    // down a road, finding the next actual decision requires the look at multiple intersections.
-    // Here we follow the road until we either reach a dead end or find the next intersection with
-    // more than a single next road.
-    inline Intersection GetActualNextIntersection(const NodeID starting_node,
-                                                  const EdgeID via_edge,
-                                                  NodeID *resulting_from_node,
-                                                  EdgeID *resulting_via_edge) const;
 };
 
 } // namespace guidance

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -50,6 +50,12 @@ class IntersectionGenerator
     OSRM_ATTR_WARN_UNUSED
     Intersection getConnectedRoads(const NodeID from_node, const EdgeID via_eid) const;
 
+    // check if two indices in an intersection can be seen as a single road in the perceived
+    // intersection representation
+    bool canMerge(const Intersection &intersection,
+                  std::size_t first_index,
+                  std::size_t second_index) const;
+
     // Merge segregated roads to omit invalid turns in favor of treating segregated roads as
     // one.
     // This function combines roads the following way:
@@ -63,6 +69,20 @@ class IntersectionGenerator
     // 160
     OSRM_ATTR_WARN_UNUSED
     Intersection mergeSegregatedRoads(Intersection intersection) const;
+
+    // The counterpiece to mergeSegregatedRoads. While we can adjust roads that split up at the
+    // intersection itself, it can also happen that intersections are connected to joining roads.
+    //
+    //     *                           *
+    //     *        is converted to    *
+    //   v   a ---                     a ---
+    //   v   ^                         +
+    //   v   ^                         +
+    //       b
+    //
+    // for the local view of b at a.
+    Intersection adjustForJoiningRoads(const NodeID node_at_intersection,
+                                       Intersection intersection) const;
 };
 
 } // namespace guidance

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -55,10 +55,16 @@ class IntersectionHandler
     // Decide on a basic turn types
     TurnType::Enum findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;
 
-    // Find the most obvious turn to follow
+    // Find the most obvious turn to follow. The function returns an index into the intersection
+    // determining whether there is a road that can be seen as obvious turn in the presence of many
+    // other possible turns. The function will consider road categories and other inputs like the
+    // turn angles.
     std::size_t findObviousTurn(const EdgeID via_edge, const Intersection &intersection) const;
 
-    // Get the Instruction for an obvious turn
+    // Obvious turns can still take multiple forms. This function looks at the turn onto a road
+    // candidate when coming from a via_edge and determines the best instruction to emit.
+    // `through_street` indicates if the street turned onto is a through sreet (think mergees and
+    // similar)
     TurnInstruction getInstructionForObvious(const std::size_t number_of_candidates,
                                              const EdgeID via_edge,
                                              const bool through_street,

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -2,6 +2,7 @@
 #define OSRM_EXTRACTOR_GUIDANCE_INTERSECTION_HANDLER_HPP_
 
 #include "extractor/guidance/intersection.hpp"
+#include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/query_node.hpp"
 #include "extractor/suffix_table.hpp"
 
@@ -28,7 +29,8 @@ class IntersectionHandler
     IntersectionHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                         const std::vector<QueryNode> &node_info_list,
                         const util::NameTable &name_table,
-                        const SuffixTable &street_name_suffix_table);
+                        const SuffixTable &street_name_suffix_table,
+                        const IntersectionGenerator &intersection_generator);
 
     virtual ~IntersectionHandler() = default;
 
@@ -45,6 +47,7 @@ class IntersectionHandler
     const std::vector<QueryNode> &node_info_list;
     const util::NameTable &name_table;
     const SuffixTable &street_name_suffix_table;
+    const IntersectionGenerator &intersection_generator;
 
     // counts the number on allowed entry roads
     std::size_t countValid(const Intersection &intersection) const;

--- a/include/extractor/guidance/motorway_handler.hpp
+++ b/include/extractor/guidance/motorway_handler.hpp
@@ -3,6 +3,7 @@
 
 #include "extractor/guidance/intersection.hpp"
 #include "extractor/guidance/intersection_handler.hpp"
+#include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/query_node.hpp"
 
 #include "util/attributes.hpp"
@@ -26,7 +27,8 @@ class MotorwayHandler : public IntersectionHandler
     MotorwayHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                     const std::vector<QueryNode> &node_info_list,
                     const util::NameTable &name_table,
-                    const SuffixTable &street_name_suffix_table);
+                    const SuffixTable &street_name_suffix_table,
+                    const IntersectionGenerator &intersection_generator);
 
     ~MotorwayHandler() override final = default;
 

--- a/include/extractor/guidance/roundabout_handler.hpp
+++ b/include/extractor/guidance/roundabout_handler.hpp
@@ -4,6 +4,7 @@
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/guidance/intersection.hpp"
 #include "extractor/guidance/intersection_handler.hpp"
+#include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/guidance/roundabout_type.hpp"
 #include "extractor/profile_properties.hpp"
 #include "extractor/query_node.hpp"
@@ -44,7 +45,8 @@ class RoundaboutHandler : public IntersectionHandler
                       const CompressedEdgeContainer &compressed_edge_container,
                       const util::NameTable &name_table,
                       const SuffixTable &street_name_suffix_table,
-                      const ProfileProperties &profile_properties);
+                      const ProfileProperties &profile_properties,
+                      const IntersectionGenerator &intersection_generator);
 
     ~RoundaboutHandler() override final = default;
 

--- a/include/extractor/guidance/sliproad_handler.hpp
+++ b/include/extractor/guidance/sliproad_handler.hpp
@@ -42,9 +42,6 @@ class SliproadHandler : public IntersectionHandler
     Intersection operator()(const NodeID nid,
                             const EdgeID via_eid,
                             Intersection intersection) const override final;
-
-  private:
-    const IntersectionGenerator &intersection_generator;
 };
 
 } // namespace guidance

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -3,6 +3,7 @@
 
 #include "extractor/guidance/intersection.hpp"
 #include "extractor/guidance/intersection_handler.hpp"
+#include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/query_node.hpp"
 
 #include "util/attributes.hpp"
@@ -28,7 +29,8 @@ class TurnHandler : public IntersectionHandler
     TurnHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                 const std::vector<QueryNode> &node_info_list,
                 const util::NameTable &name_table,
-                const SuffixTable &street_name_suffix_table);
+                const SuffixTable &street_name_suffix_table,
+                const IntersectionGenerator &intersection_generator);
 
     ~TurnHandler() override final = default;
 

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -25,8 +25,6 @@ inline void print(const engine::guidance::RouteStep &step)
     std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
               << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
               << static_cast<int>(step.maneuver.waypoint_type) << " "
-              << " Lanes: (" << static_cast<int>(lanes.lanes_in_turn) << ", "
-              << static_cast<int>(lanes.first_lane_from_the_right) << ")"
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
               << " exit: " << step.maneuver.exit << " Intersections: " << step.intersections.size()
@@ -40,6 +38,8 @@ inline void print(const engine::guidance::RouteStep &step)
         std::cout << ", entry: ";
         for (auto entry : intersection.entry)
             std::cout << " " << (entry ? "true" : "false");
+        std::cout << " Lanes: (" << static_cast<int>(intersection.lanes.lanes_in_turn) << ", "
+                  << static_cast<int>(intersection.lanes.first_lane_from_the_right) << ")";
         std::cout << ")";
     }
     std::cout << "] name[" << step.name_id << "]: " << step.name;

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -20,8 +20,6 @@ namespace guidance
 {
 inline void print(const engine::guidance::RouteStep &step)
 {
-    const auto lanes = step.intersections.front().lanes;
-
     std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
               << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
               << static_cast<int>(step.maneuver.waypoint_type) << " "

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -51,7 +51,7 @@ struct NodeBasedEdgeData
     LaneDescriptionID lane_description_id;
     extractor::guidance::RoadClassification road_classification;
 
-    bool IsCompatibleToExceptForName(const NodeBasedEdgeData &other) const
+    bool IsCompatibleTo(const NodeBasedEdgeData &other) const
     {
         return (reversed == other.reversed) &&
                (roundabout == other.roundabout) && (startpoint == other.startpoint) &&
@@ -60,9 +60,9 @@ struct NodeBasedEdgeData
                (road_classification == other.road_classification);
     }
 
-    bool IsCompatibleTo(const NodeBasedEdgeData &other) const
+    bool CanCombineWith(const NodeBasedEdgeData &other) const
     {
-        return (name_id == other.name_id) && IsCompatibleToExceptForName(other);
+        return (name_id == other.name_id) && IsCompatibleTo(other);
     }
 };
 

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -51,13 +51,18 @@ struct NodeBasedEdgeData
     LaneDescriptionID lane_description_id;
     extractor::guidance::RoadClassification road_classification;
 
-    bool IsCompatibleTo(const NodeBasedEdgeData &other) const
+    bool IsCompatibleToExceptForName(const NodeBasedEdgeData &other) const
     {
-        return (name_id == other.name_id) && (reversed == other.reversed) &&
+        return (reversed == other.reversed) &&
                (roundabout == other.roundabout) && (startpoint == other.startpoint) &&
                (access_restricted == other.access_restricted) &&
                (travel_mode == other.travel_mode) &&
                (road_classification == other.road_classification);
+    }
+
+    bool IsCompatibleTo(const NodeBasedEdgeData &other) const
+    {
+        return (name_id == other.name_id) && IsCompatibleToExceptForName(other);
     }
 };
 

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1,3 +1,5 @@
+#include "util/debug.hpp"
+
 #include "extractor/guidance/turn_instruction.hpp"
 #include "engine/guidance/post_processing.hpp"
 
@@ -584,6 +586,7 @@ std::vector<RouteStep> removeNoTurnInstructions(std::vector<RouteStep> steps)
 // that we come across.
 std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
 {
+    util::guidance::print(steps);
     // the steps should always include the first/last step in form of a location
     BOOST_ASSERT(steps.size() >= 2);
     if (steps.size() == 2)

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -815,6 +815,20 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
                     invalidateStep(steps[step_index]);
                 }
             }
+            else if (step_index + 2 < steps.size() &&
+                     current_step.maneuver.instruction.type == TurnType::NewName &&
+                     steps[step_index + 1].maneuver.instruction.type == TurnType::NewName &&
+                     one_back_step.name == steps[step_index + 1].name)
+            {
+                // if we are crossing an intersection and go immediately after into a name change,
+                // we don't wan't to collapse the initial intersection.
+                // a - b ---BRIDGE -- c
+                steps[one_back_index] =
+                    elongate(std::move(steps[one_back_index]),
+                             elongate(std::move(steps[step_index]), steps[step_index + 1]));
+                invalidateStep(steps[step_index]);
+                invalidateStep(steps[step_index + 1]);
+            }
             else if (choiceless(current_step, one_back_step) ||
                      one_back_step.distance <= MAX_COLLAPSE_DISTANCE)
             {

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1,5 +1,3 @@
-#include "util/debug.hpp"
-
 #include "extractor/guidance/turn_instruction.hpp"
 #include "engine/guidance/post_processing.hpp"
 
@@ -586,7 +584,6 @@ std::vector<RouteStep> removeNoTurnInstructions(std::vector<RouteStep> steps)
 // that we come across.
 std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
 {
-    util::guidance::print(steps);
     // the steps should always include the first/last step in form of a location
     BOOST_ASSERT(steps.size() >= 2);
     if (steps.size() == 2)

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -99,8 +99,8 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
             continue;
         }
 
-        if (fwd_edge_data1.IsCompatibleTo(fwd_edge_data2) &&
-            rev_edge_data1.IsCompatibleTo(rev_edge_data2))
+        if (fwd_edge_data1.CanCombineWith(fwd_edge_data2) &&
+            rev_edge_data1.CanCombineWith(rev_edge_data2))
         {
             BOOST_ASSERT(graph.GetEdgeData(forward_e1).name_id ==
                          graph.GetEdgeData(reverse_e1).name_id);
@@ -108,7 +108,7 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
                          graph.GetEdgeData(reverse_e2).name_id);
 
             // Do not compress edge if it crosses a traffic signal.
-            // This can't be done in IsCompatibleTo, becase we only store the
+            // This can't be done in CanCombineWith, becase we only store the
             // traffic signals in the `traffic_lights` list, which EdgeData
             // doesn't have access to.
             const bool has_node_penalty = traffic_lights.find(node_v) != traffic_lights.end();

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -59,7 +59,6 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
         //    forward_e1
         //
         // If the edges are compatible.
-
         const bool reverse_edge_order = graph.GetEdgeData(graph.BeginEdges(node_v)).reversed;
         const EdgeID forward_e2 = graph.BeginEdges(node_v) + reverse_edge_order;
         BOOST_ASSERT(SPECIAL_EDGEID != forward_e2);

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -218,8 +218,7 @@ bool IntersectionGenerator::CanMerge(const NodeID node_at_intersection,
                               coordinate_at_intersection,
                               node_at_intersection](const std::size_t index,
                                                     const std::size_t other_index) {
-        const auto GetActualTarget = [&](const std::size_t index)
-        {
+        const auto GetActualTarget = [&](const std::size_t index) {
             EdgeID last_in_edge_id;
             GetActualNextIntersection(
                 node_at_intersection, intersection[index].turn.eid, nullptr, &last_in_edge_id);
@@ -238,6 +237,10 @@ bool IntersectionGenerator::CanMerge(const NodeID node_at_intersection,
             coordinate_at_in_edge, coordinate_at_intersection, coordinate_at_other_target);
         const double distance_to_target = util::coordinate_calculation::haversineDistance(
             coordinate_at_intersection, coordinate_at_target);
+
+        const constexpr double MAX_COLLAPSE_DISTANCE = 30;
+        if (distance_to_target < MAX_COLLAPSE_DISTANCE)
+            return false;
 
         const bool becomes_narrower =
             angularDeviation(turn_angle, other_turn_angle) < NARROW_TURN_ANGLE &&
@@ -474,14 +477,14 @@ Intersection IntersectionGenerator::MergeSegregatedRoads(const NodeID intersecti
 Intersection IntersectionGenerator::AdjustForJoiningRoads(const NodeID node_at_intersection,
                                                           Intersection intersection) const
 {
-    // FIXME remove
-    return intersection;
     // nothing to do for dead ends
     if (intersection.size() <= 1)
         return intersection;
 
-    for (auto &road : intersection)
+    // We can't adjust the very first angle, because the u-turn should always be 0
+    for (std::size_t road_index = 1; road_index < intersection.size(); ++road_index)
     {
+        auto &road = intersection[road_index];
         // to find out about the above situation, we need to look at the next intersection (at d in
         // the example). If the initial road can be merged to the left/right, we are about to adjust
         // the angle.
@@ -525,7 +528,7 @@ Intersection IntersectionGenerator::AdjustForJoiningRoads(const NodeID node_at_i
     return intersection;
 }
 
-inline Intersection
+Intersection
 IntersectionGenerator::GetActualNextIntersection(const NodeID starting_node,
                                                  const EdgeID via_edge,
                                                  NodeID *resulting_from_node = nullptr,

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -7,6 +7,7 @@
 #include "util/simple_logger.hpp"
 
 #include <algorithm>
+#include <cstddef>
 
 using EdgeData = osrm::util::NodeBasedDynamicGraph::EdgeData;
 using osrm::util::guidance::getTurnDirection;
@@ -29,9 +30,11 @@ inline bool requiresAnnouncement(const EdgeData &from, const EdgeData &to)
 IntersectionHandler::IntersectionHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                                          const std::vector<QueryNode> &node_info_list,
                                          const util::NameTable &name_table,
-                                         const SuffixTable &street_name_suffix_table)
+                                         const SuffixTable &street_name_suffix_table,
+                                         const IntersectionGenerator &intersection_generator)
     : node_based_graph(node_based_graph), node_info_list(node_info_list), name_table(name_table),
-      street_name_suffix_table(street_name_suffix_table)
+      street_name_suffix_table(street_name_suffix_table),
+      intersection_generator(intersection_generator)
 {
 }
 
@@ -469,10 +472,10 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
     }
 
     // has no obvious continued road
+    const auto &best_data = node_based_graph.GetEdgeData(intersection[best].turn.eid);
     if (best_continue == 0 || num_continue_names > 2 ||
-        (node_based_graph.GetEdgeData(intersection[best_continue].turn.eid).road_classification ==
-             node_based_graph.GetEdgeData(intersection[best].turn.eid).road_classification &&
-         std::abs(best_continue_deviation) > 1 && best_deviation / best_continue_deviation < 0.75))
+        (num_continue_names > 2 && best_continue_deviation >= 2 * NARROW_TURN_ANGLE) ||
+        (best_deviation < FUZZY_ANGLE_DIFFERENCE && !best_data.road_classification.IsRampClass()))
     {
         // Find left/right deviation
         const double left_deviation = angularDeviation(
@@ -484,7 +487,6 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
             std::min(left_deviation, right_deviation) > FUZZY_ANGLE_DIFFERENCE)
             return best;
 
-        const auto &best_data = node_based_graph.GetEdgeData(intersection[best].turn.eid);
         const auto left_index = (best + 1) % intersection.size();
         const auto right_index = best - 1;
         const auto &left_data = node_based_graph.GetEdgeData(intersection[left_index].turn.eid);
@@ -538,14 +540,87 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
             if (i == best_continue || !intersection[i].entry_allowed)
                 continue;
 
-            if (angularDeviation(intersection[i].turn.angle, STRAIGHT_ANGLE) / deviation < 1.1 &&
-                !obvious_by_road_class(
-                    in_data.road_classification,
-                    continue_data.road_classification,
-                    node_based_graph.GetEdgeData(intersection[i].turn.eid).road_classification))
+            const auto &turn_data = node_based_graph.GetEdgeData(intersection[i].turn.eid);
+            const bool is_obvious_by_road_class =
+                obvious_by_road_class(in_data.road_classification,
+                                      continue_data.road_classification,
+                                      turn_data.road_classification);
+
+            // if the main road is obvious by class, we ignore the current road as a potential
+            // prevention of obviousness
+            if (is_obvious_by_road_class)
+                continue;
+
+            // continuation could be grouped with a straight turn and the turning road is a ramp
+            if (turn_data.road_classification.IsRampClass() && deviation < GROUP_ANGLE)
+                continue;
+
+            // perfectly straight turns prevent obviousness
+            const auto turn_deviation =
+                angularDeviation(intersection[i].turn.angle, STRAIGHT_ANGLE);
+            if (turn_deviation < FUZZY_ANGLE_DIFFERENCE)
+                return 0;
+
+            const auto deviation_ratio = turn_deviation / deviation;
+
+            // in comparison to normal devitions, a continue road can offer a smaller distinction
+            // ratio. Other roads close to the turn angle are not as obvious, if one road continues.
+            if (deviation_ratio < DISTINCTION_RATIO / 1.5)
+                return 0;
+
+            // in comparison to another continuing road, we need a better distinction. This prevents
+            // situations where the turn is probably less obvious. An example are places that have a
+            // road with the same name entering/exiting:
+            //
+            //         d
+            //        /
+            //       /
+            // a -- b
+            //       \
+            //        \
+            //         c
+
+            if (turn_data.name_id == continue_data.name_id &&
+                deviation_ratio < 1.5 * DISTINCTION_RATIO)
                 return 0;
         }
-        return best_continue; // no obvious turn
+
+        // Segregated intersections can result in us finding an obvious turn, even though its only
+        // obvious due to a very short segment in between. So if the segment coming in is very
+        // short, we check the previous intersection for other continues in the opposite bearing.
+        const auto node_at_intersection = node_based_graph.GetTarget(via_edge);
+        const util::Coordinate coordinate_at_intersection = node_info_list[node_at_intersection];
+
+        const auto node_at_u_turn = node_based_graph.GetTarget(intersection[0].turn.eid);
+        const util::Coordinate coordinate_at_u_turn = node_info_list[node_at_u_turn];
+
+        const double constexpr MAX_COLLAPSE_DISTANCE = 30;
+        if (util::coordinate_calculation::haversineDistance(
+                coordinate_at_intersection, coordinate_at_u_turn) < MAX_COLLAPSE_DISTANCE)
+        {
+            // this request here actually goes against the direction of the ingoing edgeid. This can
+            // even reverse the direction. Since we don't want to compute actual turns but simply
+            // try to find whether there is a turn going to the opposite direction of our obvious
+            // turn, this should be alright.
+            const auto previous_intersection = intersection_generator.GetActualNextIntersection(
+                node_at_intersection, intersection[0].turn.eid, nullptr, nullptr);
+
+            const auto continue_road = intersection[best_continue];
+            for (const auto &comparison_road : previous_intersection)
+            {
+                // since we look at the intersection in the wrong direction, a similar angle
+                // actually represents a near 180 degree different in bearings between the two
+                // roads.
+                if (angularDeviation(comparison_road.turn.angle, STRAIGHT_ANGLE) > GROUP_ANGLE &&
+                    angularDeviation(comparison_road.turn.angle, continue_road.turn.angle) <
+                        FUZZY_ANGLE_DIFFERENCE &&
+                    continue_data.IsCompatibleTo(
+                        node_based_graph.GetEdgeData(comparison_road.turn.eid)))
+                    return 0;
+            }
+        }
+
+        return best_continue;
     }
 
     return 0;

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -23,7 +23,7 @@ namespace detail
 {
 inline bool requiresAnnouncement(const EdgeData &from, const EdgeData &to)
 {
-    return !from.IsCompatibleTo(to);
+    return !from.CanCombineWith(to);
 }
 }
 
@@ -610,12 +610,13 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
             {
                 // since we look at the intersection in the wrong direction, a similar angle
                 // actually represents a near 180 degree different in bearings between the two
-                // roads.
+                // roads. So if there is a road that is enterable in the opposite direction just
+                // prior, a turn is not obvious
+                const auto &turn_data = node_based_graph.GetEdgeData(comparison_road.turn.eid);
                 if (angularDeviation(comparison_road.turn.angle, STRAIGHT_ANGLE) > GROUP_ANGLE &&
                     angularDeviation(comparison_road.turn.angle, continue_road.turn.angle) <
                         FUZZY_ANGLE_DIFFERENCE &&
-                    continue_data.IsCompatibleTo(
-                        node_based_graph.GetEdgeData(comparison_road.turn.eid)))
+                    !turn_data.reversed && continue_data.CanCombineWith(turn_data))
                     return 0;
             }
         }

--- a/src/extractor/guidance/motorway_handler.cpp
+++ b/src/extractor/guidance/motorway_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/motorway_handler.hpp"
 #include "extractor/guidance/constants.hpp"
+#include "extractor/guidance/motorway_handler.hpp"
 #include "extractor/guidance/road_classification.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
@@ -43,8 +43,13 @@ inline bool isRampClass(EdgeID eid, const util::NodeBasedDynamicGraph &node_base
 MotorwayHandler::MotorwayHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                                  const std::vector<QueryNode> &node_info_list,
                                  const util::NameTable &name_table,
-                                 const SuffixTable &street_name_suffix_table)
-    : IntersectionHandler(node_based_graph, node_info_list, name_table, street_name_suffix_table)
+                                 const SuffixTable &street_name_suffix_table,
+                                 const IntersectionGenerator &intersection_generator)
+    : IntersectionHandler(node_based_graph,
+                          node_info_list,
+                          name_table,
+                          street_name_suffix_table,
+                          intersection_generator)
 {
 }
 

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/roundabout_handler.hpp"
 #include "extractor/guidance/constants.hpp"
+#include "extractor/guidance/roundabout_handler.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include "util/coordinate_calculation.hpp"
@@ -26,8 +26,13 @@ RoundaboutHandler::RoundaboutHandler(const util::NodeBasedDynamicGraph &node_bas
                                      const CompressedEdgeContainer &compressed_edge_container,
                                      const util::NameTable &name_table,
                                      const SuffixTable &street_name_suffix_table,
-                                     const ProfileProperties &profile_properties)
-    : IntersectionHandler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
+                                     const ProfileProperties &profile_properties,
+                                     const IntersectionGenerator &intersection_generator)
+    : IntersectionHandler(node_based_graph,
+                          node_info_list,
+                          name_table,
+                          street_name_suffix_table,
+                          intersection_generator),
       compressed_edge_container(compressed_edge_container), profile_properties(profile_properties)
 {
 }

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -26,8 +26,11 @@ SliproadHandler::SliproadHandler(const IntersectionGenerator &intersection_gener
                                  const std::vector<QueryNode> &node_info_list,
                                  const util::NameTable &name_table,
                                  const SuffixTable &street_name_suffix_table)
-    : IntersectionHandler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
-      intersection_generator(intersection_generator)
+    : IntersectionHandler(node_based_graph,
+                          node_info_list,
+                          name_table,
+                          street_name_suffix_table,
+                          intersection_generator)
 {
 }
 

--- a/src/extractor/guidance/turn_analysis.cpp
+++ b/src/extractor/guidance/turn_analysis.cpp
@@ -1,6 +1,6 @@
-#include "extractor/guidance/turn_analysis.hpp"
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/road_classification.hpp"
+#include "extractor/guidance/turn_analysis.hpp"
 
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
@@ -49,9 +49,18 @@ TurnAnalysis::TurnAnalysis(const util::NodeBasedDynamicGraph &node_based_graph,
                          compressed_edge_container,
                          name_table,
                          street_name_suffix_table,
-                         profile_properties),
-      motorway_handler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
-      turn_handler(node_based_graph, node_info_list, name_table, street_name_suffix_table),
+                         profile_properties,
+                         intersection_generator),
+      motorway_handler(node_based_graph,
+                       node_info_list,
+                       name_table,
+                       street_name_suffix_table,
+                       intersection_generator),
+      turn_handler(node_based_graph,
+                   node_info_list,
+                   name_table,
+                   street_name_suffix_table,
+                   intersection_generator),
       sliproad_handler(intersection_generator,
                        node_based_graph,
                        node_info_list,

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -24,8 +24,13 @@ namespace guidance
 TurnHandler::TurnHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                          const std::vector<QueryNode> &node_info_list,
                          const util::NameTable &name_table,
-                         const SuffixTable &street_name_suffix_table)
-    : IntersectionHandler(node_based_graph, node_info_list, name_table, street_name_suffix_table)
+                         const SuffixTable &street_name_suffix_table,
+                         const IntersectionGenerator &intersection_generator)
+    : IntersectionHandler(node_based_graph,
+                          node_info_list,
+                          name_table,
+                          street_name_suffix_table,
+                          intersection_generator)
 {
 }
 


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/2725.

- [Mapillary Trace](https://www.mapillary.com/app/?lat=52.46648333333334&lng=13.431908333333325&z=17&focus=photo&pKey=LWXnKqoGqUNLnG0lofiO0Q)
- [OSM data layer](http://www.openstreetmap.org/#map=19/52.46747/13.43158&layers=D)

```cucumber
 waypoints |     turns |     route
 |     a,f |     depart,arrive |     Hermannstr,Hermannstr | 

 | (-) f,a | (-) depart,arrive | (-) Hermannstr,Hermannstr | 
 | (+) f,a | (+) depart,turn right,new name slight left,arrive | (+) Hermannstr,Hermannbruecke,Hermannstr,Hermannstr | 

 | (-) y,f | (-) depart,arrive | (-) Hermannstr,Hermannstr | 
 | (+) y,f | (+) depart,turn slight left,turn right,arrive | (+) Hermannstr,Hermannbruecke,Hermannstr,Hermannstr | 

 | (-) f,y | (-) depart,arrive | (-) Hermannstr,Hermannstr | 
 | (+) f,y | (+) depart,turn right,new name slight left,arrive | (+) Hermannstr,Hermannbruecke,Hermannstr,Hermannstr | 
```

## Requirements
 - [x] create working rebase on #2750 
 - [x] merge of https://github.com/Project-OSRM/osrm-backend/pull/2750
 - [x] adjusted for comments