### PR TITLE
Backport 5.3 behavior for name and add way_name

### DIFF
--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -234,9 +234,14 @@ util::json::Object makeRouteStep(guidance::RouteStep step, util::json::Value geo
     util::json::Object route_step;
     route_step.values["distance"] = std::round(step.distance * 10) / 10.;
     route_step.values["duration"] = std::round(step.duration * 10) / 10.;
-    route_step.values["name"] = std::move(step.name);
-    if (!step.ref.empty())
+    route_step.values["way_name"] = std::move(step.name);
+    if (step.ref.empty())
+        route.step.values["name"] = std::move(step.name);
+    else
+    {
+        route_step.values["name"] = std::move(step.name) << " (" << std::move(step.ref) << ")";
         route_step.values["ref"] = std::move(step.ref);
+    }
     if (!step.pronunciation.empty())
         route_step.values["pronunciation"] = std::move(step.pronunciation);
     if (!step.destinations.empty())


### PR DESCRIPTION
# Issue

Fixes https://github.com/Project-OSRM/osrm-backend/issues/2968

This PR aims at retaining the old 5.3 design of how `name` works, but also allows clients to benefit from the `name`/`ref` split now already. By the release of version 6, the `way_name` would be removed again and `step.name` would be use without modification in the json_factory.

For being compatible with the 5 and 6 version, we'd advise clients to use this logic:

```
name = step.way_name || step.name
```

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] adjust changelog?
 - [ ] review
 - [ ] adjust for review comments
 - [ ] Get this into [5.4](https://github.com/Project-OSRM/osrm-backend/tree/5.4)

## Requirements / Relations

None

