### PR TITLE
De-duplicate edge-based-node data in RTree

### DIFF
--- a/include/engine/datafacade/contiguous_internalmem_datafacade_base.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade_base.hpp
@@ -96,6 +96,8 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     util::ShM<std::size_t, true>::vector m_datasource_name_lengths;
     util::ShM<util::guidance::LaneTupleIdPair, true>::vector m_lane_tupel_id_pairs;
 
+    util::ShM<extractor::EdgeBasedNode, true>::vector m_edge_based_node_list;
+
     std::unique_ptr<SharedRTree> m_static_rtree;
     std::unique_ptr<SharedGeospatialQuery> m_geospatial_query;
     boost::filesystem::path file_index_path;
@@ -472,6 +474,22 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const override final
     {
         return m_osmnodeid_list.at(id);
+    }
+
+    virtual const extractor::EdgeBasedNode &GetNodeData(const NodeID n) const override final
+    {
+        // TODO: return the correct node;
+        return m_edge_based_node_list[n];
+    }
+
+    virtual std::pair<NodeID, NodeID>
+    GetForwardSegmentNodes(const EdgeID packed_geometry_id,
+                           const unsigned forward_offset) const override final
+    {
+        const unsigned begin = m_geometry_indices.at(packed_geometry_id);
+        const unsigned end = m_geometry_indices.at(packed_geometry_id + 1);
+
+        return std::make_pair(begin + forward_offset, begin + forward_offset + 1);
     }
 
     virtual std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID id) const override final

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -40,7 +40,7 @@ class BaseDataFacade
 {
   public:
     using EdgeData = contractor::QueryEdge::EdgeData;
-    using RTreeLeaf = extractor::EdgeBasedNode;
+    using RTreeLeaf = extractor::RoadSegment;
     BaseDataFacade() {}
     virtual ~BaseDataFacade() {}
 
@@ -54,6 +54,8 @@ class BaseDataFacade
     virtual NodeID GetTarget(const EdgeID e) const = 0;
 
     virtual const EdgeData &GetEdgeData(const EdgeID e) const = 0;
+
+    virtual const extractor::EdgeBasedNode &GetNodeData(const NodeID n) const = 0;
 
     virtual EdgeID BeginEdges(const NodeID n) const = 0;
 
@@ -82,6 +84,10 @@ class BaseDataFacade
     virtual std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID id) const = 0;
 
     virtual std::vector<NodeID> GetUncompressedReverseGeometry(const EdgeID id) const = 0;
+
+    virtual std::pair<NodeID, NodeID>
+    GetForwardSegmentNodes(const EdgeID packed_geometry_id,
+                           const unsigned forward_offset) const = 0;
 
     // Gets the weight values for each segment in an uncompressed geometry.
     // Should always be 1 shorter than GetUncompressedGeometry

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -176,15 +176,20 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         auto results = rtree.Nearest(
             input_coordinate,
             [this, &has_big_component, &has_small_component](const CandidateSegment &segment) {
-                auto use_segment = (!has_small_component ||
-                                    (!has_big_component && !segment.data.component.is_tiny));
+                const auto &edge_based_node_data =
+                    datafacade.GetNodeData(segment.data.edge_based_node_id);
+                auto use_segment =
+                    (!has_small_component ||
+                     (!has_big_component && !edge_based_node_data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 const auto valid_edges = HasValidEdge(segment);
 
                 if (valid_edges.first || valid_edges.second)
                 {
-                    has_big_component = has_big_component || !segment.data.component.is_tiny;
-                    has_small_component = has_small_component || segment.data.component.is_tiny;
+                    has_big_component =
+                        has_big_component || !edge_based_node_data.component.is_tiny;
+                    has_small_component =
+                        has_small_component || edge_based_node_data.component.is_tiny;
                 }
                 use_directions = boolPairAnd(use_directions, valid_edges);
                 return use_directions;
@@ -215,8 +220,13 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         auto results = rtree.Nearest(
             input_coordinate,
             [this, &has_big_component, &has_small_component](const CandidateSegment &segment) {
-                auto use_segment = (!has_small_component ||
-                                    (!has_big_component && !segment.data.component.is_tiny));
+
+                const auto &edge_based_node_data =
+                    datafacade.GetNodeData(segment.data.edge_based_node_id);
+
+                auto use_segment =
+                    (!has_small_component ||
+                     (!has_big_component && !edge_based_node_data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 if (!use_directions.first && !use_directions.second)
                     return use_directions;
@@ -225,8 +235,10 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 if (valid_edges.first || valid_edges.second)
                 {
 
-                    has_big_component = has_big_component || !segment.data.component.is_tiny;
-                    has_small_component = has_small_component || segment.data.component.is_tiny;
+                    has_big_component =
+                        has_big_component || !edge_based_node_data.component.is_tiny;
+                    has_small_component =
+                        has_small_component || edge_based_node_data.component.is_tiny;
                 }
 
                 use_directions = boolPairAnd(use_directions, valid_edges);
@@ -257,8 +269,11 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
             input_coordinate,
             [this, bearing, bearing_range, &has_big_component, &has_small_component](
                 const CandidateSegment &segment) {
-                auto use_segment = (!has_small_component ||
-                                    (!has_big_component && !segment.data.component.is_tiny));
+                const auto &edge_based_node_data =
+                    datafacade.GetNodeData(segment.data.edge_based_node_id);
+                auto use_segment =
+                    (!has_small_component ||
+                     (!has_big_component && !edge_based_node_data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 use_directions = boolPairAnd(use_directions, HasValidEdge(segment));
 
@@ -269,8 +284,10 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                                     HasValidEdge(segment));
                     if (use_directions.first || use_directions.second)
                     {
-                        has_big_component = has_big_component || !segment.data.component.is_tiny;
-                        has_small_component = has_small_component || segment.data.component.is_tiny;
+                        has_big_component =
+                            has_big_component || !edge_based_node_data.component.is_tiny;
+                        has_small_component =
+                            has_small_component || edge_based_node_data.component.is_tiny;
                     }
                 }
 
@@ -304,8 +321,11 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
             input_coordinate,
             [this, bearing, bearing_range, &has_big_component, &has_small_component](
                 const CandidateSegment &segment) {
-                auto use_segment = (!has_small_component ||
-                                    (!has_big_component && !segment.data.component.is_tiny));
+                const auto &edge_based_node_data =
+                    datafacade.GetNodeData(segment.data.edge_based_node_id);
+                auto use_segment =
+                    (!has_small_component ||
+                     (!has_big_component && !edge_based_node_data.component.is_tiny));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 use_directions = boolPairAnd(use_directions, HasValidEdge(segment));
 
@@ -316,8 +336,10 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                                     HasValidEdge(segment));
                     if (use_directions.first || use_directions.second)
                     {
-                        has_big_component = has_big_component || !segment.data.component.is_tiny;
-                        has_small_component = has_small_component || segment.data.component.is_tiny;
+                        has_big_component =
+                            has_big_component || !edge_based_node_data.component.is_tiny;
+                        has_small_component =
+                            has_small_component || edge_based_node_data.component.is_tiny;
                     }
                 }
 
@@ -355,16 +377,10 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     }
 
     PhantomNodeWithDistance MakePhantomNode(const util::Coordinate input_coordinate,
-                                            const EdgeData &data) const
+                                            const EdgeData &leafdata) const
     {
-        util::Coordinate point_on_segment;
-        double ratio;
-        const auto current_perpendicular_distance =
-            util::coordinate_calculation::perpendicularDistance(coordinates[data.u],
-                                                                coordinates[data.v],
-                                                                input_coordinate,
-                                                                point_on_segment,
-                                                                ratio);
+
+        const auto &edge_based_node_data = datafacade.GetNodeData(leafdata.edge_based_node_id);
 
         // Find the node-based-edge that this belongs to, and directly
         // calculate the forward_weight, forward_offset, reverse_weight, reverse_offset
@@ -373,38 +389,51 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         int reverse_offset = 0, reverse_weight = 0;
 
         const std::vector<EdgeWeight> forward_weight_vector =
-            datafacade.GetUncompressedForwardWeights(data.packed_geometry_id);
+            datafacade.GetUncompressedForwardWeights(edge_based_node_data.packed_geometry_id);
         const std::vector<EdgeWeight> reverse_weight_vector =
-            datafacade.GetUncompressedReverseWeights(data.packed_geometry_id);
+            datafacade.GetUncompressedReverseWeights(edge_based_node_data.packed_geometry_id);
 
-        for (std::size_t i = 0; i < data.fwd_segment_position; i++)
+        auto uv = datafacade.GetForwardSegmentNodes(edge_based_node_data.packed_geometry_id,
+                                                    leafdata.fwd_segment_position);
+        auto u = uv.first;
+        auto v = uv.second;
+
+        util::Coordinate point_on_segment;
+        double ratio;
+        const auto current_perpendicular_distance =
+            util::coordinate_calculation::perpendicularDistance(
+                coordinates[u], coordinates[v], input_coordinate, point_on_segment, ratio);
+
+        for (std::size_t i = 0; i < leafdata.fwd_segment_position; i++)
         {
             forward_offset += forward_weight_vector[i];
         }
-        forward_weight = forward_weight_vector[data.fwd_segment_position];
+        forward_weight = forward_weight_vector[leafdata.fwd_segment_position];
 
-        BOOST_ASSERT(data.fwd_segment_position < reverse_weight_vector.size());
+        BOOST_ASSERT(leafdata.fwd_segment_position < reverse_weight_vector.size());
 
-        for (std::size_t i = 0; i < reverse_weight_vector.size() - data.fwd_segment_position - 1;
+        for (std::size_t i = 0;
+             i < reverse_weight_vector.size() - leafdata.fwd_segment_position - 1;
              i++)
         {
             reverse_offset += reverse_weight_vector[i];
         }
         reverse_weight =
-            reverse_weight_vector[reverse_weight_vector.size() - data.fwd_segment_position - 1];
+            reverse_weight_vector[reverse_weight_vector.size() - leafdata.fwd_segment_position - 1];
 
         ratio = std::min(1.0, std::max(0.0, ratio));
-        if (data.forward_segment_id.id != SPECIAL_SEGMENTID)
+        if (edge_based_node_data.forward_segment_id.id != SPECIAL_SEGMENTID)
         {
             forward_weight *= ratio;
         }
-        if (data.reverse_segment_id.id != SPECIAL_SEGMENTID)
+        if (edge_based_node_data.reverse_segment_id.id != SPECIAL_SEGMENTID)
         {
             const EdgeWeight difference = reverse_weight * ratio;
             reverse_weight -= difference;
         }
 
-        auto transformed = PhantomNodeWithDistance{PhantomNode{data,
+        auto transformed = PhantomNodeWithDistance{PhantomNode{edge_based_node_data,
+                                                               leafdata.fwd_segment_position,
                                                                forward_weight,
                                                                forward_offset,
                                                                reverse_weight,
@@ -441,8 +470,12 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         BOOST_ASSERT(segment.data.reverse_segment_id.id != SPECIAL_SEGMENTID ||
                      !segment.data.reverse_segment_id.enabled);
 
+        const auto data = datafacade.GetNodeData(segment.data.edge_based_node_id);
+        const auto nodes = datafacade.GetForwardSegmentNodes(data.packed_geometry_id,
+                                                             segment.data.fwd_segment_position);
+
         const double forward_edge_bearing = util::coordinate_calculation::bearing(
-            coordinates[segment.data.u], coordinates[segment.data.v]);
+            coordinates[nodes.first], coordinates[nodes.second]);
 
         const double backward_edge_bearing = (forward_edge_bearing + 180) > 360
                                                  ? (forward_edge_bearing - 180)
@@ -451,11 +484,11 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         const bool forward_bearing_valid =
             util::bearing::CheckInBounds(
                 std::round(forward_edge_bearing), filter_bearing, filter_bearing_range) &&
-            segment.data.forward_segment_id.enabled;
+            data.forward_segment_id.enabled;
         const bool backward_bearing_valid =
             util::bearing::CheckInBounds(
                 std::round(backward_edge_bearing), filter_bearing, filter_bearing_range) &&
-            segment.data.reverse_segment_id.enabled;
+            data.reverse_segment_id.enabled;
         return std::make_pair(forward_bearing_valid, backward_bearing_valid);
     }
 
@@ -471,20 +504,22 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         bool forward_edge_valid = false;
         bool reverse_edge_valid = false;
 
+        const auto data = datafacade.GetNodeData(segment.data.edge_based_node_id);
+
         const std::vector<EdgeWeight> forward_weight_vector =
-            datafacade.GetUncompressedForwardWeights(segment.data.packed_geometry_id);
+            datafacade.GetUncompressedForwardWeights(data.packed_geometry_id);
 
         if (forward_weight_vector[segment.data.fwd_segment_position] != INVALID_EDGE_WEIGHT)
         {
-            forward_edge_valid = segment.data.forward_segment_id.enabled;
+            forward_edge_valid = data.forward_segment_id.enabled;
         }
 
         const std::vector<EdgeWeight> reverse_weight_vector =
-            datafacade.GetUncompressedReverseWeights(segment.data.packed_geometry_id);
+            datafacade.GetUncompressedReverseWeights(data.packed_geometry_id);
         if (reverse_weight_vector[reverse_weight_vector.size() - segment.data.fwd_segment_position -
                                   1] != INVALID_EDGE_WEIGHT)
         {
-            reverse_edge_valid = segment.data.reverse_segment_id.enabled;
+            reverse_edge_valid = data.reverse_segment_id.enabled;
         }
 
         return std::make_pair(forward_edge_valid, reverse_edge_valid);

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -116,6 +116,7 @@ struct PhantomNode
 
     template <class OtherT>
     explicit PhantomNode(const OtherT &other,
+                         unsigned short fwd_segment_position_,
                          int forward_weight_,
                          int forward_offset_,
                          int reverse_weight_,
@@ -128,7 +129,7 @@ struct PhantomNode
           forward_offset{forward_offset_}, reverse_offset{reverse_offset_},
           packed_geometry_id{other.packed_geometry_id},
           component{other.component.id, other.component.is_tiny}, location{location_},
-          input_location{input_location_}, fwd_segment_position{other.fwd_segment_position},
+          input_location{input_location_}, fwd_segment_position{fwd_segment_position_},
           forward_travel_mode{other.forward_travel_mode},
           backward_travel_mode{other.backward_travel_mode}
     {

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -104,6 +104,8 @@ class EdgeBasedGraphFactory
     // The following get access functions destroy the content in the factory
     void GetEdgeBasedEdges(util::DeallocatingVector<EdgeBasedEdge> &edges);
     void GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes);
+    void GetRoadSegments(std::vector<RoadSegment> &segments);
+    void GetNodePairs(std::vector<std::pair<NodeID, NodeID>> &nodepairs);
     void GetStartPointMarkers(std::vector<bool> &node_is_startpoint);
     void GetEdgeBasedNodeWeights(std::vector<EdgeWeight> &output_node_weights);
 
@@ -138,6 +140,8 @@ class EdgeBasedGraphFactory
     std::vector<EdgeWeight> m_edge_based_node_weights;
 
     //! list of edge based nodes (compressed segments)
+    std::vector<RoadSegment> m_road_segments;
+    std::vector<std::pair<NodeID, NodeID>> m_road_segments_nodes;
     std::vector<EdgeBasedNode> m_edge_based_node_list;
     util::DeallocatingVector<EdgeBasedEdge> m_edge_based_edge_list;
     EdgeID m_max_edge_id;

--- a/include/extractor/edge_based_node.hpp
+++ b/include/extractor/edge_based_node.hpp
@@ -15,15 +15,25 @@ namespace osrm
 namespace extractor
 {
 
+struct RoadSegment
+{
+    RoadSegment() : edge_based_node_id{SPECIAL_NODEID}, fwd_segment_position{0} {}
+    RoadSegment(NodeID edge_based_node_id_, unsigned short fwd_segment_pos_, NodeID u_, NodeID v_)
+        : edge_based_node_id{edge_based_node_id_}, fwd_segment_position{fwd_segment_pos_}
+    {
+    }
+    NodeID edge_based_node_id; // edge-based-node-id
+    unsigned short fwd_segment_position;
+};
+
 /// This is what util::StaticRTree serialized and stores on disk
 /// It is generated in EdgeBasedGraphFactory.
 struct EdgeBasedNode
 {
     EdgeBasedNode()
         : forward_segment_id{SPECIAL_SEGMENTID, false},
-          reverse_segment_id{SPECIAL_SEGMENTID, false}, u(SPECIAL_NODEID), v(SPECIAL_NODEID),
-          name_id(0), packed_geometry_id(SPECIAL_GEOMETRYID), component{INVALID_COMPONENTID, false},
-          fwd_segment_position(std::numeric_limits<unsigned short>::max()),
+          reverse_segment_id{SPECIAL_SEGMENTID, false}, name_id(0),
+          packed_geometry_id(SPECIAL_GEOMETRYID), component{INVALID_COMPONENTID, false},
           forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
@@ -31,27 +41,22 @@ struct EdgeBasedNode
 
     explicit EdgeBasedNode(const SegmentID forward_segment_id_,
                            const SegmentID reverse_segment_id_,
-                           NodeID u,
-                           NodeID v,
                            unsigned name_id,
                            unsigned packed_geometry_id_,
                            bool is_tiny_component,
                            unsigned component_id,
-                           unsigned short fwd_segment_position,
                            TravelMode forward_travel_mode,
                            TravelMode backward_travel_mode)
-        : forward_segment_id(forward_segment_id_), reverse_segment_id(reverse_segment_id_), u(u),
-          v(v), name_id(name_id), packed_geometry_id(packed_geometry_id_),
-          component{component_id, is_tiny_component}, fwd_segment_position(fwd_segment_position),
-          forward_travel_mode(forward_travel_mode), backward_travel_mode(backward_travel_mode)
+        : forward_segment_id(forward_segment_id_), reverse_segment_id(reverse_segment_id_),
+          name_id(name_id), packed_geometry_id(packed_geometry_id_),
+          component{component_id, is_tiny_component}, forward_travel_mode(forward_travel_mode),
+          backward_travel_mode(backward_travel_mode)
     {
         BOOST_ASSERT(forward_segment_id.enabled || reverse_segment_id.enabled);
     }
 
     SegmentID forward_segment_id; // needed for edge-expanded graph
     SegmentID reverse_segment_id; // needed for edge-expanded graph
-    NodeID u;                     // indices into the coordinates array
-    NodeID v;                     // indices into the coordinates array
     unsigned name_id;             // id of the edge name
 
     unsigned packed_geometry_id;
@@ -60,7 +65,6 @@ struct EdgeBasedNode
         unsigned id : 31;
         bool is_tiny : 1;
     } component;
-    unsigned short fwd_segment_position; // segment id in a compressed geometry
     TravelMode forward_travel_mode : 4;
     TravelMode backward_travel_mode : 4;
 };

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -60,6 +60,8 @@ class Extractor
     BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                            std::vector<QueryNode> &internal_to_external_node_map,
                            std::vector<EdgeBasedNode> &node_based_edge_list,
+                           std::vector<RoadSegment> &road_segment_list,
+                           std::vector<std::pair<NodeID, NodeID>> &node_pair_list,
                            std::vector<bool> &node_is_startpoint,
                            std::vector<EdgeWeight> &edge_based_node_weights,
                            util::DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list,
@@ -70,8 +72,9 @@ class Extractor
     void FindComponents(unsigned max_edge_id,
                         const util::DeallocatingVector<EdgeBasedEdge> &edges,
                         std::vector<EdgeBasedNode> &nodes) const;
-    void BuildRTree(std::vector<EdgeBasedNode> node_based_edge_list,
+    void BuildRTree(std::vector<RoadSegment> road_segment_list,
                     std::vector<bool> node_is_startpoint,
+                    std::vector<std::pair<NodeID, NodeID>> node_pair_list,
                     const std::vector<QueryNode> &internal_to_external_node_map);
     std::shared_ptr<RestrictionMap> LoadRestrictionMap();
     std::shared_ptr<util::NodeBasedDynamicGraph>

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -166,6 +166,7 @@ class StaticRTree
     template <typename CoordinateT>
     // Construct a packed Hilbert-R-Tree with Kamel-Faloutsos algorithm [1]
     explicit StaticRTree(const std::vector<EdgeDataT> &input_data_vector,
+                         const std::vector<std::pair<NodeID, NodeID>> &nodepairs,
                          const std::string &tree_node_filename,
                          const std::string &leaf_node_filename,
                          const std::vector<CoordinateT> &coordinate_list)
@@ -177,7 +178,7 @@ class StaticRTree
         // generate auxiliary vector of hilbert-values
         tbb::parallel_for(
             tbb::blocked_range<uint64_t>(0, element_count),
-            [&input_data_vector, &input_wrapper_vector, this](
+            [&input_data_vector, &input_wrapper_vector, &nodepairs, this](
                 const tbb::blocked_range<uint64_t> &range) {
                 for (uint64_t element_counter = range.begin(), end = range.end();
                      element_counter != end;
@@ -193,7 +194,8 @@ class StaticRTree
                     BOOST_ASSERT(current_element.v < m_coordinate_list.size());
 
                     Coordinate current_centroid = coordinate_calculation::centroid(
-                        m_coordinate_list[current_element.u], m_coordinate_list[current_element.v]);
+                        m_coordinate_list[nodepairs[element_counter].first],
+                        m_coordinate_list[nodepairs[element_counter].second]);
                     current_centroid.lat = FixedLatitude{static_cast<std::int32_t>(
                         COORDINATE_PRECISION *
                         web_mercator::latToY(toFloating(current_centroid.lat)))};
@@ -231,10 +233,10 @@ class StaticRTree
                     current_leaf.object_count += 1;
                     current_leaf.objects[object_index] = object;
 
-                    Coordinate projected_u{
-                        web_mercator::fromWGS84(Coordinate{m_coordinate_list[object.u]})};
-                    Coordinate projected_v{
-                        web_mercator::fromWGS84(Coordinate{m_coordinate_list[object.v]})};
+                    Coordinate projected_u{web_mercator::fromWGS84(
+                        Coordinate{m_coordinate_list[nodepairs[input_object_index].first]})};
+                    Coordinate projected_v{web_mercator::fromWGS84(
+                        Coordinate{m_coordinate_list[nodepairs[input_object_index].second]})};
 
                     BOOST_ASSERT(std::abs(toFloating(projected_u.lon).operator double()) <= 180.);
                     BOOST_ASSERT(std::abs(toFloating(projected_u.lat).operator double()) <= 180.);
@@ -412,22 +414,25 @@ class StaticRTree
                 {
                     const auto &current_edge = current_leaf_node.objects[i];
 
-                    // we don't need to project the coordinates here,
-                    // because we use the unprojected rectangle to test against
-                    const Rectangle bbox{std::min(m_coordinate_list[current_edge.u].lon,
-                                                  m_coordinate_list[current_edge.v].lon),
-                                         std::max(m_coordinate_list[current_edge.u].lon,
-                                                  m_coordinate_list[current_edge.v].lon),
-                                         std::min(m_coordinate_list[current_edge.u].lat,
-                                                  m_coordinate_list[current_edge.v].lat),
-                                         std::max(m_coordinate_list[current_edge.u].lat,
-                                                  m_coordinate_list[current_edge.v].lat)};
+                    /*
+                                        // we don't need to project the coordinates here,
+                                        // because we use the unprojected rectangle to test against
+                                        const Rectangle
+                       bbox{std::min(m_coordinate_list[current_edge.u].lon,
+                                                                      m_coordinate_list[current_edge.v].lon),
+                                                             std::max(m_coordinate_list[current_edge.u].lon,
+                                                                      m_coordinate_list[current_edge.v].lon),
+                                                             std::min(m_coordinate_list[current_edge.u].lat,
+                                                                      m_coordinate_list[current_edge.v].lat),
+                                                             std::max(m_coordinate_list[current_edge.u].lat,
+                                                                      m_coordinate_list[current_edge.v].lat)};
 
-                    // use the _unprojected_ input rectangle here
-                    if (bbox.Intersects(search_rectangle))
-                    {
-                        results.push_back(current_edge);
-                    }
+                                        // use the _unprojected_ input rectangle here
+                                        if (bbox.Intersects(search_rectangle))
+                                        {
+                                            results.push_back(current_edge);
+                                        }
+                                        */
                 }
             }
             else
@@ -519,8 +524,11 @@ class StaticRTree
                 {
                     continue;
                 }
+                // TODO: Fix these flags!!!!!!!!!!!!!!!!!!!!!!
+                /*
                 edge_data.forward_segment_id.enabled &= use_segment.first;
                 edge_data.reverse_segment_id.enabled &= use_segment.second;
+                */
 
                 // store phantom node in result vector
                 results.push_back(std::move(edge_data));
@@ -542,6 +550,7 @@ class StaticRTree
         // current object represents a block on disk
         for (const auto i : irange(0u, current_leaf_node.object_count))
         {
+            /*
             const auto &current_edge = current_leaf_node.objects[i];
             const auto projected_u = web_mercator::fromWGS84(m_coordinate_list[current_edge.u]);
             const auto projected_v = web_mercator::fromWGS84(m_coordinate_list[current_edge.v]);
@@ -557,6 +566,7 @@ class StaticRTree
             BOOST_ASSERT(0. <= squared_distance);
             traversal_queue.push(
                 QueryCandidate{squared_distance, leaf_id, i, Coordinate{projected_nearest}});
+                */
         }
     }
 

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -5,6 +5,9 @@
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/node_based_edge.hpp"
+#include "extractor/edge_based_node.hpp"
+
+#include "engine/datafacade/datafacade_base.hpp"
 
 #include "storage/io.hpp"
 #include "util/exception.hpp"
@@ -649,6 +652,8 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
 
     if (update_edge_weights || update_turn_penalties)
     {
+        // TODO: Populate this!
+        std::vector<extractor::EdgeBasedNode> edge_based_nodes;
         // Here, we have to update the compressed geometry weights
         // First, we need the external-to-internal node lookup table
 
@@ -663,7 +668,7 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
         // Now, we iterate over all the segments stored in the StaticRTree, updating
         // the packed geometry weights in the `.geometries` file (note: we do not
         // update the RTree itself, we just use the leaf nodes to iterate over all segments)
-        using LeafNode = util::StaticRTree<extractor::EdgeBasedNode>::LeafNode;
+        using LeafNode = util::StaticRTree<engine::datafacade::BaseDataFacade::RTreeLeaf>::LeafNode;
 
         using boost::interprocess::mapped_region;
 
@@ -690,8 +695,8 @@ EdgeID Contractor::LoadEdgeExpandedGraph(
                 extractor::QueryNode *u;
                 extractor::QueryNode *v;
 
-                const unsigned forward_begin =
-                    m_geometry_indices.at(leaf_object.packed_geometry_id);
+                const unsigned forward_begin = m_geometry_indices.at(
+                    edge_based_nodes[leaf_object.edge_based_node_id].packed_geometry_id);
                 const auto current_fwd_weight =
                     m_geometry_fwd_weight_list[forward_begin + leaf_object.fwd_segment_position];
 

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -252,6 +252,7 @@ Status TilePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacad
                                  const api::TileParameters &parameters,
                                  std::string &pbf_buffer) const
 {
+    /*
     BOOST_ASSERT(parameters.IsValid());
 
     double min_lon, min_lat, max_lon, max_lat;
@@ -980,6 +981,7 @@ Status TilePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacad
     }
     // protozero serializes data during object destructors, so once the scope closes,
     // our result buffer will have all the tile data encoded into it.
+    */
 
     return Status::Ok;
 }

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -78,6 +78,18 @@ void EdgeBasedGraphFactory::GetEdgeBasedNodes(std::vector<EdgeBasedNode> &nodes)
     swap(nodes, m_edge_based_node_list);
 }
 
+void EdgeBasedGraphFactory::GetRoadSegments(std::vector<RoadSegment> &segments)
+{
+    using std::swap;
+    swap(segments, m_road_segments);
+}
+
+void EdgeBasedGraphFactory::GetNodePairs(std::vector<std::pair<NodeID, NodeID>> &nodepairs)
+{
+    using std::swap;
+    swap(nodepairs, m_road_segments_nodes);
+}
+
 void EdgeBasedGraphFactory::GetStartPointMarkers(std::vector<bool> &node_is_startpoint)
 {
     using std::swap; // Koenig swap
@@ -143,6 +155,16 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
         return SegmentID{edge_based_node_id, true};
     };
 
+    // build edges
+    m_edge_based_node_list.emplace_back(edge_id_to_segment_id(forward_data.edge_id),
+                                        edge_id_to_segment_id(reverse_data.edge_id),
+                                        forward_data.name_id,
+                                        packed_geometry_id,
+                                        false,
+                                        INVALID_COMPONENTID,
+                                        forward_data.travel_mode,
+                                        reverse_data.travel_mode);
+
     // traverse arrays
     for (const auto i : util::irange(std::size_t{0}, segment_count))
     {
@@ -153,18 +175,10 @@ void EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const NodeI
         const NodeID current_edge_target_coordinate_id = forward_geometry[i].node_id;
         BOOST_ASSERT(current_edge_target_coordinate_id != current_edge_source_coordinate_id);
 
-        // build edges
-        m_edge_based_node_list.emplace_back(edge_id_to_segment_id(forward_data.edge_id),
-                                            edge_id_to_segment_id(reverse_data.edge_id),
-                                            current_edge_source_coordinate_id,
-                                            current_edge_target_coordinate_id,
-                                            forward_data.name_id,
-                                            packed_geometry_id,
-                                            false,
-                                            INVALID_COMPONENTID,
-                                            i,
-                                            forward_data.travel_mode,
-                                            reverse_data.travel_mode);
+        m_road_segments.emplace_back(m_edge_based_node_list.size() - 1,
+                                     i,
+                                     current_edge_source_coordinate_id,
+                                     current_edge_target_coordinate_id);
 
         m_edge_based_node_is_startpoint.push_back(forward_data.startpoint ||
                                                   reverse_data.startpoint);


### PR DESCRIPTION
# Issue

The StaticRTree contains *lots* of duplicated data.  Every road segment contains a complete copy of the edge-based-node data that it's related to.

While this is good for cache efficiency, it's quite wasteful space wise.

This PR refactors all the common data into a standalone vector.  This adds an additional lookup layer for every RTree operation, but reduces the total RTree datasize by >50% (in testing so far, Texas-sized RTree data went from 42MB to 17MB).

This PR is a WIP - I'm not 100% clear on the performance impact of this change yet.  I'm hoping that it's relatively minor, and the significant space savings are worth the cost.

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments