### PR TITLE
Enable warning flag -Wshorten-64-to-32

### DIFF
--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -459,7 +459,7 @@ class GraphContractor
                         const tbb::blocked_range<std::size_t> &range) {
                         if (flushed_contractor)
                         {
-                            for (int position = range.begin(), end = range.end(); position != end;
+                            for (std::size_t position = range.begin(), end = range.end(); position != end;
                                  ++position)
                             {
                                 const NodeID x = remaining_nodes[position].id;
@@ -468,7 +468,7 @@ class GraphContractor
                         }
                         else
                         {
-                            for (int position = range.begin(), end = range.end(); position != end;
+                            for (std::size_t position = range.begin(), end = range.end(); position != end;
                                  ++position)
                             {
                                 const NodeID x = remaining_nodes[position].id;
@@ -485,7 +485,7 @@ class GraphContractor
                 [this, &remaining_nodes, &thread_data_list](
                     const tbb::blocked_range<std::size_t> &range) {
                     ContractorThreadData *data = thread_data_list.GetThreadData();
-                    for (int position = range.begin(), end = range.end(); position != end;
+                    for (std::size_t position = range.begin(), end = range.end(); position != end;
                          ++position)
                     {
                         const NodeID x = remaining_nodes[position].id;
@@ -498,7 +498,7 @@ class GraphContractor
                     begin_independent_nodes_idx, end_independent_nodes_idx, DeleteGrainSize),
                 [this, &remaining_nodes, &thread_data_list](const tbb::blocked_range<int> &range) {
                     ContractorThreadData *data = thread_data_list.GetThreadData();
-                    for (int position = range.begin(), end = range.end(); position != end;
+                    for (std::size_t position = range.begin(), end = range.end(); position != end;
                          ++position)
                     {
                         const NodeID x = remaining_nodes[position].id;
@@ -549,7 +549,7 @@ class GraphContractor
                     [this, &node_priorities, &remaining_nodes, &node_depth, &thread_data_list](
                         const tbb::blocked_range<int> &range) {
                         ContractorThreadData *data = thread_data_list.GetThreadData();
-                        for (int position = range.begin(), end = range.end(); position != end;
+                        for (std::size_t position = range.begin(), end = range.end(); position != end;
                              ++position)
                         {
                             NodeID x = remaining_nodes[position].id;
@@ -572,7 +572,7 @@ class GraphContractor
             {
                 tbb::parallel_for(tbb::blocked_range<int>(0, remaining_nodes.size(), InitGrainSize),
                                   [this, &remaining_nodes](const tbb::blocked_range<int> &range) {
-                                      for (int x = range.begin(), end = range.end(); x != end; ++x)
+                                      for (std::size_t x = range.begin(), end = range.end(); x != end; ++x)
                                       {
                                           const auto orig_id = remaining_nodes[x].id;
                                           is_core_node[orig_node_id_from_new_node_id_map[orig_id]] =
@@ -584,7 +584,7 @@ class GraphContractor
             {
                 tbb::parallel_for(tbb::blocked_range<int>(0, remaining_nodes.size(), InitGrainSize),
                                   [this, &remaining_nodes](const tbb::blocked_range<int> &range) {
-                                      for (int x = range.begin(), end = range.end(); x != end; ++x)
+                                      for (std::size_t x = range.begin(), end = range.end(); x != end; ++x)
                                       {
                                           const auto orig_id = remaining_nodes[x].id;
                                           is_core_node[orig_id] = true;

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -20,6 +20,7 @@
 #include "util/typedefs.hpp"
 
 #include <boost/optional.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #include <cstddef>
 #include <vector>
 
@@ -151,7 +152,8 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                           bearing_class.getAvailableBearings().end(),
                           std::back_inserter(intersection.bearings));
                 intersection.entry.clear();
-                for (auto idx : util::irange<std::size_t>(0, intersection.bearings.size()))
+                std::uint32_t bearing_size = boost::numeric_cast<std::uint32_t>(intersection.bearings.size());
+                for (std::uint32_t idx : util::irange<std::uint32_t>(0, bearing_size))
                 {
                     intersection.entry.push_back(entry_class.allowsEntry(idx));
                 }

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -153,7 +153,7 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                           std::back_inserter(intersection.bearings));
                 intersection.entry.clear();
                 std::uint32_t bearing_size = boost::numeric_cast<std::uint32_t>(intersection.bearings.size());
-                for (std::uint32_t idx : util::irange<std::uint32_t>(0, bearing_size))
+                for (auto idx : util::irange<std::uint32_t>(0, bearing_size))
                 {
                     intersection.entry.push_back(entry_class.allowsEntry(idx));
                 }

--- a/include/engine/map_matching/sub_matching.hpp
+++ b/include/engine/map_matching/sub_matching.hpp
@@ -15,7 +15,7 @@ namespace map_matching
 struct SubMatching
 {
     std::vector<PhantomNode> nodes;
-    std::vector<unsigned> indices;
+    std::vector<std::size_t> indices;
     double confidence;
 };
 }

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -160,7 +160,7 @@ class ManyToManyRouting final
 
     void ForwardRoutingStep(const DataFacadeT &facade,
                             const unsigned row_idx,
-                            const unsigned number_of_targets,
+                            const std::size_t number_of_targets,
                             QueryHeap &query_heap,
                             const SearchSpaceWithBuckets &search_space_with_buckets,
                             std::vector<EdgeWeight> &result_table) const

--- a/include/util/io.hpp
+++ b/include/util/io.hpp
@@ -99,7 +99,7 @@ bool serializeVectorIntoAdjacencyArray(const std::string &filename,
     std::vector<std::uint32_t> offsets;
     offsets.reserve(data.size() + 1);
     std::uint64_t current_offset = 0;
-    offsets.push_back(current_offset);
+    offsets.push_back(static_cast<std::uint32_t>(current_offset));
     for (auto const &vec : data)
     {
         current_offset += vec.size();
@@ -175,7 +175,7 @@ inline bool serializeFlags(const boost::filesystem::path &path, const std::vecto
 
     writeFingerprint(flag_stream);
 
-    std::uint32_t number_of_bits = flags.size();
+    std::uint32_t number_of_bits = boost::numeric_cast<std::uint32_t>(flags.size());
     flag_stream.write(reinterpret_cast<const char *>(&number_of_bits), sizeof(number_of_bits));
     // putting bits in ints
     std::uint32_t chunk = 0;
@@ -187,7 +187,7 @@ inline bool serializeFlags(const boost::filesystem::path &path, const std::vecto
              ++chunk_bit, ++bit_nr)
             chunk_bitset[chunk_bit] = flags[bit_nr];
 
-        chunk = chunk_bitset.to_ulong();
+        chunk = boost::numeric_cast<std::uint32_t>(chunk_bitset.to_ulong());
         ++chunk_count;
         flag_stream.write(reinterpret_cast<const char *>(&chunk), sizeof(chunk));
     }

--- a/src/engine/polyline_compressor.cpp
+++ b/src/engine/polyline_compressor.cpp
@@ -37,7 +37,7 @@ std::string encode(std::vector<int> &numbers)
 
         if (isNegative)
         {
-            const unsigned binary = std::llabs(number);
+            const unsigned binary = std::abs(number);
             const unsigned twos = (~binary) + 1u;
             number = twos;
         }
@@ -89,8 +89,9 @@ std::string encodePolyline(CoordVectorForwardIter begin, CoordVectorForwardIter 
 std::vector<util::Coordinate> decodePolyline(const std::string &geometry_string)
 {
     std::vector<util::Coordinate> new_coordinates;
-    int index = 0, len = geometry_string.size();
     int lat = 0, lng = 0;
+    std::size_t index = 0;
+    std::size_t len = geometry_string.size();
 
     while (index < len)
     {

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -4,6 +4,7 @@
 #include <boost/assert.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 
 #include <limits>
 #include <string>
@@ -76,8 +77,8 @@ unsigned CompressedEdgeContainer::GetZippedPositionForReverseID(const EdgeID edg
 void CompressedEdgeContainer::SerializeInternalVector(const std::string &path) const
 {
     boost::filesystem::fstream geometry_out_stream(path, std::ios::binary | std::ios::out);
-    const unsigned compressed_geometry_indices = m_compressed_geometry_index.size() + 1;
-    const unsigned compressed_geometries = m_compressed_geometry_nodes.size();
+    const std::size_t compressed_geometry_indices = m_compressed_geometry_index.size() + 1;
+    const std::size_t compressed_geometries = m_compressed_geometry_nodes.size();
     BOOST_ASSERT(std::numeric_limits<unsigned>::max() != compressed_geometry_indices);
     geometry_out_stream.write((char *)&compressed_geometry_indices, sizeof(unsigned));
 
@@ -253,7 +254,7 @@ unsigned CompressedEdgeContainer::ZipEdges(const EdgeID f_edge_id, const EdgeID 
 
     BOOST_ASSERT(forward_bucket.size() == reverse_bucket.size());
 
-    const unsigned zipped_geometry_id = m_compressed_geometry_index.size();
+    const EdgeID zipped_geometry_id = boost::numeric_cast<EdgeID>(m_compressed_geometry_index.size());
     m_forward_edge_id_to_zipped_index_map[f_edge_id] = zipped_geometry_id;
     m_reverse_edge_id_to_zipped_index_map[r_edge_id] = zipped_geometry_id;
 


### PR DESCRIPTION
# Issue

This PR works towards #3164 and starts with solving all warnings that come with enabling `-Wshorten-64-to-32`

cc @springmeyer 
## Tasklist
- [ ] KILL ALL WARNINGS
- [ ] add `-Wshorten-64-to-32` and `-Werror`(?) to CMake File 
- [ ] rebase with master
- [ ] review
- [ ] adjust for comments
