### PR TITLE
Output resource usage stats at end of extract/contract jobs

### DIFF
--- a/include/util/meminfo.hpp
+++ b/include/util/meminfo.hpp
@@ -1,0 +1,43 @@
+#ifndef MEMINFO_HPP
+#define MEMINFO_HPP
+
+#include "util/log.hpp"
+
+#include <stxxl/mng>
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+namespace osrm
+{
+namespace util
+{
+inline void DumpMemoryStats()
+{
+#if STXXL_VERSION_MAJOR > 1 || (STXXL_VERSION_MAJOR == 1 && STXXL_VERSION_MINOR >= 4)
+    auto manager = stxxl::block_manager::get_instance();
+    util::Log() << "STXXL: peak bytes used: " << manager->get_maximum_allocation();
+    util::Log() << "STXXL: total disk allocated: " << manager->get_total_bytes();
+#else
+#warning STXXL 1.4+ recommended - STXXL memory summary will not be available
+    util::Log() << "STXXL: memory summary not available, needs STXXL 1.4 or higher";
+#endif
+
+#ifndef _WIN32
+    rusage usage;
+    getrusage(RUSAGE_SELF, &usage);
+#ifdef __linux__
+    // Under linux, ru.maxrss is in kb
+    util::Log() << "RAM: peak bytes used: " << usage.ru_maxrss * 1024;
+#else  // __linux__
+    // Under BSD systems (OSX), it's in bytes
+    util::Log() << "RAM: peak bytes used: " << usage.ru_maxrss;
+#endif // __linux__
+#else  // _WIN32
+    util::Log() << "RAM: peak bytes used: <not implemented on Windows>";
+#endif // _WIN32
+}
+}
+}
+
+#endif

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -15,6 +15,8 @@
 #include <new>
 #include <ostream>
 
+#include "util/meminfo.hpp"
+
 using namespace osrm;
 
 enum class return_code : unsigned
@@ -166,7 +168,11 @@ int main(int argc, char *argv[]) try
 
     tbb::task_scheduler_init init(contractor_config.requested_num_threads);
 
-    return contractor::Contractor(contractor_config).Run();
+    auto exitcode = contractor::Contractor(contractor_config).Run();
+
+    util::DumpMemoryStats();
+
+    return exitcode;
 }
 catch (const std::bad_alloc &e)
 {

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -13,6 +13,8 @@
 #include <exception>
 #include <new>
 
+#include "util/meminfo.hpp"
+
 using namespace osrm;
 
 enum class return_code : unsigned
@@ -153,7 +155,11 @@ int main(int argc, char *argv[]) try
     // setup scripting environment
     extractor::LuaScriptingEnvironment scripting_environment(
         extractor_config.profile_path.string().c_str());
-    return extractor::Extractor(extractor_config).run(scripting_environment);
+    auto exitcode = extractor::Extractor(extractor_config).run(scripting_environment);
+
+    util::DumpMemoryStats();
+
+    return exitcode;
 }
 catch (const std::bad_alloc &e)
 {


### PR DESCRIPTION
# Issue

This PR addresses #2445.  At the end of `osrm-extract` and `osrm-contract`, there are now some additional log lines:

```
[info] STXXL: peak bytes used: 150994944
[info] STXXL: total disk allocated: 1048576000
[info] RAM: peak bytes used: 1011208192
```

These should be helpful for monitoring production servers, and not using machines that are any larger than necessary.

If using STXXL < 1.4, a warning message will be issued instead (STXXL < 1.4 lacks the required functions).  Peak RAM measurement isn't implemented for Windows and results in another warning.

Comments appreciated.

## Tasklist
 - [x] review
 - [x] adjust for comments