### PR TITLE
Add toolkit function that returns right and left turn lane info

### DIFF
--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -147,7 +147,7 @@ class BaseDataFacade
                                                       const int bearing_range) const = 0;
 
     virtual bool hasLaneData(const EdgeID id) const = 0;
-    virtual util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const = 0;
+    virtual util::guidance::LaneTupleIdPair GetLaneData(const EdgeID id) const = 0;
     virtual extractor::guidance::TurnLaneDescription
     GetTurnDescription(const LaneDescriptionID lane_description_id) const = 0;
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -80,7 +80,7 @@ class InternalDataFacade final : public BaseDataFacade
     util::ShM<unsigned, false>::vector m_name_ID_list;
     util::ShM<extractor::guidance::TurnInstruction, false>::vector m_turn_instruction_list;
     util::ShM<LaneDataID, false>::vector m_lane_data_id;
-    util::ShM<util::guidance::LaneTupelIdPair, false>::vector m_lane_tupel_id_pairs;
+    util::ShM<util::guidance::LaneTupleIdPair, false>::vector m_lane_tuple_id_pairs;
     util::ShM<extractor::TravelMode, false>::vector m_travel_mode_list;
     util::ShM<char, false>::vector m_names_char_list;
     util::ShM<unsigned, false>::vector m_geometry_indices;
@@ -123,7 +123,7 @@ class InternalDataFacade final : public BaseDataFacade
                        sizeof(m_profile_properties));
     }
 
-    void LoadLaneTupelIdPairs(const boost::filesystem::path &lane_data_path)
+    void LoadLaneTupleIdPairs(const boost::filesystem::path &lane_data_path)
     {
         boost::filesystem::ifstream in_stream(lane_data_path);
         if (!in_stream)
@@ -132,9 +132,9 @@ class InternalDataFacade final : public BaseDataFacade
         }
         std::uint64_t size;
         in_stream.read(reinterpret_cast<char *>(&size), sizeof(size));
-        m_lane_tupel_id_pairs.resize(size);
-        in_stream.read(reinterpret_cast<char *>(&m_lane_tupel_id_pairs[0]),
-                       sizeof(m_lane_tupel_id_pairs) * size);
+        m_lane_tuple_id_pairs.resize(size);
+        in_stream.read(reinterpret_cast<char *>(&m_lane_tuple_id_pairs[0]),
+                       sizeof(m_lane_tuple_id_pairs) * size);
     }
 
     void LoadTimestamp(const boost::filesystem::path &timestamp_path)
@@ -426,7 +426,7 @@ class InternalDataFacade final : public BaseDataFacade
         LoadIntersectionClasses(config.intersection_class_path);
 
         util::SimpleLogger().Write() << "Loading Lane Data Pairs";
-        LoadLaneTupelIdPairs(config.turn_lane_data_path);
+        LoadLaneTupleIdPairs(config.turn_lane_data_path);
     }
 
     // search graph access
@@ -921,10 +921,10 @@ class InternalDataFacade final : public BaseDataFacade
         return m_lane_data_id[id] != INVALID_LANE_DATAID;
     }
 
-    util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const override final
+    util::guidance::LaneTupleIdPair GetLaneData(const EdgeID id) const override final
     {
         BOOST_ASSERT(hasLaneData(id));
-        return m_lane_tupel_id_pairs[m_lane_data_id[id]];
+        return m_lane_tuple_id_pairs[m_lane_data_id[id]];
     }
 
     extractor::guidance::TurnLaneDescription

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -96,7 +96,7 @@ class SharedDataFacade final : public BaseDataFacade
     util::ShM<char, true>::vector m_datasource_name_data;
     util::ShM<std::size_t, true>::vector m_datasource_name_offsets;
     util::ShM<std::size_t, true>::vector m_datasource_name_lengths;
-    util::ShM<util::guidance::LaneTupelIdPair, true>::vector m_lane_tupel_id_pairs;
+    util::ShM<util::guidance::LaneTupleIdPair, true>::vector m_lane_tupel_id_pairs;
 
     std::unique_ptr<SharedRTree> m_static_rtree;
     std::unique_ptr<SharedGeospatialQuery> m_geospatial_query;
@@ -198,9 +198,9 @@ class SharedDataFacade final : public BaseDataFacade
             lane_data_id_ptr, data_layout->num_entries[storage::SharedDataLayout::LANE_DATA_ID]);
         m_lane_data_id = std::move(lane_data_id);
 
-        auto lane_tupel_id_pair_ptr = data_layout->GetBlockPtr<util::guidance::LaneTupelIdPair>(
+        auto lane_tupel_id_pair_ptr = data_layout->GetBlockPtr<util::guidance::LaneTupleIdPair>(
             shared_memory, storage::SharedDataLayout::TURN_LANE_DATA);
-        util::ShM<util::guidance::LaneTupelIdPair, true>::vector lane_tupel_id_pair(
+        util::ShM<util::guidance::LaneTupleIdPair, true>::vector lane_tupel_id_pair(
             lane_tupel_id_pair_ptr,
             data_layout->num_entries[storage::SharedDataLayout::TURN_LANE_DATA]);
         m_lane_tupel_id_pairs = std::move(lane_tupel_id_pair);
@@ -960,7 +960,7 @@ class SharedDataFacade final : public BaseDataFacade
         return INVALID_LANE_DATAID != m_lane_data_id.at(id);
     }
 
-    util::guidance::LaneTupelIdPair GetLaneData(const EdgeID id) const override final
+    util::guidance::LaneTupleIdPair GetLaneData(const EdgeID id) const override final
     {
         BOOST_ASSERT(hasLaneData(id));
         return m_lane_tupel_id_pairs.at(m_lane_data_id.at(id));

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -79,7 +79,7 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                               std::vector<bool>({true}),
                               Intersection::NO_INDEX,
                               0,
-                              util::guidance::LaneTupel(),
+                              util::guidance::LaneTuple(),
                               {}};
 
     if (leg_data.size() > 0)
@@ -227,7 +227,7 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
         std::vector<bool>({true}),
         0,
         Intersection::NO_INDEX,
-        util::guidance::LaneTupel(),
+        util::guidance::LaneTuple(),
         {}};
 
     BOOST_ASSERT(!leg_geometry.locations.empty());

--- a/include/engine/guidance/route_step.hpp
+++ b/include/engine/guidance/route_step.hpp
@@ -39,7 +39,7 @@ struct Intersection
     std::size_t out;
 
     // turn lane information
-    util::guidance::LaneTupel lanes;
+    util::guidance::LaneTuple lanes;
     extractor::guidance::TurnLaneDescription lane_description;
 };
 
@@ -50,7 +50,7 @@ inline Intersection getInvalidIntersection()
             {},
             Intersection::NO_INDEX,
             Intersection::NO_INDEX,
-            util::guidance::LaneTupel(),
+            util::guidance::LaneTuple(),
             {}};
 }
 

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -28,7 +28,7 @@ struct PathData
     // instruction to execute at the turn
     extractor::guidance::TurnInstruction turn_instruction;
     // turn lane data
-    util::guidance::LaneTupelIdPair lane_data;
+    util::guidance::LaneTupleIdPair lane_data;
     // travel mode of the street that leads to the turn
     extractor::TravelMode travel_mode : 4;
     // entry class of the turn, indicating possibility of turns

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -71,7 +71,7 @@ const constexpr Enum MaxTurnType = 27; // Special value for static asserts
 // turn angle in 1.40625 degree -> 128 == 180 degree
 struct TurnInstruction
 {
-    using LaneTupel = util::guidance::LaneTupel;
+    using LaneTuple = util::guidance::LaneTuple;
     TurnInstruction(const TurnType::Enum type = TurnType::Invalid,
                     const DirectionModifier::Enum direction_modifier = DirectionModifier::UTurn)
         : type(type), direction_modifier(direction_modifier)

--- a/include/util/guidance/turn_lanes.hpp
+++ b/include/util/guidance/turn_lanes.hpp
@@ -16,16 +16,16 @@ namespace util
 {
 namespace guidance
 {
-class LaneTupel;
+class LaneTuple;
 } // namespace guidance
 } // namespace util
 } // namespace osrm
 
 namespace std
 {
-template <> struct hash<::osrm::util::guidance::LaneTupel>
+template <> struct hash<::osrm::util::guidance::LaneTuple>
 {
-    inline std::size_t operator()(const ::osrm::util::guidance::LaneTupel &bearing_class) const;
+    inline std::size_t operator()(const ::osrm::util::guidance::LaneTuple &bearing_class) const;
 };
 } // namespace std
 
@@ -52,19 +52,19 @@ namespace guidance
 //
 // we generate a set of tuples in the form of:
 // (2,1), (1,1), (1,0) for left, through and right respectively
-class LaneTupel
+class LaneTuple
 {
   public:
-    LaneTupel();
-    LaneTupel(const LaneID lanes_in_turn, const LaneID first_lane_from_the_right);
+    LaneTuple();
+    LaneTuple(const LaneID lanes_in_turn, const LaneID first_lane_from_the_right);
 
-    bool operator==(const LaneTupel other) const;
-    bool operator!=(const LaneTupel other) const;
+    bool operator==(const LaneTuple other) const;
+    bool operator!=(const LaneTuple other) const;
 
     LaneID lanes_in_turn;
     LaneID first_lane_from_the_right;
 
-    friend std::size_t hash_value(const LaneTupel &tup)
+    friend std::size_t hash_value(const LaneTuple &tup)
     {
         std::size_t seed{0};
         boost::hash_combine(seed, tup.lanes_in_turn);
@@ -73,7 +73,7 @@ class LaneTupel
     }
 };
 
-using LaneTupelIdPair = std::pair<util::guidance::LaneTupel, LaneDescriptionID>;
+using LaneTupleIdPair = std::pair<util::guidance::LaneTuple, LaneDescriptionID>;
 } // namespace guidance
 } // namespace util
 } // namespace osrm

--- a/src/engine/guidance/lane_processing.cpp
+++ b/src/engine/guidance/lane_processing.cpp
@@ -4,7 +4,7 @@
 
 #include "extractor/guidance/turn_instruction.hpp"
 #include "engine/guidance/post_processing.hpp"
-#include "engine/guidance/toolkit.hpp"
+#include "extractor/guidance/toolkit.hpp"
 
 #include <iterator>
 #include <unordered_set>
@@ -16,6 +16,8 @@ namespace DirectionModifier = osrm::extractor::guidance::DirectionModifier;
 
 using osrm::util::guidance::isLeftTurn;
 using osrm::util::guidance::isRightTurn;
