### PR TITLE
add locations feature to allow testing turn locations, fix minor bug …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - Changes from 5.4.1
     - Bugfixes
       - #3254 Fixed a bug that could end up hiding roundabout instructions
+      - #3260 fixed a bug that provided the wrong location in the arrival instruction
 
 # 5.4.2
   - Changes from 5.4.1

--- a/features/guidance/turn-location.feature
+++ b/features/guidance/turn-location.feature
@@ -1,0 +1,23 @@
+@routing  @guidance
+Feature: Turn Location Feature
+
+    Background:
+        Given the profile "car"
+        Given a grid size of 10 meters
+
+    Scenario: Simple feature to test turn locations
+        Given the node map
+            """
+              c
+            a b d
+            """
+
+        And the ways
+            | nodes  | highway |
+            | ab     | primary |
+            | cb     | primary |
+            | db     | primary |
+
+       When I route I should get
+            | waypoints | route    | turns                   | locations |
+            | a,c       | ab,cb,cb | depart,turn left,arrive | a,b,c     |

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -126,6 +126,20 @@ module.exports = function () {
         return fromNode;
     };
 
+    // find a node based on an array containing lon/lat
+    this.findNodeByLocation = (node_location) => {
+        var searched_coordinate = new classes.Location(node_location[0],node_location[1]);
+        for (var node in this.nameNodeHash)
+        {
+            var node_coordinate = new classes.Location(this.nameNodeHash[node].lon,this.nameNodeHash[node].lat);
+            if (this.FuzzyMatch.matchCoordinate(searched_coordinate, node_coordinate, this.zoom))
+            {
+                return node;
+            }
+        }
+        return '_';
+    };
+
     this.findWayByName = (s) => {
         return this.nameWayHash[s.toString()] || this.nameWayHash[s.toString().split('').reverse().join('')];
     };

--- a/features/support/data_classes.js
+++ b/features/support/data_classes.js
@@ -111,5 +111,12 @@ module.exports = {
             return this.match(got[0], util.format('%d ~0.0025%', want.lon)) &&
                 this.match(got[1], util.format('%d ~0.0025%', want.lat));
         }
+
+        matchCoordinate (got, want, zoom) {
+            if (got == null || want == null) return false;
+            return this.match(got.lon, util.format('%d +- %d', want.lon, 0.25*zoom)) &&
+                this.match(got.lat, util.format('%d +- %d', want.lat, 0.25*zoom));
+        }
+
     }
 };

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -218,6 +218,14 @@ module.exports = function () {
             .join(',');
     };
 
+    this.locations = (instructions) => {
+        return instructions.legs.reduce((m, v) => m.concat(v.steps), [])
+            .map(v => {
+                return this.findNodeByLocation(v.maneuver.location);
+            })
+            .join(',');
+    };
+
     this.intersectionList = (instructions) => {
         return instructions.legs.reduce((m, v) => m.concat(v.steps), [])
             .map( v => {

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -35,7 +35,7 @@ module.exports = function () {
                     if (err) return cb(err);
                     if (body && body.length) {
                         let destinations, pronunciations, instructions, refs, bearings, turns, modes, times,
-                            distances, summary, intersections, lanes;
+                            distances, summary, intersections, lanes, locations;
 
                         let json = JSON.parse(body);
 
@@ -54,6 +54,7 @@ module.exports = function () {
                             distances = this.distanceList(json.routes[0]);
                             lanes = this.lanesList(json.routes[0]);
                             summary = this.summary(json.routes[0]);
+                            locations = this.locations(json.routes[0]);
                         }
 
                         if (headers.has('status')) {
@@ -123,6 +124,10 @@ module.exports = function () {
 
                             if (headers.has('intersections')) {
                                 got.intersections = (intersections || '').trim();
+                            }
+
+                            if (headers.has('locations')){
+                                got.locations = (locations || '').trim();
                             }
 
                             var putValue = (key, value) => {

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -215,13 +215,6 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
 
     BOOST_ASSERT(segment_index == number_of_segments - 1);
     bearings = detail::getArriveBearings(leg_geometry);
-    // This step has length zero, the only reason we need it is the target location
-    maneuver = {intersection.location,
-                bearings.first,
-                bearings.second,
-                extractor::guidance::TurnInstruction::NO_TURN(),
-                WaypointType::Arrive,
-                0};
 
     intersection = {
         target_node.location,
@@ -231,6 +224,15 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
         Intersection::NO_INDEX,
         util::guidance::LaneTuple(),
         {}};
+
+    // This step has length zero, the only reason we need it is the target location
+    maneuver = {intersection.location,
+                bearings.first,
+                bearings.second,
+                extractor::guidance::TurnInstruction::NO_TURN(),
+                WaypointType::Arrive,
+                0};
+
 
     BOOST_ASSERT(!leg_geometry.locations.empty());
     steps.push_back(RouteStep{target_node.name_id,

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -26,6 +26,7 @@ inline void print(const engine::guidance::RouteStep &step)
     std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
               << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
               << static_cast<int>(step.maneuver.waypoint_type) << " "
+              << step.maneuver.location << " "
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
               << "\n\tIntersections: " << step.intersections.size() << " [";


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/3260.
This PR adds the ability to test for `locations` in our cucumber tests. Doing so we can test which location a turn is announced at.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
none