### PR TITLE
mark via-case todo

### DIFF
--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -173,7 +173,7 @@ Feature: Via points
             | c,d,a     | abc,bd,bd,bd,abc,abc |
 
     # See issue #2349
-    @bug
+    @bug @todo
     Scenario: Via point at a dead end with oneway
         Given the node map
             | a | b | c |


### PR DESCRIPTION
We have a cucumber case that indicates a known bug (for a rare special case). To be consistent with other such cases, this PR marks the respective case as todo to not have the failure show up on a normal cucumber run with the default profile.