### PR TITLE
Catch and report errors during osrm-contract tests.

### DIFF
--- a/features/step_definitions/options.js
+++ b/features/step_definitions/options.js
@@ -30,6 +30,10 @@ module.exports = function () {
         assert.equal(this.exitCode, parseInt(code));
     });
 
+    this.Then(/^it should exit with code not (\d+)$/, (code) => {
+        assert.notEqual(this.exitCode, parseInt(code));
+    });
+
     this.Then(/^stdout should contain "(.*?)"$/, (str) => {
         assert.ok(this.stdout.indexOf(str) > -1);
     });

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -339,7 +339,8 @@ module.exports = function () {
     };
 
     this.reprocessAndLoadData = (callback) => {
-        this.reprocess(() => {
+        this.reprocess((e) => {
+            if (e) return callback(e);
             this.OSRMLoader.load(util.format('%s.osrm', this.osmData.contractedFile), callback);
         });
     };

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -24,7 +24,8 @@ module.exports = function () {
     };
 
     this.WhenIRouteIShouldGet = (table, callback) => {
-        this.reprocessAndLoadData(() => {
+        this.reprocessAndLoadData((e) => {
+            if (e) return callback(e);
             var headers = new Set(table.raw()[0]);
 
             var requestRow = (row, ri, cb) => {


### PR DESCRIPTION
Some tests were feeding `osrm-contract` data that caused it to exit with a non-zero return code.
We weren't catching this error, and the test was logging the problem, but continuing anyway.

Because data from the previous test was often still in shared memory, and the tests shared the same data, the test that should have failed was passing.

This change properly feeds errors to the execution callback, and modifies the problematic tests so that they use different data so this problem can't repeat here.

This test now also checks for "not 0" return codes, as the way we're throwing errors now gives platform-specific error codes (uncaught exceptions leading to `abort()` on OSX causes return code 134, but code 1 on Linux).