### PR TITLE
Avoid doubled reprocessing for scenarios without caching

### DIFF
--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -265,7 +265,7 @@ module.exports = function () {
     });
 
     this.Given(/^the data has been saved to disk$/, (callback) => {
-        this.reprocess(callback);
+        this.writeAndLinkOSM(callback);
     });
 
     this.Given(/^the data has been extracted$/, (callback) => {

--- a/features/step_definitions/options.js
+++ b/features/step_definitions/options.js
@@ -1,5 +1,7 @@
-var assert = require('assert');
-var fs = require('fs');
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
 
 module.exports = function () {
     this.resetOptionsOutput = () => {
@@ -24,11 +26,19 @@ module.exports = function () {
     });
 
     this.When(/^I run "osrm\-extract\s?(.*?)"$/, (options, callback) => {
-        this.runAndSafeOutput('osrm-extract', options, callback);
+        const stamp = this.processedCacheFile + '.extract';
+        this.runAndSafeOutput('osrm-extract', options, (err) => {
+            if (err) return callback(err);
+            fs.writeFile(stamp, 'ok', callback);
+        });
     });
 
     this.When(/^I run "osrm\-contract\s?(.*?)"$/, (options, callback) => {
-        this.runAndSafeOutput('osrm-contract', options, callback);
+        const stamp = this.processedCacheFile + '.contract';
+        this.runAndSafeOutput('osrm-contract', options, (err) => {
+            if (err) return callback(err);
+            fs.writeFile(stamp, 'ok', callback);
+        });
     });
 
     this.When(/^I try to run "osrm\-routed\s?(.*?)"$/, (options, callback) => {
@@ -65,12 +75,12 @@ module.exports = function () {
     });
 
     this.Then(/^stdout should contain \/(.*)\/$/, (regexStr) => {
-        var re = new RegExp(regexStr);
+        const re = new RegExp(regexStr);
         assert.ok(this.stdout.match(re));
     });
 
     this.Then(/^stderr should contain \/(.*)\/$/, (regexStr) => {
-        var re = new RegExp(regexStr);
+        const re = new RegExp(regexStr);
         assert.ok(this.stdout.match(re));
     });
 
@@ -91,7 +101,7 @@ module.exports = function () {
     });
 
     this.Then(/^datasource names should contain "(.+)"$/, (expectedData) => {
-        var actualData = fs.readFileSync(this.processedCacheFile + '.datasource_names', {encoding:'UTF-8'}).trim().split('\n').join(',');
+        const actualData = fs.readFileSync(this.processedCacheFile + '.datasource_names', {encoding:'UTF-8'}).trim().split('\n').join(',');
         assert.equal(actualData, expectedData);
     });
 

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -204,18 +204,23 @@ module.exports = function () {
         queue.awaitAll(callback);
     };
 
-    this.reprocess = (callback) => {
+    this.writeAndLinkOSM = (callback) => {
         let queue = d3.queue(1);
         queue.defer(this.writeOSM.bind(this));
         queue.defer(this.linkOSM.bind(this));
+        queue.awaitAll(callback);
+    };
+
+    this.reprocess = (callback) => {
+        let queue = d3.queue(1);
+        queue.defer(this.writeAndLinkOSM.bind(this));
         queue.defer(this.extractAndContract.bind(this));
         queue.awaitAll(callback);
     };
 
     this.reprocessAndLoadData = (callback) => {
         let queue = d3.queue(1);
-        queue.defer(this.writeOSM.bind(this));
-        queue.defer(this.linkOSM.bind(this));
+        queue.defer(this.writeAndLinkOSM.bind(this));
         queue.defer(this.extractAndContract.bind(this));
         queue.defer(this.osrmLoader.load.bind(this.osrmLoader), this.processedCacheFile);
         queue.awaitAll(callback);


### PR DESCRIPTION
# Issue

A small independent addition to  #2965: the step "the data has been saved to disk" should not trigger `reprocess` to only create stamp files for next steps. Now non-caching steps will  create stamps to prevent reprocessing at routing steps. This reduces for my local setup time from 3m16.455s to 2m56.530s.

## Tasklist
 - [x] review
 - [x] adjust for for comments


## Requirements / Relations
#2971
