### PR TITLE
Sort nodes spatially to speed up later queries.

### DIFF
--- a/include/extractor/external_memory_node.hpp
+++ b/include/extractor/external_memory_node.hpp
@@ -25,33 +25,65 @@ struct ExternalMemoryNode : QueryNode
 
     ExternalMemoryNode() : barrier(false), traffic_lights(false) {}
 
-    static ExternalMemoryNode min_value()
-    {
-        return ExternalMemoryNode(
-            util::FixedLongitude{0}, util::FixedLatitude{0}, MIN_OSM_NODEID, false, false);
-    }
-
-    static ExternalMemoryNode max_value()
-    {
-        return ExternalMemoryNode(util::FixedLongitude{std::numeric_limits<std::int32_t>::max()},
-                                  util::FixedLatitude{std::numeric_limits<std::int32_t>::max()},
-                                  MAX_OSM_NODEID,
-                                  false,
-                                  false);
-    }
-
     bool barrier;
     bool traffic_lights;
 };
 
-struct ExternalMemoryNodeSTXXLCompare
+struct ExternalMemoryNodeWithHilbert : ExternalMemoryNode
 {
-    using value_type = ExternalMemoryNode;
+    ExternalMemoryNodeWithHilbert(
+        const util::FixedLongitude lon_,
+        const util::FixedLatitude lat_,
+        OSMNodeID node_id_,
+        bool barrier_,
+        bool traffic_lights_,
+        std::uint64_t hilbert_code_ = std::numeric_limits<std::uint64_t>::max())
+        : ExternalMemoryNode(lon_, lat_, node_id_, barrier_, traffic_lights_),
+          hilbert_code(hilbert_code_)
+    {
+    }
+
+    ExternalMemoryNodeWithHilbert() : hilbert_code(std::numeric_limits<std::uint64_t>::max()) {}
+
+    static ExternalMemoryNodeWithHilbert min_value()
+    {
+        return ExternalMemoryNodeWithHilbert(
+            util::FixedLongitude{0}, util::FixedLatitude{0}, MIN_OSM_NODEID, false, false, 0);
+    }
+
+    static ExternalMemoryNodeWithHilbert max_value()
+    {
+        return ExternalMemoryNodeWithHilbert(
+            util::FixedLongitude{std::numeric_limits<std::int32_t>::max()},
+            util::FixedLatitude{std::numeric_limits<std::int32_t>::max()},
+            MAX_OSM_NODEID,
+            false,
+            false,
+            std::numeric_limits<std::uint64_t>::max());
+    }
+
+    bool used;
+    std::uint64_t hilbert_code;
+};
+
+struct ExternalMemoryNodeWithHilbertSTXXLIDCompare
+{
+    using value_type = ExternalMemoryNodeWithHilbert;
     value_type max_value() { return value_type::max_value(); }
     value_type min_value() { return value_type::min_value(); }
     bool operator()(const value_type &left, const value_type &right) const
     {
         return left.node_id < right.node_id;
+    }
+};
+struct ExternalMemoryNodeWithHilbertSTXXLUsedSpatialCompare
+{
+    using value_type = ExternalMemoryNodeWithHilbert;
+    value_type max_value() { return value_type::max_value(); }
+    value_type min_value() { return value_type::min_value(); }
+    bool operator()(const value_type &left, const value_type &right) const
+    {
+        return left.hilbert_code < right.hilbert_code;
     }
 };
 }

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -44,7 +44,7 @@ class ExtractionContainers
 
   public:
     using STXXLNodeIDVector = stxxl::vector<OSMNodeID>;
-    using STXXLNodeVector = stxxl::vector<ExternalMemoryNode>;
+    using STXXLNodeVector = stxxl::vector<ExternalMemoryNodeWithHilbert>;
     using STXXLEdgeVector = stxxl::vector<InternalExtractorEdge>;
     using STXXLRestrictionsVector = stxxl::vector<InputRestrictionContainer>;
     using STXXLWayIDStartEndVector = stxxl::vector<FirstAndLastSegmentOfWay>;

--- a/include/util/hilbert_value.hpp
+++ b/include/util/hilbert_value.hpp
@@ -11,7 +11,8 @@ namespace util
 {
 
 // Computes a 64 bit value that corresponds to the hilbert space filling curve
-std::uint64_t hilbertCode(const Coordinate coordinate);
+std::uint64_t hilbertCode(const Coordinate &coordinate);
+std::uint64_t hilbertCode(const FixedLongitude &lon, const FixedLatitude &lat);
 }
 }
 

--- a/src/util/hilbert_value.cpp
+++ b/src/util/hilbert_value.cpp
@@ -69,16 +69,21 @@ void transposeCoordinate(std::uint32_t *x)
 }
 } // anonymous ns
 
-std::uint64_t hilbertCode(const Coordinate coordinate)
+std::uint64_t hilbertCode(const FixedLongitude &lon, const FixedLatitude &lat)
 {
     std::uint32_t location[2];
-    location[0] = static_cast<std::int32_t>(coordinate.lon) +
-                  static_cast<std::int32_t>(180 * COORDINATE_PRECISION);
-    location[1] = static_cast<std::int32_t>(coordinate.lat) +
-                  static_cast<std::int32_t>(90 * COORDINATE_PRECISION);
+    location[0] =
+        static_cast<std::int32_t>(lon) + static_cast<std::int32_t>(180 * COORDINATE_PRECISION);
+    location[1] =
+        static_cast<std::int32_t>(lat) + static_cast<std::int32_t>(90 * COORDINATE_PRECISION);
 
     transposeCoordinate(location);
     return bitInterleaving(location[0], location[1]);
+}
+
+std::uint64_t hilbertCode(const Coordinate &coordinate)
+{
+    return hilbertCode(coordinate.lon, coordinate.lat);
 }
 }
 }


### PR DESCRIPTION
# Issue

Addresses #3311 

This change sorts node IDs on a Hilbert curve, on the assumption that this will improve cache locality during later queries of this data (coordinate data is heavily used during edge-based-graph construction when the guidance code does lots of localize graph exploring).

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments