### PR TITLE
Make SharedDataFacade immutable

### DIFF
--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -3,9 +3,9 @@
 
 #include "engine/datafacade/shared_datafacade.hpp"
 
+#include "storage/shared_barriers.hpp"
 #include "storage/shared_datatype.hpp"
 #include "storage/shared_memory.hpp"
-#include "storage/shared_barriers.hpp"
 
 #include <boost/interprocess/sync/named_upgradable_mutex.hpp>
 #include <boost/thread/lock_types.hpp>
@@ -102,8 +102,10 @@ class DataWatchdog
         boost::upgrade_to_unique_lock<boost::upgrade_mutex> unique_facade_lock(facade_lock);
 
         current_timestamp = *shared_timestamp;
-        facade = std::make_shared<datafacade::SharedDataFacade>(
-            current_timestamp.layout, current_timestamp.data, current_timestamp.timestamp);
+        facade = std::make_shared<datafacade::SharedDataFacade>(shared_barriers,
+                                                                current_timestamp.layout,
+                                                                current_timestamp.data,
+                                                                current_timestamp.timestamp);
 
         return get_locked_facade();
     }

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -1,3 +1,6 @@
+#ifndef OSRM_ENGINE_DATA_WATCHDOG_HPP
+#define OSRM_ENGINE_DATA_WATCHDOG_HPP
+
 #include "engine/datafacade/shared_datafacade.hpp"
 
 #include "storage/shared_datatype.hpp"
@@ -82,3 +85,5 @@ class DataWatchdog
 };
 }
 }
+
+#endif

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -1,0 +1,84 @@
+#include "engine/datafacade/shared_datafacade.hpp"
+
+#include "storage/shared_datatype.hpp"
+#include "storage/shared_memory.hpp"
+
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/thread/lock_types.hpp>
+
+#include <memory>
+
+namespace osrm
+{
+namespace engine
+{
+
+// This class monitors the shared memory region that contains the pointers to
+// the data and layout regions that should be used. This region is updated
+// once a new dataset arrives.
+//
+// TODO: This also needs a shared memory reader lock with other clients and
+// possibly osrm-datastore since updating the CURRENT_REGIONS data is not atomic.
+// Currently we enfore this by waiting that all queries have finished before
+// osrm-datastore writes to this section.
+class DataWatchdog
+{
+  public:
+    DataWatchdog()
+        : shared_regions(storage::makeSharedMemory(
+              storage::CURRENT_REGIONS, sizeof(storage::SharedDataTimestamp), false, false)),
+        current_timestamp {storage::LAYOUT_NONE, storage::DATA_NONE, 0}
+    {
+    }
+
+    // Tries to connect to the shared memory containing the regions table
+    static bool TryConnect()
+    {
+        return storage::SharedMemory::RegionExists(storage::CURRENT_REGIONS);
+    }
+
+    // Check if it might be worth to try to aquire a exclusive lock
+    bool HasNewRegion() const
+    {
+        const boost::shared_lock<boost::shared_mutex> lock(current_timestamp_mutex);
+
+        const auto shared_timestamp =
+            static_cast<const storage::SharedDataTimestamp *>(shared_regions->Ptr());
+
+        return shared_timestamp->layout != current_timestamp.layout ||
+               shared_timestamp->data != current_timestamp.data ||
+               shared_timestamp->timestamp != current_timestamp.timestamp;
+    }
+
+    // Note this can still return an emptry pointer if this function got overtaken by another thread
+    std::shared_ptr<datafacade::SharedDataFacade> MaybeLoadNewRegion()
+    {
+        const boost::lock_guard<boost::shared_mutex> lock(current_timestamp_mutex);
+
+        const auto shared_timestamp =
+            static_cast<const storage::SharedDataTimestamp *>(shared_regions->Ptr());
+
+        if (shared_timestamp->timestamp == current_timestamp.timestamp)
+        {
+            BOOST_ASSERT(shared_timestamp->layout == current_timestamp.layout);
+            BOOST_ASSERT(shared_timestamp->data == current_timestamp.data);
+            return std::shared_ptr<datafacade::SharedDataFacade>();
+        }
+
+        current_timestamp = *shared_timestamp;
+
+        return std::make_shared<datafacade::SharedDataFacade>(
+            current_timestamp.layout, current_timestamp.data, current_timestamp.timestamp);
+    }
+
+  private:
+    // shared memory table containing pointers to all shared regions
+    std::unique_ptr<storage::SharedMemory> shared_regions;
+
+    // mutexes should be mutable even on const objects: This enables
+    // marking functions as logical const and thread-safe.
+    mutable boost::shared_mutex current_timestamp_mutex;
+    storage::SharedDataTimestamp current_timestamp;
+};
+}
+}

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -5,10 +5,11 @@
 
 #include "storage/shared_datatype.hpp"
 #include "storage/shared_memory.hpp"
