### PR TITLE
Workaround for simple intersections that aren't: uturn lanes with oneway combination

### DIFF
--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -768,8 +768,8 @@ Feature: Turn Lane Guidance
             | waypoints | route     | turns                   | lanes                   |
             | a,c       | ab,bc,bc  | depart,turn left,arrive | ,left:true right:false, |
 
-    # http://www.openstreetmap.org/export#map=19/47.97685/7.82933&layers=D
-    Scenario: Lane Parsing Issue #2706: None Assignments
+    # http://www.openstreetmap.org/#map=19/47.97685/7.82933&layers=D
+    Scenario: Lane Parsing Issue #2706: None Assignments I
         Given the node map
             |   | f |   |   | j  |   |
             |   |   |   |   |    |   |
@@ -805,4 +805,39 @@ Feature: Turn Lane Guidance
         When I route I should get
             | waypoints | route     | turns                   | lanes                  |
             | h,a ||||
+            # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
+
+   # https://www.openstreetmap.org/#map=19/47.99257/7.83276&layers=D
+    Scenario: Lane Parsing Issue #2706: None Assignments II
+        Given the node map
+            |   | k | l |   |
+            | j | a | b | f |
+            | i | c | d | e |
+            |   | h | g |   |
+
+        And the ways
+            | nodes | highway        | name           | oneway | turn:lanes                           |
+            | ka    | secondary      | Eschholzstr    | yes    | left;reverse\|through\|through\|none |
+            | kj    | unclassified   | kj             | yes    |                                      |
+            | ac    | secondary      | Eschholzstr    | yes    | left;reverse\|none\|none\|none       |
+            | ch    | secondary      | Eschholzstr    | yes    |                                      |
+            | gd    | secondary      | Eschholzstr    | yes    | left;reverse\|through\|through\|none |
+            | db    | secondary      | Eschholzstr    | yes    | left;reverse\|through\|through\|none |
+            | bl    | secondary      | Eschholzstr    | yes    |                                      |
+            | fb    | residential    | Haslacher Str  | yes    | left;reverse\|left;through\|right    |
+            | ba    | secondary_link | Haslacher Str  | yes    | left;reverse\|left;through           |
+            | aj    | unclassified   | Haslacher Str  | yes    |                                      |
+            | ic    | unclassified   | Haslacher Str  | yes    | left;reverse\|left\|through          |
+            | cd    | secondary_link | Haslacher Str  | yes    | left;reverse\|left\|through          |
+            | de    | residential    | Haslacher Str  | yes    |                                      |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction      |
+            | restriction | ka       | ac     | a        | only_straight_on |
+            | restriction | ic       | cd     | c        | only_straight_on |
+            | restriction | gd       | db     | d        | only_straight_on |
+
+        When I route I should get
+            | waypoints | route     | turns                   | lanes                  |
+            | i,e ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -769,6 +769,7 @@ Feature: Turn Lane Guidance
             | a,c       | ab,bc,bc  | depart,turn left,arrive | ,left:true right:false, |
 
     # http://www.openstreetmap.org/#map=19/47.97685/7.82933&layers=D
+    @bug @todo
     Scenario: Lane Parsing Issue #2706: None Assignments I
         Given the node map
             |   | f |   |   | j  |   |
@@ -807,7 +808,8 @@ Feature: Turn Lane Guidance
             | h,a ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
 
-   # https://www.openstreetmap.org/#map=19/47.99257/7.83276&layers=D
+    # https://www.openstreetmap.org/#map=19/47.99257/7.83276&layers=D
+    @bug @todo
     Scenario: Lane Parsing Issue #2706: None Assignments II
         Given the node map
             |   | k | l |   |
@@ -842,6 +844,7 @@ Feature: Turn Lane Guidance
             | i,e ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
 
+    @bug @todo
     Scenario: Lane Parsing Issue #2706: None Assignments III - Minimal reproduction recipe
         Given the node map
             |   |   | l |   |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -767,3 +767,42 @@ Feature: Turn Lane Guidance
         When I route I should get
             | waypoints | route     | turns                   | lanes                   |
             | a,c       | ab,bc,bc  | depart,turn left,arrive | ,left:true right:false, |
+
+    # http://www.openstreetmap.org/export#map=19/47.97685/7.82933&layers=D
+    Scenario: Lane Parsing Issue #2706: None Assignments
+        Given the node map
+            |   | f |   |   | j  |   |
+            |   |   |   |   |    |   |
+            | a | b | c |   | d  | e |
+            |   |   |   |   |    |   |
+            |   |   |   |   | i  |   |
+            |   | g |   |   | h  |   |
+
+        And the nodes
+            | node | highway         |
+            | a    | traffic_signals |
+            | i    | traffic_signals |
+
+        And the ways
+            | nodes | highway        | name           | oneway | turn:lanes:forward       |
+            | ab    | secondary      | Wiesentalstr   |        | through;left\|right      |
+            | bc    | secondary      | Wiesentalstr   |        | none\|left;through       |
+            | cd    | secondary      | Wiesentalstr   |        | none\|left;through       |
+            | de    | residential    | Wippertstr     |        |                          |
+            | fb    | secondary      | Merzhauser Str | yes    | through\|through\|right  |
+            | bg    | secondary      | Merzhauser Str | yes    |                          |
+            | hi    | secondary      | Merzhauser Str | yes    | left;reverse\|none\|none |
+            | ic    | secondary_link | Merzhauser Str | yes    |                          |
+            | id    | secondary      | Merzhauser Str | yes    | through;right\|none      |
+            | dj    | secondary      | Merzhauser Str | yes    |                          |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction    |
+            | restriction | fb       | fb     | b        | no_left_turn   |
+            | restriction | ic       | cb     | c        | only_left_turn |
+            | restriction | id       | dc     | d        | no_left_turn   |
+
+        When I route I should get
+            | waypoints | route     | turns                   | lanes                  |
+            | h,a ||||
+            # Note: at the moment we don't care about routes, we care about the extract process triggering assertions

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -841,3 +841,21 @@ Feature: Turn Lane Guidance
             | waypoints | route     | turns                   | lanes                  |
             | i,e ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
+
+    Scenario: Lane Parsing Issue #2706: None Assignments III - Minimal reproduction recipe
+        Given the node map
+            |   |   | l |   |
+            |   | a | b |   |
+            |   |   | d |   |
+            |   |   |   |   |
+
+        And the ways
+            | nodes | highway        | name           | oneway | turn:lanes                           |
+            | db    | secondary      | Eschholzstr    | yes    | left;reverse\|through\|through\|none |
+            | bl    | secondary      | Eschholzstr    | yes    |                                      |
+            | ba    | secondary_link | Haslacher Str  | yes    |                                      |
+
+        When I route I should get
+            | waypoints | route     | turns                   | lanes                  |
+            | d,a ||||
+            # Note: at the moment we don't care about routes, we care about the extract process triggering assertions

--- a/src/extractor/guidance/turn_lane_augmentation.cpp
+++ b/src/extractor/guidance/turn_lane_augmentation.cpp
@@ -289,10 +289,12 @@ LaneDataVector handleNoneValueAtSimpleTurn(LaneDataVector lane_data,
         //
         if (connection_count + 1 != lane_data.size())
         {
-            goto these_intersections_are_clearly_broken_at_the_moment;
+            // skip broken intersections
         }
-
-        lane_data = mergeNoneTag(none_index, std::move(lane_data));
+        else
+        {
+            lane_data = mergeNoneTag(none_index, std::move(lane_data));
+        }
     }
     // we have to rename and possibly augment existing ones. The pure count remains the
     // same.
@@ -300,8 +302,6 @@ LaneDataVector handleNoneValueAtSimpleTurn(LaneDataVector lane_data,
     {
         lane_data = handleRenamingSituations(none_index, std::move(lane_data), intersection);
     }
-
-these_intersections_are_clearly_broken_at_the_moment:
 
     // finally make sure we are still sorted
     std::sort(lane_data.begin(), lane_data.end());

--- a/src/extractor/guidance/turn_lane_augmentation.cpp
+++ b/src/extractor/guidance/turn_lane_augmentation.cpp
@@ -283,7 +283,14 @@ LaneDataVector handleNoneValueAtSimpleTurn(LaneDataVector lane_data,
         // a pgerequisite is simple turns. Larger differences should not end up here
         // an additional line at the side is only reasonable if it is targeting public
         // service vehicles. Otherwise, we should not have it
-        BOOST_ASSERT(connection_count + 1 == lane_data.size());
+        //
+        // TODO(mokob): #2730 have a look please
+        // BOOST_ASSERT(connection_count + 1 == lane_data.size());
+        //
+        if (connection_count + 1 != lane_data.size())
+        {
+            goto these_intersections_are_clearly_broken_at_the_moment;
+        }
 
         lane_data = mergeNoneTag(none_index, std::move(lane_data));
     }
@@ -293,6 +300,9 @@ LaneDataVector handleNoneValueAtSimpleTurn(LaneDataVector lane_data,
     {
         lane_data = handleRenamingSituations(none_index, std::move(lane_data), intersection);
     }
+
+these_intersections_are_clearly_broken_at_the_moment:
+
     // finally make sure we are still sorted
     std::sort(lane_data.begin(), lane_data.end());
     return lane_data;

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -352,6 +352,10 @@ bool TurnLaneHandler::isSimpleIntersection(const LaneDataVector &lane_data,
             if (lane_data.back().tag == TurnLaneType::uturn)
                 return findBestMatchForReverse(lane_data[lane_data.size() - 2].tag, intersection);
 
+            // TODO(mokob): #2730 have a look please
+            // BOOST_ASSERT(lane_data.front().tag == TurnLaneType::uturn);
+            // return findBestMatchForReverse(lane_data[1].tag, intersection);
+            //
             if (lane_data.front().tag == TurnLaneType::uturn)
                 return findBestMatchForReverse(lane_data[1].tag, intersection);
 

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -352,8 +352,10 @@ bool TurnLaneHandler::isSimpleIntersection(const LaneDataVector &lane_data,
             if (lane_data.back().tag == TurnLaneType::uturn)
                 return findBestMatchForReverse(lane_data[lane_data.size() - 2].tag, intersection);
 
-            BOOST_ASSERT(lane_data.front().tag == TurnLaneType::uturn);
-            return findBestMatchForReverse(lane_data[1].tag, intersection);
+            if (lane_data.front().tag == TurnLaneType::uturn)
+                return findBestMatchForReverse(lane_data[1].tag, intersection);
+
+            return findBestMatch(data.tag, intersection);
         }();
         std::size_t match_index = std::distance(intersection.begin(), best_match);
         all_simple &= (matched_indices.count(match_index) == 0);


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/2730.

This is a workaround at best. See the issue above for more context.

We traced this down by dumping the breaking locations, trying to come up with cucumber tests reproducing the issue, simplifying the cucumber test down to a small self contained scenario and trying various things before falling back to this workaround.

Affected are 190 intersections on the planet, from what I can see in the demo server logs.

Note: see the `fix/2706-debug` branch for what we deployed on the demo server.
This changeset is the gist of it.

@MoKob @danpat @TheMarex 

Not closing the original issue since this definitely needs a follow up.