### PR TITLE
Adding nodes's and ways's version access in lua binding.

### DIFF
--- a/include/extractor/extractor_config.hpp
+++ b/include/extractor/extractor_config.hpp
@@ -102,6 +102,8 @@ struct ExtractorConfig
     bool generate_edge_lookup;
     std::string edge_penalty_path;
     std::string edge_segment_lookup_path;
+
+    bool use_metadata;
 };
 }
 }

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -130,7 +130,11 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         auto extractor_callbacks = std::make_unique<ExtractorCallbacks>(extraction_containers);
 
         const osmium::io::File input_file(config.input_path.string());
-        osmium::io::Reader reader(input_file, osmium::io::read_meta::no);
+
+        osmium::io::Reader reader(
+            input_file,
+            (config.use_metadata ? osmium::io::read_meta::yes : osmium::io::read_meta::no));
+
         const osmium::io::Header header = reader.header();
 
         unsigned number_of_nodes = 0;

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -189,7 +189,9 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "id",
         &osmium::Way::id,
         "get_nodes",
-        [](const osmium::Way &way) { return sol::as_table(way.nodes()); });
+        [](const osmium::Way &way) { return sol::as_table(way.nodes()); },
+        "version",
+        &osmium::Way::version);
 
     context.state.new_usertype<osmium::Node>("Node",
                                              "location",
@@ -197,7 +199,9 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                              "get_value_by_key",
                                              &get_value_by_key<osmium::Node>,
                                              "id",
-                                             &osmium::Node::id);
+                                             &osmium::Node::id,
+                                             "version",
+                                             &osmium::Way::version);
 
     context.state.new_usertype<ExtractionNode>("ResultNode",
                                                "traffic_lights",

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -50,7 +50,12 @@ return_code parseArguments(int argc, char *argv[], extractor::ExtractorConfig &e
         boost::program_options::value<unsigned int>(&extractor_config.small_component_size)
             ->default_value(1000),
         "Number of nodes required before a strongly-connected-componennt is considered big "
-        "(affects nearest neighbor snapping)");
+        "(affects nearest neighbor snapping)")(
+        "with-osm-metadata",
+        boost::program_options::value<bool>(&extractor_config.use_metadata)
+            ->implicit_value(true)
+            ->default_value(false),
+        "Use metada during osm parsing (This can affect the extraction performance).");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user


### PR DESCRIPTION
Adding nodes's and ways's version access in lua binding for users who need this information.

## Tasklist
 - [x] Add node version access.
 - [x] Add way version access.
 - [x] requires https://github.com/Project-OSRM/osrm-backend/issues/3452 to be resolved first

Signed-off-by: FILLAU Jean-Maxime <jean-maxime.fillau@mapotempo.com>