### PR TITLE
Fixes compilation against newer Boost versions; seems like we were lucky before; closes #2889

### DIFF
--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -17,6 +17,7 @@
 #include <boost/assert.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/format.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
 
 #include <tbb/parallel_for.h>


### PR DESCRIPTION
For #2889.

Seems like some headers were depending on format internally, and that changed in recent versions.
