### PR TITLE
[Ready] Collapse Staggered Intersections.

### DIFF
--- a/features/guidance/staggered-intersections.feature
+++ b/features/guidance/staggered-intersections.feature
@@ -1,0 +1,92 @@
+@routing  @guidance @staggered-intersections
+Feature: Staggered Intersections
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 1 meters
+        # Note the one meter grid size: staggered intersections make zig-zags of a couple of meters only
+
+    # https://www.openstreetmap.org/#map=19/39.26022/-84.25144
+    Scenario: Staggered Intersection: Oak St, Cedar Dr
+        Given the node map
+            |   |   | j |   |   |
+            | a | b | c |   |   |
+            |   |   | d |   |   |
+            |   |   | e | f | g |
+            |   |   | h |   |   |
+            |   |   | i |   |   |
+
+        And the ways
+            | nodes  | highway     | name     |
+            | abc    | residential | Oak St   |
+            | efg    | residential | Oak St   |
+            | jcdehi | residential | Cedar Dr |
+
+        When I route I should get
+            | waypoints | route         | turns |
+            | a,g       | Oak St,Oak St | depart,arrive |
+            | g,a       | Oak St,Oak St | depart,arrive |
+
+    Scenario: Staggered Intersection: do not collapse if long segment in between
+        Given the node map
+            |   |   | j |   |   |
+            | a | b | c |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   | d |   |   |
+            |   |   |   |   |   |
+            |   |   |   |   |   |
+            |   |   | e | f | g |
+            |   |   | h |   |   |
+            |   |   | i |   |   |
+
+        And the ways
+            | nodes  | highway     | name     |
+            | abc    | residential | Oak St   |
+            | efg    | residential | Oak St   |
+            | jcdehi | residential | Cedar Dr |
+
+        When I route I should get
+            | waypoints | route                         | turns                              |
+            | a,g       | Oak St,Cedar Dr,Oak St,Oak St | depart,turn right,turn left,arrive |
+            | g,a       | Oak St,Cedar Dr,Oak St,Oak St | depart,turn right,turn left,arrive |
+
+    Scenario: Staggered Intersection: do not collapse if not left-right or right-left
+        Given the node map
+            |   |   | j |   |   |
+            | a | b | c |   |   |
+            |   |   | d |   |   |
+            | g | f | e |   |   |
+            |   |   | h |   |   |
+            |   |   | i |   |   |
+
+        And the ways
+            | nodes  | highway     | name     |
+            | abc    | residential | Oak St   |
+            | efg    | residential | Oak St   |
+            | jcdehi | residential | Cedar Dr |
+
+        When I route I should get
+            | waypoints | route                | turns                        |
+            | a,g       | Oak St,Oak St,Oak St | depart,continue uturn,arrive |
+            | g,a       | Oak St,Oak St,Oak St | depart,continue uturn,arrive |
+
+    Scenario: Staggered Intersection: do not collapse if the names are not the same
+        Given the node map
+            |   |   | j |   |   |
+            | a | b | c |   |   |
+            |   |   | d |   |   |
+            |   |   | e | f | g |
+            |   |   | h |   |   |
+            |   |   | i |   |   |
+
+        And the ways
+            | nodes  | highway     | name     |
+            | abc    | residential | Oak St   |
+            | efg    | residential | Elm St   |
+            | jcdehi | residential | Cedar Dr |
+
+        When I route I should get
+            | waypoints | route                         | turns                              |
+            | a,g       | Oak St,Cedar Dr,Elm St,Elm St | depart,turn right,turn left,arrive |
+            | g,a       | Elm St,Cedar Dr,Oak St,Oak St | depart,turn right,turn left,arrive |


### PR DESCRIPTION
Staggered intersection are very short zig-zags of only a few meters,
where the street name changes only temporarily.

They are common in rural and exurban areas, especially in the US.
(In addition, these cases could as well be tagging issues)

We do not want to announce these short left-rights or right-lefts:

          * -> b      a -> *
          |       or       |       becomes  a   ->   b
     a -> *                * -> b

Here is one example:

- https://www.openstreetmap.org/edit#map=20/39.26017/-84.25182

And here are two edge-cases that we don't handle at the moment:

- http://www.openstreetmap.org/edit#map=20/38.87900/-76.98519
- http://www.openstreetmap.org/edit#map=19/45.51056/-122.63462

and probably should not handle since the distance in between is
quite long (roughly 7-15 meters). For these we want to announce
two turns to not confuse the user.

Thanks to @1ec5 for raising this issue and @karenzshea for
providing additional US examples and cultural insights.