### PR TITLE
Makes the OSRM interface threadsafe

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -34,7 +34,7 @@ int main(int argc, const char *argv[])
     config.use_shared_memory = false;
 
     // Routing machine with several services (such as Route, Table, Nearest, Trip, Match)
-    OSRM osrm{config};
+    const OSRM osrm{config};
 
     // The following shows how to use the Route service; configure this service
     RouteParameters params;

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -55,7 +55,7 @@ class Engine final
     // Needs to be public
     struct EngineLock;
 
-    explicit Engine(EngineConfig &config);
+    explicit Engine(const EngineConfig &config);
 
     Engine(Engine &&) noexcept;
     Engine &operator=(Engine &&) noexcept;
@@ -63,12 +63,12 @@ class Engine final
     // Impl. in cpp since for unique_ptr of incomplete types
     ~Engine();
 
-    Status Route(const api::RouteParameters &parameters, util::json::Object &result);
-    Status Table(const api::TableParameters &parameters, util::json::Object &result);
-    Status Nearest(const api::NearestParameters &parameters, util::json::Object &result);
-    Status Trip(const api::TripParameters &parameters, util::json::Object &result);
-    Status Match(const api::MatchParameters &parameters, util::json::Object &result);
-    Status Tile(const api::TileParameters &parameters, std::string &result);
+    Status Route(const api::RouteParameters &parameters, util::json::Object &result) const;
+    Status Table(const api::TableParameters &parameters, util::json::Object &result) const;
+    Status Nearest(const api::NearestParameters &parameters, util::json::Object &result) const;
+    Status Trip(const api::TripParameters &parameters, util::json::Object &result) const;
+    Status Match(const api::MatchParameters &parameters, util::json::Object &result) const;
+    Status Tile(const api::TileParameters &parameters, std::string &result) const;
 
   private:
     std::unique_ptr<EngineLock> lock;

--- a/include/osrm/osrm.hpp
+++ b/include/osrm/osrm.hpp
@@ -83,7 +83,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, RouteParameters and json::Object
      */
-    Status Route(const RouteParameters &parameters, json::Object &result);
+    Status Route(const RouteParameters &parameters, json::Object &result) const;
 
     /**
      * Distance tables for coordinates.
@@ -92,7 +92,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, TableParameters and json::Object
      */
-    Status Table(const TableParameters &parameters, json::Object &result);
+    Status Table(const TableParameters &parameters, json::Object &result) const;
 
     /**
      * Nearest street segment for coordinate.
@@ -101,7 +101,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, NearestParameters and json::Object
      */
-    Status Nearest(const NearestParameters &parameters, json::Object &result);
+    Status Nearest(const NearestParameters &parameters, json::Object &result) const;
 
     /**
      * Trip: shortest round trip between coordinates.
@@ -110,7 +110,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, TripParameters and json::Object
      */
-    Status Trip(const TripParameters &parameters, json::Object &result);
+    Status Trip(const TripParameters &parameters, json::Object &result) const;
 
     /**
      * Match: snaps noisy coordinate traces to the road network
@@ -119,7 +119,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, MatchParameters and json::Object
      */
-    Status Match(const MatchParameters &parameters, json::Object &result);
+    Status Match(const MatchParameters &parameters, json::Object &result) const;
 
     /**
      * Tile: vector tiles with internal graph representation
@@ -128,7 +128,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, TileParameters and json::Object
      */
