### PR TITLE
Fixes sign mismatch in Nearest limit comparison

### DIFF
--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <boost/assert.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 
 namespace osrm
 {
@@ -26,7 +27,8 @@ Status NearestPlugin::HandleRequest(const api::NearestParameters &params,
 {
     BOOST_ASSERT(params.IsValid());
 
-    if (params.number_of_results > max_results)
+    if (max_results > 0 &&
+        (boost::numeric_cast<std::int64_t>(params.number_of_results) > max_results))
     {
         return Error("TooBig",
                      "Number of results " + std::to_string(params.number_of_results) +


### PR DESCRIPTION
Compiling on the demo server just gave me an unsigned <-> signed comparison warning.

Turns out we're missing a cast here:

`number_of_results` is unsigned, `max_results` is signed.

Because unsigned wins by the standard `max_results` is converted to unsigned first and only then compared. That's why e.g. `2u > -1` is false.