### PR TITLE
don't assign unused name to exception

### DIFF
--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -161,7 +161,7 @@ class FileReader
         {
             std::getline(input_stream, thisline);
         }
-        catch (const std::ios_base::failure &e)
+        catch (const std::ios_base::failure & /*e*/)
         {
             // EOF is OK here, everything else, re-throw
             if (!input_stream.eof())


### PR DESCRIPTION
# Issue
Remove unused variable name

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
none

