### PR TITLE
Allow passing options to lua profiles

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -181,9 +181,7 @@ Feature: Car - Restricted access
             | primary | no          | x     |
             | primary | snowmobile  | x     |
 
-     # To test this we need issue #2781
-     @todo
      Scenario: Car - only toll=yes ways are ignored by default
         Then routability should be
             | highway | toll        | bothw |
-            | primary | yes         |       |
+            | primary | yes         | x     |

--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -181,7 +181,15 @@ Feature: Car - Restricted access
             | primary | no          | x     |
             | primary | snowmobile  | x     |
 
-     Scenario: Car - only toll=yes ways are ignored by default
+     Scenario: Car - ignore_toll_ways is false by default
         Then routability should be
             | highway | toll        | bothw |
             | primary | yes         | x     |
+            | primary | no          | x     |
+
+     Scenario: Car - ignore_toll_ways=true enables toll way ignoring
+        Given the environment variable "ignore_toll_ways" "true"
+        Then routability should be
+            | highway | toll        | bothw |
+            | primary | yes         |       |
+            | primary | no          | x     |

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -278,4 +278,9 @@ module.exports = function () {
         this.httpMethod = method;
         callback();
     });
+
+    this.Given(/^the environment variable "([^"]*)" "([^"]*)"$/, function (name, value, callback) {
+      this.setEnvVar(name, value);
+      callback();
+    });
 };

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -3,6 +3,7 @@ local find_access_tag = require("lib/access").find_access_tag
 local get_destination = require("lib/destination").get_destination
 local set_classification = require("lib/guidance").set_classification
 local get_turn_lanes = require("lib/guidance").get_turn_lanes
+local set_option = require("lib/set_option")
 
 -- Begin of globals
 barrier_whitelist = { ["cattle_grid"] = true, ["border_control"] = true, ["checkpoint"] = true, ["toll_booth"] = true, ["sally_port"] = true, ["gate"] = true, ["lift_gate"] = true, ["no"] = true, ["entrance"] = true }
@@ -158,7 +159,7 @@ local turn_bias                  = properties.left_hand_driving and 1/1.075 or 1
 local obey_oneway                = true
 local ignore_areas               = true
 local ignore_hov_ways            = true
-local ignore_toll_ways           = false
+local ignore_toll_ways = set_option("ignore_toll_ways", false)
 
 local abs = math.abs
 local min = math.min

--- a/profiles/lib/set_option.lua
+++ b/profiles/lib/set_option.lua
@@ -1,0 +1,11 @@
+-- Check run environment for variable value, otherwise return default
+
+function set_option(optionName, default)
+    if os.getenv(optionName) == "" then
+        return default
+    else
+        return os.getenv(optionName)
+    end
+end
+
+return set_option


### PR DESCRIPTION
# Issue

Allows dynamic testing of profile changes by adding a lua function that will first look for a given variable in the run environment, and fallback to a given default.

## Tasklist
 - [x] Make regression / cucumber case pass
-  [ ] Add test for lua environment reading function
 - [ ] review
 - [ ] adjust for for comments

## Requirements / Relations
https://github.com/Project-OSRM/osrm-backend/issues/2781
https://github.com/Project-OSRM/osrm-backend/pull/2795
