### PR TITLE
Disables ld.gold on binutils < 2.26, resolves #2984

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,8 @@ if(ENABLE_GOLD_LINKER)
 
         # Issue 2785: check gold binutils version and don't use gc-sections for versions prior 2.25
         string(REGEX REPLACE ".*\\(GNU Binutils[^\\)0-9]+([0-9]+\\.[0-9]+)[^\\)]*\\).*" "\\1" GOLD_BINUTILS_VERSION "${LD_VERSION}")
-        if ("${GOLD_BINUTILS_VERSION}" VERSION_LESS "2.25")
-          message(STATUS "Disabling gc-sections on gold binutils < 2.25, see: https://sourceware.org/bugzilla/show_bug.cgi?id=17639")
+        if ("${GOLD_BINUTILS_VERSION}" VERSION_LESS "2.26")
+          message(STATUS "Disabling gc-sections on gold binutils < 2.26, see: https://sourceware.org/bugzilla/show_bug.cgi?id=17639")
           set(LD_AVOID_GC_SECTIONS TRUE)
         endif()
     else()


### PR DESCRIPTION
In https://github.com/Project-OSRM/osrm-backend/issues/2984 a user reported trouble building osrm-backend on Debian Jessie. I could reproduce it in a fresh Docker container with packages from apt. The linking error comes from the gc-sections <-> ld.gold interaction as ticketed in

- https://github.com/Project-OSRM/osrm-backend/pull/2601 enabling Gold linker by default
- https://github.com/Project-OSRM/osrm-backend/pull/2800 disabling gc-sections for Gold on binutils < 2.25

Debian Jessie ships binutils 2.25-5 (see https://packages.debian.org/jessie/binutils) but it's still hitting this issue. I'm simply bumping the version number here, although reading the tickets and the upstream bug tracker here 2.25 should already have the fix backported.