+#include "storage/shared_barriers.hpp"
 
 #include <boost/interprocess/sync/named_upgradable_mutex.hpp>
-#include <boost/thread/locks.hpp>
 #include <boost/thread/lock_types.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
 #include <memory>
@@ -31,7 +32,7 @@ class DataWatchdog
   public:
     DataWatchdog()
         : shared_barriers{std::make_shared<storage::SharedBarriers>()},
-          shared_regions(storage::makeSharedMemoryView(storage::CURRENT_REGIONS)),
+          shared_regions(storage::makeSharedMemory(storage::CURRENT_REGIONS)),
           current_timestamp{storage::LAYOUT_NONE, storage::DATA_NONE, 0}
     {
     }
@@ -42,26 +43,13 @@ class DataWatchdog
         return storage::SharedMemory::RegionExists(storage::CURRENT_REGIONS);
     }
 
-    // Check if it might be worth to try to aquire a exclusive lock
-    bool HasNewRegion() const
-    {
-        const boost::interprocess::sharable_lock<boost::interprocess::named_upgradable_mutex> lock(
-            shared_barriers->current_regions_mutex);
-
-        const auto shared_timestamp =
-            static_cast<const storage::SharedDataTimestamp *>(shared_regions->Ptr());
-
-        // sanity check: if the timestamp is the same all other data needs to be the same as well
-        BOOST_ASSERT(shared_timestamp->timestamp != current_timestamp.timestamp ||
-                     (shared_timestamp->layout == current_timestamp.layout &&
-                      shared_timestamp->data == current_timestamp.data));
-
-        return shared_timestamp->timestamp != current_timestamp.timestamp;
-    }
+    using RegionsLock =
+        boost::interprocess::sharable_lock<boost::interprocess::named_sharable_mutex>;
+    using LockAndFacade = std::pair<RegionsLock, std::shared_ptr<datafacade::BaseDataFacade>>;
 
     // This will either update the contens of facade or just leave it as is
     // if the update was already done by another thread
-    void MaybeLoadNewRegion(std::shared_ptr<datafacade::BaseDataFacade> &facade)
+    LockAndFacade GetDataFacade()
     {
         const boost::interprocess::sharable_lock<boost::interprocess::named_upgradable_mutex> lock(
             shared_barriers->current_regions_mutex);
@@ -69,31 +57,55 @@ class DataWatchdog
         const auto shared_timestamp =
             static_cast<const storage::SharedDataTimestamp *>(shared_regions->Ptr());
 
+        const auto get_locked_facade = [this, shared_timestamp]() {
+            if (current_timestamp.data == storage::DATA_1)
+            {
+                BOOST_ASSERT(current_timestamp.layout == storage::LAYOUT_1);
+                return std::make_pair(RegionsLock(shared_barriers->regions_1_mutex), facade);
+            }
+            else
+            {
+                BOOST_ASSERT(current_timestamp.layout == storage::LAYOUT_2);
+                BOOST_ASSERT(current_timestamp.data == storage::DATA_2);
+                return std::make_pair(RegionsLock(shared_barriers->regions_2_mutex), facade);
+            }
+        };
+
+        // this blocks handle the common case when there is no data update -> we will only need a
+        // shared lock
+        {
+            boost::shared_lock<boost::shared_mutex> facade_lock(facade_mutex);
+
+            if (shared_timestamp->timestamp == current_timestamp.timestamp)
+            {
+                BOOST_ASSERT(shared_timestamp->layout == current_timestamp.layout);
+                BOOST_ASSERT(shared_timestamp->data == current_timestamp.data);
+                return get_locked_facade();
+            }
+        }
+
+        // if we reach this code there is a data update to be made. multiple
+        // requests can reach this, but only ever one goes through at a time.
         boost::upgrade_lock<boost::shared_mutex> facade_lock(facade_mutex);
 
-        // if more then one request tried to aquire the write lock
         // we might get overtaken before we actually do the writing
         // in that case we don't modify anthing
         if (shared_timestamp->timestamp == current_timestamp.timestamp)
         {
             BOOST_ASSERT(shared_timestamp->layout == current_timestamp.layout);
             BOOST_ASSERT(shared_timestamp->data == current_timestamp.data);
-        }
-        // this thread has won and can update the data
-        else
-        {
-            boost::upgrade_to_unique_lock<boost::upgrade_mutex> unique_facade_lock(facade_lock);
 
-            current_timestamp = *shared_timestamp;
-            // TODO remove once we allow for more then one SharedMemoryFacade at the same time
-            // at this point no other query is allowed to reference this facade!
-            // the old facade will die exactly here
-            BOOST_ASSERT(!facade || facade.use_count() == 1);
-            facade = std::make_shared<datafacade::SharedDataFacade>(shared_barriers,
-                                                                    current_timestamp.layout,
-                                                                    current_timestamp.data,
-                                                                    current_timestamp.timestamp);
+            return get_locked_facade();
         }
+
+        // this thread has won and can update the data
+        boost::upgrade_to_unique_lock<boost::upgrade_mutex> unique_facade_lock(facade_lock);
+
+        current_timestamp = *shared_timestamp;
+        facade = std::make_shared<datafacade::SharedDataFacade>(
+            current_timestamp.layout, current_timestamp.data, current_timestamp.timestamp);
+
+        return get_locked_facade();
     }
 
   private:
