### PR TITLE
Makes toll=yes way's routability configurable in profiles.

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -155,3 +155,10 @@ Feature: Car - Restricted access
             | primary | designated |       |
             | primary | yes        | x     |
             | primary | no         | x     |
+
+     Scenario: Car - only toll=yes ways are ignored by default
+        Then routability should be
+            | highway | toll        | bothw |
+            | primary | yes         |       |
+            | primary | no          | x     |
+            | primary | snowmobile  | x     |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -149,6 +149,7 @@ local turn_bias                  = 1.2
 local obey_oneway                = true
 local ignore_areas               = true
 local ignore_hov_ways            = true
+local ignore_toll_ways           = true
 
 local abs = math.abs
 local min = math.min
@@ -237,6 +238,12 @@ function way_function (way, result)
   -- respect user-preference for HOV-only ways
   local hov = way:get_value_by_key("hov")
   if ignore_hov_ways and hov and "designated" == hov then
+    return
+  end
+
+  -- respect user-preference for toll=yes ways
+  local toll = way:get_value_by_key("toll")
+  if ignore_toll_ways and toll and "yes" == toll then
     return
   end
 

--- a/taginfo.json
+++ b/taginfo.json
@@ -53,6 +53,12 @@
             "description": "Roads with hov=designated are ignored by default."
         },
         {
+            "key": "toll",
+            "value": "yes",
+            "object_types": [ "way" ],
+            "description": "Roads with toll=yes are ignored by default."
+        },
+        {
             "key": "impassable",
             "description": "This is used by HOT."
         },


### PR DESCRIPTION
The primary use-case is conditionally filtering ways such as:

https://www.openstreetmap.org/edit#map=18/38.94198/-77.28127

which we are guiding the user onto in the route from DC to IAD:

http://map.project-osrm.org/?z=12&center=38.934443%2C-77.167969&loc=38.902656%2C-77.029095&loc=38.952210%2C-77.453424&hl=en&alt=0

There are additional toll-free ways available for this route which are
a bit slower but do not require a fee.

This changeset makes `toll=yes` configurable in the profiles, disabling
them by default. Neither do we support time-based fees nor vehicle
category fees at the moment.

References:
- http://wiki.openstreetmap.org/wiki/Key:toll

cc @willwhite 