### PR TITLE
fix update to length cache

### DIFF
--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -260,8 +260,10 @@ CoordinateExtractor::GetCoordinateAlongRoad(const NodeID intersection_node,
          */
         const double offset = 0.5 * considered_lanes * ASSUMED_LANE_WIDTH;
         coordinates = TrimCoordinatesToLength(std::move(coordinates), offset, segment_distances);
+        BOOST_ASSERT(coordinates.size() >= 2);
         segment_distances.resize(coordinates.size());
-        segment_distances.back() = offset;
+        segment_distances.back() = util::coordinate_calculation::haversineDistance(
+            *(coordinates.end() - 2), coordinates.back());
         const auto vector_head = coordinates.back();
         coordinates =
             TrimCoordinatesToLength(std::move(coordinates), 0.5 * offset, segment_distances);


### PR DESCRIPTION
# Issue

Minor issue with not updating the length cache correctly. The length cache assumes distances between coordinates. The update (at the changed location) assumes a prefix sum

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations