### PR TITLE
Conditionally checks std::is_trivially_copyable only if available.

### DIFF
--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -5,17 +5,18 @@
 #include "extractor/extractor.hpp"
 #include "extractor/original_edge_data.hpp"
 #include "extractor/query_node.hpp"
+#include "util/exception.hpp"
 #include "util/fingerprint.hpp"
 #include "util/simple_logger.hpp"
 #include "util/static_graph.hpp"
-#include "util/exception.hpp"
 
 #include <boost/filesystem/fstream.hpp>
 #include <boost/iostreams/seek.hpp>
 
-#include <tuple>
-#include <cstring>
 #include <cerrno>
+#include <cstring>
+#include <tuple>
+#include <type_traits>
 
 namespace osrm
 {
@@ -57,8 +58,11 @@ class FileReader
     /* Read count objects of type T into pointer dest */
     template <typename T> void ReadInto(T *dest, const std::size_t count)
     {
+#if not defined __GNUC__ or __GNUC__ > 4
         static_assert(std::is_trivially_copyable<T>::value,
                       "bytewise reading requires trivially copyable type");
+#endif
+
         if (count == 0)
             return;
 

--- a/include/util/guidance/entry_class.hpp
+++ b/include/util/guidance/entry_class.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <type_traits>
 
 #include <bitset>
 

--- a/include/util/isatty.hpp
+++ b/include/util/isatty.hpp
@@ -10,7 +10,7 @@
 #define isatty _isatty
 #define fileno _fileno
 #else
-#error Unknown platform - don't know which header to include for isatty()
+#error Unknown platform - isatty implementation required
 #endif // win32
 #endif // unix
 


### PR DESCRIPTION
Master doesn't build for some stdlibs since we merged the [datafacade changeset](https://github.com/Project-OSRM/osrm-backend/pull/3165).

Also a user [reported](https://github.com/Project-OSRM/osrm-backend/issues/3299#issuecomment-260940464) seeing a lot of

> /home/georgbachmann/osrm-backend/include/util/isatty.hpp:13:30: warning: missing terminating ' character
> #error Unknown platform - don't know which header to include for isatty()

warnings coming from the same changeset.

## Tasklist

 - [x] review
 - [x] adjust for comments
