### PR TITLE
Fix debug tile turn data

### DIFF
--- a/include/util/vector_tile.hpp
+++ b/include/util/vector_tile.hpp
@@ -36,7 +36,7 @@ const constexpr std::uint32_t VARIANT_TYPE_BOOL = 7;
 
 // Vector tiles are 4096 virtual pixels on each side
 const constexpr double EXTENT = 4096.0;
-const constexpr double BUFFER = 128.0;
+const constexpr double BUFFER = 512.0;
 }
 }
 }

--- a/include/util/vector_tile.hpp
+++ b/include/util/vector_tile.hpp
@@ -36,7 +36,7 @@ const constexpr std::uint32_t VARIANT_TYPE_BOOL = 7;
 
 // Vector tiles are 4096 virtual pixels on each side
 const constexpr double EXTENT = 4096.0;
-const constexpr double BUFFER = 512.0;
+const constexpr double BUFFER = 128.0;
 }
 }
 }

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -141,12 +141,13 @@ inline FloatCoordinate toWGS84(const FloatCoordinate &mercator_coordinate)
 
 // Converts a WMS tile coordinate (z,x,y) into a wgs bounding box
 inline void xyzToWGS84(
-    const int x, const int y, const int z, double &minx, double &miny, double &maxx, double &maxy)
+    const int x, const int y, const int z, double &minx, double &miny, double &maxx, double &maxy,
+    int mercator_buffer = 0)
 {
-    minx = x * TILE_SIZE;
-    miny = (y + 1.0) * TILE_SIZE;
-    maxx = (x + 1.0) * TILE_SIZE;
-    maxy = y * TILE_SIZE;
+    minx = x * TILE_SIZE - mercator_buffer;
+    miny = (y + 1.0) * TILE_SIZE - mercator_buffer;
+    maxx = (x + 1.0) * TILE_SIZE + mercator_buffer;
+    maxy = y * TILE_SIZE + mercator_buffer;
     // 2^z * TILE_SIZE
     const double shift = (1u << static_cast<unsigned>(z)) * TILE_SIZE;
     pixelToDegree(shift, minx, miny);

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -140,14 +140,19 @@ inline FloatCoordinate toWGS84(const FloatCoordinate &mercator_coordinate)
 }
 
 // Converts a WMS tile coordinate (z,x,y) into a wgs bounding box
-inline void xyzToWGS84(
-    const int x, const int y, const int z, double &minx, double &miny, double &maxx, double &maxy,
-    int mercator_buffer = 0)
+inline void xyzToWGS84(const int x,
+                       const int y,
+                       const int z,
+                       double &minx,
+                       double &miny,
+                       double &maxx,
+                       double &maxy,
+                       int mercator_buffer = 0)
 {
     minx = x * TILE_SIZE - mercator_buffer;
-    miny = (y + 1.0) * TILE_SIZE - mercator_buffer;
+    miny = (y + 1.0) * TILE_SIZE + mercator_buffer;
     maxx = (x + 1.0) * TILE_SIZE + mercator_buffer;
-    maxy = y * TILE_SIZE + mercator_buffer;
+    maxy = y * TILE_SIZE - mercator_buffer;
     // 2^z * TILE_SIZE
     const double shift = (1u << static_cast<unsigned>(z)) * TILE_SIZE;
     pixelToDegree(shift, minx, miny);

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -286,7 +286,7 @@ Status TilePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacad
                                    min_lat,
                                    max_lon,
                                    max_lat,
-                                   util::web_mercator::TILE_SIZE * 0.05);
+                                   util::web_mercator::TILE_SIZE * 0.10);
 
     util::Coordinate southwest{util::FloatLongitude{min_lon}, util::FloatLatitude{min_lat}};
     util::Coordinate northeast{util::FloatLongitude{max_lon}, util::FloatLatitude{max_lat}};

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     }
 
     BOOST_CHECK_EQUAL(number_of_turn_keys, 3);
-    BOOST_CHECK_EQUAL(number_of_turns_found, 137);
+    BOOST_CHECK_EQUAL(number_of_turns_found, 732);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -172,6 +172,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     };
 
     auto number_of_turn_keys = 0u;
+    auto number_of_turns_found = 0u;
 
     while (layer_message.next())
     {
@@ -188,6 +189,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
             break;
         case util::vector_tile::FEATURE_TAG:
             check_turn_feature(layer_message.get_message());
+            number_of_turns_found++;
             break;
         case util::vector_tile::KEY_TAG:
             layer_message.get_string();
@@ -203,6 +205,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     }
 
     BOOST_CHECK_EQUAL(number_of_turn_keys, 3);
+    BOOST_CHECK_EQUAL(number_of_turns_found, 137);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR addresses two tickets:

https://github.com/Project-OSRM/osrm-backend/issues/3248 - turn angles are wrong, and some turns aren't showing up.

This was caused by changes to the geometry encoding - the plugin to be updated to find the reverse geometry properly in the new GetForward/GetReverse world.

https://github.com/Project-OSRM/osrm-backend/issues/3064 - losing geometry near tile edges.  This was caused by a basic math error when adding a buffer to the bounding box - I was effectively shrinking the bounding box vertically, rather than growing it.

With this PR, we now get:
<img width="798" alt="screen shot 2016-11-04 at 2 54 46 pm" src="https://cloud.githubusercontent.com/assets/1892250/20022523/961c22d2-a2a0-11e6-95bb-b3bb839edb54.png">

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments