### PR TITLE
Makes Throughput Numbers Integral Types

### DIFF
--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -6,11 +6,11 @@
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/node_based_edge.hpp"
 
+#include "storage/io.hpp"
 #include "util/exception.hpp"
 #include "util/graph_loader.hpp"
 #include "util/integer_range.hpp"
 #include "util/io.hpp"
-#include "storage/io.hpp"
 #include "util/simple_logger.hpp"
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
@@ -193,10 +193,14 @@ int Contractor::Run()
 
     TIMER_STOP(preparing);
 
+    const auto nodes_per_second =
+        static_cast<std::uint64_t>((max_edge_id + 1) / TIMER_SEC(contraction));
+    const auto edges_per_second =
+        static_cast<std::uint64_t>(number_of_used_edges / TIMER_SEC(contraction));
+
     util::SimpleLogger().Write() << "Preprocessing : " << TIMER_SEC(preparing) << " seconds";
-    util::SimpleLogger().Write() << "Contraction: " << ((max_edge_id + 1) / TIMER_SEC(contraction))
-                                 << " nodes/sec and "
-                                 << number_of_used_edges / TIMER_SEC(contraction) << " edges/sec";
+    util::SimpleLogger().Write() << "Contraction: " << nodes_per_second << " nodes/sec and "
+                                 << edges_per_second << " edges/sec";
 
     util::SimpleLogger().Write() << "finished preprocessing";
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -289,9 +289,13 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
 
         WriteEdgeBasedGraph(config.edge_graph_output_path, max_edge_id, edge_based_edge_list);
 
-        util::SimpleLogger().Write()
-            << "Expansion  : " << (number_of_node_based_nodes / TIMER_SEC(expansion))
-            << " nodes/sec and " << ((max_edge_id + 1) / TIMER_SEC(expansion)) << " edges/sec";
+        const auto nodes_per_second =
+            static_cast<std::uint64_t>(number_of_node_based_nodes / TIMER_SEC(expansion));
+        const auto edges_per_second =
+            static_cast<std::uint64_t>((max_edge_id + 1) / TIMER_SEC(expansion));
+
+        util::SimpleLogger().Write() << "Expansion: " << nodes_per_second << " nodes/sec and "
+                                     << edges_per_second << " edges/sec";
         util::SimpleLogger().Write() << "To prepare the data for routing, run: "
                                      << "./osrm-contract " << config.output_file_name << std::endl;
     }


### PR DESCRIPTION
Noticed this while having to look at our logs, otherwise you'd get floating point e-notation default printing.