### PR TITLE
Asserts on valid v5 conforming maneuver types, resolves #3035

### DIFF
--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -175,10 +175,18 @@ std::string modeToString(const extractor::TravelMode mode)
 util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
 {
     util::json::Object step_maneuver;
+
+    std::string maneuver_type;
+
     if (maneuver.waypoint_type == guidance::WaypointType::None)
-        step_maneuver.values["type"] = detail::instructionTypeToString(maneuver.instruction.type);
+        maneuver_type = detail::instructionTypeToString(maneuver.instruction.type);
     else
-        step_maneuver.values["type"] = detail::waypointTypeToString(maneuver.waypoint_type);
+        maneuver_type = detail::waypointTypeToString(maneuver.waypoint_type);
+
+    // These invalid responses should never happen: log if they do happen
+    BOOST_ASSERT_MSG(maneuver_type != "invalid", "unexpected invalid maneuver type");
+
+    step_maneuver.values["type"] = std::move(maneuver_type);
 
     if (detail::isValidModifier(maneuver))
         step_maneuver.values["modifier"] =


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/3035. At the moment we have no idea when we're accidentally returning an "invalid" type. This type is not in the v5 - let's get a notification for when this happens (=> bug).

## Tasklist
 - [x] review
 - [ ] adjust for for comments