### PR TITLE
Add headers consistency check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
       compiler: "gcc-6-release-i686"
       env: >
         TARGET_ARCH='i686' CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Release'
-        CFLAGS='-m32 -msse2 -mfpmath=sse' CXXFLAGS='-m32 -msse2 -mfpmath=sse'
+        CFLAGS='-m32 -msse2 -mfpmath=sse' CXXFLAGS='-m32 -msse2 -mfpmath=sse' CHECK_HEADERS=yes
 
     - os: linux
       compiler: "gcc-4.9-release"
@@ -170,6 +170,7 @@ install:
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       sudo ldconfig
     fi
+  - if [[ ${CHECK_HEADERS} == yes ]] ; then make check-headers ; fi
   - popd
   - mkdir example/build && pushd example/build
   - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,3 +735,21 @@ if (ENABLE_FUZZING)
 
   add_subdirectory(fuzz)
 endif ()
+
+
+## add headers sanity check target that includes all headers independently
+set(check_headers_dir "${PROJECT_BINARY_DIR}/check-headers")
+file(GLOB_RECURSE headers_to_check
+  ${PROJECT_BINARY_DIR}/*.hpp
+  ${PROJECT_SOURCE_DIR}/include/*.hpp)
+foreach(header ${headers_to_check})
+  get_filename_component(filename ${header} NAME_WE)
+  set(filename "${check_headers_dir}/${filename}.cpp")
+  if (NOT EXISTS ${filename})
+    file(WRITE ${filename} "#include \"${header}\"\n")
+  endif()
+  list(APPEND sources ${filename})
+endforeach()
+add_library(check-headers STATIC EXCLUDE_FROM_ALL ${sources})
+set_target_properties(check-headers PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${check_headers_dir})
+

--- a/include/engine/datafacade/contiguous_internalmem_datafacade_base.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade_base.hpp
@@ -7,6 +7,7 @@
 #include "extractor/guidance/turn_instruction.hpp"
 #include "extractor/guidance/turn_lane_types.hpp"
 #include "extractor/profile_properties.hpp"
+#include "storage/shared_datatype.hpp"
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
 #include "util/guidance/turn_lanes.hpp"

--- a/include/extractor/guidance/road_classification.hpp
+++ b/include/extractor/guidance/road_classification.hpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 
 #include "extractor/guidance/constants.hpp"

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -8,6 +8,7 @@
 #include <boost/assert.hpp>
 
 #include "extractor/guidance/road_classification.hpp"
+#include "extractor/guidance/turn_lane_types.hpp"
 #include "osrm/coordinate.hpp"
 #include <utility>
 

--- a/include/util/container.hpp
+++ b/include/util/container.hpp
@@ -1,6 +1,8 @@
 #ifndef CONTAINER_HPP
 #define CONTAINER_HPP
 
+#include <utility>
+
 namespace osrm
 {
 namespace util

--- a/include/util/dist_table_wrapper.hpp
+++ b/include/util/dist_table_wrapper.hpp
@@ -1,6 +1,8 @@
 #ifndef DIST_TABLE_WRAPPER_H
 #define DIST_TABLE_WRAPPER_H
 
+#include "util/typedefs.hpp"
+
 #include <algorithm>
 #include <boost/assert.hpp>
 #include <cstddef>

--- a/include/util/fingerprint_impl.hpp.in
+++ b/include/util/fingerprint_impl.hpp.in
@@ -1,3 +1,4 @@
+#include "util/fingerprint.hpp"
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
 

--- a/include/util/geojson_debug_logger.hpp
+++ b/include/util/geojson_debug_logger.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <string>
 
+#include "util/exception.hpp"
 #include "util/json_container.hpp"
 #include "util/json_renderer.hpp"
 #include "util/log.hpp"

--- a/include/util/geojson_debug_policy_toolkit.hpp
+++ b/include/util/geojson_debug_policy_toolkit.hpp
@@ -1,9 +1,12 @@
 #ifndef OSRM_GEOJSON_DEBUG_POLICY_TOOLKIT_HPP
 #define OSRM_GEOJSON_DEBUG_POLICY_TOOLKIT_HPP
 
+#include "extractor/external_memory_node.hpp"
+#include "util/coordinate.hpp"
 #include "util/json_container.hpp"
 
 #include <algorithm>
+#include <iterator>
 
 #include <boost/optional.hpp>
 


### PR DESCRIPTION
# Issue

Added a simple check for headers consistency. It creates a set of cpp files that only include hpp files and `make check-headers` will show incorrect  header files. It will not work for files with duplicated names.


## Tasklist
 - [x] review
 - [x] adjust for comments

## Code Review Checklist - author check these when done, reviewer verify
 - [ ] Code formatted with `scripts/format.sh`
 - [ ] Changes have test coverage
 - [ ] New exceptions, logging, errors - are messages distinct enough to track down in the code if they get thrown in production on non-debug builds?
 - [ ] The PR is one logically integrated piece of work.  If there are unrelated changes, are they at least separate commits?
 - [ ] Commit messages - are they clear enough to understand the intent of the change if we have to look at them later?
 - [ ] Code comments - are there comments explaining the intent?
 - [ ] Relevant docs updated
 - [ ] Changelog entry if required
 - [ ] Impact on the API surface
   - [ ] If HTTP/libosrm.o is backward compatible features, bump the minor version
   - [ ] File format changes require at minor release
   - [ ] If old clients can't use the API after changes, bump the major version

If something doesn't apply, please ~~cross it out~~


## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?

