### PR TITLE
Fix ubsan runtime error: left shift of negative value -9

### DIFF
--- a/src/engine/polyline_compressor.cpp
+++ b/src/engine/polyline_compressor.cpp
@@ -33,20 +33,16 @@ std::string encode(std::vector<int> &numbers)
     std::string output;
     for (auto &number : numbers)
     {
-        bool isNegative = number < 0;
-
-        if (isNegative)
+        if (number < 0)
         {
             const unsigned binary = std::llabs(number);
             const unsigned twos = (~binary) + 1u;
-            number = twos;
+            const unsigned shl = twos << 1u;
+            number = static_cast<int>(~shl);
         }
-
-        number <<= 1u;
-
-        if (isNegative)
+        else
         {
-            number = ~number;
+            number <<= 1u;
         }
     }
     for (const int number : numbers)


### PR DESCRIPTION
# Issue

Fixes #3222, a left shift of signed integer is undefined due to 5.8.2
Now unsigned 2's complement is shifted, inverted and statically casted to int.

Added also a check to avoid another UB in `m_lane_tuple_id_pairs[0]` if m_lane_tuple_id_pairs is empty.

## Tasklist
 - [x] review
 - [x] adjust for comments

