### PR TITLE
cache minimal adjacent edge weights to speed up contraction

### DIFF
--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -133,6 +133,137 @@ class GraphContractor
         EnumerableThreadData data;
     };
 
+    EdgeWeight GetMinimalAdjacentWeight(const NodeID nid) const
+    {
+        const auto range = contractor_graph->GetAdjacentEdgeRange(nid);
+        if (range.empty())
+            return std::numeric_limits<EdgeWeight>::max() / 2;
+
+        const auto edge_weight = [this](const EdgeID edge_id) -> EdgeWeight {
+            return contractor_graph->GetEdgeData(edge_id).weight;
+        };
+
+        // cannot be std::min_elment, since edge_range does not fit the concept
+        auto minimum = edge_weight(range.front());
+        for (auto eid : range)
+            minimum = std::min(minimum, edge_weight(eid));
+        return minimum;
+    }
+
+    std::vector<EdgeWeight> BuildMinimalAdjacentWeightCache() const
+    {
+        const auto number_of_nodes = contractor_graph->GetNumberOfNodes();
+        std::vector<EdgeWeight> minimal_adjacent_weight_cache(number_of_nodes);
+
+        const decltype(number_of_nodes) grain_size = 10000;
+
+        tbb::parallel_for(
+            tbb::blocked_range<NodeID>(0, number_of_nodes, grain_size),
+            [this, &minimal_adjacent_weight_cache](const tbb::blocked_range<NodeID> &range) {
+                for (int x = range.begin(), end = range.end(); x != end; ++x)
+                    minimal_adjacent_weight_cache[x] = GetMinimalAdjacentWeight(x);
+            });
+
+        return minimal_adjacent_weight_cache;
+    }
+
+    /* Flush all data from the contraction to disc and reorder stuff for better locality */
+    void FlushDataAndRebuildContractorGraph(ThreadDataContainer &thread_data_list,
+                                            std::vector<RemainingNodeData> &remaining_nodes,
+                                            std::vector<float> &node_priorities)
+    {
+        util::DeallocatingVector<ContractorEdge> new_edge_set; // this one is not explicitely
+                                                               // cleared since it goes out of
+                                                               // scope anywa
+
+        // Delete old heap data to free memory that we need for the coming operations
+        thread_data_list.data.clear();
+
+        // Create new priority array
+        std::vector<float> new_node_priority(remaining_nodes.size());
+        std::vector<EdgeWeight> new_node_weights(remaining_nodes.size());
+        // this map gives the old IDs from the new ones, necessary to get a consistent graph
+        // at the end of contraction
+        orig_node_id_from_new_node_id_map.resize(remaining_nodes.size());
+        // this map gives the new IDs from the old ones, necessary to remap targets from the
+        // remaining graph
+        const auto number_of_nodes = contractor_graph->GetNumberOfNodes();
+        std::vector<NodeID> new_node_id_from_orig_id_map(number_of_nodes, SPECIAL_NODEID);
+
+        for (const auto new_node_id : util::irange<std::size_t>(0UL, remaining_nodes.size()))
+        {
+            auto &node = remaining_nodes[new_node_id];
+            BOOST_ASSERT(node_priorities.size() > node.id);
+            new_node_priority[new_node_id] = node_priorities[node.id];
+            BOOST_ASSERT(node_weights.size() > node.id);
+            new_node_weights[new_node_id] = node_weights[node.id];
+        }
+
+        // build forward and backward renumbering map and remap ids in remaining_nodes
+        for (const auto new_node_id : util::irange<std::size_t>(0UL, remaining_nodes.size()))
+        {
+            auto &node = remaining_nodes[new_node_id];
+            // create renumbering maps in both directions
+            orig_node_id_from_new_node_id_map[new_node_id] = node.id;
+            new_node_id_from_orig_id_map[node.id] = new_node_id;
+            node.id = new_node_id;
+        }
+        // walk over all nodes
+        for (const auto source : util::irange<NodeID>(0UL, contractor_graph->GetNumberOfNodes()))
+        {
+            for (auto current_edge : contractor_graph->GetAdjacentEdgeRange(source))
+            {
+                ContractorGraph::EdgeData &data = contractor_graph->GetEdgeData(current_edge);
+                const NodeID target = contractor_graph->GetTarget(current_edge);
+                if (SPECIAL_NODEID == new_node_id_from_orig_id_map[source])
+                {
+                    external_edge_list.push_back({source, target, data});
+                }
+                else
+                {
+                    // node is not yet contracted.
+                    // add (renumbered) outgoing edges to new util::DynamicGraph.
+                    ContractorEdge new_edge = {new_node_id_from_orig_id_map[source],
+                                               new_node_id_from_orig_id_map[target],
+                                               data};
+
+                    new_edge.data.is_original_via_node_ID = true;
+                    BOOST_ASSERT_MSG(SPECIAL_NODEID != new_node_id_from_orig_id_map[source],
+                                     "new source id not resolveable");
+                    BOOST_ASSERT_MSG(SPECIAL_NODEID != new_node_id_from_orig_id_map[target],
+                                     "new target id not resolveable");
+                    new_edge_set.push_back(new_edge);
+                }
+            }
+        }
+
+        // Delete map from old NodeIDs to new ones.
+        new_node_id_from_orig_id_map.clear();
+        new_node_id_from_orig_id_map.shrink_to_fit();
+
+        // Replace old priorities array by new one
+        node_priorities.swap(new_node_priority);
+        // Delete old node_priorities vector
+        // Due to the scope, these should get cleared automatically? @daniel-j-h do you
+        // agree?
+        new_node_priority.clear();
+        new_node_priority.shrink_to_fit();
+
+        node_weights.swap(new_node_weights);
+        // old Graph is removed
+        contractor_graph.reset();
+
+        // create new graph
+        tbb::parallel_sort(new_edge_set.begin(), new_edge_set.end());
+        contractor_graph = std::make_shared<ContractorGraph>(remaining_nodes.size(), new_edge_set);
+
+        new_edge_set.clear();
+
+        // INFO: MAKE SURE THIS IS THE LAST OPERATION OF THE FLUSH!
+        // reinitialize heaps and ThreadData objects with appropriate size
+        thread_data_list.number_of_nodes = contractor_graph->GetNumberOfNodes();
+    }
+
   public:
     template <class ContainerT>
     GraphContractor(int nodes, ContainerT &input_edge_list)
