### PR TITLE
Pass additional variables to turn_function

### DIFF
--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -53,7 +53,7 @@ class ScriptingEnvironment
     virtual std::vector<std::string> GetNameSuffixList() = 0;
     virtual std::vector<std::string> GetExceptions() = 0;
     virtual void SetupSources() = 0;
-    virtual int32_t GetTurnPenalty(double angle) = 0;
+    virtual int32_t GetTurnPenalty(const double angle, const double approach_road_speed, const double exit_road_speed) = 0;
     virtual void ProcessSegment(const osrm::util::Coordinate &source,
                                 const osrm::util::Coordinate &target,
                                 double distance,

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -55,7 +55,7 @@ class LuaScriptingEnvironment final : public ScriptingEnvironment
     std::vector<std::string> GetNameSuffixList() override;
     std::vector<std::string> GetExceptions() override;
     void SetupSources() override;
-    int32_t GetTurnPenalty(double angle) override;
+    int32_t GetTurnPenalty(const double angle, const double approach_road_speed, const double exit_road_speed) override;
     void ProcessSegment(const osrm::util::Coordinate &source,
                         const osrm::util::Coordinate &target,
                         double distance,

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -400,7 +400,7 @@ function way_function (way, result)
   limit( result, maxspeed, maxspeed_forward, maxspeed_backward )
 end
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
   -- compute turn penalty as angle^2, with a left/right bias
   -- multiplying by 10 converts to deci-seconds see issue #1318
   k = 10*turn_penalty/(90.0*90.0)

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -543,7 +543,7 @@ function way_function (way, result)
   result.is_startpoint = result.forward_mode == mode.driving or result.backward_mode == mode.driving
 end
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
   ---- compute turn penalty as angle^2, with a left/right bias
   -- multiplying by 10 converts to deci-seconds see issue #1318
   k = 10*turn_penalty/(90.0*90.0)

--- a/profiles/lhs.lua
+++ b/profiles/lhs.lua
@@ -8,7 +8,7 @@ properties.left_hand_driving = true
 local turn_penalty           = 50
 local turn_bias              = properties.left_hand_driving and 1/1.2 or 1.2
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
   ---- compute turn penalty as angle^2, with a left/right bias
   -- multiplying by 10 converts to deci-seconds see issue #1318
   k = 10*turn_penalty/(90.0*90.0)

--- a/profiles/rhs.lua
+++ b/profiles/rhs.lua
@@ -8,7 +8,7 @@ properties.left_hand_driving = false
 local turn_penalty           = 50
 local turn_bias              = properties.left_hand_driving and 1/1.2 or 1.2
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
   ---- compute turn penalty as angle^2, with a left/right bias
   -- multiplying by 10 converts to deci-seconds see issue #1318
   k = 10*turn_penalty/(90.0*90.0)

--- a/profiles/turnbot.lua
+++ b/profiles/turnbot.lua
@@ -3,7 +3,7 @@
 
 require 'testbot'
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
     -- multiplying by 10 converts to deci-seconds see issue #1318
     return 10*20*math.abs(angle)/180
 end

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -350,7 +350,7 @@ void LuaScriptingEnvironment::SetupSources()
     }
 }
 
-int32_t LuaScriptingEnvironment::GetTurnPenalty(const double angle)
+int32_t LuaScriptingEnvironment::GetTurnPenalty(const double angle, const double approach_road_speed, const double exit_road_speed)
 {
     auto &context = GetLuaContext();
     if (context.has_turn_penalty_function)
@@ -360,7 +360,7 @@ int32_t LuaScriptingEnvironment::GetTurnPenalty(const double angle)
         {
             // call lua profile to compute turn penalty
             const double penalty =
-                luabind::call_function<double>(context.state, "turn_function", angle);
+                luabind::call_function<double>(context.state, "turn_function", angle, approach_road_speed, exit_road_speed);
             BOOST_ASSERT(penalty < std::numeric_limits<int32_t>::max());
             BOOST_ASSERT(penalty > std::numeric_limits<int32_t>::min());
             return boost::numeric_cast<int32_t>(penalty);


### PR DESCRIPTION
This PR is to address https://github.com/Project-OSRM/osrm-backend/issues/1735, and hopefully make turn penalties better by considering the approach/exit speeds for each turn.  As pointed out on #1735, doing a u-turn on a 70mph (112km/h) road should be super expensive.  On the car profile, currently we only penalize this turn by 3.3 seconds, and most 60km/h 90 degree turns are penalized by ~0.8 to ~1.2 (left vs right, depending on the bias).

This turn penalty calculation only occurs during `osrm-extract`, this PR will not include a mechanism to adjust the turn penalty if traffic data updates are used in `osrm-contract`.

My plan is to update the `turn_function` for the `car.lua` profile only.  Other profiles are probably a bit less affected by this, although @emiltin, any thoughts you have on how this might apply to the bike turn penalty would be appreciated.

## Tasklist
 - [ ] Test coverage
 - [ ] Do some test driving to get some better values for the car profile
 - [ ] Do some test riding?
 - [ ] review
 - [ ] adjust for for comments

## References
http://nacto.org/docs/usdg/effect_of_radius_of_curvature_for_right_turning_vehicles_wolfe.pdf
http://onlinepubs.trb.org/onlinepubs/conferences/2011/RSS/3/Wolfermann,A.pdf
http://www.istiee.org/te/papers/N55/ET_2013_55_1_Mehar.pdf

# Other useful factors
https://github.com/Project-OSRM/osrm-backend/issues/592