### PR TITLE
don't emit invalid on sliproads with incompatible modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
     - Debug Tiles
       - Added support for turn penalties
 
+# 5.4.2
+  - Changes from 5.4.1
+    - Bugfixes
+      - #3032 Fixed a bug that could result in emitting `invalid` as an instruction type on sliproads with mode changes
+
 # 5.4.1
   - Changes from 5.4.0
     - Bugfixes

--- a/features/guidance/bicycle-sliproads.feature
+++ b/features/guidance/bicycle-sliproads.feature
@@ -1,0 +1,33 @@
+@routing @bicycle @mode
+Feature: Bike - Mode flag
+
+	Background:
+		Given the profile "bicycle"
+        Given a grid size of 5 meters
+
+    Scenario: Bike Sliproad
+        Given the node map
+            """
+                  i
+            a b - c-d
+                ` |
+                g-e-h
+                  |
+                  |
+                  f
+            """
+
+        And the nodes
+            | node | highway         |
+            | c    | traffic_signals |
+
+        And the ways
+            | nodes | highway   | name   | oneway:bicycle |
+            | abcd  | cycleway  | street |                |
+            | eb    | path      |        | yes            |
+            | icef  | tertiary  | road   |                |
+            | geh   | secondary | street |                |
+
+        When I route I should get
+            | waypoints | route                           | turns                               |
+            | a,f       | street,{highway:path},road,road | depart,turn right,turn right,arrive |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -1,5 +1,5 @@
-#include "engine/guidance/post_processing.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
+#include "engine/guidance/post_processing.hpp"
 
 #include "engine/guidance/assemble_steps.hpp"
 #include "engine/guidance/lane_processing.hpp"
@@ -837,6 +837,11 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
                     steps[one_back_index].maneuver.instruction.direction_modifier =
                         ::osrm::util::guidance::getTurnDirection(angle);
                     invalidateStep(steps[step_index]);
+                }
+                else
+                {
+                    //the sliproad turn is incompatible. So we handle it as a turn
+                    steps[one_back_index].maneuver.instruction.type = TurnType::Turn;
                 }
             }
         }


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/3032

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for for comments

## Requirements / Relations
none