### PR TITLE
fix turn scenarios

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -635,12 +635,14 @@ Feature: Collapse
             | bd    | road  | yes    | primary   |
             | bc    | road  | yes    | primary   |
             | de    | road  | yes    | primary   |
-            | fdcg  | cross | no     | secondary |
+            | fd    | cross | no     | secondary |
+            | dc    | cross | no     | secondary |
+            | cg    | cross | no     | secondary |
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |
-            | restriction | bd       | fdcg   | d        | no_left_turn  |
-            | restriction | bc       | fdcg   | c        | no_right_turn |
+            | restriction | bd       | dc     | d        | no_left_turn  |
+            | restriction | bc       | dc     | c        | no_right_turn |
 
         When I route I should get
           | waypoints | route            | turns                   |

--- a/features/guidance/dedicated-turn-roads.feature
+++ b/features/guidance/dedicated-turn-roads.feature
@@ -21,13 +21,15 @@ Feature: Slipways and Dedicated Turn Lanes
 
         And the ways
             | nodes | highway    | name   |
-            | abcd  | trunk      | first  |
+            | abc   | trunk      | first  |
+            | cd    | trunk      | first  |
             | bhf   | trunk_link |        |
-            | ecfg  | primary    | second |
+            | cfg   | primary    | second |
+            | ec    | primary    | second |
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |
-            | restriction | abcd     | ecfg   | c        | no_right_turn |
+            | restriction | abc      | cfg    | c        | no_right_turn |
 
        When I route I should get
             | waypoints | route               | turns                           |
@@ -53,8 +55,8 @@ Feature: Slipways and Dedicated Turn Lanes
             | abc   | trunk      | first  | 70       |
             | cd    | trunk      | first  | 2        |
             | bhf   | trunk_link |        | 2        |
-            | ec    | primary    | second | 50       |
             | cfg   | primary    | second | 50       |
+            | ec    | primary    | second | 50       |
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -281,18 +281,23 @@ Feature: Basic Roundabout
             | a,e       | crescent,crescent,crescent                            | depart,roundabout-exit-3,arrive | US 130,US 130,US 130    |
             | j,l       | ,,                                                    | depart,roundabout-exit-2,arrive | NJ 38,NJ 38,NJ 38       |
 
+    @todo
+    # this test previously only passed by accident. We need to handle throughabouts correctly, since staying on massachusetts is actually
+    # the desired setting. Rotary instructions here are not wanted but rather no instruction at all to go through the roundabout (or add
+    # a throughabout instruction)
+    # see https://github.com/Project-OSRM/osrm-backend/issues/3142
     Scenario: Double Roundabout with through-lane
     #http://map.project-osrm.org/?z=18&center=38.911752%2C-77.048667&loc=38.912003%2C-77.050831&loc=38.909277%2C-77.042516&hl=en&alt=0
         Given the node map
             """
                     o                       n
-                    e                       j
-
-                        q
-            a   b           s   f       g       i   k
-                        r                     p
-                                t
-                    c   d                   h
+                   .e.                     _j_.
+                  /   '.                  /    \
+                 /      q__             /       |
+            a---b       |  >s---f-------g       i---k
+                .       r''     |       .' . .p'|
+                 .      |       t        .     .'
+                   'c---d                  'h'
                     l                       m
             """
 
@@ -304,9 +309,13 @@ Feature: Basic Roundabout
             | nodes   | junction   | name            | oneway |
             | bcdrqeb | roundabout | sheridan circle | yes    |
             | ghi     | roundabout | dupont circle   | yes    |
-            | ijg     | roundabout | dupont circle   | yes    |
+            | ij      | roundabout | dupont circle   | yes    |
+            | jg      | roundabout | dupont circle   | yes    |
             | ab      |            | massachusetts   | no     |
-            | sfgpik  |            | massachusetts   | no     |
+            | gp      |            | massachusetts   | no     |
+            | pi      |            | massachusetts   | no     |
+            | sfg     |            | massachusetts   | no     |
+            | ik      |            | massachusetts   | no     |
             | cl      |            | 23rd street     | no     |
             | oe      |            | r street        | no     |
             | jn      |            | new hampshire   | no     |
@@ -316,11 +325,11 @@ Feature: Basic Roundabout
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |
-            | restriction | sfgpik   | ijg    | i        | no_left_turn  |
+            | restriction | pi       | ij     | i        | no_left_turn  |
 
         When I route I should get
-            | waypoints | route                                                   | turns                                                     |
-            | a,k       | massachusetts,massachusetts,massachusetts,massachusetts | depart,sheridan circle-exit-2,dupont circle-exit-1,arrive |
+            | waypoints | route                                                   | turns                                              |
+            | a,k       | massachusetts,massachusetts,massachusetts,massachusetts | depart,sheridan circle-exit-2,rotary-exit-1,arrive |
 
     #2856 - http://www.openstreetmap.org/#map=19/47.23318/-1.56563
     Scenario: Linked Roundabouts

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -907,8 +907,8 @@ Feature: Simple Turns
     Scenario: Turn Lane on Splitting up Road
         Given the node map
             """
-            g - - - f
-                     \
+            g - - - f -
+                         ' .
                     . h - - e - - c - - d
             a - - b _______/
                   i


### PR DESCRIPTION
# Issue

Some of our tests use invalid turn restrictions. This PR updates all turn restrictions in the guidance part of the code to work with OSRM. In OSRM, we cannot start a turn restriction in the middle of a way (e.g. `abc` and `bd` we can't specify a restriction `abc` via `b` to `bd`, since both `ab` and `cb` could be seen as `in` for the restriction).

## Tasklist
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?

