### PR TITLE
Clarify API and ensure bearings returned to users are in the range 0-359

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.5.1
+  - Changes from 5.5.0
+    - Bugfixes
+      - Fix #3418 and ensure we only return bearings in the range 0-359 in API responses
+
 # 5.5.0
   - Changes from 5.4.0
     - API:

--- a/docs/http.md
+++ b/docs/http.md
@@ -577,9 +577,9 @@ step.
 
 - `location`: A `[longitude, latitude]` pair describing the location of the turn.
 - `bearing_before`: The clockwise angle from true north to the
-  direction of travel immediately before the maneuver.
+  direction of travel immediately before the maneuver.  Range 0-359.
 - `bearing_after`: The clockwise angle from true north to the
-  direction of travel immediately after the maneuver.
+  direction of travel immediately after the maneuver.  Range 0-359.
 - `type` A string indicating the type of maneuver. **new identifiers might be introduced without API change**
    Types  unknown to the client should be handled like the `turn` type, the existance of correct `modifier` values is guranteed.
   
@@ -676,7 +676,7 @@ location of the StepManeuver. Further intersections are listed for every cross-w
 **Properties**
 
 - `location`: A `[longitude, latitude]` pair describing the location of the turn.
-- `bearings`: A list of bearing values (e.g. [0,90,180,270]) that are available at the intersection. The bearings describe all available roads at the intersection.
+- `bearings`: A list of bearing values (e.g. [0,90,180,270]) that are available at the intersection. The bearings describe all available roads at the intersection.  Values are between 0-359 (0=true north)
 - `entry`: A list of entry flags, corresponding in a 1:1 relationship to the bearings. A value of `true` indicates that the respective road could be entered on a valid route.
   `false` indicates that the turn onto the respective road would violate a restriction.
 - `in`: index into bearings/entry array. Used to calculate the bearing just before the turn. Namely, the clockwise angle from true north to the

--- a/features/guidance/bugs.feature
+++ b/features/guidance/bugs.feature
@@ -50,3 +50,20 @@ Feature: Features related to bugs
         And the data has been saved to disk
         When I try to run "osrm-extract {osm_file} --profile {profile_file}"
         Then it should exit successfully
+
+    @3418
+    Scenario: Bearings should be between 0-359
+        Given the node locations
+            | node | lon          | lat        |
+            | a    | -122.0232176 | 37.3282203 |
+            | b    | -122.0232199 | 37.3302422 |
+            | c    | -122.0232252 | 37.3312787 |
+
+        And the ways
+            | nodes | name               | highway     |
+            | ab    | Pear to Merrit     | residential |
+            | bc    | Merritt to Apricot | residential |
+
+        When I route I should get
+            | waypoints | route | intersections  |
+            | a,c       | Pear to Merrit,Merritt to Apricot,Merritt to Apricot | true:0;true:0 false:180;true:180  |

--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -40,6 +40,11 @@ util::json::Array coordinateToLonLat(const util::Coordinate coordinate);
 
 std::string modeToString(const extractor::TravelMode mode);
 
+/**
+ * Ensures that a bearing value is a whole number, and clamped to the range 0-359
+ */
+inline double roundAndClampBearing(double bearing) { return std::fmod(std::round(bearing), 360); }
+
 } // namespace detail
 
 template <unsigned POLYLINE_PRECISION, typename ForwardIter>

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -139,14 +139,14 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                 intersection.out = bearing_class.findMatchingBearing(bearings.second);
                 intersection.location = facade.GetCoordinateOfNode(path_point.turn_via_node);
                 intersection.bearings.clear();
-                intersection.bearings.reserve(bearing_class.getAvailableBearings().size());
+                intersection.bearings.reserve(bearing_data.size());
                 intersection.lanes = path_point.lane_data.first;
                 intersection.lane_description =
                     path_point.lane_data.second != INVALID_LANE_DESCRIPTIONID
                         ? facade.GetTurnDescription(path_point.lane_data.second)
                         : extractor::guidance::TurnLaneDescription();
