### PR TITLE
add low precision intersection_generator mode for faster graph traversal

### DIFF
--- a/include/extractor/guidance/coordinate_extractor.hpp
+++ b/include/extractor/guidance/coordinate_extractor.hpp
@@ -49,6 +49,17 @@ class CoordinateExtractor
     std::vector<util::Coordinate> GetForwardCoordinatesAlongRoad(const NodeID from,
                                                                  const EdgeID turn_edge) const;
 
+    // a less precise way to compute coordinates along a route. Due to the heavy interaction of
+    // graph traversal and turn instructions, we often don't care for high precision. We only want
+    // to check for available connections in order, or find (with room for error) the straightmost
+    // turn. This function will offer a bit more error potential but allow for much higher
+    // performance
+    OSRM_ATTR_WARN_UNUSED
+    util::Coordinate GetCoordinateCloseToTurn(const NodeID from_node,
+                                              const EdgeID turn_edge,
+                                              const bool traversed_in_reverse,
+                                              const NodeID to_node) const;
+
     /* When extracting the coordinates, we first extract all coordinates. We don't care about most
      * of them, though.
      *

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -51,8 +51,14 @@ class IntersectionGenerator
     // Check for restrictions/barriers and generate a list of valid and invalid turns present at
     // the node reached from `from_node` via `via_eid`. The resulting candidates have to be analysed
     // for their actual instructions later on.
+    // The switch for `use_low_precision_angles` enables a faster mode that will procude less
+    // accurate coordinates. It should be good enough to check order of turns, find striaghtmost
+    // turns. Even good enough to do some simple angle verifications. It is mostly available to
+    // allow for faster graph traversal in the extraction phase.
     OSRM_ATTR_WARN_UNUSED
-    Intersection GetConnectedRoads(const NodeID from_node, const EdgeID via_eid) const;
+    Intersection GetConnectedRoads(const NodeID from_node,
+                                   const EdgeID via_eid,
+                                   const bool use_low_precision_angles = false) const;
 
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;

--- a/src/extractor/guidance/turn_discovery.cpp
+++ b/src/extractor/guidance/turn_discovery.cpp
@@ -12,6 +12,11 @@ namespace guidance
 namespace lanes
 {
 
+namespace
+{
+const constexpr bool USE_LOW_PRECISION_MODE = true;
+}
+
 bool findPreviousIntersection(const NodeID node_v,
                               const EdgeID via_edge,
                               const Intersection intersection,
@@ -50,7 +55,8 @@ bool findPreviousIntersection(const NodeID node_v,
     // (looking at the reverse direction).
     const auto node_w = node_based_graph.GetTarget(via_edge);
     const auto u_turn_at_node_w = intersection[0].eid;
-    const auto node_v_reverse_intersection = intersection_generator(node_w, u_turn_at_node_w);
+    const auto node_v_reverse_intersection =
+        intersection_generator.GetConnectedRoads(node_w, u_turn_at_node_w, USE_LOW_PRECISION_MODE);
 
     // Continue along the straightmost turn. If there is no straight turn, we cannot find a valid
     // previous intersection.
@@ -64,8 +70,8 @@ bool findPreviousIntersection(const NodeID node_v,
         return false;
 
     const auto node_u = node_based_graph.GetTarget(straightmost_at_v_in_reverse->eid);
-    const auto node_u_reverse_intersection =
-        intersection_generator(node_v, straightmost_at_v_in_reverse->eid);
+    const auto node_u_reverse_intersection = intersection_generator.GetConnectedRoads(
+        node_v, straightmost_at_v_in_reverse->eid, USE_LOW_PRECISION_MODE);
 
     // now check that the u-turn at the given intersection connects to via-edge
     // The u-turn at the now found intersection should, hopefully, represent the previous edge.


### PR DESCRIPTION
# Issue

In the guidance code, we have quite a lot of situations that need to check connected road segments without need for exact turn angles with the need for the circular order.

This PR adds a low precision mode (using essentially the first non identical coordinate) to the intersection_generator to allow for faster graph traversal routines.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 should be useful to speed up https://github.com/Project-OSRM/osrm-backend/pull/3211

