### PR TITLE
Refactor file loading and move into io.hpp

### DIFF
--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -123,9 +123,8 @@ class InternalDataFacade final : public BaseDataFacade
         {
             throw util::exception("Could not open " + properties_path.string() + " for reading.");
         }
-
-        in_stream.read(reinterpret_cast<char *>(&m_profile_properties),
-                       sizeof(m_profile_properties));
+        auto PropertiesSize = storage::io::readPropertiesSize();
+        storage::io::readProperties(in_stream, reinterpret_cast<char *>(&m_profile_properties), PropertiesSize);
     }
 
     void LoadLaneTupleIdPairs(const boost::filesystem::path &lane_data_path)

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -292,14 +292,12 @@ class InternalDataFacade final : public BaseDataFacade
         }
         BOOST_ASSERT(datasources_stream);
 
-        std::uint64_t number_of_datasources = 0;
-        datasources_stream.read(reinterpret_cast<char *>(&number_of_datasources),
-                                sizeof(number_of_datasources));
+        auto number_of_datasources = storage::io::readDatasourceIndexesSize(datasources_stream);
         if (number_of_datasources > 0)
         {
             m_datasource_list.resize(number_of_datasources);
-            datasources_stream.read(reinterpret_cast<char *>(&(m_datasource_list[0])),
-                                    number_of_datasources * sizeof(uint8_t));
+            storage::io::readDatasourceIndexes(
+                datasources_stream, &m_datasource_list.front(), number_of_datasources);
         }
 
         boost::filesystem::ifstream datasourcenames_stream(datasource_names_file, std::ios::binary);
@@ -309,10 +307,16 @@ class InternalDataFacade final : public BaseDataFacade
                                   " for reading!");
         }
         BOOST_ASSERT(datasourcenames_stream);
-        std::string name;
-        while (std::getline(datasourcenames_stream, name))
+
+        auto datasource_names_data = storage::io::readDatasourceNamesData(datasourcenames_stream);
+        m_datasource_names.resize(datasource_names_data.lengths.size());
+        for (std::uint32_t i = 0; i < datasource_names_data.lengths.size(); ++i)
         {
-            m_datasource_names.push_back(std::move(name));
+            auto name_begin =
+                datasource_names_data.names.begin() + datasource_names_data.offsets[i];
+            auto name_end = datasource_names_data.names.begin() + datasource_names_data.offsets[i] +
+                            datasource_names_data.lengths[i];
+            m_datasource_names[i] = std::move(std::string(name_begin, name_end));
         }
     }
 

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -181,27 +181,27 @@ class InternalDataFacade final : public BaseDataFacade
         util::SimpleLogger().Write() << "Data checksum is " << m_check_sum;
     }
 
-    void LoadNodeAndEdgeInformation(const boost::filesystem::path &nodes_file,
-                                    const boost::filesystem::path &edges_file)
+    void LoadNodeAndEdgeInformation(const boost::filesystem::path &nodes_file_path,
+                                    const boost::filesystem::path &edges_file_path)
     {
-        boost::filesystem::ifstream nodes_input_stream(nodes_file, std::ios::binary);
-
-        extractor::QueryNode current_node;
-        unsigned number_of_coordinates = 0;
-        nodes_input_stream.read((char *)&number_of_coordinates, sizeof(unsigned));
-        m_coordinate_list.resize(number_of_coordinates);
-        m_osmnodeid_list.reserve(number_of_coordinates);
-        for (unsigned i = 0; i < number_of_coordinates; ++i)
+        boost::filesystem::ifstream nodes_input_stream(nodes_file_path, std::ios::binary);
+        if (!nodes_input_stream)
         {
-            nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
-            m_coordinate_list[i] = util::Coordinate(current_node.lon, current_node.lat);
-            m_osmnodeid_list.push_back(current_node.node_id);
-            BOOST_ASSERT(m_coordinate_list[i].IsValid());
+            throw util::exception("Could not open " + nodes_file_path.string() + " for reading.");
         }
 
-        boost::filesystem::ifstream edges_input_stream(edges_file, std::ios::binary);
-        unsigned number_of_edges = 0;
-        edges_input_stream.read((char *)&number_of_edges, sizeof(unsigned));
+        std::uint32_t number_of_coordinates = storage::io::readNodesSize(nodes_input_stream);
+        m_coordinate_list.resize(number_of_coordinates);
+        m_osmnodeid_list.reserve(number_of_coordinates);
+        storage::io::readNodesData(
+            nodes_input_stream, m_coordinate_list.data(), m_osmnodeid_list, number_of_coordinates);
+
+        boost::filesystem::ifstream edges_input_stream(edges_file_path, std::ios::binary);
+        if (!edges_input_stream)
+        {
+            throw util::exception("Could not open " + edges_file_path.string() + " for reading.");
+        }
+        auto number_of_edges = storage::io::readEdgesSize(edges_input_stream);
         m_via_geometry_list.resize(number_of_edges);
         m_name_ID_list.resize(number_of_edges);
         m_turn_instruction_list.resize(number_of_edges);
@@ -211,20 +211,16 @@ class InternalDataFacade final : public BaseDataFacade
         m_pre_turn_bearing.resize(number_of_edges);
         m_post_turn_bearing.resize(number_of_edges);
 
-        extractor::OriginalEdgeData current_edge_data;
-        for (unsigned i = 0; i < number_of_edges; ++i)
-        {
-            edges_input_stream.read((char *)&(current_edge_data),
-                                    sizeof(extractor::OriginalEdgeData));
-            m_via_geometry_list[i] = current_edge_data.via_geometry;
-            m_name_ID_list[i] = current_edge_data.name_id;
-            m_turn_instruction_list[i] = current_edge_data.turn_instruction;
-            m_lane_data_id[i] = current_edge_data.lane_data_id;
-            m_travel_mode_list[i] = current_edge_data.travel_mode;
-            m_entry_class_id_list[i] = current_edge_data.entry_classid;
-            m_pre_turn_bearing[i] = current_edge_data.pre_turn_bearing;
-            m_post_turn_bearing[i] = current_edge_data.post_turn_bearing;
-        }
+        storage::io::readEdgesData(edges_input_stream,
+                                   m_via_geometry_list.data(),
+                                   m_name_ID_list.data(),
+                                   m_turn_instruction_list.data(),
+                                   m_lane_data_id.data(),
+                                   m_travel_mode_list.data(),
+                                   m_entry_class_id_list.data(),
+                                   m_pre_turn_bearing.data(),
+                                   m_post_turn_bearing.data(),
+                                   number_of_edges);
     }
 
     void LoadCoreInformation(const boost::filesystem::path &core_data_file)

--- a/include/engine/datafacade/internal_datafacade.hpp
+++ b/include/engine/datafacade/internal_datafacade.hpp
@@ -124,7 +124,7 @@ class InternalDataFacade final : public BaseDataFacade
             throw util::exception("Could not open " + properties_path.string() + " for reading.");
         }
         auto PropertiesSize = storage::io::readPropertiesSize();
-        storage::io::readProperties(in_stream, reinterpret_cast<char *>(&m_profile_properties), PropertiesSize);
+        storage::io::readProperties(in_stream, &m_profile_properties, PropertiesSize);
     }
 
     void LoadLaneTupleIdPairs(const boost::filesystem::path &lane_data_path)

--- a/include/extractor/original_edge_data.hpp
+++ b/include/extractor/original_edge_data.hpp
@@ -17,7 +17,7 @@ namespace extractor
 struct OriginalEdgeData
 {
     explicit OriginalEdgeData(GeometryID via_geometry,
-                              unsigned name_id,
+                              NameID name_id,
                               LaneDataID lane_data_id,
                               guidance::TurnInstruction turn_instruction,
                               EntryClassID entry_classid,

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -1,6 +1,8 @@
 #ifndef OSRM_STORAGE_IO_HPP_
 #define OSRM_STORAGE_IO_HPP_
 
+#include "extractor/original_edge_data.hpp"
+#include "extractor/query_node.hpp"
 #include "util/fingerprint.hpp"
 #include "util/simple_logger.hpp"
 
@@ -68,6 +70,8 @@ void readHSGR(boost::filesystem::ifstream &input_stream,
               EdgeT edge_buffer[],
               std::uint32_t number_of_edges)
 {
+    BOOST_ASSERT(node_buffer);
+    BOOST_ASSERT(edge_buffer);
     input_stream.read(reinterpret_cast<char *>(node_buffer), number_of_nodes * sizeof(NodeT));
     input_stream.read(reinterpret_cast<char *>(edge_buffer), number_of_edges * sizeof(EdgeT));
 }
@@ -85,6 +89,7 @@ inline void readTimestamp(boost::filesystem::ifstream &timestamp_input_stream,
                           char timestamp[],
                           std::size_t timestamp_length)
 {
+    BOOST_ASSERT(timestamp);
     timestamp_input_stream.read(timestamp, timestamp_length * sizeof(char));
 }
 
@@ -118,6 +123,12 @@ void readEdgesData(boost::filesystem::ifstream &edges_input_stream,
                    PostTurnBearingT post_turn_bearing_list[],
                    std::uint32_t number_of_edges)
 {
+    BOOST_ASSERT(geometry_list);
+    BOOST_ASSERT(name_id_list);
+    BOOST_ASSERT(turn_instruction_list);
+    BOOST_ASSERT(lane_data_id_list);
+    BOOST_ASSERT(travel_mode_list);
+    BOOST_ASSERT(entry_class_id_list);
     extractor::OriginalEdgeData current_edge_data;
     for (std::uint32_t i = 0; i < number_of_edges; ++i)
     {
@@ -149,6 +160,7 @@ void readNodesData(boost::filesystem::ifstream &nodes_input_stream,
                    OSMNodeIDVectorT &osmnodeid_list,
                    std::uint32_t number_of_coordinates)
 {
+    BOOST_ASSERT(coordinate_list);
     extractor::QueryNode current_node;
     for (std::uint32_t i = 0; i < number_of_coordinates; ++i)
     {
@@ -160,8 +172,6 @@ void readNodesData(boost::filesystem::ifstream &nodes_input_stream,
 }
 
 // Returns the number of indexes in a .datasource_indexes file
-// TODO: The original code used uint_64t to store the number of indexes. Can someone confirm that
-// this makes sense?
 inline std::uint64_t
 readDatasourceIndexesSize(boost::filesystem::ifstream &datasource_indexes_input_stream)
 {
@@ -177,6 +187,7 @@ inline void readDatasourceIndexes(boost::filesystem::ifstream &datasource_indexe
                                   uint8_t datasource_buffer[],
                                   std::uint32_t number_of_datasource_indexes)
 {
+    BOOST_ASSERT(datasource_buffer);
     datasource_indexes_input_stream.read(reinterpret_cast<char *>(datasource_buffer),
                                          number_of_datasource_indexes * sizeof(std::uint8_t));
 }
@@ -207,6 +218,24 @@ readDatasourceNamesData(boost::filesystem::ifstream &datasource_names_input_stre
     }
     return datasource_names_data;
 }
+
+// Returns the number of ram indexes
+inline std::uint32_t readRamIndexSize(boost::filesystem::ifstream &ram_index_input_stream)
+{
+    std::uint32_t tree_size = 0;
+    ram_index_input_stream.read((char *)&tree_size, sizeof(std::uint32_t));
+    return tree_size;
+}
+
+template <typename RTreeNodeT>
+void readRamIndexData(boost::filesystem::ifstream &ram_index_input_stream,
+                 RTreeNodeT rtree_buffer[],
+                 std::uint32_t tree_size)
+{
+    BOOST_ASSERT(rtree_buffer);
+    ram_index_input_stream.read(reinterpret_cast<char *>(rtree_buffer), sizeof(RTreeNodeT) * tree_size);
+}
+
 }
 }
 }

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -63,9 +63,9 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
 // Needs to be called after readHSGRHeader() to get the correct offset in the stream
 template <typename NodeT, typename EdgeT>
 void readHSGR(boost::filesystem::ifstream &input_stream,
-              NodeT *node_buffer,
+              NodeT node_buffer[],
               std::uint32_t number_of_nodes,
-              EdgeT *edge_buffer,
+              EdgeT edge_buffer[],
               std::uint32_t number_of_edges)
 {
     input_stream.read(reinterpret_cast<char *>(node_buffer), number_of_nodes * sizeof(NodeT));
@@ -74,20 +74,88 @@ void readHSGR(boost::filesystem::ifstream &input_stream,
 // Returns the size of the timestamp in a file
 inline std::uint32_t readTimestampSize(boost::filesystem::ifstream &timestamp_input_stream)
 {
-    timestamp_input_stream.seekg (0, timestamp_input_stream.end);
+    timestamp_input_stream.seekg(0, timestamp_input_stream.end);
     auto length = timestamp_input_stream.tellg();
-    timestamp_input_stream.seekg (0, timestamp_input_stream.beg);
+    timestamp_input_stream.seekg(0, timestamp_input_stream.beg);
     return length;
 }
 
 // Reads the timestamp in a file
 inline void readTimestamp(boost::filesystem::ifstream &timestamp_input_stream,
-                          char *timestamp,
+                          char timestamp[],
                           std::size_t timestamp_length)
 {
     timestamp_input_stream.read(timestamp, timestamp_length * sizeof(char));
 }
 
+// Returns the number of edges in a .edges file
+inline std::uint32_t readEdgesSize(boost::filesystem::ifstream &edges_input_stream)
+{
+    std::uint32_t number_of_edges;
+    edges_input_stream.read((char *)&number_of_edges, sizeof(std::uint32_t));
+    return number_of_edges;
+}
+
+// Reads edge data from .edge files which includes its
+// geometry, name ID, turn instruction, lane data ID, travel mode, entry class ID
+template <typename GeometryIDT,
+          typename NameIDT,
+          typename TurnInstructionT,
+          typename LaneDataIDT,
+          typename TravelModeT,
+          typename EntryClassIDT,
+          typename PreTurnBearingT,
+          typename PostTurnBearingT>
+void readEdgesData(boost::filesystem::ifstream &edges_input_stream,
+                   GeometryIDT geometry_list[],
+                   NameIDT name_id_list[],
+                   TurnInstructionT turn_instruction_list[],
+                   LaneDataIDT lane_data_id_list[],
+                   TravelModeT travel_mode_list[],
+                   EntryClassIDT entry_class_id_list[],
+                   PreTurnBearingT pre_turn_bearing_list[],
+                   PostTurnBearingT post_turn_bearing_list[],
+                   std::uint32_t number_of_edges)
+{
+    extractor::OriginalEdgeData current_edge_data;
+    for (std::uint32_t i = 0; i < number_of_edges; ++i)
+    {
+        edges_input_stream.read((char *)&(current_edge_data), sizeof(extractor::OriginalEdgeData));
+        geometry_list[i] = current_edge_data.via_geometry;
+        name_id_list[i] = current_edge_data.name_id;
+        turn_instruction_list[i] = current_edge_data.turn_instruction;
+        lane_data_id_list[i] = current_edge_data.lane_data_id;
+        travel_mode_list[i] = current_edge_data.travel_mode;
+        entry_class_id_list[i] = current_edge_data.entry_classid;
+        pre_turn_bearing_list[i] = current_edge_data.pre_turn_bearing;
+        post_turn_bearing_list[i] = current_edge_data.post_turn_bearing;
+    }
+}
+
+// Returns the number of nodes in a .nodes file
+inline std::uint32_t readNodesSize(boost::filesystem::ifstream &nodes_input_stream)
+{
+    std::uint32_t number_of_coordinates;
+    nodes_input_stream.read((char *)&number_of_coordinates, sizeof(std::uint32_t));
+    return number_of_coordinates;
+}
+
+// Reads coordinates and OSM node IDs from .nodes files
+template <typename CoordinateT, typename OSMNodeIDVectorT>
+void readNodesData(boost::filesystem::ifstream &nodes_input_stream,
+                   CoordinateT coordinate_list[],
+                   OSMNodeIDVectorT &osmnodeid_list,
+                   std::uint32_t number_of_coordinates)
+{
+    extractor::QueryNode current_node;
+    for (std::uint32_t i = 0; i < number_of_coordinates; ++i)
+    {
+        nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
+        coordinate_list[i] = CoordinateT(current_node.lon, current_node.lat);
+        osmnodeid_list.push_back(current_node.node_id);
+        BOOST_ASSERT(coordinate_list[i].IsValid());
+    }
+}
 }
 }
 }

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -15,6 +15,16 @@ namespace storage
 namespace io
 {
 
+inline std::size_t readPropertiesSize() { return 1; }
+
+template <typename PropertiesT>
+inline void readProperties(boost::filesystem::ifstream &properties_stream,
+                           PropertiesT properties[],
+                           std::size_t PropertiesSize)
+{
+    properties_stream.read(properties, PropertiesSize);
+}
+
 #pragma pack(push, 1)
 struct HSGRHeader
 {
@@ -39,8 +49,10 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
 
     HSGRHeader header;
     input_stream.read(reinterpret_cast<char *>(&header.checksum), sizeof(header.checksum));
-    input_stream.read(reinterpret_cast<char *>(&header.number_of_nodes), sizeof(header.number_of_nodes));
-    input_stream.read(reinterpret_cast<char *>(&header.number_of_edges), sizeof(header.number_of_edges));
+    input_stream.read(reinterpret_cast<char *>(&header.number_of_nodes),
+                      sizeof(header.number_of_nodes));
+    input_stream.read(reinterpret_cast<char *>(&header.number_of_edges),
+                      sizeof(header.number_of_edges));
 
     BOOST_ASSERT_MSG(0 != header.number_of_nodes, "number of nodes is zero");
     // number of edges can be zero, this is the case in a few test fixtures
@@ -48,7 +60,7 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
     return header;
 }
 
-// Needs to be called after HSGRHeader() to get the correct offset in the stream
+// Needs to be called after readHSGRHeader() to get the correct offset in the stream
 template <typename NodeT, typename EdgeT>
 void readHSGR(boost::filesystem::ifstream &input_stream,
               NodeT *node_buffer,
@@ -59,7 +71,6 @@ void readHSGR(boost::filesystem::ifstream &input_stream,
     input_stream.read(reinterpret_cast<char *>(node_buffer), number_of_nodes * sizeof(NodeT));
     input_stream.read(reinterpret_cast<char *>(edge_buffer), number_of_edges * sizeof(EdgeT));
 }
-
 // Returns the size of the timestamp in a file
 inline std::uint32_t readTimestampSize(boost::filesystem::ifstream &timestamp_input_stream)
 {

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -1,10 +1,13 @@
 #ifndef OSRM_STORAGE_IO_HPP_
 #define OSRM_STORAGE_IO_HPP_
 
+#include "contractor/query_edge.hpp"
+#include "extractor/extractor.hpp"
 #include "extractor/original_edge_data.hpp"
 #include "extractor/query_node.hpp"
 #include "util/fingerprint.hpp"
 #include "util/simple_logger.hpp"
+#include "util/static_graph.hpp"
 
 #include <boost/filesystem/fstream.hpp>
 
@@ -17,27 +20,38 @@ namespace storage
 namespace io
 {
 
-inline std::size_t readPropertiesSize() { return 1; }
-
-template <typename PropertiesT>
-inline void readProperties(boost::filesystem::ifstream &properties_stream,
-                           PropertiesT *properties,
-                           std::size_t properties_size)
+// Reads the count of elements that is written in the file header and returns the number
+inline std::uint64_t readElementCount(boost::filesystem::ifstream &input_stream)
 {
-    properties_stream.read(reinterpret_cast<char *>(properties), properties_size);
+    std::uint64_t number_of_elements = 0;
+    input_stream.read((char *)&number_of_elements, sizeof(std::uint64_t));
+    return number_of_elements;
+}
+
+// To make function calls consistent, this function returns the fixed number of properties
+inline std::size_t readPropertiesCount() { return 1; }
+
+// Returns the number of bytes in a file
+inline std::size_t readNumberOfBytes(boost::filesystem::ifstream &input_stream)
+{
+    input_stream.seekg(0, input_stream.end);
+    auto length = input_stream.tellg();
+    input_stream.seekg(0, input_stream.beg);
+    return length;
 }
 
 #pragma pack(push, 1)
 struct HSGRHeader
 {
     std::uint32_t checksum;
-    std::uint32_t number_of_nodes;
-    std::uint32_t number_of_edges;
+    std::uint64_t number_of_nodes;
+    std::uint64_t number_of_edges;
 };
 #pragma pack(pop)
-static_assert(sizeof(HSGRHeader) == 12, "HSGRHeader is not packed");
+static_assert(sizeof(HSGRHeader) == 20, "HSGRHeader is not packed");
 
-// Returns the checksum and the number of nodes and number of edges
+// Reads the checksum, number of nodes and number of edges written in the header file of a `.hsgr`
+// file and returns them in a HSGRHeader struct
 inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
 {
     const util::FingerPrint fingerprint_valid = util::FingerPrint::GetValid();
@@ -62,66 +76,65 @@ inline HSGRHeader readHSGRHeader(boost::filesystem::ifstream &input_stream)
     return header;
 }
 
+// Reads the graph data of a `.hsgr` file into memory
 // Needs to be called after readHSGRHeader() to get the correct offset in the stream
-template <typename NodeT, typename EdgeT>
-void readHSGR(boost::filesystem::ifstream &input_stream,
-              NodeT node_buffer[],
-              std::uint32_t number_of_nodes,
-              EdgeT edge_buffer[],
-              std::uint32_t number_of_edges)
+using NodeT = typename util::StaticGraph<contractor::QueryEdge::EdgeData>::NodeArrayEntry;
+using EdgeT = typename util::StaticGraph<contractor::QueryEdge::EdgeData>::EdgeArrayEntry;
+inline void readHSGR(boost::filesystem::ifstream &input_stream,
+              NodeT *node_buffer,
+              const std::uint64_t number_of_nodes,
+              EdgeT *edge_buffer,
+              const std::uint64_t number_of_edges)
 {
     BOOST_ASSERT(node_buffer);
     BOOST_ASSERT(edge_buffer);
     input_stream.read(reinterpret_cast<char *>(node_buffer), number_of_nodes * sizeof(NodeT));
     input_stream.read(reinterpret_cast<char *>(edge_buffer), number_of_edges * sizeof(EdgeT));
 }
-// Returns the size of the timestamp in a file
-inline std::uint32_t readTimestampSize(boost::filesystem::ifstream &timestamp_input_stream)
+
+// Loads properties from a `.properties` file into memory
+inline void readProperties(boost::filesystem::ifstream &properties_stream,
+                           extractor::ProfileProperties *properties,
+                           const std::size_t properties_size)
 {
-    timestamp_input_stream.seekg(0, timestamp_input_stream.end);
-    auto length = timestamp_input_stream.tellg();
-    timestamp_input_stream.seekg(0, timestamp_input_stream.beg);
-    return length;
+    BOOST_ASSERT(properties);
+    properties_stream.read(reinterpret_cast<char *>(properties), properties_size);
 }
 
-// Reads the timestamp in a file
+// Reads the timestamp in a `.timestamp` file
+// Use readNumberOfBytes() beforehand to get the length of the file
 inline void readTimestamp(boost::filesystem::ifstream &timestamp_input_stream,
-                          char timestamp[],
-                          std::size_t timestamp_length)
+                          char *timestamp,
+                          const std::size_t timestamp_length)
 {
     BOOST_ASSERT(timestamp);
     timestamp_input_stream.read(timestamp, timestamp_length * sizeof(char));
 }
 
-// Returns the number of edges in a .edges file
-inline std::uint32_t readEdgesSize(boost::filesystem::ifstream &edges_input_stream)
+// Loads datasource_indexes from .datasource_indexes into memory
+// Needs to be called after readElementCount() to get the correct offset in the stream
+inline void readDatasourceIndexes(boost::filesystem::ifstream &datasource_indexes_input_stream,
+                                  uint8_t *datasource_buffer,
+                                  const std::uint64_t number_of_datasource_indexes)
 {
-    std::uint32_t number_of_edges;
-    edges_input_stream.read((char *)&number_of_edges, sizeof(std::uint32_t));
-    return number_of_edges;
+    BOOST_ASSERT(datasource_buffer);
+    datasource_indexes_input_stream.read(reinterpret_cast<char *>(datasource_buffer),
+                                         number_of_datasource_indexes * sizeof(std::uint8_t));
 }
 
-// Reads edge data from .edge files which includes its
+// Loads edge data from .edge files into memory which includes its
 // geometry, name ID, turn instruction, lane data ID, travel mode, entry class ID
-// Needs to be called after readEdgesSize() to get the correct offset in the stream
-template <typename GeometryIDT,
-          typename NameIDT,
-          typename TurnInstructionT,
-          typename LaneDataIDT,
-          typename TravelModeT,
-          typename EntryClassIDT,
-          typename PreTurnBearingT,
-          typename PostTurnBearingT>
-void readEdgesData(boost::filesystem::ifstream &edges_input_stream,
-                   GeometryIDT geometry_list[],
-                   NameIDT name_id_list[],
-                   TurnInstructionT turn_instruction_list[],
-                   LaneDataIDT lane_data_id_list[],
-                   TravelModeT travel_mode_list[],
-                   EntryClassIDT entry_class_id_list[],
-                   PreTurnBearingT pre_turn_bearing_list[],
-                   PostTurnBearingT post_turn_bearing_list[],
-                   std::uint32_t number_of_edges)
+// Needs to be called after readElementCount() to get the correct offset in the stream
+inline void readEdges(boost::filesystem::ifstream &edges_input_stream,
+                      GeometryID *geometry_list,
+                      NameID *name_id_list,
+                      extractor::guidance::TurnInstruction *turn_instruction_list,
+                      LaneDataID *lane_data_id_list,
+                      extractor::TravelMode *travel_mode_list,
+                      EntryClassID *entry_class_id_list,
+                      util::guidance::TurnBearing *pre_turn_bearing_list,
+                      util::guidance::TurnBearing *post_turn_bearing_list,
+                      const std::uint64_t number_of_edges)
 {
     BOOST_ASSERT(geometry_list);
     BOOST_ASSERT(name_id_list);
@@ -130,9 +143,10 @@ void readEdgesData(boost::filesystem::ifstream &edges_input_stream,
     BOOST_ASSERT(travel_mode_list);
     BOOST_ASSERT(entry_class_id_list);
     extractor::OriginalEdgeData current_edge_data;
-    for (std::uint32_t i = 0; i < number_of_edges; ++i)
+    for (std::uint64_t i = 0; i < number_of_edges; ++i)
     {
         edges_input_stream.read((char *)&(current_edge_data), sizeof(extractor::OriginalEdgeData));
+
         geometry_list[i] = current_edge_data.via_geometry;
         name_id_list[i] = current_edge_data.name_id;
         turn_instruction_list[i] = current_edge_data.turn_instruction;
@@ -144,96 +158,62 @@ void readEdgesData(boost::filesystem::ifstream &edges_input_stream,
     }
 }
 
-// Returns the number of nodes in a .nodes file
-inline std::uint32_t readNodesSize(boost::filesystem::ifstream &nodes_input_stream)
-{
-    std::uint32_t number_of_coordinates;
-    nodes_input_stream.read((char *)&number_of_coordinates, sizeof(std::uint32_t));
-    return number_of_coordinates;
-}
-
-// Reads coordinates and OSM node IDs from .nodes files
-// Needs to be called after readNodesSize() to get the correct offset in the stream
-template <typename CoordinateT, typename OSMNodeIDVectorT>
-void readNodesData(boost::filesystem::ifstream &nodes_input_stream,
-                   CoordinateT coordinate_list[],
-                   OSMNodeIDVectorT &osmnodeid_list,
-                   std::uint32_t number_of_coordinates)
+// Loads coordinates and OSM node IDs from .nodes files into memory
+// Needs to be called after readElementCount() to get the correct offset in the stream
+template <typename OSMNodeIDVectorT>
+void readNodes(boost::filesystem::ifstream &nodes_input_stream,
+               util::Coordinate *coordinate_list,
+               OSMNodeIDVectorT &osmnodeid_list,
+               const std::uint64_t number_of_coordinates)
 {
     BOOST_ASSERT(coordinate_list);
     extractor::QueryNode current_node;
-    for (std::uint32_t i = 0; i < number_of_coordinates; ++i)
+    for (std::uint64_t i = 0; i < number_of_coordinates; ++i)
     {
         nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
-        coordinate_list[i] = CoordinateT(current_node.lon, current_node.lat);
+        coordinate_list[i] = util::Coordinate(current_node.lon, current_node.lat);
         osmnodeid_list.push_back(current_node.node_id);
         BOOST_ASSERT(coordinate_list[i].IsValid());
     }
 }
 
-// Returns the number of indexes in a .datasource_indexes file
-inline std::uint64_t
-readDatasourceIndexesSize(boost::filesystem::ifstream &datasource_indexes_input_stream)
-{
-    std::uint64_t number_of_datasource_indexes;
-    datasource_indexes_input_stream.read(reinterpret_cast<char *>(&number_of_datasource_indexes),
-                                         sizeof(std::uint64_t));
-    return number_of_datasource_indexes;
-}
-
-// Reads datasource_indexes
-// Needs to be called after readDatasourceIndexesSize() to get the correct offset in the stream
-inline void readDatasourceIndexes(boost::filesystem::ifstream &datasource_indexes_input_stream,
-                                  uint8_t datasource_buffer[],
-                                  std::uint32_t number_of_datasource_indexes)
-{
-    BOOST_ASSERT(datasource_buffer);
-    datasource_indexes_input_stream.read(reinterpret_cast<char *>(datasource_buffer),
-                                         number_of_datasource_indexes * sizeof(std::uint8_t));
-}
 
 // Reads datasource names out of .datasource_names files and metadata such as
 // the length and offset of each name
 struct DatasourceNamesData
 {
     std::vector<char> names;
-    std::vector<std::uint32_t> offsets;
-    std::vector<std::uint32_t> lengths;
+    std::vector<std::size_t> offsets;
+    std::vector<std::size_t> lengths;
 };
-inline DatasourceNamesData
-readDatasourceNamesData(boost::filesystem::ifstream &datasource_names_input_stream)
+inline DatasourceNamesData readDatasourceNames(boost::filesystem::ifstream &datasource_names_input_stream)
 {
     DatasourceNamesData datasource_names_data;
-    if (datasource_names_input_stream)
+    std::string name;
+    while (std::getline(datasource_names_input_stream, name))
     {
-        std::string name;
-        while (std::getline(datasource_names_input_stream, name))
-        {
-            datasource_names_data.offsets.push_back(datasource_names_data.names.size());
-            datasource_names_data.lengths.push_back(name.size());
-            std::copy(name.c_str(),
-                      name.c_str() + name.size(),
-                      std::back_inserter(datasource_names_data.names));
-        }
+        datasource_names_data.offsets.push_back(datasource_names_data.names.size());
+        datasource_names_data.lengths.push_back(name.size());
+        std::copy(name.c_str(),
+                  name.c_str() + name.size(),
+                  std::back_inserter(datasource_names_data.names));
     }
     return datasource_names_data;
 }
 
-// Returns the number of ram indexes
-inline std::uint32_t readRamIndexSize(boost::filesystem::ifstream &ram_index_input_stream)
-{
-    std::uint32_t tree_size = 0;
-    ram_index_input_stream.read((char *)&tree_size, sizeof(std::uint32_t));
-    return tree_size;
-}
-
+// Loads ram indexes of R-Trees from `.ramIndex` files into memory
+// Needs to be called after readElementCount() to get the correct offset in the stream
+// template <bool UseSharedMemory>
+// NB Cannot be written without templated type because of cyclic depencies between
+// `static_rtree.hpp` and `io.hpp`
 template <typename RTreeNodeT>
-void readRamIndexData(boost::filesystem::ifstream &ram_index_input_stream,
-                 RTreeNodeT rtree_buffer[],
-                 std::uint32_t tree_size)
+void readRamIndex(boost::filesystem::ifstream &ram_index_input_stream,
+                  RTreeNodeT *rtree_buffer,
+                  const std::uint64_t tree_size)
 {
     BOOST_ASSERT(rtree_buffer);
-    ram_index_input_stream.read(reinterpret_cast<char *>(rtree_buffer), sizeof(RTreeNodeT) * tree_size);
+    ram_index_input_stream.read(reinterpret_cast<char *>(rtree_buffer),
+                                sizeof(RTreeNodeT) * tree_size);
 }
 
 }

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -98,6 +98,7 @@ inline std::uint32_t readEdgesSize(boost::filesystem::ifstream &edges_input_stre
 
 // Reads edge data from .edge files which includes its
 // geometry, name ID, turn instruction, lane data ID, travel mode, entry class ID
+// Needs to be called after readEdgesSize() to get the correct offset in the stream
 template <typename GeometryIDT,
           typename NameIDT,
           typename TurnInstructionT,
@@ -141,6 +142,7 @@ inline std::uint32_t readNodesSize(boost::filesystem::ifstream &nodes_input_stre
 }
 
 // Reads coordinates and OSM node IDs from .nodes files
+// Needs to be called after readNodesSize() to get the correct offset in the stream
 template <typename CoordinateT, typename OSMNodeIDVectorT>
 void readNodesData(boost::filesystem::ifstream &nodes_input_stream,
                    CoordinateT coordinate_list[],
@@ -155,6 +157,55 @@ void readNodesData(boost::filesystem::ifstream &nodes_input_stream,
         osmnodeid_list.push_back(current_node.node_id);
         BOOST_ASSERT(coordinate_list[i].IsValid());
     }
+}
+
+// Returns the number of indexes in a .datasource_indexes file
+// TODO: The original code used uint_64t to store the number of indexes. Can someone confirm that
+// this makes sense?
+inline std::uint64_t
+readDatasourceIndexesSize(boost::filesystem::ifstream &datasource_indexes_input_stream)
+{
+    std::uint64_t number_of_datasource_indexes;
+    datasource_indexes_input_stream.read(reinterpret_cast<char *>(&number_of_datasource_indexes),
+                                         sizeof(std::uint64_t));
+    return number_of_datasource_indexes;
+}
+
+// Reads datasource_indexes
+// Needs to be called after readDatasourceIndexesSize() to get the correct offset in the stream
+inline void readDatasourceIndexes(boost::filesystem::ifstream &datasource_indexes_input_stream,
+                                  uint8_t datasource_buffer[],
+                                  std::uint32_t number_of_datasource_indexes)
+{
+    datasource_indexes_input_stream.read(reinterpret_cast<char *>(datasource_buffer),
+                                         number_of_datasource_indexes * sizeof(std::uint8_t));
+}
+
+// Reads datasource names out of .datasource_names files and metadata such as
+// the length and offset of each name
+struct DatasourceNamesData
+{
+    std::vector<char> names;
+    std::vector<std::uint32_t> offsets;
+    std::vector<std::uint32_t> lengths;
+};
+inline DatasourceNamesData
+readDatasourceNamesData(boost::filesystem::ifstream &datasource_names_input_stream)
+{
+    DatasourceNamesData datasource_names_data;
+    if (datasource_names_input_stream)
+    {
+        std::string name;
+        while (std::getline(datasource_names_input_stream, name))
+        {
+            datasource_names_data.offsets.push_back(datasource_names_data.names.size());
+            datasource_names_data.lengths.push_back(name.size());
+            std::copy(name.c_str(),
+                      name.c_str() + name.size(),
+                      std::back_inserter(datasource_names_data.names));
+        }
+    }
+    return datasource_names_data;
 }
 }
 }

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -19,10 +19,10 @@ inline std::size_t readPropertiesSize() { return 1; }
 
 template <typename PropertiesT>
 inline void readProperties(boost::filesystem::ifstream &properties_stream,
-                           PropertiesT properties[],
-                           std::size_t PropertiesSize)
+                           PropertiesT *properties,
+                           std::size_t properties_size)
 {
-    properties_stream.read(properties, PropertiesSize);
+    properties_stream.read(reinterpret_cast<char *>(properties), properties_size);
 }
 
 #pragma pack(push, 1)

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -333,9 +333,9 @@ class StaticRTree
         // open tree file
         boost::filesystem::ofstream tree_node_file(tree_node_filename, std::ios::binary);
 
-        std::uint32_t size_of_tree = m_search_tree.size();
+        std::uint64_t size_of_tree = m_search_tree.size();
         BOOST_ASSERT_MSG(0 < size_of_tree, "tree empty");
-        tree_node_file.write((char *)&size_of_tree, sizeof(std::uint32_t));
+        tree_node_file.write((char *)&size_of_tree, sizeof(size_of_tree));
         tree_node_file.write((char *)&m_search_tree[0], sizeof(TreeNode) * size_of_tree);
 
         MapLeafNodesFile(leaf_node_filename);
@@ -357,11 +357,10 @@ class StaticRTree
         }
         boost::filesystem::ifstream tree_node_file(node_file, std::ios::binary);
 
-
-        std::uint32_t tree_size = storage::io::readRamIndexSize(tree_node_file);
+        const auto tree_size = storage::io::readElementCount(tree_node_file);
 
         m_search_tree.resize(tree_size);
-        storage::io::readRamIndexData(tree_node_file, &m_search_tree[0], tree_size);
+        storage::io::readRamIndex(tree_node_file, &m_search_tree[0], tree_size);
 
         MapLeafNodesFile(leaf_file);
     }

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -1,6 +1,7 @@
 #ifndef STATIC_RTREE_HPP
 #define STATIC_RTREE_HPP
 
+#include "storage/io.hpp"
 #include "util/bearing.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/deallocating_vector.hpp"
@@ -356,14 +357,11 @@ class StaticRTree
         }
         boost::filesystem::ifstream tree_node_file(node_file, std::ios::binary);
 
-        std::uint32_t tree_size = 0;
-        tree_node_file.read((char *)&tree_size, sizeof(std::uint32_t));
+
+        std::uint32_t tree_size = storage::io::readRamIndexSize(tree_node_file);
 
         m_search_tree.resize(tree_size);
-        if (tree_size > 0)
-        {
-            tree_node_file.read((char *)&m_search_tree[0], sizeof(TreeNode) * tree_size);
-        }
+        storage::io::readRamIndexData(tree_node_file, &m_search_tree[0], tree_size);
 
         MapLeafNodesFile(leaf_file);
     }

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -420,8 +420,8 @@ parse_turn_penalty_lookup_from_csv_files(const std::vector<std::string> &turn_pe
             local.push_back(std::move(val));
         }
 
