### PR TITLE
Refactor/remember intersection shapes

### DIFF
--- a/features/guidance/advanced-lanes.feature
+++ b/features/guidance/advanced-lanes.feature
@@ -72,16 +72,16 @@ Feature: Turn Lane Guidance
         Given the node map
             """
                           e
-            a     b       c g
-                          d
-                          f
-
-
-
-
-
-
-            i     h       j
+            a - - b.-.- - c-g
+                  |    ' 'd
+                  |       f
+                  |
+                  |
+                  |
+                  |
+                  |
+                  |
+            i - - h - - - j
             """
 
         And the ways

--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -10,12 +10,12 @@ Feature: Simple Turns
             """
               a
               b
-
-
+              ^
+             / \
             c   d
-
-                  e
-
+                |\
+                | e
+                |
                 f
             """
 
@@ -96,16 +96,16 @@ Feature: Simple Turns
         Given the node map
             """
               a
-
-              b
+              |
+             .b.
             c   h
-
-
+            |   |
+            |   |
             1   2
-
+            |   |
             d   g
-              e
-
+             'e'
+              |
               f
             """
 

--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -443,9 +443,9 @@ Feature: Simple Turns
             | ef      | residential  | road | 2     | yes    |
 
        When I route I should get
-            | waypoints | route          | turns                        |
-            | g,f       | turn,road      | depart,arrive                |
-            | c,f       | road,road,road | depart,continue right,arrive |
+            | waypoints | route          | turns                        | locations |
+            | g,f       | turn,road,road | depart,turn left,arrive      | g,e,f     |
+            | c,f       | road,road,road | depart,continue right,arrive | c,b,f     |
 
     #http://www.openstreetmap.org/search?query=52.479264%2013.295617#map=19/52.47926/13.29562
     Scenario: Splitting Roads with curved split

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -116,24 +116,25 @@ Feature: Turn Lane Guidance
     Scenario: Basic Turn Lane 4-Way With U-Turn Lane
         Given the node map
             """
-                e
-            a 1 b   c
-                d
+                   e
+            f  a-1-b---c
+                   d
             """
 
         And the ways
-            | nodes  | turn:lanes     | turn:lanes:forward          | name     |
-            | ab     |                | reverse;left\|through;right | in       |
-            | bc     |                |                             | straight |
-            | bd     |                |                             | right    |
-            | be     |                |                             | left     |
+            | nodes  | turn:lanes     | turn:lanes:forward          | name          | #                                                                |
+            | ab     |                | reverse;left\|through;right | in            |                                                                  |
+            | bc     |                |                             | straight      |                                                                  |
+            | bd     |                |                             | right         |                                                                  |
+            | be     |                |                             | left          |                                                                  |
+            | fa     |                |                             | uturn-avoider | #due to https://github.com/Project-OSRM/osrm-backend/issues/3359 |
 
        When I route I should get
-            | from | to | bearings        | route                | turns                           | lanes                                  |
-            | a    | c  | 180,180 180,180 | in,straight,straight | depart,new name straight,arrive | ,left;uturn:false straight;right:true, |
-            | a    | d  | 180,180 180,180 | in,right,right       | depart,turn right,arrive        | ,left;uturn:false straight;right:true, |
-            | a    | e  | 180,180 180,180 | in,left,left         | depart,turn left,arrive         | ,left;uturn:true straight;right:false, |
-            | 1    | a  | 90,2 270,2      | in,in,in             | depart,turn uturn,arrive        | ,left;uturn:true straight;right:false, |
+            | from | to | bearings        | route                | turns                           | lanes                                  | locations |
+            | a    | c  | 180,180 180,180 | in,straight,straight | depart,new name straight,arrive | ,left;uturn:false straight;right:true, | a,b,c     |
+            | a    | d  | 180,180 180,180 | in,right,right       | depart,turn right,arrive        | ,left;uturn:false straight;right:true, | a,b,d     |
+            | a    | e  | 180,180 180,180 | in,left,left         | depart,turn left,arrive         | ,left;uturn:true straight;right:false, | a,b,e     |
+            | 1    | a  | 90,2 270,2      | in,in,in             | depart,turn uturn,arrive        | ,left;uturn:true straight;right:false, | _,b,a     |
 
 
     #this next test requires decision on how to announce lanes for going straight if there is no turn

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -1179,8 +1179,8 @@ Feature: Simple Turns
      Scenario: Obvious Index wigh very narrow turn to the right
         Given the node map
             """
-            a   b           c
-                            d
+            a - b -.-.- - - c
+                       ' ' 'd
             """
 
         And the ways
@@ -1198,8 +1198,8 @@ Feature: Simple Turns
      Scenario: Obvious Index wigh very narrow turn to the right
         Given the node map
             """
-            a   b           c
-                    e       d f
+            a - b - . -.- - c
+                    e - -'-'d-f
             """
 
         And the ways
@@ -1218,8 +1218,8 @@ Feature: Simple Turns
     Scenario: Obvious Index wigh very narrow turn to the left
         Given the node map
             """
-                            d
-            a   b           c
+                       . . .d
+            a - b -'-'- - - c
             """
 
         And the ways
@@ -1237,8 +1237,8 @@ Feature: Simple Turns
      Scenario: Obvious Index wigh very narrow turn to the left
         Given the node map
             """
-                    e       d f
-            a   b           c
+                    e - -.- d-f
+            a - b - ' - - - c
             """
 
         And the ways

--- a/include/contractor/query_edge.hpp
+++ b/include/contractor/query_edge.hpp
@@ -26,6 +26,9 @@ struct QueryEdge
             forward = other.forward;
             backward = other.backward;
         }
+        // this ID is either the middle node of the shortcut, or the ID of the edge based node (node
+        // based edge) storing the appropriate data. If `shortcut` is set to true, we get the middle
+        // node. Otherwise we see the edge based node to access node data.
         NodeID id : 31;
         bool shortcut : 1;
         int weight : 30;

--- a/include/extractor/edge_based_edge.hpp
+++ b/include/extractor/edge_based_edge.hpp
@@ -3,6 +3,7 @@
 
 #include "extractor/travel_mode.hpp"
 #include "util/typedefs.hpp"
