### PR TITLE
Removing caching from edge weight update test

### DIFF
--- a/features/options/contract/edge-weight-updates-over-factor.feature
+++ b/features/options/contract/edge-weight-updates-over-factor.feature
@@ -2,8 +2,6 @@
 Feature: osrm-contract command line option: edge-weight-updates-over-factor
 
     Background: Log edge weight updates over given factor
-
-    Scenario: Logging weight with updates over factor of 2, long segment
         Given the node locations
             | node | lat        | lon      |
             | a    | 0.1        | 0.1      |
@@ -14,13 +12,15 @@ Feature: osrm-contract command line option: edge-weight-updates-over-factor
             | ab    | residential |
             | ac    | primary     |
         Given the profile "testbot"
-        Given the extract extra arguments "--generate-edge-lookup"
         Given the speed file
         """
         1,2,100
         1,3,100
         """
-        And the data has been extracted
+        And the data has been saved to disk
+
+    Scenario: Logging weight with updates over factor of 2, long segment
+        When I run "osrm-extract --profile {profile_file} {osm_file} --generate-edge-lookup"
         When I run "osrm-contract --edge-weight-updates-over-factor 2 --segment-speed-file {speeds_file} {processed_file}"
         And stderr should contain "weight updates"
         And stderr should contain "New speed: 100 kph"


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/2965

I was bad and had my edge weight update pr merged into master with some bad caching behavior. This test is intended to run on freshly extracted files each time, so disabling caching for it should let it run repeatedly without breaking.

## Tasklist
 - [ ] review
 - [ ] adjust for for comments

## Requirements / Relations
cc @oxidase 