-    Status Tile(const TileParameters &parameters, std::string &result);
+    Status Tile(const TileParameters &parameters, std::string &result) const;
 
   private:
     std::unique_ptr<engine::Engine> engine_;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -124,7 +124,7 @@ namespace osrm
 namespace engine
 {
 
-Engine::Engine(EngineConfig &config)
+Engine::Engine(const EngineConfig &config)
 {
     if (config.use_shared_memory)
     {
@@ -157,32 +157,32 @@ Engine::~Engine() = default;
 Engine::Engine(Engine &&) noexcept = default;
 Engine &Engine::operator=(Engine &&) noexcept = default;
 
-Status Engine::Route(const api::RouteParameters &params, util::json::Object &result)
+Status Engine::Route(const api::RouteParameters &params, util::json::Object &result) const
 {
     return RunQuery(lock, *query_data_facade, params, *route_plugin, result);
 }
 
-Status Engine::Table(const api::TableParameters &params, util::json::Object &result)
+Status Engine::Table(const api::TableParameters &params, util::json::Object &result) const
 {
     return RunQuery(lock, *query_data_facade, params, *table_plugin, result);
 }
 
-Status Engine::Nearest(const api::NearestParameters &params, util::json::Object &result)
+Status Engine::Nearest(const api::NearestParameters &params, util::json::Object &result) const
 {
     return RunQuery(lock, *query_data_facade, params, *nearest_plugin, result);
 }
 
-Status Engine::Trip(const api::TripParameters &params, util::json::Object &result)
+Status Engine::Trip(const api::TripParameters &params, util::json::Object &result) const
 {
     return RunQuery(lock, *query_data_facade, params, *trip_plugin, result);
 }
 
-Status Engine::Match(const api::MatchParameters &params, util::json::Object &result)
+Status Engine::Match(const api::MatchParameters &params, util::json::Object &result) const
 {
     return RunQuery(lock, *query_data_facade, params, *match_plugin, result);
 }
 
-Status Engine::Tile(const api::TileParameters &params, std::string &result)
+Status Engine::Tile(const api::TileParameters &params, std::string &result) const
 {
     return RunQuery(lock, *query_data_facade, params, *tile_plugin, result);
 }

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -21,32 +21,32 @@ OSRM &OSRM::operator=(OSRM &&) noexcept = default;
 
 // Forward to implementation
 
-engine::Status OSRM::Route(const engine::api::RouteParameters &params, util::json::Object &result)
+engine::Status OSRM::Route(const engine::api::RouteParameters &params, util::json::Object &result) const
 {
     return engine_->Route(params, result);
 }
 
-engine::Status OSRM::Table(const engine::api::TableParameters &params, json::Object &result)
+engine::Status OSRM::Table(const engine::api::TableParameters &params, json::Object &result) const
 {
     return engine_->Table(params, result);
 }
 
-engine::Status OSRM::Nearest(const engine::api::NearestParameters &params, json::Object &result)
+engine::Status OSRM::Nearest(const engine::api::NearestParameters &params, json::Object &result) const
 {
     return engine_->Nearest(params, result);
 }
 
-engine::Status OSRM::Trip(const engine::api::TripParameters &params, json::Object &result)
+engine::Status OSRM::Trip(const engine::api::TripParameters &params, json::Object &result) const
 {
     return engine_->Trip(params, result);
 }
 
-engine::Status OSRM::Match(const engine::api::MatchParameters &params, json::Object &result)
+engine::Status OSRM::Match(const engine::api::MatchParameters &params, json::Object &result) const
 {
     return engine_->Match(params, result);
 }
 
-engine::Status OSRM::Tile(const engine::api::TileParameters &params, std::string &result)
+engine::Status OSRM::Tile(const engine::api::TileParameters &params, std::string &result) const
 {
     return engine_->Tile(params, result);
 }


### PR DESCRIPTION
# Issue

For https://github.com/Project-OSRM/osrm-backend/issues/2861. I still need to check the `mutable unique_ptr<T>` semantics. To be honest I though it would be `unique_ptr<mutable T>` since not the `unique_ptr` should be `mutable` but the type it's storing.


Technically speaking we're changing the `libosrm` API. But since we're only lifting restrictions by marking the API threadsafe, we should be fine here. I'd like to be careful here, anyway.

## Tasklist
 - [x] check `mutable unique_ptr<T>` vs `unique_ptr<mutable T>`
 - [x] review
 - [x] adjust for for comments
 - [x] adapt node-osrm - does node-osrm needs to be adapted anyway? should be fine

@jcoupey