+#include <tuple>
 
 namespace osrm
 {
@@ -60,19 +61,12 @@ inline EdgeBasedEdge::EdgeBasedEdge(const NodeID source,
 
 inline bool EdgeBasedEdge::operator<(const EdgeBasedEdge &other) const
 {
-    if (source == other.source)
-    {
-        if (target == other.target)
-        {
-            if (weight == other.weight)
-            {
-                return forward && backward && ((!other.forward) || (!other.backward));
-            }
-            return weight < other.weight;
-        }
-        return target < other.target;
-    }
-    return source < other.source;
+    const auto unidirectional = (!forward || !backward);
+    const auto other_is_unidirectional = (!other.forward || !other.backward);
+    // if all items are the same, we want to keep bidirectional edges. due to the `<` operator,
+    // preferring 0 (false) over 1 (true), we need to compare the inverse of `bidirectional`
+    return std::tie(source, target, weight, unidirectional) <
+           std::tie(other.source, other.target, other.weight, other_is_unidirectional);
 }
 } // ns extractor
 } // ns osrm

--- a/include/extractor/guidance/coordinate_extractor.hpp
+++ b/include/extractor/guidance/coordinate_extractor.hpp
@@ -38,7 +38,8 @@ class CoordinateExtractor
                                             const NodeID to_node,
                                             const std::uint8_t number_of_in_lanes) const;
 
-    // same as above, only with precomputed coordinate vector (move it in)
+    // Given a set of precomputed coordinates, select the representative coordinate along the road
+    // that best describes the turn
     OSRM_ATTR_WARN_UNUSED
     util::Coordinate
     ExtractRepresentativeCoordinate(const NodeID intersection_node,
@@ -240,6 +241,14 @@ class CoordinateExtractor
                         const double segment_length,
                         const std::vector<double> &segment_distances,
                         const std::uint8_t considered_lanes) const;
+
+    // find the coordinate at a specific location in the vector
+    util::Coordinate ExtractCoordinateAtLength(const double distance,
+                                               const std::vector<util::Coordinate> &coordinates,
+                                               const std::vector<double> &length_cache) const;
+    util::Coordinate
+    ExtractCoordinateAtLength(const double distance,
+                              const std::vector<util::Coordinate> &coordinates) const;
 };
 
 } // namespace guidance

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -11,7 +11,10 @@
 #include "util/typedefs.hpp"
 
 #include <unordered_set>
+#include <utility>
 #include <vector>
+
+#include <boost/optional.hpp>
 
 namespace osrm
 {
@@ -32,7 +35,18 @@ class IntersectionGenerator
                           const std::vector<QueryNode> &node_info_list,
                           const CompressedEdgeContainer &compressed_edge_container);
 
-    Intersection operator()(const NodeID nid, const EdgeID via_eid) const;
+    IntersectionView operator()(const NodeID nid, const EdgeID via_eid) const;
+
+    /*
+     * Compute the shape of an intersection, returning a set of connected roads, without any further
+     * concern for which of the entries are actually allowed.
+     * The shape also only comes with turn bearings, not with turn angles. All turn angles will be
+     * set to zero
+     */
+    IntersectionShape
+    ComputeIntersectionShape(const NodeID center_node,
+                             const boost::optional<NodeID> sorting_base = boost::none,
+                             bool use_low_precision_angles = false) const;
 
     // Graph Compression cannot compress every setting. For example any barrier/traffic light cannot
     // be compressed. As a result, a simple road of the form `a ----- b` might end up as having an
@@ -40,10 +54,10 @@ class IntersectionGenerator
     // down a road, finding the next actual decision requires the look at multiple intersections.
     // Here we follow the road until we either reach a dead end or find the next intersection with
     // more than a single next road.
-    Intersection GetActualNextIntersection(const NodeID starting_node,
-                                           const EdgeID via_edge,
-                                           NodeID *resulting_from_node,
-                                           EdgeID *resulting_via_edge) const;
+    IntersectionView GetActualNextIntersection(const NodeID starting_node,
+                                               const EdgeID via_edge,
+                                               NodeID *resulting_from_node,
+                                               EdgeID *resulting_via_edge) const;
 
     // Allow access to the coordinate extractor for all owners
     const CoordinateExtractor &GetCoordinateExtractor() const;
@@ -56,9 +70,28 @@ class IntersectionGenerator
     // turns. Even good enough to do some simple angle verifications. It is mostly available to
     // allow for faster graph traversal in the extraction phase.
     OSRM_ATTR_WARN_UNUSED
-    Intersection GetConnectedRoads(const NodeID from_node,
-                                   const EdgeID via_eid,
-                                   const bool use_low_precision_angles = false) const;
+    IntersectionView GetConnectedRoads(const NodeID from_node,
+                                       const EdgeID via_eid,
+                                       const bool use_low_precision_angles = false) const;
+
+    /*
+     * To be used in the road network, we need to check for valid/restricted turns. These two
+     * functions transform a basic intersection / a normalised intersection into the
+     * correct view when entering via a given edge.
+     */
+    OSRM_ATTR_WARN_UNUSED
+    IntersectionView
+    TransformIntersectionShapeIntoView(const NodeID previous_node,
+                                       const EdgeID entering_via_edge,
+                                       const IntersectionShape &intersection) const;
+    // version for normalised intersection
+    OSRM_ATTR_WARN_UNUSED
+    IntersectionView TransformIntersectionShapeIntoView(
+        const NodeID previous_node,
+        const EdgeID entering_via_edge,
+        const IntersectionShape &normalised_intersection,
+        const IntersectionShape &intersection,
+        const std::vector<std::pair<EdgeID, EdgeID>> &merging_map) const;
 
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;
@@ -68,6 +101,14 @@ class IntersectionGenerator
 
     // own state, used to find the correct coordinates along a road
     const CoordinateExtractor coordinate_extractor;
+
+    // check turn restrictions to find a node that is the only allowed target when coming from a
+    // node to an intersection
+    //     d
+    //     |
+    // a - b - c  and `only_straight_on ab | bc would return `c` for `a,b`
+    boost::optional<NodeID> GetOnlyAllowedTurnIfExistent(const NodeID coming_from_node,
+                                                         const NodeID node_at_intersection) const;
 };
 
 } // namespace guidance

--- a/include/extractor/guidance/node_based_graph_walker.hpp
+++ b/include/extractor/guidance/node_based_graph_walker.hpp
@@ -133,7 +133,7 @@ struct IntersectionFinderAccumulator
     // the result we are looking for
     NodeID nid;
     EdgeID via_edge_id;
-    Intersection intersection;
+    IntersectionView intersection;
 };
 
 template <class accumulator_type, class selector_type>

--- a/include/extractor/guidance/turn_discovery.hpp
+++ b/include/extractor/guidance/turn_discovery.hpp
@@ -28,7 +28,7 @@ bool findPreviousIntersection(
     // output parameters, will be in an arbitrary state on failure
     NodeID &result_node,
     EdgeID &result_via_edge,
-    Intersection &result_intersection);
+    IntersectionView &result_intersection);
 
 } // namespace lanes
 } // namespace guidance

--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -73,8 +73,9 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
 
 inline NodeBasedEdge::NodeBasedEdge()
     : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight(0), forward(false),
-      backward(false), roundabout(false), circular(false), access_restricted(false), startpoint(true),
-      is_split(false), travel_mode(false), lane_description_id(INVALID_LANE_DESCRIPTIONID)
+      backward(false), roundabout(false), circular(false), access_restricted(false),
+      startpoint(true), is_split(false), travel_mode(false),
+      lane_description_id(INVALID_LANE_DESCRIPTIONID)
 {
 }
 
@@ -93,9 +94,10 @@ inline NodeBasedEdge::NodeBasedEdge(NodeID source,
                                     const LaneDescriptionID lane_description_id,
                                     guidance::RoadClassification road_classification)
     : source(source), target(target), name_id(name_id), weight(weight), forward(forward),
-      backward(backward), roundabout(roundabout), circular(circular), access_restricted(access_restricted),
-      startpoint(startpoint), is_split(is_split), travel_mode(travel_mode),
-      lane_description_id(lane_description_id), road_classification(std::move(road_classification))
+      backward(backward), roundabout(roundabout), circular(circular),
+      access_restricted(access_restricted), startpoint(startpoint), is_split(is_split),
+      travel_mode(travel_mode), lane_description_id(lane_description_id),
+      road_classification(std::move(road_classification))
 {
 }
 

--- a/include/util/bearing.hpp
+++ b/include/util/bearing.hpp
@@ -8,9 +8,9 @@ namespace osrm
 {
 namespace util
 {
-
 namespace bearing
 {
+
 inline std::string get(const double heading)
 {
     BOOST_ASSERT(heading >= 0);
@@ -96,8 +96,40 @@ inline double reverseBearing(const double bearing)
         return bearing - 180.;
     return bearing + 180;
 }
+
+// Compute the angle between two bearings on a normal turn circle
+//
+//      Bearings                      Angles
+//
+//         0                           180
+//   315         45               225       135
+//
+// 270     x       90           270     x      90
+//
+//   225        135               315        45
+//        180                           0
+//
+// A turn from north to north-east offerst bearing 0 and 45 has to be translated
+// into a turn of 135 degrees. The same holdes for 90 - 135 (east to south
+// east).
+// For north, the transformation works by angle = 540 (360 + 180) - exit_bearing
+// % 360;
+// All other cases are handled by first rotating both bearings to an
+// entry_bearing of 0.
+inline double angleBetweenBearings(const double entry_bearing, const double exit_bearing)
+{
+    const double offset = 360 - entry_bearing;
+    const double rotated_exit = [](double bearing, const double offset) {
+        bearing += offset;
+        return bearing > 360 ? bearing - 360 : bearing;
+    }(exit_bearing, offset);
+
+    const auto angle = 540 - rotated_exit;
+    return angle >= 360 ? angle - 360 : angle;
 }
-}
-}
+
+} // namespace bearing
+} // namespace util
+} // namespace osrm
 
 #endif // BEARING_HPP

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -363,25 +363,60 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
     bearing_class_by_node_based_node.resize(m_node_based_graph->GetNumberOfNodes(),
                                             std::numeric_limits<std::uint32_t>::max());
 
-    for (const auto node_u : util::irange(0u, m_node_based_graph->GetNumberOfNodes()))
+    // going over all nodes (which form the center of an intersection), we compute all
+    // possible turns along these intersections.
+    for (const auto node_at_center_of_intersection :
+         util::irange(0u, m_node_based_graph->GetNumberOfNodes()))
     {
-        progress.PrintStatus(node_u);
-        for (const EdgeID edge_from_u : m_node_based_graph->GetAdjacentEdgeRange(node_u))
-        {
-            if (m_node_based_graph->GetEdgeData(edge_from_u).reversed)
-            {
-                continue;
-            }
+        progress.PrintStatus(node_at_center_of_intersection);
 
-            const NodeID node_v = m_node_based_graph->GetTarget(edge_from_u);
+        const auto shape_result =
+            turn_analysis.ComputeIntersectionShapes(node_at_center_of_intersection);
+
+        // all nodes in the graph are connected in both directions. We check all outgoing nodes to
+        // find the incoming edge. This is a larger search overhead, but the cost we need to pay to
+        // generate edges here is worth the additional search overhead.
+        //
+        // a -> b <-> c
+        //      |
+        //      v
+        //      d
+        //
+        // will have:
+        // a: b,rev=0
+        // b: a,rev=1 c,rev=0 d,rev=0
+        // c: b,rev=0
+        //
+        // From the flags alone, we cannot determine which nodes are connected to `b` by an outgoing
+        // edge. Therefore, we have to search all connected edges for edges entering `b`
+        for (const EdgeID outgoing_edge :
+             m_node_based_graph->GetAdjacentEdgeRange(node_at_center_of_intersection))
+        {
+            const NodeID node_along_road_entering = m_node_based_graph->GetTarget(outgoing_edge);
+
+            const auto incoming_edge = m_node_based_graph->FindEdge(node_along_road_entering,
+                                                                    node_at_center_of_intersection);
+
+            if (m_node_based_graph->GetEdgeData(incoming_edge).reversed)
+                continue;
+
             ++node_based_edge_counter;
-            auto intersection = turn_analysis(node_u, edge_from_u);
+
+            auto intersection_with_flags_and_angles =
+                turn_analysis.GetIntersectionGenerator().TransformIntersectionShapeIntoView(
+                    node_along_road_entering,
+                    incoming_edge,
+                    shape_result.normalised_intersection_shape,
+                    shape_result.intersection_shape,
+                    shape_result.merging_map);
+
+            auto intersection = turn_analysis.AssignTurnTypes(
+                node_along_road_entering, incoming_edge, intersection_with_flags_and_angles);
+
             BOOST_ASSERT(intersection.valid());
 
-            intersection =
-                turn_lane_handler.assignTurnLanes(node_u, edge_from_u, std::move(intersection));
-
-            const auto possible_turns = turn_analysis.transformIntersectionIntoTurns(intersection);
+            intersection = turn_lane_handler.assignTurnLanes(
+                node_along_road_entering, incoming_edge, std::move(intersection));
 
             // the entry class depends on the turn, so we have to classify the interesction for
             // every edge
@@ -412,12 +447,16 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     return bearing_class_hash.find(bearing_class)->second;
                 }
             }(turn_classification.second);
-            bearing_class_by_node_based_node[node_v] = bearing_class_id;
+            bearing_class_by_node_based_node[node_at_center_of_intersection] = bearing_class_id;
 
-            for (const auto turn : possible_turns)
+            for (const auto &turn : intersection)
             {
+                // only keep valid turns
+                if (!turn.entry_allowed)
+                    continue;
+
                 // only add an edge if turn is not prohibited
-                const EdgeData &edge_data1 = m_node_based_graph->GetEdgeData(edge_from_u);
+                const EdgeData &edge_data1 = m_node_based_graph->GetEdgeData(incoming_edge);
                 const EdgeData &edge_data2 = m_node_based_graph->GetEdgeData(turn.eid);
 
                 BOOST_ASSERT(edge_data1.edge_id != edge_data2.edge_id);
@@ -426,7 +465,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
                 // the following is the core of the loop.
                 unsigned distance = edge_data1.distance;
-                if (m_traffic_lights.find(node_v) != m_traffic_lights.end())
+                if (m_traffic_lights.find(node_at_center_of_intersection) != m_traffic_lights.end())
                 {
                     distance += profile_properties.traffic_signal_penalty;
                 }
@@ -435,7 +474,6 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     scripting_environment.GetTurnPenalty(180. - turn.angle);
 
                 const auto turn_instruction = turn.instruction;
-
                 if (turn_instruction.direction_modifier == guidance::DirectionModifier::UTurn)
                 {
                     distance += profile_properties.u_turn_penalty;
@@ -447,16 +485,16 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     distance += turn_penalty;
 
                 const bool is_encoded_forwards =
-                    m_compressed_edge_container.HasZippedEntryForForwardID(edge_from_u);
+                    m_compressed_edge_container.HasZippedEntryForForwardID(incoming_edge);
                 const bool is_encoded_backwards =
-                    m_compressed_edge_container.HasZippedEntryForReverseID(edge_from_u);
+                    m_compressed_edge_container.HasZippedEntryForReverseID(incoming_edge);
                 BOOST_ASSERT(is_encoded_forwards || is_encoded_backwards);
                 if (is_encoded_forwards)
                 {
                     original_edge_data_vector.emplace_back(
-                        GeometryID{
-                            m_compressed_edge_container.GetZippedPositionForForwardID(edge_from_u),
-                            true},
+                        GeometryID{m_compressed_edge_container.GetZippedPositionForForwardID(
+                                       incoming_edge),
+                                   true},
                         edge_data1.name_id,
                         turn.lane_data_id,
                         turn_instruction,
@@ -468,9 +506,9 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                 else if (is_encoded_backwards)
                 {
                     original_edge_data_vector.emplace_back(
-                        GeometryID{
-                            m_compressed_edge_container.GetZippedPositionForReverseID(edge_from_u),
-                            false},
+                        GeometryID{m_compressed_edge_container.GetZippedPositionForReverseID(
+                                       incoming_edge),
+                                   false},
                         edge_data1.name_id,
                         turn.lane_data_id,
                         turn_instruction,
@@ -498,6 +536,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                                                     distance,
                                                     true,
                                                     false);
+                BOOST_ASSERT(original_edges_counter == m_edge_based_edge_list.size());
 
                 // Here is where we write out the mapping between the edge-expanded edges, and
                 // the node-based edges that are originally used to calculate the `distance`
@@ -514,8 +553,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                 if (generate_edge_lookup)
                 {
                     const auto node_based_edges =
-                        m_compressed_edge_container.GetBucketReference(edge_from_u);
-                    NodeID previous = node_u;
+                        m_compressed_edge_container.GetBucketReference(incoming_edge);
+                    NodeID previous = node_along_road_entering;
 
                     const unsigned node_count = node_based_edges.size() + 1;
                     const QueryNode &first_node = m_node_info_list[previous];
@@ -547,18 +586,19 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
                     // If this edge is 'trivial' -- where the compressed edge corresponds
                     // exactly to an original OSM segment -- we can pull the turn's preceding
-                    // node ID directly with `node_u`; otherwise, we need to look up the node
+                    // node ID directly with `node_along_road_entering`; otherwise, we need to look
+                    // up the node
                     // immediately preceding the turn from the compressed edge container.
-                    const bool isTrivial = m_compressed_edge_container.IsTrivial(edge_from_u);
+                    const bool isTrivial = m_compressed_edge_container.IsTrivial(incoming_edge);
 
                     const auto &from_node =
                         isTrivial
-                            ? m_node_info_list[node_u]
+                            ? m_node_info_list[node_along_road_entering]
                             : m_node_info_list[m_compressed_edge_container.GetLastEdgeSourceID(
-                                  edge_from_u)];
+                                  incoming_edge)];
                     const auto &via_node =
                         m_node_info_list[m_compressed_edge_container.GetLastEdgeTargetID(
-                            edge_from_u)];
+                            incoming_edge)];
                     const auto &to_node =
                         m_node_info_list[m_compressed_edge_container.GetFirstEdgeTargetID(
                             turn.eid)];

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -245,7 +245,6 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         // Transform the node-based graph that OSM is based on into an edge-based graph
         // that is better for routing.  Every edge becomes a node, and every valid
         // movement (e.g. turn from A->B, and B->A) becomes an edge
-        //
         util::SimpleLogger().Write() << "Generating edge-expanded graph representation";
 
         TIMER_START(expansion);

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -17,11 +17,9 @@ namespace extractor
 namespace guidance
 {
 
-ConnectedRoad::ConnectedRoad(const TurnOperation turn,
-                             const bool entry_allowed,
-                             boost::optional<double> segment_length)
-    : TurnOperation(turn), entry_allowed(entry_allowed), segment_length(segment_length)
+bool IntersectionViewData::CompareByAngle(const IntersectionViewData &other) const
 {
+    return angle < other.angle;
 }
 
 bool ConnectedRoad::compareByAngle(const ConnectedRoad &other) const { return angle < other.angle; }
@@ -70,6 +68,23 @@ std::string toString(const ConnectedRoad &road)
               std::to_string(static_cast<std::int32_t>(road.instruction.direction_modifier)) + " " +
               std::to_string(static_cast<std::int32_t>(road.lane_data_id));
     return result;
+}
+
+IntersectionView::Base::iterator IntersectionView::findClosestTurn(double angle)
+{
+    // use the const operator to avoid code duplication
+    return begin() +
+           std::distance(cbegin(),
+                         static_cast<const IntersectionView *>(this)->findClosestTurn(angle));
+}
+
+IntersectionView::Base::const_iterator IntersectionView::findClosestTurn(double angle) const
+{
+    return std::min_element(
+        begin(), end(), [angle](const IntersectionViewData &lhs, const IntersectionViewData &rhs) {
+            return util::guidance::angularDeviation(lhs.angle, angle) <
+                   util::guidance::angularDeviation(rhs.angle, angle);
+        });
 }
 
 Intersection::Base::iterator Intersection::findClosestTurn(double angle)

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -749,16 +749,9 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
         // obvious due to a very short segment in between. So if the segment coming in is very
         // short, we check the previous intersection for other continues in the opposite bearing.
         const auto node_at_intersection = node_based_graph.GetTarget(via_edge);
-        const util::Coordinate coordinate_at_intersection = node_info_list[node_at_intersection];
-
-        const auto node_at_u_turn = node_based_graph.GetTarget(intersection[0].eid);
-        const util::Coordinate coordinate_at_u_turn = node_info_list[node_at_u_turn];
 
         const double constexpr MAX_COLLAPSE_DISTANCE = 30;
-        const auto distance_at_u_turn = intersection[0].segment_length
-                                            ? *intersection[0].segment_length
-                                            : util::coordinate_calculation::haversineDistance(
-                                                  coordinate_at_intersection, coordinate_at_u_turn);
+        const auto distance_at_u_turn = intersection[0].segment_length;
         if (distance_at_u_turn < MAX_COLLAPSE_DISTANCE)
         {
             // this request here actually goes against the direction of the ingoing edgeid. This can

--- a/src/extractor/guidance/intersection_normalizer.cpp
+++ b/src/extractor/guidance/intersection_normalizer.cpp
@@ -1,5 +1,6 @@
 #include "extractor/guidance/intersection_normalizer.hpp"
 #include "extractor/guidance/toolkit.hpp"
+#include "util/bearing.hpp"
 #include "util/guidance/toolkit.hpp"
 
 namespace osrm
@@ -21,32 +22,70 @@ IntersectionNormalizer::IntersectionNormalizer(
 {
 }
 
-Intersection IntersectionNormalizer::operator()(const NodeID node_at_intersection,
-                                                Intersection intersection) const
+std::pair<IntersectionShape, std::vector<std::pair<EdgeID, EdgeID>>> IntersectionNormalizer::
+operator()(const NodeID node_at_intersection, IntersectionShape intersection) const
 {
-    return AdjustForJoiningRoads(
-        node_at_intersection, MergeSegregatedRoads(node_at_intersection, std::move(intersection)));
+    auto merged_shape_and_merges =
+        MergeSegregatedRoads(node_at_intersection, std::move(intersection));
+    merged_shape_and_merges.first = AdjustBearingsForMergeAtDestination(
+        node_at_intersection, std::move(merged_shape_and_merges.first));
+    return merged_shape_and_merges;
+}
+
+bool IntersectionNormalizer::CanMerge(const NodeID intersection_node,
+                                      const IntersectionShape &intersection,
+                                      std::size_t first_index,
+                                      std::size_t second_index) const
+{
+    BOOST_ASSERT(((first_index + 1) % intersection.size()) == second_index);
+
+    // call wrapper to capture intersection_node and intersection
+    const auto mergable = [this, intersection_node, &intersection](const std::size_t left_index,
+                                                                   const std::size_t right_index) {
+        return InnerCanMerge(intersection_node, intersection, left_index, right_index);
+    };
+
+    /*
+     * Merging should never depend on order/never merge more than two roads. To ensure that we don't
+     * merge anything that is impacted by neighboring roads (e.g. three roads of the same name as in
+     * parking lots/border checkpoints), we check if the neigboring roads would be merged as well.
+     * In that case, we cannot merge, since we would end up merging multiple items together
+     */
+    if (mergable(first_index, second_index))
+    {
+        const auto is_distinct_merge =
+            !mergable(second_index, (second_index + 1) % intersection.size()) &&
+            !mergable((first_index + intersection.size() - 1) % intersection.size(), first_index) &&
+            !mergable(second_index,
+                      (first_index + intersection.size() - 1) % intersection.size()) &&
+            !mergable(first_index, (second_index + 1) % intersection.size());
+        return is_distinct_merge;
+    }
+    else
+        return false;
 }
 
 // Checks for mergability of two ways that represent the same intersection. For further
-// information
-// see interface documentation in header.
-bool IntersectionNormalizer::CanMerge(const NodeID node_at_intersection,
-                                      const Intersection &intersection,
-                                      std::size_t first_index,
-                                      std::size_t second_index) const
+// information see interface documentation in header.
+bool IntersectionNormalizer::InnerCanMerge(const NodeID node_at_intersection,
+                                           const IntersectionShape &intersection,
+                                           std::size_t first_index,
+                                           std::size_t second_index) const
 {
     const auto &first_data = node_based_graph.GetEdgeData(intersection[first_index].eid);
     const auto &second_data = node_based_graph.GetEdgeData(intersection[second_index].eid);
 
     // only merge named ids
-    if (first_data.name_id == EMPTY_NAMEID)
+    if (first_data.name_id == EMPTY_NAMEID || second_data.name_id == EMPTY_NAMEID)
         return false;
 
     // need to be same name
-    if (second_data.name_id != EMPTY_NAMEID &&
-        util::guidance::requiresNameAnnounced(
+    if (util::guidance::requiresNameAnnounced(
             first_data.name_id, second_data.name_id, name_table, street_name_suffix_table))
+        return false;
+    // needs to be symmetrical for names
+    if (util::guidance::requiresNameAnnounced(
+            second_data.name_id, first_data.name_id, name_table, street_name_suffix_table))
         return false;
 
     // compatibility is required
@@ -64,35 +103,17 @@ bool IntersectionNormalizer::CanMerge(const NodeID node_at_intersection,
     if (first_data.reversed == second_data.reversed)
         return false;
 
-    // one of them needs to be invalid
-    if (intersection[first_index].entry_allowed && intersection[second_index].entry_allowed)
-        return false;
-
     // mergeable if the angle is not too big
     const auto angle_between =
-        angularDeviation(intersection[first_index].angle, intersection[second_index].angle);
-
-    const auto intersection_lanes = intersection.getHighestConnectedLaneCount(node_based_graph);
-
-    const auto coordinate_at_in_edge =
-        intersection_generator.GetCoordinateExtractor().GetCoordinateAlongRoad(
-            node_at_intersection,
-            intersection[0].eid,
-            !INVERT,
-            node_based_graph.GetTarget(intersection[0].eid),
-            intersection_lanes);
+        angularDeviation(intersection[first_index].bearing, intersection[second_index].bearing);
 
     const auto coordinate_at_intersection = node_coordinates[node_at_intersection];
 
     if (angle_between >= 120)
         return false;
 
-    const auto isValidYArm = [this,
-                              intersection,
-                              coordinate_at_in_edge,
-                              coordinate_at_intersection,
-                              node_at_intersection](const std::size_t index,
-                                                    const std::size_t other_index) {
+    const auto isValidYArm = [this, intersection, coordinate_at_intersection, node_at_intersection](
+        const std::size_t index, const std::size_t other_index) {
         const auto GetActualTarget = [&](const std::size_t index) {
             EdgeID last_in_edge_id;
             intersection_generator.GetActualNextIntersection(
@@ -108,21 +129,19 @@ bool IntersectionNormalizer::CanMerge(const NodeID node_at_intersection,
         const auto coordinate_at_target = node_coordinates[target_id];
         const auto coordinate_at_other_target = node_coordinates[other_target_id];
 
-        const auto turn_angle = util::coordinate_calculation::computeAngle(
-            coordinate_at_in_edge, coordinate_at_intersection, coordinate_at_target);
-        const auto other_turn_angle = util::coordinate_calculation::computeAngle(
-            coordinate_at_in_edge, coordinate_at_intersection, coordinate_at_other_target);
+        const auto turn_bearing =
+            util::coordinate_calculation::bearing(coordinate_at_intersection, coordinate_at_target);
+        const auto other_turn_bearing = util::coordinate_calculation::bearing(
+            coordinate_at_intersection, coordinate_at_other_target);
 
+        // fuzzy becomes narrower due to minor differences in angle computations, yay floating point
         const bool becomes_narrower =
-            angularDeviation(turn_angle, other_turn_angle) < NARROW_TURN_ANGLE &&
-            angularDeviation(turn_angle, other_turn_angle) <=
-                angularDeviation(intersection[index].angle, intersection[other_index].angle);
+            angularDeviation(turn_bearing, other_turn_bearing) < NARROW_TURN_ANGLE &&
+            angularDeviation(turn_bearing, other_turn_bearing) <=
+                angularDeviation(intersection[index].bearing, intersection[other_index].bearing) +
+                    MAXIMAL_ALLOWED_NO_TURN_DEVIATION;
 
-        const bool has_same_deviation =
-            std::abs(angularDeviation(intersection[index].angle, STRAIGHT_ANGLE) -
-                     angularDeviation(intersection[other_index].angle, STRAIGHT_ANGLE)) <
-            MAXIMAL_ALLOWED_NO_TURN_DEVIATION;
-        return becomes_narrower || has_same_deviation;
+        return becomes_narrower;
     };
 
     const bool is_y_arm_first = isValidYArm(first_index, second_index);
@@ -162,8 +181,8 @@ bool IntersectionNormalizer::CanMerge(const NodeID node_at_intersection,
     // we only allow collapsing of a Y like fork. So the angle to the third index has to be
     // roughly equal:
     const auto y_angle_difference = angularDeviation(
-        angularDeviation(intersection[third_index].angle, intersection[first_index].angle),
-        angularDeviation(intersection[third_index].angle, intersection[second_index].angle));
+        angularDeviation(intersection[third_index].bearing, intersection[first_index].bearing),
+        angularDeviation(intersection[third_index].bearing, intersection[second_index].bearing));
     // Allow larger angles if its three roads only of the same name
     // This is a heuristic and might need to be revised.
     const bool assume_y_intersection =
@@ -194,8 +213,9 @@ bool IntersectionNormalizer::CanMerge(const NodeID node_at_intersection,
  * Anything containing the first u-turn in a merge affects all other angles
  * and is handled separately from all others.
  */
-Intersection IntersectionNormalizer::MergeSegregatedRoads(const NodeID intersection_node,
-                                                          Intersection intersection) const
+std::pair<IntersectionShape, std::vector<std::pair<EdgeID, EdgeID>>>
+IntersectionNormalizer::MergeSegregatedRoads(const NodeID intersection_node,
+                                             IntersectionShape intersection) const
 {
     const auto getRight = [&](std::size_t index) {
         return (index + intersection.size() - 1) % intersection.size();
@@ -216,34 +236,34 @@ Intersection IntersectionNormalizer::MergeSegregatedRoads(const NodeID intersect
         {
             const auto offset = angularDeviation(first, second);
             auto new_angle = std::max(first, second) + .5 * offset;
-            if (new_angle > 360)
+            if (new_angle >= 360)
                 return new_angle - 360;
             return new_angle;
         }
     };
 
-    const auto merge = [combineAngles](const ConnectedRoad &first,
-                                       const ConnectedRoad &second) -> ConnectedRoad {
-        ConnectedRoad result = first.entry_allowed ? first : second;
-        result.angle = combineAngles(first.angle, second.angle);
+    // This map stores for all edges that participated in a merging operation in which edge id they
+    // end up in the end. We only store what we have merged into other edges.
+    std::vector<std::pair<EdgeID, EdgeID>> merging_map;
+
+    const auto merge = [this, combineAngles, &merging_map](const IntersectionShapeData &first,
+                                                           const IntersectionShapeData &second) {
+        IntersectionShapeData result =
+            !node_based_graph.GetEdgeData(first.eid).reversed ? first : second;
         result.bearing = combineAngles(first.bearing, second.bearing);
-        BOOST_ASSERT(0 <= result.angle && result.angle <= 360.0);
-        BOOST_ASSERT(0 <= result.bearing && result.bearing <= 360.0);
+        BOOST_ASSERT(0 <= result.bearing && result.bearing < 360.0);
+        // the other ID
+        const auto merged_from = result.eid == first.eid ? second.eid : first.eid;
+        BOOST_ASSERT(
+            std::find_if(merging_map.begin(), merging_map.end(), [merged_from](const auto pair) {
+                return pair.first == merged_from;
+            }) == merging_map.end());
+        merging_map.push_back(std::make_pair(merged_from, result.eid));
         return result;
     };
 
     if (intersection.size() <= 1)
-        return intersection;
-
-    const bool is_connected_to_roundabout = [this, &intersection]() {
-        for (const auto &road : intersection)
-        {
-            if (node_based_graph.GetEdgeData(road.eid).roundabout ||
-                node_based_graph.GetEdgeData(road.eid).circular)
-                return true;
-        }
-        return false;
-    }();
+        return std::make_pair(intersection, merging_map);
 
     // check for merges including the basic u-turn
     // these result in an adjustment of all other angles. This is due to how these angles are
@@ -278,52 +298,27 @@ Intersection IntersectionNormalizer::MergeSegregatedRoads(const NodeID intersect
     // the difference to all angles. Otherwise we subtract it.
     bool merged_first = false;
     // these result in an adjustment of all other angles
-    if (CanMerge(intersection_node, intersection, 0, intersection.size() - 1))
+    if (CanMerge(intersection_node, intersection, intersection.size() - 1, 0))
     {
         merged_first = true;
         // moving `a` to the left
-        const double correction_factor = (360 - intersection[intersection.size() - 1].angle) / 2;
-        for (std::size_t i = 1; i + 1 < intersection.size(); ++i)
-            intersection[i].angle += correction_factor;
-
+        intersection[0] = merge(intersection.front(), intersection.back());
         // FIXME if we have a left-sided country, we need to switch this off and enable it
         // below
-        intersection[0] = merge(intersection.front(), intersection.back());
-        intersection[0].angle = 0;
         intersection.pop_back();
     }
     else if (CanMerge(intersection_node, intersection, 0, 1))
     {
         merged_first = true;
-        // moving `a` to the right
-        const double correction_factor = (intersection[1].angle) / 2;
-        for (std::size_t i = 2; i < intersection.size(); ++i)
-            intersection[i].angle -= correction_factor;
-        intersection[0] = merge(intersection[0], intersection[1]);
-        intersection[0].angle = 0;
+        intersection[0] = merge(intersection.front(), intersection[1]);
         intersection.erase(intersection.begin() + 1);
-    }
-
-    if (merged_first && is_connected_to_roundabout)
-    {
-        /*
-         * We are merging a u-turn against the direction of a roundabout
-         *
-         *     -----------> roundabout
-         *        /    \
-         *     out      in
-         *
-         * These cases have to be disabled, even if they are not forbidden specifically by a
-         * relation
-         */
-        intersection[0].entry_allowed = false;
     }
 
     // a merge including the first u-turn requires an adjustment of the turn angles
     // therefore these are handled prior to this step
     for (std::size_t index = 2; index < intersection.size(); ++index)
     {
-        if (CanMerge(intersection_node, intersection, index, getRight(index)))
+        if (CanMerge(intersection_node, intersection, getRight(index), index))
         {
             intersection[getRight(index)] =
                 merge(intersection[getRight(index)], intersection[index]);
@@ -332,10 +327,7 @@ Intersection IntersectionNormalizer::MergeSegregatedRoads(const NodeID intersect
         }
     }
 
-    std::sort(std::begin(intersection),
-              std::end(intersection),
-              std::mem_fn(&ConnectedRoad::compareByAngle));
-    return intersection;
+    return std::make_pair(intersection, merging_map);
 }
 
 // OSM can have some very steep angles for joining roads. Considering the following intersection:
@@ -358,8 +350,9 @@ Intersection IntersectionNormalizer::MergeSegregatedRoads(const NodeID intersect
 // Where we see the turn to `d` as a right turn, rather than going straight.
 // We do this by adjusting the local turn angle at `x` to turn onto `d` to be reflective of this
 // situation, where `v` would be the node at the intersection.
-Intersection IntersectionNormalizer::AdjustForJoiningRoads(const NodeID node_at_intersection,
-                                                           Intersection intersection) const
+IntersectionShape
+IntersectionNormalizer::AdjustBearingsForMergeAtDestination(const NodeID node_at_intersection,
+                                                            IntersectionShape intersection) const
 {
     // nothing to do for dead ends
     if (intersection.size() <= 1)
@@ -369,18 +362,18 @@ Intersection IntersectionNormalizer::AdjustForJoiningRoads(const NodeID node_at_
     // since the road is probably too long otherwise to impact perception.
     const double constexpr PRUNING_DISTANCE = 30;
     // never adjust u-turns
-    for (std::size_t index = 1; index < intersection.size(); ++index)
+    for (std::size_t index = 0; index < intersection.size(); ++index)
     {
         auto &road = intersection[index];
         // only consider roads that are close
-        if (road.segment_length && *(road.segment_length) > PRUNING_DISTANCE)
+        if (road.segment_length > PRUNING_DISTANCE)
             continue;
 
         // to find out about the above situation, we need to look at the next intersection (at d in
         // the example). If the initial road can be merged to the left/right, we are about to adjust
         // the angle.
-        const auto next_intersection_along_road =
-            intersection_generator(node_at_intersection, road.eid);
+        const auto next_intersection_along_road = intersection_generator.ComputeIntersectionShape(
+            node_based_graph.GetTarget(road.eid), node_at_intersection);
 
         if (next_intersection_along_road.size() <= 1)
             continue;
@@ -401,18 +394,20 @@ Intersection IntersectionNormalizer::AdjustForJoiningRoads(const NodeID node_at_
             continue;
 
         // the order does not matter
-        const auto get_offset = [](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
-            return 0.5 * angularDeviation(lhs.angle, rhs.angle);
+        const auto get_offset = [](const IntersectionShapeData &lhs,
+                                   const IntersectionShapeData &rhs) {
+            return 0.5 * angularDeviation(lhs.bearing, rhs.bearing);
         };
 
         // When offsetting angles in our turns, we don't want to get past the next turn. This
         // function simply limits an offset to be at most half the distance to the next turn in the
         // offfset direction
-        const auto get_corrected_offset = [](const double offset,
-                                             const ConnectedRoad &road,
-                                             const ConnectedRoad &next_road_in_offset_direction) {
+        const auto get_corrected_offset = [](
+            const double offset,
+            const IntersectionShapeData &road,
+            const IntersectionShapeData &next_road_in_offset_direction) {
             const auto offset_limit =
-                angularDeviation(road.angle, next_road_in_offset_direction.angle);
+                angularDeviation(road.bearing, next_road_in_offset_direction.bearing);
             // limit the offset with an additional buffer
             return (offset + MAXIMAL_ALLOWED_NO_TURN_DEVIATION > offset_limit) ? 0.5 * offset_limit
                                                                                : offset;
@@ -426,28 +421,28 @@ Intersection IntersectionNormalizer::AdjustForJoiningRoads(const NodeID node_at_
             const auto offset =
                 get_offset(next_intersection_along_road[0], next_intersection_along_road[1]);
 
-            const auto corrected_offset =
-                get_corrected_offset(offset, road, intersection[(index + 1) % intersection.size()]);
+            const auto corrected_offset = get_corrected_offset(
+                offset,
+                road,
+                intersection[(intersection.size() + index - 1) % intersection.size()]);
             // at the target intersection, we merge to the right, so we need to shift the current
             // angle to the left
-            road.angle = adjustAngle(road.angle, corrected_offset);
-            road.bearing = adjustAngle(road.bearing, corrected_offset);
+            road.bearing = adjustAngle(road.bearing, -corrected_offset);
         }
         else if (CanMerge(node_at_next_intersection,
                           next_intersection_along_road,
-                          0,
-                          next_intersection_along_road.size() - 1))
+                          next_intersection_along_road.size() - 1,
+                          0))
         {
             const auto offset =
                 get_offset(next_intersection_along_road[0],
                            next_intersection_along_road[next_intersection_along_road.size() - 1]);
 
             const auto corrected_offset =
-                get_corrected_offset(offset, road, intersection[index - 1]);
+                get_corrected_offset(offset, road, intersection[(index + 1) % intersection.size()]);
             // at the target intersection, we merge to the left, so we need to shift the current
             // angle to the right
-            road.angle = adjustAngle(road.angle, -corrected_offset);
-            road.bearing = adjustAngle(road.bearing, -corrected_offset);
+            road.bearing = adjustAngle(road.bearing, corrected_offset);
         }
     }
     return intersection;

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -106,7 +106,7 @@ operator()(const NodeID, const EdgeID source_edge_id, Intersection intersection)
             // itself. If that is the case, the road is obviously not a sliproad.
 
             // a sliproad has to enter a road without choice
-            const auto couldBeSliproad = [](const Intersection &intersection) {
+            const auto couldBeSliproad = [](const IntersectionView &intersection) {
                 if (intersection.size() != 3)
                     return false;
                 if ((intersection[1].entry_allowed && intersection[2].entry_allowed) ||
@@ -218,7 +218,7 @@ operator()(const NodeID, const EdgeID source_edge_id, Intersection intersection)
                     std::find_if(
                         target_intersection.begin() + 1,
                         target_intersection.end(),
-                        [this, &link_data](const ConnectedRoad &road) {
+                        [this, &link_data](const IntersectionViewData &road) {
                             const auto &road_edge_data = node_based_graph.GetEdgeData(road.eid);
 
                             const auto same_name =

--- a/src/extractor/guidance/turn_discovery.cpp
+++ b/src/extractor/guidance/turn_discovery.cpp
@@ -25,7 +25,7 @@ bool findPreviousIntersection(const NodeID node_v,
                               // output parameters
                               NodeID &result_node,
                               EdgeID &result_via_edge,
-                              Intersection &result_intersection)
+                              IntersectionView &result_intersection)
 {
     /* We need to find the intersection that is located prior to via_edge.
 
@@ -55,6 +55,7 @@ bool findPreviousIntersection(const NodeID node_v,
     // (looking at the reverse direction).
     const auto node_w = node_based_graph.GetTarget(via_edge);
     const auto u_turn_at_node_w = intersection[0].eid;
+
     // make sure the ID is actually valid
     BOOST_ASSERT(node_based_graph.BeginEdges(node_w) <= u_turn_at_node_w &&
                  u_turn_at_node_w <= node_based_graph.EndEdges(node_w));
@@ -65,7 +66,6 @@ bool findPreviousIntersection(const NodeID node_v,
 
     const auto node_v_reverse_intersection =
         intersection_generator.GetConnectedRoads(node_w, u_turn_at_node_w, USE_LOW_PRECISION_MODE);
-
     // Continue along the straightmost turn. If there is no straight turn, we cannot find a valid
     // previous intersection.
     const auto straightmost_at_v_in_reverse =
@@ -102,7 +102,7 @@ bool findPreviousIntersection(const NodeID node_v,
         result_intersection.end() !=
         std::find_if(result_intersection.begin(),
                      result_intersection.end(),
-                     [via_edge](const ConnectedRoad &road) { return road.eid == via_edge; });
+                     [via_edge](const IntersectionViewData &road) { return road.eid == via_edge; });
 
     if (!check_via_edge)
     {

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -186,6 +186,7 @@ TurnLaneScenario TurnLaneHandler::deduceScenario(const NodeID at,
     // Due to sliproads, we might need access to the previous intersection at this point already;
     previous_node = SPECIAL_NODEID;
     previous_via_edge = SPECIAL_EDGEID;
+    IntersectionView previous_intersection_view;
     if (findPreviousIntersection(at,
                                  via_edge,
                                  intersection,
@@ -193,11 +194,11 @@ TurnLaneScenario TurnLaneHandler::deduceScenario(const NodeID at,
                                  node_based_graph,
                                  previous_node,
                                  previous_via_edge,
-                                 previous_intersection))
+                                 previous_intersection_view))
     {
         extractLaneData(previous_via_edge, previous_description_id, previous_lane_data);
-        previous_intersection = turn_analysis.assignTurnTypes(
-            previous_node, previous_via_edge, std::move(previous_intersection));
+        previous_intersection = turn_analysis.AssignTurnTypes(
+            previous_node, previous_via_edge, previous_intersection_view);
         for (std::size_t road_index = 0; road_index < previous_intersection.size(); ++road_index)
         {
             const auto &road = previous_intersection[road_index];
@@ -542,7 +543,7 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
 
     // find out about the next intersection. To check for valid matches, we also need the turn
     // types. We can skip merging/angle adjustments, though
-    const auto next_intersection = turn_analysis.assignTurnTypes(
+    const auto next_intersection = turn_analysis.AssignTurnTypes(
         at, straightmost->eid, turn_analysis.GetIntersectionGenerator()(at, straightmost->eid));
 
     // check where we can match turn lanes

--- a/unit_tests/util/io.cpp
+++ b/unit_tests/util/io.cpp
@@ -117,7 +117,8 @@ BOOST_AUTO_TEST_CASE(io_read_lines)
         auto startiter = infile.GetLineIteratorBegin();
         auto enditer = infile.GetLineIteratorEnd();
         std::vector<std::string> resultlines;
-        while (startiter != enditer) {
+        while (startiter != enditer)
+        {
             resultlines.push_back(*startiter);
             ++startiter;
         }


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/3313

During the PR, I've kept the old implementation around to make sure the results remain the same. I've found a few problematic scenarios along the way, which required adjustments to the coordinate extraction (border cases, currently handled incorrectly).

As a side-effect, this PR also fixes https://github.com/Project-OSRM/osrm-backend/issues/3241

## Tasklist
 - [x] find source of potential memory corruption after rebase
 - [x] requires https://github.com/Project-OSRM/osrm-backend/pull/3315 merged
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 based on https://github.com/Project-OSRM/osrm-backend/pull/3315