### PR TITLE
Fix/2852

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - Bugfixes
       - Fixed an issue that would result in segfaults for viaroutes with an invalid intermediate segment when u-turns were allowed at the via-location
       - Invalid only_* restrictions could result in loss of connectivity. As a fallback, we assume all turns allowed when the restriction is not valid
+      - Fixed a bug that could result in an infinite loop when finding information about an upcoming intersection
 
 # 5.3.0
   Changes from 5.3.0-rc.3

--- a/features/guidance/bugs.feature
+++ b/features/guidance/bugs.feature
@@ -1,0 +1,35 @@
+@routing @guidance
+Feature: Features related to bugs
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 5 meters
+
+    @2852
+    Scenario: Loop
+        Given the node map
+            | a | 1 |   | g |   |   | b |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   |   |
+            | e |   |   |   |   |   | f |
+            |   |   |   |   |   |   |   |
+            |   |   |   |   |   |   | 2 |
+            | d |   |   | h |   |   | c |
+
+        And the ways
+            | nodes | name   | oneway |
+            | agb   | top    | yes    |
+            | bfc   | right  | yes    |
+            | chd   | bottom | yes    |
+            | dea   | left   | yes    |
+
+        And the nodes
+            | node | highway         |
+            | g    | traffic_signals |
+            | f    | traffic_signals |
+            | h    | traffic_signals |
+            | e    | traffic_signals |
+
+        When I route I should get
+            | waypoints | route           | turns                        |
+            | 1,2       | top,right,right | depart,new name right,arrive |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1158,7 +1158,6 @@ std::vector<RouteStep> buildIntersections(std::vector<RouteStep> steps)
     std::size_t last_valid_instruction = 0;
     for (std::size_t step_index = 0; step_index < steps.size(); ++step_index)
     {
-        const auto next_step_index = step_index + 1;
         auto &step = steps[step_index];
         const auto instruction = step.maneuver.instruction;
         if (instruction.type == TurnType::Suppressed)

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -574,6 +574,9 @@ IntersectionGenerator::GetActualNextIntersection(const NodeID starting_node,
     NodeID node_at_intersection = starting_node;
     EdgeID incoming_edge = via_edge;
 
+    // to prevent endless loops
+    const auto termination_node = node_based_graph.GetTarget(via_edge);
+
     while (result.size() == 2 &&
            node_based_graph.GetEdgeData(via_edge).IsCompatibleTo(
                node_based_graph.GetEdgeData(result[1].turn.eid)))
@@ -581,6 +584,10 @@ IntersectionGenerator::GetActualNextIntersection(const NodeID starting_node,
         node_at_intersection = node_based_graph.GetTarget(incoming_edge);
         incoming_edge = result[1].turn.eid;
         result = GetConnectedRoads(node_at_intersection, incoming_edge);
+
+        // When looping back to the original node, we obviously are in a loop. Stop there.
+        if (termination_node == node_based_graph.GetTarget(incoming_edge))
+            break;
     }
 
     // return output if requested


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/2852

We should probably verify on the huge extract as well, I was able to reproduce a loop in a cucumber case though and added some code to catch it. The loops should be caught now, but it would be great to verify this on the larger extract. @danpat do you have a setup running here?

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for for comments
