### PR TITLE
Prevents the Matching getting confused when users are time-travelling.

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -275,7 +275,7 @@ In addition to the [general options](#general-options) the following options are
 |geometries  |`polyline` (default), `geojson`                 |Returned route geometry format (influences overview and per step)                        |
 |annotations |`true`, `false` (default)                       |Returns additional metadata for each coordinate along the route geometry.                |
 |overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
-|timestamps  |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamp of the input location.                                                          |
+|timestamps  |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamp of the input location. Timestamps need to be monotonically increasing.          |
 |radiuses    |`{radius};{radius}[;{radius} ...]`              |Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy.|
 
 |Parameter   |Values                        |

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -12,6 +12,8 @@
 #include <cstdlib>
 
 #include <algorithm>
+#include <functional>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <vector>
@@ -121,6 +123,16 @@ Status MatchPlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFaca
     if (!CheckAllCoordinates(parameters.coordinates))
     {
         return Error("InvalidValue", "Invalid coordinate value.", json_result);
+    }
+
+    // Check for same or increasing timestamps. Impl. note: Incontrast to `sort(first,
+    // last, less_equal)` checking `greater` in reverse meets irreflexive requirements.
+    const auto time_increases_monotonically = std::is_sorted(
+        parameters.timestamps.rbegin(), parameters.timestamps.rend(), std::greater<>{});
+
+    if (!time_increases_monotonically)
+    {
+        return Error("InvalidValue", "Timestamps need to be monotonically increasing.", json_result);
     }
 
     // assuming radius is the standard deviation of a normal distribution


### PR DESCRIPTION
Error code when timestamps in traces are not monotonically increasing.

What about time-syncs on devices (think hard ntpd re-syncs)? I'm fine with adding the no-jumps-into-the- past pre-condition, heck even my [Dovecot shut down hard](http://wiki.dovecot.org/TimeMovedBackwards) when this occurred (happened to me before).
 
## Tasklist
 - [x] Add a note to Wiki
 - [x] review
 - [x] adjust for comments
