### PR TITLE
Fix "Error: write after end" and removed @bug tags

### DIFF
--- a/features/guidance/advanced-lanes.feature
+++ b/features/guidance/advanced-lanes.feature
@@ -103,7 +103,7 @@ Feature: Turn Lane Guidance
             | a,j       | in,turn,other,other  | depart,turn right,turn left,arrive  | ,,left:true right:false,               |
             | a,i       | in,turn,other,other  | depart,turn right,turn right,arrive | ,,left:false right:true,               |
 
-    @todo @bug @2654 @none
+    @todo @2654 @none
     #https://github.com/Project-OSRM/osrm-backend/issues/2645
     #http://www.openstreetmap.org/export#map=19/52.56054/13.32152
     Scenario: Kurt-Schuhmacher-Damm
@@ -131,7 +131,7 @@ Feature: Turn Lane Guidance
             | a,f       | ,ksd,ksd | depart,turn left,arrive  | ,left:true none:true right:false, |
             | a,i       | ,ksd,ksd | depart,turn right,arrive | ,left:false none:true right:true, |
 
-    @todo @bug @2650 @sliproads
+    @todo @2650 @sliproads
     #market and haight in SF, restricted turn
     #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
     Scenario: Market/Haight without Through Street
@@ -177,7 +177,7 @@ Feature: Turn Lane Guidance
             | a,j       | ghough,market,market | depart,turn left,arrive            | ,none:true straight:false straight:false straight:false, |
             | a,f       | ghough,ghough,ghough | depart,continue slight left,arrive | ,none:true straight:true straight:false straight:false,  |
 
-    @todo @2650 @bug @sliproads
+    @todo @2650 @sliproads
     #market and haight in SF, unrestricted
     #http://www.openstreetmap.org/#map=19/37.77308/-122.42238
     Scenario: Market/Haight without Through Street

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -145,7 +145,6 @@ Feature: Turn Lane Guidance
             | a,c       | road,road      | depart,arrive           | ,                           |
 
     # This tests whether empty/invalid PSV tags cause osrm-extract to crash
-    @bug
     Scenario: Turn with Bus-Lane
         Given the node map
             | a |   | b |   | c |
@@ -181,7 +180,7 @@ Feature: Turn Lane Guidance
             | a,c       | road,road      | depart,arrive            |
 
     #turn lanes are often drawn at the incoming road, even though the actual turn requires crossing the intersection first
-    @todo @bug @collapse @partition-lanes
+    @todo @collapse @partition-lanes
     Scenario: Turn Lanes at Segregated Road
         Given the node map
             |   |   | i | l |   |   |
@@ -383,7 +382,7 @@ Feature: Turn Lane Guidance
             | a,f       | road,turn,turn   | depart,turn left,arrive  | ,left:true right:false, |
             | a,g       | road,right,right | depart,turn right,arrive | ,left:false right:true, |
 
-    @todo @bug @partition-lanes @previous-lanes
+    @todo @partition-lanes @previous-lanes
     Scenario: Narrowing Turn Lanes
         Given the node map
             |   |   |   |   | g |   |
@@ -428,7 +427,7 @@ Feature: Turn Lane Guidance
             | a,d       | road,road      | depart,arrive            | ,                           |
             | a,e       | road,turn,turn | depart,turn right,arrive | ,straight:false right:true, |
 
-    @bug @todo @roundabout
+    @todo @roundabout
     Scenario: Theodor Heuss Platz
         Given the node map
             |   |   |   | i | o |   |   | l |   |
@@ -555,7 +554,7 @@ Feature: Turn Lane Guidance
             | a,e       | road,road,road         | depart,turn uturn,arrive        | ,left:true left:false left:false straight:false straight:false, |
             | a,g       | road,straight,straight | depart,new name straight,arrive | ,left:false left:false left:false straight:true straight:true,  |
 
-    @bug @todo @roundabout
+    @todo @roundabout
     Scenario: Passing Through a Roundabout
         Given the node map
             |   |   | h |   | g |   |   |
@@ -864,7 +863,7 @@ Feature: Turn Lane Guidance
             | a,c       | ab,bc,bc  | depart,turn left,arrive | ,left:true right:false, |
 
     # http://www.openstreetmap.org/#map=19/47.97685/7.82933&layers=D
-    @bug @todo
+    @todo
     Scenario: Lane Parsing Issue #2706: None Assignments I
         Given the node map
             |   | f |   |   | j  |   |
@@ -904,7 +903,7 @@ Feature: Turn Lane Guidance
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
 
     # https://www.openstreetmap.org/#map=19/47.99257/7.83276&layers=D
-    @bug @todo
+    @todo
     Scenario: Lane Parsing Issue #2706: None Assignments II
         Given the node map
             |   | k | l |   |
@@ -939,7 +938,7 @@ Feature: Turn Lane Guidance
             | i,e ||||
             # Note: at the moment we don't care about routes, we care about the extract process triggering assertions
 
-    @bug @todo
+    @todo
     Scenario: Lane Parsing Issue #2706: None Assignments III - Minimal reproduction recipe
         Given the node map
             |   |   | l |   |

--- a/features/support/run.js
+++ b/features/support/run.js
@@ -44,7 +44,7 @@ module.exports = function () {
         // with lots of log output
         let child = child_process.execFile(cmd, opts, {maxBuffer: 1024 * 1024 * 1000, env: env}, callback);
         child.on('exit', function(code) {
-            log.end(util.format('*** %s exited with code %d\n', bin, code));
+            log.write(util.format('*** %s exited with code %d\n', bin, code));
         }.bind(this));
         this.setupOutputLog(child, log);
         return child;


### PR DESCRIPTION
# Issue

Fix the problem that is caused by too early close of a log stream at process exit, but https://nodejs.org/api/child_process.html#child_process_event_exit
```
Note that when the 'exit' event is triggered, child process stdio streams might still be open.
```

@daniel-j-h  please could you check the change of `log.end`  to `log.write`  locally. I could reproduce it only with a release build and timeout 500ms.
/cc @springmeyer 

## Tasklist
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations
Supersedes #2934, if retest will be  positive. Related to #2795 

