### PR TITLE
Try to fix msvc build error "base class undefined"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ add_custom_target(FingerPrintConfigure ALL ${CMAKE_COMMAND}
   COMMENT "Configuring revision fingerprint"
   VERBATIM)
 
-set(BOOST_COMPONENTS date_time filesystem iostreams program_options regex system thread unit_test_framework)
+set(BOOST_COMPONENTS date_time chrono filesystem iostreams program_options regex system thread unit_test_framework)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/util/version.hpp.in
@@ -226,7 +226,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-intel -wd10237 -Wall -ipo -fPIC")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   # using Visual Studio C++
-  set(BOOST_COMPONENTS ${BOOST_COMPONENTS} date_time chrono zlib)
+  set(BOOST_COMPONENTS ${BOOST_COMPONENTS} zlib)
   add_dependency_defines(-DBOOST_LIB_DIAGNOSTIC)
   add_dependency_defines(-D_CRT_SECURE_NO_WARNINGS)
   add_dependency_defines(-DNOMINMAX) # avoid min and max macros that can break compilation
@@ -337,23 +337,22 @@ include_directories(SYSTEM ${OSRM_INCLUDE_PATHS})
 
 set(BOOST_BASE_LIBRARIES
    ${Boost_DATE_TIME_LIBRARY}
+   ${Boost_CHRONO_LIBRARY}
    ${Boost_FILESYSTEM_LIBRARY}
    ${Boost_IOSTREAMS_LIBRARY}
    ${Boost_THREAD_LIBRARY}
    ${Boost_SYSTEM_LIBRARY})
 
 set(BOOST_ENGINE_LIBRARIES
-   ${Boost_FILESYSTEM_LIBRARY}
-   ${Boost_IOSTREAMS_LIBRARY}
-   ${Boost_REGEX_LIBRARY}
-   ${Boost_THREAD_LIBRARY}
-   ${Boost_SYSTEM_LIBRARY})
+  ${Boost_ZLIB_LIBRARY}
+  ${Boost_REGEX_LIBRARY}
+  ${BOOST_BASE_LIBRARIES})
 
 # Binaries
 target_link_libraries(osrm-datastore osrm_store ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_BASE_LIBRARIES})
 target_link_libraries(osrm-extract osrm_extract ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_REGEX_LIBRARY} ${BOOST_BASE_LIBRARIES})
 target_link_libraries(osrm-contract ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_BASE_LIBRARIES} ${TBB_LIBRARIES} osrm_contract)
-target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_BASE_LIBRARIES} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
+target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_ENGINE_LIBRARIES} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
 
 set(EXTRACTOR_LIBRARIES
     ${BZIP2_LIBRARIES}

--- a/appveyor-build.bat
+++ b/appveyor-build.bat
@@ -8,18 +8,18 @@ SET PROJECT_DIR=%CD%
 ECHO PROJECT_DIR^: %PROJECT_DIR%
 ECHO NUMBER_OF_PROCESSORS^: %NUMBER_OF_PROCESSORS%
 ECHO cmake^: && cmake --version
-IF %ERRORLEVEL% NEQ 0 ECHO CMAKE not found GOTO ERROR
+IF %ERRORLEVEL% NEQ 0 ECHO CMAKE not found && GOTO CMAKE_NOT_OK
 
-FOR /F %%G IN ("--version") DO cmake %%G 2>&1 | findstr /C:"3.5.0" > nul && goto CMAKE_NOT_OK
-GOTO CMAKE_OK
+cmake --version | findstr /C:"3.7.0" && GOTO CMAKE_OK
 
 :CMAKE_NOT_OK
-ECHO CMAKE NOT OK - downloading new CMake
-IF NOT EXIST cm.zip powershell Invoke-WebRequest https://cmake.org/files/v3.5/cmake-3.5.1-win32-x86.zip -OutFile $env:PROJECT_DIR\cm.zip
+SET CMAKE_VERSION=3.7.0-rc2
+ECHO CMAKE NOT OK - downloading new CMake %CMAKE_VERSION%
+IF NOT EXIST cm.zip powershell Invoke-WebRequest https://cmake.org/files/v3.7/cmake-%CMAKE_VERSION%-win32-x86.zip -OutFile $env:PROJECT_DIR\cm.zip
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF NOT EXIST cmake-3.5.1-win32-x86 7z -y x cm.zip | %windir%\system32\FIND "ing archive"
+IF NOT EXIST cmake-%CMAKE_VERSION%-win32-x86 7z -y x cm.zip | %windir%\system32\FIND "ing archive"
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-SET PATH=%PROJECT_DIR%\cmake-3.5.1-win32-x86\bin;%PATH%
+SET PATH=%PROJECT_DIR%\cmake-%CMAKE_VERSION%-win32-x86\bin;%PATH%
 
 :CMAKE_OK
 ECHO CMAKE_OK

--- a/build-local.bat
+++ b/build-local.bat
@@ -11,8 +11,7 @@ SET CONFIGURATION=Release
 FOR /F "tokens=*" %%i in ('git rev-parse --abbrev-ref HEAD') do SET APPVEYOR_REPO_BRANCH=%%i
 ECHO APPVEYOR_REPO_BRANCH^: %APPVEYOR_REPO_BRANCH%
 
-::SET PATH=C:\mb\windows-builds-64\tmp-bin\cmake-3.5.0-win32-x86\bin;%PATH%
-SET PATH=C:\mb\windows-builds-64\tmp-bin\cmake-3.5.1-win32-x86\bin;%PATH%
+SET PATH=C:\mb\windows-builds-64\tmp-bin\cmake-3.7.0-rc2-win32-x86\bin;%PATH%
 SET PATH=C:\Program Files\7-Zip;%PATH%
 
 powershell Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted -Force


### PR DESCRIPTION
# Issue

Try to fix msvc build error "base class undefined":
if `#include <boost/range/adaptor/transformed.hpp>` that is in assemble_leg.hpp
is included after
`#include "engine/data_watchdog.hpp"`
`#include "storage/shared_barriers.hpp"`
that include
`#include <boost/detail/workaround.hpp>`
`#include <boost/interprocess/detail/workaround.hpp>`
than something is going wrong, probably with forced inlines.

I can not reproduce the issue with 1.60 http://rextester.com/live/SZDL55018

Also fixed msvc related boost linking, because engine requires explicit linking of zlib, chrono and date_time libraries.

## Tasklist
 - [x] review
 - [x] adjust for for comments

Related issue #3088
