### PR TITLE
Fix failing on windows io read test

### DIFF
--- a/unit_tests/util/io.cpp
+++ b/unit_tests/util/io.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(io_corrupt_fingerprint)
 BOOST_AUTO_TEST_CASE(io_read_lines)
 {
     {
-        std::ofstream f(IO_TEXT_FILE);
+        std::ofstream f(IO_TEXT_FILE, std::ios::binary);
         char str[] = "A\nB\nC\nD";
         f.write(str, strlen(str));
     }


### PR DESCRIPTION
# Issue

#3388
istream is opened as std::ios::binary, but in the test ostream opened in text mode, so read strings are "A\r..."
Changed the test ostream to binary mode.

Fixing in the file reader would require to use "\r" explicitly as a delimiter  or open istream in the text mode.

## Tasklist
 - [x] review
 - [ ] adjust for comments

