### PR TITLE
Make absolute fixtures path

### DIFF
--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -15,7 +15,7 @@ PROFILE:=$(PROFILE_ROOT)/car.lua
 all: $(DATA_NAME).osrm.hsgr
 
 clean:
-	rm $(DATA_NAME).*
+	-rm $(DATA_NAME).*
 
 $(DATA_NAME).osm.pbf:
 	wget $(DATA_URL) -O $(DATA_NAME).osm.pbf

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -48,6 +48,8 @@ if(NOT WIN32 AND NOT Boost_USE_STATIC_LIBS)
   add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 
+target_compile_definitions(extractor-tests PRIVATE COMPILE_DEFINITIONS OSRM_FIXTURES_DIR="${CMAKE_SOURCE_DIR}/unit_tests/fixtures")
+
 target_include_directories(engine-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(library-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(util-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/unit_tests/extractor/raster_source.cpp
+++ b/unit_tests/extractor/raster_source.cpp
@@ -23,8 +23,8 @@ int normalize(double coord) { return static_cast<int>(coord * COORDINATE_PRECISI
 BOOST_AUTO_TEST_CASE(raster_test)
 {
     SourceContainer sources;
-    int source_id = sources.LoadRasterSource(
-        "../unit_tests/fixtures/raster_data.asc", 1, 1.09, 1, 1.09, 10, 10);
+    int source_id =
+        sources.LoadRasterSource(OSRM_FIXTURES_DIR "/raster_data.asc", 1, 1.09, 1, 1.09, 10, 10);
     BOOST_CHECK_EQUAL(source_id, 0);
 
     // Expected nearest-neighbor queries
@@ -67,15 +67,15 @@ BOOST_AUTO_TEST_CASE(raster_test)
     CHECK_INTERPOLATE(0, 1.056, 1.028, 68);
     CHECK_INTERPOLATE(0, 1.05, 1.028, 56);
 
-    int source_already_loaded_id = sources.LoadRasterSource(
-        "../unit_tests/fixtures/raster_data.asc", 1, 1.09, 1, 1.09, 10, 10);
+    int source_already_loaded_id =
+        sources.LoadRasterSource(OSRM_FIXTURES_DIR "/raster_data.asc", 1, 1.09, 1, 1.09, 10, 10);
 
     BOOST_CHECK_EQUAL(source_already_loaded_id, 0);
     BOOST_CHECK_THROW(sources.GetRasterDataFromSource(1, normalize(1.02), normalize(1.02)),
                       util::exception);
 
     BOOST_CHECK_THROW(
-        sources.LoadRasterSource("../unit_tests/fixtures/nonexistent.asc", 0, 1.1, 0, 1.1, 7, 7),
+        sources.LoadRasterSource(OSRM_FIXTURES_DIR "/nonexistent.asc", 0, 1.1, 0, 1.1, 7, 7),
         util::exception);
 }
 


### PR DESCRIPTION
# Issue

If the build directory is not in CMAKE_SOURCE_DIR than some tests that use relative paths may fail.
PR adds compile definition `FIXTURES_DIR="${CMAKE_SOURCE_DIR}/unit_tests/fixtures"`  to `extractor-tests`.

Also PR makes `rm $(DATA_NAME).*` non-failing if `$(DATA_NAME).*` files do not exist.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Code Review Checklist - author check these when done, reviewer verify
 - [x] Code formatted with `scripts/format.sh`
 - [x] Changes have test coverage
 - [x] New exceptions, logging, errors - are messages distinct enough to track down in the code if they get thrown in production on non-debug builds?
 - [x] The PR is one logically integrated piece of work.  If there are unrelated changes, are they at least separate commits?
 - [x] Commit messages - are they clear enough to understand the intent of the change if we have to look at them later?
 - [x] Code comments - are there comments explaining the intent?
~~- [ ] Relevant docs updated~~
~~- [ ] Changelog entry if required~~
~~- [ ] Impact on the API surface~~
~~- [ ] If HTTP/libosrm.o is backward compatible features, bump the minor version~~
~~- [ ] File format changes require at minor release~~
~~- [ ] If old clients can't use the API after changes, bump the major version~~

If something doesn't apply, please ~~cross it out~~


