### PR TITLE
Removes constant speed offset from calibration two years ago, resolves #3023.

### DIFF
--- a/features/car/advisory.feature
+++ b/features/car/advisory.feature
@@ -19,8 +19,8 @@ OSRM will use 4/5 of the projected free-flow speed.
 
         When I route I should get
             | from | to | route | speed        |
-            | a    | b  | ab,ab | 47 km/h +- 1 |
-            | b    | c  | bc,bc | 47 km/h +- 1 |
+            | a    | b  | ab,ab | 36 km/h +- 1 |
+            | b    | c  | bc,bc | 36 km/h +- 1 |
 
     Scenario: Car - Advisory speed overwrites forward maxspeed
         Given the node map
@@ -35,8 +35,8 @@ OSRM will use 4/5 of the projected free-flow speed.
 
         When I route I should get
             | from | to | route | speed        |
-            | a    | b  | ab,ab | 47 km/h +- 1 |
-            | b    | c  | bc,bc | 47 km/h +- 1 |
+            | a    | b  | ab,ab | 36 km/h +- 1 |
+            | b    | c  | bc,bc | 36 km/h +- 1 |
 
     Scenario: Car - Advisory speed overwrites backwards maxspeed
         Given the node map
@@ -51,8 +51,8 @@ OSRM will use 4/5 of the projected free-flow speed.
 
         When I route I should get
             | from | to | route | speed        |
-            | b    | a  | ab,ab | 47 km/h +- 1 |
-            | c    | b  | bc,bc | 47 km/h +- 1 |
+            | b    | a  | ab,ab | 36 km/h +- 1 |
+            | c    | b  | bc,bc | 36 km/h +- 1 |
 
     Scenario: Car - Advisory speed overwrites backwards maxspeed
         Given the node map
@@ -68,8 +68,8 @@ OSRM will use 4/5 of the projected free-flow speed.
 
         When I route I should get
             | from | to | route | speed        |
-            | c    | b  | bc,bc | 47 km/h +- 1 |
-            | d    | c  | cd,cd | 47 km/h +- 1 |
+            | c    | b  | bc,bc | 36 km/h +- 1 |
+            | d    | c  | cd,cd | 36 km/h +- 1 |
 
     Scenario: Car - Directional advisory speeds play nice with eachother
         Given the node map
@@ -84,9 +84,9 @@ OSRM will use 4/5 of the projected free-flow speed.
 
         When I route I should get
             | from | to | route | speed        |
-            | a    | b  | ab,ab | 47 km/h +- 1 |
-            | b    | a  | ab,ab | 59 km/h +- 1 |
-            | b    | c  | bc,bc | 59 km/h +- 1 |
-            | c    | b  | bc,bc | 47 km/h +- 1 |
+            | a    | b  | ab,ab | 36 km/h +- 1 |
+            | b    | a  | ab,ab | 48 km/h +- 1 |
+            | b    | c  | bc,bc | 48 km/h +- 1 |
+            | c    | b  | bc,bc | 36 km/h +- 1 |
 
 

--- a/features/car/bridge.feature
+++ b/features/car/bridge.feature
@@ -19,13 +19,13 @@ Feature: Car - Handle driving
             | efg   | primary |         |         |
 
         When I route I should get
-            | from | to | route           | modes                                  |
+            | from | to | route           | modes                           |
             | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving |
             | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving |
-            | e    | c  | cde,cde         | driving,driving          |
+            | e    | c  | cde,cde         | driving,driving                 |
             | e    | b  | cde,abc,abc     | driving,driving,driving         |
             | e    | a  | cde,abc,abc     | driving,driving,driving         |
-            | c    | e  | cde,cde         | driving,driving          |
+            | c    | e  | cde,cde         | driving,driving                 |
             | c    | f  | cde,efg,efg     | driving,driving,driving         |
             | c    | g  | cde,efg,efg     | driving,driving,driving         |
 
@@ -44,8 +44,8 @@ Feature: Car - Handle driving
             | efg   | primary |         |          |
 
         When I route I should get
