### PR TITLE
Deduplicate code for loading profile properties

### DIFF
--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -124,9 +124,8 @@ class InternalDataFacade final : public BaseDataFacade
         {
             throw util::exception("Could not open " + properties_path.string() + " for reading.");
         }
-
-        in_stream.read(reinterpret_cast<char *>(&m_profile_properties),
-                       sizeof(m_profile_properties));
+        auto PropertiesSize = storage::io::readPropertiesSize();
+        storage::io::readProperties(in_stream, reinterpret_cast<char *>(&m_profile_properties), PropertiesSize);
     }
 
     void LoadLaneTupleIdPairs(const boost::filesystem::path &lane_data_path)

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -125,7 +125,7 @@ class InternalDataFacade final : public BaseDataFacade
             throw util::exception("Could not open " + properties_path.string() + " for reading.");
         }
         auto PropertiesSize = storage::io::readPropertiesSize();
-        storage::io::readProperties(in_stream, reinterpret_cast<char *>(&m_profile_properties), PropertiesSize);
+        storage::io::readProperties(in_stream, &m_profile_properties, PropertiesSize);
     }
 
     void LoadLaneTupleIdPairs(const boost::filesystem::path &lane_data_path)

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -15,6 +15,16 @@ namespace storage
 namespace io
 {
 
+inline std::size_t readPropertiesSize() { return 1; }
+
+template <typename PropertiesT>
+inline void readProperties(boost::filesystem::ifstream &properties_stream,
+                           PropertiesT properties[],
+                           std::size_t PropertiesSize)
+{
+    properties_stream.read(properties, PropertiesSize);
+}
+
 #pragma pack(push, 1)
 struct HSGRHeader
 {
@@ -39,8 +49,10 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
 
     HSGRHeader header;
     input_stream.read(reinterpret_cast<char *>(&header.checksum), sizeof(header.checksum));
-    input_stream.read(reinterpret_cast<char *>(&header.number_of_nodes), sizeof(header.number_of_nodes));
-    input_stream.read(reinterpret_cast<char *>(&header.number_of_edges), sizeof(header.number_of_edges));
+    input_stream.read(reinterpret_cast<char *>(&header.number_of_nodes),
+                      sizeof(header.number_of_nodes));
+    input_stream.read(reinterpret_cast<char *>(&header.number_of_edges),
+                      sizeof(header.number_of_edges));
 
     BOOST_ASSERT_MSG(0 != header.number_of_nodes, "number of nodes is zero");
     // number of edges can be zero, this is the case in a few test fixtures
@@ -48,7 +60,7 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
     return header;
 }
 
-// Needs to be called after HSGRHeader() to get the correct offset in the stream
+// Needs to be called after readHSGRHeader() to get the correct offset in the stream
 template <typename NodeT, typename EdgeT>
 void readHSGR(boost::filesystem::ifstream &input_stream,
               NodeT *node_buffer,
@@ -59,7 +71,6 @@ void readHSGR(boost::filesystem::ifstream &input_stream,
     input_stream.read(reinterpret_cast<char *>(node_buffer), number_of_nodes * sizeof(NodeT));
     input_stream.read(reinterpret_cast<char *>(edge_buffer), number_of_edges * sizeof(EdgeT));
 }
-
 // Returns the size of the timestamp in a file
 inline std::uint32_t readTimestampSize(boost::filesystem::ifstream &timestamp_input_stream)
 {

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -19,10 +19,10 @@ inline std::size_t readPropertiesSize() { return 1; }
 
 template <typename PropertiesT>
 inline void readProperties(boost::filesystem::ifstream &properties_stream,
-                           PropertiesT properties[],
-                           std::size_t PropertiesSize)
+                           PropertiesT *properties,
+                           std::size_t properties_size)
 {
-    properties_stream.read(properties, PropertiesSize);
+    properties_stream.read(reinterpret_cast<char *>(properties), properties_size);
 }
 
 #pragma pack(push, 1)

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -771,8 +771,8 @@ Storage::ReturnCode Storage::Run(int max_wait)
         util::exception("Could not open " + config.properties_path.string() + " for reading!");
     }
     io::readProperties(profile_properties_stream,
-                       reinterpret_cast<char *>(profile_properties_ptr),
-                       PropertiesSize);
+                       profile_properties_ptr,
+                       sizeof(extractor::ProfileProperties));
 
     // load intersection classes
     if (!bearing_class_id_table.empty())

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -273,8 +273,10 @@ Storage::ReturnCode Storage::Run(int max_wait)
     tree_node_file.read((char *)&tree_size, sizeof(uint32_t));
     shared_layout_ptr->SetBlockSize<RTreeNode>(SharedDataLayout::R_SEARCH_TREE, tree_size);
 
-    // load profile properties
-    shared_layout_ptr->SetBlockSize<extractor::ProfileProperties>(SharedDataLayout::PROPERTIES, 1);
+    // allocate space in shared memory for profile properties
+    std::size_t PropertiesSize = io::readPropertiesSize();
+    shared_layout_ptr->SetBlockSize<extractor::ProfileProperties>(SharedDataLayout::PROPERTIES,
+                                                                  PropertiesSize);
 
     // read timestampsize
     boost::filesystem::ifstream timestamp_stream(config.timestamp_path);
@@ -760,7 +762,7 @@ Storage::ReturnCode Storage::Run(int max_wait)
     hsgr_input_stream.close();
 
     // load profile properties
-    auto profile_properties_ptr =
+    extractor::ProfileProperties *profile_properties_ptr =
         shared_layout_ptr->GetBlockPtr<extractor::ProfileProperties, true>(
             shared_memory_ptr, SharedDataLayout::PROPERTIES);
     boost::filesystem::ifstream profile_properties_stream(config.properties_path);
@@ -768,8 +770,9 @@ Storage::ReturnCode Storage::Run(int max_wait)
     {
         util::exception("Could not open " + config.properties_path.string() + " for reading!");
     }
-    profile_properties_stream.read(reinterpret_cast<char *>(profile_properties_ptr),
-                                   sizeof(extractor::ProfileProperties));
+    io::readProperties(profile_properties_stream,
+                       reinterpret_cast<char *>(profile_properties_ptr),
+                       PropertiesSize);
 
     // load intersection classes
     if (!bearing_class_id_table.empty())


### PR DESCRIPTION
# Issue

Hits one item on https://github.com/Project-OSRM/osrm-backend/issues/2989

I've moved the code for loading the `osrm.profile_properties` file into shared memory into the shared header `storage/io.hpp` and used it in datastore and the internal datafacade.

## Tasklist
 - [ ] add regression / cucumber cases?
 - [ ] review
 - [ ] adjust for for comments

## Requirements / Relations
cc @chaupow @TheMarex @danpat 