-        util::SimpleLogger().Write() << "Loaded penalty file " << filename << " with " << local.size()
-                                     << " turn penalties";
+        util::SimpleLogger().Write() << "Loaded penalty file " << filename << " with "
+                                     << local.size() << " turn penalties";
 
         {
             Mutex::scoped_lock _{flatten_mutex};
@@ -437,8 +437,10 @@ parse_turn_penalty_lookup_from_csv_files(const std::vector<std::string> &turn_pe
     // With flattened map-ish view of all the files, sort and unique them on from,to,source
     // The greater '>' is used here since we want to give files later on higher precedence
     const auto sort_by = [](const TurnPenaltySource &lhs, const TurnPenaltySource &rhs) {
-        return std::tie(lhs.segment.from, lhs.segment.via, lhs.segment.to, lhs.penalty_source.source) >
-               std::tie(rhs.segment.from, rhs.segment.via, rhs.segment.to, rhs.penalty_source.source);
+        return std::tie(
+                   lhs.segment.from, lhs.segment.via, lhs.segment.to, lhs.penalty_source.source) >
+               std::tie(
+                   rhs.segment.from, rhs.segment.via, rhs.segment.to, rhs.penalty_source.source);
     };
 
     std::stable_sort(begin(map), end(map), sort_by);
@@ -569,8 +571,8 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
             throw util::exception("Failed to open " + nodes_filename);
         }
 
-        unsigned number_of_nodes = 0;
-        nodes_input_stream.read((char *)&number_of_nodes, sizeof(unsigned));
+        std::uint64_t number_of_nodes = 0;
+        nodes_input_stream.read((char *)&number_of_nodes, sizeof(std::uint64_t));
         internal_to_external_node_map.resize(number_of_nodes);
 
         // Load all the query nodes into a vector
@@ -976,7 +978,7 @@ Contractor::WriteContractedGraph(unsigned max_node_id,
 {
     // Sorting contracted edges in a way that the static query graph can read some in in-place.
     tbb::parallel_sort(contracted_edge_list.begin(), contracted_edge_list.end());
-    const unsigned contracted_edge_count = contracted_edge_list.size();
+    const std::uint64_t contracted_edge_count = contracted_edge_list.size();
     util::SimpleLogger().Write() << "Serializing compacted graph of " << contracted_edge_count
                                  << " edges";
 
@@ -1033,13 +1035,13 @@ Contractor::WriteContractedGraph(unsigned max_node_id,
     const unsigned edges_crc32 = crc32_calculator(contracted_edge_list);
     util::SimpleLogger().Write() << "Writing CRC32: " << edges_crc32;
 
-    const unsigned node_array_size = node_array.size();
+    const std::uint64_t node_array_size = node_array.size();
     // serialize crc32, aka checksum
     hsgr_output_stream.write((char *)&edges_crc32, sizeof(unsigned));
     // serialize number of nodes
-    hsgr_output_stream.write((char *)&node_array_size, sizeof(unsigned));
+    hsgr_output_stream.write((char *)&node_array_size, sizeof(std::uint64_t));
     // serialize number of edges
-    hsgr_output_stream.write((char *)&contracted_edge_count, sizeof(unsigned));
+    hsgr_output_stream.write((char *)&contracted_edge_count, sizeof(std::uint64_t));
     // serialize all nodes
     if (node_array_size > 0)
     {

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -331,7 +331,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     }
 
     // Writes a dummy value at the front that is updated later with the total length
-    const unsigned length_prefix_empty_space{0};
+    const std::uint64_t length_prefix_empty_space{0};
     edge_data_file.write(reinterpret_cast<const char *>(&length_prefix_empty_space),
                          sizeof(length_prefix_empty_space));
 
@@ -598,7 +598,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     // Finally jump back to the empty space at the beginning and write length prefix
     edge_data_file.seekp(std::ios::beg);
 
-    const auto length_prefix = boost::numeric_cast<unsigned>(original_edges_counter);
+    const auto length_prefix = boost::numeric_cast<std::uint64_t>(original_edges_counter);
     static_assert(sizeof(length_prefix_empty_space) == sizeof(length_prefix), "type mismatch");
 
     edge_data_file.write(reinterpret_cast<const char *>(&length_prefix), sizeof(length_prefix));

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -112,8 +112,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
     TIMER_START(extracting);
 
     const unsigned recommended_num_threads = tbb::task_scheduler_init::default_num_threads();
-    const auto number_of_threads =
-        std::min(recommended_num_threads, config.requested_num_threads);
+    const auto number_of_threads = std::min(recommended_num_threads, config.requested_num_threads);
     tbb::task_scheduler_init init(number_of_threads);
 
     {
@@ -527,8 +526,8 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
 void Extractor::WriteNodeMapping(const std::vector<QueryNode> &internal_to_external_node_map)
 {
     boost::filesystem::ofstream node_stream(config.node_output_path, std::ios::binary);
-    const unsigned size_of_mapping = internal_to_external_node_map.size();
-    node_stream.write((char *)&size_of_mapping, sizeof(unsigned));
+    const std::uint64_t size_of_mapping = internal_to_external_node_map.size();
+    node_stream.write((char *)&size_of_mapping, sizeof(std::uint64_t));
     if (size_of_mapping > 0)
     {
         node_stream.write((char *)internal_to_external_node_map.data(),

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -771,8 +771,8 @@ Storage::ReturnCode Storage::Run(int max_wait)
         util::exception("Could not open " + config.properties_path.string() + " for reading!");
     }
     io::readProperties(profile_properties_stream,
-                       reinterpret_cast<char *>(profile_properties_ptr),
-                       PropertiesSize);
+                       profile_properties_ptr,
+                       sizeof(extractor::ProfileProperties));
 
     // load intersection classes
     if (!bearing_class_id_table.empty())

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -1,3 +1,4 @@
+#include "storage/storage.hpp"
 #include "contractor/query_edge.hpp"
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
@@ -9,7 +10,6 @@
 #include "storage/shared_barriers.hpp"
 #include "storage/shared_datatype.hpp"
 #include "storage/shared_memory.hpp"
-#include "storage/storage.hpp"
 #include "engine/datafacade/datafacade_base.hpp"
 #include "util/coordinate.hpp"
 #include "util/exception.hpp"
@@ -346,15 +346,15 @@ Storage::ReturnCode Storage::Run(int max_wait)
     std::uint64_t number_of_compressed_datasources = 0;
     if (geometry_datasource_input_stream)
     {
-        geometry_datasource_input_stream.read(
-            reinterpret_cast<char *>(&number_of_compressed_datasources),
-            sizeof(number_of_compressed_datasources));
+        number_of_compressed_datasources =
+            io::readDatasourceIndexesSize(geometry_datasource_input_stream);
     }
     shared_layout_ptr->SetBlockSize<uint8_t>(SharedDataLayout::DATASOURCES_LIST,
                                              number_of_compressed_datasources);
 
     // Load datasource name sizes.  This file is optional, and it's non-fatal if it doesn't
     // exist
+
     boost::filesystem::ifstream datasource_names_input_stream(config.datasource_names_path,
                                                               std::ios::binary);
     if (!datasource_names_input_stream)
@@ -362,30 +362,22 @@ Storage::ReturnCode Storage::Run(int max_wait)
         throw util::exception("Could not open " + config.datasource_names_path.string() +
                               " for reading.");
     }
-    std::vector<char> m_datasource_name_data;
-    std::vector<std::size_t> m_datasource_name_offsets;
-    std::vector<std::size_t> m_datasource_name_lengths;
+    io::DatasourceNamesData datasource_names_data;
     if (datasource_names_input_stream)
     {
-        std::string name;
-        while (std::getline(datasource_names_input_stream, name))
-        {
-            m_datasource_name_offsets.push_back(m_datasource_name_data.size());
-            std::copy(name.c_str(),
-                      name.c_str() + name.size(),
-                      std::back_inserter(m_datasource_name_data));
-            m_datasource_name_lengths.push_back(name.size());
-        }
+        datasource_names_data = io::readDatasourceNamesData(datasource_names_input_stream);
     }
+
     shared_layout_ptr->SetBlockSize<char>(SharedDataLayout::DATASOURCE_NAME_DATA,
-                                          m_datasource_name_data.size());
-    shared_layout_ptr->SetBlockSize<std::size_t>(SharedDataLayout::DATASOURCE_NAME_OFFSETS,
-                                                 m_datasource_name_offsets.size());
-    shared_layout_ptr->SetBlockSize<std::size_t>(SharedDataLayout::DATASOURCE_NAME_LENGTHS,
-                                                 m_datasource_name_lengths.size());
+                                          datasource_names_data.names.size());
+    shared_layout_ptr->SetBlockSize<std::uint32_t>(SharedDataLayout::DATASOURCE_NAME_OFFSETS,
+                                                   datasource_names_data.offsets.size());
+    shared_layout_ptr->SetBlockSize<std::uint32_t>(SharedDataLayout::DATASOURCE_NAME_LENGTHS,
+                                                   datasource_names_data.lengths.size());
 
     boost::filesystem::ifstream intersection_stream(config.intersection_class_path,
                                                     std::ios::binary);
+
     if (!static_cast<bool>(intersection_stream))
         throw util::exception("Could not open " + config.intersection_class_path.string() +
                               " for reading.");
@@ -643,35 +635,37 @@ Storage::ReturnCode Storage::Run(int max_wait)
         shared_memory_ptr, SharedDataLayout::DATASOURCES_LIST);
     if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCES_LIST) > 0)
     {
-        geometry_datasource_input_stream.read(
-            reinterpret_cast<char *>(datasources_list_ptr),
-            shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCES_LIST));
+        io::readDatasourceIndexes(geometry_datasource_input_stream,
+                                  datasources_list_ptr,
+                                  number_of_compressed_datasources);
     }
 
     // load datasource name information (if it exists)
