### PR TITLE
 Add cache into scripting_environment (new behavior best performance).

### DIFF
--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -16,7 +16,7 @@ namespace osrm
 {
 namespace extractor
 {
-
+class ScriptingEnvironment;
 /**
  * Uses external memory containers from stxxl to store all the data that
  * is collected by the extractor callbacks.
@@ -60,6 +60,10 @@ class ExtractionContainers
     STXXLRestrictionsVector restrictions_list;
     STXXLWayIDStartEndVector way_start_end_id_list;
     std::unordered_map<OSMNodeID, NodeID> external_to_internal_node_id_map;
+    // FIXME This map store the vector id for each osm_id contain in "all_nodes_list"
+    // FIXME add a lazy loading to init this cache when user need location on noderef
+    std::unordered_map<OSMNodeID, osmium::Location> nodeCache;
+
     unsigned max_internal_node_id;
 
     ExtractionContainers();
@@ -68,6 +72,9 @@ class ExtractionContainers
                      const std::string &output_file_name,
                      const std::string &restrictions_file_name,
                      const std::string &names_file_name);
+
+    void prepareCache();
+    void clearCache();
 };
 }
 }

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -58,10 +58,14 @@ class ScriptingEnvironment
                                 const osrm::util::Coordinate &target,
                                 double distance,
                                 InternalExtractorEdge::WeightData &weight) = 0;
+
+    virtual bool
+    ProcessNodeElements(const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
+                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes) = 0;
+
     virtual void
     ProcessElements(const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
                     const RestrictionParser &restriction_parser,
-                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes,
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) = 0;

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -5,6 +5,7 @@
 #include "extractor/internal_extractor_edge.hpp"
 #include "extractor/profile_properties.hpp"
 #include "extractor/restriction.hpp"
+#include "extractor/extraction_containers.hpp"
 
 #include <osmium/memory/buffer.hpp>
 
@@ -31,7 +32,7 @@ struct Coordinate;
 
 namespace extractor
 {
-
+class ExtractionContainers;
 class RestrictionParser;
 struct ExtractionNode;
 struct ExtractionWay;
@@ -69,6 +70,8 @@ class ScriptingEnvironment
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) = 0;
+
+    virtual void setupCache(std::unordered_map<OSMNodeID, osmium::Location> &cache) = 0;
 };
 }
 }

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -2,8 +2,8 @@
 #define SCRIPTING_ENVIRONMENT_LUA_HPP
 
 #include "extractor/scripting_environment.hpp"
-
 #include "extractor/raster_source.hpp"
+#include "extractor/extraction_containers.hpp"
 
 #include "util/lua_util.hpp"
 
@@ -71,6 +71,12 @@ class LuaScriptingEnvironment final : public ScriptingEnvironment
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) override;
+
+    void setupCache(std::unordered_map<OSMNodeID, osmium::Location> &cache) override;
+    // FIXME This is static because I don't know how to access to this in lua nodeRef class binding.
+    //static ExtractionContainers *extraction_containers;
+    //osmium::Location getLocation(osmium::NodeRef &nref);
+    static std::unordered_map<OSMNodeID, osmium::Location> nodeCache;
 
   private:
     void InitContext(LuaScriptingContext &context);

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -60,10 +60,14 @@ class LuaScriptingEnvironment final : public ScriptingEnvironment
                         const osrm::util::Coordinate &target,
                         double distance,
                         InternalExtractorEdge::WeightData &weight) override;
+
+    bool
+    ProcessNodeElements(const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
+                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes) override;
+
     void
     ProcessElements(const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
                     const RestrictionParser &restriction_parser,
-                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes,
                     tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
                     tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
                         &resulting_restrictions) override;

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -288,7 +288,6 @@ end
 -- abort early if this way is obviouslt not routable
 function initial_routability_check(way,result,data)
   data.speed_type = way:get_value_by_key('highway')
-
   return data.speed_type ~= nil or
          way:get_value_by_key('route') ~= nil or
          way:get_value_by_key('bridge') ~= nil
@@ -717,6 +716,15 @@ end
 
 -- main entry point for processsing a way
 function way_function(way, result)
+
+  -- Only for test, remove before merge.
+  print("way id : ", way:id());
+  for node in way:get_nodes() do
+   print("  node id  : ", node:id())
+   print("  node lat : ", node:location():lat())
+   print("  node lon : ", node:location():lon())
+  end
+
   -- intermediate values used during processing
   local data = {}
 

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -136,6 +136,22 @@ void ExtractionContainers::FlushVectors()
     way_start_end_id_list.flush();
 }
 
+void ExtractionContainers::prepareCache()
+{
+    nodeCache.reserve(all_nodes_list.size());
+    for(size_t i = 0; i < all_nodes_list.size(); i++)
+    {
+        //ExternalMemoryNode data = all_nodes_list[i];
+        osmium::Location location(static_cast<double>(util::toFloating(all_nodes_list[i].lon)), static_cast<double>(util::toFloating(all_nodes_list[i].lat)));
+        nodeCache.insert({OSMNodeID{static_cast<std::uint64_t>(all_nodes_list[i].node_id)}, location});
+    }
+}
+
+void ExtractionContainers::clearCache()
+{
+    nodeCache.clear();
+}
+
 /**
  * Processes the collected data and serializes it.
  * At this point nodes are still referenced by their OSM id.

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -194,6 +194,11 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
                         static_cast<const osmium::Node &>(*(osm_elements[result.first])),
                         result.second);
                 }
+                
+                if(!node)
+                {
+                    extraction_containers.prepareCache();
+                }
             }
 
             if(!node)
@@ -216,6 +221,10 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
             }
         }
         TIMER_STOP(parsing);
+
+// Clear cache data
+extraction_containers.clearCache();
+
         util::SimpleLogger().Write() << "Parsing finished after " << TIMER_SEC(parsing)
                                      << " seconds";
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -198,6 +198,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
                 if(!node)
                 {
                     extraction_containers.prepareCache();
+                    scripting_environment.setupCache(extraction_containers.nodeCache);
                 }
             }
 

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -267,13 +267,12 @@ LuaScriptingContext &LuaScriptingEnvironment::GetLuaContext()
     return *ref;
 }
 
-void LuaScriptingEnvironment::ProcessElements(
+bool LuaScriptingEnvironment::ProcessNodeElements(
     const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
-    const RestrictionParser &restriction_parser,
-    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes,
-    tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
-    tbb::concurrent_vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions)
+    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes)
 {
+    bool res = true;
+
     // parse OSM entities in parallel, store in resulting vectors
     tbb::parallel_for(
         tbb::blocked_range<std::size_t>(0, osm_elements.size()),
@@ -297,6 +296,46 @@ void LuaScriptingEnvironment::ProcessElements(
                     }
                     resulting_nodes.push_back(std::make_pair(x, std::move(result_node)));
                     break;
+                default:
+                    res = false;
+                    break;
+                }
+            }
+        });
+    return res;
+}
+
+void LuaScriptingEnvironment::ProcessElements(
+    const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
+    const RestrictionParser &restriction_parser,
+//     tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes,
+    tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
+    tbb::concurrent_vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions)
+{
+    // parse OSM entities in parallel, store in resulting vectors
+    tbb::parallel_for(
+        tbb::blocked_range<std::size_t>(0, osm_elements.size()),
+        [&](const tbb::blocked_range<std::size_t> &range) {
+            ExtractionNode result_node;
+            ExtractionWay result_way;
+            auto &local_context = this->GetLuaContext();
+
+            for (auto x = range.begin(), end = range.end(); x != end; ++x)
+            {
+                const auto entity = osm_elements[x];
+
+                switch (entity->type())
+                {
+// FIXME supress this
+//                 case osmium::item_type::node:
+//                     result_node.clear();
+//                     if (local_context.has_node_function)
+//                     {
+//                         local_context.processNode(static_cast<const osmium::Node &>(*entity),
+//                                                   result_node);
+//                     }
+//                     resulting_nodes.push_back(std::make_pair(x, std::move(result_node)));
+//                     break;
                 case osmium::item_type::way:
                     result_way.clear();
                     if (local_context.has_way_function)


### PR DESCRIPTION
#3180

The purpose of this PR is to inject a cache into LuaScriptingEnvironment class to access at nodeRef location in .lua script.

@daniel-j-h,
This is the last behavior I was talking to you in the previous PR.
Without cache feeding, performances increases 0%  and with cache feeding, increases 12-13%.
But i will feed the cache only the first time user need to access at location in lua script, as this way only users using location in luascript will be affected by this changes.