### PR TITLE
Allow Services to support several API versions simultaneously

### DIFF
--- a/include/server/service/base_service.hpp
+++ b/include/server/service/base_service.hpp
@@ -28,7 +28,7 @@ class BaseService
     virtual engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) = 0;
 
-    virtual unsigned GetVersion() = 0;
+    virtual bool SupportsVersion(unsigned version) = 0;
 
   protected:
     OSRM &routing_machine;

--- a/include/server/service/match_service.hpp
+++ b/include/server/service/match_service.hpp
@@ -25,7 +25,7 @@ class MatchService final : public BaseService
     engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) final override;
 
-    unsigned GetVersion() final override { return 1; }
+    bool SupportsVersion(unsigned version) final override { return version == 1; }
 };
 }
 }

--- a/include/server/service/nearest_service.hpp
+++ b/include/server/service/nearest_service.hpp
@@ -25,7 +25,7 @@ class NearestService final : public BaseService
     engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) final override;
 
-    unsigned GetVersion() final override { return 1; }
+    bool SupportsVersion(unsigned version) final override { return version == 1; }
 };
 }
 }

--- a/include/server/service/route_service.hpp
+++ b/include/server/service/route_service.hpp
@@ -25,7 +25,7 @@ class RouteService final : public BaseService
     engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) final override;
 
-    unsigned GetVersion() final override { return 1; }
+    bool SupportsVersion(unsigned version) final override { return version == 1; }
 };
 }
 }

--- a/include/server/service/table_service.hpp
+++ b/include/server/service/table_service.hpp
@@ -25,7 +25,7 @@ class TableService final : public BaseService
     engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) final override;
 
-    unsigned GetVersion() final override { return 1; }
+    bool SupportsVersion(unsigned version) final override { return version == 1; }
 };
 }
 }

--- a/include/server/service/tile_service.hpp
+++ b/include/server/service/tile_service.hpp
@@ -25,7 +25,7 @@ class TileService final : public BaseService
     engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) final override;
 
-    unsigned GetVersion() final override { return 1; }
+    bool SupportsVersion(unsigned version) final override { return version == 1; }
 };
 }
 }

--- a/include/server/service/trip_service.hpp
+++ b/include/server/service/trip_service.hpp
@@ -25,7 +25,7 @@ class TripService final : public BaseService
     engine::Status
     RunQuery(std::size_t prefix_length, std::string &query, ResultT &result) final override;
 
-    unsigned GetVersion() final override { return 1; }
+    bool SupportsVersion(unsigned version) final override { return version == 1; }
 };
 }
 }

--- a/src/server/service_handler.cpp
+++ b/src/server/service_handler.cpp
@@ -39,7 +39,7 @@ engine::Status ServiceHandler::RunQuery(api::ParsedURL parsed_url,
     }
     auto &service = service_iter->second;
 
-    if (service->GetVersion() != parsed_url.version)
+    if (!service->SupportsVersion(parsed_url.version))
     {
         result = util::json::Object();
         auto &json_result = result.get<util::json::Object>();


### PR DESCRIPTION
I changed the way API-Version compatiblity is checked when parsing requests.

**Old:**
The service reports the version it supports, the service_handler checks if this number matches the version number from the query.

**New:**
The service handler passes the required version number to service. The service then decides if this version is supported or not.

This has the advantage of being able to support multiple versions. 

E.g.  for the API-Changes made in https://github.com/Project-OSRM/osrm-backend/pull/2764, one could increase the API Version to 2, but have all services support both API-Versions 1 and 2, this way being fully backward compatible.