### PR TITLE
handle service roads next to roundabouts - ambiguous exit... :(

### DIFF
--- a/features/guidance/roundabout-left-sided.feature
+++ b/features/guidance/roundabout-left-sided.feature
@@ -1,0 +1,59 @@
+@routing  @guidance @left-handed
+Feature: Basic Roundabout
+
+    Background:
+        Given a grid size of 10 meters
+        Given the profile file
+           """
+           require 'car'
+            properties.left_hand_driving = true
+           """
+
+    Scenario: Roundabout exit counting for left sided driving
+        And a grid size of 10 meters
+        And the node map
+            """
+                a
+                b
+            h g   c d
+                e
+                f
+            """
+        And the ways
+            | nodes  | junction   |
+            | ab     |            |
+            | cd     |            |
+            | ef     |            |
+            | gh     |            |
+            | bcegb  | roundabout |
+
+        When I route I should get
+           | waypoints | route    | turns                                         |
+           | a,d       | ab,cd,cd | depart,roundabout turn left exit-1,arrive     |
+           | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
+           | a,h       | ab,gh,gh | depart,roundabout turn right exit-3,arrive    |
+
+    Scenario: Mixed Entry and Exit
+        And a grid size of 10 meters
+        And the node map
+           """
+             c   a
+           j   b   f
+             k   e
+           l   h   d
+             g   i
+           """
+
+        And the ways
+           | nodes | junction   | oneway |
+           | cba   |            | yes    |
+           | fed   |            | yes    |
+           | ihg   |            | yes    |
+           | lkj   |            | yes    |
+           | behkb | roundabout | yes    |
+
+        When I route I should get
+           | waypoints | route       | turns                           |
+           | c,a       | cba,cba,cba | depart,roundabout-exit-1,arrive |
+           | l,a       | lkj,cba,cba | depart,roundabout-exit-2,arrive |
+           | i,a       | ihg,cba,cba | depart,roundabout-exit-3,arrive |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -38,6 +38,30 @@ Feature: Basic Roundabout
            | h,c       | gh,bcegb,bcegb | depart,roundabout-exit-undefined,arrive |
            | h,e       | gh,bcegb,bcegb | depart,roundabout-exit-undefined,arrive |
 
+    Scenario: Roundabout With Service
+        Given the node map
+            """
+                a h
+                bg
+            d c
+                e
+                f
+            """
+
+        And the ways
+            | nodes  | junction   | highway |
+            | ab     |            | primary |
+            | cd     |            | primary |
+            | ef     |            | service |
+            | gh     |            | primary |
+            | bcegb  | roundabout | primary |
+
+        When I route I should get
+            | waypoints | route    | turns                           |
+            | a,d       | ab,cd,cd | depart,roundabout-exit-1,arrive |
+            | a,h       | ab,gh,gh | depart,roundabout-exit-2,arrive |
+            | a,f       | ab,ef,ef | depart,roundabout-exit-2,arrive |
+
     #2927
     Scenario: Only Roundabout
         Given the node map

--- a/features/testbot/side_bias.feature
+++ b/features/testbot/side_bias.feature
@@ -83,28 +83,3 @@ Feature: Testbot - side bias
            | a,d       | ab,cd,cd | depart,roundabout turn left exit-1,arrive     |
            | a,f       | ab,ef,ef | depart,roundabout turn straight exit-2,arrive |
            | a,h       | ab,gh,gh | depart,roundabout turn right exit-3,arrive    |
-
-    Scenario: Mixed Entry and Exit
-        And a grid size of 10 meters
-        And the node map
-           """
-             c   a
-           j   b   f
-             k   e
-           l   h   d
-             g   i
-           """
-
-        And the ways
-           | nodes | junction   | oneway |
-           | cba   |            | yes    |
-           | fed   |            | yes    |
-           | ihg   |            | yes    |
-           | lkj   |            | yes    |
-           | behkb | roundabout | yes    |
-
-        When I route I should get
-           | waypoints | route       | turns                           |
-           | c,a       | cba,cba,cba | depart,roundabout-exit-1,arrive |
-           | l,a       | lkj,cba,cba | depart,roundabout-exit-2,arrive |
-           | i,a       | ihg,cba,cba | depart,roundabout-exit-3,arrive |

--- a/include/extractor/guidance/road_classification.hpp
+++ b/include/extractor/guidance/road_classification.hpp
@@ -65,7 +65,7 @@ class RoadClassification
   public:
     // default construction
     RoadClassification()
-        : motorway_class(0), link_class(0), may_be_ignored(1),
+        : motorway_class(0), link_class(0), may_be_ignored(0),
           road_priority_class(RoadPriorityClass::CONNECTIVITY), number_of_lanes(0)
     {
     }


### PR DESCRIPTION
# Issue

Turns out parking isles in exit counting is a really bad idea. However, we create ambiguities here.
![](https://cloud.githubusercontent.com/assets/527241/20598719/c12101d2-b24a-11e6-8b5b-2d5e65949932.png)

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none

