### PR TITLE
Removes Gnu Date Usage

### DIFF
--- a/scripts/timer.sh
+++ b/scripts/timer.sh
@@ -7,6 +7,6 @@ START=$(date "+%s.%N")
 /bin/bash -c "$CMD"
 END=$(date "+%s.%N")
 TIME="$(echo "$END - $START" | bc)s"
-NEW_ENTRY="$NAME\t$TIME\t$(date -Iseconds)"
+NEW_ENTRY="$NAME\t$TIME"
 
 echo -e "$NEW_ENTRY" >> $TIMINGS_FILE


### PR DESCRIPTION
There is no -Iseconds in non-Gnu date binaries. I'm sorry.

\U+1Fstallman-emoji