### PR TITLE
fix getTurnDirection, widen `straight` range, adjust tests accordingly

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -724,11 +724,11 @@ Feature: Collapse
             | restriction | bc       | dc     | c        | no_right_turn |
 
         When I route I should get
-            | waypoints | route                 | turns                                          |
-            | a,g       | road,cross,cross      | depart,turn left,arrive                        |
-            | a,e       | road,road,road        | depart,continue slight right,arrive            |
+            | waypoints | route                 | turns                                      |
+            | a,g       | road,cross,cross      | depart,turn left,arrive                    |
+            | a,e       | road,road,road        | depart,continue straight,arrive            |
             # We should discuss whether the next item should be collapsed to depart,turn right,arrive.
-            | a,f       | road,road,cross,cross | depart,continue slight right,turn right,arrive |
+            | a,f       | road,road,cross,cross | depart,continue straight,turn right,arrive |
 
     Scenario: On-Off on Highway
         Given the node map
@@ -755,12 +755,13 @@ Feature: Collapse
     Scenario: Don't collapse going straight if actual turn
         Given the node map
             """
-              c e
-                d   f
-
+                e
+             c  |
+              \ d - - - f
+               \|
                 b
-
-
+                |
+                |
                 a
             """
 
@@ -771,10 +772,10 @@ Feature: Collapse
             | df    | right    | residential |
 
         When I route I should get
-            | waypoints | route                     | turns                                  |
-            | a,c       | main,main                 | depart,arrive                          |
-            | a,e       | main,straight,straight    | depart,turn straight,arrive            |
-            | a,f       | main,straight,right,right | depart,turn straight,turn right,arrive |
+            | waypoints | route                     | turns                                  | locations |
+            | a,c       | main,main                 | depart,arrive                          | a,c       |
+            | a,e       | main,straight,straight    | depart,turn straight,arrive            | a,b,e     |
+            | a,f       | main,straight,right,right | depart,turn straight,turn right,arrive | a,b,d,f   |
 
     Scenario: Entering a segregated road
         Given the node map

--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -773,7 +773,7 @@ Feature: Simple Turns
 
         When I route I should get
             | waypoints | route                   | turns                               |
-            | a,j       | Siemens,Siemens,Siemens | depart,continue slight right,arrive |
+            | a,j       | Siemens,Siemens,Siemens | depart,continue straight,arrive     |
             | a,g       | Siemens,Erna,Erna       | depart,new name slight left,arrive  |
             | g,j       | Erna,Siemens,Siemens    | depart,turn sharp left,arrive       |
             | g,a       | Erna,Siemens,Siemens    | depart,new name slight right,arrive |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -1373,5 +1373,5 @@ Feature: Simple Turns
             | kchm  | Alexanderstr  | primary   | yes    |
 
         When I route I should get
-            | waypoints | turns                           | route                                   |
-            | a,d       | depart,new name straight,arrive | Stralauer Str,Holzmarktstr,Holzmarktstr |
+            | waypoints | turns         | route                      |
+            | a,d       | depart,arrive | Stralauer Str,Holzmarktstr |

--- a/include/util/guidance/toolkit.hpp
+++ b/include/util/guidance/toolkit.hpp
@@ -3,6 +3,7 @@
 
 /* A set of tools required for guidance in both pre and post-processing */
 
+#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
 #include "extractor/suffix_table.hpp"
 #include "engine/guidance/route_step.hpp"
@@ -50,11 +51,11 @@ inline extractor::guidance::DirectionModifier::Enum getTurnDirection(const doubl
         return extractor::guidance::DirectionModifier::SharpRight;
     if (angle >= 60 && angle < 140)
         return extractor::guidance::DirectionModifier::Right;
-    if (angle >= 140 && angle < 170)
+    if (angle >= 140 && angle < 160)
         return extractor::guidance::DirectionModifier::SlightRight;
-    if (angle >= 165 && angle <= 195)
+    if (angle >= 160 && angle <= 200)
         return extractor::guidance::DirectionModifier::Straight;
-    if (angle > 190 && angle <= 220)
+    if (angle > 200 && angle <= 220)
         return extractor::guidance::DirectionModifier::SlightLeft;
     if (angle > 220 && angle <= 300)
         return extractor::guidance::DirectionModifier::Left;


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/3282

<img width="723" alt="screen shot 2016-11-11 at 11 34 58" src="https://cloud.githubusercontent.com/assets/12932279/20212403/491c5a3e-a803-11e6-8e8d-f780691909b8.png">

Turned out we had some inconsistent `if` conditions [here](https://github.com/Project-OSRM/osrm-backend/blob/12ded539aaba3f730638ab008db1a3ad3c0c345a/include/util/guidance/toolkit.hpp#L53-L57), resulting in this intersection not being identified as `straight` in the first place.

I widened the range for straight by `5` degree as well.

This required the adjustment of a few tests.

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?

