### PR TITLE
Fixes ODR Violation in Graph Loader, closes #3308

### DIFF
--- a/include/util/graph_loader.hpp
+++ b/include/util/graph_loader.hpp
@@ -32,8 +32,8 @@ namespace util
  * The since the restrictions reference nodes using their external node id,
  * we need to renumber it to the new internal id.
 */
-unsigned loadRestrictionsFromFile(std::istream &input_stream,
-                                  std::vector<extractor::TurnRestriction> &restriction_list)
+inline unsigned loadRestrictionsFromFile(std::istream &input_stream,
+                                         std::vector<extractor::TurnRestriction> &restriction_list)
 {
     const FingerPrint fingerprint_valid = FingerPrint::GetValid();
     FingerPrint fingerprint_loaded;
@@ -62,10 +62,10 @@ unsigned loadRestrictionsFromFile(std::istream &input_stream,
  *  - list of traffic lights
  *  - nodes indexed by their internal (non-osm) id
  */
-NodeID loadNodesFromFile(std::istream &input_stream,
-                         std::vector<NodeID> &barrier_node_list,
-                         std::vector<NodeID> &traffic_light_node_list,
-                         std::vector<extractor::QueryNode> &node_array)
+inline NodeID loadNodesFromFile(std::istream &input_stream,
+                                std::vector<NodeID> &barrier_node_list,
+                                std::vector<NodeID> &traffic_light_node_list,
+                                std::vector<extractor::QueryNode> &node_array)
 {
     const FingerPrint fingerprint_valid = FingerPrint::GetValid();
     FingerPrint fingerprint_loaded;
@@ -107,8 +107,8 @@ NodeID loadNodesFromFile(std::istream &input_stream,
 /**
  * Reads a .osrm file and produces the edges.
  */
-NodeID loadEdgesFromFile(std::istream &input_stream,
-                         std::vector<extractor::NodeBasedEdge> &edge_list)
+inline NodeID loadEdgesFromFile(std::istream &input_stream,
+                                std::vector<extractor::NodeBasedEdge> &edge_list)
 {
     EdgeID m;
     input_stream.read(reinterpret_cast<char *>(&m), sizeof(unsigned));


### PR DESCRIPTION
Undefined Behavior, we include the header in the internal datafacade header for example. Should be cherry-picked into master / 5.4 / 5.5 asap.

## Tasklist
 - [x] review
 - [x] adjust for comments