+using osrm::extractor::guidance::numLanesToTheRight;
+using osrm::extractor::guidance::numLanesToTheLeft;
 
 namespace osrm
 {
@@ -80,12 +82,8 @@ std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
             // where lanes in the turn fan in but for example the overall lanes at that location
             // fan out, we would have to know the asymmetric mapping of lanes. This is currently
             // not possible at the moment. In the following we implement a heuristic instead.
-            const LaneID current_num_all_lanes =
-                current.intersections.front().lane_description.size();
-            const LaneID current_num_lanes_right_of_turn = current_lanes.first_lane_from_the_right;
-            const LaneID current_num_lanes_left_of_turn =
-                current_num_all_lanes -
-                (current_lanes.lanes_in_turn + current_num_lanes_right_of_turn);
+            const LaneID current_num_lanes_right_of_turn = numLanesToTheRight(current);
+            const LaneID current_num_lanes_left_of_turn = numLanesToTheLeft(current);
 
             const LaneID num_shared_lanes = std::min(current_lanes.lanes_in_turn,   //
                                                      previous_lanes.lanes_in_turn); //

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -564,7 +564,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
     util::SimpleLogger().Write() << "Writing Turn Lane Data to File...";
     std::ofstream turn_lane_data_file(turn_lane_data_filename.c_str(), std::ios::binary);
-    std::vector<util::guidance::LaneTupelIdPair> lane_data(lane_data_map.size());
+    std::vector<util::guidance::LaneTupleIdPair> lane_data(lane_data_map.size());
     // extract lane data sorted by ID
     for (auto itr : lane_data_map)
         lane_data[itr.second] = itr.first;
@@ -574,7 +574,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
     if (!lane_data.empty())
         turn_lane_data_file.write(reinterpret_cast<const char *>(&lane_data[0]),
-                                  sizeof(util::guidance::LaneTupelIdPair) * lane_data.size());
+                                  sizeof(util::guidance::LaneTupleIdPair) * lane_data.size());
 
     util::SimpleLogger().Write() << "done.";
 

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -205,7 +205,7 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
     std::size_t road_index = 1, lane = 0;
 
     const auto matchRoad = [&](ConnectedRoad &road, const TurnLaneData &data) {
-        LaneTupelIdPair key{{LaneID(data.to - data.from + 1), data.from}, lane_string_id};
+        LaneTupleIdPair key{{LaneID(data.to - data.from + 1), data.from}, lane_string_id};
 
         auto lane_data_id = boost::numeric_cast<LaneDataID>(lane_data_to_id.size());
         const auto it = lane_data_to_id.find(key);

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -388,7 +388,7 @@ int Storage::Run()
     boost::filesystem::ifstream lane_data_stream(config.turn_lane_data_path, std::ios::binary);
     std::uint64_t lane_tupel_count = 0;
     lane_data_stream.read(reinterpret_cast<char *>(&lane_tupel_count), sizeof(lane_tupel_count));
-    shared_layout_ptr->SetBlockSize<util::guidance::LaneTupelIdPair>(
+    shared_layout_ptr->SetBlockSize<util::guidance::LaneTupleIdPair>(
         SharedDataLayout::TURN_LANE_DATA, lane_tupel_count);
 
     if (!static_cast<bool>(intersection_stream))
@@ -463,7 +463,7 @@ int Storage::Run()
 
     // make sure do write canary...
     auto *turn_lane_data_ptr =
-        shared_layout_ptr->GetBlockPtr<util::guidance::LaneTupelIdPair, true>(
+        shared_layout_ptr->GetBlockPtr<util::guidance::LaneTupleIdPair, true>(
             shared_memory_ptr, SharedDataLayout::TURN_LANE_DATA);
     if (shared_layout_ptr->GetBlockSize(SharedDataLayout::TURN_LANE_DATA) > 0)
     {

--- a/src/util/guidance/turn_lanes.cpp
+++ b/src/util/guidance/turn_lanes.cpp
@@ -12,24 +12,24 @@ namespace util
 {
 namespace guidance
 {
-LaneTupel::LaneTupel() : lanes_in_turn(0), first_lane_from_the_right(INVALID_LANEID)
+LaneTuple::LaneTuple() : lanes_in_turn(0), first_lane_from_the_right(INVALID_LANEID)
 {
     // basic constructor, set everything to zero
 }
 
-LaneTupel::LaneTupel(const LaneID lanes_in_turn, const LaneID first_lane_from_the_right)
+LaneTuple::LaneTuple(const LaneID lanes_in_turn, const LaneID first_lane_from_the_right)
     : lanes_in_turn(lanes_in_turn), first_lane_from_the_right(first_lane_from_the_right)
 {
 }
 
 // comparation based on interpretation as unsigned 32bit integer
-bool LaneTupel::operator==(const LaneTupel other) const
+bool LaneTuple::operator==(const LaneTuple other) const
 {
     return std::tie(lanes_in_turn, first_lane_from_the_right) ==
            std::tie(other.lanes_in_turn, other.first_lane_from_the_right);
 }
 
-bool LaneTupel::operator!=(const LaneTupel other) const { return !(*this == other); }
+bool LaneTuple::operator!=(const LaneTuple other) const { return !(*this == other); }
 
 } // namespace guidance
 } // namespace util

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -209,7 +209,7 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     EntryClassID GetEntryClassID(const EdgeID /*id*/) const override { return 0; }
 
     bool hasLaneData(const EdgeID /*id*/) const override final { return true; };
-    util::guidance::LaneTupelIdPair GetLaneData(const EdgeID /*id*/) const override final
+    util::guidance::LaneTupleIdPair GetLaneData(const EdgeID /*id*/) const override final
     {
         return {{0, 0}, 0};
     }


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/2679

This should add a layer of abstraction atop accessing other turn lanes from a given turn lane. Eventually there will be
- function `lanesToTheRight` which returns a range of turn lane description of lanes
- function `lanesToTheLeft` which returns a range of turn lane description of lanes
- function `numLanesToTheRight`, returns number of lanes
- function `numLanesToLeft`, returns number of lanes

## Tasklist
 - [x] Write `numLanesToTheRight/Left` functions
-  [x] Implement in LaneAnticipation
-  [x] Implement in `collapseUseLane`
-  [ ] Add unit test
 - [x] review
 - [ ] adjust for for comments

## Requirements / Relations
