### PR TITLE
Update node weights if traffic data is applied

### DIFF
--- a/include/contractor/contractor.hpp
+++ b/include/contractor/contractor.hpp
@@ -81,6 +81,7 @@ class Contractor
     EdgeID
     LoadEdgeExpandedGraph(const std::string &edge_based_graph_path,
                           util::DeallocatingVector<extractor::EdgeBasedEdge> &edge_based_edge_list,
+                          std::vector<EdgeWeight> &node_weights,
                           const std::string &edge_segment_lookup_path,
                           const std::string &edge_penalty_path,
                           const std::vector<std::string> &segment_speed_path,


### PR DESCRIPTION
# Issue

This is an attempt at fixing #3429.  Our extractor saves the edge-based-node weights into the `.enw` file.  However, if traffic data is applied, those node weights are invalidated, yet we still use them during graph contraction.

This PR moves the location that the `.enw` file is loaded and updates node weights with new values if traffic data is supplied.

With this change, can no longer reproduce the problem described in #3429

@MoKob @TheMarex can you sanity check this please?

TODO: an isolated test case - I have so far only reproduced this problem with large sets of internal data, I haven't narrowed it down to something I document as a cucumber test.

## Tasklist
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments