### PR TITLE
Turn restriction extraction, explicitly return false for no_* restrictions

### DIFF
--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -430,3 +430,27 @@ Feature: Car - Turn restrictions
             | a    | b  | ax,xy,yb,yb |
             | b    | a  | yb,xy,ax,ax |
 
+    @specific
+    Scenario: Car - Ignore unrecognized restriction
+        Given the node map
+            |   | n |   |
+            | w | j | e |
+            |   | s |   |
+
+        And the ways
+            | nodes | oneway |
+            | sj    | yes    |
+            | nj    | -1     |
+            | wj    | -1     |
+            | ej    | -1     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction  |
+            | restriction | sj       | wj     | j        | yield        |
+
+        When I route I should get
+            | from | to | route    |
+            | s    | w  | sj,wj,wj |
+            | s    | n  | sj,nj,nj |
+            | s    | e  | sj,ej,ej |
+

--- a/src/extractor/restriction_parser.cpp
+++ b/src/extractor/restriction_parser.cpp
@@ -96,10 +96,13 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
         if (value.find("only_") == 0)
         {
             is_only_restriction = true;
-        } else if (value.find("no_") == 0)
+        }
+        else if (value.find("no_") == 0)
         {
             is_only_restriction = false;
-        } else // unrecognized value type
+        }
+        else // unrecognized value type
+        {
             return {};
         }
 

--- a/src/extractor/restriction_parser.cpp
+++ b/src/extractor/restriction_parser.cpp
@@ -48,8 +48,8 @@ RestrictionParser::RestrictionParser(ScriptingEnvironment &scripting_environment
 }
 
 /**
- * Tries to parse an relation as turn restriction. This can fail for a number of
- * reasons, this the return type is a boost::optional<T>.
+ * Tries to parse a relation as a turn restriction. This can fail for a number of
+ * reasons. The return type is a boost::optional<T>.
  *
  * Some restrictions can also be ignored: See the ```get_exceptions``` function
  * in the corresponding profile.
@@ -71,7 +71,7 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
     osmium::tags::KeyPrefixFilter::iterator fi_begin(filter, tag_list.begin(), tag_list.end());
     osmium::tags::KeyPrefixFilter::iterator fi_end(filter, tag_list.end(), tag_list.end());
 
-    // if it's a restriction, continue;
+    // if it's not a restriction, continue;
     if (std::distance(fi_begin, fi_end) == 0)
     {
         return {};
@@ -91,9 +91,16 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
         const std::string key(fi_begin->key());
         const std::string value(fi_begin->value());
 
+        // documented OSM restriction tags start either with only_* or no_*;
+        // check and return on these values, and ignore unrecognized values
         if (value.find("only_") == 0)
         {
             is_only_restriction = true;
+        } else if (value.find("no_") == 0)
+        {
+            is_only_restriction = false;
+        } else // unrecognized value type
+            return {};
         }
 
         // if the "restriction*" key is longer than 11 chars, it is a conditional exception (i.e.


### PR DESCRIPTION
# Issue

Closes https://github.com/Project-OSRM/osrm-backend/issues/2802. This doesn't address the caveat that @codain brought up here, https://github.com/Project-OSRM/osrm-backend/issues/2802#issuecomment-241796627, but I think this would require rewriting the parser to be able to know what had been previously returned to the `InputRestrictionContainer` on the same relation. 

Also adds a test for a restriction `yield`, which is the undocumented restriction this was originally found on.

## Tasklist
 - [x] review
 - [ ] adjust for for comments

## Requirements / Relations
n/a

cc @danpat @MoKob 