### PR TITLE
Squashes non-internal 5.4 RC changelogs into 5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,3 @@
-# 5.4.0-rc.7
-  - Chages from 5.4.0-rc.6
-    - Bugfixes re-introduce space between two entries in summaries
-
-# 5.4.0-rc.6
-  - Changes from 5.4.0-rc.5
-    - Bugfixes
-      - fixed a bug where polyline decoding on a defective polyline could end up in out-of-bound access on a vector
-    - Guidance
-      - Summaries have been improved to consider references as well
-
-# 5.4.0-rc.5
-  - Changes from 5.4.0-rc.4
-    - Guidance
-      - Improved detection of obvious name changes
-    - Profiles
-      - The default profile for car now excludes HOV-only routes in navigation by default
-    - Bugfixes
-      - Fixed a bug that could result in endless loops in combination with sliproads
-
-# 5.4.0-rc.4
-  - Changes from 5.4.0-rc.3
-    - Bugfixes
-      - Fixed a bug where roundabout intersections could result in breaking assertions when immediately exited
-
-# 5.4.0-rc.3
-  - Changes from 5.4.0-rc.2
-    - Bugfixes
-      - BREAKING: Fixed a bug where some roads could be falsly identified as sliproadsi This change requires reprocessing datasets with osrm-extract and osrm-contract
-      - BREAKING: Fixed a bug that resulted in false names/ref/destination/pronunciation This change requires reprocessing datasets with osrm-extract and osrm-contract
-      - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
-      - replaced lhs/rhs profiles by using test defined profiles
-    - Trip Plugin
-      - changed internal behaviour to prefer the smallest lexicographic result over the largest one
-
 # 5.4.0
   - Changes from 5.3.0
     - Profiles
@@ -40,23 +5,36 @@
       - added left_hand_driving flag in global profile properties
       - modified turn penalty function for car profile - better fit to real data
       - return `ref` and `name` as separate fields. Do no use ref or destination as fallback for name value
+      - The default profile for car now excludes HOV-only routes in navigation by default
     - Guidance
       - Handle Access tags for lanes, only considering valid lanes in lane-guidance (think car | car | bike | car)
+      - Improved detection of obvious name changes, most visibly reducing `NewName` instructions
+      - Summaries have been improved to consider references as well
     - API:
       - `annotations=true` now returns the data source id for each segment as `datasources`
       - Reduced semantic of merge to refer only to merges from a lane onto a motorway-like road
       - new `ref` field in the `RouteStep` object. It contains the reference code or name of a way. Previously merged into the `name` property like `name (ref)` and are now separate fields.
     - Bugfixes
+      - BREAKING: Fixed a bug that could crash postprocessing of instructions on invalid roundabout taggings. This change requires reprocessing datasets with osrm-extract and osrm-contract
+      - BREAKING: Fixed a bug where some roads could be falsly identified as sliproadsi This change requires reprocessing datasets with osrm-extract and osrm-contract
+      - BREAKING: Fixed a bug that resulted in false names/ref/destination/pronunciation This change requires reprocessing datasets with osrm-extract and osrm-contract
       - Fixed an issue that would result in segfaults for viaroutes with an invalid intermediate segment when u-turns were allowed at the via-location
       - Invalid only_* restrictions could result in loss of connectivity. As a fallback, we assume all turns allowed when the restriction is not valid
       - Fixed a bug that could result in an infinite loop when finding information about an upcoming intersection
       - Fixed a bug that led to not discovering if a road simply looses a considered prefix
-      - BREAKING: Fixed a bug that could crash postprocessing of instructions on invalid roundabout taggings. This change requires reprocessing datasets with osrm-extract and osrm-contract
       - Fixed an issue that could emit `invalid` as instruction when ending on a sliproad after a traffic-light
       - Fixed an issue that would detect turning circles as sliproads
       - Fixed a bug where post-processing instructions (e.g. left + left -> uturn) could result in false pronunciations
       - Fixes a bug where a bearing range of zero would cause exhaustive graph traversals
       - Fixes a bug where certain looped geometries could cause an infinite loop during extraction
+      - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
+      - replaced lhs/rhs profiles by using test defined profiles
+      - Fixed a bug where roundabout intersections could result in breaking assertions when immediately exited
+      - Fixed a bug that could result in endless loops in combination with sliproads
+      - fixed a bug where polyline decoding on a defective polyline could end up in out-of-bound access on a vector
+
+    - Trip Plugin
+      - changed internal behaviour to prefer the smallest lexicographic result over the largest one
 
     - Infrastructure:
       - Adds a feature to limit results in nearest service with a default of 100 in `osrm-routed`


### PR DESCRIPTION
Instead of having the changelog look like

> 5.4-rc.x
>   ..
> 5.4-rc.y
>   ..
> 5.4
>   ..

this squashes RC changelog items into the single 5.4-release item

> 5.4
>   ..

Note: this also removes changelog items for bugs / issues we introduced while doing RCs and then fixed in another RC (such as the summary comma bug we had between rc6 and rc7).