### PR TITLE
Add local maxspeed for Netherland

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -130,6 +130,8 @@ maxspeed_table = {
   ["uk:nsl_single"] = (60*1609)/1000,
   ["uk:nsl_dual"] = (70*1609)/1000,
   ["uk:motorway"] = (70*1609)/1000,
+  ["nl:rural"] = 80,
+  ["nl:trunk"] = 100,
   ["none"] = 140
 }
 

--- a/taginfo.json
+++ b/taginfo.json
@@ -116,6 +116,8 @@
         {"key": "maxspeed", "value": "uk:nsl_single"},
         {"key": "maxspeed", "value": "uk:nsl_dual"},
         {"key": "maxspeed", "value": "uk:motorway"},
+        {"key": "maxspeed", "value": "nl:rural"},
+        {"key": "maxspeed", "value": "nl:trunk"},
         {"key": "smoothness", "value": "intermediate"},
         {"key": "smoothness", "value": "bad"},
         {"key": "smoothness", "value": "very_bad"},


### PR DESCRIPTION
Report change from MAPS.ME mapsme/omim@d6cd9b77a8a99afae2ca65e40c11d3e4e51e1691

@Zverik on MAPS.ME side you don't need the line ["nl:motorway"] = 130, as 130 is the default for motorway.
