### PR TITLE
Refactor/performance improve

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -338,10 +338,10 @@ Feature: Collapse
         Given the node map
             """
               a f       g
-
-              b e
-
-
+              | |   . '
+              b-e '
+              / /
+             / /
             c d
             """
 
@@ -353,13 +353,13 @@ Feature: Collapse
             | ge    | primary | second | no     |
 
         When I route I should get
-            | waypoints | route               | turns                          |
-            | d,c       | first,first,first   | depart,continue uturn,arrive   |
-            | a,f       | first,first,first   | depart,continue uturn,arrive   |
-            | a,g       | first,second,second | depart,turn left,arrive        |
-            | d,g       | first,second,second | depart,turn right,arrive       |
-            | g,f       | second,first,first  | depart,turn right,arrive       |
-            | g,c       | second,first,first  | depart,end of road left,arrive |
+            | waypoints | route               | turns                        |
+            | d,c       | first,first,first   | depart,continue uturn,arrive |
+            | a,f       | first,first,first   | depart,continue uturn,arrive |
+            | a,g       | first,second,second | depart,turn left,arrive      |
+            | d,g       | first,second,second | depart,turn right,arrive     |
+            | g,f       | second,first,first  | depart,turn right,arrive     |
+            | g,c       | second,first,first  | depart,turn left,arrive      |
 
     Scenario: Do not collapse turning roads
         Given the node map

--- a/include/engine/datafacade/process_memory_datafacade.hpp
+++ b/include/engine/datafacade/process_memory_datafacade.hpp
@@ -3,8 +3,8 @@
 
 // implements all data storage when shared memory is _NOT_ used
 
-#include "engine/datafacade/contiguous_internalmem_datafacade_base.hpp"
 #include "storage/storage.hpp"
+#include "engine/datafacade/contiguous_internalmem_datafacade_base.hpp"
 
 namespace osrm
 {

--- a/include/extractor/extraction_way.hpp
+++ b/include/extractor/extraction_way.hpp
@@ -15,19 +15,18 @@ namespace extractor
 {
 namespace detail
 {
-    inline void maybeSetString(std::string &str, const char* value)
+inline void maybeSetString(std::string &str, const char *value)
+{
+    if (value == nullptr)
     {
-        if (value == nullptr)
-        {
-            str.clear();
-        }
-        else
-        {
-            str = std::string(value);
-        }
+        str.clear();
+    }
+    else
+    {
+        str = std::string(value);
     }
 }
-
+}
 
 /**
  * This struct is the direct result of the call to ```way_function```
@@ -67,18 +66,24 @@ struct ExtractionWay
     TravelMode get_backward_mode() const { return backward_travel_mode; }
 
     // wrappers to allow assigning nil (nullptr) to string values
-    void SetName(const char* value) { detail::maybeSetString(name, value); }
-    const char* GetName() const { return name.c_str(); }
-    void SetRef(const char* value) { detail::maybeSetString(ref, value); }
-    const char* GetRef() const { return ref.c_str(); }
-    void SetDestinations(const char* value) { detail::maybeSetString(destinations, value); }
-    const char* GetDestinations() const { return destinations.c_str(); }
-    void SetPronunciation(const char* value) { detail::maybeSetString(pronunciation, value); }
-    const char* GetPronunciation() const { return pronunciation.c_str(); }
-    void SetTurnLanesForward(const char* value) { detail::maybeSetString(turn_lanes_forward, value); }
-    const char* GetTurnLanesForward() const { return turn_lanes_forward.c_str(); }
-    void SetTurnLanesBackward(const char* value) { detail::maybeSetString(turn_lanes_backward, value); }
-    const char* GetTurnLanesBackward() const { return turn_lanes_backward.c_str(); }
+    void SetName(const char *value) { detail::maybeSetString(name, value); }
+    const char *GetName() const { return name.c_str(); }
+    void SetRef(const char *value) { detail::maybeSetString(ref, value); }
+    const char *GetRef() const { return ref.c_str(); }
+    void SetDestinations(const char *value) { detail::maybeSetString(destinations, value); }
+    const char *GetDestinations() const { return destinations.c_str(); }
+    void SetPronunciation(const char *value) { detail::maybeSetString(pronunciation, value); }
+    const char *GetPronunciation() const { return pronunciation.c_str(); }
+    void SetTurnLanesForward(const char *value)
+    {
+        detail::maybeSetString(turn_lanes_forward, value);
+    }
+    const char *GetTurnLanesForward() const { return turn_lanes_forward.c_str(); }
+    void SetTurnLanesBackward(const char *value)
+    {
+        detail::maybeSetString(turn_lanes_backward, value);
+    }
+    const char *GetTurnLanesBackward() const { return turn_lanes_backward.c_str(); }
 
     double forward_speed;
     double backward_speed;

--- a/include/extractor/guidance/coordinate_extractor.hpp
+++ b/include/extractor/guidance/coordinate_extractor.hpp
@@ -1,6 +1,7 @@
 #ifndef OSRM_EXTRACTOR_COORDINATE_EXTRACTOR_HPP_
 #define OSRM_EXTRACTOR_COORDINATE_EXTRACTOR_HPP_
 
+#include <utility>
 #include <vector>
 
 #include "extractor/compressed_edge_container.hpp"
@@ -28,6 +29,7 @@ class CoordinateExtractor
     /* Find a interpolated coordinate a long the compressed geometries. The desired coordinate
      * should be in a certain distance. This method is dedicated to find representative coordinates
      * at turns.
+     * Since we are computing the length of the segment anyhow, we also return it.
      */
     OSRM_ATTR_WARN_UNUSED
     util::Coordinate GetCoordinateAlongRoad(const NodeID intersection_node,
@@ -36,12 +38,23 @@ class CoordinateExtractor
                                             const NodeID to_node,
                                             const std::uint8_t number_of_in_lanes) const;
 
-    // instead of finding only a single coordinate, we can also list all coordinates along a road.
+    // same as above, only with precomputed coordinate vector (move it in)
     OSRM_ATTR_WARN_UNUSED
-    std::vector<util::Coordinate> GetCoordinatesAlongRoad(const NodeID intersection_node,
-                                                          const EdgeID turn_edge,
-                                                          const bool traversed_in_reverse,
-                                                          const NodeID to_node) const;
+    util::Coordinate
+    ExtractRepresentativeCoordinate(const NodeID intersection_node,
+                                    const EdgeID turn_edge,
+                                    const bool traversed_in_reverse,
+                                    const NodeID to_node,
+                                    const std::uint8_t intersection_lanes,
+                                    std::vector<util::Coordinate> coordinates) const;
+
+    // instead of finding only a single coordinate, we can also list all coordinates along a
+    // road.
+    OSRM_ATTR_WARN_UNUSED std::vector<util::Coordinate>
+    GetCoordinatesAlongRoad(const NodeID intersection_node,
+                            const EdgeID turn_edge,
+                            const bool traversed_in_reverse,
+                            const NodeID to_node) const;
 
     // wrapper in case of normal forward edges (traversed_in_reverse = false, to_node =
     // node_based_graph.GetTarget(turn_edge)

--- a/include/extractor/guidance/intersection.hpp
+++ b/include/extractor/guidance/intersection.hpp
@@ -9,6 +9,8 @@
 #include "util/node_based_graph.hpp"
 #include "util/typedefs.hpp" // EdgeID
 
+#include <boost/optional.hpp>
+
 namespace osrm
 {
 namespace extractor
@@ -53,10 +55,13 @@ struct ConnectedRoad final : public TurnOperation
 {
     using Base = TurnOperation;
 
-    ConnectedRoad(const TurnOperation turn, const bool entry_allowed = false);
+    ConnectedRoad(const TurnOperation turn,
+                  const bool entry_allowed = false,
+                  const boost::optional<double> segment_length = {});
 
     // a turn may be relevant to good instructions, even if we cannot enter the road
     bool entry_allowed;
+    boost::optional<double> segment_length;
 
     // used to sort the set of connected roads (we require sorting throughout turn handling)
     bool compareByAngle(const ConnectedRoad &other) const;

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -68,6 +68,9 @@ class TurnAnalysis
     std::vector<TurnOperation>
     transformIntersectionIntoTurns(const Intersection &intersection) const;
 
+    Intersection
+    assignTurnTypes(const NodeID from_node, const EdgeID via_eid, Intersection intersection) const;
+
     const IntersectionGenerator &GetIntersectionGenerator() const;
 
   private:
@@ -78,9 +81,6 @@ class TurnAnalysis
     const MotorwayHandler motorway_handler;
     const TurnHandler turn_handler;
     const SliproadHandler sliproad_handler;
-
-    Intersection
-    assignTurnTypes(const NodeID from_node, const EdgeID via_eid, Intersection intersection) const;
 
     // Utility function, setting basic turn types. Prepares for normal turn handling.
     Intersection

--- a/include/extractor/guidance/turn_discovery.hpp
+++ b/include/extractor/guidance/turn_discovery.hpp
@@ -22,7 +22,7 @@ namespace lanes
 bool findPreviousIntersection(
     const NodeID node,
     const EdgeID via_edge,
-    const Intersection intersection,
+    const Intersection &intersection,
     const IntersectionGenerator &intersection_generator,
     const util::NodeBasedDynamicGraph &node_based_graph, // query edge data
     // output parameters, will be in an arbitrary state on failure

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -134,11 +134,11 @@ struct DataLayout
     // Interface Similar to [ptr.align] but omits space computation.
     // The method can be removed and changed directly to an std::align
     // function call after dropping gcc < 5 support.
-    inline void* align(std::size_t align, std::size_t , void*& ptr) const noexcept
+    inline void *align(std::size_t align, std::size_t, void *&ptr) const noexcept
     {
         const auto intptr = reinterpret_cast<uintptr_t>(ptr);
         const auto aligned = (intptr - 1u + align) & -align;
-        return ptr = reinterpret_cast<void*>(aligned);
+        return ptr = reinterpret_cast<void *>(aligned);
     }
 
     inline void *GetAlignedBlockPtr(void *ptr, BlockID bid) const

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -19,7 +19,8 @@
 #include <string>
 #include <vector>
 
-static double search_radius_for_gps_radius(double gps_radius) {
+static double search_radius_for_gps_radius(double gps_radius)
+{
     // For a given GPS radius, determine the radius we need to search for candidate street segments
     // to have a 99.9% chance of finding the correct segment.
     // For more detail, see the analysis at https://github.com/Project-OSRM/osrm-backend/pull/3184

--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -56,12 +56,28 @@ CoordinateExtractor::GetCoordinateAlongRoad(const NodeID intersection_node,
                                             const NodeID to_node,
                                             const std::uint8_t intersection_lanes) const
 {
-    const auto considered_lanes =
-        (intersection_lanes == 0) ? ASSUMED_LANE_COUNT : intersection_lanes;
-
     // we first extract all coordinates from the road
     auto coordinates =
         GetCoordinatesAlongRoad(intersection_node, turn_edge, traversed_in_reverse, to_node);
+
+    return ExtractRepresentativeCoordinate(intersection_node,
+                                           turn_edge,
+                                           traversed_in_reverse,
+                                           to_node,
+                                           intersection_lanes,
+                                           std::move(coordinates));
+}
+
+util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
+    const NodeID intersection_node,
+    const EdgeID turn_edge,
+    const bool traversed_in_reverse,
+    const NodeID to_node,
+    const std::uint8_t intersection_lanes,
+    std::vector<util::Coordinate> coordinates) const
+{
+    const auto considered_lanes =
+        (intersection_lanes == 0) ? ASSUMED_LANE_COUNT : intersection_lanes;
 
     /* if we are looking at a straight line, we don't care where exactly the coordinate
      * is. Simply return the final coordinate. Turn angles/turn vectors are the same no matter which
@@ -406,10 +422,12 @@ CoordinateExtractor::GetCoordinatesAlongRoad(const NodeID intersection_node,
                            geometry.rend(),
                            std::back_inserter(result),
                            compressedGeometryToCoordinate);
+            BOOST_ASSERT(intersection_node < node_coordinates.size());
             result.push_back(node_coordinates[intersection_node]);
         }
         else
         {
+            BOOST_ASSERT(intersection_node < node_coordinates.size());
             result.push_back(node_coordinates[intersection_node]);
             std::transform(geometry.begin(),
                            geometry.end(),

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -17,8 +17,10 @@ namespace extractor
 namespace guidance
 {
 
-ConnectedRoad::ConnectedRoad(const TurnOperation turn, const bool entry_allowed)
-    : TurnOperation(turn), entry_allowed(entry_allowed)
+ConnectedRoad::ConnectedRoad(const TurnOperation turn,
+                             const bool entry_allowed,
+                             boost::optional<double> segment_length)
+    : TurnOperation(turn), entry_allowed(entry_allowed), segment_length(segment_length)
 {
 }
 

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -196,7 +196,7 @@ TurnLaneScenario TurnLaneHandler::deduceScenario(const NodeID at,
                                  previous_intersection))
     {
         extractLaneData(previous_via_edge, previous_description_id, previous_lane_data);
-        previous_intersection = turn_analysis.PostProcess(
+        previous_intersection = turn_analysis.assignTurnTypes(
             previous_node, previous_via_edge, std::move(previous_intersection));
         for (std::size_t road_index = 0; road_index < previous_intersection.size(); ++road_index)
         {
@@ -541,8 +541,9 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
     std::vector<bool> matched_at_second(turn_lane_data.size(), false);
 
     // find out about the next intersection. To check for valid matches, we also need the turn
-    // types
-    const auto next_intersection = turn_analysis(at, straightmost->eid);
+    // types. We can skip merging/angle adjustments, though
+    const auto next_intersection = turn_analysis.assignTurnTypes(
+        at, straightmost->eid, turn_analysis.GetIntersectionGenerator()(at, straightmost->eid));
 
     // check where we can match turn lanes
     std::size_t straightmost_tag_index = turn_lane_data.size();

--- a/src/server/request_handler.cpp
+++ b/src/server/request_handler.cpp
@@ -8,8 +8,8 @@
 #include "util/json_renderer.hpp"
 #include "util/simple_logger.hpp"
 #include "util/string_util.hpp"
-#include "util/typedefs.hpp"
 #include "util/timing_util.hpp"
+#include "util/typedefs.hpp"
 
 #include "engine/status.hpp"
 #include "osrm/osrm.hpp"
@@ -146,11 +146,11 @@ void RequestHandler::HandleRequest(const http::request &current_request, http::r
                 << 1900 + time_stamp->tm_year << " " << (time_stamp->tm_hour < 10 ? "0" : "")
                 << time_stamp->tm_hour << ":" << (time_stamp->tm_min < 10 ? "0" : "")
                 << time_stamp->tm_min << ":" << (time_stamp->tm_sec < 10 ? "0" : "")
-                << time_stamp->tm_sec << " "
-                << TIMER_MSEC(request_duration) << "ms " << current_request.endpoint.to_string() << " "
-                << current_request.referrer << (0 == current_request.referrer.length() ? "- " : " ")
-                << current_request.agent << (0 == current_request.agent.length() ? "- " : " ")
-                << current_reply.status << " " //
+                << time_stamp->tm_sec << " " << TIMER_MSEC(request_duration) << "ms "
+                << current_request.endpoint.to_string() << " " << current_request.referrer
+                << (0 == current_request.referrer.length() ? "- " : " ") << current_request.agent
+                << (0 == current_request.agent.length() ? "- " : " ") << current_reply.status
+                << " " //
                 << request_string;
         }
     }


### PR DESCRIPTION
# Issue

addressing performance overheads introduced in 5.5

The performance improvements are a result of a series of optimisations.
 - using a low precision coordinate mode (merged previously) for situations where the pure order of turns is enough
 - improved graph traversal (generate intermediate intersections only if necessary)
 - ordering of detectors in coordinate extraction for early exit on cheap tests
 - caching segment lengths during initial extraction to enable early exits on normalisation
 - skipping certain angle adjustments in post-processing when creating turn lane assignment (optimisation unnecessary here, since matching is fuzzy anyhow)
 - small performance bugs (copy instead of reference)

## Tasklist
 - [x] find out what breaks in the single test -> new interpretation of `obvious` results in not discovering end of road anymore
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
  none
