### PR TITLE
calculate roundabout radius from circumference, fix #2716

### DIFF
--- a/features/guidance/roundabout-turn.feature
+++ b/features/guidance/roundabout-turn.feature
@@ -243,9 +243,29 @@ Feature: Basic Roundabout
             | df    |            |
 
         When I route I should get
-            | waypoints | route    | turns                           |
-            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
-            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
+            | waypoints | route    | turns                                         |
+            | a,e       | ab,ce,ce | depart,roundabout turn right exit-1,arrive    |
+            | a,f       | ab,df,df | depart,roundabout turn straight exit-2,arrive |
+
+       Scenario: Collinear in Y
+        Given the node map
+            |   | a |
+            |   | b |
+            | e | c |
+            |   | d |
+            |   | f |
+
+        And the ways
+            | nodes | junction   |
+            | ab    |            |
+            | bcdb  | roundabout |
+            | ce    |            |
+            | df    |            |
+
+        When I route I should get
+            | waypoints | route    | turns                                         |
+            | a,e       | ab,ce,ce | depart,roundabout turn right exit-1,arrive    |
+            | a,f       | ab,df,df | depart,roundabout turn straight exit-2,arrive |
 
        Scenario: Collinear in X,Y
         Given the node map

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -231,43 +231,6 @@ Feature: Basic Roundabout
            | j,f       | jk,ef,ef | depart,roundabout-exit-2,arrive |
            | j,c       | jk,bc,bc | depart,roundabout-exit-3,arrive |
 
-       Scenario: Collinear in X
-        Given the node map
-            | a | b | c | d | f |
-            |   |   | e |   |   |
-
-        And the ways
-            | nodes | junction   |
-            | ab    |            |
-            | bcdb  | roundabout |
-            | ce    |            |
-            | df    |            |
-
-        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
-            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
-
-    Scenario: Collinear in Y
-        Given the node map
-            |   | a |
-            |   | b |
-            | e | c |
-            |   | d |
-            |   | f |
-
-        And the ways
-            | nodes | junction   |
-            | ab    |            |
-            | bcdb  | roundabout |
-            | ce    |            |
-            | df    |            |
-
-        When I route I should get
-            | waypoints | route    | turns                           |
-            | a,e       | ab,ce,ce | depart,roundabout-exit-1,arrive |
-            | a,f       | ab,df,df | depart,roundabout-exit-2,arrive |
-
     Scenario: Motorway Roundabout
     #See 39.933742 -75.082345
         Given the node map

--- a/include/extractor/guidance/roundabout_handler.hpp
+++ b/include/extractor/guidance/roundabout_handler.hpp
@@ -13,7 +13,7 @@
 #include "util/node_based_graph.hpp"
 #include "util/typedefs.hpp"
 
-#include <set>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -82,7 +82,8 @@ class RoundaboutHandler : public IntersectionHandler
                                    const bool can_exit_roundabout,
                                    Intersection intersection) const;
 
-    bool qualifiesAsRoundaboutIntersection(const std::set<NodeID> &roundabout_nodes) const;
+    bool
+    qualifiesAsRoundaboutIntersection(const std::unordered_set<NodeID> &roundabout_nodes) const;
 
     const CompressedEdgeContainer &compressed_edge_container;
     const ProfileProperties &profile_properties;


### PR DESCRIPTION
# Issue

fix #2716

- radius of roundabout is calculated from the total length of the edges in the roundabout
- ~~circleRadius and circleCenter are removed~~
- tests adjusted because collinear roundabouts now have the potential to become `RoundaboutIntersection`s because this [early return](https://github.com/Project-OSRM/osrm-backend/blob/7899444135858ef3e78e2309dacc5859eee49e16/src/extractor/guidance/roundabout_handler.cpp#L344) is removed

## Tasklist
 - [x] review @MoKob 
 - [x] adjust for for comments

