### PR TITLE
Improve Turn Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
       - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
       - replaced lhs/rhs profiles by using test defined profiles
       - Handle `oneway=alternating` (routed over with penalty) separately from `oneway=reversible` (not routed over due to time dependence)
+      - improved data availability in turn function / improved turn penalty calculation in default car profile (requires reprocessing)
+      - only apply traffic signal penalty if the last traffic signal was at least an intersection/minimum distance away
     - Guidance
       - Notifications are now exposed more prominently, announcing turns onto a ferry/pushing your bike more prominently
     - Trip Plugin

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -57,17 +57,17 @@ Feature: Traffic - turn penalties
                                                                   # straight
             | i    | g  | fim,fg,fg       | 53 km/h | 13.5s +-1 |
                                                                   # right
-            | a    | e  | ad,def,def      | 43 km/h | 16.7s +-1 |
+            | a    | e  | ad,def,def      | 33 km/h | 21.7s +-1 |
                                                                   # left
             | c    | g  | cd,def,fg,fg    | 63 km/h | 23s +-1   |
                                                                   # double straight
             | p    | g  | mp,fim,fg,fg    | 58 km/h | 24.9s +-1 |
                                                                   # straight-right
-            | a    | l  | ad,dhk,klm,klm  | 51 km/h | 28.1s +-1 |
+            | a    | l  | ad,dhk,klm,klm  | 44 km/h | 33.1s +-1 |
                                                                   # straight-left
             | l    | e  | klm,dhk,def,def | 53 km/h | 27s +-1   |
                                                                   # double right
-            | g    | n  | fg,fim,mn,mn    | 43 km/h | 33.4s +-1 |
+            | g    | n  | fg,fim,mn,mn    | 33 km/h | 43.4s +-1 |
                                                                   # double left
 
     Scenario: Weighting based on turn penalty file
@@ -75,31 +75,31 @@ Feature: Traffic - turn penalties
             """
             9,6,7,1.8
             9,13,14,24.5
-            8,4,3,30
+            8,4,3,40
             12,11,8,9
-            8,11,12,23
+            8,11,12,33
             1,4,5,-0.2
             """
         And the contract extra arguments "--turn-penalty-file {penalties_file}"
         When I route I should get
-            | from | to | route                 | speed   | time      |
-            | a    | h  | ad,dhk,dhk            | 63 km/h | 11.5s +-1 |
+            | from | to | route                 | speed       | time      |
+            | a    | h  | ad,dhk,dhk            | 63 km/h +-1 | 11.5s +-1 |
                                                                               # straight
-            | i    | g  | fim,fg,fg             | 55 km/h | 13s +-1   |
+            | i    | g  | fim,fg,fg             | 55 km/h +-1 | 13s +-1   |
                                                                               # right - ifg penalty
-            | a    | e  | ad,def,def            | 64 km/h | 11s +-1   |
+            | a    | e  | ad,def,def            | 64 km/h +-1 | 11s +-1   |
                                                                               # left - faster because of negative ade penalty
-            | c    | g  | cd,def,fg,fg          | 63 km/h | 23s +-1   |
+            | c    | g  | cd,def,fg,fg          | 63 km/h +-1 | 23s +-1   |
                                                                               # double straight
-            | p    | g  | mp,fim,fg,fg          | 59 km/h | 24.5s +-1 |
+            | p    | g  | mp,fim,fg,fg          | 59 km/h +-1 | 24.5s +-1 |
                                                                               # straight-right - ifg penalty
-            | a    | l  | ad,def,fim,klm,klm    | 57 km/h | 38.2s +-1 |
+            | a    | l  | ad,def,fim,klm,klm    | 57 km/h +-1 | 38.2s +-1 |
                                                                               # was straight-left - forced around by hkl penalty
-            | l    | e  | klm,fim,def,def       | 43 km/h | 33.4s +-1 |
+            | l    | e  | klm,dhk,def,def       | 43 km/h +-1 | 33.4s +-1 |
                                                                               # double right - forced left by lkh penalty
-            | g    | n  | fg,fim,mn,mn          | 27 km/h | 52.6s +-1 |
+            | g    | n  | fg,fim,mn,mn          | 25 km/h +-1 | 57.6s +-1 |
                                                                               # double left - imn penalty
-            | j    | c  | jk,klm,fim,def,cd,cd  | 51 km/h | 56.2s +-1 |
+            | j    | c  | jk,klm,fim,def,cd,cd  | 43 km/h +-1 | 66.2s +-1 |
                                                                               # double left - hdc penalty ever so slightly higher than imn; forces all the way around
 
     Scenario: Too-negative penalty clamps, but does not fail

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -10,6 +10,7 @@
 #include "extractor/profile_properties.hpp"
 #include "extractor/query_node.hpp"
 #include "extractor/restriction_map.hpp"
+#include "extractor/turn_penalty.hpp"
 
 #include "extractor/guidance/turn_analysis.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
@@ -180,6 +181,19 @@ class EdgeBasedGraphFactory
     std::unordered_map<util::guidance::BearingClass, BearingClassID> bearing_class_hash;
     std::vector<BearingClassID> bearing_class_by_node_based_node;
     std::unordered_map<util::guidance::EntryClass, EntryClassID> entry_class_hash;
+
+    void ComputeTurnFunctionParameters(const NodeID from_node,
+                                       const EdgeID in_edge,
+                                       const NodeID intersection_node,
+                                       const EdgeID out_edge,
+                                       const NodeID to_node,
+                                       const double angle,
+                                       guidance::TurnInstruction instruction,
+                                       bool crosses_through_traffic,
+                                       TurnProperties &turn_properties,
+                                       IntersectionProperties &intersection_properties,
+                                       TurnSegment &approach_segment,
+                                       TurnSegment &exit_segment);
 };
 } // namespace extractor
 } // namespace osrm

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -5,6 +5,7 @@
 #include "extractor/internal_extractor_edge.hpp"
 #include "extractor/profile_properties.hpp"
 #include "extractor/restriction.hpp"
+#include "extractor/turn_penalty.hpp"
 
 #include <osmium/memory/buffer.hpp>
 
@@ -12,6 +13,7 @@
 
 #include <tbb/concurrent_vector.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -53,7 +55,10 @@ class ScriptingEnvironment
     virtual std::vector<std::string> GetNameSuffixList() = 0;
     virtual std::vector<std::string> GetRestrictions() = 0;
     virtual void SetupSources() = 0;
