### PR TITLE
fix detection of forks in present of oneways

### DIFF
--- a/features/guidance/fork.feature
+++ b/features/guidance/fork.feature
@@ -22,6 +22,37 @@ Feature: Fork Instructions
             | a,c       | ab,bc,bc | depart,fork slight left,arrive  |
             | a,d       | ab,bd,bd | depart,fork slight right,arrive |
 
+    Scenario: Don't Fork On Single Road
+        Given the node map
+            |   |   |   |   | c |
+            | a |   | b |   |   |
+            |   |   |   |   | d |
+
+        And the ways
+            | nodes  | highway | oneway |
+            | ab     | primary | no     |
+            | cb     | primary | yes    |
+            | bd     | primary | yes    |
+
+       When I route I should get
+            | waypoints | route    | turns                               |
+            | a,d       | ab,bd,bd | depart,new name slight right,arrive |
+
+    Scenario: Don't Fork On Single Road
+        Given the node map
+            |   |   |   |   |   |   | c |
+            | a |   | b |   | d |   |   |
+
+        And the ways
+            | nodes  | highway | oneway | name |
+            | ab     | primary | no     | road |
+            | cb     | primary | yes    | road |
+            | bd     | primary | yes    | turn |
+
+       When I route I should get
+            | waypoints | route          | turns                           |
+            | a,d       | road,turn,turn | depart,new name straight,arrive |
+
     Scenario: Do not fork on link type
         Given the node map
             |   |   |   |   | c |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -133,6 +133,22 @@ Feature: Simple Turns
             | d,c       | db,cb,cb | depart,turn right,arrive        |
             | d,a       | db,ab,ab | depart,new name straight,arrive |
 
+    Scenario: Three Way Intersection - Meeting Oneways
+        Given the node map
+            |   | c |   |
+            | a | b | d |
+
+        And the ways
+            | nodes  | highway | oneway |
+            | ab     | primary | yes    |
+            | bc     | primary | yes    |
+            | db     | primary | yes    |
+
+       When I route I should get
+            | waypoints | route    | turns                           |
+            | a,c       | ab,bc,bc | depart,turn left,arrive         |
+            | d,c       | db,bc,bc | depart,turn right,arrive        |
+
     Scenario: Three Way Intersection on Through Street
         Given the node map
             |   | d |   |

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/intersection_handler.hpp"
+#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/toolkit.hpp"
 
 #include "util/coordinate_calculation.hpp"
@@ -534,26 +534,48 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
                                                       best_data.road_classification,
                                                       right_data.road_classification);
 
+        // if the best turn isn't narrow, but there is a nearly straight turn, we don't consider the
+        // turn obvious
+        const auto check_narrow = [&intersection, best_deviation](const std::size_t index) {
+            return angularDeviation(intersection[index].turn.angle, STRAIGHT_ANGLE) <=
+                       FUZZY_ANGLE_DIFFERENCE &&
+                   (best_deviation > NARROW_TURN_ANGLE || intersection[index].entry_allowed);
+        };
+
         // other narrow turns?
-        if (angularDeviation(intersection[right_index].turn.angle, STRAIGHT_ANGLE) <=
-                FUZZY_ANGLE_DIFFERENCE &&
-            !obvious_to_right)
+        if (check_narrow(right_index) && !obvious_to_right)
             return 0;
 
-        if (angularDeviation(intersection[left_index].turn.angle, STRAIGHT_ANGLE) <=
-                FUZZY_ANGLE_DIFFERENCE &&
-            !obvious_to_left)
+        if (check_narrow(left_index) && !obvious_to_left)
             return 0;
 
