### PR TITLE
Make thread-locked access to stxxl containers

### DIFF
--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -113,7 +113,7 @@ struct InternalExtractorEdge
     {
         return InternalExtractorEdge(MAX_OSM_NODEID,
                                      MAX_OSM_NODEID,
-                                     0,
+                                     SPECIAL_NODEID,
                                      WeightData(),
                                      false,
                                      false,


### PR DESCRIPTION
# Issue

From stxxl FAQ: "you should not share a data structure between
threads (without implementing proper locking yourself)."
The access to name_char_data can be implicitly parallelized
if _GLIBCXX_PARALLEL is defined and invalidate local-thread iterators, but
in CmpEdgeByInternalSourceTargetAndName there is no guaranty to have valid iterators.

Preconditions for the UB:
- defined _GLIBCXX_PARALLEL and fopenmp  
- __gnu_parallel::__get_max_threads() > 1
- all_edges_list > __gnu_parallel::_Settings::get().sort_minimal_n 
- number of touched pages in name_char_data > STXXLNameCharData::PagerType::n_pages
- unlucky execution sequence that is almost sure for europe-latest

To review:
- drop access to name_char_data, but this will lead to a random edge name selection
- make thread-safe iterators, but i can not find better solution than keep a reference to a mutex, because mutex is non-copyable and non-movable, but Comparable concept requires copyable predicate.

## Tasklist
 - [x] review
 - [x] adjust for for comments

## Requirements / Relations
 #3033 