### PR TITLE
Reworks Restriction Whitelist / Blacklist, resolves #2833

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.5.0
-  - Changes from 5.4.0
+  Changes from 5.4.0
     - Profiles
+      - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
       - replaced lhs/rhs profiles by using test defined profiles
 
 # 5.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 5.5.0
-  Changes from 5.4.0
+  - Changes from 5.4.0
     - Profiles
       - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
       - replaced lhs/rhs profiles by using test defined profiles

--- a/include/extractor/restriction_parser.hpp
+++ b/include/extractor/restriction_parser.hpp
@@ -29,7 +29,7 @@ class ScriptingEnvironment;
  *
  * While this class does not directly invoke any lua code _per relation_ it does
  * load configuration values from the profile, that are saved in variables.
- * Namely ```use_turn_restrictions``` and ```get_exceptions```.
+ * Namely ```use_turn_restrictions``` and ```get_restrictions```.
  *
  * The restriction is represented by the osm id of the from way, the osm id of the
  * to way and the osm id of the via node. This representation must be post-processed
@@ -47,7 +47,7 @@ class RestrictionParser
   private:
     bool ShouldIgnoreRestriction(const std::string &except_tag_string) const;
 
-    std::vector<std::string> restriction_exceptions;
+    std::vector<std::string> restrictions;
     bool use_turn_restrictions;
 };
 }

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -51,7 +51,7 @@ class ScriptingEnvironment
     virtual const ProfileProperties &GetProfileProperties() = 0;
 
     virtual std::vector<std::string> GetNameSuffixList() = 0;
-    virtual std::vector<std::string> GetExceptions() = 0;
+    virtual std::vector<std::string> GetRestrictions() = 0;
     virtual void SetupSources() = 0;
     virtual int32_t GetTurnPenalty(double angle) = 0;
     virtual void ProcessSegment(const osrm::util::Coordinate &source,

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -53,7 +53,7 @@ class LuaScriptingEnvironment final : public ScriptingEnvironment
     LuaScriptingContext &GetLuaContext();
 
     std::vector<std::string> GetNameSuffixList() override;
-    std::vector<std::string> GetExceptions() override;
+    std::vector<std::string> GetRestrictions() override;
     void SetupSources() override;
     int32_t GetTurnPenalty(double angle) override;
     void ProcessSegment(const osrm::util::Coordinate &source,

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -12,7 +12,7 @@ access_tag_restricted = { ["destination"] = true, ["delivery"] = true }
 access_tags_hierarchy = { "bicycle", "vehicle", "access" }
 cycleway_tags = {["track"]=true,["lane"]=true,["opposite"]=true,["opposite_lane"]=true,["opposite_track"]=true,["share_busway"]=true,["sharrow"]=true,["shared"]=true }
 service_tag_restricted = { ["parking_aisle"] = true }
-restriction_exception_tags = { "bicycle", "vehicle", "access" }
+restrictions = { "bicycle" }
 unsafe_highway_list = { ["primary"] = true, ["secondary"] = true, ["tertiary"] = true, ["primary_link"] = true, ["secondary_link"] = true, ["tertiary_link"] = true}
 
 local default_speed = 15
@@ -121,8 +121,8 @@ local function parse_maxspeed(source)
     return n
 end
 
-function get_exceptions(vector)
-  for i,v in ipairs(restriction_exception_tags) do
+function get_restrictions(vector)
+  for i,v in ipairs(restrictions) do
     vector:Add(v)
   end
 end

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -12,7 +12,7 @@ access_tag_restricted = { ["destination"] = true, ["delivery"] = true }
 access_tags_hierarchy = { "motorcar", "motor_vehicle", "vehicle", "access" }
 service_tag_restricted = { ["parking_aisle"] = true }
 service_tag_forbidden = { ["emergency_access"] = true }
-restriction_exception_tags = { "motorcar", "motor_vehicle", "vehicle" }
+restrictions = { "motorcar", "motor_vehicle", "vehicle" }
 
 -- A list of suffixes to suppress in name change instructions
 suffix_list = { "N", "NE", "E", "SE", "S", "SW", "W", "NW", "North", "South", "West", "East" }
@@ -172,8 +172,8 @@ function get_name_suffix_list(vector)
   end
 end
 
-function get_exceptions(vector)
-  for i,v in ipairs(restriction_exception_tags) do
+function get_restrictions(vector)
+  for i,v in ipairs(restrictions) do
     vector:Add(v)
   end
 end

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -10,7 +10,7 @@ access_tag_restricted = { ["destination"] = true, ["delivery"] = true }
 access_tags_hierarchy = { "foot", "access" }
 service_tag_restricted = { ["parking_aisle"] = true }
 ignore_in_grid = { ["ferry"] = true }
-restriction_exception_tags = { "foot" }
+restrictions = { "foot" }
 
 walking_speed = 5
 
@@ -71,8 +71,8 @@ properties.continue_straight_at_waypoint = false
 
 local fallback_names     = true
 
-function get_exceptions(vector)
-  for i,v in ipairs(restriction_exception_tags) do
+function get_restrictions(vector)
+  for i,v in ipairs(restrictions) do
     vector:Add(v)
   end
 end

--- a/src/extractor/restriction_parser.cpp
+++ b/src/extractor/restriction_parser.cpp
@@ -29,20 +29,19 @@ RestrictionParser::RestrictionParser(ScriptingEnvironment &scripting_environment
 {
     if (use_turn_restrictions)
     {
-        restriction_exceptions = scripting_environment.GetExceptions();
-        const unsigned exception_count = restriction_exceptions.size();
-        if (exception_count)
+        restrictions = scripting_environment.GetRestrictions();
+        const unsigned count = restrictions.size();
+        if (count > 0)
         {
-            util::SimpleLogger().Write() << "Found " << exception_count
-                                         << " exceptions to turn restrictions:";
-            for (const std::string &str : restriction_exceptions)
+            util::SimpleLogger().Write() << "Found " << count << " turn restriction tags:";
+            for (const std::string &str : restrictions)
             {
                 util::SimpleLogger().Write() << "  " << str;
             }
         }
         else
         {
-            util::SimpleLogger().Write() << "Found no exceptions to turn restrictions";
+            util::SimpleLogger().Write() << "Found no turn restriction tags";
         }
     }
 }
@@ -51,8 +50,9 @@ RestrictionParser::RestrictionParser(ScriptingEnvironment &scripting_environment
  * Tries to parse a relation as a turn restriction. This can fail for a number of
  * reasons. The return type is a boost::optional<T>.
  *
- * Some restrictions can also be ignored: See the ```get_exceptions``` function
- * in the corresponding profile.
+ * Some restrictions can also be ignored: See the ```get_restrictions``` function
+ * in the corresponding profile. We use it for both namespacing restrictions, as in
+ * restriction:motorcar as well as whitelisting if its in except:motorcar.
  */
 boost::optional<InputRestrictionContainer>
 RestrictionParser::TryParse(const osmium::Relation &relation) const
@@ -63,13 +63,17 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
         return {};
     }
 
-    osmium::tags::KeyPrefixFilter filter(false);
+    osmium::tags::KeyFilter filter(false);
     filter.add(true, "restriction");
+
+    // Not only use restriction= but also e.g. restriction:motorcar=
+    for (const auto &namespaced : restrictions)
+        filter.add(true, "restriction:" + namespaced);
 
     const osmium::TagList &tag_list = relation.tags();
 
-    osmium::tags::KeyPrefixFilter::iterator fi_begin(filter, tag_list.begin(), tag_list.end());
-    osmium::tags::KeyPrefixFilter::iterator fi_end(filter, tag_list.end(), tag_list.end());
+    osmium::tags::KeyFilter::iterator fi_begin(filter, tag_list.begin(), tag_list.end());
+    osmium::tags::KeyFilter::iterator fi_end(filter, tag_list.end(), tag_list.end());
 
     // if it's not a restriction, continue;
     if (std::distance(fi_begin, fi_end) == 0)
@@ -104,22 +108,6 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
         else // unrecognized value type
         {
             return {};
-        }
-
-        // if the "restriction*" key is longer than 11 chars, it is a conditional exception (i.e.
-        // "restriction:<transportation_type>")
-        if (key.size() > 11)
-        {
-            const auto ex_suffix = [&](const std::string &exception) {
-                return boost::algorithm::ends_with(key, exception);
-            };
-            bool is_actually_restricted =
-                std::any_of(begin(restriction_exceptions), end(restriction_exceptions), ex_suffix);
-
-            if (!is_actually_restricted)
-            {
-                return {};
-            }
         }
     }
 
@@ -195,9 +183,8 @@ bool RestrictionParser::ShouldIgnoreRestriction(const std::string &except_tag_st
 
     return std::any_of(
         std::begin(exceptions), std::end(exceptions), [&](const std::string &current_string) {
-            return std::end(restriction_exceptions) != std::find(std::begin(restriction_exceptions),
-                                                                 std::end(restriction_exceptions),
-                                                                 current_string);
+            return std::end(restrictions) !=
+                   std::find(std::begin(restrictions), std::end(restrictions), current_string);
         });
 }
 }

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -327,18 +327,17 @@ std::vector<std::string> LuaScriptingEnvironment::GetNameSuffixList()
     return suffixes_vector;
 }
 
-std::vector<std::string> LuaScriptingEnvironment::GetExceptions()
+std::vector<std::string> LuaScriptingEnvironment::GetRestrictions()
 {
     auto &context = GetLuaContext();
     BOOST_ASSERT(context.state != nullptr);
-    std::vector<std::string> restriction_exceptions;
-    if (util::luaFunctionExists(context.state, "get_exceptions"))
+    std::vector<std::string> restrictions;
+    if (util::luaFunctionExists(context.state, "get_restrictions"))
     {
         // get list of turn restriction exceptions
-        luabind::call_function<void>(
-            context.state, "get_exceptions", boost::ref(restriction_exceptions));
+        luabind::call_function<void>(context.state, "get_restrictions", boost::ref(restrictions));
     }
-    return restriction_exceptions;
+    return restrictions;
 }
 
 void LuaScriptingEnvironment::SetupSources()


### PR DESCRIPTION
# Issue

For #2833.

Takes a stricter aproach for whitelisting / blacklisting restrictions:

- uses `restriction=`
- uses more specific `restriction:<type>=`
- uses `except=<type>` to invert

Where `type` is the type of transportation to restrict, e.g. `motorcar`.

## Tasklist
 - [x] review
 - [x] adjust for for comments