-            | from | to | route           | modes                                  | speed  |
-            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 7 km/h |
-            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 5 km/h |
-            | c    | e  | cde,cde         | driving,driving          | 2 km/h |
-            | e    | c  | cde,cde         | driving,driving          | 2 km/h |
+            | from | to | route           | modes                           | speed  |
+            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 6 km/h |
+            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 4 km/h |
+            | c    | e  | cde,cde         | driving,driving                 | 2 km/h |
+            | e    | c  | cde,cde         | driving,driving                 | 2 km/h |

--- a/features/car/ferry.feature
+++ b/features/car/ferry.feature
@@ -45,7 +45,7 @@ Feature: Car - Handle ferry routes
 
         When I route I should get
             | from | to | route           | modes                         | speed   |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 24 km/h |
+            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 23 km/h |
             | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h |
             | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h |
             | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h |
@@ -66,7 +66,7 @@ Feature: Car - Handle ferry routes
 
         When I route I should get
             | from | to | route           | modes                         | speed   |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 24 km/h |
+            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 23 km/h |
             | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h |
             | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h |
             | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h |

--- a/features/car/maxspeed.feature
+++ b/features/car/maxspeed.feature
@@ -22,13 +22,13 @@ OSRM will use 4/5 of the projected free-flow speed.
             | fg    | trunk   | CH:motorway |
 
         When I route I should get
-            | from | to | route | speed         |
-            | a    | b  | ab,ab |  79 km/h      |
-            | b    | c  | bc,bc |  59 km/h +- 1 |
-            | c    | d  | cd,cd |  51 km/h      |
-            | d    | e  | de,de |  75 km/h      |
-            | e    | f  | ef,ef |  91 km/h      |
-            | f    | g  | fg,fg | 107 km/h      |
+            | from | to | route | speed   |
+            | a    | b  | ab,ab | 68 km/h |
+            | b    | c  | bc,bc | 48 km/h |
+            | c    | d  | cd,cd | 40 km/h |
+            | d    | e  | de,de | 64 km/h |
+            | e    | f  | ef,ef | 80 km/h |
+            | f    | g  | fg,fg | 96 km/h |
 
     Scenario: Car - Do not ignore maxspeed when higher than way speed
         Given the node map
@@ -43,23 +43,23 @@ OSRM will use 4/5 of the projected free-flow speed.
             | cd    | living_street | FR:urban |
 
         When I route I should get
-            | from | to | route | speed        |
-            | a    | b  | ab,ab | 31 km/h      |
-            | b    | c  | bc,bc | 83 km/h +- 1 |
-            | c    | d  | cd,cd | 51 km/h      |
+            | from | to | route | speed   |
+            | a    | b  | ab,ab | 20 km/h |
+            | b    | c  | bc,bc | 72 km/h |
+            | c    | d  | cd,cd | 40 km/h |
 
     Scenario: Car - Forward/backward maxspeed
         Given a grid size of 100 meters
 
         Then routability should be
-            | highway | maxspeed | maxspeed:forward | maxspeed:backward | forw         | backw        |
-            | primary |          |                  |                   | 63 km/h      | 63 km/h      |
-            | primary | 60       |                  |                   | 60 km/h +- 1 | 60 km/h +- 1 |
-            | primary |          | 60               |                   | 60 km/h +- 1 | 63 km/h      |
-            | primary |          |                  | 60                | 63 km/h      | 60 km/h +- 1 |
-            | primary | 15       | 60               |                   | 60 km/h +- 1 | 23 km/h      |
-            | primary | 15       |                  | 60                | 23 km/h +- 1 | 60 km/h +- 1 |
-            | primary | 15       | 30               | 60                | 34 km/h +- 1 | 60 km/h +- 1 |
+            | highway | maxspeed | maxspeed:forward | maxspeed:backward | forw    | backw   |
+            | primary |          |                  |                   | 52 km/h | 52 km/h |
+            | primary | 60       |                  |                   | 48 km/h | 48 km/h |
+            | primary |          | 60               |                   | 48 km/h | 48 km/h +- 5 |
+            | primary |          |                  | 60                | 52 km/h | 52 km/h +- 5 |
+            | primary | 15       | 60               |                   | 48 km/h | 12 km/h |
+            | primary | 15       |                  | 60                | 12 km/h | 48 km/h |
+            | primary | 15       | 30               | 60                | 24 km/h | 48 km/h |
 
     Scenario: Car - Maxspeed should not allow routing on unroutable ways
         Then routability should be
