### PR TITLE
Improve support for customized build directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,8 @@ install:
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       ./scripts/check_taginfo.py taginfo.json profiles/car.lua
     fi
-  - mkdir build && pushd build
+  - export OSRM_BUILD_DIR="$(pwd)/build-osrm"
+  - mkdir ${OSRM_BUILD_DIR} && pushd ${OSRM_BUILD_DIR}
   - export CC=${CCOMPILER} CXX=${CXXCOMPILER}
   - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_MASON=${ENABLE_MASON:-OFF} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} -DBUILD_TOOLS=ON -DBUILD_COMPONENTS=${BUILD_COMPONENTS:-OFF} -DENABLE_CCACHE=ON
   - echo "travis_fold:start:MAKE"
@@ -172,7 +173,7 @@ script:
   - echo "travis_fold:end:BENCHMARK"
   - ./example/build/osrm-example test/data/monaco.osrm
   # All tests assume to be run from the build directory
-  - pushd build
+  - pushd ${OSRM_BUILD_DIR}
   - ./unit_tests/library-tests ../test/data/monaco.osrm
   - ./unit_tests/extractor-tests
   - ./unit_tests/engine-tests

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -1,12 +1,12 @@
 DATA_NAME:=monaco
 DATA_URL:=https://s3.amazonaws.com/mapbox/osrm/testing/$(DATA_NAME).osm.pbf
 DATA_POLY_URL:=https://s3.amazonaws.com/mapbox/osrm/testing/$(DATA_NAME).poly
-TOOL_ROOT:=../../build
+OSRM_BUILD_DIR?=../../build
 PROFILE_ROOT:=../../profiles
 SCRIPT_ROOT:=../../scripts
-OSRM_EXTRACT:=$(TOOL_ROOT)/osrm-extract
-OSRM_CONTRACT:=$(TOOL_ROOT)/osrm-contract
-OSRM_ROUTED:=$(TOOL_ROOT)/osrm-routed
+OSRM_EXTRACT:=$(OSRM_BUILD_DIR)/osrm-extract
+OSRM_CONTRACT:=$(OSRM_BUILD_DIR)/osrm-contract
+OSRM_ROUTED:=$(OSRM_BUILD_DIR)/osrm-routed
 POLY2REQ:=$(SCRIPT_ROOT)/poly2req.js
 TIMER:=$(SCRIPT_ROOT)/timer.sh
 PROFILE:=$(PROFILE_ROOT)/car.lua


### PR DESCRIPTION
Our tests assume you are building osrm by doing:

```bash
mkdir build && cd build && cmake ../
```

But that `build` directory can be anything and our tests therefore should allow the developer to point at their chosen directory where the local build of osrm-backend exists.

The cucumber tests already provide an option to set this directory. They respond to the `OSRM_BUILD_DIR` environment setting: https://github.com/Project-OSRM/osrm-backend/blob/88208bfa5dffe9ee2c3f3a0decbf282dc697bb5b/features/support/env.js#L24.

However the test data setup does not allow customization of this variable. This PR fixes this by modifying the `test/data/Makefile` to respond to the `OSRM_BUILD_DIR` environment. It also starts customizing the build directory on travis to ensure this is tested and will fail if it regresses.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki) - https://github.com/Project-OSRM/osrm-backend/wiki/Building-OSRM/_compare/368ff3726f41b02ec305789cef000a6ed161582b...f53c239b0a91846dbbc569b8a541890801b32b32
