### PR TITLE
Enable toll roads by default again.

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -156,9 +156,15 @@ Feature: Car - Restricted access
             | primary | yes        | x     |
             | primary | no         | x     |
 
+     Scenario: Car - these toll roads always work
+        Then routability should be
+            | highway | toll        | bothw |
+            | primary | no          | x     |
+            | primary | snowmobile  | x     |
+
+     # To test this we need issue #2781
+     @todo
      Scenario: Car - only toll=yes ways are ignored by default
         Then routability should be
             | highway | toll        | bothw |
             | primary | yes         |       |
-            | primary | no          | x     |
-            | primary | snowmobile  | x     |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -150,7 +150,7 @@ local turn_bias                  = properties.left_hand_driving and 1/1.2 or 1.2
 local obey_oneway                = true
 local ignore_areas               = true
 local ignore_hov_ways            = true
-local ignore_toll_ways           = true
+local ignore_toll_ways           = false
 
 local abs = math.abs
 local min = math.min


### PR DESCRIPTION
Currently we don't route over the Golden Gate bridge by default.
This sets the value to false by default. To test the behavior for
tolls when ignored, we would need issue #2781 implemented.