### PR TITLE
[not-ready] Distance support for table service

### DIFF
--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -38,7 +38,7 @@ class GraphContractor
     {
         ContractorEdgeData()
             : distance(0), id(0), originalEdges(0), shortcut(0), forward(0), backward(0),
-              is_original_via_node_ID(false)
+              is_original_via_node_ID(false), distance_data(DistanceData())
         {
         }
         ContractorEdgeData(unsigned distance,
@@ -46,10 +46,12 @@ class GraphContractor
                            unsigned id,
                            bool shortcut,
                            bool forward,
-                           bool backward)
+                           bool backward,
+                           const DistanceData & distance_data)
             : distance(distance), id(id),
               originalEdges(std::min((unsigned)1 << 28, original_edges)), shortcut(shortcut),
-              forward(forward), backward(backward), is_original_via_node_ID(false)
+              forward(forward), backward(backward), is_original_via_node_ID(false),
+              distance_data(distance_data)
         {
         }
         unsigned distance;
@@ -59,6 +61,7 @@ class GraphContractor
         bool forward : 1;
         bool backward : 1;
         bool is_original_via_node_ID : 1;
+        DistanceData distance_data;
     } data;
 
     struct ContractorHeapData
@@ -172,7 +175,8 @@ class GraphContractor
                                diter->edge_id,
                                false,
                                diter->forward ? true : false,
-                               diter->backward ? true : false);
+                               diter->backward ? true : false,
+                               diter->distance_data);
 
             edges.emplace_back(diter->target,
                                diter->source,
@@ -181,7 +185,8 @@ class GraphContractor
                                diter->edge_id,
                                false,
                                diter->backward ? true : false,
-                               diter->forward ? true : false);
+                               diter->forward ? true : false,
+                               diter->distance_data);
         }
         // clear input vector
         input_edge_list.clear();
@@ -211,23 +216,28 @@ class GraphContractor
             forward_edge.data.id = reverse_edge.data.id = id;
             forward_edge.data.originalEdges = reverse_edge.data.originalEdges = 1;
             forward_edge.data.distance = reverse_edge.data.distance = INVALID_EDGE_WEIGHT;
+            forward_edge.data.distance_data = reverse_edge.data.distance_data = INVALID_DISTANCE_DATA;
             // remove parallel edges
             while (i < edges.size() && edges[i].source == source && edges[i].target == target)
             {
                 if (edges[i].data.forward)
                 {
-                    forward_edge.data.distance =
-                        std::min(edges[i].data.distance, forward_edge.data.distance);
+                    if (edges[i].data.distance < forward_edge.data.distance) {
+                        forward_edge.data.distance = edges[i].data.distance;
+                        forward_edge.data.distance_data = edges[i].data.distance_data;
+                    }
                 }
                 if (edges[i].data.backward)
                 {
-                    reverse_edge.data.distance =
-                        std::min(edges[i].data.distance, reverse_edge.data.distance);
+                    if (edges[i].data.distance < reverse_edge.data.distance) {
+                        reverse_edge.data.distance = edges[i].data.distance;
+                        reverse_edge.data.distance_data = edges[i].data.distance_data;
+                    }
                 }
                 ++i;
             }
             // merge edges (s,t) and (t,s) into bidirectional edge