@@ -105,6 +117,7 @@ class DataWatchdog
     std::unique_ptr<storage::SharedMemory> shared_regions;
 
     mutable boost::shared_mutex facade_mutex;
+    std::shared_ptr<datafacade::SharedDataFacade> facade;
     storage::SharedDataTimestamp current_timestamp;
 };
 }

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -28,8 +28,7 @@ class DataWatchdog
 {
   public:
     DataWatchdog()
-        : shared_regions(storage::makeSharedMemory(
-              storage::CURRENT_REGIONS, sizeof(storage::SharedDataTimestamp), false, false)),
+        : shared_regions(storage::makeSharedMemoryView(storage::CURRENT_REGIONS)),
         current_timestamp {storage::LAYOUT_NONE, storage::DATA_NONE, 0}
     {
     }

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -150,7 +150,7 @@ class SharedDataFacade final : public BaseDataFacade
         if (!boost::filesystem::exists(file_index_path))
         {
             util::SimpleLogger().Write(logDEBUG) << "Leaf file name " << file_index_path.string();
-            throw util::exception("Could not load leaf index file. "
+            throw util::exception("Could not load " + file_index_path.string() +
                                   "Is any data loaded into shared memory?");
         }
 

--- a/include/engine/datafacade/shared_datafacade.hpp
+++ b/include/engine/datafacade/shared_datafacade.hpp
@@ -388,12 +388,12 @@ class SharedDataFacade final : public BaseDataFacade
         util::SimpleLogger().Write(logDEBUG) << "Loading new data with shared timestamp " << shared_timestamp;
 
         BOOST_ASSERT(storage::SharedMemory::RegionExists(layout_region));
-        m_layout_memory.reset(storage::makeSharedMemory(layout_region));
+        m_layout_memory = storage::makeOwnedSharedMemoryView(layout_region);
 
         data_layout = static_cast<storage::SharedDataLayout *>(m_layout_memory->Ptr());
 
         BOOST_ASSERT(storage::SharedMemory::RegionExists(data_region));
-        m_large_memory.reset(storage::makeSharedMemory(data_region));
+        m_large_memory = storage::makeOwnedSharedMemoryView(data_region);
         shared_memory = (char *)(m_large_memory->Ptr());
 
         LoadGraph();

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -85,8 +85,9 @@ class Engine final
     std::unique_ptr<plugins::MatchPlugin> match_plugin;
     std::unique_ptr<plugins::TilePlugin> tile_plugin;
 
-    // reading and setting this is protected by locking in the watchdog
-    mutable std::shared_ptr<datafacade::BaseDataFacade> query_data_facade;
+    // note in case of shared memory this will be empty, since the watchdog
+    // will provide us with the up-to-date facade
+    std::shared_ptr<datafacade::BaseDataFacade> immutable_data_facade;
 };
 }
 }

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -85,10 +85,8 @@ class Engine final
     std::unique_ptr<plugins::MatchPlugin> match_plugin;
     std::unique_ptr<plugins::TilePlugin> tile_plugin;
 
