### PR TITLE
Route over alternating oneways but not reversible ones, closes #2837.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Profiles
       - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
       - replaced lhs/rhs profiles by using test defined profiles
+      - Handle `oneway=alternating` (routed over with penalty) separately from `oneway=reversible` (not routed over due to time dependence)
     - Guidance
       - Notifications are now exposed more prominently, announcing turns onto a ferry/pushing your bike more prominently
     - Trip Plugin

--- a/features/car/oneway.feature
+++ b/features/car/oneway.feature
@@ -85,3 +85,12 @@ Feature: Car - Oneway streets
         When I route I should get
             | from | to | route    |
             | a    | c  | ab,bc,bc |
+
+
+    # Reversible oneways (low frequency) vs alternating oneways (high frequency).
+    # See: https://github.com/Project-OSRM/osrm-backend/issues/2837
+    Scenario: Car - Route over alternating but not reversible oneways
+        Then routability should be
+            | highway | oneway      | forw | backw |
+            | primary | reversible  |      |       |
+            | primary | alternating | x    | x     |

--- a/features/car/speed.feature
+++ b/features/car/speed.feature
@@ -22,3 +22,16 @@ Feature: Car - speeds
             | residential    | no     | 31 km/h      |
             | living_street  | no     | 18 km/h      |
             | service        | no     | 23 km/h      |
+
+    # Alternating oneways have to take average waiting time into account.
+    Scenario: Car - scaled speeds for oneway=alternating
+        Then routability should be
+            | highway        | oneway      | junction   | bothw        | #              |
+            | tertiary       |             |            | 43 km/h      |                |
+            | tertiary       | alternating |            | 20 km/h +- 5 |                |
+            | motorway       |             |            | 82 km/h      | implied oneway |
+            | motorway       | alternating |            | 30 km/h +- 5 | implied oneway |
+            | motorway       | reversible  |            |              | unroutable     |
+            | primary        |             | roundabout | 63 km/h      | implied oneway |
+            | primary        | alternating | roundabout | 25 km/h +- 5 | implied oneway |
+            | primary        | reversible  | roundabout |              | unroutable     |

--- a/taginfo.json
+++ b/taginfo.json
@@ -46,8 +46,14 @@
         },
         {
             "key": "oneway",
+            "value": "alternating",
+            "description": "high frequency reversible oneways are routed over taking the waiting period into account",
+            "object_types": [ "way" ]
+        },
+        {
+            "key": "oneway",
             "value": "reversible",
-            "description": "is marked as non-routable because of time-dependence",
+            "description": "low frequency reversible oneways are marked as non-routable because of time-dependence",
             "object_types": [ "way" ]
         },
         {


### PR DESCRIPTION
For #2837.

- alternating: high frequency, route over them with penalty
- reversible: low frequency, do not route over them - time dependence

- http://wiki.openstreetmap.org/wiki/Tag:oneway%3Dreversible
- http://wiki.openstreetmap.org/wiki/Tag:oneway%3Dalternating

This distinction was made at the Elbe-Labe Meetup in Dresden, with
accompanying Wiki pages and tagging scheme. Thanks all involed!

- https://github.com/Project-OSRM/osrm-backend/issues/2837
- http://wiki.openstreetmap.org/wiki/Key:oneway