### PR TITLE
FindOsmium invoke is required for MSVC build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,10 @@ endif()
 find_package(ZLIB REQUIRED)
 add_dependency_includes(${ZLIB_INCLUDE_DIRS})
 
-include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/cmake")
+set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include")
+find_package(Osmium REQUIRED COMPONENTS io)
+include_directories(SYSTEM ${OSMIUM_INCLUDE_DIR})
 
 if(NOT WIN32 AND NOT Boost_USE_STATIC_LIBS)
   add_dependency_defines(-DBOOST_TEST_DYN_LINK)


### PR DESCRIPTION
# Issue

Commit 87d09f7 breaks msvc builds, because some osmium dependencies were missing.
PR is a partial revert of the commit

## Tasklist
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
Related issues #3088 and commit 87d09f7