### PR TITLE
Remove {highway: type} fallback from bike / walk profile, fixes #3231

### DIFF
--- a/features/bicycle/names.feature
+++ b/features/bicycle/names.feature
@@ -21,7 +21,7 @@ Feature: Bike - Street names in instructions
             | a    | c  | My Way,Your Way,Your Way                | A6,A7,A7 |
 
     @unnamed
-    Scenario: Bike - Use way type to describe unnamed ways
+    Scenario: Bike - No longer use way type to describe unnamed ways, see #3231
         Given the node map
             """
             a b c d
@@ -33,5 +33,5 @@ Feature: Bike - Street names in instructions
             | bcd   | track    |      |
 
         When I route I should get
-            | from | to | route                                              |
-            | a    | d  | {highway:cycleway},{highway:track},{highway:track} |
+            | from | to | route |
+            | a    | d  | ,     |

--- a/features/bicycle/ref.feature
+++ b/features/bicycle/ref.feature
@@ -29,8 +29,8 @@ Feature: Bike - Way ref
             | ab    |      | E7  |
 
         When I route I should get
-            | from | to | route                               | ref   |
-            | a    | b  | {highway:primary},{highway:primary} | E7,E7 |
+            | from | to | route | ref   |
+            | a    | b  | ,     | E7,E7 |
 
     Scenario: Bike - Way with only name
         Given the node map

--- a/features/foot/names.feature
+++ b/features/foot/names.feature
@@ -21,7 +21,7 @@ Feature: Foot - Street names in instructions
             | a    | c  | My Way,Your Way,Your Way                |
 
     @unnamed
-    Scenario: Foot - Use way type to describe unnamed ways
+    Scenario: Foot - No longer use way type to describe unnamed ways, see #3231
         Given the node map
             """
             a b c d
@@ -33,5 +33,5 @@ Feature: Foot - Street names in instructions
             | bcd   | track   |      |
 
         When I route I should get
-            | from | to | route                                             |
-            | a    | d  | {highway:footway},{highway:track},{highway:track} |
+            | from | to | route |
+            | a    | d  | ,     |

--- a/features/foot/ref.feature
+++ b/features/foot/ref.feature
@@ -15,8 +15,8 @@ Feature: Foot - Way ref
             | ab    | Utopia Drive | E7  |
 
         When I route I should get
-            | from | to | route                               |
-            | a    | b  | Utopia Drive,Utopia Drive           |
+            | from | to | route                     | ref   |
+            | a    | b  | Utopia Drive,Utopia Drive | E7,E7 |
 
     Scenario: Foot - Way with only ref
         Given the node map
@@ -29,8 +29,8 @@ Feature: Foot - Way ref
             | ab    |      | E7  |
 
         When I route I should get
-            | from | to | route                               |
-            | a    | b  | {highway:primary},{highway:primary} |
+            | from | to | route | ref   |
+            | a    | b  | ,     | E7,E7 |
 
     Scenario: Foot - Way with only name
         Given the node map

--- a/features/guidance/bicycle-sliproads.feature
+++ b/features/guidance/bicycle-sliproads.feature
@@ -1,8 +1,8 @@
 @routing @bicycle @mode
 Feature: Bike - Mode flag
 
-	Background:
-		Given the profile "bicycle"
+    Background:
+        Given the profile "bicycle"
         Given a grid size of 5 meters
 
     Scenario: Bike Sliproad
@@ -29,5 +29,5 @@ Feature: Bike - Mode flag
             | geh   | secondary | street |                |
 
         When I route I should get
-            | waypoints | route                           | turns                               |
-            | a,f       | street,{highway:path},road,road | depart,turn right,turn right,arrive |
+            | waypoints | route             | turns                               |
+            | a,f       | street,,road,road | depart,turn right,turn right,arrive |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -106,7 +106,6 @@ local turn_bias                 = 1.4
 -- local safety_penalty            = 0.7
 local safety_penalty            = 1.0
 local use_public_transport      = true
-local fallback_names            = true
 
 local function parse_maxspeed(source)
     if not source then
@@ -214,11 +213,6 @@ function way_function (way, result)
   -- name
   if name and "" ~= name then
     result.name = name
-  -- TODO find a better solution for encoding way type
-  elseif fallback_names and highway then
-    -- if no name exists, use way type
-    -- this encoding scheme is expected to be a temporary solution
-    result.name = "{highway:"..highway.."}"
   end
 
   -- ref

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -70,8 +70,6 @@ properties.max_speed_for_map_matching    = 40/3.6 -- kmph -> m/s
 properties.use_turn_restrictions         = false
 properties.continue_straight_at_waypoint = false
 
-local fallback_names     = true
-
 function get_restrictions(vector)
   for i,v in ipairs(restrictions) do
     vector:Add(v)
@@ -153,9 +151,6 @@ function way_function (way, result)
    -- name
   if name and "" ~= name then
     result.name = name
-  elseif highway and fallback_names then
-    result.name = "{highway:"..highway.."}"  -- if no name exists, use way type
-                                            -- this encoding scheme is excepted to be a temporary solution
   end
   if ref and "" ~= ref then
     result.ref = ref


### PR DESCRIPTION
For #3231: there should be no reason our _default_ profiles expose internals to the user.

## Tasklist
 - [x] review
 - [x] adjust for comments

References:
- https://github.com/Project-OSRM/osrm-text-instructions/issues/62#issuecomment-257889721
- https://github.com/Project-OSRM/osrm-text-instructions/pull/63