### PR TITLE
[ready] add a PR template to the repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# Issue
+
+What issue is this PR targeting? Is there no issue that covers the problem addressed here? Please open a corresponding issue and link it from here.
+
+## Tasklist
+ - [ ] ADD OWN TASKS HERE
+ - [ ] add regression / cucumber cases (see docs/testing.md)
+ - [ ] review
+ - [ ] adjust for for comments
+
+## Requirements / Relations
+ Link any requirements here. Other pull requests this PR is based on?


### PR DESCRIPTION
Following https://github.com/blog/2111-issue-and-pull-request-templates, this PR adds a small PR template to the osrm repository, structuring the default PR layout.

## Tasks 
 - [x] feedback on whats in there
 - [x] adjust for feedback

## Requirements
 none