### PR TITLE
Flush stxxl vectors before using in PrepareData

### DIFF
--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -32,6 +32,7 @@ class ExtractionContainers
 #else
     const static unsigned stxxl_memory = ((sizeof(std::size_t) == 4) ? INT_MAX : UINT_MAX);
 #endif
+    void FlushVectors();
     void PrepareNodes();
     void PrepareRestrictions();
     void PrepareEdges(ScriptingEnvironment &scripting_environment);

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -125,6 +125,17 @@ ExtractionContainers::ExtractionContainers()
     name_offsets.push_back(0);
 }
 
+void ExtractionContainers::FlushVectors()
+{
+    used_node_id_list.flush();
+    all_nodes_list.flush();
+    all_edges_list.flush();
+    name_char_data.flush();
+    name_offsets.flush();
+    restrictions_list.flush();
+    way_start_end_id_list.flush();
+}
+
 /**
  * Processes the collected data and serializes it.
  * At this point nodes are still referenced by their OSM id.
@@ -144,6 +155,8 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
     file_out_stream.open(output_file_name.c_str(), std::ios::binary);
     const util::FingerPrint fingerprint = util::FingerPrint::GetValid();
     file_out_stream.write((char *)&fingerprint, sizeof(util::FingerPrint));
+
+    FlushVectors();
 
     PrepareNodes();
     WriteNodes(file_out_stream);


### PR DESCRIPTION
# Issue

In #3145 was reported an unrelated stxxl error that leads to a vectors inconsistency 
```
[extractor] Sorting edges by renumbered start ... [STXXL-ERRMSG] READ request submitted for a BID with a pending WRITE request
[STXXL-ERRMSG] READ request submitted for a BID with a pending WRITE request
[assert] /home/routeyou/osrm-5.4.1/src/extractor/extraction_containers.cpp:85
in: bool {anonymous}::CmpEdgeByInternalSourceTargetAndName::operator()(const value_type&, const value_type&) const: !name_offsets.empty() && name_offsets.back() == name_data.size()
terminate called without an active exception
Aborted
```
One reason could some pending write requests and flushing vectors before use could prevent the error.

I was not able to reproduce the issue even with simulated hdd stress, but as was reported by @bvbever with flushing vectors
```
name_offsets.size() = 159707417, name_offsets.back() = 738862466, name_data.size() = 738862466
```
and assertion https://github.com/Project-OSRM/osrm-backend/blob/master/src/extractor/extraction_containers.cpp#L90 passes.

/cc @bvbever

## Tasklist
 - [x] review
 - [x] adjust for comments


