### PR TITLE
Move loading of .timestamp to io.hpp 

### DIFF
--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -149,9 +149,8 @@ class InternalDataFacade final : public BaseDataFacade
         }
 
         auto timestamp_size = storage::io::readTimestampSize(timestamp_stream);
-        char *timestamp_ptr = new char[timestamp_size]();
-        storage::io::readTimestamp(timestamp_stream, timestamp_ptr, timestamp_size);
-        m_timestamp = std::string(timestamp_ptr);
+        m_timestamp.resize(timestamp_size);
+        storage::io::readTimestamp(timestamp_stream, &m_timestamp.front(), timestamp_size);
     }
 
     void LoadGraph(const boost::filesystem::path &hsgr_path)

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -48,8 +48,7 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
     return header;
 }
 
-// Needs to be called after getHSGRSize() to get the correct offset in the stream
-// 
+// Needs to be called after HSGRHeader() to get the correct offset in the stream
 template <typename NodeT, typename EdgeT>
 void readHSGR(boost::filesystem::ifstream &input_stream,
               NodeT *node_buffer,
@@ -59,6 +58,21 @@ void readHSGR(boost::filesystem::ifstream &input_stream,
 {
     input_stream.read(reinterpret_cast<char *>(node_buffer), number_of_nodes * sizeof(NodeT));
     input_stream.read(reinterpret_cast<char *>(edge_buffer), number_of_edges * sizeof(EdgeT));
+}
+
+// Returns the size of the timestamp in a file
+inline std::uint32_t readTimestampSize(boost::filesystem::ifstream &timestamp_input_stream)
+{
+    timestamp_input_stream.seekg (0, timestamp_input_stream.end);
+    auto length = timestamp_input_stream.tellg();
+    timestamp_input_stream.seekg (0, timestamp_input_stream.beg);
+    return length;
+}
+
+// Reads the timestamp in a file
+inline void readTimestamp(boost::filesystem::ifstream &timestamp_input_stream, char *timestamp, std::size_t timestamp_length)
+{
+    timestamp_input_stream.read(timestamp, timestamp_length * sizeof(char));
 }
 
 }

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -70,7 +70,9 @@ inline std::uint32_t readTimestampSize(boost::filesystem::ifstream &timestamp_in
 }
 
 // Reads the timestamp in a file
-inline void readTimestamp(boost::filesystem::ifstream &timestamp_input_stream, char *timestamp, std::size_t timestamp_length)
+inline void readTimestamp(boost::filesystem::ifstream &timestamp_input_stream,
+                          char *timestamp,
+                          std::size_t timestamp_length)
 {
     timestamp_input_stream.read(timestamp, timestamp_length * sizeof(char));
 }


### PR DESCRIPTION
# Issue

Working on data loading refactoring captured here: 
https://github.com/Project-OSRM/osrm-backend/issues/2989

This issue is working on `.timestamp` files

## Tasklist
 - [x] wait for https://github.com/Project-OSRM/osrm-backend/pull/3074 to be merged
 - [x] review
 - [x] adjust for for comments

/cc @karenzshea @TheMarex  @miccolis @danpat 