@@ -82,44 +82,44 @@ OSRM will use 4/5 of the projected free-flow speed.
         Then routability should be
 
             | highway | maxspeed | width | maxspeed:forward | maxspeed:backward | forw    | backw   |
-            | primary |          |       |                  |                   | 63 km/h | 63 km/h |
+            | primary |          |       |                  |                   | 52 km/h | 52 km/h |
             | primary |          |   3   |                  |                   | 32 km/h | 32 km/h |
-            | primary | 60       |       |                  |                   | 59 km/h | 59 km/h |
+            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h |
             | primary | 60       |   3   |                  |                   | 29 km/h | 29 km/h |
-            | primary |          |       | 60               |                   | 59 km/h | 63 km/h |
+            | primary |          |       | 60               |                   | 47 km/h | 52 km/h |
             | primary |          |   3   | 60               |                   | 29 km/h | 32 km/h |
-            | primary |          |       |                  | 60                | 63 km/h | 59 km/h |
+            | primary |          |       |                  | 60                | 52 km/h | 47 km/h |
             | primary |          |   3   |                  | 60                | 32 km/h | 29 km/h |
-            | primary | 15       |       | 60               |                   | 59 km/h | 23 km/h |
+            | primary | 15       |       | 60               |                   | 47 km/h | 12 km/h |
             | primary | 15       |   3   | 60               |                   | 29 km/h |  7 km/h |
-            | primary | 15       |       |                  | 60                | 22 km/h | 59 km/h |
+            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h |
             | primary | 15       |   3   |                  | 60                |  7 km/h | 29 km/h |
-            | primary | 15       |       | 30               | 60                | 35 km/h | 59 km/h |
+            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h |
             | primary | 15       |   3   | 30               | 60                | 14 km/h | 29 km/h |
 
     Scenario: Car - Single lane streets be ignored or incur a penalty
         Then routability should be
 
             | highway | maxspeed | lanes | maxspeed:forward | maxspeed:backward | forw    | backw   |
-            | primary |          |       |                  |                   | 63 km/h | 63 km/h |
+            | primary |          |       |                  |                   | 52 km/h | 52 km/h |
             | primary |          |   1   |                  |                   | 32 km/h | 32 km/h |
-            | primary | 60       |       |                  |                   | 59 km/h | 59 km/h |
+            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h |
             | primary | 60       |   1   |                  |                   | 29 km/h | 29 km/h |
-            | primary |          |       | 60               |                   | 59 km/h | 63 km/h |
+            | primary |          |       | 60               |                   | 47 km/h | 52 km/h |
             | primary |          |   1   | 60               |                   | 29 km/h | 32 km/h |
-            | primary |          |       |                  | 60                | 63 km/h | 59 km/h |
+            | primary |          |       |                  | 60                | 52 km/h | 47 km/h |
             | primary |          |   1   |                  | 60                | 32 km/h | 29 km/h |
-            | primary | 15       |       | 60               |                   | 59 km/h | 23 km/h |
+            | primary | 15       |       | 60               |                   | 47 km/h | 12 km/h |
             | primary | 15       |   1   | 60               |                   | 29 km/h |  7 km/h |
-            | primary | 15       |       |                  | 60                | 22 km/h | 59 km/h |
+            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h |
             | primary | 15       |   1   |                  | 60                |  7 km/h | 29 km/h |
-            | primary | 15       |       | 30               | 60                | 35 km/h | 59 km/h |
+            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h |
             | primary | 15       |   1   | 30               | 60                | 14 km/h | 29 km/h |
 
     Scenario: Car - Single lane streets only incure a penalty for two-way streets
         Then routability should be
             | highway | maxspeed | lanes  | oneway | forw    | backw   |
-            | primary |   30     |   1    | yes    | 35 km/h |         |
-            | primary |   30     |   1    | -1     |         | 35 km/h |
+            | primary |   30     |   1    | yes    | 23 km/h |         |
+            | primary |   30     |   1    | -1     |         | 23 km/h |
             | primary |   30     |   1    |        | 15 km/h | 15 km/h |
-            | primary |   30     |   2    |        | 35 km/h | 35 km/h |
+            | primary |   30     |   2    |        | 23 km/h | 23 km/h |

