### PR TITLE
Abstracts away over differences in IntersectionView and Intersection.

### DIFF
--- a/include/extractor/guidance/intersection_normalizer.hpp
+++ b/include/extractor/guidance/intersection_normalizer.hpp
@@ -57,16 +57,17 @@ class IntersectionNormalizer
 
     const IntersectionGenerator &intersection_generator;
 
-    // check if two indices in an intersection can be seen as a single road in the perceived
-    // intersection representation. See below for an example. Utility function for
-    // MergeSegregatedRoads. It also checks for neighboring merges.
-    // This is due possible segments where multiple roads could end up being merged into one.
-    // We only support merging two roads, not three or more, though.
-    //       c                                  c
-    //      /                                  /
-    // a - b     -> a - b - (c,d) but not a - b d   -> a,b,(cde)
-    //      \                                  \
-    //       d                                  e
+    /* check if two indices in an intersection can be seen as a single road in the perceived
+     * intersection representation. See below for an example. Utility function for
+     * MergeSegregatedRoads. It also checks for neighboring merges.
+     * This is due possible segments where multiple roads could end up being merged into one.
+     * We only support merging two roads, not three or more, though.
+     *        c                                  c
+     *       /                                  /
+     *  a - b     -> a - b - (c,d) but not a - b d   -> a,b,(cde)
+     *       \                                  \
+     *       d                                  e
+     */
     bool CanMerge(const NodeID intersection_node,
                   const IntersectionShape &intersection,
                   std::size_t first_index,

--- a/src/extractor/geojson_debug_policies.cpp
+++ b/src/extractor/geojson_debug_policies.cpp
@@ -14,7 +14,9 @@ IntersectionPrinter::IntersectionPrinter(
     const std::vector<extractor::QueryNode> &node_coordinates,
     const extractor::guidance::CoordinateExtractor &coordinate_extractor)
     : node_based_graph(node_based_graph), node_coordinates(node_coordinates),
-      coordinate_extractor(coordinate_extractor){};
+      coordinate_extractor(coordinate_extractor)
+{
+}
 
 util::json::Array IntersectionPrinter::
 operator()(const NodeID intersection_node,

--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -55,7 +55,7 @@ double GetOffsetCorrectionFactor(const RoadClassification &road_classification)
     default:
         return 1.0;
     };
-};
+}
 }
 
 CoordinateExtractor::CoordinateExtractor(

--- a/src/extractor/guidance/intersection.cpp
+++ b/src/extractor/guidance/intersection.cpp
@@ -70,39 +70,6 @@ std::string toString(const ConnectedRoad &road)
     return result;
 }
 
-IntersectionView::Base::iterator IntersectionView::findClosestTurn(double angle)
-{
-    // use the const operator to avoid code duplication
-    return begin() +
-           std::distance(cbegin(),
-                         static_cast<const IntersectionView *>(this)->findClosestTurn(angle));
-}
-
-IntersectionView::Base::const_iterator IntersectionView::findClosestTurn(double angle) const
-{
-    return std::min_element(
-        begin(), end(), [angle](const IntersectionViewData &lhs, const IntersectionViewData &rhs) {
-            return util::guidance::angularDeviation(lhs.angle, angle) <
-                   util::guidance::angularDeviation(rhs.angle, angle);
-        });
-}
-
-Intersection::Base::iterator Intersection::findClosestTurn(double angle)
-{
-    // use the const operator to avoid code duplication
-    return begin() +
-           std::distance(cbegin(), static_cast<const Intersection *>(this)->findClosestTurn(angle));
-}
-
-Intersection::Base::const_iterator Intersection::findClosestTurn(double angle) const
-{
-    return std::min_element(
-        begin(), end(), [angle](const ConnectedRoad &lhs, const ConnectedRoad &rhs) {
-            return util::guidance::angularDeviation(lhs.angle, angle) <
-                   util::guidance::angularDeviation(rhs.angle, angle);
-        });
-}
-
 bool Intersection::valid() const
 {
     return !empty() &&


### PR DESCRIPTION
CRTP-away the differences in `IntersectionView` and `Intersection` for re-usable intersection features.

## Tasklist
 - [x] review
 - [x] adjust for comments

Usage:

```c++
struct MyIntersection : EnableIntersectionOps<MyIntersection> {

};
```

Done.

We require `MyIntersection` having at least the member attributes from
`IntersectionViewData` but don't enforce a inheritance hierarchy.