### PR TITLE
Fix/1318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Profiles
       - includes library guidance.lua that offers preliminary configuration on guidance.
       - added left_hand_driving flag in global profile properties
+      - refactor of turn penalties: turn penalties are now specified in seconds, just as all other penalties. Previously tenths of a second.
     - Guidance
       - Handle Access tags for lanes, only considering valid lanes in lane-guidance (think car | car | bike | car)
     - API:

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -99,7 +99,7 @@ properties.continue_straight_at_waypoint = false
 
 local obey_oneway               = true
 local ignore_areas              = true
-local turn_penalty              = 60
+local turn_penalty              = 6
 local turn_bias                 = 1.4
 -- reduce the driving speed by 30% for unsafe roads
 -- local safety_penalty            = 0.7

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -142,7 +142,7 @@ properties.left_hand_driving               = false
 
 local side_road_speed_multiplier = 0.8
 
-local turn_penalty               = 10
+local turn_penalty               = 1
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
 local turn_bias                  = properties.left_hand_driving and 1/1.2 or 1.2

--- a/profiles/lhs.lua
+++ b/profiles/lhs.lua
@@ -5,7 +5,7 @@ require 'testbot'
 
 properties.left_hand_driving = true
 
-local turn_penalty           = 500
+local turn_penalty           = 50
 local turn_bias              = properties.left_hand_driving and 1/1.2 or 1.2
 
 function turn_function (angle)

--- a/profiles/rhs.lua
+++ b/profiles/rhs.lua
@@ -5,7 +5,7 @@ require 'testbot'
 
 properties.left_hand_driving = false
 
-local turn_penalty           = 500
+local turn_penalty           = 50
 local turn_bias              = properties.left_hand_driving and 1/1.2 or 1.2
 
 function turn_function (angle)

--- a/profiles/turnbot.lua
+++ b/profiles/turnbot.lua
@@ -4,5 +4,5 @@
 require 'testbot'
 
 function turn_function (angle)
-    return 200*math.abs(angle)/180 -- penalty 
+    return 20*math.abs(angle)/180 -- penalty 
 end

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -363,7 +363,9 @@ int32_t LuaScriptingEnvironment::GetTurnPenalty(const double angle)
                 luabind::call_function<double>(context.state, "turn_function", angle);
             BOOST_ASSERT(penalty < std::numeric_limits<int32_t>::max());
             BOOST_ASSERT(penalty > std::numeric_limits<int32_t>::min());
-            return boost::numeric_cast<int32_t>(penalty);
+            // OSRM operates in 10ths of a second. Penalties are specified in seconds in the
+            // profile. Here we adjust this accordingly.
+            return boost::numeric_cast<int32_t>(10 * penalty);
         }
         catch (const luabind::error &er)
         {


### PR DESCRIPTION
Penalties in the profile are currently specified in seconds, except for the turn penalty.

This PR unifies this to specify seconds in general for all time-based penalty values.

/cc @karenzshea if this gets merged, we need to adjust our internal profiles