-        const bool distinct_to_left =
-            left_deviation / best_deviation >= DISTINCTION_RATIO ||
-            (left_deviation > best_deviation &&
-             (!intersection[left_index].entry_allowed && in_data.distance > 30));
-        const bool distinct_to_right =
-            right_deviation / best_deviation >= DISTINCTION_RATIO ||
-            (right_deviation > best_deviation &&
-             (!intersection[right_index].entry_allowed && in_data.distance > 30));
+        // check if a turn is distinct enough
+        const auto isDistinct = [&](const std::size_t index, const double deviation) {
+            /*
+               If the neighbor is not possible to enter, we allow for a lower
+               distinction rate. If the road category is smaller, its also adjusted. Only
+               roads of the same priority require the full distinction ratio.
+             */
+            const auto adjusted_distinction_ratio = [&]() {
+                // not allowed competitors are easily distinct
+                if (!intersection[index].entry_allowed)
+                    return 0.7 * DISTINCTION_RATIO;
+                // a bit less obvious are road classes
+                else if (in_data.road_classification == best_data.road_classification &&
+                         best_data.road_classification.GetPriority() <
+                             node_based_graph.GetEdgeData(intersection[index].turn.eid)
+                                 .road_classification.GetPriority())
+                    return 0.8 * DISTINCTION_RATIO;
+                // if road classes are the same, we use the full ratio
+                else
+                    return DISTINCTION_RATIO;
+            }();
+            return index == 0 || deviation / best_deviation >= adjusted_distinction_ratio ||
+                   (deviation <= NARROW_TURN_ANGLE && !intersection[index].entry_allowed);
+        };
 
+        const bool distinct_to_left = isDistinct(left_index, left_deviation);
+        const bool distinct_to_right = isDistinct(right_index, right_deviation);
         // Well distinct turn that is nearly straight
         if ((distinct_to_left || obvious_to_left) && (distinct_to_right || obvious_to_right))
             return best;


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/3004

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations
none

New Result:

```
{
	"waypoints": [{
		"location": [13.429427, 52.509385],
		"hint": "wUkAgI0xAYAodAAAEgAAAC0AAAAAAAAAAAAAAKOYAQAgFwIAqgAAALPqzADJOiEDeurMANw6IQMAAAEBA59CQA==",
		"name": "Schillingbrücke"
	}, {
		"location": [13.427301, 52.506914],
		"hint": "0EkAgP___38oPwAAFgAAACEAAAA4AAAAdAAAAAUpAABOxQAAqgAAAGXizAAiMSED7eHMAEUxIQMEAAEBA59CQA==",
		"name": "Engeldamm"
	}],
	"routes": [{
		"distance": 311.9,
		"duration": 26.4,
		"legs": [{
			"distance": 311.9,
			"steps": [{
				"distance": 156.6,
				"duration": 11,
				"name": "Schillingbrücke",
				"maneuver": {
					"type": "depart",
					"location": [13.429427, 52.509385],
					"bearing_before": 0,
					"bearing_after": 208
				},
				"geometry": "uvn_I}|}pAfBzAb@`@v@n@VN\\V",
				"mode": "driving",
				"intersections": [{
					"location": [13.429427, 52.509385],
					"bearings": [208],
					"entry": [true],
					"out": 0
				}, {
					"location": [13.428973, 52.508874],
					"bearings": [30, 210],
					"entry": [false, true],
					"in": 0,
					"out": 1
				}, {
					"location": [13.428804, 52.508687],
					"bearings": [30, 210, 315],
					"entry": [false, true, true],
					"in": 0,
					"out": 1
				}]
			}, {
				"distance": 155.3,
				"duration": 15.4,
				"name": "Engeldamm",
				"maneuver": {
					"type": "new name",
					"modifier": "straight",
					"bearing_before": 204,
					"bearing_after": 205,
					"location": [13.42836, 52.508137]
				},
				"geometry": "{nn_Igv}pAt@f@JJJPP^TRRL\\T^RHDb@Z",
				"mode": "driving",
				"intersections": [{
					"location": [13.42836, 52.508137],
					"bearings": [30, 195, 210],
					"entry": [false, false, true],
					"in": 0,
					"out": 2
				}, {
					"location": [13.427751, 52.507549],
					"bearings": [30, 120, 195, 300],
					"lanes": [{
						"indications": ["left"],
						"valid": false
					}, {
						"valid": true,
						"indications": ["straight", "right"]
					}],
					"entry": [false, true, true, true],
					"in": 0,
					"out": 2
				}]
			}, {
				"distance": 0,
				"duration": 0,
				"name": "Engeldamm",
				"maneuver": {
					"type": "arrive",
					"modifier": "right",
					"bearing_before": 205,
					"bearing_after": 0,
					"location": [13.427751, 52.507549]
				},
				"geometry": "egn_Iso}pA",
				"mode": "driving",
				"intersections": [{
					"location": [13.427301, 52.506914],
					"bearings": [25],
					"entry": [true],
					"in": 0
				}]
			}],
			"duration": 26.4,
			"summary": "Bethaniendamm, Engeldamm"
		}]
	}],
	"code": "Ok"
}
```