### PR TITLE
Add static cache into scripting_environment.

### DIFF
--- a/include/extractor/extractor_config.hpp
+++ b/include/extractor/extractor_config.hpp
@@ -37,7 +37,6 @@ namespace osrm
 {
 namespace extractor
 {
-
 struct ExtractorConfig
 {
     ExtractorConfig() noexcept : requested_num_threads(0) {}
@@ -102,8 +101,13 @@ struct ExtractorConfig
     bool generate_edge_lookup;
     std::string edge_penalty_path;
     std::string edge_segment_lookup_path;
+
+    std::string cache_file_type;
+    std::string cache_file_path;
 };
 }
 }
+
+
 
 #endif // EXTRACTOR_CONFIG_HPP

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -15,6 +15,11 @@
 #include <string>
 #include <vector>
 
+#include <osmium/index/map/sparse_file_array.hpp>
+#include <osmium/index/map/dense_file_array.hpp>
+#include <osmium/handler/node_locations_for_ways.hpp>
+#include <osmium/dynamic_handler.hpp>
+
 namespace osmium
 {
 class Node;
@@ -35,6 +40,13 @@ namespace extractor
 class RestrictionParser;
 struct ExtractionNode;
 struct ExtractionWay;
+
+using index_sparse_type = osmium::index::map::SparseFileArray<osmium::unsigned_object_id_type, osmium::Location>;
+using index_dense_type = osmium::index::map::DenseFileArray<osmium::unsigned_object_id_type, osmium::Location>;
+
+// The location handler always depends on the index type
+using location_handler_sparse_type = osmium::handler::NodeLocationsForWays<index_sparse_type>;
+using location_handler_dense_type = osmium::handler::NodeLocationsForWays<index_dense_type>;
 
 /**
  * Abstract class that handles processing osmium ways, nodes and relation objects by applying
@@ -65,8 +77,14 @@ class ScriptingEnvironment
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) = 0;
+
+    static location_handler_sparse_type *location_sparse_handler;
+    static location_handler_dense_type *location_dense_handler;
+    static void setSparseCache(location_handler_sparse_type &cache) {
+        location_sparse_handler = &cache;};
+    static void setDenseCache(location_handler_dense_type &cache) {
+        location_dense_handler = &cache;};
 };
 }
 }
-
 #endif /* SCRIPTING_ENVIRONMENT_HPP */

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -234,9 +234,17 @@ function node_function (node, result)
 end
 
 function way_function (way, result)
+
+ -- print("way id : ", way:id());
+ -- for node in way:get_nodes() do
+   -- print("  node id  : ", node:id())
+   -- print("  node lat :", node:location():lat())
+ -- end
+
   local highway = way:get_value_by_key("highway")
   local route = way:get_value_by_key("route")
   local bridge = way:get_value_by_key("bridge")
+
 
   if not ((highway and highway ~= "") or (route and route ~= "") or (bridge and bridge ~= "")) then
     return

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -67,6 +67,9 @@ LuaScriptingEnvironment::LuaScriptingEnvironment(const std::string &file_name)
     util::SimpleLogger().Write() << "Using script " << file_name;
 }
 
+location_handler_sparse_type *ScriptingEnvironment::location_sparse_handler = nullptr;
+location_handler_dense_type *ScriptingEnvironment::location_dense_handler = nullptr;
+
 void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
 {
     typedef double (osmium::Location::*location_member_ptr_type)() const;
@@ -202,6 +205,20 @@ void LuaScriptingEnvironment::InitContext(LuaScriptingContext &context)
              .def(luabind::constructor<>())
              // Dear ambitious reader: registering .location() as in:
              // .def("location", +[](const osmium::NodeRef& nref){ return nref.location(); })
+             .def("location", +[](const osmium::NodeRef& nref){
+                 if(location_sparse_handler)
+                 {
+                     osmium::Location location = LuaScriptingEnvironment::location_sparse_handler->get_node_location(nref.ref());
+                     return location;
+                 }
+                 else if(location_sparse_handler)
+                 {
+                     osmium::Location location = LuaScriptingEnvironment::location_sparse_handler->get_node_location(nref.ref());
+                     return location;
+                 }
+                 else
+                     return nref.location();
+             })
              // will crash at runtime, since we're not (yet?) using libosnmium's
              // NodeLocationsForWays cache
              .def("id", &osmium::NodeRef::ref),

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -3,6 +3,7 @@
 #include "extractor/scripting_environment_lua.hpp"
 #include "util/simple_logger.hpp"
 #include "util/version.hpp"
+#include <../test/t/geom/test_tile_data.hpp>
 
 #include <tbb/task_scheduler_init.h>
 
@@ -48,7 +49,17 @@ return_code parseArguments(int argc, char *argv[], extractor::ExtractorConfig &e
         boost::program_options::value<unsigned int>(&extractor_config.small_component_size)
             ->default_value(1000),
         "Number of nodes required before a strongly-connected-componennt is considered big "
-        "(affects nearest neighbor snapping)");
+        "(affects nearest neighbor snapping)")(
+        "cache,c",
+	boost::program_options::value<std::string>(&extractor_config.cache_file_type)
+            ->implicit_value("SPARSE")
+            ->default_value("NONE"),
+        "Use cache to stocking location, NONE (default), SPARSE or DENSE, DENSE cache for generate world.")(
+        "cache-path",
+        boost::program_options::value<std::string>(&extractor_config.cache_file_path)
+            ->implicit_value("d")
+            ->default_value("d"),
+        "Path where generate node cache");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user
@@ -147,6 +158,15 @@ int main(int argc, char *argv[]) try
     {
         util::SimpleLogger().Write(logWARNING)
             << "Profile " << extractor_config.profile_path.string() << " not found!";
+        return EXIT_FAILURE;
+    }
+
+    if(!(extractor_config.cache_file_type == "NONE" ||
+        extractor_config.cache_file_type == "SPARSE" ||
+        extractor_config.cache_file_type == "DENSE"))
+    {
+        util::SimpleLogger().Write(logWARNING)
+            << "The type of cache " << extractor_config.cache_file_type << "is invalid, it can be only SPARSE, NONE or DENSE!";
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
#3180 

This is just a test, the code is a little dirty, sorry.
The purpose of this PR is to inject a cache into LuaScriptingEnvironment class to access at nodeRef location in .lua script.
The cache is successfully filled. But when i try to access the static cache into the lua binding I have this exceotion : 
```
terminate called after throwing an instance of 'tbb::captured_exception'
  what():  id 3655224911 not found
```