### PR TITLE
Fix -flto support with clang++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,6 @@ before_install:
       # and therefore don't need to us ld.gold or llvm tools for linking
       # for debug builds
       if [[ ${BUILD_TYPE} == 'Release' ]]; then
-        export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_RANLIB=$(which llvm-ranlib)"
         ./third_party/mason/mason install binutils 2.27
         export PATH=$(./third_party/mason/mason prefix binutils 2.27)/bin:${PATH}
       fi
@@ -158,7 +157,7 @@ install:
   - export OSRM_BUILD_DIR="$(pwd)/build-osrm"
   - mkdir ${OSRM_BUILD_DIR} && pushd ${OSRM_BUILD_DIR}
   - export CC=${CCOMPILER} CXX=${CXXCOMPILER}
-  - cmake .. ${CMAKE_EXTRA:-} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_MASON=${ENABLE_MASON:-OFF} -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} -DBUILD_TOOLS=ON -DBUILD_COMPONENTS=${BUILD_COMPONENTS:-OFF} -DENABLE_CCACHE=ON
+  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_MASON=${ENABLE_MASON:-OFF} -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} -DBUILD_TOOLS=ON -DBUILD_COMPONENTS=${BUILD_COMPONENTS:-OFF} -DENABLE_CCACHE=ON
   - echo "travis_fold:start:MAKE"
   - make --jobs=${JOBS}
   - make tests --jobs=${JOBS}
@@ -172,7 +171,7 @@ install:
     fi
   - popd
   - mkdir example/build && pushd example/build
-  - cmake .. ${CMAKE_EXTRA:-} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
   - make --jobs=${JOBS}
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,15 @@ before_install:
       export CXXCOMPILER='clang++'
       ./third_party/mason/mason install clang++ ${CLANG_VERSION}
       export PATH=$(./third_party/mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
+      ./third_party/mason/mason install binutils 2.27
+      export PATH=$(./third_party/mason/mason prefix binutils 2.27)/bin:${PATH}
+      which ld
+      ./third_party/mason/mason install llvm ${CLANG_VERSION}
+      export PATH=$(./third_party/mason/mason prefix llvm ${CLANG_VERSION})/bin:${PATH}
+      which llvm-ar
+      which llvm-ranlib
+      which llvm-nm
+      export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_NM=$(which llvm-nm) -DCMAKE_RANLIB=$(which llvm-ranlib)"
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 
@@ -150,7 +159,7 @@ install:
   - export OSRM_BUILD_DIR="$(pwd)/build-osrm"
   - mkdir ${OSRM_BUILD_DIR} && pushd ${OSRM_BUILD_DIR}
   - export CC=${CCOMPILER} CXX=${CXXCOMPILER}
-  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_MASON=${ENABLE_MASON:-OFF} -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} -DBUILD_TOOLS=ON -DBUILD_COMPONENTS=${BUILD_COMPONENTS:-OFF} -DENABLE_CCACHE=ON
+  - cmake .. ${CMAKE_EXTRA:-} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_MASON=${ENABLE_MASON:-OFF} -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} -DBUILD_TOOLS=ON -DBUILD_COMPONENTS=${BUILD_COMPONENTS:-OFF} -DENABLE_CCACHE=ON
   - echo "travis_fold:start:MAKE"
   - make --jobs=${JOBS}
   - make tests --jobs=${JOBS}
@@ -164,7 +173,7 @@ install:
     fi
   - popd
   - mkdir example/build && pushd example/build
-  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+  - cmake .. ${CMAKE_EXTRA:-} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
   - make --jobs=${JOBS}
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,9 +139,14 @@ before_install:
       export CXXCOMPILER='clang++'
       ./third_party/mason/mason install clang++ ${CLANG_VERSION}
       export PATH=$(./third_party/mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
-      export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_RANLIB=$(which llvm-ranlib)"
-      ./third_party/mason/mason install binutils 2.27
-      export PATH=$(./third_party/mason/mason prefix binutils 2.27)/bin:${PATH}
+      # we only enable lto for release builds
+      # and therefore don't need to us ld.gold or llvm tools for linking
+      # for debug builds
+      if [[ ${BUILD_TYPE} == 'Release' ]]; then
+        export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_RANLIB=$(which llvm-ranlib)"
+        ./third_party/mason/mason install binutils 2.27
+        export PATH=$(./third_party/mason/mason prefix binutils 2.27)/bin:${PATH}
+      fi
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ before_install:
       which llvm-ar
       which llvm-ranlib
       which llvm-nm
-      export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_NM=$(which llvm-nm) -DCMAKE_RANLIB=$(which llvm-ranlib)"
+      export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_RANLIB=$(which llvm-ranlib)"
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,15 +139,9 @@ before_install:
       export CXXCOMPILER='clang++'
       ./third_party/mason/mason install clang++ ${CLANG_VERSION}
       export PATH=$(./third_party/mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
+      export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_RANLIB=$(which llvm-ranlib)"
       ./third_party/mason/mason install binutils 2.27
       export PATH=$(./third_party/mason/mason prefix binutils 2.27)/bin:${PATH}
-      which ld
-      ./third_party/mason/mason install llvm ${CLANG_VERSION}
-      export PATH=$(./third_party/mason/mason prefix llvm ${CLANG_VERSION})/bin:${PATH}
-      which llvm-ar
-      which llvm-ranlib
-      which llvm-nm
-      export CMAKE_EXTRA="-DCMAKE_AR=$(which llvm-ar) -DCMAKE_RANLIB=$(which llvm-ranlib)"
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,17 +192,8 @@ endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES MinRelSize OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
   message(STATUS "Configuring release mode optimizations")
-  # clang requires -flto in linker flags as well as cxxflags
-  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    # skip check_cxx_compiler_flag since we know it works
-    # bug causes cmake to ignore LINKER_FLAGS, so we use ENV['LDFLAGS']
-    # https://cmake.org/Bug/view.php?id=15264
-    set(OLD_LDFLAGS_ENV ENV{LDFLAGS})
-    set(ENV{LDFLAGS} "$ENV{LDFLAGS} -flto")
-  endif()
-
   # Check if LTO is available
-  check_cxx_compiler_flag("-flto" LTO_AVAILABLE)
+  check_cxx_compiler_flag("-Wl,-flto" LTO_AVAILABLE)
 
   if(ENABLE_LTO AND LTO_AVAILABLE)
     set(OLD_CXX_FLAGS ${CMAKE_CXX_FLAGS})
@@ -219,36 +210,53 @@ if(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES MinRelSize OR CM
     if(LTO_WORKS)
       message(STATUS "LTO working")
       set(OSRM_CXXFLAGS "${OSRM_CXXFLAGS} -flto")
-      if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-        set(OSRM_LDFLAGS "${OSRM_LDFLAGS} -flto")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto")
-        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -flto")
-      endif()
+      set(OSRM_LDFLAGS "${OSRM_LDFLAGS} -flto")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto")
+      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -flto")
     else()
       message(STATUS "LTO broken")
       set(CMAKE_CXX_FLAGS "${OLD_CXX_FLAGS}")
+      set(ENABLE_LTO Off)
     endif()
 
     # Since gcc 4.9 the LTO format is non-standart ('slim'), so we need to use the build-in tools
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
         NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9.0" AND NOT MINGW)
-      message(STATUS "Using gcc specific binutils for LTO.")
-      set(CMAKE_AR     "/usr/bin/gcc-ar")
-      set(CMAKE_RANLIB "/usr/bin/gcc-ranlib")
+      find_program(GCC_AR gcc-ar)
+      find_program(GCC_RANLIB gcc-ranlib)
+      if ("${GCC_AR}" STREQUAL "GCC_AR-NOTFOUND" OR "${GCC_RANLIB}" STREQUAL "GCC_RANLIB-NOTFOUND")
+        message(WARNING "GCC specific binutils not found.")
+      else()
+        message(STATUS "Using GCC specific binutils for LTO:")
+        message(STATUS " ${GCC_AR}")
+        message(STATUS " ${GCC_RANLIB}")
+        set(CMAKE_AR ${GCC_AR})
+        set(CMAKE_RANLIB ${GCC_RANLIB})
+      endif()
+    endif()
+
+    # Same for clang LTO requires their own toolchain
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      find_program(LLVM_AR llvm-ar)
+      find_program(LLVM_RANLIB llvm-ranlib)
+      if ("${LLVM_AR}" STREQUAL "LLVM_AR-NOTFOUND" OR "${LLVM_RANLIB}" STREQUAL "LLVM_RANLIB-NOTFOUND")
+        message(WARNING "LLVM specific binutils not found.")
+      else()
+        message(STATUS "Using LLVM specific binutils for LTO:")
+        message(STATUS " ${LLVM_AR}")
+        message(STATUS " ${LLVM_RANLIB}")
+        set(CMAKE_AR ${LLVM_AR})
+        set(CMAKE_RANLIB ${LLVM_RANLIB})
+      endif()
     endif()
 
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9.0")
       message(STATUS "Disabling LTO on GCC < 4.9.0 since it is broken, see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57038")
       set(CMAKE_CXX_FLAGS "${OLD_CXX_FLAGS}")
+      set(ENABLE_LTO Off)
     endif()
   endif()
-
-  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND NOT LTO_AVAILABLE OR NOT LTO_WORKS)
-    # restore the original, unmodified linker flags
-    set(ENV{LDFLAGS} "${OLD_LDFLAGS_ENV}")
-  endif()
-
 endif()
 
 if(UNIX AND NOT APPLE AND ENABLE_MASON AND (LTO_WORKS OR ENABLE_GOLD_LINKER))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,7 @@ option(ENABLE_FUZZING "Fuzz testing using LLVM's libFuzzer" OFF)
 option(ENABLE_GOLD_LINKER "Use GNU gold linker if available" ON)
 
 if(ENABLE_MASON)
-
   # versions in use
-  set(MASON_CLANG_VERSION "3.8.1")
   set(MASON_BOOST_VERSION "1.61.0")
   set(MASON_STXXL_VERSION "1.4.1")
   set(MASON_EXPAT_VERSION "2.2.0")
@@ -36,7 +34,6 @@ if(ENABLE_MASON)
   set(MASON_LUABIND_VERSION "e414c57bcb687bb3091b7c55bbff6947f052e46b")
   set(MASON_BZIP2_VERSION "1.0.6")
   set(MASON_TBB_VERSION "43_20150316")
-  set(MASON_CCACHE_VERSION "3.3.1")
 
   message(STATUS "Enabling mason")
 
@@ -434,15 +431,6 @@ if(ENABLE_MASON)
   # current mason packages target -D_GLIBCXX_USE_CXX11_ABI=0
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
 
-  if(ENABLE_CCACHE)
-    mason_use(ccache VERSION ${MASON_CCACHE_VERSION})
-    message(STATUS "Setting ccache to ccache ${MASON_CCACHE_VERSION} (via mason) ${MASON_PACKAGE_ccache_PREFIX}/bin/ccache")
-    message(STATUS "Using ccache to speed up incremental builds")
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${MASON_PACKAGE_ccache_PREFIX}/bin/ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${MASON_PACKAGE_ccache_PREFIX}/bin/ccache)
-    set(ENV{CCACHE_CPP2} "true")
-  endif()
-
   # note: we avoid calling find_package(Osmium ...) here to ensure that the
   # expat and bzip2 are used from mason rather than the system
   include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include)
@@ -486,23 +474,23 @@ else()
   )
   endif()
 
-  # prefix compilation with ccache by default if available and on clang or gcc
-  if(ENABLE_CCACHE AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"))
-    find_program(CCACHE_FOUND ccache)
-    if(CCACHE_FOUND)
-      message(STATUS "Using ccache to speed up incremental builds")
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-      set(ENV{CCACHE_CPP2} "true")
-    endif()
-  endif()
-
   # note libosmium depends on expat and bzip2
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/cmake")
   set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include")
   find_package(Osmium REQUIRED COMPONENTS io)
   include_directories(SYSTEM ${OSMIUM_INCLUDE_DIR})
 
+endif()
+
+# prefix compilation with ccache by default if available and on clang or gcc
+if(ENABLE_CCACHE AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"))
+  find_program(CCACHE_FOUND ccache)
+  if(CCACHE_FOUND)
+    message(STATUS "Using ccache to speed up incremental builds")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    set(ENV{CCACHE_CPP2} "true")
+  endif()
 endif()
 
 # even with mason builds we want to link to system zlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ if(ENABLE_GOLD_LINKER)
     if("${LD_VERSION}" MATCHES "GNU gold")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
+        set(OSRM_LDFLAGS "${OSRM_LDFLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
         message(STATUS "Using GNU gold as linker.")
 
         # Issue 2785: check gold binutils version and don't use gc-sections for versions prior 2.25
@@ -194,8 +195,18 @@ endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES MinRelSize OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
   message(STATUS "Configuring release mode optimizations")
+  # clang requires -flto in linker flags as well as cxxflags
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    # skip check_cxx_compiler_flag since we know it works
+    # bug causes cmake to ignore LINKER_FLAGS, so we use ENV['LDFLAGS']
+    # https://cmake.org/Bug/view.php?id=15264
+    set(OLD_LDFLAGS_ENV ENV{LDFLAGS})
+    set(ENV{LDFLAGS} "$ENV{LDFLAGS} -flto")
+  endif()
+
   # Check if LTO is available
   check_cxx_compiler_flag("-flto" LTO_AVAILABLE)
+
   if(ENABLE_LTO AND LTO_AVAILABLE)
     set(OLD_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     # GCC in addition allows parallelizing LTO
@@ -210,6 +221,13 @@ if(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES MinRelSize OR CM
     check_cxx_source_compiles("${CHECK_LTO_SRC}" LTO_WORKS)
     if(LTO_WORKS)
       message(STATUS "LTO working")
+      set(OSRM_CXXFLAGS "${OSRM_CXXFLAGS} -flto")
+      if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+        set(OSRM_LDFLAGS "${OSRM_LDFLAGS} -flto")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -flto")
+      endif()
     else()
       message(STATUS "LTO broken")
       set(CMAKE_CXX_FLAGS "${OLD_CXX_FLAGS}")
@@ -228,9 +246,15 @@ if(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES MinRelSize OR CM
       set(CMAKE_CXX_FLAGS "${OLD_CXX_FLAGS}")
     endif()
   endif()
+
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND NOT LTO_AVAILABLE OR NOT LTO_WORKS)
+    # restore the original, unmodified linker flags
+    set(ENV{LDFLAGS} "${OLD_LDFLAGS_ENV}")
+  endif()
+
 endif()
 
-if (ENABLE_MASON AND (LTO_WORKS OR ENABLE_GOLD_LINKER))
+if(UNIX AND NOT APPLE AND ENABLE_MASON AND (LTO_WORKS OR ENABLE_GOLD_LINKER))
   message(WARNING "ENABLE_MASON and ENABLE_LTO/ENABLE_GOLD_LINKER may not work on all linux systems currently")
   message(WARNING "For more details see: https://github.com/Project-OSRM/osrm-backend/issues/3202")
 endif()
@@ -293,9 +317,11 @@ if("${LINKER_VERSION}" MATCHES "GNU gold" OR "${LINKER_VERSION}" MATCHES "GNU ld
   endif()
   # Default linker optimization flags
   set(LINKER_FLAGS "${LINKER_FLAGS} -Wl,-O1 -Wl,--hash-style=gnu -Wl,--sort-common")
+
 else()
   message(STATUS "Using unknown linker, not setting linker optimizations")
 endif ()
+set(OSRM_LDFLAGS "${OSRM_LDFLAGS} ${LINKER_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKER_FLAGS}")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
@@ -655,6 +681,7 @@ endfunction()
 
 JOIN("${OSRM_DEFINES}" " " TMP_OSRM_DEFINES)
 set(LibOSRM_CXXFLAGS "${OSRM_CXXFLAGS} ${TMP_OSRM_DEFINES}")
+set(LibOSRM_LDFLAGS "${OSRM_LDFLAGS}")
 
 if(BUILD_AS_SUBPROJECT)
   set(LibOSRM_CXXFLAGS "${LibOSRM_CXXFLAGS}" PARENT_SCOPE)
@@ -671,6 +698,7 @@ endif()
 
 # pkgconfig defines
 set(PKGCONFIG_OSRM_CXXFLAGS "${LibOSRM_CXXFLAGS}")
+set(PKGCONFIG_OSRM_LDFLAGS "${LibOSRM_LDFLAGS}")
 set(PKGCONFIG_LIBRARY_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 set(PKGCONFIG_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
 
@@ -703,6 +731,7 @@ if (ENABLE_FUZZING)
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-coverage=edge,indirect-calls,8bit-counters -fsanitize=address")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(OSRM_LDFLAGS "${OSRM_LDFLAGS} -fsanitize=address")
 
   message(STATUS "Using -fsanitize=${FUZZ_SANITIZER} for Fuzz testing")
 

--- a/cmake/pkgconfig.in
+++ b/cmake/pkgconfig.in
@@ -6,6 +6,6 @@ Name: libOSRM
 Description: Project OSRM library
 Version: v@OSRM_VERSION@
 Requires:
-Libs: -L${libdir} -losrm
+Libs: -L${libdir} -losrm @PKGCONFIG_OSRM_LDFLAGS@
 Libs.private: @PKGCONFIG_OSRM_DEPENDENT_LIBRARIES@
 Cflags: @PKGCONFIG_OSRM_INCLUDE_FLAGS@ @PKGCONFIG_OSRM_CXXFLAGS@


### PR DESCRIPTION
# Issue

Targeting #2120.

The gcc -flto support works currently by:

  - Telling cmake about gcc-ar and gcc-ranlib (https://github.com/Project-OSRM/osrm-backend/blob/ef087f963d2f50ce7bc7b7019c4cf7170cf8005e/CMakeLists.txt#L221-L223)
  - Gcc internally using its `lto-wrapper` for linking

For clang++ and -flto to work we need to:

 - 1) Add the `-flto` flag in both compile flags and link flags manually (since no equivalent `lto-wrapper` exists for linking with clang++)
 - 2) Use recent binutils for gold linker that understands clang++ lto format
 - 3) Provide the absolute paths to `llvm-ar` and `llvm-ranlib`

This PR builds **i** into the CMakeLists.txt and **ii** + **iii** into the `.travis.yml`.

This PR also:

  - Starts passing `-flto` and related flags to the pkg config file. Without this the example.cpp will not link because it is not compiled with `-flto` and the lto-enabled `libosrm.a` cannot be used.
  - Changes the warning about ENABLE_MASON possibly not working with lto on some systems to only display on linux (since OS X and windows are not impacted)

## Tasklist
 - [x] review
 - [x] adjust for comments
