### PR TITLE
Collapses Double OSRM <-> Engine <-> .. PImpl Indirection, Resolves #3019

### DIFF
--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -1,71 +1,44 @@
 #ifndef ENGINE_HPP
 #define ENGINE_HPP
 
+#include "storage/shared_barriers.hpp"
+#include "engine/api/match_parameters.hpp"
+#include "engine/api/nearest_parameters.hpp"
+#include "engine/api/route_parameters.hpp"
+#include "engine/api/table_parameters.hpp"
+#include "engine/api/tile_parameters.hpp"
+#include "engine/api/trip_parameters.hpp"
+#include "engine/data_watchdog.hpp"
+#include "engine/datafacade/datafacade_base.hpp"
+#include "engine/engine_config.hpp"
+#include "engine/plugins/match.hpp"
+#include "engine/plugins/nearest.hpp"
+#include "engine/plugins/table.hpp"
+#include "engine/plugins/tile.hpp"
+#include "engine/plugins/trip.hpp"
+#include "engine/plugins/viaroute.hpp"
 #include "engine/status.hpp"
 #include "util/json_container.hpp"
 
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 
 namespace osrm
 {
-
-namespace util
-{
-namespace json
-{
-struct Object;
-}
-}
-
-namespace storage
-{
-struct SharedBarriers;
-}
-
-// Fwd decls
 namespace engine
 {
-struct EngineConfig;
-namespace api
-{
-struct RouteParameters;
-struct TableParameters;
-struct NearestParameters;
-struct TripParameters;
-struct MatchParameters;
-struct TileParameters;
-}
-namespace plugins
-{
-class ViaRoutePlugin;
-class TablePlugin;
-class NearestPlugin;
-class TripPlugin;
-class MatchPlugin;
-class TilePlugin;
-}
-// End fwd decls
-
-namespace datafacade
-{
-class BaseDataFacade;
-}
-
-class DataWatchdog;
 
 class Engine final
 {
   public:
     explicit Engine(const EngineConfig &config);
 
-    Engine(Engine &&) noexcept;
-    Engine &operator=(Engine &&) noexcept;
+    Engine(Engine &&) noexcept = delete;
+    Engine &operator=(Engine &&) noexcept = delete;
 
-    // Impl. in cpp since for unique_ptr of incomplete types
-    ~Engine();
+    Engine(const Engine &) = delete;
+    Engine &operator=(const Engine &) = delete;
 
     Status Route(const api::RouteParameters &parameters, util::json::Object &result) const;
     Status Table(const api::TableParameters &parameters, util::json::Object &result) const;
@@ -78,12 +51,12 @@ class Engine final
     std::unique_ptr<storage::SharedBarriers> lock;
     std::unique_ptr<DataWatchdog> watchdog;
 
-    std::unique_ptr<plugins::ViaRoutePlugin> route_plugin;
-    std::unique_ptr<plugins::TablePlugin> table_plugin;
-    std::unique_ptr<plugins::NearestPlugin> nearest_plugin;
-    std::unique_ptr<plugins::TripPlugin> trip_plugin;
-    std::unique_ptr<plugins::MatchPlugin> match_plugin;
-    std::unique_ptr<plugins::TilePlugin> tile_plugin;
+    const plugins::ViaRoutePlugin route_plugin;
+    const plugins::TablePlugin table_plugin;
+    const plugins::NearestPlugin nearest_plugin;
+    const plugins::TripPlugin trip_plugin;
+    const plugins::MatchPlugin match_plugin;
+    const plugins::TilePlugin tile_plugin;
 
     // note in case of shared memory this will be empty, since the watchdog
     // will provide us with the up-to-date facade

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -35,13 +35,13 @@ class MatchPlugin : public BasePlugin
 
     Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                          const api::MatchParameters &parameters,
-                         util::json::Object &json_result);
+                         util::json::Object &json_result) const;
 
   private:
-    SearchEngineData heaps;
-    routing_algorithms::MapMatching<datafacade::BaseDataFacade> map_matching;
-    routing_algorithms::ShortestPathRouting<datafacade::BaseDataFacade> shortest_path;
-    int max_locations_map_matching;
+    mutable SearchEngineData heaps;
+    mutable routing_algorithms::MapMatching<datafacade::BaseDataFacade> map_matching;
+    mutable routing_algorithms::ShortestPathRouting<datafacade::BaseDataFacade> shortest_path;
+    const int max_locations_map_matching;
 };
 }
 }

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -22,12 +22,12 @@ class TablePlugin final : public BasePlugin
 
     Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                          const api::TableParameters &params,
-                         util::json::Object &result);
+                         util::json::Object &result) const;
 
   private:
-    SearchEngineData heaps;
-    routing_algorithms::ManyToManyRouting<datafacade::BaseDataFacade> distance_table;
-    int max_locations_distance_table;
+    mutable SearchEngineData heaps;
+    mutable routing_algorithms::ManyToManyRouting<datafacade::BaseDataFacade> distance_table;
+    const int max_locations_distance_table;
 };
 }
 }

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -29,14 +29,14 @@ namespace plugins
 class TripPlugin final : public BasePlugin
 {
   private:
-    SearchEngineData heaps;
-    routing_algorithms::ShortestPathRouting<datafacade::BaseDataFacade> shortest_path;
-    routing_algorithms::ManyToManyRouting<datafacade::BaseDataFacade> duration_table;
-    int max_locations_trip;
+    mutable SearchEngineData heaps;
+    mutable routing_algorithms::ShortestPathRouting<datafacade::BaseDataFacade> shortest_path;
+    mutable routing_algorithms::ManyToManyRouting<datafacade::BaseDataFacade> duration_table;
+    const int max_locations_trip;
 
     InternalRouteResult ComputeRoute(const datafacade::BaseDataFacade &facade,
                                      const std::vector<PhantomNode> &phantom_node_list,
-                                     const std::vector<NodeID> &trip);
+                                     const std::vector<NodeID> &trip) const;
 
   public:
     explicit TripPlugin(const int max_locations_trip_)
@@ -46,7 +46,7 @@ class TripPlugin final : public BasePlugin
 
     Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                          const api::TripParameters &parameters,
-                         util::json::Object &json_result);
+                         util::json::Object &json_result) const;
 };
 }
 }

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -28,18 +28,18 @@ namespace plugins
 class ViaRoutePlugin final : public BasePlugin
 {
   private:
-    SearchEngineData heaps;
-    routing_algorithms::ShortestPathRouting<datafacade::BaseDataFacade> shortest_path;
-    routing_algorithms::AlternativeRouting<datafacade::BaseDataFacade> alternative_path;
-    routing_algorithms::DirectShortestPathRouting<datafacade::BaseDataFacade> direct_shortest_path;
-    int max_locations_viaroute;
+    mutable SearchEngineData heaps;
+    mutable routing_algorithms::ShortestPathRouting<datafacade::BaseDataFacade> shortest_path;
+    mutable routing_algorithms::AlternativeRouting<datafacade::BaseDataFacade> alternative_path;
+    mutable routing_algorithms::DirectShortestPathRouting<datafacade::BaseDataFacade> direct_shortest_path;
+    const int max_locations_viaroute;
 
   public:
     explicit ViaRoutePlugin(int max_locations_viaroute);
 
     Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                          const api::RouteParameters &route_parameters,
-                         util::json::Object &json_result);
+                         util::json::Object &json_result) const;
 };
 }
 }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1,17 +1,8 @@
-#include "engine/api/route_parameters.hpp"
-#include "engine/data_watchdog.hpp"
 #include "engine/engine.hpp"
+#include "engine/api/route_parameters.hpp"
 #include "engine/engine_config.hpp"
 #include "engine/status.hpp"
 
-#include "engine/plugins/match.hpp"
-#include "engine/plugins/nearest.hpp"
-#include "engine/plugins/table.hpp"
-#include "engine/plugins/tile.hpp"
-#include "engine/plugins/trip.hpp"
-#include "engine/plugins/viaroute.hpp"
-
-#include "engine/datafacade/datafacade_base.hpp"
 #include "engine/datafacade/internal_datafacade.hpp"
 #include "engine/datafacade/shared_datafacade.hpp"
 
@@ -34,11 +25,12 @@ namespace
 // Abstracted away the query locking into a template function
 // Works the same for every plugin.
 template <typename ParameterT, typename PluginT, typename ResultT>