--- a/features/car/speed.feature
+++ b/features/car/speed.feature
@@ -7,31 +7,31 @@ Feature: Car - speeds
 
     Scenario: Car - speed of various way types
         Then routability should be
-            | highway        | oneway | bothw        |
-            | motorway       | no     | 82 km/h +- 1 |
-            | motorway_link  | no     | 47 km/h +- 1 |
-            | trunk          | no     | 79 km/h +- 1 |
-            | trunk_link     | no     | 43 km/h +- 1 |
-            | primary        | no     | 63 km/h +- 1 |
-            | primary_link   | no     | 35 km/h +- 1 |
-            | secondary      | no     | 54 km/h +- 1 |
-            | secondary_link | no     | 31 km/h +- 1 |
-            | tertiary       | no     | 43 km/h +- 1 |
-            | tertiary_link  | no     | 27 km/h +- 1 |
-            | unclassified   | no     | 31 km/h +- 1 |
-            | residential    | no     | 31 km/h +- 1 |
-            | living_street  | no     | 18 km/h +- 1 |
-            | service        | no     | 23 km/h +- 1 |
+            | highway        | oneway | bothw   |
+            | motorway       | no     | 71 km/h |
+            | motorway_link  | no     | 36 km/h |
+            | trunk          | no     | 68 km/h |
+            | trunk_link     | no     | 31 km/h |
+            | primary        | no     | 52 km/h |
+            | primary_link   | no     | 23 km/h |
+            | secondary      | no     | 44 km/h |
+            | secondary_link | no     | 19 km/h |
+            | tertiary       | no     | 31 km/h |
+            | tertiary_link  | no     | 16 km/h |
+            | unclassified   | no     | 19 km/h |
+            | residential    | no     | 19 km/h |
+            | living_street  | no     | 8 km/h  |
+            | service        | no     | 11 km/h |
 
     # Alternating oneways have to take average waiting time into account.
     Scenario: Car - scaled speeds for oneway=alternating
         Then routability should be
             | highway        | oneway      | junction   | forw          | backw        | #              |
-            | tertiary       |             |            | 43 km/h       | 43 km/h      |                |
-            | tertiary       | alternating |            | 20 km/h +- 5  | 20 km/h +- 5 |                |
-            | motorway       |             |            | 82 km/h       |              | implied oneway |
-            | motorway       | alternating |            | 30 km/h +- 5  |              | implied oneway |
+            | tertiary       |             |            | 31 km/h       | 31 km/h      |                |
+            | tertiary       | alternating |            | 12 km/h +- 1  | 12 km/h +- 1 |                |
+            | motorway       |             |            | 71 km/h       |              | implied oneway |
+            | motorway       | alternating |            | 28 km/h +- 1  |              | implied oneway |
             | motorway       | reversible  |            |               |              | unroutable     |
-            | primary        |             | roundabout | 63 km/h       |              | implied oneway |
-            | primary        | alternating | roundabout | 25 km/h +- 5  |              | implied oneway |
+            | primary        |             | roundabout | 52 km/h       |              | implied oneway |
+            | primary        | alternating | roundabout | 20 km/h +- 1  |              | implied oneway |
             | primary        | reversible  | roundabout |               |              | unroutable     |

--- a/features/car/surface.feature
+++ b/features/car/surface.feature
@@ -64,64 +64,64 @@ Feature: Car - Surfaces
     Scenario: Car - Surface should reduce speed
         Then routability should be
             | highway  | oneway | surface         | forw        | backw       |
