### PR TITLE
[ready] adjusting u-turn handling in lane matching to fully fix 2706

### DIFF
--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -863,7 +863,7 @@ Feature: Turn Lane Guidance
             | d,a ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
 
-    @reverse @2730
+    @reverse @2730 @todo
     Scenario: Reverse on the right
         Given the node map
             | a |   |   | c |   |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -740,8 +740,8 @@ Feature: Turn Lane Guidance
 
         And the ways
             | nodes | name | highway | turn:lanes:forward |
-            | ab    | road | primary | through,right      |
-            | bc    | road | primary | through,right      |
+            | ab    | road | primary | through;right      |
+            | bc    | road | primary | through;right      |
             | cd    | road | primary |                    |
             | xa    | road | primary |                    |
             | be    | turn | primary |                    |
@@ -862,3 +862,24 @@ Feature: Turn Lane Guidance
             | waypoints | route     | turns                   | lanes                  |
             | d,a ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
+
+    @reverse @2730
+    Scenario: Reverse on the right
+        Given the node map
+            | a |   |   | c |   |
+            |   |   |   | b | d |
+            | f |   |   | e |   |
+
+        And the ways
+            | nodes | highway | name    | turn:lanes:forward           | oneway |
+            | ab    | primary | in      | left\|through\|right;reverse | yes    |
+            | bc    | primary | left    |                              | no     |
+            | bd    | primary | through |                              | no     |
+            | be    | primary | right   |                              | no     |
+            | bf    | primary | in      |                              | yes    |
+
+        When I route I should get
+            | waypoints | route              | turns                           | lanes                                        |
+            | a,c       | in,left,left       | depart,turn left,arrive         | ,left:true straight:false right;uturn:false, |
+            | a,d       | in,through,through | depart,new name straight,arrive | ,left:false straight:true right;uturn:false, |
+            | a,e       | in,right,right     | depart,turn right,arrive        | ,left:false straight:false right;uturn:true, |

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -323,7 +323,7 @@ trimLaneString(std::string lane_string, std::int32_t count_left, std::int32_t co
         for (std::int32_t i = 0; i < count_left; ++i)
             // this is adjusted for our fake pipe. The moment cucumber can handle multiple escaped
             // pipes, the '&' part can be removed
-            if (lane_string[i] != '|' && lane_string[i] != '&')
+            if (lane_string[i] != '|')
             {
                 sane = false;
                 break;
@@ -341,7 +341,7 @@ trimLaneString(std::string lane_string, std::int32_t count_left, std::int32_t co
              itr != lane_string.rend() && itr != lane_string.rbegin() + count_right;
              ++itr)
         {
-            if (*itr != '|' && *itr != '&')
+            if (*itr != '|')
             {
                 sane = false;
                 break;

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -277,7 +277,7 @@ Intersection IntersectionGenerator::mergeSegregatedRoads(Intersection intersecti
     {
         const double correction_factor = (intersection[1].turn.angle) / 2;
         for (std::size_t i = 2; i < intersection.size(); ++i)
-            intersection[i].turn.angle += correction_factor;
+            intersection[i].turn.angle -= correction_factor;
         intersection[0] = merge(intersection[0], intersection[1]);
         intersection[0].turn.angle = 0;
         intersection.erase(intersection.begin() + 1);

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -38,6 +38,28 @@ bool TurnLaneData::operator<(const TurnLaneData &other) const
                                                             TurnLaneType::left,
                                                             TurnLaneType::sharp_left,
                                                             TurnLaneType::uturn};
+    // U-Turns are supposed to be on the outside. So if the first lane is 0 and we are looking at a
+    // u-turn, it has to be on the very left. If it is equal to the number of lanes, it has to be on
+    // the right. These sorting function assume reverse to be on the outside always. Might need to
+    // be reconsidered if there are situations that offer a reverse from some middle lane (seems
+    // improbable)
+
+    if (tag == TurnLaneType::uturn)
+    {
+        if (from == 0)
+            return true;
+        else
+            return false;
+    }
+
+    if (other.tag == TurnLaneType::uturn)
+    {
+        if (other.from == 0)
+            return false;
+        else
+            return true;
+    }
+
     return std::find(tag_by_modifier, tag_by_modifier + 8, this->tag) <
            std::find(tag_by_modifier, tag_by_modifier + 8, other.tag);
 }

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -116,6 +116,13 @@ LaneDataVector laneDataFromDescription(const TurnLaneDescription &turn_lane_desc
         // which is invalid
         for (std::size_t index = 1; index < lane_data.size(); ++index)
         {
+            // u-turn located somewhere in the middle
+            // Right now we can only handle u-turns at the sides. If we find a u-turn somewhere in
+            // the middle of the tags, we abort the handling right here.
+            if (index + 1 < lane_data.size() &&
+                ((lane_data[index].tag & TurnLaneType::uturn) != TurnLaneType::empty))
+                return false;
+
             if (lane_data[index - 1].to > lane_data[index].from)
                 return false;
         }

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -104,9 +104,7 @@ LaneDataVector laneDataFromDescription(const TurnLaneDescription &turn_lane_desc
     // transform the map into the lane data vector
     LaneDataVector lane_data;
     for (const auto tag : lane_map)
-    {
         lane_data.push_back({tag.first, tag.second.first, tag.second.second});
-    }
 
     std::sort(lane_data.begin(), lane_data.end());
 

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -1,7 +1,7 @@
-#include "extractor/guidance/turn_lane_handler.hpp"
 #include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/turn_discovery.hpp"
 #include "extractor/guidance/turn_lane_augmentation.hpp"
+#include "extractor/guidance/turn_lane_handler.hpp"
 #include "extractor/guidance/turn_lane_matcher.hpp"
 #include "util/simple_logger.hpp"
 #include "util/typedefs.hpp"
@@ -119,9 +119,8 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
 
     if (!lane_data.empty() && canMatchTrivially(intersection, lane_data) &&
         lane_data.size() !=
-            static_cast<std::size_t>(
-                lane_data.back().tag != TurnLaneType::uturn && intersection[0].entry_allowed ? 1
-                                                                                             : 0) +
+            static_cast<std::size_t>((
+                !hasTag(TurnLaneType::uturn, lane_data) && intersection[0].entry_allowed ? 1 : 0)) +
                 possible_entries &&
         intersection[0].entry_allowed && !hasTag(TurnLaneType::none, lane_data))
         lane_data.push_back({TurnLaneType::uturn, lane_data.back().to, lane_data.back().to});
@@ -352,14 +351,8 @@ bool TurnLaneHandler::isSimpleIntersection(const LaneDataVector &lane_data,
             if (lane_data.back().tag == TurnLaneType::uturn)
                 return findBestMatchForReverse(lane_data[lane_data.size() - 2].tag, intersection);
 
-            // TODO(mokob): #2730 have a look please
-            // BOOST_ASSERT(lane_data.front().tag == TurnLaneType::uturn);
-            // return findBestMatchForReverse(lane_data[1].tag, intersection);
-            //
-            if (lane_data.front().tag == TurnLaneType::uturn)
-                return findBestMatchForReverse(lane_data[1].tag, intersection);
-
-            return findBestMatch(data.tag, intersection);
+            BOOST_ASSERT(lane_data.front().tag == TurnLaneType::uturn);
+            return findBestMatchForReverse(lane_data[1].tag, intersection);
         }();
         std::size_t match_index = std::distance(intersection.begin(), best_match);
         all_simple &= (matched_indices.count(match_index) == 0);

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -117,12 +117,18 @@ Intersection TurnLaneHandler::assignTurnLanes(const NodeID at,
     if (has_merge_lane || has_non_usable_u_turn)
         return intersection;
 
-    if (!lane_data.empty() && canMatchTrivially(intersection, lane_data) &&
+    // check if a u-turn is allowed (for some reason) and is missing from the list of tags (u-turn
+    // is often allowed from the `left` lane without an additional indication dedicated to u-turns).
+    const bool is_missing_valid_u_turn =
         lane_data.size() !=
             static_cast<std::size_t>((
                 !hasTag(TurnLaneType::uturn, lane_data) && intersection[0].entry_allowed ? 1 : 0)) +
                 possible_entries &&
-        intersection[0].entry_allowed && !hasTag(TurnLaneType::none, lane_data))
+        intersection[0].entry_allowed;
+
+    // FIXME the lane to add depends on the side of driving/u-turn rules in the country
+    if (!lane_data.empty() && canMatchTrivially(intersection, lane_data) &&
+        !is_missing_valid_u_turn && !hasTag(TurnLaneType::none, lane_data))
         lane_data.push_back({TurnLaneType::uturn, lane_data.back().to, lane_data.back().to});
 
     bool is_simple = isSimpleIntersection(lane_data, intersection);
@@ -335,24 +341,34 @@ bool TurnLaneHandler::isSimpleIntersection(const LaneDataVector &lane_data,
     bool all_simple = true;
     bool has_none = false;
     std::unordered_set<std::size_t> matched_indices;
-    for (const auto &data : lane_data)
+    for (std::size_t data_index = 0; data_index < lane_data.size(); ++data_index)
     {
+        const auto &data = lane_data[data_index];
         if (data.tag == TurnLaneType::none)
         {
             has_none = true;
             continue;
         }
 
+        // u-turn tags are at the outside of the lane-tags and require special handling, since
+        // locating their best match requires knowledge on the neighboring tag. (see documentation
+        // on findBestMatch/findBestMatchForReverse
         const auto best_match = [&]() {
+            // normal tag or u-turn as only choice (no other tag present)
             if (data.tag != TurnLaneType::uturn || lane_data.size() == 1)
                 return findBestMatch(data.tag, intersection);
 
-            // lane_data.size() > 1
-            if (lane_data.back().tag == TurnLaneType::uturn)
-                return findBestMatchForReverse(lane_data[lane_data.size() - 2].tag, intersection);
+            BOOST_ASSERT(data.tag == TurnLaneType::uturn);
+            // u-turn at the very left, leftmost turn at data_index - 1
+            if (data_index + 1 == lane_data.size())
+                return findBestMatchForReverse(lane_data[data_index - 1].tag, intersection);
 
-            BOOST_ASSERT(lane_data.front().tag == TurnLaneType::uturn);
-            return findBestMatchForReverse(lane_data[1].tag, intersection);
+            // u-turn to the right (left-handed driving) -> rightmost turn to the left (data_index +
+            // 1)
+            if (data_index == 0)
+                return findBestMatchForReverse(lane_data[data_index + 1].tag, intersection);
+
+            return intersection.begin();
         }();
         std::size_t match_index = std::distance(intersection.begin(), best_match);
         all_simple &= (matched_indices.count(match_index) == 0);

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -137,7 +137,7 @@ typename Intersection::const_iterator
 findBestMatchForReverse(const TurnLaneType::Mask &neighbor_tag, const Intersection &intersection)
 {
     const auto neighbor_itr = findBestMatch(neighbor_tag, intersection);
-    if ((neighbor_itr + 1 == intersection.cend()) || (neighbor_itr == intersection.cbegin() + 1))
+    if (neighbor_itr + 1 == intersection.cend())
         return intersection.begin();
 
     const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
@@ -239,6 +239,8 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
             // continue with the first lane
             lane = 1;
         }
+        else
+            return intersection;
     }
 
     for (; road_index < intersection.size() && lane < lane_data.size(); ++road_index)

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/turn_lane_matcher.hpp"
 #include "extractor/guidance/toolkit.hpp"
+#include "extractor/guidance/turn_lane_matcher.hpp"
 #include "util/guidance/toolkit.hpp"
 
 #include <boost/assert.hpp>
@@ -134,17 +134,17 @@ typename Intersection::const_iterator findBestMatch(const TurnLaneType::Mask &ta
 // possible that it is forbidden. In addition, the best u-turn angle does not necessarily represent
 // the u-turn, since it could be a sharp-left turn instead on a road with a middle island.
 typename Intersection::const_iterator
-findBestMatchForReverse(const TurnLaneType::Mask &leftmost_tag, const Intersection &intersection)
+findBestMatchForReverse(const TurnLaneType::Mask &neighbor_tag, const Intersection &intersection)
 {
-    const auto leftmost_itr = findBestMatch(leftmost_tag, intersection);
-    if (leftmost_itr + 1 == intersection.cend())
+    const auto neighbor_itr = findBestMatch(neighbor_tag, intersection);
+    if ((neighbor_itr + 1 == intersection.cend()) || (neighbor_itr == intersection.cbegin() + 1))
         return intersection.begin();
 
     const constexpr double idealized_turn_angles[] = {0, 35, 90, 135, 180, 225, 270, 315};
     const TurnLaneType::Mask tag = TurnLaneType::uturn;
     const auto idealized_angle = idealized_turn_angles[getMatchingModifier(tag)];
     return std::min_element(
-        intersection.begin() + std::distance(intersection.begin(), leftmost_itr),
+        intersection.begin() + std::distance(intersection.begin(), neighbor_itr),
         intersection.end(),
         [idealized_angle, &tag](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
             // prefer valid matches
@@ -165,6 +165,12 @@ findBestMatchForReverse(const TurnLaneType::Mask &leftmost_tag, const Intersecti
 bool canMatchTrivially(const Intersection &intersection, const LaneDataVector &lane_data)
 {
     std::size_t road_index = 1, lane = 0;
+    if (!lane_data.empty() && lane_data.front().tag == TurnLaneType::uturn)
+    {
+        // the very first is a u-turn to the right
+        if (intersection[0].entry_allowed)
+            lane = 1;
+    }
     for (; road_index < intersection.size() && lane < lane_data.size(); ++road_index)
     {
         if (intersection[road_index].entry_allowed)
@@ -207,6 +213,34 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
         road.turn.lane_data_id = lane_data_id;
     };
 
+    if (!lane_data.empty() && lane_data.front().tag == TurnLaneType::uturn)
+    {
+        // the very first is a u-turn to the right
+        if (intersection[0].entry_allowed)
+        {
+            std::size_t u_turn = 0;
+            if (node_based_graph.GetEdgeData(intersection[0].turn.eid).reversed)
+            {
+                if (intersection.size() <= 1 || !intersection[1].entry_allowed ||
+                    intersection[1].turn.instruction.direction_modifier !=
+                        DirectionModifier::SharpRight)
+                {
+                    // cannot match u-turn in a valid way
+                    return intersection;
+                }
+                u_turn = 1;
+                road_index = 2;
+            }
+            intersection[u_turn].entry_allowed = true;
+            intersection[u_turn].turn.instruction.type = TurnType::Turn;
+            intersection[u_turn].turn.instruction.direction_modifier = DirectionModifier::UTurn;
+
+            matchRoad(intersection[u_turn], lane_data.back());
+            // continue with the first lane
+            lane = 1;
+        }
+    }
+
     for (; road_index < intersection.size() && lane < lane_data.size(); ++road_index)
     {
         if (intersection[road_index].entry_allowed)
@@ -231,7 +265,7 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
         std::size_t u_turn = 0;
         if (node_based_graph.GetEdgeData(intersection[0].turn.eid).reversed)
         {
-            if (intersection.back().entry_allowed ||
+            if (!intersection.back().entry_allowed ||
                 intersection.back().turn.instruction.direction_modifier !=
                     DirectionModifier::SharpLeft)
             {


### PR DESCRIPTION
https://github.com/Project-OSRM/osrm-backend/pull/2739/files#diff-e4ce6eeb194b7b13640b6b48d96a052dR355 changes behaviour of an assertion instead of fixing the root of the problem.

The problem here was that sorting u-turns in the array of lane entries. The PR open here adds a regression test-case triggering the behaviour, fixes the sorting and in addition handles right-sided u-turn lanes. 

- [x] reviewed
- [x] adjusted for comments
- [x] make sure it runs on the planet