### PR TITLE
fix changelog to not include 5.5.1 ahead of time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# 5.5.1
-  - Changes from 5.5.0
-    - Profiles:
-      - Handle `destination:forward`, `destination:backward`, `destination:ref:forward`, `destination:ref:backward` tags
-      - Properly handle destinations on `oneway=-1` roads
-
 # 5.5.0
   - Changes from 5.4.0
     - API:
@@ -13,6 +7,8 @@
       - `restrictions` is now used for namespaced restrictions and restriction exceptions (e.g. `restriction:motorcar=` as well as `except=motorcar`)
       - replaced lhs/rhs profiles by using test defined profiles
       - Handle `oneway=alternating` (routed over with penalty) separately from `oneway=reversible` (not routed over due to time dependence)
+      - Handle `destination:forward`, `destination:backward`, `destination:ref:forward`, `destination:ref:backward` tags
+      - Properly handle destinations on `oneway=-1` roads
     - Guidance
       - Notifications are now exposed more prominently, announcing turns onto a ferry/pushing your bike more prominently
     - Trip Plugin


### PR DESCRIPTION
# Issue

Making the changelog correct again. 5.5.0 is still in the works.