### PR TITLE
Re-introduces the old `RouteParameters` ctor for API compatibility, see #2978

### DIFF
--- a/include/engine/api/route_parameters.hpp
+++ b/include/engine/api/route_parameters.hpp
@@ -72,6 +72,21 @@ struct RouteParameters : public BaseParameters
     template <typename... Args>
     RouteParameters(const bool steps_,
                     const bool alternatives_,
+                    const GeometriesType geometries_,
+                    const OverviewType overview_,
+                    const boost::optional<bool> continue_straight_,
+                    Args... args_)
+        : BaseParameters{std::forward<Args>(args_)...}, steps{steps_}, alternatives{alternatives_},
+          annotations{false}, geometries{geometries_}, overview{overview_},
+          continue_straight{continue_straight_}
+    // Once we perfectly-forward `args` (see #2990) this constructor can delegate to the one below.
+    {
+    }
+
+    // RouteParameters constructor adding the `annotations` setting in a API-compatible way.
+    template <typename... Args>
+    RouteParameters(const bool steps_,
+                    const bool alternatives_,
                     const bool annotations_,
                     const GeometriesType geometries_,
                     const OverviewType overview_,


### PR DESCRIPTION
For #2978: this re-introduces the original `RouteParameters` constructor we had until 5.2 for compatibility.

Sorry we broke this between 5.2 and 5.4 :(