### PR TITLE
Fixes Cucumber's Unknown Node Error Reporting

### DIFF
--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -103,7 +103,7 @@ module.exports = function () {
             let name = row.node,
                 node = this.findNodeByName(name);
             delete row.node;
-            if (!node) throw new Error(util.format('*** unknown node %s'), name);
+            if (!node) throw new Error(util.format('*** unknown node %s', name));
             for (let key in row) {
                 if (key=='id') {
                     node.setID( row[key] );

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -16,18 +16,18 @@ module.exports = function () {
         if (symmetric) {
             columnHeaders.forEach((nodeName) => {
                 var node = this.findNodeByName(nodeName);
-                if (!node) throw new Error(util.format('*** unknown node "%s"'), nodeName);
+                if (!node) throw new Error(util.format('*** unknown node "%s"', nodeName));
                 waypoints.push({ coord: node, type: 'loc' });
             });
         } else {
             columnHeaders.forEach((nodeName) => {
                 var node = this.findNodeByName(nodeName);
-                if (!node) throw new Error(util.format('*** unknown node "%s"'), nodeName);
+                if (!node) throw new Error(util.format('*** unknown node "%s"', nodeName));
                 waypoints.push({ coord: node, type: 'dst' });
             });
             rowHeaders.forEach((nodeName) => {
                 var node = this.findNodeByName(nodeName);
-                if (!node) throw new Error(util.format('*** unknown node "%s"'), nodeName);
+                if (!node) throw new Error(util.format('*** unknown node "%s"', nodeName));
                 waypoints.push({ coord: node, type: 'src' });
             });
         }


### PR DESCRIPTION
`Error(format('%s'), x)` => `Error(format('%s', x))` - Js does not care. We do.


Before: `unknown node %s`
After: `unknown node t`

https://nodejs.org/api/util.html#util_util_format_format_args