### PR TITLE
Log helpful error message if mmap fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
       - fixed a bug that could result in inconsistent behaviour when collapsing instructions
       - fixed a bug that could result in crashes when leaving a ferry directly onto a motorway ramp
       - fixed a bug in the tile plugin that resulted in discovering invalid edges for connections
+      - improved error messages when missing files during traffic updates (#3114)
     - Debug Tiles
       - Added support for turn penalties
     - Internals

--- a/features/options/contract/invalid.feature
+++ b/features/options/contract/invalid.feature
@@ -3,10 +3,26 @@ Feature: osrm-contract command line options: invalid options
 
     Background:
         Given the profile "testbot"
+        And the node map
+            """
+            a b
+            """
+        And the ways
+            | nodes |
+            | ab    |
+        And the data has been extracted
 
     Scenario: osrm-contract - Non-existing option
         When I try to run "osrm-contract --fly-me-to-the-moon"
         Then stdout should be empty
         And stderr should contain "option"
         And stderr should contain "fly-me-to-the-moon"
+        And it should exit with an error
+
+    # This tests the error messages when you try to use --segment-speed-file,
+    # but osrm-extract has not been run with --generate-edge-lookup
+    Scenario: osrm-contract - Someone forgot --generate-edge-lookup on osrm-extract
+        When I try to run "osrm-contract --segment-speed-file /dev/null {processed_file}"
+        Then stderr should contain "Error while trying to mmap"
+        Then stderr should contain ".osrm.edge_penalties"
         And it should exit with an error

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -522,10 +522,18 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
         using boost::interprocess::mapped_region;
         using boost::interprocess::read_only;
 
-        const file_mapping mapping{filename.c_str(), read_only};
-        mapped_region region{mapping, read_only};
-        region.advise(mapped_region::advice_sequential);
-        return region;
+        try
+        {
+            const file_mapping mapping{filename.c_str(), read_only};
+            mapped_region region{mapping, read_only};
+            region.advise(mapped_region::advice_sequential);
+            return region;
+        }
+        catch (const std::exception &e)
+        {
+            util::Log(logERROR) << "Error while trying to mmap " + filename + ": " + e.what();
+            throw;
+        }
     };
 
     const auto edge_based_graph_region = mmap_file(edge_based_graph_filename);


### PR DESCRIPTION
# Issue

This is a fix for #3114 - where we weren't logging the actual filename when our attempt to `mmap` it failed.  Combined with the previous log message, this meant that log output was hard to interpret, the real error was hidden.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments