### PR TITLE
Enforce iteration order so that tiles are encoded consistently

### DIFF
--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    BOOST_CHECK_GT(result.size(), 128);
+    BOOST_CHECK_EQUAL(result.size(), 114091);
 
     protozero::pbf_reader tile_message(result);
     tile_message.next();


### PR DESCRIPTION
# Issue

This fixes #3343.  Because PBF uses variable-length encoding, differences in feature order (due to sorting differences on different platforms) leads to differently encoded files, even though they're otherwise equivalent.

This PR enforces the sort order for tile layers, features and properties, which causes tiles to be encoded the same on all platforms.

## Tasklist
 - [x] review
 - [x] adjust for comments