+
     char *datasource_name_data_ptr = shared_layout_ptr->GetBlockPtr<char, true>(
         shared_memory_ptr, SharedDataLayout::DATASOURCE_NAME_DATA);
     if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCE_NAME_DATA) > 0)
     {
-        std::copy(
-            m_datasource_name_data.begin(), m_datasource_name_data.end(), datasource_name_data_ptr);
+        std::copy(datasource_names_data.names.begin(),
+                  datasource_names_data.names.end(),
+                  datasource_name_data_ptr);
     }
 
-    auto datasource_name_offsets_ptr = shared_layout_ptr->GetBlockPtr<std::size_t, true>(
+    auto datasource_name_offsets_ptr = shared_layout_ptr->GetBlockPtr<std::uint32_t, true>(
         shared_memory_ptr, SharedDataLayout::DATASOURCE_NAME_OFFSETS);
     if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCE_NAME_OFFSETS) > 0)
     {
-        std::copy(m_datasource_name_offsets.begin(),
-                  m_datasource_name_offsets.end(),
+        std::copy(datasource_names_data.offsets.begin(),
+                  datasource_names_data.offsets.end(),
                   datasource_name_offsets_ptr);
     }
 
-    auto datasource_name_lengths_ptr = shared_layout_ptr->GetBlockPtr<std::size_t, true>(
+    auto datasource_name_lengths_ptr = shared_layout_ptr->GetBlockPtr<std::uint32_t, true>(
         shared_memory_ptr, SharedDataLayout::DATASOURCE_NAME_LENGTHS);
     if (shared_layout_ptr->GetBlockSize(SharedDataLayout::DATASOURCE_NAME_LENGTHS) > 0)
     {
-        std::copy(m_datasource_name_lengths.begin(),
-                  m_datasource_name_lengths.end(),
+        std::copy(datasource_names_data.lengths.begin(),
+                  datasource_names_data.lengths.end(),
                   datasource_name_lengths_ptr);
     }
 
@@ -803,7 +797,6 @@ Storage::ReturnCode Storage::Run(int max_wait)
         static_cast<SharedDataTimestamp *>(data_type_memory->Ptr());
 
     {
-
         boost::interprocess::scoped_lock<boost::interprocess::named_upgradable_mutex>
             current_regions_exclusive_lock;
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -266,8 +266,7 @@ Storage::ReturnCode Storage::Run(int max_wait)
     // load rsearch tree size
     boost::filesystem::ifstream tree_node_file(config.ram_index_path, std::ios::binary);
 
-    uint32_t tree_size = 0;
-    tree_node_file.read((char *)&tree_size, sizeof(uint32_t));
+    std::uint32_t tree_size = io::readRamIndexSize(tree_node_file);
     shared_layout_ptr->SetBlockSize<RTreeNode>(SharedDataLayout::R_SEARCH_TREE, tree_size);
 
     // allocate space in shared memory for profile properties
@@ -677,7 +676,6 @@ Storage::ReturnCode Storage::Run(int max_wait)
     util::PackedVector<OSMNodeID, true> osmnodeid_list;
     osmnodeid_list.reset(osmnodeid_ptr,
                          shared_layout_ptr->num_entries[SharedDataLayout::OSM_NODE_ID_LIST]);
-
     io::readNodesData(nodes_input_stream, coordinates_ptr, osmnodeid_list, coordinate_list_size);
     nodes_input_stream.close();
 
@@ -687,14 +685,9 @@ Storage::ReturnCode Storage::Run(int max_wait)
     io::readTimestamp(timestamp_stream, timestamp_ptr, timestamp_size);
 
     // store search tree portion of rtree
-    char *rtree_ptr = shared_layout_ptr->GetBlockPtr<char, true>(shared_memory_ptr,
+    RTreeNode *rtree_ptrtest = shared_layout_ptr->GetBlockPtr<RTreeNode, true>(shared_memory_ptr,
                                                                  SharedDataLayout::R_SEARCH_TREE);
-
-    if (tree_size > 0)
-    {
-        tree_node_file.read(rtree_ptr, sizeof(RTreeNode) * tree_size);
-    }
-    tree_node_file.close();
+    io::readRamIndexData(tree_node_file, rtree_ptrtest, tree_size);
 
     // load core markers
     std::vector<char> unpacked_core_markers(number_of_core_markers);

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -1,10 +1,3 @@
-#include "storage/storage.hpp"
-
-#include "storage/io.hpp"
-#include "storage/shared_barriers.hpp"
-#include "storage/shared_datatype.hpp"
-#include "storage/shared_memory.hpp"
-
 #include "contractor/query_edge.hpp"
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
@@ -12,6 +5,11 @@
 #include "extractor/profile_properties.hpp"
 #include "extractor/query_node.hpp"
 #include "extractor/travel_mode.hpp"
+#include "storage/io.hpp"
+#include "storage/shared_barriers.hpp"
+#include "storage/shared_datatype.hpp"
+#include "storage/shared_memory.hpp"
+#include "storage/storage.hpp"
 #include "engine/datafacade/datafacade_base.hpp"
 #include "util/coordinate.hpp"
 #include "util/exception.hpp"
@@ -232,8 +230,7 @@ Storage::ReturnCode Storage::Run(int max_wait)
         throw util::exception("Could not open " + config.edges_data_path.string() +
                               " for reading.");
     }
-    unsigned number_of_original_edges = 0;
-    edges_input_stream.read((char *)&number_of_original_edges, sizeof(unsigned));
+    auto number_of_original_edges = io::readEdgesSize(edges_input_stream);
 
     // note: settings this all to the same size is correct, we extract them from the same struct
     shared_layout_ptr->SetBlockSize<NodeID>(SharedDataLayout::VIA_NODE_LIST,
@@ -305,8 +302,7 @@ Storage::ReturnCode Storage::Run(int max_wait)
     {
         throw util::exception("Could not open " + config.core_data_path.string() + " for reading.");
     }
-    unsigned coordinate_list_size = 0;
-    nodes_input_stream.read((char *)&coordinate_list_size, sizeof(unsigned));
+    auto coordinate_list_size = io::readNodesSize(nodes_input_stream);
     shared_layout_ptr->SetBlockSize<util::Coordinate>(SharedDataLayout::COORDINATE_LIST,
                                                       coordinate_list_size);
     // we'll read a list of OSM node IDs from the same data, so set the block size for the same
@@ -577,19 +573,16 @@ Storage::ReturnCode Storage::Run(int max_wait)
     EntryClassID *entry_class_id_ptr = shared_layout_ptr->GetBlockPtr<EntryClassID, true>(
         shared_memory_ptr, SharedDataLayout::ENTRY_CLASSID);
 
-    extractor::OriginalEdgeData current_edge_data;
-    for (unsigned i = 0; i < number_of_original_edges; ++i)
-    {
-        edges_input_stream.read((char *)&(current_edge_data), sizeof(extractor::OriginalEdgeData));
-        via_geometry_ptr[i] = current_edge_data.via_geometry;
-        name_id_ptr[i] = current_edge_data.name_id;
-        travel_mode_ptr[i] = current_edge_data.travel_mode;
-        lane_data_id_ptr[i] = current_edge_data.lane_data_id;
-        turn_instructions_ptr[i] = current_edge_data.turn_instruction;
-        entry_class_id_ptr[i] = current_edge_data.entry_classid;
-        pre_turn_bearing_ptr[i] = current_edge_data.pre_turn_bearing;
-        post_turn_bearing_ptr[i] = current_edge_data.post_turn_bearing;
-    }
+    io::readEdgesData(edges_input_stream,
+                      via_geometry_ptr,
+                      name_id_ptr,
+                      turn_instructions_ptr,
+                      lane_data_id_ptr,
+                      travel_mode_ptr,
+                      entry_class_id_ptr,
+                      pre_turn_bearing_ptr,
+                      post_turn_bearing_ptr,
+                      number_of_original_edges);
     edges_input_stream.close();
 
     // load compressed geometry
@@ -691,13 +684,7 @@ Storage::ReturnCode Storage::Run(int max_wait)
     osmnodeid_list.reset(osmnodeid_ptr,
                          shared_layout_ptr->num_entries[SharedDataLayout::OSM_NODE_ID_LIST]);
 
-    extractor::QueryNode current_node;
-    for (unsigned i = 0; i < coordinate_list_size; ++i)
-    {
-        nodes_input_stream.read((char *)&current_node, sizeof(extractor::QueryNode));
-        coordinates_ptr[i] = util::Coordinate(current_node.lon, current_node.lat);
-        osmnodeid_list.push_back(current_node.node_id);
-    }
+    io::readNodesData(nodes_input_stream, coordinates_ptr, osmnodeid_list, coordinate_list_size);
     nodes_input_stream.close();
 
     // store timestamp

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -273,8 +273,10 @@ Storage::ReturnCode Storage::Run(int max_wait)
     tree_node_file.read((char *)&tree_size, sizeof(uint32_t));
     shared_layout_ptr->SetBlockSize<RTreeNode>(SharedDataLayout::R_SEARCH_TREE, tree_size);
 
-    // load profile properties
-    shared_layout_ptr->SetBlockSize<extractor::ProfileProperties>(SharedDataLayout::PROPERTIES, 1);
+    // allocate space in shared memory for profile properties
+    std::size_t PropertiesSize = io::readPropertiesSize();
+    shared_layout_ptr->SetBlockSize<extractor::ProfileProperties>(SharedDataLayout::PROPERTIES,
+                                                                  PropertiesSize);
 
     // read timestampsize
     boost::filesystem::ifstream timestamp_stream(config.timestamp_path);
@@ -760,7 +762,7 @@ Storage::ReturnCode Storage::Run(int max_wait)
     hsgr_input_stream.close();
 
     // load profile properties
-    auto profile_properties_ptr =
+    extractor::ProfileProperties *profile_properties_ptr =
         shared_layout_ptr->GetBlockPtr<extractor::ProfileProperties, true>(
             shared_memory_ptr, SharedDataLayout::PROPERTIES);
     boost::filesystem::ifstream profile_properties_stream(config.properties_path);
@@ -768,8 +770,9 @@ Storage::ReturnCode Storage::Run(int max_wait)
     {
         util::exception("Could not open " + config.properties_path.string() + " for reading!");
     }
-    profile_properties_stream.read(reinterpret_cast<char *>(profile_properties_ptr),
-                                   sizeof(extractor::ProfileProperties));
+    io::readProperties(profile_properties_stream,
+                       reinterpret_cast<char *>(profile_properties_ptr),
+                       PropertiesSize);
 
     // load intersection classes
     if (!bearing_class_id_table.empty())


### PR DESCRIPTION
# Issue

Working on data loading refactoring captured here: 
https://github.com/Project-OSRM/osrm-backend/issues/2989

This issue is working on 

* `.nodes` and `.edges` files
* `.datasource_names` and `.datasource_indexes` files
* `.ramIndex` files
* `.profile_properties`

## Tasklist
 - [x] Decide on plain pointer `*` or `[]` bracket coding style
 - [x] review
 - [x] adjust for for comments
