### PR TITLE
Adds failing tests for directional access overrides, discovered in #3345

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -220,3 +220,15 @@ Feature: Car - Restricted access
         Then routability should be
             | highway | toll        | bothw |
             | primary | yes         |       |
+
+    Scenario: Car - directional access tags
+        Then routability should be
+            | highway | access | access:forward | access:backward | forw | backw |
+            | primary | yes    | yes            | yes             | x    | x     |
+            | primary | yes    |                | no              | x    |       |
+            | primary | yes    | no             |                 |      | x     |
+            | primary | yes    | no             | no              |      |       |
+            | primary | no     | no             | no              |      |       |
+            | primary | no     |                | yes             |      | x     |
+            | primary | no     | yes            |                 | x    |       |
+            | primary | no     | yes            | yes             | x    | x     |


### PR DESCRIPTION
We don't handle directional overrides.

This adds an initial failing (!) test for the situation outlined by @emiltin in https://github.com/Project-OSRM/osrm-backend/pull/3345#discussion_r89841432.