@@ -289,6 +420,7 @@ class GraphContractor
         bool use_cached_node_priorities = !node_levels.empty();
         if (use_cached_node_priorities)
         {
+            minimum_adjacent_weight_cache = BuildMinimalAdjacentWeightCache();
             util::UnbufferedLog log;
             log << "using cached node priorities ...";
             node_priorities.swap(node_levels);
@@ -296,6 +428,8 @@ class GraphContractor
         }
         else
         {
+            // Evaluate Node Priority will update the cache
+            minimum_adjacent_weight_cache.resize(number_of_nodes);
             node_depth.resize(number_of_nodes, 0);
             node_priorities.resize(number_of_nodes);
             node_levels.resize(number_of_nodes);
@@ -326,106 +460,16 @@ class GraphContractor
         while (number_of_nodes > 2 &&
                number_of_contracted_nodes < static_cast<NodeID>(number_of_nodes * core_factor))
         {
+            // if the remaining number of nodes is small enough, we rebuild the graph for better
+            // cache efficiency
             if (!flushed_contractor && (number_of_contracted_nodes >
                                         static_cast<NodeID>(number_of_nodes * 0.65 * core_factor)))
             {
-                util::DeallocatingVector<ContractorEdge>
-                    new_edge_set; // this one is not explicitely
-                                  // cleared since it goes out of
-                                  // scope anywa
                 log << " [flush " << number_of_contracted_nodes << " nodes] ";
-
-                // Delete old heap data to free memory that we need for the coming operations
-                thread_data_list.data.clear();
-
-                // Create new priority array
-                std::vector<float> new_node_priority(remaining_nodes.size());
-                std::vector<EdgeWeight> new_node_weights(remaining_nodes.size());
-                // this map gives the old IDs from the new ones, necessary to get a consistent graph
-                // at the end of contraction
-                orig_node_id_from_new_node_id_map.resize(remaining_nodes.size());
-                // this map gives the new IDs from the old ones, necessary to remap targets from the
-                // remaining graph
-                std::vector<NodeID> new_node_id_from_orig_id_map(number_of_nodes, SPECIAL_NODEID);
-
-                for (const auto new_node_id :
-                     util::irange<std::size_t>(0UL, remaining_nodes.size()))
-                {
-                    auto &node = remaining_nodes[new_node_id];
-                    BOOST_ASSERT(node_priorities.size() > node.id);
-                    new_node_priority[new_node_id] = node_priorities[node.id];
-                    BOOST_ASSERT(node_weights.size() > node.id);
-                    new_node_weights[new_node_id] = node_weights[node.id];
-                }
-
-                // build forward and backward renumbering map and remap ids in remaining_nodes
-                for (const auto new_node_id :
-                     util::irange<std::size_t>(0UL, remaining_nodes.size()))
-                {
-                    auto &node = remaining_nodes[new_node_id];
-                    // create renumbering maps in both directions
-                    orig_node_id_from_new_node_id_map[new_node_id] = node.id;
-                    new_node_id_from_orig_id_map[node.id] = new_node_id;
-                    node.id = new_node_id;
-                }
-                // walk over all nodes
-                for (const auto source :
-                     util::irange<NodeID>(0UL, contractor_graph->GetNumberOfNodes()))
-                {
-                    for (auto current_edge : contractor_graph->GetAdjacentEdgeRange(source))
-                    {
-                        ContractorGraph::EdgeData &data =
-                            contractor_graph->GetEdgeData(current_edge);
-                        const NodeID target = contractor_graph->GetTarget(current_edge);
-                        if (SPECIAL_NODEID == new_node_id_from_orig_id_map[source])
-                        {
-                            external_edge_list.push_back({source, target, data});
-                        }
-                        else
-                        {
-                            // node is not yet contracted.
-                            // add (renumbered) outgoing edges to new util::DynamicGraph.
-                            ContractorEdge new_edge = {new_node_id_from_orig_id_map[source],
-                                                       new_node_id_from_orig_id_map[target],
-                                                       data};
-
-                            new_edge.data.is_original_via_node_ID = true;
-                            BOOST_ASSERT_MSG(SPECIAL_NODEID != new_node_id_from_orig_id_map[source],
-                                             "new source id not resolveable");
-                            BOOST_ASSERT_MSG(SPECIAL_NODEID != new_node_id_from_orig_id_map[target],
-                                             "new target id not resolveable");
-                            new_edge_set.push_back(new_edge);
-                        }
-                    }
-                }
-
-                // Delete map from old NodeIDs to new ones.
-                new_node_id_from_orig_id_map.clear();
-                new_node_id_from_orig_id_map.shrink_to_fit();
-
-                // Replace old priorities array by new one
-                node_priorities.swap(new_node_priority);
-                // Delete old node_priorities vector
-                // Due to the scope, these should get cleared automatically? @daniel-j-h do you
-                // agree?
-                new_node_priority.clear();
-                new_node_priority.shrink_to_fit();
-
-                node_weights.swap(new_node_weights);
-                // old Graph is removed
-                contractor_graph.reset();
-
-                // create new graph
-                tbb::parallel_sort(new_edge_set.begin(), new_edge_set.end());
-                contractor_graph =
-                    std::make_shared<ContractorGraph>(remaining_nodes.size(), new_edge_set);
-
-                new_edge_set.clear();
+                FlushDataAndRebuildContractorGraph(
+                    thread_data_list, remaining_nodes, node_priorities);
                 flushed_contractor = true;
-
-                // INFO: MAKE SURE THIS IS THE LAST OPERATION OF THE FLUSH!
-                // reinitialize heaps and ThreadData objects with appropriate size
-                thread_data_list.number_of_nodes = contractor_graph->GetNumberOfNodes();
+                minimum_adjacent_weight_cache = BuildMinimalAdjacentWeightCache();
             }
 
             tbb::parallel_for(
@@ -743,7 +787,9 @@ class GraphContractor
                 }
             }
 
-            RelaxNode(node, middle_node, weight, heap);
+            // only relax nodes that can actually help us
+            if (weight + minimum_adjacent_weight_cache[node] < max_weight)
+                RelaxNode(node, middle_node, weight, heap);
         }
     }
 
