### PR TITLE
fix coordinate extraction with less than 1 meters past lane distance

### DIFF
--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -1149,3 +1149,22 @@ Feature: Simple Turns
         When I route I should get
             | waypoints | route          | turns                        |
             | a,m       | gato,hain,hain | depart,turn left,arrive      |
+
+    Scenario: Segfaulting Regression
+        Given the node map
+            """
+            a - - - - - - - - - - - - - - b c
+                                            |
+                                            |
+                                            |
+                                            d--------------e
+            """
+
+        And the ways
+            | nodes | lanes:forward |
+            | ab    |               |
+            | bcde  | 6             |
+
+        When I route I should get
+            | waypoints | route        |
+            | a,e       | ab,bcde,bcde |


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/3168

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
none

