### PR TITLE
Offset turn angle into +/-180 range correctly

### DIFF
--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -431,8 +431,9 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     distance += profile_properties.traffic_signal_penalty;
                 }
 
+                const auto turn_angle = turn.angle > 180 ? 180 - turn.angle : turn.angle;
                 const int32_t turn_penalty =
-                    scripting_environment.GetTurnPenalty(180. - turn.angle);
+                    scripting_environment.GetTurnPenalty(turn_angle);
                 const auto turn_instruction = turn.instruction;
 
                 if (turn_instruction.direction_modifier == guidance::DirectionModifier::UTurn)


### PR DESCRIPTION
# Issue

Fixes https://github.com/Project-OSRM/osrm-backend/issues/2918. Turn angles were being subtracted from 180 before being passed into the lua `turn_penalty` function, which is possibly how the the old `turn_penalty` function expected them (essentially flipped, as an angle of 0 became 180 and an angle of 180 became 0). The new function expects values between -180 and 180. 

h/t to @jakepruitt for help with debugging this

## Tasklist
 - [ ] add regression test
 - [ ] review
 - [ ] adjust for for comments

## Requirements / Relations
https://github.com/Project-OSRM/osrm-backend/milestone/16
