### PR TITLE
Added percent-encoding to URL parser

### DIFF
--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -27,7 +27,8 @@ struct URLParser final : qi::grammar<Iterator, Into>
         using boost::spirit::repository::qi::iter_pos;
 
         alpha_numeral = qi::char_("a-zA-Z0-9");
-        polyline_chars = qi::char_("a-zA-Z0-9_.--[]{}@?|\\%~`^");
+        percent_encoding = qi::char_('%') > qi::uint_parser<char, 16, 2, 2>()[qi::_val = qi::_1];
+        polyline_chars = qi::char_("a-zA-Z0-9_.--[]{}@?|\\~`^") | percent_encoding;
         all_chars = polyline_chars | qi::char_("=,;:&().");
 
         service = +alpha_numeral;
@@ -55,6 +56,7 @@ struct URLParser final : qi::grammar<Iterator, Into>
     qi::rule<Iterator, char()> alpha_numeral;
     qi::rule<Iterator, char()> all_chars;
     qi::rule<Iterator, char()> polyline_chars;
+    qi::rule<Iterator, char()> percent_encoding;
 };
 
 } // anon.

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -102,6 +102,18 @@ BOOST_AUTO_TEST_CASE(valid_urls)
     BOOST_CHECK_EQUAL(reference_6.profile, result_6->profile);
     CHECK_EQUAL_RANGE(reference_6.query, result_6->query);
     BOOST_CHECK_EQUAL(reference_6.prefix_length, result_6->prefix_length);
+
+    // polyline with %HEX
+    api::ParsedURL reference_7{
+        "match", 1, "car", "polyline(}jmwFz~ubMyCa@`@yDJqE)?你好&\n \"%~", 14UL};
+    auto result_7 = api::parseURL(
+        "/match/v1/car/polyline(%7DjmwFz~ubMyCa@%60@yDJqE)?%e4%bd%a0%e5%a5%bd&%0A%20%22%25%7e");
+    BOOST_CHECK(result_7);
+    BOOST_CHECK_EQUAL(reference_7.service, result_7->service);
+    BOOST_CHECK_EQUAL(reference_7.version, result_7->version);
+    BOOST_CHECK_EQUAL(reference_7.profile, result_7->profile);
+    CHECK_EQUAL_RANGE(reference_7.query, result_7->query);
+    BOOST_CHECK_EQUAL(reference_7.prefix_length, result_7->prefix_length);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Added percent-encoding to URL parser, so _query_ part of parse accepts %HEX and converts the triple to char value.


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
Issue #3251
https://tools.ietf.org/html/rfc1738