### PR TITLE
JSON instruction serialization fix.

### DIFF
--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -17,9 +17,10 @@ namespace guidance
 
 enum class WaypointType : std::uint8_t
 {
-    None,
-    Arrive,
-    Depart,
+    None = 0,
+    Arrive = 1,
+    Depart = 2,
+    MaxWaypointType = 3
 };
 
 struct StepManeuver

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -16,12 +16,6 @@ namespace extractor
 namespace guidance
 {
 
-namespace detail
-{
-// inclusive bounds for turn modifiers
-const constexpr uint8_t num_direction_modifiers = 8;
-} // detail
-
 // direction modifiers based on angle
 namespace DirectionModifier
 {
@@ -34,6 +28,7 @@ const constexpr Enum Straight = 4;
 const constexpr Enum SlightLeft = 5;
 const constexpr Enum Left = 6;
 const constexpr Enum SharpLeft = 7;
+const constexpr Enum MaxDirectionModifier = 8;
 }
 
 namespace TurnType
@@ -70,6 +65,7 @@ const constexpr Enum ExitRoundaboutIntersection = 24; // Exiting a small Roundab
 const constexpr Enum StayOnRoundabout = 25; // Continue on Either a small or a large Roundabout
 const constexpr Enum Sliproad =
     26; // Something that looks like a ramp, but is actually just a small sliproad
+const constexpr Enum MaxTurnType = 27; // Special value for static asserts
 }
 
 // turn angle in 1.40625 degree -> 128 == 180 degree

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -50,7 +50,7 @@ const constexpr char *turn_type_names[] = {
     "roundabout",      "roundabout", "rotary",   "rotary",      "roundabout turn",
     "roundabout turn", "use lane",   "invalid",  "invalid",     "invalid",
     "invalid",         "invalid",    "invalid",  "invalid",     "invalid",
-    "invalid"};
+    "invalid",         "invalid"};
 
 const constexpr char *waypoint_type_names[] = {"invalid", "arrive", "depart"};
 
@@ -68,6 +68,7 @@ inline bool hasValidLanes(const guidance::Intersection &intersection)
 
 std::string instructionTypeToString(const TurnType::Enum type)
 {
+    BOOST_ASSERT(static_cast<std::size_t>(type) < sizeof(turn_type_names)/sizeof(turn_type_names[0]));
     return turn_type_names[static_cast<std::size_t>(type)];
 }
 

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -68,7 +68,8 @@ inline bool hasValidLanes(const guidance::Intersection &intersection)
 
 std::string instructionTypeToString(const TurnType::Enum type)
 {
-    BOOST_ASSERT(static_cast<std::size_t>(type) < sizeof(turn_type_names)/sizeof(turn_type_names[0]));
+    static_assert(sizeof(turn_type_names)/sizeof(turn_type_names[0]) >= TurnType::MaxTurnType,
+            "Some turn types has not string representation.");
     return turn_type_names[static_cast<std::size_t>(type)];
 }
 
@@ -98,11 +99,15 @@ util::json::Array lanesFromIntersection(const guidance::Intersection &intersecti
 
 std::string instructionModifierToString(const DirectionModifier::Enum modifier)
 {
+    static_assert(sizeof(modifier_names)/sizeof(modifier_names[0]) >= DirectionModifier::MaxDirectionModifier,
+            "Some direction modifiers has not string representation.");
     return modifier_names[static_cast<std::size_t>(modifier)];
 }
 
 std::string waypointTypeToString(const guidance::WaypointType waypoint_type)
 {
+    static_assert(sizeof(waypoint_type_names)/sizeof(waypoint_type_names[0]) >= static_cast<size_t>(guidance::WaypointType::MaxWaypointType),
+            "Some waypoint types has not string representation.");
     return waypoint_type_names[static_cast<std::size_t>(waypoint_type)];
 }
 

--- a/unit_tests/engine/json_factory.cpp
+++ b/unit_tests/engine/json_factory.cpp
@@ -1,0 +1,16 @@
+#include "engine/api/json_factory.hpp"
+
+#include <boost/test/test_case_template.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(json_factory)
+
+BOOST_AUTO_TEST_CASE(instructionTypeToString_test_size)
+{
+    using namespace osrm::engine::api::json::detail;
+    using namespace osrm::extractor::guidance;
+
+    BOOST_CHECK_EQUAL(instructionTypeToString(TurnType::Sliproad), "invalid");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In some cases the OSRM server returns ```{"code": "InternalError","message":"Internal Server Error"}```. 
We reproduce it on request:
```
route/v1/car/-73.92415,40.86168;-73.93144,40.86696;-73.80145,40.67074;-74.30066,40.51935;-74.38946,40.5267?steps=true&geometries=geojson&bearings=0,180;282,45;180,45;272,45;336,45&overview=false
```
This happens because TurnType::Sliproad has not translation. I fix it.