-            | motorway | no     |                 | 83 km/h     | 83 km/h     |
-            | motorway | no     | asphalt         | 84 km/h     | 83 km/h +-1 |
-            | motorway | no     | concrete        | 83 km/h +-1 | 83 km/h +-1 |
-            | motorway | no     | concrete:plates | 83 km/h +-1 | 83 km/h +-1 |
-            | motorway | no     | concrete:lanes  | 83 km/h +-1 | 83 km/h +-1 |
-            | motorway | no     | paved           | 83 km/h +-1 | 83 km/h +-1 |
-            | motorway | no     | cement          | 75 km/h +-1 | 75 km/h +-1 |
-            | motorway | no     | compacted       | 75 km/h +-1 | 75 km/h +-1 |
-            | motorway | no     | fine_gravel     | 75 km/h +-1 | 75 km/h +-1 |
-            | motorway | no     | paving_stones   | 60 km/h +-1 | 60 km/h +-1 |
-            | motorway | no     | metal           | 60 km/h +-1 | 60 km/h +-1 |
-            | motorway | no     | bricks          | 60 km/h +-1 | 60 km/h +-1 |
-            | motorway | no     | grass           | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | wood            | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | sett            | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | grass_paver     | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | gravel          | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | unpaved         | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | ground          | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | dirt            | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | pebblestone     | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | tartan          | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | cobblestone     | 34 km/h +-1 | 34 km/h +-1 |
-            | motorway | no     | clay            | 34 km/h +-1 | 34 km/h +-1 |
-            | motorway | no     | earth           | 26 km/h +-1 | 26 km/h +-1 |
-            | motorway | no     | stone           | 26 km/h +-1 | 26 km/h +-1 |
-            | motorway | no     | rocky           | 26 km/h +-1 | 26 km/h +-1 |
-            | motorway | no     | sand            | 26 km/h +-1 | 26 km/h +-1 |
+            | motorway | no     |                 | 72 km/h     | 72 km/h     |
+            | motorway | no     | asphalt         | 72 km/h     | 72 km/h +-1 |
+            | motorway | no     | concrete        | 72 km/h +-1 | 72 km/h +-1 |
+            | motorway | no     | concrete:plates | 72 km/h +-1 | 72 km/h +-1 |
+            | motorway | no     | concrete:lanes  | 72 km/h +-1 | 72 km/h +-1 |
+            | motorway | no     | paved           | 72 km/h +-1 | 72 km/h +-1 |
+            | motorway | no     | cement          | 64 km/h +-1 | 64 km/h +-1 |
+            | motorway | no     | compacted       | 64 km/h +-1 | 64 km/h +-1 |
+            | motorway | no     | fine_gravel     | 64 km/h +-1 | 64 km/h +-1 |
+            | motorway | no     | paving_stones   | 48 km/h +-1 | 48 km/h +-1 |
+            | motorway | no     | metal           | 48 km/h +-1 | 48 km/h +-1 |
+            | motorway | no     | bricks          | 48 km/h +-1 | 48 km/h +-1 |
+            | motorway | no     | grass           | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | wood            | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | sett            | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | grass_paver     | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | gravel          | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | unpaved         | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | ground          | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | dirt            | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | pebblestone     | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | tartan          | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | cobblestone     | 24 km/h +-1 | 24 km/h +-1 |
+            | motorway | no     | clay            | 24 km/h +-1 | 24 km/h +-1 |
+            | motorway | no     | earth           | 16 km/h +-1 | 16 km/h +-1 |
+            | motorway | no     | stone           | 16 km/h +-1 | 16 km/h +-1 |
+            | motorway | no     | rocky           | 16 km/h +-1 | 16 km/h +-1 |
+            | motorway | no     | sand            | 16 km/h +-1 | 16 km/h +-1 |
 
     Scenario: Car - Tracktypes should reduce speed
         Then routability should be
             | highway  | oneway | tracktype | forw        | backw       |
-            | motorway | no     |           | 83 km/h     | 83 km/h     |
-            | motorway | no     | grade1    | 60 km/h +-1 | 60 km/h +-1 |
-            | motorway | no     | grade2    | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | grade3    | 34 km/h +-1 | 34 km/h +-1 |
-            | motorway | no     | grade4    | 31 km/h +-1 | 31 km/h +-1 |
-            | motorway | no     | grade5    | 26 km/h +-1 | 26 km/h +-1 |
+            | motorway | no     |           | 72 km/h     | 72 km/h     |
+            | motorway | no     | grade1    | 48 km/h +-1 | 48 km/h +-1 |
+            | motorway | no     | grade2    | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | grade3    | 24 km/h +-1 | 24 km/h +-1 |
+            | motorway | no     | grade4    | 20 km/h +-1 | 20 km/h +-1 |
+            | motorway | no     | grade5    | 16 km/h +-1 | 16 km/h +-1 |
 
     Scenario: Car - Smoothness should reduce speed
         Then routability should be
             | highway  | oneway | smoothness    | forw        | backw       |
