### PR TITLE
Fix alignments in shared facade via alignof/std::align

### DIFF
--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -143,15 +143,12 @@ class FileReader
 // To make function calls consistent, this function returns the fixed number of properties
 inline std::size_t readPropertiesCount() { return 1; }
 
-#pragma pack(push, 1)
 struct HSGRHeader
 {
     std::uint32_t checksum;
     std::uint64_t number_of_nodes;
     std::uint64_t number_of_edges;
 };
-#pragma pack(pop)
-static_assert(sizeof(HSGRHeader) == 20, "HSGRHeader is not packed");
 
 // Reads the checksum, number of nodes and number of edges written in the header file of a `.hsgr`
 // file and returns them in a HSGRHeader struct

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -28,8 +28,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef STORAGE_HPP
 #define STORAGE_HPP
 
-#include "storage/storage_config.hpp"
 #include "storage/shared_datatype.hpp"
+#include "storage/storage_config.hpp"
 
 #include <boost/filesystem/path.hpp>
 

--- a/include/util/io.hpp
+++ b/include/util/io.hpp
@@ -14,8 +14,8 @@
 #include <stxxl/vector>
 #include <vector>
 
-#include "util/fingerprint.hpp"
 #include "storage/io.hpp"
+#include "util/fingerprint.hpp"
 
 namespace osrm
 {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -520,8 +520,7 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
         const auto name_char_ptr =
             layout.GetBlockPtr<char, true>(memory_ptr, DataLayout::NAME_CHAR_LIST);
 
-        BOOST_ASSERT_MSG(layout.AlignBlockSize(temp_count) ==
-                             layout.GetBlockSize(DataLayout::NAME_CHAR_LIST),
+        BOOST_ASSERT_MSG(temp_count == layout.GetBlockSize(DataLayout::NAME_CHAR_LIST),
                          "Name file corrupted!");
 
         name_file.ReadInto(name_char_ptr, temp_count);


### PR DESCRIPTION
# Issue

Related issue #3326 caused by fixed 4 bytes alignment in AlignBlockSize

DataLayout now stores also alignof T and uses it GetSizeOfLayout with an overhead of \sum alignof T that is of order 100 bytes. 

GetAlignedBlockPtr returns a pointer that meets alignment requirement for T in the corresponding bid.
Memory layout is

| padding for bid 1 | OSRM | aligned bid 1 data | OSRM | padding for bid 2 | OSRM | aligned bid 2 data | OSRM | ... | OSRM | some unused space  < 200 bytes |

To check osrm must be compiled with ubsan
```
CXXFLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer" cmake .. -DCMAKE_BUILD_TYPE=Debug
```

## Tasklist
 - [x] review
 - [x] adjust for comments