-    // reading and setting this is protected by lock
+    // reading and setting this is protected by locking in the watchdog
     mutable std::shared_ptr<datafacade::BaseDataFacade> query_data_facade;
-    // ensures that when we set facade we can do it without race conditions
-    mutable std::unique_ptr<std::mutex> facade_update_mutex;
 };
 }
 }

--- a/include/storage/shared_barriers.hpp
+++ b/include/storage/shared_barriers.hpp
@@ -19,11 +19,23 @@ struct SharedBarriers
     {
     }
 
+    static void resetCurrentRegions()
+    {
+        boost::interprocess::named_sharable_mutex::remove("current_regions");
+    }
+    static void resetRegions1()
+    {
+        boost::interprocess::named_sharable_mutex::remove("regions_1");
+    }
+    static void resetRegions2()
+    {
+        boost::interprocess::named_sharable_mutex::remove("regions_2");
+    }
+
     boost::interprocess::named_upgradable_mutex current_regions_mutex;
     boost::interprocess::named_sharable_mutex regions_1_mutex;
     boost::interprocess::named_sharable_mutex regions_2_mutex;
 };
-
 }
 }
 

--- a/include/storage/shared_barriers.hpp
+++ b/include/storage/shared_barriers.hpp
@@ -1,27 +1,29 @@
 #ifndef SHARED_BARRIERS_HPP
 #define SHARED_BARRIERS_HPP
 
-#include <boost/interprocess/sync/named_condition.hpp>
-#include <boost/interprocess/sync/named_mutex.hpp>
 #include <boost/interprocess/sync/named_sharable_mutex.hpp>
+#include <boost/interprocess/sync/named_upgradable_mutex.hpp>
 
 namespace osrm
 {
 namespace storage
 {
+
 struct SharedBarriers
 {
 
     SharedBarriers()
-        : pending_update_mutex(boost::interprocess::open_or_create, "pending_update"),
-          query_mutex(boost::interprocess::open_or_create, "query")
+        : current_regions_mutex(boost::interprocess::open_or_create, "current_regions"),
+          regions_1_mutex(boost::interprocess::open_or_create, "regions_1"),
+          regions_2_mutex(boost::interprocess::open_or_create, "regions_2")
     {
     }
 
-    // Mutex to protect access to the boolean variable
-    boost::interprocess::named_mutex pending_update_mutex;
-    boost::interprocess::named_sharable_mutex query_mutex;
+    boost::interprocess::named_upgradable_mutex current_regions_mutex;
+    boost::interprocess::named_sharable_mutex regions_1_mutex;
+    boost::interprocess::named_sharable_mutex regions_2_mutex;
 };
+
 }
 }
 

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -183,6 +183,29 @@ struct SharedDataTimestamp
     unsigned timestamp;
 };
 
+inline std::string regionToString(const SharedDataType region)
+{
+    switch (region)
+    {
+    case CURRENT_REGIONS:
+        return "CURRENT_REGIONS";
+    case LAYOUT_1:
+        return "LAYOUT_1";
+    case DATA_1:
+        return "DATA_1";
+    case LAYOUT_2:
+        return "LAYOUT_2";
+    case DATA_2:
+        return "DATA_2";
+    case LAYOUT_NONE:
+        return "LAYOUT_NONE";
+    case DATA_NONE:
+        return "DATA_NONE";
+    default:
+        return "INVALID_REGION";
+    }
+}
+
 static_assert(sizeof(block_id_to_name) / sizeof(*block_id_to_name) == SharedDataLayout::NUM_BLOCKS,
               "Number of blocks needs to match the number of Block names.");
 }

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -93,6 +93,8 @@ class SharedMemory
         { // read_only
             shm = boost::interprocess::xsi_shared_memory(boost::interprocess::open_only, key);
 
+            util::SimpleLogger().Write(logDEBUG) << "opening " << shm.get_shmid() << " from id "
+                                                 << id;
             region = boost::interprocess::mapped_region(
                 shm,
                 (read_write ? boost::interprocess::read_write : boost::interprocess::read_only));
@@ -106,6 +108,8 @@ class SharedMemory
             }
             shm = boost::interprocess::xsi_shared_memory(
                 boost::interprocess::open_or_create, key, size);
+            util::SimpleLogger().Write(logDEBUG) << "opening/creating " << shm.get_shmid()
+                                                 << " from id " << id << " with size " << size;
 #ifdef __linux__
             if (-1 == shmctl(shm.get_shmid(), SHM_LOCK, nullptr))
             {
@@ -166,8 +170,8 @@ class SharedMemory
         bool ret = false;
         try
         {
-            util::SimpleLogger().Write(logDEBUG) << "deallocating prev memory";
             boost::interprocess::xsi_shared_memory xsi(boost::interprocess::open_only, key);
+            util::SimpleLogger().Write(logDEBUG) << "deallocating prev memory " << xsi.get_shmid();
             ret = boost::interprocess::xsi_shared_memory::remove(xsi.get_shmid());
         }
         catch (const boost::interprocess::interprocess_exception &e)
@@ -306,7 +310,7 @@ class SharedMemory
         bool ret = false;
         try
         {
-            util::SimpleLogger().Write(logDEBUG) << "deallocating prev memory";
+            util::SimpleLogger().Write(logDEBUG) << "deallocating prev memory for key " << key;
             ret = boost::interprocess::shared_memory_object::remove(key);
         }
         catch (const boost::interprocess::interprocess_exception &e)

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -42,7 +42,15 @@ class Storage
 {
   public:
     Storage(StorageConfig config);
-    int Run();
+
+    enum ReturnCode
+    {
+        Ok,
+        Error,
+        Retry
+    };
+
+    ReturnCode Run(int max_wait);
 
   private:
     StorageConfig config;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -22,7 +22,6 @@
 #include <boost/interprocess/sync/named_condition.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 #include <boost/interprocess/sync/sharable_lock.hpp>
-#include <boost/thread/lock_types.hpp>
 
 #include <algorithm>
 #include <fstream>
@@ -36,28 +35,15 @@ namespace
 // Works the same for every plugin.
 template <typename ParameterT, typename PluginT, typename ResultT>
 osrm::engine::Status
-RunQuery(const std::unique_ptr<osrm::storage::SharedBarriers> &lock,
-         osrm::engine::DataWatchdog& watchdog,
+RunQuery(const std::unique_ptr<osrm::engine::DataWatchdog>& watchdog,
          std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &facade,
          const ParameterT &parameters,
          PluginT &plugin,
          ResultT &result)
 {
-    if (!lock)
+    if (watchdog && watchdog->HasNewRegion())
     {
-        return plugin.HandleRequest(facade, parameters, result);
-    }
-
-    BOOST_ASSERT(lock);
-    // this locks aquires shared ownership of the query mutex: other requets are allowed
-    // to run, but data updates need to wait for all queries to finish until they can aquire an
-    // exclusive lock
-    boost::interprocess::sharable_lock<boost::interprocess::named_sharable_mutex> query_lock(
-        lock->query_mutex);
-
-    if (watchdog.HasNewRegion())
-    {
-        watchdog.MaybeLoadNewRegion(facade);
+        watchdog->MaybeLoadNewRegion(facade);
     }
 
     osrm::engine::Status status = plugin.HandleRequest(facade, parameters, result);
@@ -84,14 +70,12 @@ Engine::Engine(const EngineConfig &config)
                 "No shared memory blocks found, have you forgotten to run osrm-datastore?");
         }
 
-        facade_update_mutex = std::make_unique<std::mutex>();
         watchdog = std::make_unique<DataWatchdog>();
         // this will always either return a value or throw an exception
         // in the initial run
         watchdog->MaybeLoadNewRegion(query_data_facade);
         BOOST_ASSERT(query_data_facade);
         BOOST_ASSERT(watchdog);
-        BOOST_ASSERT(lock);
     }
     else
     {
@@ -120,32 +104,32 @@ Engine &Engine::operator=(Engine &&) noexcept = default;
 
 Status Engine::Route(const api::RouteParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, *watchdog, query_data_facade, params, *route_plugin, result);
+    return RunQuery(watchdog, query_data_facade, params, *route_plugin, result);
 }
 
 Status Engine::Table(const api::TableParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, *watchdog, query_data_facade, params, *table_plugin, result);
+    return RunQuery(watchdog, query_data_facade, params, *table_plugin, result);
 }
 
 Status Engine::Nearest(const api::NearestParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, *watchdog, query_data_facade, params, *nearest_plugin, result);