-            | motorway | no     |               | 83 km/h     | 83 km/h     |
-            | motorway | no     | intermediate  | 75 km/h     | 75 km/h     |
-            | motorway | no     | bad           | 42 km/h +-1 | 42 km/h +-1 |
-            | motorway | no     | very_bad      | 26 km/h +-1 | 26 km/h +-1 |
-            | motorway | no     | horrible      | 18 km/h +-1 | 18 km/h +-1 |
-            | motorway | no     | very_horrible | 15 km/h +-1 | 15 km/h +-1 |
+            | motorway | no     |               | 72 km/h     | 72 km/h     |
+            | motorway | no     | intermediate  | 64 km/h     | 64 km/h     |
+            | motorway | no     | bad           | 32 km/h +-1 | 32 km/h +-1 |
+            | motorway | no     | very_bad      | 16 km/h +-1 | 16 km/h +-1 |
+            | motorway | no     | horrible      |  8 km/h +-1 |  8 km/h +-1 |
+            | motorway | no     | very_horrible |  4 km/h +-1 |  4 km/h +-1 |
 
     Scenario: Car - Combination of surface tags should use lowest speed
         Then routability should be
             | highway  | oneway | tracktype | surface | smoothness    | backw   | forw    |
-            | motorway | no     |           |         |               | 83 km/h | 83 km/h |
-            | service  | no     | grade1    | asphalt | excellent     | 23 km/h | 23 km/h |
-            | motorway | no     | grade5    | asphalt | excellent     | 27 km/h | 27 km/h |
-            | motorway | no     | grade1    | mud     | excellent     | 19 km/h | 19 km/h |
-            | motorway | no     | grade1    | asphalt | very_horrible | 15 km/h | 15 km/h |
-            | service  | no     | grade5    | mud     | very_horrible | 15 km/h | 15 km/h |
+            | motorway | no     |           |         |               | 72 km/h | 72 km/h |
+            | service  | no     | grade1    | asphalt | excellent     | 12 km/h | 12 km/h |
+            | motorway | no     | grade5    | asphalt | excellent     | 16 km/h | 16 km/h |
+            | motorway | no     | grade1    | mud     | excellent     |  8 km/h |  8 km/h |
+            | motorway | no     | grade1    | asphalt | very_horrible |  4 km/h |  4 km/h |
+            | service  | no     | grade5    | mud     | very_horrible |  4 km/h |  4 km/h |
 
     Scenario: Car - Surfaces should not affect oneway direction
         Then routability should be
@@ -138,4 +138,3 @@ Feature: Car - Surfaces
             | primary | -1     | grade1    | excellent  | asphalt  |      | x     |
             | primary | -1     | grade5    | very_bad   | mud      |      | x     |
             | primary | -1     | nonsense  | nonsense   | nonsense |      | x     |
-    

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -53,21 +53,21 @@ Feature: Traffic - turn penalties
     Scenario: Weighting not based on turn penalty file
         When I route I should get
             | from | to | route           | speed   | time      |
-            | a    | h  | ad,dhk,dhk      | 63 km/h | 11.5s +-1 |
+            | a    | h  | ad,dhk,dhk      | 52 km/h | 14s +-1   |
                                                                   # straight
-            | i    | g  | fim,fg,fg       | 53 km/h | 13.5s +-1 |
+            | i    | g  | fim,fg,fg       | 45 km/h | 16s +-1   |
                                                                   # right
-            | a    | e  | ad,def,def      | 43 km/h | 16.7s +-1 |
+            | a    | e  | ad,def,def      | 38 km/h | 19s +-1   |
                                                                   # left
-            | c    | g  | cd,def,fg,fg    | 63 km/h | 23s +-1   |
+            | c    | g  | cd,def,fg,fg    | 52 km/h | 27s +-1   |
                                                                   # double straight
-            | p    | g  | mp,fim,fg,fg    | 58 km/h | 24.9s +-1 |
+            | p    | g  | mp,fim,fg,fg    | 48 km/h | 29s +-1   |
                                                                   # straight-right
-            | a    | l  | ad,dhk,klm,klm  | 51 km/h | 28.1s +-1 |
+            | a    | l  | ad,dhk,klm,klm  | 44 km/h | 33s +-1   |
                                                                   # straight-left
