### PR TITLE
Refactor fork handling in guidance

### DIFF
--- a/include/extractor/guidance/intersection.hpp
+++ b/include/extractor/guidance/intersection.hpp
@@ -300,7 +300,7 @@ struct Intersection final : std::vector<ConnectedRoad>,         //
     std::uint8_t getHighestConnectedLaneCount(const util::NodeBasedDynamicGraph &) const;
 
     // check if all roads between first and last allow entry
-    bool hasValidEntries(std::size_t first, std::size_t last) const;
+    bool hasValidEntries(Intersection::iterator first, Intersection::iterator last) const;
 
     Base::iterator findClosestTurn(double angle);
     Base::const_iterator findClosestTurn(double angle) const;

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -42,34 +42,10 @@ class IntersectionHandler
     virtual ~IntersectionHandler() = default;
 
     // check whether the handler can actually handle the intersection
-    //
-    // note that `intersection` is a ordered list of connected roads ordered from from sharp right
-    // counter-clockwise to sharp left where `intersection[0]` is always a u-turn
-    // #IntersectionExplanation@intersection_handler.hpp
-    //
-    //                                           |
-    //                                           |
-    //                                     (intersec[3])
-    //                                           |
-    //                                           |
-    //                                           |
-    //  nid ---(via_eid/intersec[0])--- nbg.GetTarget(via)  ---(intersec[2])---
-    //                                           |
-    //                                           |
-    //                                           |
-    //                                     (intersec[1])
-    //                                           |
-    //                                           |
-    //
-    // intersec := intersection
-    // nbh := node_based_graph
-    //
-    // #IntersectionExplanation@intersection_handler.hpp
     virtual bool
     canProcess(const NodeID nid, const EdgeID via_eid, const Intersection &intersection) const = 0;
 
-    // handle and process the intersection with parameters as described in
-    // #IntersectionExplanation@intersection_handler.hpp
+    // handle and process the intersection
     virtual Intersection
     operator()(const NodeID nid, const EdgeID via_eid, Intersection intersection) const = 0;
 
@@ -80,8 +56,6 @@ class IntersectionHandler
     const SuffixTable &street_name_suffix_table;
     const IntersectionGenerator &intersection_generator;
     const NodeBasedGraphWalker graph_walker; // for skipping traffic signal, distances etc.
-
-    std::size_t countValid(const Intersection &intersection) const;
 
     // Decide on a basic turn types
     TurnType::Enum findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -42,10 +42,34 @@ class IntersectionHandler
     virtual ~IntersectionHandler() = default;
 
     // check whether the handler can actually handle the intersection
+    //
+    // note that `intersection` is a ordered list of connected roads ordered from from sharp right
+    // counter-clockwise to sharp left where `intersection[0]` is always a u-turn
+    // #IntersectionExplanation@intersection_handler.hpp
+    //
+    //                                           |
+    //                                           |
+    //                                     (intersec[3])
+    //                                           |
+    //                                           |
+    //                                           |
+    //  nid ---(via_eid/intersec[0])--- nbg.GetTarget(via)  ---(intersec[2])---
+    //                                           |
+    //                                           |
+    //                                           |
+    //                                     (intersec[1])
+    //                                           |
+    //                                           |
+    //
+    // intersec := intersection
+    // nbh := node_based_graph
+    //
+    // #IntersectionExplanation@intersection_handler.hpp
     virtual bool
     canProcess(const NodeID nid, const EdgeID via_eid, const Intersection &intersection) const = 0;
 
-    // process the intersection
+    // handle and process the intersection with parameters as described in
+    // #IntersectionExplanation@intersection_handler.hpp
     virtual Intersection
     operator()(const NodeID nid, const EdgeID via_eid, Intersection intersection) const = 0;
 
@@ -56,6 +80,8 @@ class IntersectionHandler
     const SuffixTable &street_name_suffix_table;
     const IntersectionGenerator &intersection_generator;
     const NodeBasedGraphWalker graph_walker; // for skipping traffic signal, distances etc.
+
+    std::size_t countValid(const Intersection &intersection) const;
 
     // Decide on a basic turn types
     TurnType::Enum findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -50,11 +50,10 @@ class TurnHandler : public IntersectionHandler
   private:
     struct Fork
     {
-        const std::size_t right;
-        const std::size_t left;
+        Intersection::iterator right;
+        Intersection::iterator left;
         const std::size_t size;
-
-        Fork(const std::size_t right, const std::size_t left);
+        Fork(Intersection::iterator right, Intersection::iterator left);
     };
 
     bool isObviousOfTwo(const EdgeID via_edge,
@@ -63,15 +62,13 @@ class TurnHandler : public IntersectionHandler
 
     bool hasObvious(const EdgeID &via_edge,
                     const Intersection &intersection,
-                    const std::size_t right,
-                    const std::size_t left) const;
+                    const Fork) const;
 
     boost::optional<Fork>
-    findLeftAndRightmostForkCandidates(const Intersection &intersection) const;
+    findLeftAndRightmostForkCandidates(Intersection &intersection) const;
 
     bool isCompatibleByRoadClass(const Intersection &intersection,
-                                 const std::size_t right,
-                                 const std::size_t left) const;
+                                 const Fork fork) const;
 
     // Dead end.
     OSRM_ATTR_WARN_UNUSED
@@ -93,7 +90,7 @@ class TurnHandler : public IntersectionHandler
     handleDistinctConflict(const EdgeID via_edge, ConnectedRoad &left, ConnectedRoad &right) const;
 
     // Classification
-    boost::optional<Fork> findFork(const EdgeID via_edge, const Intersection &intersection) const;
+    boost::optional<Fork> findFork(const EdgeID via_edge, Intersection &intersection) const;
 
     OSRM_ATTR_WARN_UNUSED
     Intersection assignLeftTurns(const EdgeID via_edge,

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -10,6 +10,9 @@
 #include "util/name_table.hpp"
 #include "util/node_based_graph.hpp"
 
+#include <boost/optional.hpp>
+
+
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -45,6 +48,15 @@ class TurnHandler : public IntersectionHandler
                             Intersection intersection) const override final;
 
   private:
+    struct Fork
+    {
+        const std::size_t right;
+        const std::size_t left;
+        const std::size_t size;
+
+        Fork(const std::size_t right, const std::size_t left);
+    };
+
     bool isObviousOfTwo(const EdgeID via_edge,
                         const ConnectedRoad &road,
                         const ConnectedRoad &other) const;
@@ -54,9 +66,7 @@ class TurnHandler : public IntersectionHandler
                     const std::size_t right,
                     const std::size_t left) const;
 
-    std::tuple<std::size_t, double> findClosestToStraight(const Intersection &intersection) const;
-
-    std::pair<std::size_t, std::size_t>
+    boost::optional<Fork>
     findLeftAndRightmostForkCandidates(const Intersection &intersection) const;
 
     bool isCompatibleByRoadClass(const Intersection &intersection,
@@ -83,8 +93,7 @@ class TurnHandler : public IntersectionHandler
     handleDistinctConflict(const EdgeID via_edge, ConnectedRoad &left, ConnectedRoad &right) const;
 
     // Classification
-    std::pair<std::size_t, std::size_t> findFork(const EdgeID via_edge,
-                                                 const Intersection &intersection) const;
+    boost::optional<Fork> findFork(const EdgeID via_edge, const Intersection &intersection) const;
 
     OSRM_ATTR_WARN_UNUSED
     Intersection assignLeftTurns(const EdgeID via_edge,

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -48,6 +48,21 @@ class TurnHandler : public IntersectionHandler
     bool isObviousOfTwo(const EdgeID via_edge,
                         const ConnectedRoad &road,
                         const ConnectedRoad &other) const;
+
+    bool hasObvious(const EdgeID &via_edge,
+                    const Intersection &intersection,
+                    const std::size_t right,
+                    const std::size_t left) const;
+
+    std::tuple<std::size_t, double> findClosestToStraight(const Intersection &intersection) const;
+
+    std::pair<std::size_t, std::size_t>
+    findLeftAndRightmostForkCandidates(const Intersection &intersection) const;
+
+    bool isCompatibleByRoadClass(const Intersection &intersection,
+                                 const std::size_t right,
+                                 const std::size_t left) const;
+
     // Dead end.
     OSRM_ATTR_WARN_UNUSED
     Intersection handleOneWayTurn(Intersection intersection) const;

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/optional.hpp>
 
-
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -50,25 +49,21 @@ class TurnHandler : public IntersectionHandler
   private:
     struct Fork
     {
-        Intersection::iterator right;
-        Intersection::iterator left;
+        const Intersection::iterator right;
+        const Intersection::iterator left;
         const std::size_t size;
-        Fork(Intersection::iterator right, Intersection::iterator left);
+        Fork(const Intersection::iterator right, const Intersection::iterator left);
     };
 
     bool isObviousOfTwo(const EdgeID via_edge,
                         const ConnectedRoad &road,
                         const ConnectedRoad &other) const;
 
-    bool hasObvious(const EdgeID &via_edge,
-                    const Intersection &intersection,
-                    const Fork) const;
+    bool hasObvious(const EdgeID &via_edge, const Fork &fork) const;
 
-    boost::optional<Fork>
-    findLeftAndRightmostForkCandidates(Intersection &intersection) const;
+    boost::optional<Fork> findForkCandidatesByGeometry(Intersection &intersection) const;
 
-    bool isCompatibleByRoadClass(const Intersection &intersection,
-                                 const Fork fork) const;
+    bool isCompatibleByRoadClass(const Intersection &intersection, const Fork fork) const;
 
     // Dead end.
     OSRM_ATTR_WARN_UNUSED

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -55,6 +55,11 @@
 #include <unordered_map>
 #include <vector>
 
+// // uncomment for @fork_geoprinting
+// #include "util/geojson_debug_logger.hpp"
+// #include "util/geojson_debug_policies.hpp"
+
+
 namespace osrm
 {
 namespace extractor
@@ -491,6 +496,11 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
         turn_lane_offsets,
         turn_lane_masks,
         turn_lane_map);
+
+
+    // // uncomment for @fork_geoprinting
+    // util::ScopedGeojsonLoggerGuard<util::NodeIdVectorToLineString> line_logger_guard("fork-lines.geojson", internal_to_external_node_map);
+    // util::ScopedGeojsonLoggerGuard<util::NodeIdVectorToMultiPoint> point_logger_guard("fork-points.geojson", internal_to_external_node_map);
 
     edge_based_graph_factory.Run(scripting_environment,
                                  config.edge_output_path,

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -55,11 +55,6 @@
 #include <unordered_map>
 #include <vector>
 
-// // uncomment for @fork_geoprinting
-// #include "util/geojson_debug_logger.hpp"
-// #include "util/geojson_debug_policies.hpp"
-
-
 namespace osrm
 {
 namespace extractor
@@ -496,11 +491,6 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
         turn_lane_offsets,
         turn_lane_masks,
         turn_lane_map);
-
-
-    // // uncomment for @fork_geoprinting
-    // util::ScopedGeojsonLoggerGuard<util::NodeIdVectorToLineString> line_logger_guard("fork-lines.geojson", internal_to_external_node_map);
-    // util::ScopedGeojsonLoggerGuard<util::NodeIdVectorToMultiPoint> point_logger_guard("fork-points.geojson", internal_to_external_node_map);
 
     edge_based_graph_factory.Run(scripting_environment,
                                  config.edge_output_path,

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -85,6 +85,65 @@ std::string toString(const ConnectedRoad &road)
     return result;
 }
 
+Intersection::Base::iterator Intersection::findClosestTurn(double angle)
+{
+    // use the const operator to avoid code duplication
+    return begin() +
+           std::distance(cbegin(), static_cast<const Intersection *>(this)->findClosestTurn(angle));
+}
+
+Intersection::Base::const_iterator Intersection::findClosestTurn(double angle) const
+{
+    return std::min_element(
+        begin(), end(), [angle](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
+            return angularDeviation(lhs.angle, angle) < angularDeviation(rhs.angle, angle);
+        });
+}
+bool Intersection::valid() const
+{
+    return !empty() &&
+           std::is_sorted(begin(), end(), std::mem_fn(&ConnectedRoad::compareByAngle)) &&
+           operator[](0).angle < std::numeric_limits<double>::epsilon();
+}
+
+std::uint8_t
+Intersection::getHighestConnectedLaneCount(const util::NodeBasedDynamicGraph &graph) const
+{
+    BOOST_ASSERT(valid()); // non empty()
+
+    const std::function<std::uint8_t(const ConnectedRoad &)> to_lane_count =
+        [&](const ConnectedRoad &road) {
+            return graph.GetEdgeData(road.eid).road_classification.GetNumberOfLanes();
+        };
+
+    std::uint8_t max_lanes = 0;
+    const auto extract_maximal_value = [&max_lanes](std::uint8_t value) {
+        max_lanes = std::max(max_lanes, value);
+        return false;
+    };
+
+    const auto view = *this | boost::adaptors::transformed(to_lane_count);
+    boost::range::find_if(view, extract_maximal_value);
+    return max_lanes;
+}
+
+// check if all entries in the given range allow entry
+bool Intersection::hasValidEntries(std::size_t first, std::size_t last) const
+{
+    BOOST_ASSERT(last < size());
+
+    for (std::size_t i = first; i <= last; ++i)
+    {
+        if (!operator[](i).entry_allowed)
+        {
+            return false;
+        }
+    }
+    // if no entry was found that forbids entry, the intersection entries in the range are all
+    // valid.
+    return true;
+}
+
 } // namespace guidance
 } // namespace extractor
 } // namespace osrm

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -3,6 +3,8 @@
 #include <limits>
 #include <string>
 
+#include <boost/range/adaptors.hpp>
+
 using osrm::util::angularDeviation;
 
 namespace osrm
@@ -132,16 +134,9 @@ bool Intersection::hasValidEntries(std::size_t first, std::size_t last) const
 {
     BOOST_ASSERT(last < size());
 
-    for (std::size_t i = first; i <= last; ++i)
-    {
-        if (!operator[](i).entry_allowed)
-        {
-            return false;
-        }
-    }
-    // if no entry was found that forbids entry, the intersection entries in the range are all
-    // valid.
-    return true;
+    return all_of(begin() + first, begin() + last + 1, [&](const ConnectedRoad &road) {
+        return road.entry_allowed;
+    });
 }
 
 } // namespace guidance

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -130,11 +130,11 @@ Intersection::getHighestConnectedLaneCount(const util::NodeBasedDynamicGraph &gr
 }
 
 // check if all entries in the given range allow entry
-bool Intersection::hasValidEntries(std::size_t first, std::size_t last) const
+bool Intersection::hasValidEntries(Intersection::iterator first, Intersection::iterator last) const
 {
-    BOOST_ASSERT(last < size());
+    BOOST_ASSERT(last < end());
 
-    return all_of(begin() + first, begin() + last + 1, [&](const ConnectedRoad &road) {
+    return all_of(first, last + 1, [&](const ConnectedRoad &road) {
         return road.entry_allowed;
     });
 }

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -11,6 +11,11 @@
 #include <algorithm>
 #include <cstddef>
 
+// // uncomment for @fork_geoprinting
+// #include "util/geojson_debug_logger.hpp"
+// #include "util/geojson_debug_policies.hpp"
+
+
 using EdgeData = osrm::util::NodeBasedDynamicGraph::EdgeData;
 using osrm::extractor::guidance::getTurnDirection;
 using osrm::util::angularDeviation;
@@ -172,6 +177,22 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
     }
 }
 