+    return RunQuery(watchdog, query_data_facade, params, *nearest_plugin, result);
 }
 
 Status Engine::Trip(const api::TripParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, *watchdog, query_data_facade, params, *trip_plugin, result);
+    return RunQuery(watchdog, query_data_facade, params, *trip_plugin, result);
 }
 
 Status Engine::Match(const api::MatchParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, *watchdog, query_data_facade, params, *match_plugin, result);
+    return RunQuery(watchdog, query_data_facade, params, *match_plugin, result);
 }
 
 Status Engine::Tile(const api::TileParameters &params, std::string &result) const
 {
-    return RunQuery(lock, *watchdog, query_data_facade, params, *tile_plugin, result);
+    return RunQuery(watchdog, query_data_facade, params, *tile_plugin, result);
 }
 
 } // engine ns

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -2,6 +2,7 @@
 #include "engine/api/route_parameters.hpp"
 #include "engine/engine_config.hpp"
 #include "engine/status.hpp"
+#include "engine/data_watchdog.hpp"
 
 #include "engine/plugins/match.hpp"
 #include "engine/plugins/nearest.hpp"
@@ -36,7 +37,9 @@ namespace
 template <typename ParameterT, typename PluginT, typename ResultT>
 osrm::engine::Status
 RunQuery(const std::unique_ptr<osrm::storage::SharedBarriers> &lock,
-         const std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &facade,
+         std::mutex &facade_update_mutex,
+         osrm::engine::DataWatchdog& watchdog,
+         std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &facade,
          const ParameterT &parameters,
          PluginT &plugin,
          ResultT &result)
@@ -53,11 +56,32 @@ RunQuery(const std::unique_ptr<osrm::storage::SharedBarriers> &lock,
     boost::interprocess::sharable_lock<boost::interprocess::named_sharable_mutex> query_lock(
         lock->query_mutex);
 
-    auto &shared_facade = static_cast<osrm::engine::datafacade::SharedDataFacade &>(*facade);
-    shared_facade.CheckAndReloadFacade();
-    // Get a shared data lock so that other threads won't update
-    // things while the query is running
-    boost::shared_lock<boost::shared_mutex> data_lock{shared_facade.data_mutex};
+    {
+        // this lock ensures that we are never overtaken while creating a new
+        // facade and setting it.
+        // This is important since we need to ensure there is always exactly
+        // one facade per shared memory region.
+        // TODO: Remove this once the SharedDataFacade doesn't own the shared memory
+        // segment anymore.
+        std::lock_guard<std::mutex> update_lock(facade_update_mutex);
+
+        if (watchdog.HasNewRegion())
+        {
+
+            auto new_facade = watchdog.MaybeLoadNewRegion();
+            // for now the external locking will ensure that loading the new region
+            // will ways work. In the future we might allow being overtaken
+            // by other threads and they will also try to update.
+            if (new_facade)
+            {
+                // TODO remove once we allow for more then one SharedMemoryFacade at the same time
+                // at this point no other query is allowed to reference this facade!
+                // the old facade will die exactly here
+                BOOST_ASSERT(facade.use_count() == 1);
+                facade = std::move(new_facade);
+            }
+        }
+    }
 
     osrm::engine::Status status = plugin.HandleRequest(facade, parameters, result);
 
@@ -77,7 +101,20 @@ Engine::Engine(const EngineConfig &config)
 {
     if (config.use_shared_memory)
     {
-        query_data_facade = std::make_shared<datafacade::SharedDataFacade>();
+        if (!DataWatchdog::TryConnect())
+        {
+            throw util::exception(
+                "No shared memory blocks found, have you forgotten to run osrm-datastore?");
+        }
+
+        facade_update_mutex = std::make_unique<std::mutex>();
+        watchdog = std::make_unique<DataWatchdog>();
+        // this will always either return a value or throw an exception
+        // in the initial run
+        query_data_facade = watchdog->MaybeLoadNewRegion();
+        BOOST_ASSERT(query_data_facade);
+        BOOST_ASSERT(watchdog);
+        BOOST_ASSERT(lock);
     }
     else
     {
@@ -106,32 +143,32 @@ Engine &Engine::operator=(Engine &&) noexcept = default;
 
 Status Engine::Route(const api::RouteParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, query_data_facade, params, *route_plugin, result);
+    return RunQuery(lock, *facade_update_mutex, *watchdog, query_data_facade, params, *route_plugin, result);
 }
 
 Status Engine::Table(const api::TableParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, query_data_facade, params, *table_plugin, result);
+    return RunQuery(lock, *facade_update_mutex, *watchdog, query_data_facade, params, *table_plugin, result);
 }
 
 Status Engine::Nearest(const api::NearestParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, query_data_facade, params, *nearest_plugin, result);
+    return RunQuery(lock, *facade_update_mutex, *watchdog, query_data_facade, params, *nearest_plugin, result);
 }
 
 Status Engine::Trip(const api::TripParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, query_data_facade, params, *trip_plugin, result);
+    return RunQuery(lock, *facade_update_mutex, *watchdog, query_data_facade, params, *trip_plugin, result);
 }
 
 Status Engine::Match(const api::MatchParameters &params, util::json::Object &result) const
 {
-    return RunQuery(lock, query_data_facade, params, *match_plugin, result);
+    return RunQuery(lock, *facade_update_mutex, *watchdog, query_data_facade, params, *match_plugin, result);
 }
 
 Status Engine::Tile(const api::TileParameters &params, std::string &result) const
 {
-    return RunQuery(lock, query_data_facade, params, *tile_plugin, result);
+    return RunQuery(lock, *facade_update_mutex, *watchdog, query_data_facade, params, *tile_plugin, result);
 }
 
 } // engine ns

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -119,7 +119,7 @@ int Storage::Run()
     }();
 
     // Allocate a memory layout in shared memory, deallocate previous
-    auto *layout_memory = makeSharedMemory(layout_region, sizeof(SharedDataLayout));
+    auto layout_memory = makeSharedMemory(layout_region, sizeof(SharedDataLayout));
     auto shared_layout_ptr = new (layout_memory->Ptr()) SharedDataLayout();
     auto absolute_file_index_path = boost::filesystem::absolute(config.file_index_path);
 
@@ -406,7 +406,7 @@ int Storage::Run()
     // allocate shared memory block
     util::SimpleLogger().Write() << "allocating shared memory of "
                                  << shared_layout_ptr->GetSizeOfLayout() << " bytes";
-    auto *shared_memory = makeSharedMemory(data_region, shared_layout_ptr->GetSizeOfLayout());
+    auto shared_memory = makeSharedMemory(data_region, shared_layout_ptr->GetSizeOfLayout());
     char *shared_memory_ptr = static_cast<char *>(shared_memory->Ptr());
 
     // read actual data into shared memory object //
@@ -733,8 +733,7 @@ int Storage::Run()
     }
 
     // acquire lock