-            | l    | e  | klm,dhk,def,def | 53 km/h | 27s +-1   |
+            | l    | e  | klm,dhk,def,def | 45 km/h | 32s +-1   |
                                                                   # double right
-            | g    | n  | fg,fim,mn,mn    | 43 km/h | 33.4s +-1 |
+            | g    | n  | fg,fim,mn,mn    | 38 km/h | 38s +-1   |
                                                                   # double left
 
     Scenario: Weighting based on turn penalty file
@@ -75,7 +75,7 @@ Feature: Traffic - turn penalties
             """
             9,6,7,1.8
             9,13,14,24.5
-            8,4,3,30
+            8,4,3,35
             12,11,8,9
             8,11,12,23
             1,4,5,-0.2
@@ -83,23 +83,23 @@ Feature: Traffic - turn penalties
         And the contract extra arguments "--turn-penalty-file {penalties_file}"
         When I route I should get
             | from | to | route                 | speed   | time      |
-            | a    | h  | ad,dhk,dhk            | 63 km/h | 11.5s +-1 |
+            | a    | h  | ad,dhk,dhk            | 52 km/h | 14s +-1   |
                                                                               # straight
-            | i    | g  | fim,fg,fg             | 55 km/h | 13s +-1   |
+            | i    | g  | fim,fg,fg             | 46 km/h | 15s +-1   |
                                                                               # right - ifg penalty
-            | a    | e  | ad,def,def            | 64 km/h | 11s +-1   |
+            | a    | e  | ad,def,def            | 53 km/h | 14s +-1   |
                                                                               # left - faster because of negative ade penalty
-            | c    | g  | cd,def,fg,fg          | 63 km/h | 23s +-1   |
+            | c    | g  | cd,def,fg,fg          | 52 km/h | 27s +-1   |
                                                                               # double straight
-            | p    | g  | mp,fim,fg,fg          | 59 km/h | 24.5s +-1 |
+            | p    | g  | mp,fim,fg,fg          | 49 km/h | 29s +-1   |
                                                                               # straight-right - ifg penalty
-            | a    | l  | ad,def,fim,klm,klm    | 57 km/h | 38.2s +-1 |
+            | a    | l  | ad,def,fim,klm,klm    | 48 km/h | 45s +-1   |
                                                                               # was straight-left - forced around by hkl penalty
-            | l    | e  | klm,fim,def,def       | 43 km/h | 33.4s +-1 |
+            | l    | e  | klm,fim,def,def       | 38 km/h | 38s +-1   |
                                                                               # double right - forced left by lkh penalty
-            | g    | n  | fg,fim,mn,mn          | 27 km/h | 52.6s +-1 |
+            | g    | n  | fg,fim,mn,mn          | 25 km/h | 57s +-1   |
                                                                               # double left - imn penalty
-            | j    | c  | jk,klm,fim,def,cd,cd  | 51 km/h | 56.2s +-1 |
+            | j    | c  | jk,klm,fim,def,cd,cd  | 44 km/h | 65.8s +-1 |
                                                                               # double left - hdc penalty ever so slightly higher than imn; forces all the way around
 
     Scenario: Too-negative penalty clamps, but does not fail

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -571,7 +571,7 @@ function way_function (way, result)
 
   -- scale speeds to get better avg driving times
   if result.forward_speed > 0 then
-    local scaled_speed = result.forward_speed*speed_reduction + 11
+    local scaled_speed = result.forward_speed * speed_reduction
     local penalized_speed = math.huge
     if service and service ~= "" and service_speeds[service] then
       penalized_speed = service_speeds[service]
@@ -582,7 +582,7 @@ function way_function (way, result)
   end
 
   if result.backward_speed > 0 then
-    local scaled_speed = result.backward_speed*speed_reduction + 11
+    local scaled_speed = result.backward_speed * speed_reduction
     local penalized_speed = math.huge
     if service and service ~= "" and service_speeds[service]then
       penalized_speed = service_speeds[service]


### PR DESCRIPTION
For #3023.

## Tasklist
 - [x] Why are unrelated turn lane and name tests failing? Investigate!
 - [ ] review
 - [ ] adjust for for comments

Our fine-tuned profiles are better in modelling real speed by now. This
constant offset is no longer needed. We still scale maxspeed, though.