### PR TITLE
Propose new PR checklist.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,22 @@ What issue is this PR targeting? If there is no issue that addresses the problem
  - [ ] review
  - [ ] adjust for comments
 
+## Code Review Checklist - author check these when done, reviewer verify
+ - [ ] Travis builds pass
+ - [ ] Code formatted with `scripts/format.sh`
+ - [ ] Changes have test coverage
+ - [ ] New exceptions, logging, errors - are messages distinct enough to track down in the code if they get thrown in production on non-debug builds?
+ - [ ] The PR is one logically integrated piece of work.  If there are unrelated changes, are they at least separate commits?
+ - [ ] Commit messages - are they clear enough to understand the intent of the change if we have to look at them later?
+ - [ ] Code comments - are there comments explaining the intent?
+ - [ ] Relevant docs updated
+ - [ ] Changelog entry if required (new features, bugfixes, behaviour changes)
+ - [ ] Impact on the API surface
+   - [ ] If HTTP/libosrm.o is backward compatible features, bump the minor version
+   - [ ] File format changes require at minor release
+   - [ ] If old clients can't use the API after changes, bump the major version
+
+If something doesn't apply, please ~~cross it out~~
+
 ## Requirements / Relations
  Link any requirements here. Other pull requests this PR is based on?


### PR DESCRIPTION
After blindly pushing out a change to our PR template, I realized the error of my ways and pulled that change.

Presented here is the same thing as a PR for group discussion.  I am proposing a larger set of checklist items for all PRs for `osrm-backend`.

There are a few motivations behind this proposal:

  1. Help reviewers focus on the functional change and not the minutae
  2. Ensure that stuff we need later (i.e. release notes) gets done now so it's not hard to track down
  3. Reduce the element of surprise in reviews, and increase the quality of the feedback
  4. Highlight some of the things that have bitten us in the past (explicitly noting API changes) that we don't want to repeat

I realize this list is somewhat longer than before, but after looking over past errors, comments on PRs and tickets, this list represents many of the common things that we pick up on.

There's a balance here - if the list gets too long, folks will rubber-stamp it - if it's too short, we continue to miss some important steps and fail to learn from lessons of the past.

This list is a proposal, I'd like this PR to start a discussion about how we accept contributions to this project, and I expect to make changes before we push this out.  I apologize for pushing it out earlier without going through this discussion.