-            if (forward_edge.data.distance == reverse_edge.data.distance)
+            if (forward_edge.data.distance == reverse_edge.data.distance && forward_edge.data.distance_data == reverse_edge.data.distance_data)
             {
                 if ((int)forward_edge.data.distance != INVALID_EDGE_WEIGHT)
                 {
@@ -646,6 +656,7 @@ class GraphContractor
                     BOOST_ASSERT_MSG(SPECIAL_NODEID != new_edge.source, "Source id invalid");
                     BOOST_ASSERT_MSG(SPECIAL_NODEID != new_edge.target, "Target id invalid");
                     new_edge.data.distance = data.distance;
+                    new_edge.data.distance_data = data.distance_data;
                     new_edge.data.shortcut = data.shortcut;
                     if (!data.is_original_via_node_ID && !orig_node_id_from_new_node_id_map.empty())
                     {
@@ -844,15 +855,17 @@ class GraphContractor
                             // guarantees that source is not connected to another node that is
                             // contracted
                             node_weights[source] = path_distance; // make sure to prune better
+                            DistanceData path_distance_data = in_data.distance_data + out_data.distance_data;
                             inserted_edges.emplace_back(source,
                                                         target,
-                                                        path_distance,
+                                                        path_distance,                                                 
                                                         out_data.originalEdges +
                                                             in_data.originalEdges,
                                                         node,
                                                         SHORTCUT_ARC,
                                                         FORWARD_DIRECTION_ENABLED,
-                                                        REVERSE_DIRECTION_DISABLED);
+                                                        REVERSE_DIRECTION_DISABLED,
+                                                        path_distance_data);
 
                             inserted_edges.emplace_back(target,
                                                         source,
@@ -862,7 +875,8 @@ class GraphContractor
                                                         node,
                                                         SHORTCUT_ARC,
                                                         FORWARD_DIRECTION_DISABLED,
-                                                        REVERSE_DIRECTION_ENABLED);
+                                                        REVERSE_DIRECTION_ENABLED,
+                                                        path_distance_data);
                         }
                     }
                     continue;
@@ -909,6 +923,7 @@ class GraphContractor
                     }
                     else
                     {
+                        DistanceData path_distance_data = in_data.distance_data + out_data.distance_data;
                         inserted_edges.emplace_back(source,
                                                     target,
                                                     path_distance,
@@ -916,7 +931,8 @@ class GraphContractor
                                                     node,
                                                     SHORTCUT_ARC,
                                                     FORWARD_DIRECTION_ENABLED,
-                                                    REVERSE_DIRECTION_DISABLED);
+                                                    REVERSE_DIRECTION_DISABLED,
+                                                    path_distance_data);
 
                         inserted_edges.emplace_back(target,
                                                     source,
@@ -925,7 +941,8 @@ class GraphContractor
                                                     node,
                                                     SHORTCUT_ARC,
                                                     FORWARD_DIRECTION_DISABLED,
-                                                    REVERSE_DIRECTION_ENABLED);
+                                                    REVERSE_DIRECTION_ENABLED,
+                                                    path_distance_data);
                     }
                 }
             }
@@ -953,6 +970,10 @@ class GraphContractor
                         continue;
                     }
                     if (inserted_edges[other].data.shortcut != inserted_edges[i].data.shortcut)
+                    {
+                        continue;
+                    }
+                    if (inserted_edges[other].data.distance_data != inserted_edges[i].data.distance_data)
                     {
                         continue;
                     }

--- a/include/contractor/query_edge.hpp
+++ b/include/contractor/query_edge.hpp
@@ -16,7 +16,7 @@ struct QueryEdge
     NodeID target;
     struct EdgeData
     {
-        EdgeData() : id(0), shortcut(false), distance(0), forward(false), backward(false) {}
+        EdgeData() : id(0), shortcut(false), distance(0), forward(false), backward(false), distance_data(DistanceData()) {}
 
         template <class OtherT> EdgeData(const OtherT &other)
         {
@@ -25,12 +25,14 @@ struct QueryEdge
             id = other.id;
             forward = other.forward;
             backward = other.backward;
+            distance_data = other.distance_data;
         }
         NodeID id : 31;
         bool shortcut : 1;
         int distance : 30;
         bool forward : 1;
         bool backward : 1;
+        DistanceData distance_data;
     } data;
 
     QueryEdge() : source(SPECIAL_NODEID), target(SPECIAL_NODEID) {}
@@ -50,7 +52,8 @@ struct QueryEdge
         return (source == right.source && target == right.target &&
                 data.distance == right.data.distance && data.shortcut == right.data.shortcut &&
                 data.forward == right.data.forward && data.backward == right.data.backward &&
-                data.id == right.data.id);
+                data.id == right.data.id &&
+                data.distance_data == right.data.distance_data);
     }
 };
 }

