### PR TITLE
Update turn penalty function to better fit some measured data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Profiles
       - includes library guidance.lua that offers preliminary configuration on guidance.
       - added left_hand_driving flag in global profile properties
+      - modified turn penalty function for car profile - better fit to real data
     - Guidance
       - Handle Access tags for lanes, only considering valid lanes in lane-guidance (think car | car | bike | car)
     - API:

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -150,10 +150,10 @@ properties.left_hand_driving               = false
 
 local side_road_speed_multiplier = 0.8
 
-local turn_penalty               = 1
+local turn_penalty               = 7.5
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
-local turn_bias                  = properties.left_hand_driving and 1/1.2 or 1.2
+local turn_bias                  = properties.left_hand_driving and 1/1.075 or 1.075
 
 local obey_oneway                = true
 local ignore_areas               = true
@@ -544,12 +544,13 @@ function way_function (way, result)
 end
 
 function turn_function (angle)
-  ---- compute turn penalty as angle^2, with a left/right bias
+  -- Use a sigmoid function to return a penalty that maxes out at turn_penalty
+  -- over the space of 0-180 degrees.  Values here were chosen by fitting
+  -- the function to some turn penalty samples from real driving.
   -- multiplying by 10 converts to deci-seconds see issue #1318
-  k = 10*turn_penalty/(90.0*90.0)
   if angle>=0 then
-    return angle*angle*k/turn_bias
+    return 10 * turn_penalty / (1 + 2.718 ^ - ((13 / turn_bias) * angle/180 - 6.5*turn_bias))
   else
-    return angle*angle*k*turn_bias
+    return 10 * turn_penalty / (1 + 2.718 ^  - ((13 * turn_bias) * - angle/180 - 6.5/turn_bias))
   end
 end


### PR DESCRIPTION
This PR modifies the existing `car.lua` turn function to attempt to better model car turning penalties.

I went out driving and measured a bunch of turning movements:

![screen shot 2016-09-02 at 5 21 03 pm](https://cloud.githubusercontent.com/assets/1892250/18221405/af02981c-7131-11e6-9a7b-ab95c0bada68.png)

The key observations from the sample data were:

  1. We weren't penalizing 90 degree turns enough - typical values were from the 2-4 second range.
  2. There is not as much bias from left-to-right as we applied.
  3. Turns <45 degrees incurred relatively little penalty.
  4. Traffic-control mechisms (lights, stop signs) play a big part in the cost of turns.

Our existing turn function only accepts an angle value.  This PR updates the turn function (and default parameters) for the `car.lua` profile to attempt to get a slighly better fit.  In general, turns >90 degrees should have significantly higher penalties (2x or more), and shallower angle turns should have smaller penalties.  There is a left/right bias still, shallow-angle left turns (in right-driving countries) do incur an extra cost.

As can be seen on the plot above, turns that traverse intersections with traffic control (lights and stop signs) incur a higher penalty than those that do not.  At this stage we don't have that data available to the turn function, so this change is incomplete.

This PR is intended as a stepping stone towards https://github.com/Project-OSRM/osrm-backend/pull/2822 that *will* pass additional data to the turn function.

## Tasklist
 - [ ] review
 - [ ] merge

