### PR TITLE
Speed up osx builds: use Mason + Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ env:
    - CCACHE_COMPRESS=1
    - CASHER_TIME_OUT=599 # one second less than 10m to avoid 10m timeout error: https://github.com/Project-OSRM/osrm-backend/issues/2742
    - JOBS=4
+   - CCACHE_VERSION=3.3.1
+   - CMAKE_VERSION=3.6.2
 
 matrix:
   fast_finish: true
@@ -39,7 +41,7 @@ matrix:
       addons: &gcc6
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
+          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
       env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_COVERAGE=ON ENABLE_SANITIZER=ON BUILD_COMPONENTS=ON
 
     - os: linux
@@ -47,11 +49,12 @@ matrix:
       addons: &clang38
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
-      env: CLANG_VERSION='3.8.1' CLANG_PACKAGE="clang++" BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON BUILD_COMPONENTS=ON CUCUMBER_TIMEOUT=60000
+          packages: ['libstdc++-5-dev', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
+      env: CLANG_VERSION='3.8.1' BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON BUILD_COMPONENTS=ON CUCUMBER_TIMEOUT=60000
 
     - os: osx
-      osx_image: xcode8
+      # TODO: xcode8 triggers undefined symbol 'clock_gettime' in boost::interprocess
+      osx_image: xcode7.3
       compiler: clang
       env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++'
 
@@ -61,7 +64,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev', 'ccache']
+          packages: ['libstdc++-5-dev']
       env: BUILD_TYPE='Release' ENABLE_MASON=ON
 
     - os: linux
@@ -69,7 +72,7 @@ matrix:
       addons: &gcc6
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
+          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
       env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Release' BUILD_COMPONENTS=ON
 
     - os: linux
@@ -91,7 +94,7 @@ matrix:
       addons: &gcc6
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
+          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
       env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Release' BUILD_SHARED_LIBS=ON BUILD_COMPONENTS=ON
 
       # Disabled because CI slowness
@@ -108,16 +111,16 @@ before_install:
   - if [[ $(uname -s) == 'Darwin' ]]; then sudo mdutil -i off /; fi;
   - source ./scripts/install_node.sh 4
   - npm install
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - export PATH=${DEPS_DIR}/bin:${PATH} && mkdir -p ${DEPS_DIR}
-  - CMAKE_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/cmake/3.5.2.tar.gz"
-  - travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR} || exit 1
+  - ./third_party/mason/mason install ccache ${CCACHE_VERSION}
+  - export PATH=$(./third_party/mason/mason prefix ccache ${CCACHE_VERSION})/bin:${PATH}
+  - ./third_party/mason/mason install cmake ${CMAKE_VERSION}
+  - export PATH=$(./third_party/mason/mason prefix cmake ${CMAKE_VERSION})/bin:${PATH}
   - |
     if [[ ${CLANG_VERSION:-false} != false ]]; then
       export CCOMPILER='clang'
       export CXXCOMPILER='clang++'
