### PR TITLE
Refactor find obvious turn handling

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -947,16 +947,17 @@ Feature: Collapse
 
     #http://www.openstreetmap.org/#map=19/52.48778/13.30024
     Scenario: Hohenzollerdammbrücke
+        Given a grid size of 10 meters
         Given the node map
             """
                   q          s
                   p          o
-                  ..       . .
-                .     .  .      .
+                  ..        ..
+                 .    .   .    .
             j - i - - - h - - - g - f
                   > k <   > l <
             a - b - - - c - - - d - e
-                .     .  .      .
+                 .    .  .     .
                   ..        ..
                   m          n
                   t          r
@@ -1013,13 +1014,13 @@ Feature: Collapse
             | restriction | ph       | hi     | h        | no_right_turn |
 
         When I route I should get
-            | waypoints | route          | turns                       |
-            | a,e       | hohe,hohe      | depart,arrive               |
-            | a,s       | hohe,a100,a100 | depart,on ramp left,arrive  |
-            | a,t       | hohe,a100,a100 | depart,on ramp right,arrive |
-            | a,j       |                |                             |
-            | f,j       | hohe,hohe      | depart,arrive               |
-            | a,t       | hohe,a100,a100 | depart,on ramp right,arrive |
-            | f,e       |                |                             |
-            | q,j       | a100,hohe,hohe | depart,turn right,arrive    |
-            | q,e       | a100,a100,hohe | depart,continue left,arrive |
+            | waypoints | route                 | turns                       | locations |
+            | a,e       | hohe,hohe             | depart,arrive               | a,e       |
+            | a,s       | hohe,a100,a100        | depart,on ramp left,arrive  | a,b,s     |
+            | a,t       | hohe,a100,a100        | depart,on ramp right,arrive | a,b,t     |
+            | a,j       |                       |                             |           |
+            | f,j       | hohe,hohe             | depart,arrive               | f,j       |
+            | a,t       | hohe,a100,a100        | depart,on ramp right,arrive | a,b,t     |
+            | f,e       |                       |                             |           |
+            | q,j       | a100,hohe,hohe        | depart,turn right,arrive    | q,p,j     |
+            | q,e       | a100,hohebruecke,hohe | depart,turn left,arrive     | q,p,e     |

--- a/features/guidance/low-priority.feature
+++ b/features/guidance/low-priority.feature
@@ -1,0 +1,119 @@
+@routing  @guidance
+Feature: Exceptions for routing onto low-priority roads
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 10 meters
+
+    Scenario: Straight onto low-priority: same name
+        Given the node map
+            """
+                c
+
+            a   b d
+
+                e
+            """
+
+        And the ways
+            | nodes  | highway     | name    |
+            | abd    | residential | road    |
+            | eb     | service     | service |
+            | bc     | service     | service |
+
+       When I route I should get
+            | waypoints | route            | turns         |
+            | c,e       | service,service  | depart,arrive |
+            | e,c       | service,service  | depart,arrive |
+
+    Scenario: Straight onto low-priority: onto and from unnamed
+        Given the node map
+            """
+                c
+
+            a   b d
+
+                e
+            """
+
+        And the ways
+            | nodes  | highway     | name    |
+            | abd    | residential | road    |
+            | eb     | service     |         |
+            | bc     | service     |         |
+
+       When I route I should get
+            | waypoints | route | turns         |
+            | e,c       | ,     | depart,arrive |
+            | c,e       | ,     | depart,arrive |
+
+    Scenario: Straight onto low-priority: unnamed
+        Given the node map
+            """
+                c
+
+            a   b d
+
+                e
+            """
+
+        And the ways
+            | nodes  | highway     | name    |
+            | abd    | residential | road    |
+            | eb     | service     | service |
+            | bc     | service     |         |
+
+       When I route I should get
+            | waypoints | route             | turns                       |
+            | e,c       | service,          | depart,arrive               |
+            | c,e       | ,service,service  | depart,turn straight,arrive |
+
+    Scenario: Straight onto low-priority
+        Given the node map
+            """
+            a b c
+            """
+
+        And the ways
+            | nodes  | highway     | name    |
+            | ab     | residential | road    |
+            | bc     | service     | service |
+
+       When I route I should get
+            | waypoints | route                | turns                           |
+            | a,c       | road,service,service | depart,new name straight,arrive |
+
+    Scenario: Straight onto low-priority, with driveway
+        Given the node map
+            """
+                  f
+            a b   c
+            """
+
+        And the ways
+            | nodes  | highway     | name  |
+            | ab     | residential | road  |
+            | bc     | service     | road  |
+            | bf     | driveway    |       |
+
+       When I route I should get
+            | waypoints | route      | turns         |
+            | a,c       | road,road  | depart,arrive |
+
+    Scenario: Straight onto low-priority, with driveway
+        Given the node map
+            """
+                  f
+            a b   c
+            """
+
+        And the ways
+            | nodes  | highway     | name  |
+            | ab     | residential | road  |
+            | bc     | service     |       |
+            | bf     | driveway    |       |
+
+       When I route I should get
+            | waypoints | route      | turns                           |
+            | a,c       | road,      | depart,arrive                   |
+            | c,a       | ,road,road | depart,new name straight,arrive |

--- a/include/extractor/guidance/toolkit.hpp
+++ b/include/extractor/guidance/toolkit.hpp
@@ -165,6 +165,7 @@ inline bool obviousByRoadClass(const RoadClassification in_classification,
                                const RoadClassification obvious_candidate,
                                const RoadClassification compare_candidate)
 {
+    // lower numbers are of higher priority
     const bool has_high_priority = PRIORITY_DISTINCTION_FACTOR * obvious_candidate.GetPriority() <
                                    compare_candidate.GetPriority();
 


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/3081

I made a pass at this code to hopefully make it cleaner and easier to follow, but more or less tried to preserve the same logic and handling via `best` and `best_continue` candidates.

## Tasklist
 - [x] Make a refactor pass at the second half of the function
-  [x] Investigate all of the cucumber test failures
-  [ ] ~~Return `boost::optional` instead of `0` for no obvious turn found~~ https://github.com/Project-OSRM/osrm-backend/issues/3337
-  [x] Comments
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
cc @MoKob 