-                std::copy(bearing_class.getAvailableBearings().begin(),
-                          bearing_class.getAvailableBearings().end(),
+                std::copy(bearing_data.begin(),
+                          bearing_data.end(),
                           std::back_inserter(intersection.bearings));
                 intersection.entry.clear();
                 for (auto idx : util::irange<std::size_t>(0, intersection.bearings.size()))

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -211,7 +211,7 @@ util::json::Object makeIntersection(const guidance::Intersection &intersection)
         intersection.bearings.begin(),
         intersection.bearings.end(),
         std::back_inserter(bearings.values),
-        [](const double bearing) -> util::json::Value { return std::fmod(bearing, 360); });
+        [](const double bearing) -> util::json::Value { BOOST_ASSERT(bearing != 360.0); return std::fmod(bearing, 360); });
 
     entry.values.reserve(intersection.entry.size());
     std::transform(intersection.entry.begin(),

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -192,8 +192,8 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
             detail::instructionModifierToString(maneuver.instruction.direction_modifier);
 
     step_maneuver.values["location"] = detail::coordinateToLonLat(maneuver.location);
-    step_maneuver.values["bearing_before"] = std::fmod(std::round(maneuver.bearing_before), 360);
-    step_maneuver.values["bearing_after"] = std::fmod(std::round(maneuver.bearing_after), 360);
+    step_maneuver.values["bearing_before"] = detail::roundAndClampBearing(maneuver.bearing_before);
+    step_maneuver.values["bearing_after"] = detail::roundAndClampBearing(maneuver.bearing_after);
     if (maneuver.exit != 0)
         step_maneuver.values["exit"] = maneuver.exit;
 
@@ -207,11 +207,10 @@ util::json::Object makeIntersection(const guidance::Intersection &intersection)
     util::json::Array entry;
 
     bearings.values.reserve(intersection.bearings.size());
-    std::transform(
-        intersection.bearings.begin(),
-        intersection.bearings.end(),
-        std::back_inserter(bearings.values),
-        [](const double bearing) -> util::json::Value { BOOST_ASSERT(bearing != 360.0); return std::fmod(bearing, 360); });
+    std::transform(intersection.bearings.begin(),
+                   intersection.bearings.end(),
+                   std::back_inserter(bearings.values),
+                   detail::roundAndClampBearing);
 
     entry.values.reserve(intersection.entry.size());
     std::transform(intersection.entry.begin(),

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -192,8 +192,8 @@ util::json::Object makeStepManeuver(const guidance::StepManeuver &maneuver)
             detail::instructionModifierToString(maneuver.instruction.direction_modifier);
 
     step_maneuver.values["location"] = detail::coordinateToLonLat(maneuver.location);
-    step_maneuver.values["bearing_before"] = std::round(maneuver.bearing_before);
-    step_maneuver.values["bearing_after"] = std::round(maneuver.bearing_after);
+    step_maneuver.values["bearing_before"] = std::fmod(std::round(maneuver.bearing_before), 360);
+    step_maneuver.values["bearing_after"] = std::fmod(std::round(maneuver.bearing_after), 360);
     if (maneuver.exit != 0)
         step_maneuver.values["exit"] = maneuver.exit;
 
@@ -207,9 +207,11 @@ util::json::Object makeIntersection(const guidance::Intersection &intersection)
     util::json::Array entry;
 
     bearings.values.reserve(intersection.bearings.size());
-    std::copy(intersection.bearings.begin(),
-              intersection.bearings.end(),
-              std::back_inserter(bearings.values));
+    std::transform(
+        intersection.bearings.begin(),
+        intersection.bearings.end(),
+        std::back_inserter(bearings.values),
+        [](const double bearing) -> util::json::Value { return std::fmod(bearing, 360); });
 
     entry.values.reserve(intersection.entry.size());
     std::transform(intersection.entry.begin(),

--- a/src/util/guidance/bearing_class.cpp
+++ b/src/util/guidance/bearing_class.cpp
@@ -56,7 +56,7 @@ DiscreteBearing BearingClass::getDiscreteBearing(const double bearing)
 {
     BOOST_ASSERT(0. <= bearing && bearing <= 360.);
     auto shifted_bearing = (bearing + 0.5 * discrete_step_size);
-    if (shifted_bearing > 360.)
+    if (shifted_bearing >= 360.)
         shifted_bearing -= 360;
     return static_cast<DiscreteBearing>(shifted_bearing / discrete_step_size);
 }

--- a/src/util/guidance/turn_bearing.cpp
+++ b/src/util/guidance/turn_bearing.cpp
@@ -14,7 +14,7 @@ constexpr double bearing_scale = 360.0 / 256.0;
 // discretizes a bearing into distinct units of 1.4 degrees
 TurnBearing::TurnBearing(const double value) : bearing(value / bearing_scale)
 {
-    BOOST_ASSERT_MSG(value >= 0 && value <= 360.0, "Bearing value needs to be between 0 and 360");
+    BOOST_ASSERT_MSG(value >= 0 && value < 360.0, "Bearing value needs to be between 0 and 360 (exclusive)");
 }
 
 double TurnBearing::Get() const { return bearing * bearing_scale; }


### PR DESCRIPTION
# Issue

Fixes #3418 where the value "360" was being returned as a bearing value in some cases where we expected 0.  Although not strictly incorrect, the value was unexpected (see ticket). This change is mostly about implementing the principal-of-least-surprise rather than strict mathematical correctness.

The problem was caused by some internal calculations figuring "359.6" as the answer, then rounding that value.  This PR adds a modulo 360 to the JSON formatting, which restricts the range returned to users to 0-359.  Internal math remains unchanged.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments