### PR TITLE
reserve when possible

### DIFF
--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -42,7 +42,8 @@ std::string modeToString(const extractor::TravelMode mode);
 
 } // namespace detail
 
-template <unsigned POLYLINE_PRECISION, typename ForwardIter> util::json::String makePolyline(ForwardIter begin, ForwardIter end)
+template <unsigned POLYLINE_PRECISION, typename ForwardIter>
+util::json::String makePolyline(ForwardIter begin, ForwardIter end)
 {
     return {encodePolyline<POLYLINE_PRECISION>(begin, end)};
 }

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -196,16 +196,16 @@ class RouteAPI : public BaseAPI
                 [this, &leg_geometry](const guidance::RouteStep &step) {
                     if (parameters.geometries == RouteParameters::GeometriesType::Polyline)
                     {
-                        return static_cast<util::json::Value>(
-                            json::makePolyline<100000>(leg_geometry.locations.begin() + step.geometry_begin,
-                                               leg_geometry.locations.begin() + step.geometry_end));
+                        return static_cast<util::json::Value>(json::makePolyline<100000>(
+                            leg_geometry.locations.begin() + step.geometry_begin,
+                            leg_geometry.locations.begin() + step.geometry_end));
                     }
 
                     if (parameters.geometries == RouteParameters::GeometriesType::Polyline6)
                     {
-                        return static_cast<util::json::Value>(
-                            json::makePolyline<1000000>(leg_geometry.locations.begin() + step.geometry_begin,
-                                               leg_geometry.locations.begin() + step.geometry_end));
+                        return static_cast<util::json::Value>(json::makePolyline<1000000>(
+                            leg_geometry.locations.begin() + step.geometry_begin,
+                            leg_geometry.locations.begin() + step.geometry_end));
                     }
 
                     BOOST_ASSERT(parameters.geometries == RouteParameters::GeometriesType::GeoJSON);

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -233,7 +233,6 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                 WaypointType::Arrive,
                 0};
 
