### PR TITLE
Allocates memory for the node info list upfront.

### DIFF
--- a/include/util/graph_loader.hpp
+++ b/include/util/graph_loader.hpp
@@ -81,6 +81,8 @@ NodeID loadNodesFromFile(std::istream &input_stream,
     input_stream.read(reinterpret_cast<char *>(&n), sizeof(NodeID));
     SimpleLogger().Write() << "Importing n = " << n << " nodes ";
 
+    node_array.reserve(n);
+
     extractor::ExternalMemoryNode current_node;
     for (NodeID i = 0; i < n; ++i)
     {


### PR DESCRIPTION
Turns out we were not doing this. Huh.

Callstack:
- https://github.com/Project-OSRM/osrm-backend/blob/78583d2c8c639466bdde01c848398b2a48b72f44/include/util/graph_loader.hpp#L65-L68
- https://github.com/Project-OSRM/osrm-backend/blob/538bbd47d1ee169764b66df3ef67ecfe131cdfec/src/extractor/extractor.cpp#L423-L424
- https://github.com/Project-OSRM/osrm-backend/blob/78583d2c8c639466bdde01c848398b2a48b72f44/src/extractor/extractor.cpp#L465-L466
- https://github.com/Project-OSRM/osrm-backend/blob/78583d2c8c639466bdde01c848398b2a48b72f44/src/extractor/extractor.cpp#L254-L261

## Tasklist
 - [ ] review
 - [ ] adjust for comments
