### PR TITLE
Limits the object cache size to 256M

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,7 @@ before_install:
       # implicit deps, but seem to be installed by default with recent images: libxml2 GDAL boost
       brew install libzip libstxxl lua51 luabind tbb md5sha1sum ccache
     fi
+  - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 
 install:
   - |


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/3062. Trying if that helps.

We need a bit time to see how this will help: idea is to merge this, clear the Travis caches multiple times today (since multiple builds in in-flight and will restore the caches), and then see how this goes.