-      CLANG_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/${CLANG_PACKAGE}/${CLANG_VERSION}.tar.gz"
-      travis_retry wget --quiet -O - ${CLANG_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR} || exit 1
+      ./third_party/mason/mason install clang++ ${CLANG_VERSION}
+      export PATH=$(./third_party/mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ matrix:
       env: CLANG_VERSION='3.8.1' CLANG_PACKAGE="clang++" BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON BUILD_COMPONENTS=ON CUCUMBER_TIMEOUT=60000
 
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       compiler: clang
-      env: CCOMPILER='clang' CXXCOMPILER='clang++' BUILD_TYPE='Debug' JOBS=1 CUCUMBER_TIMEOUT=60000
+      env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++'
 
     # Release Builds
     - os: linux
@@ -84,12 +84,6 @@ matrix:
       #-     sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
       #-     packages: ['clang-3.8', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
       #- env: CCOMPILER='clang-3.8' CXXCOMPILER='clang++-3.8' BUILD_TYPE='Release'
-
-      # Disabled because of CI slowness
-      #- os: osx
-      #- osx_image: xcode7.3
-      #- compiler: clang
-      #- env: CCOMPILER='clang' CXXCOMPILER='clang++' BUILD_TYPE='Release'
 
     # Shared Library
     - os: linux
@@ -124,11 +118,6 @@ before_install:
       export CXXCOMPILER='clang++'
       CLANG_URL="https://mason-binaries.s3.amazonaws.com/${TRAVIS_OS_NAME}-x86_64/${CLANG_PACKAGE}/${CLANG_VERSION}.tar.gz"
       travis_retry wget --quiet -O - ${CLANG_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR} || exit 1
-    fi
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      # implicit deps, but seem to be installed by default with recent images: libxml2 GDAL boost
-      brew install libzip libstxxl lua51 luabind tbb md5sha1sum ccache
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 

--- a/scripts/md5sum.js
+++ b/scripts/md5sum.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+'use strict'
+
+var crypto = require('crypto');
+var fs = require('fs');
+
+var idx = process.argv.indexOf('-c');
+if (idx > -1) {
+  var validate_file = process.argv[idx+1];
+  if (!process.argv[idx+1]) {
+      console.error('Please pass arg to -c with a path to the data.md5sum file used to validate');
+      process.exit(1);
+  }
+  validate(validate_file);
+} else {
+  // we are generating checksums for all filenames passed
+  var args = process.argv.slice(2);
+  if (args.length > 0) {
+      generate(args);
+  } else {
+      console.error('Please pass either a list of files to generate an md5sum for or validate with "-c data.md5sum"');
+      process.exit(1);
+  }
+}
+
+
+function md5FileSync (filename) {
+  var BUFFER_SIZE = 8192;
+  var fd = fs.openSync(filename, 'r');
+  var hash = crypto.createHash('md5');
+  var buffer = new Buffer(BUFFER_SIZE);
+
+  try {
+    var bytesRead;
+
+    do {
+      bytesRead = fs.readSync(fd, buffer, 0, BUFFER_SIZE);
+      hash.update(buffer.slice(0, bytesRead));
+    } while (bytesRead === BUFFER_SIZE)
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  return hash.digest('hex');
+}
+
+function generate(files) {
+  files.forEach(function(filename) {
+    var md5_actual = md5FileSync(filename);
+    console.log(md5_actual,'',filename);
+  })
+}
+
+function validate(validate_file) {
+
+  var sums = {};
+  var lines = fs.readFileSync(validate_file).
+    toString().
+    split('\n').
+    filter(function(line) {
+      return line !== "";
+  });
+
+  var error = 0;
+
+  lines.forEach(function(line) {
+      var parts = line.split('  ');
+      var filename = parts[1];
+      var md5 = parts[0];
+      sums[filename] = md5;
+      var md5_actual = md5FileSync(filename);
+      if (md5_actual !== md5) {
+          error++;
+          console.error(filename + ': FAILED')
+      } else {
+          console.log(filename + ': OK');
+      }
+  })
+
+  if (error > 0) {
+      console.error('ms5sum.js WARNING: 1 computed checksum did NOT match');
+      console.error('\nExpected:')
+      lines.forEach(function(line) {
+          var parts = line.split('  ');
+          var filename = parts[1];
+          var md5 = parts[0];
+          console.log(md5 + '  ' + filename);
+      })
+      process.exit(1);
+  } else {
+      process.exit(0);
+  }
+}

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -8,6 +8,7 @@ OSRM_EXTRACT:=$(TOOL_ROOT)/osrm-extract
 OSRM_CONTRACT:=$(TOOL_ROOT)/osrm-contract
 OSRM_ROUTED:=$(TOOL_ROOT)/osrm-routed
 POLY2REQ:=$(SCRIPT_ROOT)/poly2req.js
+MD5SUM:=$(SCRIPT_ROOT)/md5sum.js
 TIMER:=$(SCRIPT_ROOT)/timer.sh
 PROFILE:=$(PROFILE_ROOT)/car.lua
 
@@ -24,7 +25,7 @@ $(DATA_NAME).poly:
 
 $(DATA_NAME).osrm: $(DATA_NAME).osm.pbf $(DATA_NAME).poly $(PROFILE) $(OSRM_EXTRACT)
 	@echo "Verifiyng data file integrity..."
-	md5sum -c data.md5sum
+	$(MD5SUM) -c data.md5sum
 	@echo "Running osrm-extract..."
 	$(TIMER) "osrm-extract" $(OSRM_EXTRACT) $(DATA_NAME).osm.pbf -p $(PROFILE)
 
@@ -49,6 +50,6 @@ benchmark: $(DATA_NAME).requests osrm-routed.pid
 	@echo "****************"
 
 checksum:
-	md5sum $(DATA_NAME).osm.pbf $(DATA_NAME).poly > data.md5sum
+	$(MD5SUM) $(DATA_NAME).osm.pbf $(DATA_NAME).poly > data.md5sum
 
 .PHONY: clean checksum benchmark


### PR DESCRIPTION
As we know, OS X builds on travis are slow. Today [a build took 30 minutes](https://travis-ci.org/Project-OSRM/osrm-backend/jobs/174879851). For this build the longest running steps, sorted by time, are below:

 - 754s (npm test)
 - 235s (brew install)
 - 104s (make osrm-extract --jobs=3)
 - 98s (make --jobs=3)
 - 57s (npm install)
 - 47s (./unit_tests/util-tests)
 - 32s (make tests)
 - 32s (make install)

Of those the longest `npm test` is easy to improve upon. We can build in `Release` mode instead of `Debug` to ensure the tests run much faster. This PR therefore moves the `osx` build to `Release` mode.

Also, of those the second longest is also easy to improve upon. Instead of using `brew` we can use mason deps pulled from s3. This PR therefore moves the `osx` build to use mason.

## Tasklist
 - [x] review
 - [x] adjust for comments
