### PR TITLE
fix invalid assertion in coordinate_extractor

### DIFF
--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -132,7 +132,7 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
     {
         const auto result = ExtractCoordinateAtLength(
             skipping_inaccuracies_distance, coordinates);
-        BOOST_ASSERT(is_valid_result(coordinates.back()));
+        BOOST_ASSERT(is_valid_result(result));
         return result;
     }
 


### PR DESCRIPTION
# Issue

Discovered while reviewing https://github.com/Project-OSRM/osrm-backend/pull/3264. Invalid assertion.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none