-
     BOOST_ASSERT(!leg_geometry.locations.empty());
     steps.push_back(RouteStep{target_node.name_id,
                               facade.GetNameForID(target_node.name_id),

--- a/include/engine/polyline_compressor.hpp
+++ b/include/engine/polyline_compressor.hpp
@@ -3,8 +3,8 @@
 
 #include "util/coordinate.hpp"
 
-#include <boost/assert.hpp>
 #include <algorithm>
+#include <boost/assert.hpp>
 #include <string>
 #include <vector>
 
@@ -13,17 +13,17 @@ namespace osrm
 namespace engine
 {
 namespace detail
- {
- constexpr double POLYLINE_DECODING_PRECISION = 1e5;
- constexpr double POLYLINE_TO_COORDINATE = COORDINATE_PRECISION / POLYLINE_DECODING_PRECISION;
+{
+constexpr double POLYLINE_DECODING_PRECISION = 1e5;
+constexpr double POLYLINE_TO_COORDINATE = COORDINATE_PRECISION / POLYLINE_DECODING_PRECISION;
 
- std::string encode(std::vector<int> &numbers);
- }
+std::string encode(std::vector<int> &numbers);
+}
 using CoordVectorForwardIter = std::vector<util::Coordinate>::const_iterator;
 // Encodes geometry into polyline format.
 // See: https://developers.google.com/maps/documentation/utilities/polylinealgorithm
 
-template<unsigned POLYLINE_PRECISION=100000>
+template <unsigned POLYLINE_PRECISION = 100000>
 std::string encodePolyline(CoordVectorForwardIter begin, CoordVectorForwardIter end)
 {
     double coordinate_to_polyline = POLYLINE_PRECISION / COORDINATE_PRECISION;
@@ -39,7 +39,10 @@ std::string encodePolyline(CoordVectorForwardIter begin, CoordVectorForwardIter 
     int current_lat = 0;
     int current_lon = 0;
     std::for_each(
-        begin, end, [&delta_numbers, &current_lat, &current_lon, coordinate_to_polyline](const util::Coordinate loc) {
+        begin,
+        end,
+        [&delta_numbers, &current_lat, &current_lon, coordinate_to_polyline](
+            const util::Coordinate loc) {
             const int lat_diff =
                 std::round(static_cast<int>(loc.lat) * coordinate_to_polyline) - current_lat;
             const int lon_diff =

--- a/include/extractor/guidance/node_based_graph_walker.hpp
+++ b/include/extractor/guidance/node_based_graph_walker.hpp
@@ -87,7 +87,8 @@ struct LengthLimitedCoordinateAccumulator
 };
 
 /*
- * The SelectRoadByNameOnlyChoiceAndStraightness tries to follow a given name along a route. We offer methods to skip
+ * The SelectRoadByNameOnlyChoiceAndStraightness tries to follow a given name along a route. We
+ * offer methods to skip
  * over bridges/similar situations if desired, following narrow turns
  * This struct offers an example implementation of a possible road selector for traversing the
  * node-based graph using the NodeBasedGraphWalker
@@ -115,14 +116,13 @@ struct SelectRoadByNameOnlyChoiceAndStraightness
 // find the next intersection given a hop limit
 struct IntersectionFinderAccumulator
 {
-    IntersectionFinderAccumulator(const std::uint8_t hop_limit, const IntersectionGenerator &intersection_generator);
+    IntersectionFinderAccumulator(const std::uint8_t hop_limit,
+                                  const IntersectionGenerator &intersection_generator);
     // true if the path has traversed enough distance
     bool terminate();
 
     // update the accumulator
-    void update(const NodeID from_node,
-                const EdgeID via_edge,
-                const NodeID to_node);
+    void update(const NodeID from_node, const EdgeID via_edge, const NodeID to_node);
 
     std::uint8_t hops;
     const std::uint8_t hop_limit;
@@ -135,8 +135,6 @@ struct IntersectionFinderAccumulator
     EdgeID via_edge_id;
     Intersection intersection;
 };
-
-
 
 template <class accumulator_type, class selector_type>
 boost::optional<std::pair<NodeID, EdgeID>>

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -25,8 +25,8 @@ inline void print(const engine::guidance::RouteStep &step)
 {
     std::cout << static_cast<int>(step.maneuver.instruction.type) << " "
               << static_cast<int>(step.maneuver.instruction.direction_modifier) << "  "
-              << static_cast<int>(step.maneuver.waypoint_type) << " "
-              << step.maneuver.location << " "
+              << static_cast<int>(step.maneuver.waypoint_type) << " " << step.maneuver.location
+              << " "
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
               << "\n\tIntersections: " << step.intersections.size() << " [";
@@ -44,7 +44,8 @@ inline void print(const engine::guidance::RouteStep &step)
             std::cout << " " << (entry ? "true" : "false");
         std::cout << ")";
     }
-    std::cout << "] name[" << step.name_id << "]: " << step.name << " Ref: " << step.ref << " Pronunciation: " << step.pronunciation;
+    std::cout << "] name[" << step.name_id << "]: " << step.name << " Ref: " << step.ref
+              << " Pronunciation: " << step.pronunciation;
 }
 
 inline void print(const std::vector<engine::guidance::RouteStep> &steps)

--- a/include/util/guidance/bearing_class.hpp
+++ b/include/util/guidance/bearing_class.hpp
@@ -39,6 +39,8 @@ namespace guidance
 class BearingClass
 {
   public:
+    BearingClass();
+
     // Add a bearing to the set
     void add(const DiscreteBearing bearing);
 

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -818,7 +818,7 @@ void collapseTurnAt(std::vector<RouteStep> &steps,
 //
 bool isStaggeredIntersection(const RouteStep &previous, const RouteStep &current)
 {
-    //don't touch roundabouts
+    // don't touch roundabouts
     if (entersRoundabout(previous.maneuver.instruction) ||
         entersRoundabout(current.maneuver.instruction))
         return false;

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -56,6 +56,8 @@ Intersection IntersectionGenerator::GetConnectedRoads(const NodeID from_node,
 {
     Intersection intersection;
     const NodeID turn_node = node_based_graph.GetTarget(via_eid);
+    // reserve enough items (+ the possibly missing u-turn edge)
+    intersection.reserve(node_based_graph.GetOutDegree(turn_node) + 1);
     const NodeID only_restriction_to_node = [&]() {
         // If only restrictions refer to invalid ways somewhere far away, we rather ignore the
         // restriction than to not route over the intersection at all.

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -215,22 +215,21 @@ operator()(const NodeID, const EdgeID source_edge_id, Intersection intersection)
             const bool is_through_street =
                 !target_intersection.empty() && link_data.name_id != EMPTY_NAMEID &&
                 target_intersection.end() !=
-                    std::find_if(target_intersection.begin() + 1,
-                                 target_intersection.end(),
-                                 [this, &link_data](const ConnectedRoad &road) {
-                                     const auto &road_edge_data =
-                                         node_based_graph.GetEdgeData(road.eid);
+                    std::find_if(
+                        target_intersection.begin() + 1,
+                        target_intersection.end(),
+                        [this, &link_data](const ConnectedRoad &road) {
+                            const auto &road_edge_data = node_based_graph.GetEdgeData(road.eid);
 
-                                     const auto same_name =
-                                         road_edge_data.name_id != EMPTY_NAMEID &&
-                                         !util::guidance::requiresNameAnnounced(
-                                             road_edge_data.name_id,
-                                             link_data.name_id,
-                                             name_table,
-                                             street_name_suffix_table);
+                            const auto same_name =
+                                road_edge_data.name_id != EMPTY_NAMEID &&
+                                !util::guidance::requiresNameAnnounced(road_edge_data.name_id,
+                                                                       link_data.name_id,
+                                                                       name_table,
+                                                                       street_name_suffix_table);
 
-                                     return same_name;
-                                 });
+                            return same_name;
+                        });
 
             // if the sliproad candidate is a through street, we cannot handle it as a sliproad
             if (is_through_street)

--- a/src/extractor/guidance/turn_lane_data.cpp
+++ b/src/extractor/guidance/turn_lane_data.cpp
@@ -106,6 +106,7 @@ LaneDataVector laneDataFromDescription(TurnLaneDescription turn_lane_description
 
     // transform the map into the lane data vector
     LaneDataVector lane_data;
+    lane_data.reserve(lane_map.size());
     for (const auto tag : lane_map)
         lane_data.push_back({tag.first, tag.second.first, tag.second.second, false});
 

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -619,6 +619,8 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
     };
 
     LaneDataVector first, second;
+    first.reserve(turn_lane_data.size());
+    second.reserve(turn_lane_data.size());
     for (std::size_t lane = 0; lane < turn_lane_data.size(); ++lane)
     {
         if (matched_at_second[lane])

--- a/src/util/guidance/bearing_class.cpp
+++ b/src/util/guidance/bearing_class.cpp
@@ -11,6 +11,8 @@ namespace util
 namespace guidance
 {
 
+BearingClass::BearingClass() { available_bearings.reserve(10); }
+
 bool BearingClass::operator==(const BearingClass &other) const
 {
     BOOST_ASSERT(std::is_sorted(available_bearings.begin(), available_bearings.end()));

--- a/unit_tests/engine/geometry_string.cpp
+++ b/unit_tests/engine/geometry_string.cpp
@@ -65,7 +65,6 @@ BOOST_AUTO_TEST_CASE(encode)
     BOOST_CHECK_EQUAL(encodedPolyline, polyline);
 }
 
-
 BOOST_AUTO_TEST_CASE(encode6)
 {
     // Coordinates; these would be the coordinates we give the loc parameter,


### PR DESCRIPTION
# Issue

Improves the performance of extraction by reserving all vectors used.

Moves extraction timing from
```
real	3m0.669s
user	6m8.051s
sys	0m10.860s
```
to
```
real	2m53.581s
user	5m57.764s
sys	0m10.452s
```
on Baden Wuertemberg. I expect bigger impacts on the planet.
## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 none

