### PR TITLE
[Ready] Adapt lane dump to lanes at intersection (#2675), resolves #2709

### DIFF
--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -20,11 +20,13 @@ namespace guidance
 {
 inline void print(const engine::guidance::RouteStep &step)
 {
+    const auto lanes = step.intersections.front().lanes;
+
     std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
               << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
               << static_cast<int>(step.maneuver.waypoint_type) << " "
-              << " Lanes: (" << static_cast<int>(step.maneuver.lanes.lanes_in_turn) << ", "
-              << static_cast<int>(step.maneuver.lanes.first_lane_from_the_right) << ")"
+              << " Lanes: (" << static_cast<int>(lanes.lanes_in_turn) << ", "
+              << static_cast<int>(lanes.first_lane_from_the_right) << ")"
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
               << " exit: " << step.maneuver.exit << " Intersections: " << step.intersections.size()

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -22,6 +22,9 @@
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
 
+// Keep debug include to make sure the debug header is in sync with types.
+#include "util/debug.hpp"
+
 #include "extractor/tarjan_scc.hpp"
 
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
Makes the lane dumping code compile again for debugging purposes.

Let's keep the include at least in one cpp file to get warnings when things break again.