### PR TITLE
[feature] Enable a check on edge weight updates

### DIFF
--- a/features/options/contract/edge-weight-updates-over-factor.feature
+++ b/features/options/contract/edge-weight-updates-over-factor.feature
@@ -1,0 +1,30 @@
+@contract @options @edge-weight-updates-over-factor
+Feature: osrm-contract command line option: edge-weight-updates-over-factor
+
+    Background: Log edge weight updates over given factor
+
+    Scenario: Logging weight with updates over factor of 2, long segment
+        Given the node locations
+            | node | lat        | lon      |
+            | a    | 0.1        | 0.1      |
+            | b    | .05        | 0.1      |
+            | c    | 0.3        | 0.1      |
+        And the ways
+            | nodes | highway     |
+            | ab    | residential |
+            | ac    | primary     |
+        Given the profile "testbot"
+        Given the extract extra arguments "--generate-edge-lookup"
+        Given the speed file
+        """
+        1,2,100
+        1,3,100
+        """
+        And the data has been extracted
+        When I run "osrm-contract --edge-weight-updates-over-factor 2 --segment-speed-file {speeds_file} {processed_file}"
+        And stderr should contain "weight updates"
+        And stderr should contain "New speed: 100 kph"
+        And I route I should get
+            | from | to | route    | speed     |
+            | a    | b  | ab,ab    | 100 km/h  |
+            | a    | c  | ac,ac    | 100 km/h  |

--- a/features/options/contract/version.feature
+++ b/features/options/contract/version.feature
@@ -6,7 +6,7 @@ Feature: osrm-contract command line options: version
 
     Background:
         Given the profile "testbot"
-    
+
     Scenario: osrm-contract - Version, short
         When I run "osrm-contract --v"
         Then stderr should be empty

--- a/features/step_definitions/options.js
+++ b/features/step_definitions/options.js
@@ -86,6 +86,10 @@ module.exports = function () {
         assert.equal(this.stdout.split('\n').length - 1, parseInt(lines));
     });
 
+    this.Then(/^stderr should contain (\d+) lines?$/, (lines) => {
+        assert.equal(this.stderr.split('\n').length - 1, parseInt(lines));
+    });
+
     this.Then(/^datasource names should contain "(.+)"$/, (expectedData) => {
         var actualData = fs.readFileSync(this.processedCacheFile + '.datasource_names', {encoding:'UTF-8'}).trim().split('\n').join(',');
         assert.equal(actualData, expectedData);

--- a/include/contractor/contractor.hpp
+++ b/include/contractor/contractor.hpp
@@ -89,7 +89,8 @@ class Contractor
                           const std::string &geometry_filename,
                           const std::string &datasource_names_filename,
                           const std::string &datasource_indexes_filename,
-                          const std::string &rtree_leaf_filename);
+                          const std::string &rtree_leaf_filename,
+                          const double log_edge_updates_factor);
 };
 }
 }

--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -73,6 +73,7 @@ struct ContractorConfig
     bool use_cached_priority;
 
     unsigned requested_num_threads;
+    double log_edge_updates_factor;
 
     // A percentage of vertices that will be contracted for the hierarchy.
     // Offers a trade-off between preprocessing and query time.

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -52,7 +52,11 @@ return_code parseArguments(int argc, char *argv[], contractor::ContractorConfig 
         "level-cache,o",
         boost::program_options::value<bool>(&contractor_config.use_cached_priority)
             ->default_value(false),
-        "Use .level file to retain the contaction level for each node from the last run.");
+        "Use .level file to retain the contaction level for each node from the last run.")(
+        "edge-weight-updates-over-factor",
+        boost::program_options::value<double>(&contractor_config.log_edge_updates_factor)
+            ->default_value(0.0),
+        "Use with `--segment-speed-file`. Provide an `x` factor, by which Extractor will log edge weights updated by more than this factor");
 
     // hidden options, will be allowed on command line, but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");


### PR DESCRIPTION
# Issue

Ref https://github.com/Project-OSRM/osrm-backend/issues/2882

This is a QA feature that runs a check on all edge weight updates that happen during contraction that the update is a reasonable update based on the previous value. ~~It's still a todo to determine a reliable heuristic for what a reasonable update is.~~ The flag now takes a value, a `double` value that's used as a factor of change from old to new weights. It's still on the table as to how to implement an absolute value in seconds as input for the flag. Should this be done with a completely different flag?

## Tasklist
 - [x] Put feature behind a flag `--verify-weights` or so
 - [x] Print the corresponding filename from datasource_names in log output
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations
