### PR TITLE
Handle All-Designated HOV Lanes (e.g. hov:lanes:forward=designated|designated)

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -156,6 +156,25 @@ Feature: Car - Restricted access
             | primary | yes        | x     |
             | primary | no         | x     |
 
+    Scenario: Car - a way with all lanes HOV-designated is inaccessible by default (similar to hov=designated)
+        Then routability should be
+            | highway | hov:lanes:forward      | hov:lanes:backward     | hov:lanes              | oneway | forw | backw |
+            | primary | designated             | designated             |                        |        |      |       |
+            | primary |                        | designated             |                        |        | x    |       |
+            | primary | designated             |                        |                        |        |      | x     |
+            | primary | designated\|designated | designated\|designated |                        |        |      |       |
+            | primary | designated\|no         | designated\|no         |                        |        | x    | x     |
+            | primary | yes\|no                | yes\|no                |                        |        | x    | x     |
+            | primary |                        |                        |                        |        | x    | x     |
+            | primary | designated             |                        |                        | -1     |      |       |
+            | primary |                        | designated             |                        | -1     |      | x     |
+            | primary |                        |                        | designated             | yes    |      |       |
+            | primary |                        |                        | designated             | -1     |      |       |
+            | primary |                        |                        | designated\|designated | yes    |      |       |
+            | primary |                        |                        | designated\|designated | -1     |      |       |
+            | primary |                        |                        | designated\|yes        | yes    | x    |       |
+            | primary |                        |                        | designated\|no         | -1     |      | x     |
+
      Scenario: Car - these toll roads always work
         Then routability should be
             | highway | toll        | bothw |

--- a/taginfo.json
+++ b/taginfo.json
@@ -63,6 +63,24 @@
             "description": "Roads with hov=designated are ignored by default."
         },
         {
+            "key": "hov:lanes",
+            "value": "designated",
+            "object_types": [ "way" ],
+            "description": "Roads with hov:lanes all-designated are ignored by default."
+        },
+        {
+            "key": "hov:lanes:forward",
+            "value": "designated",
+            "object_types": [ "way" ],
+            "description": "Roads with hov:lanes:forward all-designated are ignored by default."
+        },
+        {
+            "key": "hov:lanes:backward",
+            "value": "designated",
+            "object_types": [ "way" ],
+            "description": "Roads with hov:lanes:backward all-designated are ignored by default."
+        },
+        {
             "key": "toll",
             "value": "yes",
             "object_types": [ "way" ],


### PR DESCRIPTION
# Issue

This implements handling HOV-only lanes similarly to `hov=designated`. For more details, check https://github.com/Project-OSRM/osrm-backend/issues/2929.

## Tasklist
 - [x] review
 - [x] adjust for for comments

cc @willwhite 