### PR TITLE
Added a copy of std::align due to missing implementation in gcc < 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,14 @@ matrix:
       compiler: "gcc-6-release-i686"
       env: TARGET_ARCH='i686' CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Release'
 
+    - os: linux
+      compiler: "gcc-4.9-release"
+      addons: &gcc49
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-4.9', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev', 'ccache']
+      env: CCOMPILER='gcc-4.9' CXXCOMPILER='g++-4.9' BUILD_TYPE='Release'
+
       # Disabled because of CI slowness
       #- os: linux
       #- compiler: clang


### PR DESCRIPTION
# Issue

Due to missing implementation std::align in gcc 4.9 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57350#c8
own align is still needed. 
The method is directly copied from /usr/include/c++/6/memory but has no space computation support.

To check a new job with gcc 4.9 must added in .travis file.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Resolves #3334

References:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57350