### PR TITLE
Output newlines for each progress indicator when not on a tty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
       - Added support for turn penalties
     - Internals
       - Internal/Shared memory datafacades now share common memory layout and data loading code
+    - Misc
+      - Progress indicators now print newlines when stdout is not a TTY
 
 # 5.4.3
   - Changes from 5.4.2

--- a/include/util/isatty.hpp
+++ b/include/util/isatty.hpp
@@ -1,0 +1,32 @@
+#ifndef ISATTY_HPP
+#define ISATTY_HPP
+
+// For isatty()
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <unistd.h>
+#else
+#ifdef WIN32
+#include <io.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#error Unknown platform - don't know which header to include for isatty()
+#endif // win32
+#endif // unix
+
+#include <cstdio>
+
+namespace osrm
+{
+namespace util
+{
+
+// Returns true if stdout is a tty, false otherwise
+//   Useful for when you want to do something different when
+//   output is redirected to a logfile
+inline bool IsStdoutATTY() { return isatty(fileno(stdout)); }
+
+} // namespace util
+} // namespace osrm
+
+#endif

--- a/include/util/percent.hpp
+++ b/include/util/percent.hpp
@@ -4,6 +4,8 @@
 #include <atomic>
 #include <iostream>
 
+#include "util/isatty.hpp"
+
 namespace osrm
 {
 namespace util
@@ -71,6 +73,12 @@ class Percent
             {
                 std::cout << ".";
             }
+
+            // When not on a TTY, print newlines after each progress indicator so
+            // so that progress is visible to line-buffered logging systems
+            if (!IsStdoutATTY())
+                std::cout << std::endl;
+
             std::cout.flush();
         }
     }

--- a/src/util/simple_logger.cpp
+++ b/src/util/simple_logger.cpp
@@ -1,11 +1,5 @@
 #include "util/simple_logger.hpp"
-#ifdef _MSC_VER
-#include <io.h>
-#define isatty _isatty
-#define fileno _fileno
-#else
-#include <unistd.h>
-#endif
+#include "util/isatty.hpp"
 #include <cstdio>
 #include <iostream>
 #include <mutex>
@@ -77,7 +71,7 @@ SimpleLogger::~SimpleLogger()
     std::lock_guard<std::mutex> lock(get_mutex());
     if (!LogPolicy::GetInstance().IsMute())
     {
-        const bool is_terminal = static_cast<bool>(isatty(fileno(stdout)));
+        const bool is_terminal = IsStdoutATTY();
         switch (level)
         {
         case logWARNING:


### PR DESCRIPTION
# Issue

With long-running OSRM processing jobs, it's nice to see how far along things have got.
Currently, some of the very slow steps use the `Percent` class to output a sequence of dots and `N%` markers.

Unfortunately, many piped process perform line buffering, so when we've got a multi-hour long `osrm-contract` process running, we get nothing logged until we hit the 100% marker.

This change adds a newline after every progress marker, when the output is *not* a TTY (i.e. redirected to a file, or otherwise piped).  This causes progress markers to be visible in logfiles.  Behaviour when on a TTY is unchanged.

## Tasklist
 - [x] review
 - [x] adjust for comments
