### PR TITLE
Explicitly set minimum OSX version and search for SDK path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,8 @@ endif()
 
 # Configuring other platform dependencies
 if(APPLE)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10")
+  execute_process(COMMAND xcrun --sdk macosx --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT OUTPUT_STRIP_TRAILING_WHITESPACE)
   set(CMAKE_OSX_ARCHITECTURES "x86_64")
   message(STATUS "Set Architecture to x64 on OS X")
   exec_program(uname ARGS -v  OUTPUT_VARIABLE DARWIN_VERSION)


### PR DESCRIPTION
This is a fix for https://github.com/Project-OSRM/osrm-backend/issues/3197 where cmake fails on OSX when an XCode upgrade leaves you with an SDK newer that your current OS version.