### PR TITLE
Add -l to rt and gcov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ if (ENABLE_COVERAGE)
     message(ERROR "ENABLE_COVERAGE=ON only make sense with a Debug build")
   endif()
   message(INFO "Enabling coverage")
-  set(MAYBE_COVERAGE_LIBRARIES "gcov")
+  set(MAYBE_COVERAGE_LIBRARIES "-lgcov")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage -fprofile-arcs")
 endif()
 if (ENABLE_SANITIZER)
@@ -278,7 +278,7 @@ if(APPLE)
 endif()
 
 if(UNIX AND NOT APPLE)
-  set(MAYBE_RT_LIBRARY rt)
+  set(MAYBE_RT_LIBRARY -lrt)
 endif()
 
 


### PR DESCRIPTION
This is a followup to #3130, which regressed node-osrm builds against linux because `rt` not `-lrt` was being added to the libosrm.pc file.

Currently testing that this fixes linux builds via https://travis-ci.org/Project-OSRM/node-osrm/builds/170309569.