--- a/include/engine/api/table_api.hpp
+++ b/include/engine/api/table_api.hpp
@@ -27,6 +27,18 @@ namespace engine
 {
 namespace api
 {
+    
+inline util::json::Value duration_encoder(const std::pair<EdgeWeight,DistanceData> & entry) 
+{
+    if (entry.first == INVALID_EDGE_WEIGHT) return util::json::Value(util::json::Null());
+    return util::json::Value(util::json::Number(entry.first / 10.));
+}
+
+inline util::json::Value distance_encoder(const std::pair<EdgeWeight,DistanceData> & entry) 
+{
+    if (entry.second == INVALID_DISTANCE_DATA) return util::json::Value(util::json::Null());
+    return util::json::Value(util::json::Number(entry.second));
+}
 
 class TableAPI final : public BaseAPI
 {
@@ -36,9 +48,11 @@ class TableAPI final : public BaseAPI
     {
     }
 
-    virtual void MakeResponse(const std::vector<EdgeWeight> &durations,
+    virtual void MakeResponse(const std::vector<std::pair<EdgeWeight,DistanceData>> &entries,
                               const std::vector<PhantomNode> &phantoms,
-                              util::json::Object &response) const
+                              util::json::Object &response,
+                              const std::vector<TableOutputComponent> & output_components
+                              ) const
     {
         auto number_of_sources = parameters.sources.size();
         auto number_of_destinations = parameters.destinations.size();
@@ -64,9 +78,20 @@ class TableAPI final : public BaseAPI
         {
             response.values["destinations"] = MakeWaypoints(phantoms, parameters.destinations);
         }
+        
+        bool durationsRequested = output_components.size() == 0 || std::find(output_components.begin(), output_components.end(), DURATION) != output_components.end();
+        bool distancesRequested = output_components.size() > 0 && std::find(output_components.begin(), output_components.end(), DISTANCE) != output_components.end();
 
-        response.values["durations"] =
-            MakeTable(durations, number_of_sources, number_of_destinations);
+        if (durationsRequested)
+        {
+            response.values["durations"] =
+                MakeTable(entries, number_of_sources, number_of_destinations, duration_encoder);
+        }
+        if (distancesRequested)
+        {
+            response.values["distances"] =
+                MakeTable(entries, number_of_sources, number_of_destinations, distance_encoder);
+        }
         response.values["code"] = "Ok";
     }
 
@@ -99,9 +124,12 @@ class TableAPI final : public BaseAPI
         return json_waypoints;
     }
 
-    virtual util::json::Array MakeTable(const std::vector<EdgeWeight> &values,
+    template<typename JSON_VALUE_ENCODER> 
+    util::json::Array MakeTable(const std::vector<std::pair<EdgeWeight,DistanceData>> &values,
                                         std::size_t number_of_rows,
-                                        std::size_t number_of_columns) const
+                                        std::size_t number_of_columns,
+                                        JSON_VALUE_ENCODER encoder
+                                      ) const
     {
         util::json::Array json_table;
         for (const auto row : util::irange<std::size_t>(0UL, number_of_rows))
@@ -113,13 +141,7 @@ class TableAPI final : public BaseAPI
             std::transform(row_begin_iterator,
                            row_end_iterator,
                            json_row.values.begin(),
-                           [](const EdgeWeight duration) {
-                               if (duration == INVALID_EDGE_WEIGHT)
-                               {
-                                   return util::json::Value(util::json::Null());
-                               }
-                               return util::json::Value(util::json::Number(duration / 10.));
-                           });
+                           encoder);
             json_table.values.push_back(std::move(json_row));
         }
         return json_table;

--- a/include/engine/api/table_parameters.hpp
+++ b/include/engine/api/table_parameters.hpp
@@ -42,6 +42,11 @@ namespace engine
 {
 namespace api
 {
+    
+enum TableOutputComponent {
+  DURATION,
+  DISTANCE
+};
 
 /**
  * Parameters specific to the OSRM Table service.
@@ -51,6 +56,7 @@ namespace api
  *             use all coordinates as sources
  *  - destinations: indices into coordinates indicating destinations for the Table service, no
  *                  destinations means use all coordinates as destinations
+ *  - output_components: entry components that should get returned (durations, distances)
  *
  * \see OSRM, Coordinate, Hint, Bearing, RouteParame, RouteParameters, TableParameters,
  *      NearestParameters, TripParameters, MatchParameters and TileParameters
@@ -59,14 +65,16 @@ struct TableParameters : public BaseParameters
 {
     std::vector<std::size_t> sources;
     std::vector<std::size_t> destinations;
+    std::vector<TableOutputComponent> output_components;
 
     TableParameters() = default;
     template <typename... Args>
     TableParameters(std::vector<std::size_t> sources_,
                     std::vector<std::size_t> destinations_,
+                    std::vector<TableOutputComponent> output_components,
                     Args... args_)
         : BaseParameters{std::forward<Args>(args_)...}, sources{std::move(sources_)},
-          destinations{std::move(destinations_)}
+          destinations{std::move(destinations_)}, output_components(output_components)
     {
     }
 

--- a/include/engine/hint.hpp
+++ b/include/engine/hint.hpp
@@ -63,8 +63,8 @@ struct Hint
     friend std::ostream &operator<<(std::ostream &, const Hint &);
 };
 
-static_assert(sizeof(Hint) == 60 + 4, "Hint is bigger than expected");
-constexpr std::size_t ENCODED_HINT_SIZE = 88;
+static_assert(sizeof(Hint) == sizeof(PhantomNode) + 4, "Hint is bigger than expected");
+constexpr std::size_t ENCODED_HINT_SIZE = 104;
 static_assert(ENCODED_HINT_SIZE / 4 * 3 >= sizeof(Hint),
               "ENCODED_HINT_SIZE does not match size of Hint");
 }

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -53,6 +53,8 @@ struct PhantomNode
                 int reverse_weight,
                 int forward_offset,
                 int reverse_offset,
+                DistanceData forward_distance_data_,
+                DistanceData reverse_distance_data_,
                 unsigned forward_packed_geometry_id_,
                 unsigned reverse_packed_geometry_id_,
                 bool is_tiny_component,
@@ -65,6 +67,7 @@ struct PhantomNode
         : forward_segment_id(forward_segment_id), reverse_segment_id(reverse_segment_id),
           name_id(name_id), forward_weight(forward_weight), reverse_weight(reverse_weight),
           forward_offset(forward_offset), reverse_offset(reverse_offset),
+          forward_distance_data{forward_distance_data_}, reverse_distance_data{reverse_distance_data_},
           forward_packed_geometry_id(forward_packed_geometry_id_),
           reverse_packed_geometry_id(reverse_packed_geometry_id_),
           component{component_id, is_tiny_component}, location(std::move(location)),
@@ -78,6 +81,7 @@ struct PhantomNode
           reverse_segment_id{SPECIAL_SEGMENTID, false},
           name_id(std::numeric_limits<unsigned>::max()), forward_weight(INVALID_EDGE_WEIGHT),
           reverse_weight(INVALID_EDGE_WEIGHT), forward_offset(0), reverse_offset(0),
+          forward_distance_data(INVALID_DISTANCE_DATA), reverse_distance_data(INVALID_DISTANCE_DATA), 
           forward_packed_geometry_id(SPECIAL_EDGEID), reverse_packed_geometry_id(SPECIAL_EDGEID),
           component{INVALID_COMPONENTID, false}, fwd_segment_position(0),
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
@@ -121,14 +125,17 @@ struct PhantomNode
     explicit PhantomNode(const OtherT &other,
                          int forward_weight_,
                          int forward_offset_,
+                         DistanceData forward_distance_data_,
                          int reverse_weight_,
                          int reverse_offset_,
+                         DistanceData reverse_distance_data_,
                          const util::Coordinate location_,
                          const util::Coordinate input_location_)
         : forward_segment_id{other.forward_segment_id},
           reverse_segment_id{other.reverse_segment_id}, name_id{other.name_id},
           forward_weight{forward_weight_}, reverse_weight{reverse_weight_},
           forward_offset{forward_offset_}, reverse_offset{reverse_offset_},
+          forward_distance_data{forward_distance_data_}, reverse_distance_data{reverse_distance_data_},
           forward_packed_geometry_id{other.forward_packed_geometry_id},
           reverse_packed_geometry_id{other.reverse_packed_geometry_id},
           component{other.component.id, other.component.is_tiny}, location{location_},
@@ -145,6 +152,8 @@ struct PhantomNode
     int reverse_weight;
     int forward_offset;
     int reverse_offset;
+    DistanceData forward_distance_data;   
+    DistanceData reverse_distance_data;
     unsigned forward_packed_geometry_id;
     unsigned reverse_packed_geometry_id;
     struct ComponentType
@@ -163,7 +172,7 @@ struct PhantomNode
     extractor::TravelMode backward_travel_mode;
 };
 
-static_assert(sizeof(PhantomNode) == 60, "PhantomNode has more padding then expected");
+static_assert(sizeof(PhantomNode) == 68, "PhantomNode has more padding then expected");
 
 using PhantomNodePair = std::pair<PhantomNode, PhantomNode>;
 

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -204,6 +204,24 @@ template <class DataFacadeT, class Derived> class BasicRoutingInterface
         }
         return loop_weight;
     }
+    
+    inline std::pair<EdgeWeight,DistanceData> GetLoopWeightAndDistance(NodeID node) const
+    {
+        std::pair<EdgeWeight,DistanceData> result = std::make_pair(INVALID_EDGE_WEIGHT, INVALID_DISTANCE_DATA);
+        for (auto edge : facade->GetAdjacentEdgeRange(node))
+        {
+            const auto &data = facade->GetEdgeData(edge);
+            if (data.forward)
+            {
+                const NodeID to = facade->GetTarget(edge);
+                if (to == node && data.distance < result.first)
+                {
+                    result = std::make_pair(data.distance, data.distance_data);
+                }
+            }
+        }
+        return result;
+    }
 
     template <typename RandomIter>
     void UnpackPath(RandomIter packed_path_begin,

--- a/include/extractor/edge_based_edge.hpp
+++ b/include/extractor/edge_based_edge.hpp
@@ -21,7 +21,8 @@ struct EdgeBasedEdge
                   const NodeID edge_id,
                   const EdgeWeight weight,
                   const bool forward,
-                  const bool backward);
+                  const bool backward,
+                  const DistanceData & distance_data);
 
     bool operator<(const EdgeBasedEdge &other) const;
 
@@ -31,19 +32,20 @@ struct EdgeBasedEdge
     EdgeWeight weight : 30;
     bool forward : 1;
     bool backward : 1;
+    DistanceData distance_data;
 };
 
 // Impl.
 
 inline EdgeBasedEdge::EdgeBasedEdge()
-    : source(0), target(0), edge_id(0), weight(0), forward(false), backward(false)
+    : source(0), target(0), edge_id(0), weight(0), forward(false), backward(false), distance_data(DistanceData())
 {
 }
 
 template <class EdgeT>
 inline EdgeBasedEdge::EdgeBasedEdge(const EdgeT &other)
     : source(other.source), target(other.target), edge_id(other.data.via),
-      weight(other.data.distance), forward(other.data.forward), backward(other.data.backward)
+      weight(other.data.distance), forward(other.data.forward), backward(other.data.backward), distance_data(other.data.distance_data)
 {
 }
 
@@ -52,9 +54,10 @@ inline EdgeBasedEdge::EdgeBasedEdge(const NodeID source,
                                     const NodeID edge_id,
                                     const EdgeWeight weight,
                                     const bool forward,
-                                    const bool backward)
+                                    const bool backward,
+                                    const DistanceData & distance_data)
     : source(source), target(target), edge_id(edge_id), weight(weight), forward(forward),
-      backward(backward)
+      backward(backward), distance_data(distance_data)
 {
 }
 

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -51,7 +51,8 @@ struct InternalExtractorEdge
                  TRAVEL_MODE_INACCESSIBLE,
                  false,
                  guidance::TurnLaneType::empty,
-                 guidance::RoadClassification())
+                 guidance::RoadClassification(),
+                 DistanceData())
     {
     }
 
@@ -80,7 +81,8 @@ struct InternalExtractorEdge
                  travel_mode,
                  is_split,
                  lane_description,
-                 std::move(road_classification)),
+                 std::move(road_classification),
+                 DistanceData()),
           weight_data(std::move(weight_data))
     {
     }

--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -27,7 +27,8 @@ struct NodeBasedEdge
                   TravelMode travel_mode,
                   bool is_split,
                   const LaneDescriptionID lane_description_id,
-                  guidance::RoadClassification road_classification);
+                  guidance::RoadClassification road_classification,
+                  const DistanceData & distance_data);
 
     bool operator<(const NodeBasedEdge &other) const;
 
@@ -44,6 +45,7 @@ struct NodeBasedEdge
     TravelMode travel_mode : 4;
     LaneDescriptionID lane_description_id;
     guidance::RoadClassification road_classification;
+    DistanceData distance_data;
 };
 
 struct NodeBasedEdgeWithOSM : NodeBasedEdge
@@ -60,7 +62,8 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
                          TravelMode travel_mode,
                          bool is_split,
                          const LaneDescriptionID lane_description_id,
-                         guidance::RoadClassification road_classification);
+                         guidance::RoadClassification road_classification,
+                         const DistanceData & distance_data);
 
     OSMNodeID osm_source_id;
     OSMNodeID osm_target_id;
@@ -71,7 +74,7 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
 inline NodeBasedEdge::NodeBasedEdge()
     : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight(0), forward(false),
       backward(false), roundabout(false), access_restricted(false), startpoint(true),
-      is_split(false), travel_mode(false), lane_description_id(INVALID_LANE_DESCRIPTIONID)
+      is_split(false), travel_mode(false), lane_description_id(INVALID_LANE_DESCRIPTIONID), distance_data(DistanceData())
 {
 }
 
@@ -87,11 +90,12 @@ inline NodeBasedEdge::NodeBasedEdge(NodeID source,
                                     TravelMode travel_mode,
                                     bool is_split,
                                     const LaneDescriptionID lane_description_id,
-                                    guidance::RoadClassification road_classification)
+                                    guidance::RoadClassification road_classification,
+                                    const DistanceData & distance_data)
     : source(source), target(target), name_id(name_id), weight(weight), forward(forward),
       backward(backward), roundabout(roundabout), access_restricted(access_restricted),
       startpoint(startpoint), is_split(is_split), travel_mode(travel_mode),
-      lane_description_id(lane_description_id), road_classification(std::move(road_classification))
+      lane_description_id(lane_description_id), road_classification(std::move(road_classification)), distance_data(distance_data)
 {
 }
 
@@ -124,7 +128,8 @@ inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM(OSMNodeID source,
                                                   TravelMode travel_mode,
                                                   bool is_split,
                                                   const LaneDescriptionID lane_description_id,
-                                                  guidance::RoadClassification road_classification)
+                                                  guidance::RoadClassification road_classification,
+                                                  const DistanceData & distance_data)
     : NodeBasedEdge(SPECIAL_NODEID,
                     SPECIAL_NODEID,
                     name_id,
@@ -137,7 +142,8 @@ inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM(OSMNodeID source,
                     travel_mode,
                     is_split,
                     lane_description_id,
-                    std::move(road_classification)),
+                    std::move(road_classification),
+                    distance_data),
       osm_source_id(std::move(source)), osm_target_id(std::move(target))
 {
 }

--- a/include/server/api/table_parameter_grammar.hpp
+++ b/include/server/api/table_parameter_grammar.hpp
@@ -48,7 +48,13 @@ struct TableParametersGrammar final : public BaseParametersGrammar<Iterator, Sig
             (qi::lit("all") |
              (size_t_ % ';')[ph::bind(&engine::api::TableParameters::sources, qi::_r1) = qi::_1]);
 
-        table_rule = destinations_rule(qi::_r1) | sources_rule(qi::_r1);
+        output_component = (qi::lit("durations")[qi::_val = engine::api::DURATION] | qi::lit("distances")[qi::_val = engine::api::DISTANCE]);    
+
+        output_components_rule =
+            qi::lit("output_components=") >
+            (output_component % ';')[ph::bind(&engine::api::TableParameters::output_components, qi::_r1) = qi::_1];
+
+        table_rule = destinations_rule(qi::_r1) | sources_rule(qi::_r1) | output_components_rule(qi::_r1);
 
         root_rule = BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
                     -('?' > (table_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1)) % '&');
@@ -59,7 +65,9 @@ struct TableParametersGrammar final : public BaseParametersGrammar<Iterator, Sig
     qi::rule<Iterator, Signature> table_rule;
     qi::rule<Iterator, Signature> sources_rule;
     qi::rule<Iterator, Signature> destinations_rule;
+    qi::rule<Iterator, Signature> output_components_rule;
     qi::rule<Iterator, std::size_t()> size_t_;
+    qi::rule<Iterator, engine::api::TableOutputComponent()> output_component;
 };
 }
 }

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -21,7 +21,7 @@ struct NodeBasedEdgeData
         : distance(INVALID_EDGE_WEIGHT), edge_id(SPECIAL_NODEID),
           name_id(std::numeric_limits<unsigned>::max()), access_restricted(false), reversed(false),
           roundabout(false), travel_mode(TRAVEL_MODE_INACCESSIBLE),
-          lane_description_id(INVALID_LANE_DESCRIPTIONID)
+          lane_description_id(INVALID_LANE_DESCRIPTIONID), distance_data(DistanceData())
     {
     }
 
@@ -33,10 +33,12 @@ struct NodeBasedEdgeData
                       bool roundabout,
                       bool startpoint,
                       extractor::TravelMode travel_mode,
-                      const LaneDescriptionID lane_description_id)
+                      const LaneDescriptionID lane_description_id,
+                      const DistanceData & distance_data)
         : distance(distance), edge_id(edge_id), name_id(name_id),
           access_restricted(access_restricted), reversed(reversed), roundabout(roundabout),
-          startpoint(startpoint), travel_mode(travel_mode), lane_description_id(lane_description_id)
+          startpoint(startpoint), travel_mode(travel_mode), 
+          lane_description_id(lane_description_id), distance_data(distance_data)
     {
     }
 
@@ -50,6 +52,7 @@ struct NodeBasedEdgeData
     extractor::TravelMode travel_mode : 4;
     LaneDescriptionID lane_description_id;
     extractor::guidance::RoadClassification road_classification;
+    DistanceData distance_data;
 
     bool IsCompatibleTo(const NodeBasedEdgeData &other) const
     {
@@ -84,6 +87,7 @@ NodeBasedDynamicGraphFromEdges(NodeID number_of_nodes,
             output_edge.data.startpoint = input_edge.startpoint;
             output_edge.data.road_classification = input_edge.road_classification;
             output_edge.data.lane_description_id = input_edge.lane_description_id;
+            output_edge.data.distance_data = input_edge.distance_data;
         });
 
     tbb::parallel_sort(edges_list.begin(), edges_list.end());

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -67,6 +67,9 @@ using LaneDescriptionID = std::uint16_t;
 static const LaneDescriptionID INVALID_LANE_DESCRIPTIONID =
     std::numeric_limits<LaneDescriptionID>::max();
 
+using DistanceData = float;
+static const DistanceData INVALID_DISTANCE_DATA = -1;
+
 using BearingClassID = std::uint32_t;
 static const BearingClassID INVALID_BEARING_CLASSID = std::numeric_limits<BearingClassID>::max();
 

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -86,9 +86,9 @@ int Contractor::Run()
 #ifdef WIN32
 #pragma message("Memory consumption on Windows can be higher due to different bit packing")
 #else
-    static_assert(sizeof(extractor::NodeBasedEdge) == 24,
+    static_assert(sizeof(extractor::NodeBasedEdge) == 28,
                   "changing extractor::NodeBasedEdge type has influence on memory consumption!");
-    static_assert(sizeof(extractor::EdgeBasedEdge) == 16,
+    static_assert(sizeof(extractor::EdgeBasedEdge) == 20,
                   "changing EdgeBasedEdge type has influence on memory consumption!");
 #endif
 

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -67,7 +67,7 @@ Status TablePlugin::HandleRequest(const api::TableParameters &params, util::json
     }
 
     api::TableAPI table_api{facade, params};
-    table_api.MakeResponse(result_table, snapped_phantoms, result);
+    table_api.MakeResponse(result_table, snapped_phantoms, result, params.output_components);
 
     return Status::Ok;
 }

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -173,7 +173,7 @@ Status TripPlugin::HandleRequest(const api::TripParameters &parameters,
 
     // compute the duration table of all phantom nodes
     const auto result_table = util::DistTableWrapper<EdgeWeight>(
-        duration_table(snapped_phantoms, {}, {}), number_of_locations);
+        duration_table.durations(snapped_phantoms, {}, {}), number_of_locations);
 
     if (result_table.size() == 0)
     {

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -418,6 +418,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
                 // the following is the core of the loop.
                 unsigned distance = edge_data1.distance;
+                DistanceData distance_data = edge_data1.distance_data;
                 if (m_traffic_lights.find(node_v) != m_traffic_lights.end())
                 {
                     distance += profile_properties.traffic_signal_penalty;
@@ -460,7 +461,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                                                     m_edge_based_edge_list.size(),
                                                     distance,
                                                     true,
-                                                    false);
+                                                    false,
+                                                    distance_data);
 
                 // Here is where we write out the mapping between the edge-expanded edges, and
                 // the node-based edges that are originally used to calculate the `distance`

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -432,6 +432,7 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
 
         auto &edge = edge_iterator->result;
         edge.weight = std::max(1, static_cast<int>(std::floor(weight + .5)));
+        edge.distance_data = DistanceData(distance);
 
         // assign new node id
         auto id_iter = external_to_internal_node_id_map.find(node_iterator->node_id);

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -132,6 +132,9 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
             // add weight of e2's to e1
             graph.GetEdgeData(forward_e1).distance += fwd_edge_data2.distance;
             graph.GetEdgeData(reverse_e1).distance += rev_edge_data2.distance;
+	    // add distance of e2's to e1
+	    graph.GetEdgeData(forward_e1).distance_data += fwd_edge_data2.distance_data;
+            graph.GetEdgeData(reverse_e1).distance_data += rev_edge_data2.distance_data;
 
             // extend e1's to targets of e2's
             graph.SetTarget(forward_e1, node_w);


### PR DESCRIPTION
The "table" service now optionally provides distances next to driving durations.

**Api-Changes:**
QUERY: The table service accepts a new (optional) parameter
"output_components" to specify which data-components to output. The parameters value is a ';'-separated list of keywords. Currently the keywords "durations" and "distances" are supported with obvious meanings. In case the "output-components" parameter is not specified, the default value is "durations". This way the API is backward compatible.
RESPONSE: The "durations" output is provided only when requested as output component, the format is unchanged. If the output-component "distances" is requested, the response contains a "distances" field of the same format as "distances".

**Code-Changes:**
- Distances are passed through the entire extraction/contration process and are part of the input files for osrm-routed.
- The many-to-many router calculates distances alongside durations
- During PhantomNode creation, the required partial distances on the "first-leg"/"last-leg" are computed on the uncompressed geometry (analogous to the PhantomNode's forward_weight/-offset)

**Status:**
The current version is fully functional and already in use in a customized version. It is marked as "not-ready", because updates to the API-documentation are still missing. I am waiting for your approval on the changes before
updating the documentation.

**Use-Case:**
The algorithms of our supply-chain optimization software PSIglobal 
(http://www.psilogistics.com/en/solutions/supply-chain-management/) require pairwise distances for a huge number of points (for freight cost calculations the optimizations are based on). The excellent performance of OSRM would make it a perfect provider for the distance matrices. However, obtaining distances instead of durations is crucial for us. This is why we customized OSRM accordingly, and would be very happy if this customization would find its way into the main branch.

**Memory-Concerns:**
We are running this customization (more precisely, this customization rebased on tag v.5.2.7) on *planet* dataset. Memory consumption of osrm-routed is about 68,5 GB.
(Option --max-table-size 10000 was used)
Memory consumption on *europe* dataset is about 24 GB