### PR TITLE
Add cache into scripting_environment (new behavior).

### DIFF
--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -16,7 +16,7 @@ namespace osrm
 {
 namespace extractor
 {
-
+class ScriptingEnvironment;
 /**
  * Uses external memory containers from stxxl to store all the data that
  * is collected by the extractor callbacks.
@@ -60,6 +60,10 @@ class ExtractionContainers
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;
+    // FIXME This map store the vector id for each osm_id contain in "all_nodes_list"
+    // FIXME add a lazy loading to init this cache when user need location on noderef
+    std::unordered_map<OSMNodeID, osmium::Location> nodeCache;
+
     unsigned max_internal_node_id;
 
     ExtractionContainers();
@@ -68,6 +72,9 @@ class ExtractionContainers
                      const std::string &output_file_name,
                      const std::string &restrictions_file_name,
                      const std::string &names_file_name);
+
+    void prepareCache();
+    void clearCache();
 };
 }
 }

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -5,6 +5,7 @@
 #include "extractor/internal_extractor_edge.hpp"
 #include "extractor/profile_properties.hpp"
 #include "extractor/restriction.hpp"
+#include "extractor/extraction_containers.hpp"
 
 #include <osmium/memory/buffer.hpp>
 
@@ -31,7 +32,7 @@ struct Coordinate;
 
 namespace extractor
 {
-
+class ExtractionContainers;
 class RestrictionParser;
 struct ExtractionNode;
 struct ExtractionWay;
@@ -65,6 +66,8 @@ class ScriptingEnvironment
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) = 0;
+
+    virtual void setupCache(std::unordered_map<OSMNodeID, osmium::Location> &cache) = 0;
 };
 }
 }

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -2,8 +2,8 @@
 #define SCRIPTING_ENVIRONMENT_LUA_HPP
 
 #include "extractor/scripting_environment.hpp"
-
 #include "extractor/raster_source.hpp"
+#include "extractor/extraction_containers.hpp"
 
 #include "util/lua_util.hpp"
 
@@ -67,6 +67,12 @@ class LuaScriptingEnvironment final : public ScriptingEnvironment
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) override;
+
+    void setupCache(std::unordered_map<OSMNodeID, osmium::Location> &cache) override;
+    // FIXME This is static because I don't know how to access to this in lua nodeRef class binding.
+    //static ExtractionContainers *extraction_containers;
+    //osmium::Location getLocation(osmium::NodeRef &nref);
+    static std::unordered_map<OSMNodeID, osmium::Location> nodeCache;
 
   private:
     void InitContext(LuaScriptingContext &context);

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -288,7 +288,6 @@ end
 -- abort early if this way is obviouslt not routable
 function initial_routability_check(way,result,data)
   data.speed_type = way:get_value_by_key('highway')
-
   return data.speed_type ~= nil or
          way:get_value_by_key('route') ~= nil or
          way:get_value_by_key('bridge') ~= nil
@@ -717,6 +716,15 @@ end
 
 -- main entry point for processsing a way
 function way_function(way, result)
+
+  -- Only for test, remove before merge.
+  print("way id : ", way:id());
+  for node in way:get_nodes() do
+   print("  node id  : ", node:id())
+   print("  node lat : ", node:location():lat())
+   print("  node lon : ", node:location():lon())
+  end
+
   -- intermediate values used during processing
   local data = {}
 

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -136,6 +136,22 @@ void ExtractionContainers::FlushVectors()
     way_start_end_id_list.flush();
 }
 
+void ExtractionContainers::prepareCache()
+{
+    nodeCache.reserve(all_nodes_list.size());
+    for(size_t i = 0; i < all_nodes_list.size(); i++)
+    {
+        //ExternalMemoryNode data = all_nodes_list[i];
+        osmium::Location location(static_cast<double>(util::toFloating(all_nodes_list[i].lon)), static_cast<double>(util::toFloating(all_nodes_list[i].lat)));
+        nodeCache.insert({OSMNodeID{static_cast<std::uint64_t>(all_nodes_list[i].node_id)}, location});
+    }
+}
+
+void ExtractionContainers::clearCache()
+{
+    nodeCache.clear();
+}
+
 /**
  * Processes the collected data and serializes it.
  * At this point nodes are still referenced by their OSM id.

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -197,6 +197,8 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         }
         nodeReader.close();
 
+        extraction_containers.prepareCache();
+
         // WAY AND RELATION PARSING
         osmium::io::Reader wayReader(input_file, osmium::osm_entity_bits::way | osmium::osm_entity_bits::relation, osmium::io::read_meta::no);
         while (const osmium::memory::Buffer buffer = wayReader.read())
@@ -231,6 +233,9 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
             }
         }
         TIMER_STOP(parsing);
+
+        // Clear cache data
+        extraction_containers.clearCache();
 
         util::SimpleLogger().Write() << "Parsing finished after " << TIMER_SEC(parsing)
                                      << " seconds";

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -198,6 +198,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         nodeReader.close();
 
         extraction_containers.prepareCache();
+        scripting_environment.setupCache(extraction_containers.nodeCache);
 
         // WAY AND RELATION PARSING
         osmium::io::Reader wayReader(input_file, osmium::osm_entity_bits::way | osmium::osm_entity_bits::relation, osmium::io::read_meta::no);

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -128,8 +128,8 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         auto extractor_callbacks = std::make_unique<ExtractorCallbacks>(extraction_containers);
 
         const osmium::io::File input_file(config.input_path.string());
-        osmium::io::Reader reader(input_file, osmium::io::read_meta::no);
-        const osmium::io::Header header = reader.header();
+        osmium::io::Reader nodeReader(input_file, osmium::osm_entity_bits::node, osmium::io::read_meta::no);
+        const osmium::io::Header header = nodeReader.header();
 
         unsigned number_of_nodes = 0;
         unsigned number_of_ways = 0;
@@ -167,7 +167,8 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         // setup restriction parser
         const RestrictionParser restriction_parser(scripting_environment);
 
-        while (const osmium::memory::Buffer buffer = reader.read())
+        // NODE PARSING
+        while (const osmium::memory::Buffer buffer = nodeReader.read())
         {
             // create a vector of iterators into the buffer
             std::vector<osmium::memory::Buffer::const_iterator> osm_elements;
@@ -178,8 +179,6 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
 
             // clear resulting vectors
             resulting_nodes.clear();
-            resulting_ways.clear();
-            resulting_restrictions.clear();
 
             scripting_environment.ProcessElements(osm_elements,
                                                   restriction_parser,
@@ -195,6 +194,30 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
                     static_cast<const osmium::Node &>(*(osm_elements[result.first])),
                     result.second);
             }
+        }
+        nodeReader.close();
+
+        // WAY AND RELATION PARSING
+        osmium::io::Reader wayReader(input_file, osmium::osm_entity_bits::way | osmium::osm_entity_bits::relation, osmium::io::read_meta::no);
+        while (const osmium::memory::Buffer buffer = wayReader.read())
+        {
+            // create a vector of iterators into the buffer
+            std::vector<osmium::memory::Buffer::const_iterator> osm_elements;
+            for (auto iter = std::begin(buffer), end = std::end(buffer); iter != end; ++iter)
+            {
+                osm_elements.push_back(iter);
+            }
+
+            // clear resulting vectors
+            resulting_ways.clear();
+            resulting_restrictions.clear();
+
+            scripting_environment.ProcessElements(osm_elements,
+                                                  restriction_parser,
+                                                  resulting_nodes,
+                                                  resulting_ways,
+                                                  resulting_restrictions);
+
             number_of_ways += resulting_ways.size();
             for (const auto &result : resulting_ways)
             {
@@ -208,6 +231,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
             }
         }
         TIMER_STOP(parsing);
+
         util::SimpleLogger().Write() << "Parsing finished after " << TIMER_SEC(parsing)
                                      << " seconds";
 


### PR DESCRIPTION
#3180

The purpose of this PR is to inject a cache into LuaScriptingEnvironment class to access at nodeRef location in .lua script.

@daniel-j-h,
This is my new cache system behavior. (I use the nodes saved in the ExtractionContainers).
I splited the read in two parts. Node reader and all other geometry reader.
Between this two loop, I feed a cache who contain all vector_id of node contains in ExtractionContainers for each osm_id.
I have always a problem to access to the cache in luabind. That is the reason the "ExtractionContainers" reference is static into LuaScriptingEnvironment class. I don't know what is the right way to do this.

One last thing, I will implement a lazy loader to feed the cache only when user need to access at "location" into lua script. What do you think about that ? 