### PR TITLE
Don't fail on incorrect lane tags '1; 2'

### DIFF
--- a/features/guidance/bugs.feature
+++ b/features/guidance/bugs.feature
@@ -35,3 +35,18 @@ Feature: Features related to bugs
         When I route I should get
             | waypoints | route           | turns                        |
             | 1,2       | top,right,right | depart,new name right,arrive |
+
+    @3156
+    Scenario: Incorrect lanes tag
+        Given the node map
+            """
+            a b
+            """
+
+        And the ways
+            | nodes | lanes |
+            | ab    | 1; 2  |
+
+        And the data has been saved to disk
+        When I try to run "osrm-extract {osm_file} --profile {profile_file}"
+        Then it should exit successfully

--- a/profiles/lib/guidance.lua
+++ b/profiles/lib/guidance.lua
@@ -63,7 +63,7 @@ function Guidance.set_classification (highway, result, input_way)
     local lane_count = input_way:get_value_by_key("lanes")
     if lane_count and lane_count ~= "" then
         local lc = tonumber(lane_count)
-        if lane_count ~= nil then
+        if lc ~= nil then
             result.road_classification.num_lanes = lc
         end
     else


### PR DESCRIPTION
# Issue

Some lane tags can be incorrect like http://www.openstreetmap.org/way/30350672 and lc will be nil, that does not match num_lanes setter signature.


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
#3156