+
+// // uncomment for @fork_geoprinting
+// void printLine(const util::NodeBasedDynamicGraph &node_based_graph,
+//                const EdgeID via_edge,
+//                ConnectedRoad &road)
+// {
+//     util::ScopedGeojsonLoggerGuard<util::NodeIdVectorToLineString>::Write(std::vector<NodeID>{
+//         node_based_graph.GetTarget(via_edge), node_based_graph.GetTarget(road.eid)});
+// }
+// // uncomment for @fork_geoprinting
+// void printNode(const std::vector<NodeID> nodes)
+// {
+//     util::ScopedGeojsonLoggerGuard<util::NodeIdVectorToMultiPoint>::Write(nodes);
+// }
+
+
 void IntersectionHandler::assignFork(const EdgeID via_edge,
                                      ConnectedRoad &left,
                                      ConnectedRoad &right) const
@@ -205,6 +226,12 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
                 }
                 else
                 {
+                    // // uncomment for @fork_geoprinting
+                    // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+                    //                               node_based_graph.GetTarget(right.eid),
+                    //                               node_based_graph.GetTarget(left.eid)});
+                    // printLine(node_based_graph, via_edge, left);
+                    // printLine(node_based_graph, via_edge, right);
                     left.instruction = {TurnType::Fork, DirectionModifier::SlightLeft};
                     right.instruction = {TurnType::Fork, DirectionModifier::SlightRight};
                 }
@@ -244,6 +271,12 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
                     }
                     else
                     {
+                        // // uncomment for @fork_geoprinting
+                        // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+                        //                               node_based_graph.GetTarget(left.eid),
+                        //                               node_based_graph.GetTarget(right.eid)});
+                        // printLine(node_based_graph, via_edge, left);
+                        // printLine(node_based_graph, via_edge, right);
                         right.instruction = {TurnType::Fork, DirectionModifier::SlightRight};
                         left.instruction = {TurnType::Fork, DirectionModifier::SlightLeft};
                     }
@@ -263,9 +296,17 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
     else
     {
         if (low_priority_left && !low_priority_right)
+        {
             left.instruction = {TurnType::Turn, DirectionModifier::SlightLeft};
+        }
         else
+        {
+        //     // uncomment for @fork_geoprinting
+        //     printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+        //                                   node_based_graph.GetTarget(left.eid)});
+        //     printLine(node_based_graph, via_edge, left);
             left.instruction = {TurnType::Fork, DirectionModifier::SlightLeft};
+        }
     }
 
     // right side of fork
@@ -274,9 +315,17 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
     else
     {
         if (low_priority_right && !low_priority_left)
+        {
             right.instruction = {TurnType::Turn, DirectionModifier::SlightRight};
+        }
         else
+        {
+            // // uncomment for @fork_geoprinting
+            // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+            //                               node_based_graph.GetTarget(right.eid)});
+            // printLine(node_based_graph, via_edge, right);
             right.instruction = {TurnType::Fork, DirectionModifier::SlightRight};
+        }
     }
 }
 
