### PR TITLE
Bumps version to 5.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 project(OSRM C CXX)
 set(OSRM_VERSION_MAJOR 5)
-set(OSRM_VERSION_MINOR 3)
+set(OSRM_VERSION_MINOR 4)
 set(OSRM_VERSION_PATCH 0)
 
 # these two functions build up custom variables:


### PR DESCRIPTION
Checking releasing docs, this caught my eye. Needs to be cherry-picked into 5.4 branch, too.