### PR TITLE
Add assertion to geoprinter

### DIFF
--- a/include/util/geojson_debug_logger.hpp
+++ b/include/util/geojson_debug_logger.hpp
@@ -63,11 +63,11 @@ class GeojsonLogger
         // make sure to syncronize logging output, our writing should be sequential
         std::lock_guard<std::mutex> guard(lock);
 
-        // if there is no logfile, we cannot write
+        // if there is no logfile, we cannot write (possible reason: the guard might be out of scope
+        // (e.g. if it is anonymous))
         if (!ofs.is_open() || (nullptr == policy))
         {
-            // this can only happend between two guards when concurrent writing occurs
-            return false;
+            throw util::exception("Trying to use the geojson printer without an open logger.");
         }
 
         // use our policy to convert the arguments into geojson, this can be done in parallel


### PR DESCRIPTION
# Issue

If someone tries to print geojson output with the geojson printer and there is no logger open, an assertion will now notify the developer

## Tasklist
 - [ ] review
 - [ ] adjust for comments

@MoKob 