### PR TITLE
fix u-turn collapsing onto empty name / in presence of turning use lane

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -900,3 +900,27 @@ Feature: Collapse
         When I route I should get
             | waypoints | route                   | turns                                                                                  |
             | k,j       | on,ferry,,ferry,off,off | depart,notification straight,continue uturn,turn straight,notification straight,arrive |
+
+    # http://www.openstreetmap.org/#map=19/37.78090/-122.41251
+    Scenario: U-Turn onto unnamed-road
+        Given the node map
+            """
+            d . _           h
+                  ' b . _   |
+                    |     ' e   g
+                    |       f '
+                    |   1 '
+                    a '
+            """
+
+        And the ways
+            | nodes | highway   | turn:lanes     | name  | oneway |
+            | ab    | secondary |                | up    | yes    |
+            | gfa   | secondary |                |       | yes    |
+            | dbe   | tertiary  |                | turn  | no     |
+            | he    | secondary | through\|right | down  | yes    |
+            | ef    | secondary |                | down  | yes    |
+
+        When I route I should get
+            | waypoints | route         | turns                               |
+            | a,1       | up,turn,down, | depart,turn right,turn right,arrive |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -483,10 +483,12 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
         const auto next_step_index = step_index + 1;
         const bool continues_with_name_change =
             (next_step_index < steps.size()) &&
-            (steps[next_step_index].maneuver.instruction.type == TurnType::UseLane ||
+            ((steps[next_step_index].maneuver.instruction.type == TurnType::UseLane &&
+              steps[next_step_index].maneuver.instruction.direction_modifier ==
+                  DirectionModifier::Straight) ||
              isCollapsableInstruction(steps[next_step_index].maneuver.instruction));
         const bool u_turn_with_name_change =
-            continues_with_name_change &&
+            continues_with_name_change && steps[next_step_index].name_id != EMPTY_NAMEID &&
             !isNoticeableNameChange(steps[two_back_index], steps[next_step_index]);
 
         if (direct_u_turn || u_turn_with_name_change)
@@ -842,7 +844,7 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
                 }
                 else
                 {
-                    //the sliproad turn is incompatible. So we handle it as a turn
+                    // the sliproad turn is incompatible. So we handle it as a turn
                     steps[one_back_index].maneuver.instruction.type = TurnType::Turn;
                 }
             }
@@ -1326,8 +1328,7 @@ std::vector<RouteStep> collapseUseLane(std::vector<RouteStep> steps)
     for (std::size_t step_index = 1; step_index < steps.size(); ++step_index)
     {
         const auto &step = steps[step_index];
-        if (step.maneuver.instruction.type == TurnType::UseLane &&
-            canCollapseUseLane(step))
+        if (step.maneuver.instruction.type == TurnType::UseLane && canCollapseUseLane(step))
         {
             const auto previous = getPreviousIndex(step_index);
             steps[previous] = elongate(std::move(steps[previous]), steps[step_index]);


### PR DESCRIPTION
# Issue

The name change heuristic introduced in post-processing makes u-turn detection less strict, resulting in the following scenario:

<img width="857" alt="screen shot 2016-10-17 at 16 10 15" src="https://cloud.githubusercontent.com/assets/12932279/19441002/502cc5e4-9484-11e6-8a82-bad60f38b2f0.png">

This PR fixes this turn scenario (partly introduced due to market-street not being named)

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations

