### PR TITLE
prefer first result

### DIFF
--- a/features/step_definitions/trip.js
+++ b/features/step_definitions/trip.js
@@ -1,6 +1,10 @@
 var util = require('util');
 
 module.exports = function () {
+    function add(a, b) {
+        return a + b;
+    }
+
     this.When(/^I plan a trip I should get$/, (table, callback) => {
         var got;
 
@@ -43,6 +47,7 @@ module.exports = function () {
                     }
 
                     var subTrips;
+                    var trip_durations;
                     if (res.statusCode === 200) {
                         if (headers.has('trips')) {
                             subTrips = json.trips.filter(t => !!t).map(t => t.legs).map(tl => Array.prototype.concat.apply([], tl.map((sl, i) => {
@@ -51,6 +56,12 @@ module.exports = function () {
                                 toAdd.push(sl.steps[sl.steps.length-1].intersections[0].location);
                                 return toAdd;
                             })));
+                        }
+                        if(headers.has('durations')) {
+                            var all_durations = json.trips.filter(t => !!t).map(t => t.legs).map(tl => Array.prototype.concat.apply([], tl.map(sl => {
+                                return sl.duration;
+                            })));
+                            trip_durations = all_durations.map( a => a.reduce(add, 0));
                         }
                     }
 
@@ -62,7 +73,6 @@ module.exports = function () {
                         if (si >= subTrips.length) {
                             ok = false;
                         } else {
-                            ok = false;
                             // TODO: Check all rotations of the round trip
                             for (var ni=0; ni<sub.length; ni++) {
                                 var node = this.findNodeByName(sub[ni]),
@@ -70,8 +80,8 @@ module.exports = function () {
                                 if (this.FuzzyMatch.matchLocation(outNode, node)) {
                                     encodedResult += sub[ni];
                                     extendedTarget += sub[ni];
-                                    ok = true;
                                 } else {
+                                    ok = false;
                                     encodedResult += util.format('? [%s,%s]', outNode[0], outNode[1]);
                                     extendedTarget += util.format('%s [%d,%d]', sub[ni], node.lat, node.lon);
                                 }
@@ -86,6 +96,8 @@ module.exports = function () {
                         got.trips = encodedResult;
                         got.trips = extendedTarget;
                     }
+
+                    got.durations = trip_durations;
 
                     for (var key in row) {
                         if (this.FuzzyMatch.match(got[key], row[key])) {

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -8,7 +8,7 @@ Feature: Basic trip planning
     Scenario: Testbot - Trip planning with less than 10 nodes
         Given the node map
             | a | b |
-            | d | c |
+            | c | d |
 
         And the ways
             | nodes |
@@ -18,8 +18,9 @@ Feature: Basic trip planning
             | da    |
 
         When I plan a trip I should get
-            | waypoints | trips |
-            | a,b,c,d   | dcba  |
+            | waypoints | trips | durations |
+            | a,b,c,d   | abcd  | 7.6       |
+            | d,b,c,a   | dbca  | 7.6       |
 
     Scenario: Testbot - Trip planning with more than 10 nodes
         Given the node map
@@ -55,8 +56,8 @@ Feature: Basic trip planning
             | k |   |   | f |
             | j | i | h | g |
             |   |   |   |   |
-            | m | n |   |   |
-            | p | o |   |   |
+            | q | m | n |   |
+            |   | p | o |   |
 
         And the ways
             | nodes |
@@ -75,12 +76,13 @@ Feature: Basic trip planning
             | mn    |
             | no    |
             | op    |
-            | pm    |
+            | pq    |
+            | qm    |
 
 
         When I plan a trip I should get
             | waypoints                       | trips              |
-            | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | cbalkjihgfedc,ponm |
+            | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | cbalkjihgfedc,mnop |
 
     # Test single node in each component #1850
     Scenario: Testbot - Trip planning with less than 10 nodes

--- a/include/engine/trip/trip_brute_force.hpp
+++ b/include/engine/trip/trip_brute_force.hpp
@@ -53,8 +53,7 @@ std::vector<NodeID> BruteForceTrip(const NodeIDIterator start,
     const auto component_size = std::distance(start, end);
 
     std::vector<NodeID> perm(start, end);
-    std::vector<NodeID> route;
-    route.reserve(component_size);
+    std::vector<NodeID> route = perm;
 
     EdgeWeight min_route_dist = INVALID_EDGE_WEIGHT;
 
@@ -68,7 +67,10 @@ std::vector<NodeID> BruteForceTrip(const NodeIDIterator start,
     do
     {
         const auto new_distance = ReturnDistance(dist_table, perm, min_route_dist, component_size);
-        if (new_distance <= min_route_dist)
+        // we can use `<` instead of `<=` here, since all distances are `!=` INVALID_EDGE_WEIGHT
+        // In case we really sum up to invalid edge weight for all permutations, keeping the very
+        // first one is fine too.
+        if (new_distance < min_route_dist)
         {
             min_route_dist = new_distance;
             route = perm;

--- a/include/engine/trip/trip_farthest_insertion.hpp
+++ b/include/engine/trip/trip_farthest_insertion.hpp
@@ -119,7 +119,7 @@ std::vector<NodeID> FindRoute(const std::size_t &number_of_locations,
 
                 // add the location to the current trip such that it results in the shortest total
                 // tour
-                if (insert_candidate.first >= farthest_distance)
+                if (insert_candidate.first > farthest_distance)
                 {
                     farthest_distance = insert_candidate.first;
                     next_node = *i;


### PR DESCRIPTION
# Issue

Not really an issue. This PR simply prefers the first lexicographical result instead of switching the results in our brute-force method. In addition, we can now query the durations of different trips in the cucumber tests.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for for comments