-    virtual int32_t GetTurnPenalty(double angle) = 0;
+    virtual std::int32_t GetTurnPenalty(const TurnProperties &turn_properties,
+                                        const IntersectionProperties &intersection_properties,
+                                        const TurnSegment &approach_segment,
+                                        const TurnSegment &exit_segment) = 0;
     virtual void ProcessSegment(const osrm::util::Coordinate &source,
                                 const osrm::util::Coordinate &target,
                                 double distance,

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -2,6 +2,7 @@
 #define SCRIPTING_ENVIRONMENT_LUA_HPP
 
 #include "extractor/scripting_environment.hpp"
+#include "extractor/turn_penalty.hpp"
 
 #include "extractor/raster_source.hpp"
 
@@ -9,6 +10,7 @@
 
 #include <tbb/enumerable_thread_specific.h>
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -30,6 +32,7 @@ struct LuaScriptingContext final
     util::LuaState state;
 
     bool has_turn_penalty_function;
+    bool has_detailed_penalty_function;
     bool has_node_function;
     bool has_way_function;
     bool has_segment_function;
@@ -55,7 +58,10 @@ class LuaScriptingEnvironment final : public ScriptingEnvironment
     std::vector<std::string> GetNameSuffixList() override;
     std::vector<std::string> GetRestrictions() override;
     void SetupSources() override;
-    int32_t GetTurnPenalty(double angle) override;
+    std::int32_t GetTurnPenalty(const TurnProperties &turn_properties,
+                                const IntersectionProperties &intersection_properties,
+                                const TurnSegment &approach_segment,
+                                const TurnSegment &exit_segment) override;
     void ProcessSegment(const osrm::util::Coordinate &source,
                         const osrm::util::Coordinate &target,
                         double distance,

--- a/include/extractor/turn_penalty.hpp
+++ b/include/extractor/turn_penalty.hpp
@@ -1,0 +1,46 @@
+#ifndef OSRM_TURN_PENALTY_HPP_
+#define OSRM_TURN_PENALTY_HPP_
+
+/* The turn functions offered by osrm come in two variations. One uses a basic angle. The other one
+ * offers a list of additional entries to improve the turn penalty */
+
+namespace osrm
+{
+namespace extractor
+{
+
+// properties describing the turn
+struct TurnProperties
+{
+    // the turn angle between the ingoing/outgoing segments
+    double angle;
+    // the radius of the turn at the curve (approximated)
+    double radius;
+    // the turn is crossing through opposing traffic
+    bool crossing_through_traffic;
+    // indicate if the turn needs to be announced or if it is a turn following the obvious road
+    bool requires_announcement;
+};
+
+// properties describing intersection related penalties
+struct IntersectionProperties
+{
+    // is the turn at a traffic light
+    bool traffic_light;
+    // is the turn at a stop-light
+    bool stop_sign;
+    // is the turn following a right-of-way situation
+    bool right_of_way;
+};
+
+// information about the segments coming in/out of the intersection
+struct TurnSegment
+{
+    double length_in_meters;
+    double speed_in_meters_per_second;
+};
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_TURN_PENALTY_HPP_

--- a/include/extractor/turn_penalty.hpp
+++ b/include/extractor/turn_penalty.hpp
@@ -20,6 +20,8 @@ struct TurnProperties
     bool crossing_through_traffic;
     // indicate if the turn needs to be announced or if it is a turn following the obvious road
     bool requires_announcement;
+    // check if we are continuing on the normal road on an obvious turn
+    bool is_through_street;
 };
 
 // properties describing intersection related penalties

--- a/include/extractor/turn_penalty.hpp
+++ b/include/extractor/turn_penalty.hpp
@@ -24,6 +24,9 @@ struct TurnProperties
     bool requires_announcement;
     // check if we are continuing on the normal road on an obvious turn
     bool is_through_street;
+    // on/off ramp
+    bool on_ramp;
+    bool off_ramp;
 };
 
 // properties describing intersection related penalties

--- a/include/extractor/turn_penalty.hpp
+++ b/include/extractor/turn_penalty.hpp
@@ -30,7 +30,7 @@ struct TurnProperties
 struct IntersectionProperties
 {
     // is the turn at a traffic light
-    bool traffic_light;
+    bool regulated;
     // is the turn following a right-of-way situation
     bool right_of_way;
     // has to give way describes situations where we have to let traffic pass (e.g. due to stop
@@ -59,7 +59,7 @@ inline std::string toString(const TurnProperties &props)
 inline std::string toString(const IntersectionProperties &props)
 {
     std::string result;
-    result += std::string("[") + "Traffic Light: " + (props.traffic_light ? "true" : "false") +
+    result += std::string("[") + "Regulated: " + (props.regulated ? "true" : "false") +
               " | Right Of Way: " + (props.right_of_way ? "true" : "false") + " | Give Way: " +
               (props.give_way ? "true" : "false") + "]";
     return result;

--- a/include/extractor/turn_penalty.hpp
+++ b/include/extractor/turn_penalty.hpp
@@ -27,7 +27,7 @@ struct IntersectionProperties
 {
     // is the turn at a traffic light
     bool traffic_light;
-    // is the turn at a stop-light
+    // is the turn at a stop-sign
     bool stop_sign;
     // is the turn following a right-of-way situation
     bool right_of_way;

--- a/include/extractor/turn_penalty.hpp
+++ b/include/extractor/turn_penalty.hpp
@@ -4,6 +4,8 @@
 /* The turn functions offered by osrm come in two variations. One uses a basic angle. The other one
  * offers a list of additional entries to improve the turn penalty */
 
+#include <string>
+
 namespace osrm
 {
 namespace extractor
@@ -29,10 +31,11 @@ struct IntersectionProperties
 {
     // is the turn at a traffic light
     bool traffic_light;
-    // is the turn at a stop-sign
-    bool stop_sign;
     // is the turn following a right-of-way situation
     bool right_of_way;
+    // has to give way describes situations where we have to let traffic pass (e.g. due to stop
+    // signs) but also simply due to driveways
+    bool give_way;
 };
 
 // information about the segments coming in/out of the intersection
@@ -41,6 +44,34 @@ struct TurnSegment
     double length_in_meters;
     double speed_in_meters_per_second;
 };
+
+inline std::string toString(const TurnProperties &props)
+{
+    std::string result;
+    result += "[Angle: " + std::to_string(props.angle) + " Radius: " +
+              std::to_string(props.radius) + " | Through Traffic: " +
+              (props.crossing_through_traffic ? "true" : "false") + " | Announced: " +
+              (props.requires_announcement ? "true" : "false") + " | Through Traffic: " +
+              (props.is_through_street ? "true" : "false") + "]";
+    return result;
+}
+
+inline std::string toString(const IntersectionProperties &props)
+{
+    std::string result;
+    result += std::string("[") + "Traffic Light: " + (props.traffic_light ? "true" : "false") +
+              " | Right Of Way: " + (props.right_of_way ? "true" : "false") + " | Give Way: " +
+              (props.give_way ? "true" : "false") + "]";
+    return result;
+}
+
+inline std::string toString(const TurnSegment &segment)
+{
+    std::string result;
+    result += std::string("[") + "Length: " + std::to_string(segment.length_in_meters) +
+              " Speed: " + std::to_string(segment.speed_in_meters_per_second) + "]";
+    return result;
+}
 
 } // namespace extractor
 } // namespace osrm

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -85,15 +85,11 @@ double bearing(const Coordinate first_coordinate, const Coordinate second_coordi
 // Get angle of line segment (A,C)->(C,B)
 double computeAngle(const Coordinate first, const Coordinate second, const Coordinate third);
 
-// find the center of a circle through three coordinates
-boost::optional<Coordinate> circleCenter(const Coordinate first_coordinate,
-                                         const Coordinate second_coordinate,
-                                         const Coordinate third_coordinate);
+// find the center of a circle via fitting
+boost::optional<Coordinate> circleCenter(const std::vector<Coordinate> &coords);
 
-// find the radius of a circle through three coordinates
-double circleRadius(const Coordinate first_coordinate,
-                    const Coordinate second_coordinate,
-                    const Coordinate third_coordinate);
+// find the radius of a circle via curve fitting
+double circleRadius(const std::vector<Coordinate> &coords);
 
 // factor in [0,1]. Returns point along the straight line between from and to. 0 returns from, 1
 // returns to

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -6,6 +6,7 @@
 #include <boost/optional.hpp>
 
 #include <utility>
+#include <vector>
 
 namespace osrm
 {

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -401,7 +401,7 @@ function way_function (way, result)
   limit( result, maxspeed, maxspeed_forward, maxspeed_backward )
 end
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
   -- compute turn penalty as angle^2, with a left/right bias
   -- multiplying by 10 converts to deci-seconds see issue #1318
   k = 10*turn_penalty/(90.0*90.0)

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -155,6 +155,8 @@ local turn_penalty               = 7.5
 local crossing_through_traffic_penalty = 5
 local stop_sign_penalty          = 5
 local turn_announcement_penalty = 5
+-- penalty to enter/exit a motorway
+local motorway_penalty = 30
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
 local turn_bias                  = properties.left_hand_driving and 1/1.075 or 1.075
@@ -660,6 +662,10 @@ function turn_function(angle, turn_properties, intersection_properties, approach
   -- crossing through traffic is expensive
   if turn_properties.crossing_through_traffic then
     penalty = penalty + crossing_through_traffic_penalty
+  end
+
+  if turn_properties.off_ramp or turn_properties.on_ramp then
+    penalty = penalty + motorway_penalty
   end
 
   return 10 * penalty;

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -142,15 +142,18 @@ maxspeed_table = {
 }
 
 -- set profile properties
-properties.u_turn_penalty                  = 20
-properties.traffic_signal_penalty          = 2
-properties.use_turn_restrictions           = true
-properties.continue_straight_at_waypoint   = true
-properties.left_hand_driving               = false
+properties.u_turn_penalty                 = 20
+properties.traffic_signal_penalty         = 2
+-- if we are crossing through traffic on a turn, we add this penalty
+properties.use_turn_restrictions          = true
+properties.continue_straight_at_waypoint  = true
+properties.left_hand_driving              = false
 
 local side_road_speed_multiplier = 0.8
 
 local turn_penalty               = 7.5
+local crossing_through_traffic_penalty = 5
+local turn_announcement_penalty = 3
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
 local turn_bias                  = properties.left_hand_driving and 1/1.075 or 1.075
@@ -602,14 +605,28 @@ function way_function (way, result)
   result.is_startpoint = result.forward_mode == mode.driving or result.backward_mode == mode.driving
 end
 
-function turn_function (angle)
-  -- Use a sigmoid function to return a penalty that maxes out at turn_penalty
-  -- over the space of 0-180 degrees.  Values here were chosen by fitting
-  -- the function to some turn penalty samples from real driving.
-  -- multiplying by 10 converts to deci-seconds see issue #1318
-  if angle>=0 then
-    return 10 * turn_penalty / (1 + 2.718 ^ - ((13 / turn_bias) * angle/180 - 6.5*turn_bias))
+-- a detailed turn function as an alternative to turn function, offering more properties to decide on a good penalty
+-- returns penalty in seconds
+function turn_function(angle, turn_properties, intersection_properties, approach_segment, exit_segment)
+  local penalty = 0;
+  if turn_properties.angle>=0 then
+    penalty = turn_penalty / (1 + 2.718 ^ - ((13 / turn_bias) * angle/180 - 6.5*turn_bias))
   else
-    return 10 * turn_penalty / (1 + 2.718 ^  - ((13 * turn_bias) * - angle/180 - 6.5/turn_bias))
+    penalty = turn_penalty / (1 + 2.718 ^  - ((13 * turn_bias) * - angle/180 - 6.5/turn_bias))
   end
+
+  -- we make announced turns more expensive while, at the same time, we reduce the cost of suppressed turns
+  if turn_properties.requires_announcement then
+    penalty = penalty + turn_announcement_penalty
+  else
+    -- unanounced turns are cheaper than normal turns
+    penalty = penalty * 0.8;
+  end
+
+  -- crossing through traffic is expensive
+  if turn_properties.crossing_through_traffic then
+    penalty = penalty + crossing_through_traffic_penalty
+  end
+
+  return penalty;
 end

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -31,7 +31,7 @@ speed_profile = {
   ["unclassified"] = 25,
   ["residential"] = 25,
   ["living_street"] = 10,
-  ["service"] = 15,
+  ["service"] = 5,
 --  ["track"] = 5,
   ["ferry"] = 5,
   ["movable"] = 5,
@@ -153,7 +153,8 @@ local side_road_speed_multiplier = 0.8
 
 local turn_penalty               = 7.5
 local crossing_through_traffic_penalty = 5
-local turn_announcement_penalty = 3
+local stop_sign_penalty          = 5
+local turn_announcement_penalty = 5
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
 local turn_bias                  = properties.left_hand_driving and 1/1.075 or 1.075
@@ -607,11 +608,21 @@ end
 
 local function getTurningSpeed(turn_properties,intersection_properties,approach_segment, exit_segment)
     -- should probably consider the turn angle, radius, ... as well
-    return math.min(approach_segment.speed_in_meters_per_second, exit_segment.speed_in_meters_per_second)
+    local base_speed = math.min(approach_segment.speed_in_meters_per_second, exit_segment.speed_in_meters_per_second)
+
+    -- uturns are assuming a ten percent turning speed, based on angle and all others are interpolated linear to a hundred percent speed
+    local modifier = 0.9 * (math.abs(turn_properties.angle) / 180.0) + 0.1;
+
+    return base_speed * modifier;
 end
 
 -- compute the time it takes to achieve a speed difference via an acceleration
-local function getDeltaTime(speed_difference,acceleration)
+local function getDeltaTime(speed_difference,length)
+    -- don't penalise very short segments additionally
+    if( length < 30 ) then
+        return 0;
+    end
+
     local avg_deceleration = 1.9
     local avg_acceleration = 2.78
     -- assuming constant acceleration for simplicity
@@ -625,13 +636,17 @@ end
 function turn_function(angle, turn_properties, intersection_properties, approach_segment, exit_segment)
   local turning_speed = getTurningSpeed(turn_properties,intersection_properties,approach_segment,exit_segment)
 
-  local penalty = getDeltaTime(approach_segment.speed_in_meters_per_second-turning_speed)
-                  + getDeltaTime(exit_segment.speed_in_meters_per_second-turning_speed)
+  local penalty = getDeltaTime(approach_segment.speed_in_meters_per_second-turning_speed, approach_segment.length_in_meters)
+                  + getDeltaTime(exit_segment.speed_in_meters_per_second-turning_speed, exit_segment.length_in_meters)
 
   if turn_properties.angle>=0 then
     penalty = turn_penalty / (1 + 2.718 ^ - ((13 / turn_bias) * angle/180 - 6.5*turn_bias))
   else
     penalty = turn_penalty / (1 + 2.718 ^  - ((13 * turn_bias) * - angle/180 - 6.5/turn_bias))
+  end
+
+  if intersection_properties.give_way then
+      penalty = penalty + stop_sign_penalty;
   end
 
   -- we make announced turns more expensive while, at the same time, we reduce the cost of suppressed turns

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -605,8 +605,6 @@ function way_function (way, result)
   result.is_startpoint = result.forward_mode == mode.driving or result.backward_mode == mode.driving
 end
 
--- a detailed turn function as an alternative to turn function, offering more properties to decide on a good penalty
--- returns penalty in seconds
 function turn_function(angle, turn_properties, intersection_properties, approach_segment, exit_segment)
   local penalty = 0;
   if turn_properties.angle>=0 then

--- a/profiles/turnbot.lua
+++ b/profiles/turnbot.lua
@@ -3,7 +3,7 @@
 
 require 'testbot'
 
-function turn_function (angle)
+function turn_function (angle, approach_road_speed, exit_road_speed)
     -- multiplying by 10 converts to deci-seconds see issue #1318
     return 10*20*math.abs(angle)/180
 end

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1,3 +1,5 @@
+#include "util/debug.hpp"
+
 #include "extractor/guidance/turn_instruction.hpp"
 #include "engine/guidance/post_processing.hpp"
 
@@ -653,6 +655,7 @@ std::vector<RouteStep> removeNoTurnInstructions(std::vector<RouteStep> steps)
 // that we come across.
 std::vector<RouteStep> postProcess(std::vector<RouteStep> steps)
 {
+    util::guidance::print(steps);
     // the steps should always include the first/last step in form of a location
     BOOST_ASSERT(steps.size() >= 2);
     if (steps.size() == 2)

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -1,5 +1,6 @@
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/edge_based_edge.hpp"
+#include "extractor/turn_penalty.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/exception.hpp"
@@ -367,7 +368,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
         progress.PrintStatus(node_u);
         for (const EdgeID edge_from_u : m_node_based_graph->GetAdjacentEdgeRange(node_u))
         {
-            if (m_node_based_graph->GetEdgeData(edge_from_u).reversed)
+            const auto &data_from_u = m_node_based_graph->GetEdgeData(edge_from_u);
+            if (data_from_u.reversed)
             {
                 continue;
             }
@@ -417,25 +419,62 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
             }(turn_classification.second);
             bearing_class_by_node_based_node[node_v] = bearing_class_id;
 
+            const bool crosses_traffic_light =
+                m_traffic_lights.find(node_v) != m_traffic_lights.end();
+
+            bool crosses_through_traffic = false;
+            const EdgeData &edge_data_from_u = m_node_based_graph->GetEdgeData(edge_from_u);
+            const TurnSegment approach_segment = {static_cast<double>(edge_data_from_u.distance),
+                                                  static_cast<double>(edge_data_from_u.distance)};
+            const IntersectionProperties intersection_properties = {
+                crosses_traffic_light, false, false};
             for (const auto turn : possible_turns)
             {
                 // only add an edge if turn is not prohibited
-                const EdgeData &edge_data1 = m_node_based_graph->GetEdgeData(edge_from_u);
+
                 const EdgeData &edge_data2 = m_node_based_graph->GetEdgeData(turn.eid);
 
-                BOOST_ASSERT(edge_data1.edge_id != edge_data2.edge_id);
-                BOOST_ASSERT(!edge_data1.reversed);
+                BOOST_ASSERT(edge_data_from_u.edge_id != edge_data2.edge_id);
+                BOOST_ASSERT(!edge_data_from_u.reversed);
                 BOOST_ASSERT(!edge_data2.reversed);
 
                 // the following is the core of the loop.
-                unsigned distance = edge_data1.distance;
-                if (m_traffic_lights.find(node_v) != m_traffic_lights.end())
+                unsigned distance = edge_data_from_u.distance;
+
+                if (crosses_traffic_light)
                 {
                     distance += profile_properties.traffic_signal_penalty;
                 }
 
-                const int32_t turn_penalty =
-                    scripting_environment.GetTurnPenalty(180. - turn.angle);
+                distance += turn_penalty;
+
+                if (crosses_through_traffic)
+                    distance += profile_properties.crossing_through_traffic_penalty;
+
+                // a through street is an obvious turn on which we can expect traffic coming onto
+                // our direction
+                const auto isThrough = [&](const guidance::TurnOperation &turn) {
+                    if (!((turn.instruction.type == guidance::TurnType::Suppressed) ||
+                          (turn.instruction.type == guidance::TurnType::NewName) ||
+                          (turn.instruction.type == guidance::TurnType::Notification)))
+                        return false;
+                    auto eid = m_node_based_graph->FindEdge(m_node_based_graph->GetTarget(turn.eid),
+                                                            node_v);
+                    if (eid == SPECIAL_EDGEID)
+                        return false;
+                    return !m_node_based_graph->GetEdgeData(eid).reversed;
+                };
+
+                const bool requires_announcement = isThrough(turn);
+
+                const TurnProperties turn_properties = {
+                    180. - turn.angle, turn.angle, crosses_through_traffic, requires_announcement};
+
+                const TurnSegment exit_segment = {static_cast<double>(edge_data2.distance),
+                                                  static_cast<double>(edge_data2.distance)};
+
+                const int32_t turn_penalty = scripting_environment.GetTurnPenalty(
+                    turn_properties, intersection_properties, approach_segment, exit_segment);
                 const auto turn_instruction = turn.instruction;
 
                 if (turn_instruction.direction_modifier == guidance::DirectionModifier::UTurn)
@@ -445,26 +484,31 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
                 distance += turn_penalty;
 
-                const bool is_encoded_forwards = m_compressed_edge_container.HasZippedEntryForForwardID(edge_from_u);
-                const bool is_encoded_backwards = m_compressed_edge_container.HasZippedEntryForReverseID(edge_from_u);
+                // if a turn is a through turn, all following turns are crossing through the
+                // opposite traffic
+                if (isThrough(turn))
+                    crosses_through_traffic = true;
+
+                const bool is_encoded_forwards =
+                    m_compressed_edge_container.HasZippedEntryForForwardID(edge_from_u);
+                const bool is_encoded_backwards =
+                    m_compressed_edge_container.HasZippedEntryForReverseID(edge_from_u);
                 BOOST_ASSERT(is_encoded_forwards || is_encoded_backwards);
-                if (is_encoded_forwards) {
-                    original_edge_data_vector.emplace_back(
-                        GeometryID{m_compressed_edge_container.GetZippedPositionForForwardID(edge_from_u), true},
-                        edge_data1.name_id,
-                        turn.lane_data_id,
-                        turn_instruction,
-                        entry_class_id,
-                        edge_data1.travel_mode);
-                } else if (is_encoded_backwards) {
-                    original_edge_data_vector.emplace_back(
-                        GeometryID{m_compressed_edge_container.GetZippedPositionForReverseID(edge_from_u), false},
-                        edge_data1.name_id,
-                        turn.lane_data_id,
-                        turn_instruction,
-                        entry_class_id,
-                        edge_data1.travel_mode);
-                }
+
+                const auto geometry_id =
+                    is_encoded_forwards
+                        ? GeometryID{m_compressed_edge_container.GetZippedPositionForForwardID(
+                                         edge_from_u),
+                                     true}
+                        : GeometryID{m_compressed_edge_container.GetZippedPositionForReverseID(
+                                         edge_from_u),
+                                     false};
+                original_edge_data_vector.emplace_back(geometry_id,
+                                                       edge_data1.name_id,
+                                                       turn.lane_data_id,
+                                                       turn_instruction,
+                                                       entry_class_id,
+                                                       edge_data1.travel_mode);
 
                 ++original_edges_counter;
 
@@ -473,12 +517,12 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     FlushVectorToStream(edge_data_file, original_edge_data_vector);
                 }
 
-                BOOST_ASSERT(SPECIAL_NODEID != edge_data1.edge_id);
+                BOOST_ASSERT(SPECIAL_NODEID != edge_data_from_u.edge_id);
                 BOOST_ASSERT(SPECIAL_NODEID != edge_data2.edge_id);
 
                 // NOTE: potential overflow here if we hit 2^32 routable edges
                 BOOST_ASSERT(m_edge_based_edge_list.size() <= std::numeric_limits<NodeID>::max());
-                m_edge_based_edge_list.emplace_back(edge_data1.edge_id,
+                m_edge_based_edge_list.emplace_back(edge_data_from_u.edge_id,
                                                     edge_data2.edge_id,
                                                     m_edge_based_edge_list.size(),
                                                     distance,
@@ -489,9 +533,10 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                 // the node-based edges that are originally used to calculate the `distance`
                 // for the edge-expanded edges.  About 40 lines back, there is:
                 //
-                //                 unsigned distance = edge_data1.distance;
+                //                 unsigned distance = edge_data_from_u.distance;
                 //
-                // This tells us that the weight for an edge-expanded-edge is based on the weight
+                // This tells us that the weight for an edge-expanded-edge is based on the
+                // weight
                 // of the *source* node-based edge.  Therefore, we will look up the individual
                 // segments of the source node-based edge, and write out a mapping between
                 // those and the edge-based-edge ID.
@@ -549,7 +594,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                         m_node_info_list[m_compressed_edge_container.GetFirstEdgeTargetID(
                             turn.eid)];
 
-                    const unsigned fixed_penalty = distance - edge_data1.distance;
+                    const unsigned fixed_penalty = distance - edge_data_from_u.distance;
                     lookup::PenaltyBlock penaltyblock = {
                         fixed_penalty, from_node.node_id, via_node.node_id, to_node.node_id};
                     edge_penalty_file.write(reinterpret_cast<const char *>(&penaltyblock),

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -348,8 +348,6 @@ void EdgeBasedGraphFactory::ComputeTurnFunctionParameters(
         // even though we might need to announce lanes, but it's still going straight on a major
         // road. Penalising these would be going into the opposite of what we want
         (instruction.type == guidance::TurnType::UseLane) ||
-        // don't double penalise collapse segments
-        (approach_segment.length_in_meters <= 30) ||
         leavesRoundabout(instruction); // don't penalise roundabouts twice
 
     const auto is_through = [&]() {
@@ -363,7 +361,13 @@ void EdgeBasedGraphFactory::ComputeTurnFunctionParameters(
     }();
 
     const double radius = 0;
-    turn_properties = {180 - angle, radius, crosses_through_traffic, !is_silent, is_through};
+    turn_properties = {180 - angle,
+                       radius,
+                       crosses_through_traffic,
+                       !is_silent,
+                       is_through,
+                       instruction.type == guidance::TurnType::OnRamp,
+                       instruction.type == guidance::TurnType::OffRamp};
 
     const bool crosses_traffic_light =
         m_traffic_lights.find(intersection_node) != m_traffic_lights.end();

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -225,7 +225,6 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
     // check whether the obvious choice is actually a through street
     if (obvious_index != 0)
     {
-        std::cout << "Obvious:" << obvious_index << std::endl;
         intersection[obvious_index].turn.instruction =
             getInstructionForObvious(intersection.size(),
                                      via_edge,

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -225,6 +225,7 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
     // check whether the obvious choice is actually a through street
     if (obvious_index != 0)
     {
+        std::cout << "Obvious:" << obvious_index << std::endl;
         intersection[obvious_index].turn.instruction =
             getInstructionForObvious(intersection.size(),
                                      via_edge,

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -213,7 +213,7 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
              .def_readonly("requires_announcement", &TurnProperties::requires_announcement),
 
          luabind::class_<IntersectionProperties>("IntersectionProperties")
-             .def_readonly("traffic_light", &IntersectionProperties::traffic_light)
+             .def_readonly("regulated", &IntersectionProperties::regulated)
              .def_readonly("give_way", &IntersectionProperties::give_way)
              .def_readonly("right_of_way", &IntersectionProperties::right_of_way),
 

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -374,11 +374,11 @@ void LuaScriptingEnvironment::SetupSources()
     }
 }
 
-std::int32_t LuaScriptingEnvironment::GetTurnPenalty(
-    const TurnProperties &turn_properties,
-    const IntersectionProperties &intersection_properties,
-    const TurnSegment &approach_segment,
-    const TurnSegment &exit_segment)
+std::int32_t
+LuaScriptingEnvironment::GetTurnPenalty(const TurnProperties &turn_properties,
+                                        const IntersectionProperties &intersection_properties,
+                                        const TurnSegment &approach_segment,
+                                        const TurnSegment &exit_segment)
 {
     auto &context = GetLuaContext();
     if (context.has_turn_penalty_function)
@@ -388,13 +388,13 @@ std::int32_t LuaScriptingEnvironment::GetTurnPenalty(
         {
             // call lua profile to compute turn penalty
             const double penalty =
-                10.0 * luabind::call_function<double>(context.state,
-                                                      "turn_function",
-                                                      turn_properties.angle,
-                                                      boost::cref(turn_properties),
-                                                      boost::cref(intersection_properties),
-                                                      boost::cref(approach_segment),
-                                                      boost::cref(exit_segment));
+                luabind::call_function<double>(context.state,
+                                               "turn_function",
+                                               turn_properties.angle,
+                                               boost::cref(turn_properties),
+                                               boost::cref(intersection_properties),
+                                               boost::cref(approach_segment),
+                                               boost::cref(exit_segment));
             BOOST_ASSERT(penalty < std::numeric_limits<int32_t>::max());
             BOOST_ASSERT(penalty > std::numeric_limits<int32_t>::min());
             return boost::numeric_cast<int32_t>(penalty);

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -209,6 +209,9 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
          luabind::class_<TurnProperties>("TurnProperties")
              .def_readonly("angle", &TurnProperties::angle)
              .def_readonly("radius", &TurnProperties::radius)
+             .def_readonly("on_ramp", &TurnProperties::on_ramp)
+             .def_readonly("off_ramp", &TurnProperties::off_ramp)
+             .def_readonly("through_street", &TurnProperties::is_through_street)
              .def_readonly("crossing_through_traffic", &TurnProperties::crossing_through_traffic)
              .def_readonly("requires_announcement", &TurnProperties::requires_announcement),
 

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -214,7 +214,7 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
 
          luabind::class_<IntersectionProperties>("IntersectionProperties")
              .def_readonly("traffic_light", &IntersectionProperties::traffic_light)
-             .def_readonly("stop_sign", &IntersectionProperties::stop_sign)
+             .def_readonly("give_way", &IntersectionProperties::give_way)
              .def_readonly("right_of_way", &IntersectionProperties::right_of_way),
 
          luabind::class_<TurnSegment>("TurnSegment")

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -395,6 +395,8 @@ std::int32_t LuaScriptingEnvironment::GetTurnPenalty(
                                                       boost::cref(intersection_properties),
                                                       boost::cref(approach_segment),
                                                       boost::cref(exit_segment));
+            BOOST_ASSERT(penalty < std::numeric_limits<int32_t>::max());
+            BOOST_ASSERT(penalty > std::numeric_limits<int32_t>::min());
             return boost::numeric_cast<int32_t>(penalty);
         }
         catch (const luabind::error &er)

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -191,6 +191,7 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
                        &ExtractionWay::get_backward_mode,
                        &ExtractionWay::set_backward_mode),
          luabind::class_<osmium::WayNodeList>("WayNodeList").def(luabind::constructor<>()),
+
          luabind::class_<osmium::NodeRef>("NodeRef")
              .def(luabind::constructor<>())
              // Dear ambitious reader: registering .location() as in:
@@ -198,22 +199,43 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
              // will crash at runtime, since we're not (yet?) using libosnmium's
              // NodeLocationsForWays cache
              .def("id", &osmium::NodeRef::ref),
+
          luabind::class_<osmium::Way>("Way")
              .def("get_value_by_key", &osmium::Way::get_value_by_key)
              .def("get_value_by_key", &get_value_by_key<osmium::Way>)
              .def("id", &osmium::Way::id)
              .def("get_nodes", get_nodes_for_way, luabind::return_stl_iterator),
+
+         luabind::class_<TurnProperties>("TurnProperties")
+             .def_readonly("angle", &TurnProperties::angle)
+             .def_readonly("radius", &TurnProperties::radius)
+             .def_readonly("crossing_through_traffic", &TurnProperties::crossing_through_traffic)
+             .def_readonly("requires_announcement", &TurnProperties::requires_announcement),
+
+         luabind::class_<IntersectionProperties>("IntersectionProperties")
+             .def_readonly("traffic_light", &IntersectionProperties::traffic_light)
+             .def_readonly("stop_sign", &IntersectionProperties::stop_sign)
+             .def_readonly("right_of_way", &IntersectionProperties::right_of_way),
+
+         luabind::class_<TurnSegment>("TurnSegment")
+             .def_readonly("length_in_meters", &TurnSegment::length_in_meters)
+             .def_readonly("speed_in_meters_per_second", &TurnSegment::speed_in_meters_per_second),
+
          luabind::class_<InternalExtractorEdge>("EdgeSource")
              .def_readonly("source_coordinate", &InternalExtractorEdge::source_coordinate)
              .def_readwrite("weight_data", &InternalExtractorEdge::weight_data),
+
          luabind::class_<InternalExtractorEdge::WeightData>("WeightData")
              .def_readwrite("speed", &InternalExtractorEdge::WeightData::speed),
+
          luabind::class_<ExternalMemoryNode>("EdgeTarget")
              .property("lon", &lonToDouble<ExternalMemoryNode>)
              .property("lat", &latToDouble<ExternalMemoryNode>),
+
          luabind::class_<util::Coordinate>("Coordinate")
              .property("lon", &lonToDouble<util::Coordinate>)
              .property("lat", &latToDouble<util::Coordinate>),
+
          luabind::class_<RasterDatum>("RasterDatum")
              .def_readonly("datum", &RasterDatum::datum)
              .def("invalid_data", &RasterDatum::get_invalid)];
@@ -230,6 +252,8 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
     }
 
     context.has_turn_penalty_function = util::luaFunctionExists(context.state, "turn_function");
+    context.has_detailed_penalty_function =
+        util::luaFunctionExists(context.state, "detailed_turn_function");
     context.has_node_function = util::luaFunctionExists(context.state, "node_function");
     context.has_way_function = util::luaFunctionExists(context.state, "way_function");
     context.has_segment_function = util::luaFunctionExists(context.state, "segment_function");
@@ -350,7 +374,11 @@ void LuaScriptingEnvironment::SetupSources()
     }
 }
 
-int32_t LuaScriptingEnvironment::GetTurnPenalty(const double angle)
+std::int32_t LuaScriptingEnvironment::GetTurnPenalty(
+    const TurnProperties &turn_properties,
+    const IntersectionProperties &intersection_properties,
+    const TurnSegment &approach_segment,
+    const TurnSegment &exit_segment)
 {
     auto &context = GetLuaContext();
     if (context.has_turn_penalty_function)
@@ -360,9 +388,13 @@ int32_t LuaScriptingEnvironment::GetTurnPenalty(const double angle)
         {
             // call lua profile to compute turn penalty
             const double penalty =
-                luabind::call_function<double>(context.state, "turn_function", angle);
-            BOOST_ASSERT(penalty < std::numeric_limits<int32_t>::max());
-            BOOST_ASSERT(penalty > std::numeric_limits<int32_t>::min());
+                10.0 * luabind::call_function<double>(context.state,
+                                                      "turn_function",
+                                                      turn_properties.angle,
+                                                      boost::cref(turn_properties),
+                                                      boost::cref(intersection_properties),
+                                                      boost::cref(approach_segment),
+                                                      boost::cref(exit_segment));
             return boost::numeric_cast<int32_t>(penalty);
         }
         catch (const luabind::error &er)

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -28,6 +28,10 @@ bool circleCenterTaubin(const std::vector<Coordinate> &coords,
                         std::pair<double, double> &center,
                         double &estimated_radius)
 {
+    // guard against empty coordinates
+    if( coords.empty() )
+        return false;
+
     // Compute mean and covariances with the two-pass algorithm
     double meanX = 0., meanY = 0.;
     for (const auto &c : coords)
@@ -279,16 +283,6 @@ double computeAngle(const Coordinate first, const Coordinate second, const Coord
 
     BOOST_ASSERT(angle >= 0);
     return angle;
-}
-
-double circleRadius(const Coordinate C1, const Coordinate C2, const Coordinate C3)
-{
-    // a circle by three points requires thee distinct points
-    auto center = circleCenter(C1, C2, C3);
-    if (center)
-        return haversineDistance(C1, *center);
-    else
-        return std::numeric_limits<double>::infinity();
 }
 
 boost::optional<Coordinate> circleCenter(const std::vector<Coordinate> &coords)

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -91,7 +91,7 @@ bool circleCenterTaubin(const std::vector<Coordinate> &coords,
             break;
 
         const auto ynew = c0 + xnew * (c1 + xnew * (c2 + xnew * c3));
-        if (abs(ynew) >= abs(y))
+        if (std::abs(ynew) >= std::abs(y))
             break;
 
         x = xnew;

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -18,6 +18,102 @@ namespace util
 namespace coordinate_calculation
 {
 
+namespace
+{
+/// Newton-based Taubin circle algebraic fit in a plain.
+/// Chernov, N. Circular and Linear Regression: Fitting Circles and Lines by Least Squares, 2010
+/// Chapter 5.10 Implementation of the Taubin fit, p. 126
+/// Original code http://people.cas.uab.edu/~mosya/cl/CircleFitByTaubin.cpp
+bool circleCenterTaubin(const std::vector<Coordinate> &coords,
+                        std::pair<double, double> &center,
+                        double &estimated_radius)
+{
+    // Compute mean and covariances with the two-pass algorithm
+    double meanX = 0., meanY = 0.;
+    for (const auto &c : coords)
+    {
+        // Use the equirectangular projection
+        const auto x = static_cast<double>(toFloating(c.lon));
+        const auto y = static_cast<double>(toFloating(c.lat));
+        meanX += x;
+        meanY += y;
+    }
+    meanX /= coords.size();
+    meanY /= coords.size();
+
+    // Compute moments for centered x, y and z = x^2+y^2 coordinates
+    double Mxx = 0., Myy = 0., Mxy = 0., Mxz = 0., Myz = 0., Mzz = 0.;
+    for (auto &c : coords)
+    {
+        const auto Xi = static_cast<double>(toFloating(c.lon)) - meanX;
+        const auto Yi = static_cast<double>(toFloating(c.lat)) - meanY;
+        const auto Zi = Xi * Xi + Yi * Yi;
+
+        Mxx += Xi * Xi;
+        Myy += Yi * Yi;
+        Mzz += Zi * Zi;
+        Mxy += Xi * Yi;
+        Mxz += Xi * Zi;
+        Myz += Yi * Zi;
+    }
+
+    Mxx /= coords.size();
+    Myy /= coords.size();
+    Mxy /= coords.size();
+    Mxz /= coords.size();
+    Myz /= coords.size();
+    Mzz /= coords.size();
+
+    // Compute coefficients of the characteristic polynomial
+    const auto Mz = Mxx + Myy;
+    const auto cov_xy = Mxx * Myy - Mxy * Mxy;
+    const auto var_z = Mzz - Mz * Mz;
+    const auto c3 = 4. * Mz;
+    const auto c2 = -3. * Mz * Mz - Mzz;
+    const auto c1 = var_z * Mz + 4. * cov_xy * Mz - Mxz * Mxz - Myz * Myz;
+    const auto c0 = Mxz * (Mxz * Myy - Myz * Mxy) + Myz * (Myz * Mxx - Mxz * Mxy) - var_z * cov_xy;
+
+    // Find the root of the characteristic polynomial using Newton's method starting at x=0.
+    // It is guaranteed to converge to the smallest characteristic value
+    double x = 0., y = c0;
+    const auto eps = sqrt(std::numeric_limits<double>::epsilon());
+    for (int iter = 0; iter < 5; ++iter)
+    {
+        const auto dy = c1 + x * (2. * c2 + 3. * c3 * x);
+        const auto xnew = x - y / dy;
+        if (!std::isfinite(xnew))
+            return false;
+        if (std::abs(xnew - x) < eps)
+            break;
+
+        const auto ynew = c0 + xnew * (c1 + xnew * (c2 + xnew * c3));
+        if (abs(ynew) >= abs(y))
+            break;
+
+        x = xnew;
+        y = ynew;
+    }
+
+    // Computing parameters of the fitting circle
+    const auto det = x * x - x * Mz + cov_xy;
+    // Check if line is fitted
+    if (det == 0.)
+        return false;
+
+    const auto centerX = (Mxz * (Myy - x) - Myz * Mxy) / det / 2.0; // a = -B/2/A
+    const auto centerY = (Myz * (Mxx - x) - Mxz * Mxy) / det / 2.0; // b = -C/2/A
+
+    // Translate the center
+    center.first = meanX + centerX;
+    center.second = meanY + centerY;
+
+    // R^2 = (B^2 + C^2 - 4AD) / (4A^2) (3.11), D = -A Mz (5.49)
+    estimated_radius = std::sqrt(centerX * centerX + centerY * centerY + Mz);
+
+    return true;
+}
+} // namespace
+
 // Does not project the coordinates!
 std::uint64_t squaredEuclideanDistance(const Coordinate lhs, const Coordinate rhs)
 {
@@ -185,86 +281,6 @@ double computeAngle(const Coordinate first, const Coordinate second, const Coord
     return angle;
 }
 
-boost::optional<Coordinate>
-circleCenter(const Coordinate C1, const Coordinate C2, const Coordinate C3)
-{
-    // free after http://paulbourke.net/geometry/circlesphere/
-    // require three distinct points
-    if (C1 == C2 || C2 == C3 || C1 == C3)
-    {
-        return boost::none;
-    }
-
-    // define line through c1, c2 and c2,c3
-    const double C2C1_lat = static_cast<double>(toFloating(C2.lat - C1.lat)); // yDelta_a
-    const double C2C1_lon = static_cast<double>(toFloating(C2.lon - C1.lon)); // xDelta_a
-    const double C3C2_lat = static_cast<double>(toFloating(C3.lat - C2.lat)); // yDelta_b
-    const double C3C2_lon = static_cast<double>(toFloating(C3.lon - C2.lon)); // xDelta_b
-
-    // check for collinear points in X-Direction / Y-Direction
-    if ((std::abs(C2C1_lon) < std::numeric_limits<double>::epsilon() &&
-         std::abs(C3C2_lon) < std::numeric_limits<double>::epsilon()) ||
-        (std::abs(C2C1_lat) < std::numeric_limits<double>::epsilon() &&
-         std::abs(C3C2_lat) < std::numeric_limits<double>::epsilon()))
-    {
-        return boost::none;
-    }
-    else if (std::abs(C2C1_lon) < std::numeric_limits<double>::epsilon())
-    {
-        // vertical line C2C1
-        // due to c1.lon == c2.lon && c1.lon != c3.lon we can rearrange this way
-        BOOST_ASSERT(std::abs(static_cast<double>(toFloating(C3.lon - C1.lon))) >=
-                         std::numeric_limits<double>::epsilon() &&
-                     std::abs(static_cast<double>(toFloating(C2.lon - C3.lon))) >=
-                         std::numeric_limits<double>::epsilon());
-        return circleCenter(C1, C3, C2);
-    }
-    else if (std::abs(C3C2_lon) < std::numeric_limits<double>::epsilon())
-    {
-        // vertical line C3C2
-        // due to c2.lon == c3.lon && c1.lon != c3.lon we can rearrange this way
-        // after rearrangement both deltas will be zero
-        BOOST_ASSERT(std::abs(static_cast<double>(toFloating(C1.lon - C2.lon))) >=
-                         std::numeric_limits<double>::epsilon() &&
-                     std::abs(static_cast<double>(toFloating(C3.lon - C1.lon))) >=
-                         std::numeric_limits<double>::epsilon());
-        return circleCenter(C2, C1, C3);
-    }
-    else
-    {
-        const double C2C1_slope = C2C1_lat / C2C1_lon;
-        const double C3C2_slope = C3C2_lat / C3C2_lon;
-
-        if (std::abs(C2C1_slope) < std::numeric_limits<double>::epsilon())
-        {
-            // Three non-collinear points with C2,C1 on same latitude.
-            // Due to the x-values correct, we can swap C3 and C1 to obtain the correct slope value
-            return circleCenter(C3, C2, C1);
-        }
-        // valid slope values for both lines, calculate the center as intersection of the lines
-
-        // can this ever happen?
-        if (std::abs(C2C1_slope - C3C2_slope) < std::numeric_limits<double>::epsilon())
-            return boost::none;
-
-        const double C1_y = static_cast<double>(toFloating(C1.lat));
-        const double C1_x = static_cast<double>(toFloating(C1.lon));
-        const double C2_y = static_cast<double>(toFloating(C2.lat));
-        const double C2_x = static_cast<double>(toFloating(C2.lon));
-        const double C3_y = static_cast<double>(toFloating(C3.lat));
-        const double C3_x = static_cast<double>(toFloating(C3.lon));
-
-        const double lon = (C2C1_slope * C3C2_slope * (C1_y - C3_y) + C3C2_slope * (C1_x + C2_x) -
-                            C2C1_slope * (C2_x + C3_x)) /
-                           (2 * (C3C2_slope - C2C1_slope));
-        const double lat = (0.5 * (C1_x + C2_x) - lon) / C2C1_slope + 0.5 * (C1_y + C2_y);
-        if (lon < -180.0 || lon > 180.0 || lat < -90.0 || lat > 90.0)
-            return boost::none;
-        else
-            return Coordinate(FloatLongitude{lon}, FloatLatitude{lat});
-    }
-}
-
 double circleRadius(const Coordinate C1, const Coordinate C2, const Coordinate C3)
 {
     // a circle by three points requires thee distinct points
@@ -273,6 +289,49 @@ double circleRadius(const Coordinate C1, const Coordinate C2, const Coordinate C
         return haversineDistance(C1, *center);
     else
         return std::numeric_limits<double>::infinity();
+}
+
+boost::optional<Coordinate> circleCenter(const std::vector<Coordinate> &coords)
+{
+    std::pair<double, double> center;
+    double radius;
+
+    if (!circleCenterTaubin(coords, center, radius))
+        return boost::none;
+
+    const double lon = center.first, lat = center.second;
+    if (lon < -180.0 || lon > 180.0 || lat < -90.0 || lat > 90.0)
+        return boost::none;
+    else
+        return Coordinate(FloatLongitude{lon}, FloatLatitude{lat});
+}
+
+double circleRadius(const std::vector<Coordinate> &coords)
+{
+    switch (coords.size())
+    {
+    case 0:
+        return std::numeric_limits<double>::quiet_NaN();
+    case 1:
+        return 0.;
+    case 2:
+        return 0.5 * haversineDistance(coords[0], coords[1]);
+    default:
+        break;
+    }
+
+    std::pair<double, double> center;
+    double radius;
+
+    if (!circleCenterTaubin(coords, center, radius))
+        return std::numeric_limits<double>::infinity();
+
+    const double lon = center.first, lat = center.second;
+    if (lon < -180.0 || lon > 180.0 || lat < -90.0 || lat > 90.0)
+        return std::numeric_limits<double>::infinity();
+
+    // The estimated radius corresponds to the arc angle in degrees, convert it to meters
+    return radius * detail::DEGREE_TO_RAD * detail::EARTH_RADIUS;
 }
 
 Coordinate interpolateLinear(double factor, const Coordinate from, const Coordinate to)

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -311,4 +311,122 @@ BOOST_AUTO_TEST_CASE(circleCenter)
     BOOST_CHECK(!result);
 }
 
+BOOST_AUTO_TEST_CASE(circleCenterFit)
+{
+    const auto dist_eps = .5; // relative difference 0.5%
+    auto dist = [](const Coordinate &x, const std::vector<Coordinate> &p) {
+        return coordinate_calculation::haversineDistance(
+            x, *coordinate_calculation::circleCenter(p[0], p[1], p[2]));
+    };
+
+    std::vector<Coordinate> p{{FloatLongitude{-100.}, FloatLatitude{10.}},
+                              {FloatLongitude{-100.002}, FloatLatitude{10.001}},
+                              {FloatLongitude{-100.001}, FloatLatitude{10.002}}};
+    auto result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(result);
+    BOOST_CHECK_SMALL(dist(*result, p), dist_eps);
+
+    // Co-linear longitude
+    p = std::vector<Coordinate>{{FloatLongitude{-100.}, FloatLatitude{10.}},
+                                {FloatLongitude{-100.001}, FloatLatitude{10.001}},
+                                {FloatLongitude{-100.001}, FloatLatitude{10.002}}};
+    result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(result);
+    BOOST_CHECK_SMALL(dist(*result, p), dist_eps);
+
+    // Co-linear longitude, impossible to calculate
+    p = std::vector<Coordinate>{{FloatLongitude{-100.001}, FloatLatitude{10.}},
+                                {FloatLongitude{-100.001}, FloatLatitude{10.001}},
+                                {FloatLongitude{-100.001}, FloatLatitude{10.002}}};
+    result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(!result);
+
+    // Co-linear latitude, this is a real case that failed
+    p = std::vector<Coordinate>{{FloatLongitude{-112.096234}, FloatLatitude{41.147101}},
+                                {FloatLongitude{-112.096606}, FloatLatitude{41.147101}},
+                                {FloatLongitude{-112.096419}, FloatLatitude{41.147259}}};
+    result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(result);
+    BOOST_CHECK_SMALL(dist(*result, p), dist_eps);
+
+    // Co-linear latitude, variation
+    p = std::vector<Coordinate>{{FloatLongitude{-112.096234}, FloatLatitude{41.147101}},
+                                {FloatLongitude{-112.096606}, FloatLatitude{41.147259}},
+                                {FloatLongitude{-112.096419}, FloatLatitude{41.147259}}};
+    result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(result);
+    BOOST_CHECK_SMALL(dist(*result, p), dist_eps);
+
+    // Co-linear latitude, impossible to calculate
+    p = std::vector<Coordinate>{{FloatLongitude{-112.096234}, FloatLatitude{41.147259}},
+                                {FloatLongitude{-112.096606}, FloatLatitude{41.147259}},
+                                {FloatLongitude{-112.096419}, FloatLatitude{41.147259}}};
+    result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(!result);
+
+    // Out of bounds
+    p = std::vector<Coordinate>{{FloatLongitude{-112.096234}, FloatLatitude{41.147258}},
+                                {FloatLongitude{-112.106606}, FloatLatitude{41.147259}},
+                                {FloatLongitude{-113.096419}, FloatLatitude{41.147258}}};
+    result = coordinate_calculation::circleCenter(p);
+    BOOST_CHECK(!result);
+}
+
+BOOST_AUTO_TEST_CASE(circleRadiusFit)
+{
+    const auto meters_in_degree = coordinate_calculation::detail::DEGREE_TO_RAD *
+                                  coordinate_calculation::detail::EARTH_RADIUS;
+
+    std::vector<Coordinate> p;
+    BOOST_CHECK(!std::isfinite(coordinate_calculation::circleRadius(p)));
+
+    p = std::vector<Coordinate>{{FloatLongitude{-100.}, FloatLatitude{10.}}};
+    BOOST_CHECK_SMALL(coordinate_calculation::circleRadius(p), 1e-8);
+
+    p = std::vector<Coordinate>{{FloatLongitude{-100.}, FloatLatitude{10.}},
+                                {FloatLongitude{-100.002}, FloatLatitude{10.001}}};
+    BOOST_CHECK_CLOSE(0.5 * coordinate_calculation::haversineDistance(p[0], p[1]),
+                      coordinate_calculation::circleRadius(p),
+                      1e-6);
+
+    p = std::vector<Coordinate>{{FloatLongitude{-100.}, FloatLatitude{10.}},
+                                {FloatLongitude{-100.002}, FloatLatitude{10.001}},
+                                {FloatLongitude{-100.001}, FloatLatitude{10.002}}};
+    BOOST_CHECK_CLOSE(coordinate_calculation::circleRadius(p[0], p[1], p[2]),
+                      coordinate_calculation::circleRadius(p),
+                      1.);
+
+    p = std::vector<Coordinate>{{FloatLongitude{-1.}, FloatLatitude{-1.}},
+                                {FloatLongitude{0.}, FloatLatitude{0.}},
+                                {FloatLongitude{1.}, FloatLatitude{1.}}};
+    BOOST_CHECK(!std::isfinite(coordinate_calculation::circleRadius(p)));
+
+    p = std::vector<Coordinate>{{FloatLongitude{-1.}, FloatLatitude{-1.}},
+                                {FloatLongitude{0.}, FloatLatitude{0.}},
+                                {FloatLongitude{1.}, FloatLatitude{1.001}}};
+    BOOST_CHECK(!std::isfinite(coordinate_calculation::circleRadius(p)));
+
+    p = std::vector<Coordinate>{{FloatLongitude{0.}, FloatLatitude{0.}},
+                                {FloatLongitude{3.}, FloatLatitude{0.}},
+                                {FloatLongitude{0.}, FloatLatitude{4.}}};
+    BOOST_CHECK_CLOSE(2.5 * meters_in_degree, coordinate_calculation::circleRadius(p), 1e-3);
+
+    p = std::vector<Coordinate>{{FloatLongitude{1.}, FloatLatitude{0.}},
+                                {FloatLongitude{0.}, FloatLatitude{1.}},
+                                {FloatLongitude{-1.}, FloatLatitude{0.}},
+                                {FloatLongitude{0.}, FloatLatitude{-1.}}};
+    BOOST_CHECK_CLOSE(meters_in_degree, coordinate_calculation::circleRadius(p), 1e-3);
+
+    p = std::vector<Coordinate>{{FloatLongitude{5}, FloatLatitude{0}},
+                                {FloatLongitude{3}, FloatLatitude{1}},
+                                {FloatLongitude{6}, FloatLatitude{2}},
+                                {FloatLongitude{5}, FloatLatitude{3}},
+                                {FloatLongitude{7}, FloatLatitude{4}},
+                                {FloatLongitude{9}, FloatLatitude{5}},
+                                {FloatLongitude{12}, FloatLatitude{6}},
+                                {FloatLongitude{16}, FloatLatitude{7}}};
+    BOOST_CHECK_LT(10. * coordinate_calculation::circleRadius(p[0], p[1], p[2]),
+                   coordinate_calculation::circleRadius(p));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Testing PR, looking at penalising turns through traffic. This essentially adds an additional penalty to left turns if they are going through opposing traffic.

```
       d
       |
a ---- b ---- c
```

Would add an additional penalty for turning left `a-b-d` but not for `d-b-c`.
## Tasklist
- [ ] add regression / cucumber cases (see docs/testing.md)
- [ ] review
- [ ] adjust for for comments