-    SharedMemory *data_type_memory =
-        makeSharedMemory(CURRENT_REGIONS, sizeof(SharedDataTimestamp), true, false);
+    auto data_type_memory = makeSharedMemory(CURRENT_REGIONS, sizeof(SharedDataTimestamp), true, false, false);
     SharedDataTimestamp *data_timestamp_ptr =
         static_cast<SharedDataTimestamp *>(data_type_memory->Ptr());
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -739,7 +739,9 @@ int Storage::Run()
         static_cast<SharedDataTimestamp *>(data_type_memory->Ptr());
 
     {
+        util::SimpleLogger().Write(logDEBUG) << "waiting for all queries to finish";
         boost::interprocess::scoped_lock<boost::interprocess::named_sharable_mutex> query_lock(barrier.query_mutex);
+        util::SimpleLogger().Write(logDEBUG) << "all queries complete, switching over.";
 
         data_timestamp_ptr->layout = layout_region;
         data_timestamp_ptr->data = data_region;

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -12,7 +12,8 @@ using namespace osrm;
 // generate boost::program_options object for the routing part
 bool generateDataStoreOptions(const int argc,
                               const char *argv[],
-                              boost::filesystem::path &base_path)
+                              boost::filesystem::path &base_path,
+                              int &max_wait)
 {
     // declare a group of options that will be allowed only on command line
     boost::program_options::options_description generic_options("Options");
@@ -21,6 +22,9 @@ bool generateDataStoreOptions(const int argc,
     // declare a group of options that will be allowed both on command line
     // as well as in a config file
     boost::program_options::options_description config_options("Configuration");
+    config_options.add_options()("max-wait",
+                                 boost::program_options::value<int>(&max_wait)->default_value(-1),
+                                 "Maximum number of seconds to wait on requests that use the old dataset.");
 
     // hidden options, will be allowed on command line but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");
@@ -87,7 +91,8 @@ int main(const int argc, const char *argv[]) try
     util::LogPolicy::GetInstance().Unmute();
 
     boost::filesystem::path base_path;
-    if (!generateDataStoreOptions(argc, argv, base_path))
+    int max_wait = -1;
+    if (!generateDataStoreOptions(argc, argv, base_path, max_wait))
     {
         return EXIT_SUCCESS;
     }
@@ -98,7 +103,29 @@ int main(const int argc, const char *argv[]) try
         return EXIT_FAILURE;
     }
     storage::Storage storage(std::move(config));
-    return storage.Run();
+
+    // We will attempt to load this dataset to memory several times if we encounter
+    // an error we can recover from. This is needed when we need to clear mutexes
+    // that have been left dangling by other processes.
+    const constexpr unsigned MAX_RETRIES = 3;
+    unsigned retry_counter = 0;
+    storage::Storage::ReturnCode code = storage::Storage::ReturnCode::Retry;
+    while(code == storage::Storage::ReturnCode::Retry && retry_counter < MAX_RETRIES)
+    {
+        if (retry_counter > 0)
+        {
+            util::SimpleLogger().Write(logWARNING) << "Try number " << (retry_counter+1)  << " to load the dataset.";
+        }
+        code = storage.Run(max_wait);
+        retry_counter++;
+    }
+
+    if (code == storage::Storage::ReturnCode::Ok)
+    {
+        return EXIT_SUCCESS;
+    }
+
+    return EXIT_FAILURE;
 }
 catch (const std::bad_alloc &e)
 {

--- a/src/tools/unlock_all_mutexes.cpp
+++ b/src/tools/unlock_all_mutexes.cpp
@@ -7,9 +7,10 @@ int main()
 {
     osrm::util::LogPolicy::GetInstance().Unmute();
     osrm::util::SimpleLogger().Write() << "Releasing all locks";
-    osrm::storage::SharedBarriers barriers;
-    boost::interprocess::named_upgradable_mutex::remove("current_regions");
-    boost::interprocess::named_sharable_mutex::remove("regions_1");
-    boost::interprocess::named_sharable_mutex::remove("regions_2");
+
+    osrm::storage::SharedBarriers::resetCurrentRegions();
+    osrm::storage::SharedBarriers::resetRegions1();
+    osrm::storage::SharedBarriers::resetRegions2();
+
     return 0;
 }

--- a/src/tools/unlock_all_mutexes.cpp
+++ b/src/tools/unlock_all_mutexes.cpp
@@ -7,8 +7,9 @@ int main()
 {
     osrm::util::LogPolicy::GetInstance().Unmute();
     osrm::util::SimpleLogger().Write() << "Releasing all locks";
-    osrm::storage::SharedBarriers barrier;
-    barrier.pending_update_mutex.unlock();
-    barrier.query_mutex.unlock();
+    osrm::storage::SharedBarriers barriers;
+    boost::interprocess::named_upgradable_mutex::remove("current_regions");
+    boost::interprocess::named_sharable_mutex::remove("regions_1");
+    boost::interprocess::named_sharable_mutex::remove("regions_2");
     return 0;
 }


### PR DESCRIPTION
# Issue

This is the second step of #2570. ~~Again this does not really improve the locking. There might even be a little bit more locking with this, as some mutexes are redundant still. It mainly cleans up the code by separating responsibilities better.~~

Switched this to fully implement #2570 because after #3017 that was an easy step. This changes the behavior of `osrm-datastore` in case there is already an update going on: It will return with an error. We don't rely anymore on having no having no requests running, thanks to the reader-writer lock:

1. Once `osrm-datastore` is ready to do the final switch, it acquires an exclusive lock that blocks all new queries.
2. Since this update is very quick, the delay between switching and new requests picking up the dataset is very short.
3. Requests already running are not affected by this, since they retain the old memory until they are finished over are reader-lock.

Testing concurrency is quite hard in an automated fashion. The cucumber tests work, but I'll only take this a general indicator for working and will do manual tests.

## Tasklist
 - [x] run `osrm-datastore` multiple times while query is running
 - [x] Try concurrent datastore runs
     - [x] with requests
     - [x] without requests
 - [x] Try hitting the server hard with a mix of slow and long queries and switch datasets
 - [x] same with fsanitize=thread
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations

This is the successor of #3012 on the quest to #2570. This closes #2570.
Merge #3017  before this.
