### PR TITLE
Return `notification` turn type when turn includes mode change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
     - Profiles
       - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
       - replaced lhs/rhs profiles by using test defined profiles
+    - Guidance
+      - Notifications are now exposed more prominently, announcing turns onto a ferry/pushing your bike more prominently
     - Trip Plugin
       - changed internal behaviour to prefer the smallest lexicographic result over the largest one
 

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -836,5 +836,5 @@ Feature: Collapse
             | ej    | primary |       | off   | yes    |
 
         When I route I should get
-            | waypoints | route                   | turns                                                                          |
-            | k,j       | on,ferry,,ferry,off,off | depart,new name straight,continue uturn,turn straight,new name straight,arrive |
+            | waypoints | route                   | turns                                                                                  |
+            | k,j       | on,ferry,,ferry,off,off | depart,notification straight,continue uturn,turn straight,notification straight,arrive |

--- a/features/guidance/notification.feature
+++ b/features/guidance/notification.feature
@@ -1,0 +1,57 @@
+@routing @guidance @mode-change
+Feature: Notification on turn onto mode change
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 400 meters
+
+    Scenario: Turn onto a Ferry
+        Given the node map
+            | f |   |   |   |   |
+            | b |   |   | d |   |
+            | a |   |   |   | e |
+
+        And the ways
+            | nodes | highway | route | name  |
+            | abf   | primary |       |       |
+            | bd    |         | ferry | ferry |
+            | de    | primary |       |       |
+
+        When I route I should get
+            | waypoints | route     | turns                                        | modes                          |
+            | a,e       | ,ferry,,  | depart,turn right,notification right,arrive  | driving,ferry,driving,driving  |
+
+    Scenario: Turn onto a Ferry
+        Given the node map
+            | h |   |   | g |
+            | a | c |   | e |
+            | b |   |   | f |
+
+        And the ways
+            | nodes | highway | route | name  |
+            | ac    | primary |       |       |
+            | bah   | primary |       |       |
+            | ec    |         | ferry | ferry |
+            | gef   | primary |       |       |
+
+        When I route I should get
+            | waypoints | route     | turns                                                      | modes                                   |
+            | g,h       | ,ferry,,, | depart,turn right,notification straight,turn right,arrive  | driving,ferry,driving,driving,driving   |
+            | b,g       | ,,ferry,, | depart,turn right,notification straight,turn left,arrive   | driving,driving,ferry,driving,driving   |
+
+    Scenario: Straight onto a Ferry
+        Given the node map
+            |   |   |   |   |   |
+            |   | c | d |   | i |
+            | a |   |   |   |   |
+            |   |   |   | f |   |
+
+        And the ways
+            | nodes | highway | route | name    |
+            | ac    | primary |       |         |
+            | dc    |         | ferry | ferry   |
+            | df    | primary |       |         |
+
+        When I route I should get
+            | waypoints | route     | turns                                                  | modes                           |
+            | a,f       | ,ferry,,  | depart,notification right,notification right,arrive    | driving,ferry,driving,driving   |

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -110,7 +110,11 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
                 else if (in_data.road_classification.IsRampClass() &&
                          out_data.road_classification.IsRampClass())
                 {
-                    return {in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification, getTurnDirection(road.turn.angle)};
+                    // This check is more a precaution than anything else. Our current travel modes
+                    // cannot reach this, since all ramps are exposing the same travel type. But we
+                    // could see toll-type at some point.
+                    return {in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification,
+                            getTurnDirection(road.turn.angle)};
                 }
                 else
                 {
@@ -137,13 +141,15 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
             }
             else
             {
-                return {in_mode == out_mode ? TurnType::NewName : TurnType::Notification, getTurnDirection(road.turn.angle)};
+                return {in_mode == out_mode ? TurnType::NewName : TurnType::Notification,
+                        getTurnDirection(road.turn.angle)};
             }
         }
         // name has not changed, suppress a turn here or indicate mode change
         else
         {
-            return {in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification, getTurnDirection(road.turn.angle)};
+            return {in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification,
+                    getTurnDirection(road.turn.angle)};
         }
     }
     BOOST_ASSERT(type == TurnType::Continue);

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/constants.hpp"
+#include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include "util/coordinate_calculation.hpp"
@@ -110,10 +110,7 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
                 else if (in_data.road_classification.IsRampClass() &&
                          out_data.road_classification.IsRampClass())
                 {
-                    if (in_mode == out_mode)
-                        return {TurnType::Suppressed, getTurnDirection(road.turn.angle)};
-                    else
-                        return {TurnType::Notification, getTurnDirection(road.turn.angle)};
+                    return {in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification, getTurnDirection(road.turn.angle)};
                 }
                 else
                 {
@@ -140,15 +137,13 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
             }
             else
             {
-                return {TurnType::NewName, getTurnDirection(road.turn.angle)};
+                return {in_mode == out_mode ? TurnType::NewName : TurnType::Notification, getTurnDirection(road.turn.angle)};
             }
         }
+        // name has not changed, suppress a turn here or indicate mode change
         else
         {
-            if (in_mode == out_mode)
-                return {TurnType::Suppressed, getTurnDirection(road.turn.angle)};
-            else
-                return {TurnType::Notification, getTurnDirection(road.turn.angle)};
+            return {in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification, getTurnDirection(road.turn.angle)};
         }
     }
     BOOST_ASSERT(type == TurnType::Continue);


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/2878
We want to prioritize returning the `notification` turn type over `newName` when a maneuver includes a mode change.

## Tasklist
 - [x] add more cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for for comments

## Requirements / Relations
None that I'm aware of. @MoKob does this impact anything else?