@@ -288,6 +337,10 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
     // TODO handle low priority road classes in a reasonable way
     if (left.entry_allowed && center.entry_allowed && right.entry_allowed)
     {
+        // // uncomment for @fork_geoprinting
+        // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+        //                               node_based_graph.GetTarget(left.eid)});
+        // printLine(node_based_graph, via_edge, left);
         left.instruction = {TurnType::Fork, DirectionModifier::SlightLeft};
         if (angularDeviation(center.angle, 180) < MAXIMAL_ALLOWED_NO_TURN_DEVIATION)
         {
@@ -295,6 +348,10 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
             const auto &out_data = node_based_graph.GetEdgeData(center.eid);
             if (detail::requiresAnnouncement(in_data, out_data))
             {
+                // // uncomment for @fork_geoprinting
+                // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+                //                               node_based_graph.GetTarget(center.eid)});
+                // printLine(node_based_graph, via_edge, center);
                 center.instruction = {TurnType::Fork, DirectionModifier::Straight};
             }
             else
@@ -304,8 +361,16 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
         }
         else
         {
+            // // uncomment for @fork_geoprinting
+            // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+            //                               node_based_graph.GetTarget(center.eid)});
+            // printLine(node_based_graph, via_edge, center);
             center.instruction = {TurnType::Fork, DirectionModifier::Straight};
         }
+        // // uncomment for @fork_geoprinting}
+        // printNode(std::vector<NodeID>{node_based_graph.GetTarget(via_edge),
+        //                               node_based_graph.GetTarget(right.eid)});
+        // printLine(node_based_graph, via_edge, right);
         right.instruction = {TurnType::Fork, DirectionModifier::SlightRight};
     }
     else if (left.entry_allowed)

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -42,6 +42,15 @@ IntersectionHandler::IntersectionHandler(const util::NodeBasedDynamicGraph &node
 {
 }
 
+std::size_t IntersectionHandler::countValid(const Intersection &intersection) const
+{
+    return std::count_if(intersection.begin(), intersection.end(), [](const ConnectedRoad &road) {
+        return road.entry_allowed;
+    });
+}
+
+// Checks whether a turn from `via_edge` onto `road` is a turn, on a ramp, a continue, or a normal
+// turn
 TurnType::Enum IntersectionHandler::findBasicTurnType(const EdgeID via_edge,
                                                       const ConnectedRoad &road) const
 {

--- a/src/extractor/guidance/turn_discovery.cpp
+++ b/src/extractor/guidance/turn_discovery.cpp
@@ -56,7 +56,8 @@ bool findPreviousIntersection(const NodeID node_v,
     if (via_edge_length > COMBINE_DISTANCE_CUTOFF)
         return false;
 
-    // Node -> Via_Edge -> Intersection[0 == UTURN] -> reverse_of(via_edge) -> Intersection at node
+    // Node -> Via_Edge -> Intersection[0 == UTURN] -> reverse_of(via_edge) -> Intersection at
+    // node
     // (looking at the reverse direction).
     const auto node_w = node_based_graph.GetTarget(via_edge);
     const auto u_turn_at_node_w = intersection[0].eid;

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -18,7 +18,7 @@ namespace
 {
 
 using namespace osrm::extractor::guidance;
-// given two adjacent roads and `road1` being a candidate for a fork,
+// given two adjacent roads in clockwise order and `road1` being a candidate for a fork,
 // return false, if next road `road2` is also a fork candidate or
 // return true, if `road2` is not a suitable fork candidate and thus, `road1` the outermost fork
 bool isOutermostForkCandidate(const ConnectedRoad &road1, const ConnectedRoad &road2)
@@ -40,7 +40,7 @@ bool isOutermostForkCandidate(const ConnectedRoad &road1, const ConnectedRoad &r
     }
     return false;
 }
-// @CHAU_TODO get rid of
+
 bool isEndOfRoad(const ConnectedRoad &,
                  const ConnectedRoad &possible_right_turn,
                  const ConnectedRoad &possible_left_turn)
@@ -51,9 +51,12 @@ bool isEndOfRoad(const ConnectedRoad &,
                2 * NARROW_TURN_ANGLE;
 }
 
-template <typename Iterator>
-Iterator findOutermostForkCandidate(const Iterator start, const Iterator end)
+template <typename InputIt>
+InputIt findOutermostForkCandidate(const InputIt start, const InputIt end)
 {
+    static_assert(std::is_base_of<std::input_iterator_tag,
+                                  typename std::iterator_traits<InputIt>::iterator_category>::value,
+                  "findOutermostForkCandidate() only accepts input iterators");
     const auto outermost = std::adjacent_find(start, end, isOutermostForkCandidate);
     if (outermost != end)
     {
@@ -65,36 +68,6 @@ Iterator findOutermostForkCandidate(const Iterator start, const Iterator end)
         return outermost - 1;
     }
 }
-
-struct StraightestTurnAtIntersection
-{
-    StraightestTurnAtIntersection(std::size_t id, double deviation_from_straight)
-        : id(id), deviation_from_straight(deviation_from_straight){};
-
-    std::size_t id;
-    double deviation_from_straight;
-};
-
-// returns a tuple {i, angle_dev} of the road at the intersection that is closest to going straight:
-//     `intersection[i]` is the actual road
-//     `angle_dev` is the angle between going straight and taking the road `intersection[i]`
-StraightestTurnAtIntersection findClosestToStraight(const Intersection &intersection)
-{
-    std::size_t best = 0;
-    double best_deviation = 180;
-
-    // find the intersection[best] that is the closest to a turn going straight
-    for (std::size_t i = 1; i < intersection.size(); ++i)
-    {
-        const double deviation = angularDeviation(intersection[i].angle, STRAIGHT_ANGLE);
-        if (intersection[i].entry_allowed && deviation < best_deviation)
-        {
-            best_deviation = deviation;
-            best = i;
-        }
-    }
-    return StraightestTurnAtIntersection(best, best_deviation);
-}
 }
 
 namespace osrm
@@ -105,8 +78,8 @@ namespace guidance
 {
 
 // a wrapper to handle road indices of forks at intersections
-TurnHandler::Fork::Fork(Intersection::iterator right, Intersection::iterator left)
-    : right(right), left(left), size((int)(left - right) + 1)
+TurnHandler::Fork::Fork(const Intersection::iterator right, const Intersection::iterator left)
+    : right(right), left(left), size((left - right) + 1)
 {
     BOOST_ASSERT(right < left);
     BOOST_ASSERT(size >= 2);
@@ -177,51 +150,33 @@ bool TurnHandler::isObviousOfTwo(const EdgeID via_edge,
                                  const ConnectedRoad &road,
                                  const ConnectedRoad &other) const
 {
-    const auto &in_data = node_based_graph.GetEdgeData(via_edge);
-    const auto &first_data = node_based_graph.GetEdgeData(road.eid);
-    const auto &second_data = node_based_graph.GetEdgeData(other.eid);
-    const auto &first_classification = first_data.road_classification;
-    const auto &second_classification = second_data.road_classification;
-    const bool is_ramp = first_classification.IsRampClass();
+    const auto &via_data = node_based_graph.GetEdgeData(via_edge);
+    const auto &road_data = node_based_graph.GetEdgeData(road.eid);
+    const auto &other_data = node_based_graph.GetEdgeData(other.eid);
+    const auto &via_classification = via_data.road_classification;
+    const auto &road_classification = road_data.road_classification;
+    const auto &other_classification = other_data.road_classification;
 
-    // check whether one of the roads is obvious just by its class
-    // @CHAU_TODO consolidate with `obviousByRoadClass()` in extractor/guidance/toolkit.hpp
-    const bool is_obvious_by_road_class =
-        (!is_ramp &&
-         (2 * first_classification.GetPriority() < second_classification.GetPriority()) &&
-         in_data.road_classification == first_classification) ||
-        (!first_classification.IsLowPriorityRoadClass() &&
-         second_classification.IsLowPriorityRoadClass());
-    if (is_obvious_by_road_class)
+    // if one of the given roads is obvious by class, obviousness is trivial
+    if (obviousByRoadClass(via_classification, road_classification, other_classification))
     {
         return true;
     }
-
-    // @CHAU_TODO consolidate with `obviousByRoadClass()` in extractor/guidance/toolkit.hpp
-    const bool other_is_obvious_by_road_class =
-        (!second_classification.IsRampClass() &&
-         (2 * second_classification.GetPriority() < first_classification.GetPriority()) &&
-         in_data.road_classification == second_classification) ||
-        (!second_classification.IsLowPriorityRoadClass() &&
-         first_classification.IsLowPriorityRoadClass());
-
-    if (other_is_obvious_by_road_class)
+    else if (obviousByRoadClass(via_classification, other_classification, road_classification))
     {
         return false;
     }
 
     const bool turn_is_perfectly_straight =
         angularDeviation(road.angle, STRAIGHT_ANGLE) < std::numeric_limits<double>::epsilon();
-
-    const auto &road_data = node_based_graph.GetEdgeData(road.eid);
-
-    const auto same_name = !util::guidance::requiresNameAnnounced(
-        in_data.name_id, road_data.name_id, name_table, street_name_suffix_table);
-
-    if (turn_is_perfectly_straight && in_data.name_id != EMPTY_NAMEID &&
-        road_data.name_id != EMPTY_NAMEID && same_name)
+    if (via_data.name_id != EMPTY_NAMEID)
     {
-        return true;
+        const auto same_name = !util::guidance::requiresNameAnnounced(
+            via_data.name_id, road_data.name_id, name_table, street_name_suffix_table);
+        if (turn_is_perfectly_straight && same_name)
+        {
+            return true;
+        }
     }
 
     const bool is_much_narrower_than_other =
@@ -234,22 +189,15 @@ bool TurnHandler::isObviousOfTwo(const EdgeID via_edge,
     return is_much_narrower_than_other;
 }
 
-bool TurnHandler::hasObvious(const EdgeID &via_edge,
-                             const Intersection &intersection,
-                             const Fork fork) const
+bool TurnHandler::hasObvious(const EdgeID &via_edge, const Fork &fork) const
 {
-    // @CHAU_TODO: refactor this in separate task
-    if (fork.size == 2)
+    for (auto road = fork.right; road < fork.left; ++road)
     {
-        return isObviousOfTwo(via_edge, *fork.left, *fork.right) ||
-               isObviousOfTwo(via_edge, *fork.right, *fork.left);
-    }
-    else if (fork.size == 3)
-    {
-        return isObviousOfTwo(via_edge, *(fork.right + 1), *fork.right) ||
-               isObviousOfTwo(via_edge, *fork.right, *(fork.right + 1)) ||
-               isObviousOfTwo(via_edge, *fork.left, *(fork.right + 1)) ||
-               isObviousOfTwo(via_edge, *(fork.right + 1), *fork.left);
+        if (isObviousOfTwo(via_edge, *road, *(road + 1)) ||
+            isObviousOfTwo(via_edge, *(road + 1), *road))
+        {
+            return true;
+        }
     }
     return false;
 }
@@ -258,6 +206,7 @@ bool TurnHandler::hasObvious(const EdgeID &via_edge,
 // with `intersection` as described as in #IntersectionExplanation@intersection_handler.hpp
 Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection intersection) const
 {
+    BOOST_ASSERT(intersection.size() == 3);
     const auto obvious_index = findObviousTurn(via_edge, intersection);
     BOOST_ASSERT(intersection[0].angle < 0.001);
     /* Two nearly straight turns -> FORK
@@ -269,8 +218,7 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
      */
 
     auto fork = findFork(via_edge, intersection);
-    if (fork && intersection.begin() < fork->right && fork->right < fork->left &&
-        obvious_index == 0)
+    if (fork && obvious_index == 0)
     {
         assignFork(via_edge, *fork->left, *fork->right);
     }
@@ -341,20 +289,12 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
 
 Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection intersection) const
 {
-    // @CHAU_TODO check whether obvious check here and obvious check in findFork are redundant
     const std::size_t obvious_index = findObviousTurn(via_edge, intersection);
     const auto fork = findFork(via_edge, intersection);
-    std::size_t straightmost_turn = 0;
-    double straightmost_deviation = 180;
-    for (std::size_t i = 0; i < intersection.size(); ++i)
-    {
-        const double deviation = angularDeviation(intersection[i].angle, STRAIGHT_ANGLE);
-        if (deviation < straightmost_deviation)
-        {
-            straightmost_deviation = deviation;
-            straightmost_turn = i;
-        }
-    }
+
+    const auto straightmost = intersection.findClosestTurn(STRAIGHT_ANGLE);
+    const auto straightmost_index = std::distance(intersection.begin(), straightmost);
+    const auto straightmost_angle_dev = angularDeviation(straightmost->angle, STRAIGHT_ANGLE);
 
     // check whether the obvious choice is actually a through street
     if (obvious_index != 0)
@@ -369,7 +309,7 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
         intersection = assignLeftTurns(via_edge, std::move(intersection), obvious_index + 1);
         intersection = assignRightTurns(via_edge, std::move(intersection), obvious_index);
     }
-    else if (fork && fork->size <= 3) // found fork
+    else if (fork) // found fork
     {
         if (fork->size == 2)
         {
@@ -378,7 +318,9 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
             const auto right_classification =
                 node_based_graph.GetEdgeData((*fork->right).eid).road_classification;
             if (canBeSeenAsFork(left_classification, right_classification))
+            {
                 assignFork(via_edge, *fork->left, *fork->right);
+            }
             else if (left_classification.GetPriority() > right_classification.GetPriority())
             {
                 (*fork->right).instruction =
@@ -409,24 +351,23 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
         intersection = assignLeftTurns(via_edge, std::move(intersection), left_index + 1);
         intersection = assignRightTurns(via_edge, std::move(intersection), right_index);
     }
-    else if (straightmost_deviation < FUZZY_ANGLE_DIFFERENCE &&
-             !intersection[straightmost_turn].entry_allowed)
+    else if (straightmost_angle_dev < FUZZY_ANGLE_DIFFERENCE && !straightmost->entry_allowed)
     {
         // invalid straight turn
-        intersection = assignLeftTurns(via_edge, std::move(intersection), straightmost_turn + 1);
-        intersection = assignRightTurns(via_edge, std::move(intersection), straightmost_turn);
+        intersection = assignLeftTurns(via_edge, std::move(intersection), straightmost_index + 1);
+        intersection = assignRightTurns(via_edge, std::move(intersection), straightmost_index);
     }
     // no straight turn
-    else if (intersection[straightmost_turn].angle > 180)
+    else if (straightmost->angle > 180)
     {
         // at most three turns on either side
-        intersection = assignLeftTurns(via_edge, std::move(intersection), straightmost_turn);
-        intersection = assignRightTurns(via_edge, std::move(intersection), straightmost_turn);
+        intersection = assignLeftTurns(via_edge, std::move(intersection), straightmost_index);
+        intersection = assignRightTurns(via_edge, std::move(intersection), straightmost_index);
     }
-    else if (intersection[straightmost_turn].angle < 180)
+    else if (straightmost->angle < 180)
     {
-        intersection = assignLeftTurns(via_edge, std::move(intersection), straightmost_turn + 1);
-        intersection = assignRightTurns(via_edge, std::move(intersection), straightmost_turn + 1);
+        intersection = assignLeftTurns(via_edge, std::move(intersection), straightmost_index + 1);
+        intersection = assignRightTurns(via_edge, std::move(intersection), straightmost_index + 1);
     }
     else
     {
@@ -590,12 +531,15 @@ Intersection TurnHandler::assignRightTurns(const EdgeID via_edge,
     return intersection;
 }
 
+// finds a fork candidate by just looking at the geometry and angle of an intersection
 boost::optional<TurnHandler::Fork>
-TurnHandler::findLeftAndRightmostForkCandidates(Intersection &intersection) const
+TurnHandler::findForkCandidatesByGeometry(Intersection &intersection) const
 {
     if (intersection.size() >= 3)
     {
-        const auto straightest = findClosestToStraight(intersection);
+        const auto straightmost = intersection.findClosestTurn(STRAIGHT_ANGLE);
+        const auto straightmost_index = std::distance(intersection.begin(), straightmost);
+        const auto straightmost_angle_dev = angularDeviation(straightmost->angle, STRAIGHT_ANGLE);
 
         // Forks can only happen when two or more roads have a pretty narrow angle between each
         // other and are close to going straight
@@ -626,16 +570,15 @@ TurnHandler::findLeftAndRightmostForkCandidates(Intersection &intersection) cons
         // left and right will be indices of the leftmost and rightmost connected roads that are
         // fork candidates
 
-        if (straightest.deviation_from_straight <= NARROW_TURN_ANGLE)
+        if (straightmost_angle_dev <= NARROW_TURN_ANGLE)
         {
             // find the rightmost road that might be part of a fork
-            const auto right = findOutermostForkCandidate(intersection.rend() - straightest.id - 1,
-                                                          intersection.rend());
+            const auto right = findOutermostForkCandidate(
+                intersection.rend() - straightmost_index - 1, intersection.rend());
             const int right_index = intersection.rend() - right - 1;
             const auto forward_right = intersection.begin() + right_index;
             // find the leftmost road that might be part of a fork
-            const auto left = findOutermostForkCandidate(intersection.begin() + straightest.id,
-                                                         intersection.end());
+            const auto left = findOutermostForkCandidate(straightmost, intersection.end());
 
             // if the leftmost and rightmost roads with the conditions above are the same
             // or if there are more than three fork candidates
@@ -655,7 +598,6 @@ bool TurnHandler::isCompatibleByRoadClass(const Intersection &intersection, cons
 {
     const auto via_class = node_based_graph.GetEdgeData(intersection[0].eid).road_classification;
 
-    // @CHAU_TODO check whether this makes sense
     // if any of the considered roads is a link road, it cannot be a fork
     // except if rightmost fork candidate is also a link road
     const auto is_right_link_class =
@@ -670,11 +612,12 @@ bool TurnHandler::isCompatibleByRoadClass(const Intersection &intersection, cons
 
     return std::all_of(fork.right, fork.left + 1, [&](ConnectedRoad &base) {
         const auto base_class = node_based_graph.GetEdgeData(base.eid).road_classification;
-        // compatible if no turn is obvious by RoadClass
+        // check that there is no turn obvious == check that all turns are non-onvious
         return std::all_of(fork.right, fork.left + 1, [&](ConnectedRoad &compare) {
             const auto compare_class =
                 node_based_graph.GetEdgeData(compare.eid).road_classification;
-            return !(obviousByRoadClass(via_class, base_class, compare_class)) || compare.eid==base.eid;
+            return compare.eid == base.eid ||
+                   !(obviousByRoadClass(via_class, base_class, compare_class));
         });
     });
 }
@@ -684,11 +627,9 @@ bool TurnHandler::isCompatibleByRoadClass(const Intersection &intersection, cons
 boost::optional<TurnHandler::Fork> TurnHandler::findFork(const EdgeID via_edge,
                                                          Intersection &intersection) const
 {
-    const auto fork = findLeftAndRightmostForkCandidates(intersection);
+    const auto fork = findForkCandidatesByGeometry(intersection);
     if (fork)
     {
-        const auto right = fork->right;
-        const auto left = fork->left;
         // makes sure that the fork is isolated from other neighbouring streets on the left and
         // right side
         const auto next =
@@ -700,13 +641,14 @@ boost::optional<TurnHandler::Fork> TurnHandler::findFork(const EdgeID via_edge,
 
         // check whether there is an obvious turn to take; forks are never obvious - if there is an
         // obvious turn, it's not a fork
-        const bool has_obvious = hasObvious(via_edge, intersection, *fork);
+        const bool has_obvious = hasObvious(via_edge, *fork);
 
         // A fork can only happen between edges of similar types where none of the ones is obvious
         const bool has_compatible_classes = isCompatibleByRoadClass(intersection, *fork);
 
         // check if all entries in the fork range allow entry
-        const bool only_valid_entries = intersection.hasValidEntries(fork->right, fork->left);
+        const bool only_valid_entries =
+            intersection.hasAllValidEntries(fork->right, fork->left + 1);
 
         if (separated_at_left_side && separated_at_right_side && !has_obvious &&
             has_compatible_classes && only_valid_entries)


### PR DESCRIPTION
# Issue

This PR works towards #3099

## Tasklist
 - [x] refactor `TurnHandler::findFork()` code
 - [x] refactor `TurnHandler::isObviousOfTwo()`
 - [ ] revise definition of forks and `TurnHandler::findFork()` 
 - [ ] refactor `IntersectionHandler::assignFork()`
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Tasklist unrelated to this PR (but arose during this work)
 - [ ] rename `struct Intersection` in `route_step.hpp`
 - [ ] revise `BasicTurnType`
 - [ ] move `isObviousByRoadClass` in `turn_handler.hpp` to a dedicated .compatible() in road_class (road class refactor)
 - [ ] refactor `struct Fork` to use a `begin` and `end` iterator instead of `right` and `left`

## Code Review Todolist
 - [x] deduplicate [leftmost / rightmost code](https://github.com/Project-OSRM/osrm-backend/blob/58537a1fe4696182a048471ca06e45758f7906f7/src/extractor/guidance/turn_handler.cpp#L530-L572)
 - [x] add `OSRM_ATTR_WARN_UNUSED` to `setTurnTypes` in `turn_handler.hpp`
 - [x] refactor `findFork()` return type
 - [x] capsule [this](https://github.com/Project-OSRM/osrm-backend/blob/58537a1fe4696182a048471ca06e45758f7906f7/src/extractor/guidance/turn_handler.cpp#L488-L497) in own function
 - [x] revert [this condition](https://github.com/Project-OSRM/osrm-backend/blob/58537a1fe4696182a048471ca06e45758f7906f7/src/extractor/guidance/turn_handler.cpp#L500)
- [x] Make member function: [1](https://github.com/Project-OSRM/osrm-backend/blob/58537a1fe4696182a048471ca06e45758f7906f7/src/extractor/guidance/turn_handler.cpp#L600) [2](https://github.com/Project-OSRM/osrm-backend/blob/58537a1fe4696182a048471ca06e45758f7906f7/src/extractor/guidance/turn_handler.cpp#L620) [3](https://github.com/Project-OSRM/osrm-backend/blob/58537a1fe4696182a048471ca06e45758f7906f7/src/extractor/guidance/turn_handler.cpp#L638).
