### PR TITLE
fix looping in sliproad handler for lanes

### DIFF
--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -235,7 +235,8 @@ util::json::Object makeRouteStep(guidance::RouteStep step, util::json::Value geo
     route_step.values["distance"] = std::round(step.distance * 10) / 10.;
     route_step.values["duration"] = std::round(step.duration * 10) / 10.;
     route_step.values["name"] = std::move(step.name);
-    if (!step.ref.empty()) route_step.values["ref"] = std::move(step.ref);
+    if (!step.ref.empty())
+        route_step.values["ref"] = std::move(step.ref);
     if (!step.pronunciation.empty())
         route_step.values["pronunciation"] = std::move(step.pronunciation);
     if (!step.destinations.empty())

--- a/src/extractor/guidance/turn_analysis.cpp
+++ b/src/extractor/guidance/turn_analysis.cpp
@@ -94,7 +94,8 @@ Intersection TurnAnalysis::assignTurnTypes(const NodeID from_nid,
         }
     }
     // Handle sliproads
-    intersection = sliproad_handler(from_nid, via_eid, std::move(intersection));
+    if (sliproad_handler.canProcess(from_nid, via_eid, intersection))
+        intersection = sliproad_handler(from_nid, via_eid, std::move(intersection));
 
     // Turn On Ramps Into Off Ramps, if we come from a motorway-like road
     if (node_based_graph.GetEdgeData(via_eid).road_classification.IsMotorwayClass())


### PR DESCRIPTION
# Issue

Finding a next intersection within a dedicated loop can generate endless looping: https://github.com/Project-OSRM/osrm-backend/issues/2896

## Tasklist
~~add regression / cucumber cases (see docs/testing.md)~~
 - [x] review
 - [ ] adjust for for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?

