### PR TITLE
Parse turn penalty files in parallel

### DIFF
--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -263,7 +263,9 @@ struct TurnPenaltySource final
 using TurnPenaltySourceFlatMap = std::vector<TurnPenaltySource>;
 using SegmentSpeedSourceFlatMap = std::vector<SegmentSpeedSource>;
 
-// Binary Search over a flattened key,val Segment storage
+// Find is a binary Search over a flattened key,val Segment storage
+// It takes the flat map and a Segment/PenaltySource object that has an overloaded
+// `==` operator, to make the std::lower_bound call work generically
 template <typename FlatMap, typename SegmentKey>
 auto find(const FlatMap &map, const SegmentKey &key)
 {


### PR DESCRIPTION
# Issue

Hits https://github.com/Project-OSRM/osrm-backend/issues/3070. We already load edge weight update files in parallel, so some code has been borrowed to load penalties in parallel as well. The `find()` function has been adapted to work on either the speed source or turn penalty flat maps.

I explored using boost's flat_map here as well, but it turned out to be less flexible in terms of sorting as a homemade flat_map. Boost's flat map handles deduplication on insertion, and can be sorted with a custom sort operator like we have, which sorts by `from, to, speed source`. However, to then use the flat_map's `find()` function, the find can only work on the same keys that the flat_map was sorted by, but the way we use `find`, we only know the `from, to` values.

## Tasklist
 - [ ] Write docs for the wiki on how turn penalty loading works
-  [ ] Test for speedup
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for for comments

## Requirements / Relations
cc @daniel-j-h 

