### PR TITLE
Adds barrier=gate regression tests, see #581

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -221,6 +221,7 @@ Feature: Car - Restricted access
             | highway | toll        | bothw |
             | primary | yes         |       |
 
+
     Scenario: Car - directional access tags
         Then routability should be
             | highway | access | access:forward | access:backward | forw | backw |
@@ -232,3 +233,15 @@ Feature: Car - Restricted access
             | primary | no     |                | yes             |      | x     |
             | primary | no     | yes            |                 | x    |       |
             | primary | no     | yes            | yes             | x    | x     |
+
+
+     Scenario: Car - barrier=gate should be routed over unless explicitely forbidden
+        Then routability should be
+            | node/barrier | access     | bothw |
+            | gate         |            | x     |
+            | gate         | no         |       |
+            | gate         | yes        | x     |
+            | gate         | permissive | x     |
+            | gate         | designated | x     |
+            | gate         | private    |       |
+            | gate         | garbagetag | x     |


### PR DESCRIPTION
See https://github.com/Project-OSRM/osrm-backend/issues/581 and the recent discussion in https://github.com/Project-OSRM/osrm-backend/issues/3435.

These tests all pass even though [`barrier=*`](http://wiki.openstreetmap.org/wiki/Key:barrier) implies `access=no` per Wiki.

But we still route e.g. over `barrier=gate` without any further access tags.