### PR TITLE
Prevents typedefs.hpp from polluting the user's namespace, resolves #2940

### DIFF
--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -36,12 +36,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 #include <limits>
 
+namespace osrm
+{
+
 // OpenStreetMap node ids are higher than 2^32
 OSRM_STRONG_TYPEDEF(std::uint64_t, OSMNodeID)
-OSRM_STRONG_TYPEDEF_HASHABLE(std::uint64_t, OSMNodeID)
 
 OSRM_STRONG_TYPEDEF(std::uint32_t, OSMWayID)
-OSRM_STRONG_TYPEDEF_HASHABLE(std::uint32_t, OSMWayID)
 
 static const OSMNodeID SPECIAL_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
 static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::max()};
@@ -114,5 +115,11 @@ struct GeometryID
 
 
 static_assert(sizeof(SegmentID) == 4, "SegmentID needs to be 4 bytes big");
+}
+
+// Hashable specializes std::hash and therefore needs to live in the global namespace
+// so it can expand into namespace std { ..
+OSRM_STRONG_TYPEDEF_HASHABLE(decltype(osrm::OSMNodeID::__value), osrm::OSMNodeID)
+OSRM_STRONG_TYPEDEF_HASHABLE(decltype(osrm::OSMWayID::__value), osrm::OSMWayID)
 
 #endif /* TYPEDEFS_H */

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -46,17 +46,19 @@
 namespace std
 {
 
-template <> struct hash<std::pair<OSMNodeID, OSMNodeID>>
+template <> struct hash<std::pair<osrm::OSMNodeID, osrm::OSMNodeID>>
 {
-    std::size_t operator()(const std::pair<OSMNodeID, OSMNodeID> &k) const noexcept
+    std::size_t operator()(const std::pair<osrm::OSMNodeID, osrm::OSMNodeID> &k) const noexcept
     {
         return static_cast<uint64_t>(k.first) ^ (static_cast<uint64_t>(k.second) << 12);
     }
 };
 
-template <> struct hash<std::tuple<OSMNodeID, OSMNodeID, OSMNodeID>>
+template <> struct hash<std::tuple<osrm::OSMNodeID, osrm::OSMNodeID, osrm::OSMNodeID>>
 {
-    std::size_t operator()(const std::tuple<OSMNodeID, OSMNodeID, OSMNodeID> &k) const noexcept
+    std::size_t
+    operator()(const std::tuple<osrm::OSMNodeID, osrm::OSMNodeID, osrm::OSMNodeID> &k) const
+        noexcept
     {
         std::size_t seed = 0;
         boost::hash_combine(seed, static_cast<uint64_t>(std::get<0>(k)));

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -23,6 +23,9 @@
 
 namespace
 {
+// for osrm:: prefixed typedefs (e.g. node/way id types)
+using namespace osrm;
+
 namespace oe = osrm::extractor;
 
 // Needed for STXXL comparison - STXXL requires max_value(), min_value(), so we can not use

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -104,6 +104,8 @@ std::size_t loadGraph(const char *path,
 
 int main(int argc, char *argv[])
 {
+    using namespace osrm;
+
     std::vector<osrm::extractor::QueryNode> coordinate_list;
     osrm::util::LogPolicy::GetInstance().Unmute();
 


### PR DESCRIPTION
For #2940: `typefefs.hpp` defined some types and type-aliases (such as node / way
id for example) but did so without a namespace, polluting the global
one. This can cause name clashes when using / embedding libosrm.

This changeset namespaces types and type aliases in `typedefs.hpp` into
the `osrm` namespace and adapts some callsites.

Because the `libosrm` headers we ship to clients depend on
`typedefs.hpp` and clients could already use it this change is breaking
the `libosrm` v5 API.
## Tasklist
- [x] review
- [x] adjust for for comments
