### PR TITLE
Fixes Tile Unit Test Compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
       - changed internal behaviour to prefer the smallest lexicographic result over the largest one
     - Bugfixes
       - fixed a bug where polyline decoding on a defective polyline could end up in out-of-bound access on a vector
+      - fixed compile errors in tile unit-test framework
 
 # 5.4.0
   - Changes from 5.3.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,9 @@ set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/includ
 find_package(Osmium REQUIRED COMPONENTS io)
 add_dependency_includes(${OSMIUM_INCLUDE_DIR})
 
+# Disallow deprecated protozero APIs
+add_definitions(-DPROTOZERO_STRICT_API)
+
 
 find_package(Boost 1.49.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -40,8 +40,6 @@ BOOST_AUTO_TEST_CASE(test_tile)
     protozero::pbf_reader layer_message = tile_message.get_message();
 
     const auto check_feature = [](protozero::pbf_reader feature_message) {
-        protozero::pbf_reader::const_uint32_iterator value_begin;
-        protozero::pbf_reader::const_uint32_iterator value_end;
         feature_message.next(); // advance parser to first entry
         BOOST_CHECK_EQUAL(feature_message.tag(), util::vector_tile::GEOMETRY_TAG);
         BOOST_CHECK_EQUAL(feature_message.get_enum(), util::vector_tile::GEOMETRY_TYPE_LINE);
@@ -53,7 +51,9 @@ BOOST_AUTO_TEST_CASE(test_tile)
         feature_message.next(); // advance to next entry
         BOOST_CHECK_EQUAL(feature_message.tag(), util::vector_tile::FEATURE_ATTRIBUTES_TAG);
         // properties
-        std::tie(value_begin, value_end) = feature_message.get_packed_uint32();
+        auto property_iter_pair = feature_message.get_packed_uint32();
+        auto value_begin = property_iter_pair.first;
+        auto value_end = property_iter_pair.second;
         BOOST_CHECK_EQUAL(std::distance(value_begin, value_end), 10);
         auto iter = value_begin;
         BOOST_CHECK_EQUAL(*iter++, 0); // speed key
@@ -73,8 +73,8 @@ BOOST_AUTO_TEST_CASE(test_tile)
         BOOST_CHECK(iter == value_end);
         // geometry
         feature_message.next();
-        std::tie(value_begin, value_end) = feature_message.get_packed_uint32();
-        BOOST_CHECK_GT(std::distance(value_begin, value_end), 1);
+        auto geometry_iter_pair = feature_message.get_packed_uint32();
+        BOOST_CHECK_GT(std::distance(geometry_iter_pair.first, geometry_iter_pair.second), 1);
     };
 
     const auto check_value = [](protozero::pbf_reader value) {


### PR DESCRIPTION
Travis build failing, noticed over at https://github.com/Project-OSRM/osrm-backend/pull/2972.

Per https://github.com/mapbox/protozero/blob/master/doc/tutorial.md#handling-repeated-packed-fields:

> Fields that are marked as [packed=true] in the .proto file are handled somewhat differently. get_packed_...() functions returning an iterator pair are used to access the data.

Travis is not happy with our current approach of `tie`ing:
https://travis-ci.org/Project-OSRM/osrm-backend/jobs/163856029#L712

```
/Users/travis/build/Project-OSRM/osrm-backend/unit_tests/library/tile.cpp:56:42: error: no viable overloaded '='

        std::tie(value_begin, value_end) = feature_message.get_packed_uint32();

        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


## Tasklist
 - [x] see if Travis likes this approach now
 - [x] review
 - [x] adjust for for comments