-osrm::engine::Status RunQuery(const std::unique_ptr<osrm::engine::DataWatchdog> &watchdog,
-                              const std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &facade,
-                              const ParameterT &parameters,
-                              PluginT &plugin,
-                              ResultT &result)
+osrm::engine::Status
+RunQuery(const std::unique_ptr<osrm::engine::DataWatchdog> &watchdog,
+         const std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &facade,
+         const ParameterT &parameters,
+         PluginT &plugin,
+         ResultT &result)
 {
     if (watchdog)
     {
@@ -62,7 +54,14 @@ namespace engine
 
 Engine::Engine(const EngineConfig &config)
     : lock(config.use_shared_memory ? std::make_unique<storage::SharedBarriers>()
-                                    : std::unique_ptr<storage::SharedBarriers>())
+                                    : std::unique_ptr<storage::SharedBarriers>()),
+      route_plugin(config.max_locations_viaroute),       //
+      table_plugin(config.max_locations_distance_table), //
+      nearest_plugin(config.max_results_nearest),        //
+      trip_plugin(config.max_locations_trip),            //
+      match_plugin(config.max_locations_map_matching),   //
+      tile_plugin()                                      //
+
 {
     if (config.use_shared_memory)
     {
@@ -81,53 +80,39 @@ Engine::Engine(const EngineConfig &config)
         {
             throw util::exception("Invalid file paths given!");
         }
-        immutable_data_facade = std::make_shared<datafacade::InternalDataFacade>(config.storage_config);
+        immutable_data_facade =
+            std::make_shared<datafacade::InternalDataFacade>(config.storage_config);
     }
-
-    // Register plugins
-    using namespace plugins;
-
-    route_plugin = std::make_unique<ViaRoutePlugin>(config.max_locations_viaroute);
-    table_plugin = std::make_unique<TablePlugin>(config.max_locations_distance_table);
-    nearest_plugin = std::make_unique<NearestPlugin>(config.max_results_nearest);
-    trip_plugin = std::make_unique<TripPlugin>(config.max_locations_trip);
-    match_plugin = std::make_unique<MatchPlugin>(config.max_locations_map_matching);
-    tile_plugin = std::make_unique<TilePlugin>();
 }
-
-// make sure we deallocate the unique ptr at a position where we know the size of the plugins
-Engine::~Engine() = default;
-Engine::Engine(Engine &&) noexcept = default;
-Engine &Engine::operator=(Engine &&) noexcept = default;
 
 Status Engine::Route(const api::RouteParameters &params, util::json::Object &result) const
 {
-    return RunQuery(watchdog, immutable_data_facade, params, *route_plugin, result);
+    return RunQuery(watchdog, immutable_data_facade, params, route_plugin, result);
 }
 
 Status Engine::Table(const api::TableParameters &params, util::json::Object &result) const
 {
-    return RunQuery(watchdog, immutable_data_facade, params, *table_plugin, result);
+    return RunQuery(watchdog, immutable_data_facade, params, table_plugin, result);
 }
 
 Status Engine::Nearest(const api::NearestParameters &params, util::json::Object &result) const
 {
-    return RunQuery(watchdog, immutable_data_facade, params, *nearest_plugin, result);
+    return RunQuery(watchdog, immutable_data_facade, params, nearest_plugin, result);
 }
 
 Status Engine::Trip(const api::TripParameters &params, util::json::Object &result) const
 {
-    return RunQuery(watchdog, immutable_data_facade, params, *trip_plugin, result);
+    return RunQuery(watchdog, immutable_data_facade, params, trip_plugin, result);
 }
 
 Status Engine::Match(const api::MatchParameters &params, util::json::Object &result) const
 {
-    return RunQuery(watchdog, immutable_data_facade, params, *match_plugin, result);
+    return RunQuery(watchdog, immutable_data_facade, params, match_plugin, result);
 }
 
 Status Engine::Tile(const api::TileParameters &params, std::string &result) const
 {
-    return RunQuery(watchdog, immutable_data_facade, params, *tile_plugin, result);
+    return RunQuery(watchdog, immutable_data_facade, params, tile_plugin, result);
 }
 
 } // engine ns

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -107,7 +107,7 @@ void filterCandidates(const std::vector<util::Coordinate> &coordinates,
 
 Status MatchPlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                                   const api::MatchParameters &parameters,
-                                  util::json::Object &json_result)
+                                  util::json::Object &json_result) const
 {
     BOOST_ASSERT(parameters.IsValid());
 

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -30,7 +30,7 @@ TablePlugin::TablePlugin(const int max_locations_distance_table)
 
 Status TablePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                                   const api::TableParameters &params,
-                                  util::json::Object &result)
+                                  util::json::Object &result) const
 {
     BOOST_ASSERT(params.IsValid());
 

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -116,7 +116,7 @@ SCC_Component SplitUnaccessibleLocations(const std::size_t number_of_locations,
 
 InternalRouteResult TripPlugin::ComputeRoute(const datafacade::BaseDataFacade &facade,
                                              const std::vector<PhantomNode> &snapped_phantoms,
-                                             const std::vector<NodeID> &trip)
+                                             const std::vector<NodeID> &trip) const
 {
     InternalRouteResult min_route;
     // given he final trip, compute total duration and return the route and location permutation
@@ -143,7 +143,7 @@ InternalRouteResult TripPlugin::ComputeRoute(const datafacade::BaseDataFacade &f
 
 Status TripPlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                                  const api::TripParameters &parameters,
-                                 util::json::Object &json_result)
+                                 util::json::Object &json_result) const
 {
     BOOST_ASSERT(parameters.IsValid());
 

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -29,7 +29,7 @@ ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute)
 
 Status ViaRoutePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
                                      const api::RouteParameters &route_parameters,
-                                     util::json::Object &json_result)
+                                     util::json::Object &json_result) const
 {
     BOOST_ASSERT(route_parameters.IsValid());
 


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/3019. We already have a PImpl abstraction with `OSRM`, no need for another PImpl with `Engine`. One level of indirection collapsed; `mutable` pushed down to search heaps and algorithms (since they're threadsafe).

## Tasklist
 - [x] review
 - [x] adjust for for comments