### PR TITLE
Fixes LTO linker issues, resolves #3221

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,10 +499,10 @@ set(BOOST_ENGINE_LIBRARIES
   ${BOOST_BASE_LIBRARIES})
 
 # Binaries
-target_link_libraries(osrm-datastore osrm_store ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_BASE_LIBRARIES})
-target_link_libraries(osrm-extract osrm_extract ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_REGEX_LIBRARY} ${BOOST_BASE_LIBRARIES})
-target_link_libraries(osrm-contract ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_BASE_LIBRARIES} ${TBB_LIBRARIES} osrm_contract)
-target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${BOOST_ENGINE_LIBRARIES} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
+target_link_libraries(osrm-datastore osrm_store ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(osrm-extract osrm_extract ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(osrm-contract osrm_contract ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
 
 set(EXTRACTOR_LIBRARIES
     ${BZIP2_LIBRARIES}


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/3221. Solves the linking issue locally when using LTO.

> /tmp/cczGqj0V.ltrans10.ltrans.o:cczGqj0V.ltrans10.o:vtable for tbb::empty_task: error: undefined reference to 'tbb::empty_task::~empty_task()'
> /tmp/cczGqj0V.ltrans10.ltrans.o:cczGqj0V.ltrans10.o:vtable for tbb::empty_task: error: undefined reference to 'tbb::empty_task::~empty_task()'

Please read: https://github.com/Project-OSRM/osrm-backend/pull/2573 With the reasoning outlined in #2573 I don't know why this now fixes the issue or why we saw the LTO issue in the first place. This is more or less reverting #2573.

Before merging I'd like to understand what's going on here..