### PR TITLE
Remove unused variable node_info_list

### DIFF
--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -26,7 +26,7 @@ namespace extractor
 namespace guidance
 {
 
-// Given an Intersection, the graph to access the data and  the turn lanes, the turn lane matcher
+// Given an Intersection, the graph to access the data and the turn lanes, the turn lane matcher
 // assigns appropriate turn tupels to the different turns.
 namespace lanes
 {
@@ -38,7 +38,6 @@ class TurnLaneHandler
     TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                     const std::vector<std::uint32_t> &turn_lane_offsets,
                     const std::vector<TurnLaneType::Mask> &turn_lane_masks,
-                    const std::vector<QueryNode> &node_info_list,
                     const TurnAnalysis &turn_analysis);
 
     Intersection assignTurnLanes(const NodeID at,
@@ -52,7 +51,6 @@ class TurnLaneHandler
     const util::NodeBasedDynamicGraph &node_based_graph;
     const std::vector<std::uint32_t> &turn_lane_offsets;
     const std::vector<TurnLaneType::Mask> &turn_lane_masks;
-    const std::vector<QueryNode> &node_info_list;
     const TurnAnalysis &turn_analysis;
 
     // check whether we can handle an intersection

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -344,7 +344,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                                          name_table,
                                          street_name_suffix_table);
     guidance::lanes::TurnLaneHandler turn_lane_handler(
-        *m_node_based_graph, turn_lane_offsets, turn_lane_masks, m_node_info_list, turn_analysis);
+        *m_node_based_graph, turn_lane_offsets, turn_lane_masks, turn_analysis);
 
     bearing_class_by_node_based_node.resize(m_node_based_graph->GetNumberOfNodes(),
                                             std::numeric_limits<std::uint32_t>::max());

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -33,10 +33,9 @@ std::size_t getNumberOfTurns(const Intersection &intersection)
 TurnLaneHandler::TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
                                  const std::vector<std::uint32_t> &turn_lane_offsets,
                                  const std::vector<TurnLaneType::Mask> &turn_lane_masks,
-                                 const std::vector<QueryNode> &node_info_list,
                                  const TurnAnalysis &turn_analysis)
     : node_based_graph(node_based_graph), turn_lane_offsets(turn_lane_offsets),
-      turn_lane_masks(turn_lane_masks), node_info_list(node_info_list), turn_analysis(turn_analysis)
+      turn_lane_masks(turn_lane_masks), turn_analysis(turn_analysis)
 {
 }
 


### PR DESCRIPTION
Small tidy up of a nearby comment with extraneous white space included.