@@ -755,6 +801,8 @@ class GraphContractor
 
         // perform simulated contraction
         ContractNode<true>(data, node, &stats);
+        // also update the node cache of the node
+        minimum_adjacent_weight_cache[node] = GetMinimalAdjacentWeight(node);
 
         // Result will contain the priority
         float result;
@@ -867,11 +915,15 @@ class GraphContractor
                     }
                     continue;
                 }
-                max_weight = std::max(max_weight, path_weight);
-                if (!heap.WasInserted(target))
+                if (path_weight >=
+                    minimum_adjacent_weight_cache[source] + minimum_adjacent_weight_cache[target])
                 {
-                    heap.Insert(target, INVALID_EDGE_WEIGHT, ContractorHeapData{0, true});
-                    ++number_of_targets;
+                    max_weight = std::max(max_weight, path_weight);
+                    if (!heap.WasInserted(target))
+                    {
+                        heap.Insert(target, INVALID_EDGE_WEIGHT, ContractorHeapData{0, true});
+                        ++number_of_targets;
+                    }
                 }
             }
 
@@ -896,8 +948,12 @@ class GraphContractor
                 if (target == node)
                     continue;
                 const int path_weight = in_data.weight + out_data.weight;
-                const int weight = heap.GetKey(target);
-                if (path_weight < weight)
+
+                const bool requires_shortcut =
+                    (path_weight < minimum_adjacent_weight_cache[source] +
+                                       minimum_adjacent_weight_cache[target]) ||
+                    heap.GetKey(target) > path_weight;
+                if (requires_shortcut)
                 {
                     if (RUNSIMULATION)
                     {
@@ -1116,6 +1172,7 @@ class GraphContractor
     std::vector<EdgeWeight> node_weights;
     std::vector<bool> is_core_node;
     util::XORFastHash<> fast_hash;
+    std::vector<EdgeWeight> minimum_adjacent_weight_cache;
 };
 }
 }

--- a/include/util/integer_range.hpp
+++ b/include/util/integer_range.hpp
@@ -36,6 +36,7 @@ template <typename Integer> class range
     Integer front() const noexcept { return iter; }
     Integer back() const noexcept { return last - 1; }
     std::size_t size() const noexcept { return static_cast<std::size_t>(last - iter); }
+    bool empty() const noexcept { return size() == 0; }
 
     // Iterator functions
     bool operator!=(const range &) const noexcept { return iter < last; }


### PR DESCRIPTION
# Issue

Contraction of large graphs is quite compute intensive. I've tried to see if the contraction can be reduced in time.

The result is pretty simple: We require a bit more complexity and more memory (one EdgeWeight entry for all nodes) during contraction.

This comes along with a reduction of about 5% in contraction time.
Germany:
 - master: 660s
 - this branch: 630s

In my view, while a nice experiment, the reduction in processing time is probably not worth the additional memory overhead/the added complexity.

Opinions?

## Tasklist
 - [ ] discuss if reasonable enough
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
none
