### PR TITLE
fixes warning due to type only used in debug

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -498,11 +498,9 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
         const auto name_blocks_count = name_file.ReadElementCount32();
         name_file.Skip<std::uint32_t>(1); // name_char_list_count
 
-        using NameRangeTable = util::RangeTable<16, true>;
-
         BOOST_ASSERT(name_blocks_count * sizeof(unsigned) ==
                      layout.GetBlockSize(DataLayout::NAME_OFFSETS));
-        BOOST_ASSERT(name_blocks_count * sizeof(typename NameRangeTable::BlockT) ==
+        BOOST_ASSERT(name_blocks_count * sizeof(typename util::RangeTable<16, true>::BlockT) ==
                      layout.GetBlockSize(DataLayout::NAME_BLOCKS));
 
         // Loading street names


### PR DESCRIPTION
# Issue

Building in release:
```
/Users/mokob/git/engine/project-osrm/osrm-backend/src/storage/storage.cpp:501:15: warning: unused type alias 'NameRangeTable' [-Wunused-local-typedef]
        using NameRangeTable = util::RangeTable<16, true>;
```

This warning is created since NameRangeTable is only used in an assertion right below.

This PR removes this additional Name in favour of reducing warnings.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none

