### PR TITLE
 Enables Optional Support for Stacktraces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(ENABLE_SANITIZER "Use memory sanitizer for Debug build" OFF)
 option(ENABLE_LTO "Use LTO if available" ON)
 option(ENABLE_FUZZING "Fuzz testing using LLVM's libFuzzer" OFF)
 option(ENABLE_GOLD_LINKER "Use GNU gold linker if available" ON)
+option(ENABLE_STACKTRACE "Enable verbose stacktraces for assertions and crashes, requires libdl" OFF)
 
 if(ENABLE_MASON)
   # versions in use
@@ -525,6 +526,22 @@ else()
 
 endif()
 
+if(ENABLE_STACKTRACE)
+  if(WIN32)
+    # For Windows support we have to write a signal handler (see util/stacktrace.hpp) and link with DbgHelp
+    message(FATAL_ERROR "Building with stacktrace support is not implemented on Windows")
+  endif()
+
+  if (Boost_VERSION VERSION_LESS 105600)
+    message(FATAL_ERROR "Building with stacktrace support requires Boost 1.56 or newer")
+  endif()
+
+  add_definitions(-DOSRM_HAS_STACKTRACE)
+  include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stacktrace/include)
+  set(MAYBE_STACKTRACE_LIBRARIES -ldl)
+  message(STATUS "Enabling stacktraces for assertions and crashes")
+endif()
+
 # prefix compilation with ccache by default if available and on clang or gcc
 if(ENABLE_CCACHE AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"))
   find_program(CCACHE_FOUND ccache)
@@ -593,7 +610,8 @@ set(EXTRACTOR_LIBRARIES
     ${STXXL_LIBRARY}
     ${TBB_LIBRARIES}
     ${ZLIB_LIBRARY}
-    ${MAYBE_COVERAGE_LIBRARIES})
+    ${MAYBE_COVERAGE_LIBRARIES}
+    ${MAYBE_STACKTRACE_LIBRARIES})
 set(CONTRACTOR_LIBRARIES
     ${BOOST_BASE_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
@@ -601,26 +619,30 @@ set(CONTRACTOR_LIBRARIES
     ${STXXL_LIBRARY}
     ${TBB_LIBRARIES}
     ${MAYBE_RT_LIBRARY}
-    ${MAYBE_COVERAGE_LIBRARIES})
+    ${MAYBE_COVERAGE_LIBRARIES}
+    ${MAYBE_STACKTRACE_LIBRARIES})
 set(ENGINE_LIBRARIES
     ${BOOST_ENGINE_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${TBB_LIBRARIES}
     ${MAYBE_RT_LIBRARY}
     ${MAYBE_COVERAGE_LIBRARIES}
-    ${ZLIB_LIBRARY})
+    ${ZLIB_LIBRARY}
+    ${MAYBE_STACKTRACE_LIBRARIES})
 set(STORAGE_LIBRARIES
     ${BOOST_BASE_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${TBB_LIBRARIES}
     ${MAYBE_RT_LIBRARY}
-    ${MAYBE_COVERAGE_LIBRARIES})
+    ${MAYBE_COVERAGE_LIBRARIES}
+    ${MAYBE_STACKTRACE_LIBRARIES})
 set(UTIL_LIBRARIES
     ${BOOST_BASE_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${STXXL_LIBRARY}
     ${TBB_LIBRARIES}
-    ${MAYBE_COVERAGE_LIBRARIES})
+    ${MAYBE_COVERAGE_LIBRARIES}
+    ${MAYBE_STACKTRACE_LIBRARIES})
 # Libraries
 target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES})
@@ -629,7 +651,7 @@ target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
 
 if(BUILD_COMPONENTS)
   if(GDAL_FOUND)
-    add_executable(osrm-components src/tools/components.cpp $<TARGET_OBJECTS:UTIL>)
+    add_executable(osrm-components src/tools/components.cpp $<TARGET_OBJECTS:UTIL> ${MAYBE_STACKTRACE_LIBRARIES})
     target_link_libraries(osrm-components ${TBB_LIBRARIES})
     include_directories(SYSTEM ${GDAL_INCLUDE_DIR})
     target_link_libraries(osrm-components ${GDAL_LIBRARIES} ${BOOST_BASE_LIBRARIES})
@@ -641,14 +663,14 @@ endif()
 
 if(BUILD_TOOLS)
   message(STATUS "Activating OSRM internal tools")
-  add_executable(osrm-io-benchmark src/tools/io-benchmark.cpp $<TARGET_OBJECTS:UTIL>)
+  add_executable(osrm-io-benchmark src/tools/io-benchmark.cpp $<TARGET_OBJECTS:UTIL> ${MAYBE_STACKTRACE_LIBRARIES})
   target_link_libraries(osrm-io-benchmark ${BOOST_BASE_LIBRARIES})
-  add_executable(osrm-unlock-all src/tools/unlock_all_mutexes.cpp $<TARGET_OBJECTS:UTIL>)
+  add_executable(osrm-unlock-all src/tools/unlock_all_mutexes.cpp $<TARGET_OBJECTS:UTIL> ${MAYBE_STACKTRACE_LIBRARIES})
   target_link_libraries(osrm-unlock-all ${BOOST_BASE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
   if(UNIX AND NOT APPLE)
     target_link_libraries(osrm-unlock-all rt)
   endif()
-  add_executable(osrm-springclean src/tools/springclean.cpp $<TARGET_OBJECTS:UTIL>)
+  add_executable(osrm-springclean src/tools/springclean.cpp $<TARGET_OBJECTS:UTIL> ${MAYBE_STACKTRACE_LIBRARIES})
   target_link_libraries(osrm-springclean ${BOOST_BASE_LIBRARIES})
 
   install(TARGETS osrm-io-benchmark DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,9 @@ else()
 
   find_package(Boost 1.54 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
   add_dependency_includes(${Boost_INCLUDE_DIRS})
+  if(WIN32 AND Boost_VERSION VERSION_LESS 106200)
+    message(FATAL_ERROR "Building with MSVC needs Boost 1.62 with CXX11_CONSTEXPR support")
+  endif()
 
   find_package(TBB REQUIRED)
   add_dependency_includes(${TBB_INCLUDE_DIR})

--- a/include/util/stacktrace.hpp
+++ b/include/util/stacktrace.hpp
@@ -1,0 +1,59 @@
+#ifndef OSRM_STACKTRACE_HPP_
+#define OSRM_STACKTRACE_HPP_
+
+#include <cstdlib>
+#include <iostream>
+#include <system_error>
+
+#ifdef OSRM_HAS_STACKTRACE
+// From vendored third_party/stacktrace for now; will be included in Boost in the future
+#include <boost/stacktrace.hpp>
+
+#include <errno.h>  // for errno
+#include <signal.h> // for sigaction, sigemptyset, siginfo_t
+#include <string.h> // for strsignal
+#endif
+
+namespace osrm
+{
+namespace util
+{
+
+#ifdef OSRM_HAS_STACKTRACE
+inline void InstallStacktraceHandler()
+{
+    struct ::sigaction sa;
+    sa.sa_flags = SA_SIGINFO;
+    ::sigemptyset(&sa.sa_mask);
+
+    sa.sa_sigaction = [](int, ::siginfo_t *si, void *) {
+        boost::stacktrace::stacktrace bt;
+
+        std::cerr << "Signal '" << ::strsignal(si->si_signo) << "' at address " << si->si_addr
+                  << " from " << si->si_call_addr << ".\n";
+
+        if (bt)
+            std::cerr << "Backtrace:\n" << boost::stacktrace::stacktrace() << "\n";
+
+        std::cerr << std::endl;
+        std::exit(EXIT_FAILURE);
+    };
+
+    if (::sigaction(SIGSEGV, &sa, nullptr) == -1)
+        throw std::system_error{errno, std::system_category()};
+
+    if (::sigaction(SIGABRT, &sa, nullptr) == -1)
+        throw std::system_error{errno, std::system_category()};
+
+    if (::sigaction(SIGBUS, &sa, nullptr) == -1)
+        throw std::system_error{errno, std::system_category()};
+}
+
+#else
+inline void InstallStacktraceHandler() {}
+#endif
+
+} // namespace util
+} // namespace osrm
+
+#endif

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -21,6 +21,9 @@ MASON_TAG=v0.1.1
 SOL_REPO="https://github.com/ThePhD/sol2.git"
 SOL_TAG=v2.15.4
 
+STACKTRACE_REPO="https://github.com/apolukhin/stacktrace.git"
+STACKTRACE_TAG="3439bcef48e2476621f6db58767bef040f5395d3"
+
 VARIANT_LATEST=$(curl https://api.github.com/repos/mapbox/variant/releases/latest | jq ".tag_name")
 OSMIUM_LATEST=$(curl https://api.github.com/repos/osmcode/libosmium/releases/latest | jq ".tag_name")
 MASON_LATEST=$(curl https://api.github.com/repos/mapbox/mason/releases/latest | jq ".tag_name")
@@ -30,6 +33,7 @@ echo "Latest osmium release is $OSMIUM_LATEST, pulling in \"$OSMIUM_TAG\""
 echo "Latest variant release is $VARIANT_LATEST, pulling in \"$VARIANT_TAG\""
 echo "Latest mason release is $MASON_LATEST, pulling in \"$MASON_TAG\""
 echo "Latest sol2 release is $SOL_LATEST, pulling in \"$SOL_TAG\""
+echo "Latest stacktrace release is on master, pulling in \"$STACKTRACE_TAG\""
 
 read -p "Looks good? (Y/n) " ok
 
@@ -39,4 +43,5 @@ then
   git subtree pull -P third_party/variant/ $VARIANT_REPO $VARIANT_TAG --squash
   git subtree pull -P third_party/mason/ $MASON_REPO $MASON_TAG --squash
   git subtree pull -P third_party/sol2/sol2/ $SOL_REPO $SOL_TAG --squash
+  git subtree pull -P third_party/stacktrace/ $STACKTRACE_REPO $STACKTRACE_TAG --squash
 fi

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -2,6 +2,7 @@
 #include "extractor/extractor_config.hpp"
 #include "extractor/scripting_environment_lua.hpp"
 #include "util/log.hpp"
+#include "util/stacktrace.hpp"
 #include "util/version.hpp"
 
 #include <tbb/task_scheduler_init.h>
@@ -115,6 +116,8 @@ return_code parseArguments(int argc, char *argv[], extractor::ExtractorConfig &e
 
 int main(int argc, char *argv[]) try
 {
+    util::InstallStacktraceHandler();
+
     util::LogPolicy::GetInstance().Unmute();
     extractor::ExtractorConfig extractor_config;
 

--- a/src/util/assert.cpp
+++ b/src/util/assert.cpp
@@ -1,5 +1,10 @@
 #include <boost/assert.hpp>
 
+#ifdef OSRM_HAS_STACKTRACE
+// From vendored third_party/stacktrace for now; will be included in Boost in the future
+#include <boost/stacktrace.hpp>
+#endif
+
 #include <exception>
 #include <iostream>
 
@@ -10,7 +15,14 @@ void assertion_failed_msg_helper(
     char const *expr, char const *msg, char const *function, char const *file, long line)
 {
     std::cerr << "[assert] " << file << ":" << line << "\nin: " << function << ": " << expr << "\n"
-              << msg;
+              << msg
+#ifdef OSRM_HAS_STACKTRACE
+              << "\nBacktrace:\n"
+              << boost::stacktrace::stacktrace() << "\n";
+#else
+              << "\n";
+#endif
+
     std::terminate();
 }
 }

--- a/third_party/stacktrace/.travis.yml
+++ b/third_party/stacktrace/.travis.yml
@@ -1,0 +1,120 @@
+# Use, modification, and distribution are
+# subject to the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Copyright Antony Polukhin 2014-2016.
+
+#
+# See https://svn.boost.org/trac/boost/wiki/TravisCoverals for description of this file
+# and how it can be used with Boost libraries.
+#
+# File revision #7
+
+sudo: false
+language: cpp
+compiler:
+    - gcc
+#    - clang
+
+os:
+    - linux
+
+env:
+    global:
+        # Autodetect Boost branch by using the following code: - BRANCH_TO_TEST=$TRAVIS_BRANCH
+        # or just directly specify it
+        #- BRANCH_TO_TEST=$TRAVIS_BRANCH
+        - BRANCH_TO_TEST=develop
+
+        # Files, which coverage results must be ignored (files from other projects).
+        # Example: - IGNORE_COVERAGE='*/boost/progress.hpp */filesystem/src/*'
+        - IGNORE_COVERAGE='*/numeric/conversion/converter_policies.hpp'
+
+        # Explicitly remove the following library from Boost. This may be usefull, if you're for example running Travis
+        # from `Boost.DLL` repo, while Boost already has `dll`.
+        #
+        # By default is eaual to - BOOST_REMOVE=$(basename $TRAVIS_BUILD_DIR)
+        # This will force to use local repo content, instead of the Boost's default.
+        - BOOST_REMOVE=$(basename $TRAVIS_BUILD_DIR)
+
+    matrix:
+        # Note that "--coverage -fsanitize=address,leak,undefined -DBOOST_TRAVISCI_BUILD" are added automatically lower in code
+        - CXX_FLAGS="-std=c++98" LINK_FLAGS="" TOOLSET=gcc-6
+        - CXX_FLAGS="-std=c++11" LINK_FLAGS="" TOOLSET=gcc-6
+        - CXX_FLAGS="-std=c++1y" LINK_FLAGS="" TOOLSET=gcc-6
+        #- CXX_FLAGS="-std=c++11 -stdlib=libc++" LINK_FLAGS="-stdlib=libc++" TOOLSET=clang
+        #- CXX_FLAGS="-std=c++1y -stdlib=libc++" LINK_FLAGS="-stdlib=libc++" TOOLSET=clang
+
+###############################################################################################################
+# From this point and below code is same for all the Boost libs
+###############################################################################################################
+
+
+# Installing additional tools
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - git-core
+    packages:
+    - git
+    - python-yaml
+    - gcc-6
+    - g++-6
+    - clang
+    - libc++-dev
+
+before_install:
+    # Set this to the name of the library
+    - PROJECT_TO_TEST=`basename $TRAVIS_BUILD_DIR`
+    # Cloning Boost libraries (fast nondeep cloning)
+    - BOOST=$HOME/boost-local
+    - echo "Testing $PROJECT_TO_TEST, to remove $BOOST/libs/$BOOST_REMOVE, testing branch $BRANCH_TO_TEST"
+    - git init $BOOST
+    - cd $BOOST
+    - git remote add --no-tags -t $BRANCH_TO_TEST origin https://github.com/boostorg/boost.git
+    - git fetch --depth=1
+    - git checkout $BRANCH_TO_TEST
+    - git submodule update --jobs=3 --init --merge
+    - git remote set-branches --add origin $BRANCH_TO_TEST
+    - git pull --recurse-submodules
+    - git status
+    - rm -rf $BOOST/libs/$BOOST_REMOVE
+    - mv $TRAVIS_BUILD_DIR $BOOST/libs/$PROJECT_TO_TEST
+    - TRAVIS_BUILD_DIR=$BOOST/libs/$PROJECT_TO_TEST
+    - ./bootstrap.sh
+    - ./b2 headers
+    - cd $BOOST/libs/$PROJECT_TO_TEST/test/
+
+script:
+    # `--coverage` flags required to generate coverage info for Coveralls
+    - ../../../b2 "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.3 " address-model=64 architecture=x86 toolset=$TOOLSET cxxflags="--coverage -fsanitize=address,leak,undefined -DBOOST_TRAVISCI_BUILD $CXX_FLAGS" linkflags="$LINK_FLAGS --coverage -lasan -lubsan"
+
+after_success:
+    # Copying Coveralls data to a separate folder
+    - mkdir -p $TRAVIS_BUILD_DIR/coverals
+    - find ../../../bin.v2/ -name "*.gcda" -exec cp "{}" $TRAVIS_BUILD_DIR/coverals/ \;
+    - find ../../../bin.v2/ -name "*.gcno" -exec cp "{}" $TRAVIS_BUILD_DIR/coverals/ \;
+    - find ../../../bin.v2/ -name "*.da" -exec cp "{}" $TRAVIS_BUILD_DIR/coverals/ \;
+    - find ../../../bin.v2/ -name "*.no" -exec cp "{}" $TRAVIS_BUILD_DIR/coverals/ \;
+    - wget https://github.com/linux-test-project/lcov/archive/v1.12.zip
+    - unzip v1.12.zip
+    - LCOV="`pwd`/lcov-1.12/bin/lcov --gcov-tool gcov-6"
+
+    # Preparing Coveralls data by changind data format to a readable one
+    - echo "$LCOV --directory $TRAVIS_BUILD_DIR/coverals --base-directory `pwd` --capture --output-file $TRAVIS_BUILD_DIR/coverals/coverage.info"
+    - $LCOV --directory $TRAVIS_BUILD_DIR/coverals --base-directory `pwd` --capture --output-file $TRAVIS_BUILD_DIR/coverals/coverage.info
+
+    # ... erasing /test/ /example/ folder data
+    - cd $BOOST
+    - $LCOV --remove $TRAVIS_BUILD_DIR/coverals/coverage.info "/usr*" "*/$PROJECT_TO_TEST/test/*" $IGNORE_COVERAGE "*/$PROJECT_TO_TEST/tests/*" "*/$PROJECT_TO_TEST/examples/*" "*/$PROJECT_TO_TEST/example/*" -o $TRAVIS_BUILD_DIR/coverals/coverage.info
+
+    # ... erasing data that is not related to this project directly
+    - OTHER_LIBS=`grep "submodule .*" .gitmodules | sed 's/\[submodule\ "\(.*\)"\]/"\*\/boost\/\1\.hpp" "\*\/boost\/\1\/\*"/g'| sed "/\"\*\/boost\/$PROJECT_TO_TEST\/\*\"/d" | sed ':a;N;$!ba;s/\n/ /g'`
+    - echo $OTHER_LIBS
+    - eval "$LCOV --remove $TRAVIS_BUILD_DIR/coverals/coverage.info $OTHER_LIBS -o $TRAVIS_BUILD_DIR/coverals/coverage.info"
+
+    # Sending data to Coveralls
+    - cd $TRAVIS_BUILD_DIR
+    - gem install coveralls-lcov
+    - coveralls-lcov coverals/coverage.info

--- a/third_party/stacktrace/README.md
+++ b/third_party/stacktrace/README.md
@@ -1,0 +1,18 @@
+### Stacktrace
+Library for storing and printing backtraces.
+
+[Documentation and examples.](http://apolukhin.github.io/stacktrace/index.html)
+
+
+### Test results
+@               | Build         | Tests coverage | More info
+----------------|-------------- | -------------- |-----------
+Master branch:  | [![Build Status](https://travis-ci.org/apolukhin/stacktrace.svg?branch=master)](https://travis-ci.org/apolukhin/stacktrace) [![Build status](https://ci.appveyor.com/api/projects/status/e070eams56vu0lm6/branch/master?svg=true)](https://ci.appveyor.com/project/apolukhin/stacktrace/branch/master) | [![Coverage Status](https://coveralls.io/repos/apolukhin/stacktrace/badge.png?branch=master)](https://coveralls.io/r/apolukhin/stacktrace?branch=master) | [details...](http://www.boost.org/development/tests/master/developer/stacktrace.html)
+
+
+### Caution
+This is not an official Boost C++ library. It wasn't reviewed and can't be downloaded from www.boost.org. This library is available to the community to know real interest and get comments for refinement. The intention is to submit library to formal review, if community think that it is interesting!
+
+
+### License
+Distributed under the [Boost Software License, Version 1.0](http://boost.org/LICENSE_1_0.txt).

--- a/third_party/stacktrace/build/Jamfile.v2
+++ b/third_party/stacktrace/build/Jamfile.v2
@@ -1,0 +1,98 @@
+#  Copyright (C) 2016, Antony Polukhin.
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+
+project
+  : source-location .
+  : requirements
+    <target-os>linux:<cxxflags>"-fvisibility=hidden"
+  ;
+
+lib dl : : <link>shared ;
+lib gcc_s : : <link>shared ;
+lib Dbghelp ;
+
+actions mp_simple_run_action
+{
+      $(>) > $(<)
+}
+
+rule mp-run-simple ( sources + : args * : input-files * : requirements * : target-name )
+{
+   exe $(target-name)_exe : $(sources) : $(requirements) ;
+   explicit $(target-name)_exe ;
+   make $(target-name).output : $(target-name)_exe : @mp_simple_run_action ;
+   explicit $(target-name).output ;
+   alias $(target-name) : $(target-name).output ;
+}
+
+mp-run-simple has_backtrace.cpp : : : : backtrace ;
+explicit backtrace ;
+
+mp-run-simple has_unwind.cpp : : : : unwind ;
+explicit unwind ;
+
+mp-run-simple has_windbg.cpp : : : : WinDbg ;
+explicit WinDbg ;
+
+lib boost_stacktrace_noop
+  : # sources
+    ../src/noop.cpp
+  : # requirements
+    <warnings>all
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+  : # default build
+  : # usage-requirements
+    #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+  ;
+
+boost-install boost_stacktrace_noop ;
+
+lib boost_stacktrace_backtrace
+  : # sources
+    ../src/backtrace.cpp
+  : # requirements
+    <warnings>all
+    <target-os>linux:<library>dl
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    [ check-target-builds ../build//backtrace : : <build>no ]
+  : # default build
+  : # usage-requirements
+    #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+  ;
+
+boost-install boost_stacktrace_backtrace ;
+
+lib boost_stacktrace_unwind
+  : # sources
+    ../src/unwind.cpp
+  : # requirements
+    <warnings>all
+    <target-os>linux:<library>dl
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    [ check-target-builds ../build//unwind : : <build>no ]
+  : # default build
+  : # usage-requirements
+    #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+  ;
+
+boost-install boost_stacktrace_unwind ;
+
+lib boost_stacktrace_windbg
+  : # sources
+    ../src/windbg.cpp
+  : # requirements
+    <warnings>all
+    <library>Dbghelp
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    [ check-target-builds ../build//WinDbg : : <build>no ]
+  : # default build
+  : # usage-requirements
+    #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+  ;
+
+boost-install boost_stacktrace_windbg ;
+

--- a/third_party/stacktrace/build/has_backtrace.cpp
+++ b/third_party/stacktrace/build/has_backtrace.cpp
@@ -1,0 +1,14 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <dlfcn.h>
+#include <execinfo.h>
+
+int main() {
+    void* buffer[10];
+    ::backtrace(buffer, 10);
+
+}

--- a/third_party/stacktrace/build/has_unwind.cpp
+++ b/third_party/stacktrace/build/has_unwind.cpp
@@ -1,0 +1,11 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <unwind.h>
+
+int main() {
+
+}

--- a/third_party/stacktrace/build/has_windbg.cpp
+++ b/third_party/stacktrace/build/has_windbg.cpp
@@ -1,0 +1,16 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <cstring>
+#include <windows.h>
+#include "Dbgeng.h"
+#pragma comment(lib, "ole32.lib")
+#pragma comment(lib, "Dbgeng.lib")
+
+int main() {
+    CoInitializeEx(0, COINIT_MULTITHREADED);
+}

--- a/third_party/stacktrace/doc/Jamfile.v2
+++ b/third_party/stacktrace/doc/Jamfile.v2
@@ -1,0 +1,48 @@
+# Copyright Antony Polukhin 2016.
+# Use, modification, and distribution are
+# subject to the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+using quickbook ;
+import boostbook : boostbook ;
+import doxygen ;
+
+doxygen autodoc
+   :
+      [ glob ../../../boost/stacktrace.hpp ]
+      [ glob ../../../boost/stacktrace/*.hpp ]
+   :
+        <doxygen:param>EXTRACT_ALL=NO
+        <doxygen:param>HIDE_UNDOC_MEMBERS=YES
+        <doxygen:param>EXTRACT_PRIVATE=NO
+        <doxygen:param>ENABLE_PREPROCESSING=YES
+        <doxygen:param>EXPAND_ONLY_PREDEF=YES
+        <doxygen:param>MACRO_EXPANSION=YES
+        <doxygen:param>"PREDEFINED=\"stl_type_info=std::type_info\" \\
+                                   \"BOOST_EXPLICIT_OPERATOR_BOOL_NOEXCEPT()=explicit operator bool() const noexcept;\" \\
+                                   \"BOOST_STATIC_CONSTEXPR=static constexpr\" \\
+                                   \"BOOST_STACKTRACE_FUNCTION\" \\
+                                   \"BOOST_STACKTRACE_DOXYGEN_INVOKED\""
+        <xsl:param>"boost.doxygen.reftitle=Boost.Stacktrace Header Reference"
+   ;
+
+xml stacktrace : stacktrace.qbk : <dependency>autodoc ;
+boostbook standalone
+    :
+        stacktrace
+    :
+        <xsl:param>boost.root=http://www.boost.org/doc/libs/1_61_0
+#        <xsl:param>boost.root=../../../..
+        <format>pdf:<xsl:param>boost.url.prefix=http://www.boost.org/doc/libs/release/doc/html
+    ;
+
+###############################################################################
+alias boostdoc
+    : stacktrace
+    :
+    : <dependency>autodoc
+    : ;
+
+explicit boostdoc ;
+alias boostrelease ;
+explicit boostrelease ;

--- a/third_party/stacktrace/doc/stacktrace.qbk
+++ b/third_party/stacktrace/doc/stacktrace.qbk
@@ -1,0 +1,296 @@
+[library Boost.Stacktrace
+    [quickbook 1.6]
+    [version 1.0]
+    [copyright 2016 Antony Polukhin]
+    [category Language Features Emulation]
+    [license
+        Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+        [@http://www.boost.org/LICENSE_1_0.txt])
+    ]
+]
+
+[section Motivation]
+How to display the call sequence in C++? From what function was called the current function? What call sequence led to an exception?
+
+Boost.Stacktrace library is a simple library that provides information about call sequence in a human-readable form.
+
+[warning This is not an official Boost library! It wasn't reviewed and can't be downloaded from www.boost.org. This library is available to the community to know real interest and get comments for refinement. The intention is to submit library for formal review, if community thinks that it is interesting!]
+
+[endsect]
+
+[section Getting Started]
+
+[import ../example/assert_handler.cpp]
+[import ../example/terminate_handler.cpp]
+[import ../example/throwing_st.cpp]
+[import ../example/trace_addresses.cpp]
+[import ../example/debug_function.cpp]
+[import ../example/user_config.hpp]
+
+[section How to print current call stack]
+
+[classref boost::stacktrace::stacktrace] contains methods for working with call-stack/backtraces/stacktraces. Here's a small example:
+```
+#include <boost/stacktrace.hpp>
+
+// ... somewere inside the `bar(int)` function that is called recursively:
+std::cout << boost::stacktrace::stacktrace();
+```
+
+In that example:
+
+* `boost::stacktrace::` is the namespace that has all the classes and functions to work with stacktraces
+* [classref boost::stacktrace::stacktrace stacktrace()] is the default constructor call; constructor stores the current function call sequence inside the stacktrace class.
+
+Code from above will output something like this:
+
+```
+ 0# bar(int) at /path/to/source/file.cpp:70
+ 1# bar(int) at /path/to/source/file.cpp:70
+ 2# bar(int) at /path/to/source/file.cpp:70
+ 3# bar(int) at /path/to/source/file.cpp:70
+ 4# main at /path/to/main.cpp:93
+ 5# __libc_start_main
+ 6# _start
+```
+
+[endsect]
+
+[section Handle terminates, aborts and Segmentation Faults]
+
+Segmentation Faults and `std::terminate` calls sometimes happen in programs. Programmers usually wish to get as much information as possible on such incidents, so having a stacktrace will significantly improve debugging and fixing.
+
+To deal with Segmentation Faults and `std::terminate` calls we would need to write handlers:
+
+[getting_started_terminate_handlers]
+
+After that we can set them as a default handlers and get some more information on incidents:
+
+[getting_started_setup_handlers]
+
+Now we'll get the following output on `std::terminate` call:
+
+```
+Terminate called:
+ 0# boost::stacktrace::detail::backend::backend(void**, unsigned long)
+ 1# my_terminate_handler() at boost/libs/stacktrace/example/terminate_handler.cpp:37
+ 2# 0x7f624107a6b6
+ 3# 0x7f624107a701
+ 4# bar(int) at boost/libs/stacktrace/example/terminate_handler.cpp:18
+ 5# foo(int) at boost/libs/stacktrace/example/terminate_handler.cpp:22
+ 6# bar(int) at boost/libs/stacktrace/example/terminate_handler.cpp:18
+ 7# foo(int) at boost/libs/stacktrace/example/terminate_handler.cpp:22
+ 8# main at boost/libs/stacktrace/example/terminate_handler.cpp:64
+ 9# __libc_start_main
+10# _start
+```
+And the following output on Abort:
+
+```
+Signal 6, backtrace:
+ 0# boost::stacktrace::detail::backend::backend(void**, unsigned long)
+ 1# my_signal_handler(int)
+ 2# 0x7f6240a3a4b0
+ 3# gsignal
+ 4# abort
+ 5# my_terminate_handler()
+ 6# 0x7f624107a6b6
+ 7# 0x7f624107a701
+ 8# bar(int) at boost/libs/stacktrace/example/terminate_handler.cpp:18
+ 9# foo(int) at boost/libs/stacktrace/example/terminate_handler.cpp:22
+10# bar(int) at boost/libs/stacktrace/example/terminate_handler.cpp:18
+11# foo(int) at boost/libs/stacktrace/example/terminate_handler.cpp:22
+12# main at boost/libs/stacktrace/example/terminate_handler.cpp:64
+13# __libc_start_main
+14# _start
+```
+
+The output stacktrace may be corrupted by previous actions. But now at least some basic information is available to work with.
+
+[endsect]
+
+[section Better asserts]
+
+Pretty often assertions provide not enough information to locate the problem. For example you can see the following message on out-of-range access:
+
+```
+../../../boost/array.hpp:123: T& boost::array<T, N>::operator[](boost::array<T, N>::size_type) [with T = int; long unsigned int N = 5ul]: Assertion '(i < N)&&("out of range")' failed.
+Aborted (core dumped)
+```
+
+That's not enough to locate the problem without debugger. There may be thousand code lines in real world examples and hundred places where that assertion could happen. Let's try to improve the assertions, and make them more informative:
+
+[getting_started_assert_handlers]
+
+We've defined the `BOOST_ENABLE_ASSERT_DEBUG_HANDLER` macro for the whole project. Now all the `BOOST_ASSERT` and `BOOST_ASSERT_MSG` will call our functions `assertion_failed` and `assertion_failed_msg` in case of failure. In `assertion_failed_msg` we output information that was provided by the assertion macro and [classref boost::stacktrace::stacktrace]:
+
+```
+Expression 'i < N' is false in function 'T& boost::array<T, N>::operator[](boost::array<T, N>::size_type) [with T = int; long unsigned int N = 5ul; boost::array<T, N>::reference = int&; boost::array<T, N>::size_type = long unsigned int]': out of range.
+Backtrace:
+ 0# boost::stacktrace::detail::backend::backend(void**, unsigned long)
+ 1# boost::assertion_failed_msg(char const*, char const*, char const*, char const*, long) at boost/libs/stacktrace/example/assert_handler.cpp:38
+ 2# boost::array<int, 5ul>::operator[](unsigned long)
+ 3# bar(int) at boost/libs/stacktrace/example/assert_handler.cpp:16
+ 4# foo(int) at boost/libs/stacktrace/example/assert_handler.cpp:24
+ 5# bar(int) at boost/libs/stacktrace/example/assert_handler.cpp:20
+ 6# foo(int) at boost/libs/stacktrace/example/assert_handler.cpp:24
+ 7# main at boost/libs/stacktrace/example/assert_handler.cpp:53
+ 8# __libc_start_main
+ 9# _start
+```
+
+Now we do know the steps that led to the assertion and can find the error without debugger.
+
+[endsect]
+
+
+[section Exceptions with stacktrace]
+
+You can provide more information along with exception by embedding stacktraces into the exception. For that you will need to:
+
+* Write a basic class that holds the stacktrace:
+
+[getting_started_class_traced]
+
+* Write a helper class for appending class `traced` to any exception:
+
+[getting_started_class_with_trace]
+
+* Throw `with_trace<Exception>` instead of just `Exception`:
+
+[getting_started_throwing_with_trace]
+
+* Catch exceptions by `traced`:
+
+[getting_started_catching_trace]
+
+Code from above will output:
+
+```
+'i' must not be greater than zero in oops()
+Backtrace:
+ 0# boost::stacktrace::detail::backend::backend(void**, unsigned long)
+ 1# traced::traced() at boost/libs/stacktrace/example/throwing_st.cpp:20
+ 2# with_trace<std::logic_error>::with_trace<char const (&) [44]>(char const (&) [44]) at boost/libs/stacktrace/example/throwing_st.cpp:33
+ 3# oops(int)
+ 4# bar(int) at boost/libs/stacktrace/example/throwing_st.cpp:70
+ 5# foo(int) at boost/libs/stacktrace/example/throwing_st.cpp:75
+ 6# bar(int) at boost/libs/stacktrace/example/throwing_st.cpp:65
+ 7# foo(int) at boost/libs/stacktrace/example/throwing_st.cpp:75
+ 8# main at boost/libs/stacktrace/example/throwing_st.cpp:93
+ 9# __libc_start_main
+10# _start
+```
+
+[endsect]
+
+[section Enabling and disabling stacktraces]
+
+At some point arises a requirement to easily enable/disable stacktraces for a whole project. That could be easily achived.
+
+Just define *BOOST_STACKTRACE_LINK* for a whole project. Now you can enable/disable stacktraces by just linking with different backends:
+
+* link with `boost_stacktrace_noop` to disable backtracing
+* link with other backends to output backtraces
+
+See [link boost_stacktrace.build_macros_and_backends section "Build, Macros and Backends"] for more info.
+
+[endsect]
+
+[section Saving stacktraces by specified format]
+
+[classref boost::stacktrace::stacktrace] provides access to individual [classref boost::stacktrace::frame frames] of the stacktrace,
+so that you could save stacktrace information in your own format. Consider the example, that saves only function addresses of each frame:
+
+[getting_started_trace_addresses]
+
+Code from above will output:
+
+```
+0x7fbcfd17f6b5,0x400d4a,0x400d61,0x400d61,0x400d61,0x400d61,0x400d77,0x400cbf,0x400dc0,0x7fbcfc82d830,0x400a79,
+```
+
+[endsect]
+
+[section Getting function information from pointer]
+
+[classref boost::stacktrace::frame] provides information about functions. You may construct that class from function pointer and get the function name at runtime:
+
+[getting_started_debug_function]
+
+Code from above will output:
+
+```
+my_signal_handler(int) at boost/libs/stacktrace/example/debug_function.cpp:21
+```
+
+[endsect]
+
+[section Global control over stacktrace output format]
+
+You may control maximal stacktrace length using [macroref BOOST_STACKTRACE_DEFAULT_MAX_DEPTH] and even override the behavior of default stacktrace output operator by defining the macro from Boost.Config [macroref BOOST_USER_CONFIG] to point to a file like following:
+
+[getting_started_user_config]
+
+Implementation of `do_stream_st` may be the following:
+
+[getting_started_user_config_impl]
+
+Code from above will output:
+
+```
+Terminate called:
+ 0# boost::stacktrace::detail::backend::backend(void**, unsigned long)
+ 1# bar(int)
+ 2# foo(int)
+ 3# bar(int)
+ 4# foo(int)
+```
+
+[endsect]
+
+[endsect]
+
+[section Build, Macros and Backends]
+
+By default Boost.Stacktrace is a header-only library and it attempts to detect the tracing backend automatically.
+
+You can define the following macros to explicitly specify backend that you're willing to use in header-only mode (those macros have no effect if defined *BOOST_STACKTRACE_LINK* or *BOOST_STACKTRACE_DYN_LINK*):
+
+[table:configbackend Header only backend specifications
+    [[Macro name] [Effect] [Platforms] [Uses debug information [footnote This will provide more readable backtraces if the binary is built with debug information.]] [Uses dynamic exports information [footnote This will provide readable function names in backtrace for functions that are exported by the binary.]] [Async signal safe[footnote Absolutely safe to construct instances of [classref boost::stacktrace::stacktrace] in async signal handlers using that backend.]]]
+    [[*BOOST_STACKTRACE_USE_UNWIND*] [Use unwind tracing backend. This is the best known backend for POSIX systems that requires LSB Core Specification 4.1 from OS. Requires linking with libdl library.] [POSIX] [yes] [yes] [yes]]
+    [[*BOOST_STACKTRACE_USE_WINDBG*] [Use Windows specific tracing backend that uses DbgHelp. This is the best and only known backend for Windows platform that requires linking with DbgHelp library.] [Windows] [yes] [yes] [???]]
+    [[*BOOST_STACKTRACE_USE_BACKTRACE*] [Use tracing backend that calls POSIX function `backtrace`. Requires linking with libdl library.] [POSIX] [no] [yes] [no]]
+    [[*BOOST_STACKTRACE_USE_NOOP*] [Use noop tracing backend that does nothing. Use this backend if you wish to disable backtracing, `stacktrace::size()` with that backend always return 0. ] [POSIX and Windows] [no] [no] [yes]]
+]
+
+
+You may use the following macros to improve build times or to be able to switch backends without recompiling your project:
+[table:linkmacro Link macros
+    [[Macro name] [Effect]]
+    [[*BOOST_STACKTRACE_LINK*] [Disable header-only build and require linking with shared or static library that contains the tracing backend. If *BOOST_ALL_DYN_LINK* is defined, then link with shared library.]]
+    [[*BOOST_STACKTRACE_DYN_LINK*] [Disable header-only build and require linking with shared library that contains tracing backend.]]
+]
+
+If one of the link macros is defined, you have to manually link your binary with one of the libraries that has the backend implementation:
+
+* boost_stacktrace_unwind
+* boost_stacktrace_windbg
+* boost_stacktrace_backtrace
+* boost_stacktrace_noop
+
+[endsect]
+
+[section Acknowledgements]
+
+In order of helping and advising:
+
+* Great thanks to Nat Goodspeed for requesting [classref boost::stacktrace::frame] like class.
+* Great thanks to Niall Douglas for making an initial review, helping with some platforms and giving great hints on library design.
+
+[endsect]
+
+[xinclude autodoc.xml]
+

--- a/third_party/stacktrace/example/assert_handler.cpp
+++ b/third_party/stacktrace/example/assert_handler.cpp
@@ -1,0 +1,56 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_ENABLE_ASSERT_HANDLER
+
+#include <boost/array.hpp>
+BOOST_NOINLINE void foo(int i);
+BOOST_NOINLINE void bar(int i);
+ 
+BOOST_NOINLINE void bar(int i) {
+    boost::array<int, 5> a = {{101, 100, 123, 23, 32}};
+    if (i >= 0) {
+        foo(a[i]);
+    } else {
+        std::exit(1);
+    }
+}
+
+BOOST_NOINLINE void foo(int i) {
+    bar(--i);
+}
+
+namespace std { inline void ignore_abort(){ std::exit(0); } }
+#define abort ignore_abort
+
+//[getting_started_assert_handlers
+
+// BOOST_ENABLE_ASSERT_DEBUG_HANDLER is defined for the whole project
+#include <stdexcept>    // std::logic_error
+#include <iostream>     // std::cerr
+#include <boost/stacktrace.hpp>
+
+namespace boost {
+    inline void assertion_failed_msg(char const* expr, char const* msg, char const* function, char const* file, long line) {
+        std::cerr << "Expression '" << expr << "' is false in function '" << function << "': " << (msg ? msg : "<...>") << ".\n"
+            << "Backtrace:\n" << boost::stacktrace::stacktrace() << '\n';
+        std::abort();
+    }
+
+    inline void assertion_failed(char const* expr, char const* function, char const* file, long line) {
+        ::boost::assertion_failed_msg(expr, 0 /*nullptr*/, function, file, line);
+    }
+} // namespace boost
+//]
+
+
+int main() {
+    foo(5);
+    
+    return 2;
+}
+
+

--- a/third_party/stacktrace/example/debug_function.cpp
+++ b/third_party/stacktrace/example/debug_function.cpp
@@ -1,0 +1,32 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[getting_started_debug_function
+#include <signal.h>     // ::signal
+#include <boost/stacktrace/frame.hpp>
+#include <iostream>     // std::cerr
+
+void print_signal_handler_and_exit() {
+    void* p = reinterpret_cast<void*>(::signal(SIGSEGV, SIG_DFL));
+    boost::stacktrace::frame f(p);
+    std::cout << f << std::endl;
+    std::exit(0);
+}
+//]
+
+
+void my_signal_handler(int signum) {
+    std::exit(1);
+}
+
+int main() {
+    ::signal(SIGSEGV, &my_signal_handler);
+    print_signal_handler_and_exit();
+    
+    return 2;
+}
+
+

--- a/third_party/stacktrace/example/terminate_handler.cpp
+++ b/third_party/stacktrace/example/terminate_handler.cpp
@@ -1,0 +1,67 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/array.hpp>
+BOOST_NOINLINE void foo(int i);
+BOOST_NOINLINE void bar(int i);
+ 
+BOOST_NOINLINE void bar(int i) {
+    boost::array<int, 5> a = {{-1, -231, -123, -23, -32}};
+    if (i >= 0) {
+        foo(a[i]);
+    } else {
+        std::terminate();
+    }
+}
+
+BOOST_NOINLINE void foo(int i) {
+    bar(--i);
+}
+
+inline void ignore_exit(int){ std::exit(0); }
+#define _Exit ignore_exit
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//[getting_started_terminate_handlers
+
+#include <exception>    // std::set_terminate, std::abort
+#include <signal.h>     // ::signal
+#include <boost/stacktrace.hpp>
+#include <iostream>     // std::cerr
+
+void my_terminate_handler() {
+    std::cerr << "Terminate called:\n" << boost::stacktrace::stacktrace() << '\n';
+    std::abort();
+}
+
+void my_signal_handler(int signum) {
+    ::signal(signum, SIG_DFL);
+    boost::stacktrace::stacktrace bt;
+    if (bt) {
+        std::cerr << "Signal " << signum << ", backtrace:\n" << boost::stacktrace::stacktrace() << '\n'; // ``[footnote Strictly speaking this code is not async-signal-safe, because it uses std::cerr. [link boost_stacktrace.build_macros_and_backends Section "Build, Macros and Backends"] describes async-signal-safe backends, so if you will use the noop backend code becomes absolutely valid as that backens always returns 0 frames and `operator<<` will be never called. ]``
+    }
+    _Exit(-1);
+}
+//]
+
+void setup_handlers() {
+//[getting_started_setup_handlers
+    std::set_terminate(&my_terminate_handler);
+    ::signal(SIGSEGV, &my_signal_handler);
+    ::signal(SIGABRT, &my_signal_handler);
+//]
+}
+
+
+int main() {
+    setup_handlers();
+    foo(5);
+    
+    return 2;
+}
+
+

--- a/third_party/stacktrace/example/throwing_st.cpp
+++ b/third_party/stacktrace/example/throwing_st.cpp
@@ -1,0 +1,97 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_NO_CXX11_NOEXCEPT) || defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+int main(){}
+
+#else
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//[getting_started_class_traced
+#include <boost/stacktrace.hpp>
+
+struct traced {
+    const boost::stacktrace::stacktrace trace;
+
+    virtual const char* what() const noexcept = 0;
+    virtual ~traced(){}
+};
+//]
+
+//[getting_started_class_with_trace
+template <class Exception>
+struct with_trace : public Exception, public traced {
+    template <class... Args>
+    with_trace(Args&&... args)
+        : Exception(std::forward<Args>(args)...)
+    {}
+
+    const char* what() const noexcept {
+        return Exception::what();
+    }
+};
+//]
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+BOOST_NOINLINE void oops(int i);
+BOOST_NOINLINE void foo(int i);
+BOOST_NOINLINE void bar(int i);
+
+#include <stdexcept>
+BOOST_NOINLINE void oops(int i) {
+    //[getting_started_throwing_with_trace
+    if (i >= 4)
+        throw with_trace<std::out_of_range>("'i' must be less than 4 in oops()");
+    if (i <= 0)
+        throw with_trace<std::logic_error>("'i' must not be greater than zero in oops()");
+    //]
+    foo(i);
+    std::exit(1);
+}
+
+#include <boost/array.hpp>
+BOOST_NOINLINE void bar(int i) {
+    boost::array<int, 5> a = {{0, 0, 0, 0, 0}};
+    if (i < 5) {
+        if (i >= 0) {
+            foo(a[i]);
+        } else {
+            oops(i);
+        }
+    }
+    std::exit(2);
+}
+
+BOOST_NOINLINE void foo(int i) {
+    bar(--i);
+}
+
+#include <iostream>
+int main() {
+
+    //[getting_started_catching_trace
+    try {
+        foo(5); // testing assert handler
+    } catch (const traced& e) {
+        std::cerr << e.what() << '\n';
+        if (e.trace) {
+            std::cerr << "Backtrace:\n" << e.trace << '\n';
+        } /*<-*/ std::exit(0); /*->*/
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n'; /*<-*/ std::exit(3); /*->*/
+    }
+    //]
+    
+    return 5;
+}
+
+#endif
+

--- a/third_party/stacktrace/example/trace_addresses.cpp
+++ b/third_party/stacktrace/example/trace_addresses.cpp
@@ -1,0 +1,63 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/config.hpp>
+
+#ifdef BOOST_NO_CXX11_RANGE_BASED_FOR
+#include <boost/stacktrace.hpp>
+#include <iostream>     // std::cout
+
+namespace bs = boost::stacktrace;
+void dump_compact(const bs::stacktrace& st) {
+    for (unsigned i = 0; i < st.size(); ++i) {
+        bs::frame frame = st[i];
+        std::cout << frame.address() << ',';
+    }
+
+    std::cout << std::endl;
+}
+#else
+//[getting_started_trace_addresses
+#include <boost/stacktrace.hpp>
+#include <iostream>     // std::cout
+
+namespace bs = boost::stacktrace;
+void dump_compact(const bs::stacktrace& st) {
+    for (bs::frame frame: st) {
+        std::cout << frame.address() << ',';
+    }
+
+    std::cout << std::endl;
+}
+//]
+#endif
+
+BOOST_NOINLINE boost::stacktrace::stacktrace rec1(int i);
+BOOST_NOINLINE boost::stacktrace::stacktrace rec2(int i);
+
+BOOST_NOINLINE boost::stacktrace::stacktrace rec1(int i) {
+    if (i < 5) {
+        if (!i) return boost::stacktrace::stacktrace();
+        return rec2(--i);
+    }
+
+    return rec2(i - 2);
+}
+
+BOOST_NOINLINE boost::stacktrace::stacktrace rec2(int i) {
+    if (i < 5) {
+        if (!i) return boost::stacktrace::stacktrace();
+        return rec2(--i);
+    }
+
+    return rec2(i - 2);
+}
+
+int main() {
+    dump_compact(rec1(8));
+}
+
+

--- a/third_party/stacktrace/example/user_config.cpp
+++ b/third_party/stacktrace/example/user_config.cpp
@@ -1,0 +1,38 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_USER_CONFIG <libs/stacktrace/example/user_config.hpp>
+
+#include <boost/array.hpp>
+#include <exception>    // std::set_terminate, std::abort
+#include <boost/stacktrace.hpp>
+#include <iostream>     // std::cerr
+BOOST_NOINLINE void foo(int i);
+BOOST_NOINLINE void bar(int i);
+ 
+BOOST_NOINLINE void bar(int i) {
+    boost::array<int, 5> a = {{-1, -231, -123, -23, -32}};
+    if (i >= 0) {
+        foo(a[i]);
+    } else {
+        std::cerr << "Terminate called:\n" << boost::stacktrace::stacktrace() << '\n';
+        std::exit(0);
+    }
+}
+
+BOOST_NOINLINE void foo(int i) {
+    bar(--i);
+}
+
+int main() {
+    foo(5);
+    
+    return 2;
+}
+
+
+
+

--- a/third_party/stacktrace/example/user_config.hpp
+++ b/third_party/stacktrace/example/user_config.hpp
@@ -1,0 +1,56 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+//[getting_started_user_config
+#ifndef USER_CONFIG_HPP
+#define USER_CONFIG_HPP
+
+#define BOOST_STACKTRACE_DEFAULT_MAX_DEPTH 5
+#include <boost/stacktrace/stacktrace_fwd.hpp>
+
+#include <iosfwd>
+
+namespace boost { namespace stacktrace {
+
+template <class CharT, class TraitsT, std::size_t Depth>
+std::basic_ostream<CharT, TraitsT>& do_stream_st(std::basic_ostream<CharT, TraitsT>& os, const basic_stacktrace<Depth>& bt);
+
+template <class CharT, class TraitsT>
+std::basic_ostream<CharT, TraitsT>& operator<<(std::basic_ostream<CharT, TraitsT>& os, const stacktrace& bt) {
+    return do_stream_st(os, bt);
+}
+
+}}  // namespace boost::stacktrace
+#endif // USER_CONFIG_HPP
+//]
+
+#ifndef USER_CONFIG2_HPP
+#define USER_CONFIG2_HPP
+//[getting_started_user_config_impl
+namespace boost { namespace stacktrace {
+
+template <class CharT, class TraitsT, std::size_t Depth>
+std::basic_ostream<CharT, TraitsT>& do_stream_st(std::basic_ostream<CharT, TraitsT>& os, const basic_stacktrace<Depth>& bt) {
+    const std::streamsize w = os.width();
+    const std::size_t frames = bt.size();
+    for (std::size_t i = 0; i < frames; ++i) {
+        os.width(2);
+        os << i;
+        os.width(w);
+        os << "# ";
+        os << bt[i].name();
+        os << '\n';
+    }
+
+    return os;
+}
+
+}}  // namespace boost::stacktrace
+//]
+
+#endif // USER_CONFIG2_HPP
+

--- a/third_party/stacktrace/include/boost/stacktrace.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace.hpp
@@ -1,0 +1,18 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_HPP
+#define BOOST_STACKTRACE_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/stacktrace/frame.hpp>
+#include <boost/stacktrace/stacktrace.hpp>
+
+#endif // BOOST_STACKTRACE_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/const_iterator.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/const_iterator.hpp
@@ -1,0 +1,86 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_CONST_ITERATOR_HPP
+#define BOOST_STACKTRACE_CONST_ITERATOR_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/assert.hpp>
+
+#include <boost/stacktrace/frame.hpp>
+
+namespace boost { namespace stacktrace {
+
+
+#ifdef BOOST_STACKTRACE_DOXYGEN_INVOKED
+/// Random access iterator over frames that returns boost::stacktrace::frame on dereference
+class const_iterator: implementation_details {};
+
+#else
+
+// Forward declarations
+template <std::size_t> class basic_stacktrace;
+
+class const_iterator: public boost::iterator_facade<
+    const_iterator,
+    frame,
+    boost::random_access_traversal_tag,
+    frame>
+{
+    typedef boost::iterator_facade<
+        const_iterator,
+        frame,
+        boost::random_access_traversal_tag,
+        frame
+    > base_t;
+
+    const boost::stacktrace::detail::backend* impl_;
+    std::size_t frame_no_;
+
+    const_iterator(const boost::stacktrace::detail::backend* impl, std::size_t frame_no) BOOST_NOEXCEPT
+        : impl_(impl)
+        , frame_no_(frame_no)
+    {}
+
+    template <std::size_t> friend class basic_stacktrace;
+    friend class ::boost::iterators::iterator_core_access;
+
+    frame dereference() const BOOST_NOEXCEPT {
+        return frame(impl_->get_address(frame_no_));
+    }
+
+    bool equal(const const_iterator& it) const BOOST_NOEXCEPT {
+        return impl_ == it.impl_ && frame_no_ == it.frame_no_;
+    }
+
+    void increment() BOOST_NOEXCEPT {
+        ++frame_no_;
+    }
+
+    void decrement() BOOST_NOEXCEPT {
+        --frame_no_;
+    }
+
+    void advance(std::size_t n) BOOST_NOEXCEPT {
+        frame_no_ += n;
+    }
+
+    base_t::difference_type distance_to(const const_iterator& it) const {
+        BOOST_ASSERT(impl_ == it.impl_);
+        return it.frame_no_ - frame_no_;
+    }
+};
+
+#endif // #ifdef BOOST_STACKTRACE_DOXYGEN_INVOKED
+
+}} // namespace boost::stacktrace
+
+#endif // BOOST_STACKTRACE_CONST_ITERATOR_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/backend.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/backend.hpp
@@ -1,0 +1,125 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_BACKEND_HPP
+#define BOOST_STACKTRACE_DETAIL_BACKEND_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <string>
+
+
+// Link or header only
+#if !defined(BOOST_STACKTRACE_LINK) && defined(BOOST_STACKTRACE_DYN_LINK)
+#   define BOOST_STACKTRACE_LINK
+#endif
+
+#if defined(BOOST_STACKTRACE_LINK) && !defined(BOOST_STACKTRACE_DYN_LINK) && defined(BOOST_ALL_DYN_LINK)
+#   define BOOST_STACKTRACE_DYN_LINK
+#endif
+
+// Backend autodetection
+#if !defined(BOOST_STACKTRACE_USE_NOOP) && !defined(BOOST_STACKTRACE_USE_WINDBG) && !defined(BOOST_STACKTRACE_USE_UNWIND) \
+    && !defined(BOOST_STACKTRACE_USE_BACKTRACE) && !defined(BOOST_STACKTRACE_USE_HEADER)
+
+#if defined(__has_include) && (!defined(__GNUC__) || __GNUC__ > 4 || BOOST_CLANG)
+#   if __has_include("Dbgeng.h")
+#       define BOOST_STACKTRACE_USE_WINDBG
+#   else
+#       define BOOST_STACKTRACE_USE_UNWIND
+#   endif
+#else
+#   if defined(BOOST_WINDOWS)
+#       define BOOST_STACKTRACE_USE_WINDBG
+#   else
+#       define BOOST_STACKTRACE_USE_UNWIND
+#   endif
+#endif
+
+#endif
+
+#ifdef BOOST_STACKTRACE_LINK
+#   if defined(BOOST_STACKTRACE_DYN_LINK)
+#       ifdef BOOST_STACKTRACE_INTERNAL_BUILD_LIBS
+#           define BOOST_STACKTRACE_FUNCTION BOOST_SYMBOL_EXPORT
+#       else
+#           define BOOST_STACKTRACE_FUNCTION BOOST_SYMBOL_IMPORT
+#       endif
+#   else
+#       define BOOST_STACKTRACE_FUNCTION
+#   endif
+#else
+#   define BOOST_STACKTRACE_FUNCTION inline
+#endif
+
+namespace boost { namespace stacktrace { namespace detail {
+
+// Class that implements the actual backtracing
+class backend {
+    std::size_t         hash_code_;
+    std::size_t         frames_count_;
+    void**              data_;
+
+    void copy_frames_from(const backend& b) BOOST_NOEXCEPT {
+        if (data_ == b.data_) {
+            return;
+        }
+
+        for (std::size_t i = 0; i < frames_count_; ++i) {
+            data_[i] = b.data_[i];
+        }
+    }
+
+public:
+    BOOST_STACKTRACE_FUNCTION backend(void** memory, std::size_t size) BOOST_NOEXCEPT;
+    BOOST_STACKTRACE_FUNCTION static std::string get_name(const void* addr);
+    const void* get_address(std::size_t frame_no) const BOOST_NOEXCEPT {
+        return frame_no < frames_count_ ? data_[frame_no] : 0;
+    }
+    BOOST_STACKTRACE_FUNCTION static std::string get_source_file(const void* addr);
+    BOOST_STACKTRACE_FUNCTION static std::size_t get_source_line(const void* addr);
+    BOOST_STACKTRACE_FUNCTION bool operator< (const backend& rhs) const BOOST_NOEXCEPT;
+    BOOST_STACKTRACE_FUNCTION bool operator==(const backend& rhs) const BOOST_NOEXCEPT;
+
+    backend(const backend& b, void** memory) BOOST_NOEXCEPT
+        : hash_code_(b.hash_code_)
+        , frames_count_(b.frames_count_)
+        , data_(memory)
+    {
+        copy_frames_from(b);
+    }
+
+    backend& operator=(const backend& b) BOOST_NOEXCEPT {
+        hash_code_ = b.hash_code_;
+        frames_count_ = b.frames_count_;
+        copy_frames_from(b);
+
+        return *this;
+    }
+
+    std::size_t size() const BOOST_NOEXCEPT {
+        return frames_count_;
+    }
+
+    std::size_t hash_code() const BOOST_NOEXCEPT {
+        return hash_code_;
+    }
+};
+
+}}} // namespace boost::stacktrace::detail
+
+/// @cond
+#undef BOOST_STACKTRACE_FUNCTION
+
+#ifndef BOOST_STACKTRACE_LINK
+#   include <boost/stacktrace/detail/backend.ipp>
+#endif
+/// @endcond
+
+#endif // BOOST_STACKTRACE_DETAIL_BACKEND_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/backend.ipp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/backend.ipp
@@ -1,0 +1,27 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_BACKEND_IPP
+#define BOOST_STACKTRACE_DETAIL_BACKEND_IPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/stacktrace/detail/backend.hpp>
+
+#if defined(BOOST_STACKTRACE_USE_NOOP)
+#   include <boost/stacktrace/detail/backend_noop.hpp>
+#elif defined(BOOST_STACKTRACE_USE_WINDBG)
+#   include <boost/stacktrace/detail/backend_windows.hpp>
+#elif defined(BOOST_STACKTRACE_USE_BACKTRACE) || defined(BOOST_STACKTRACE_USE_UNWIND)
+#   include <boost/stacktrace/detail/backend_linux.hpp>
+#else
+#   error No suitable backtrace backend found
+#endif
+
+#endif // BOOST_STACKTRACE_DETAIL_BACKEND_IPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/backend_common.ipp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/backend_common.ipp
@@ -1,0 +1,49 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_BACKEND_COMMON_IPP
+#define BOOST_STACKTRACE_DETAIL_BACKEND_COMMON_IPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <algorithm>
+
+namespace boost { namespace stacktrace { namespace detail {
+
+bool backend::operator< (const backend& rhs) const BOOST_NOEXCEPT {
+    if (frames_count_ != rhs.frames_count_) {
+        return frames_count_ < rhs.frames_count_;
+    } else if (hash_code_ != rhs.hash_code_) {
+        return hash_code_ < rhs.hash_code_;
+    } else if (data_ == rhs.data_) {
+        return false;
+    }
+
+    return std::lexicographical_compare(
+        data_, data_ + frames_count_,
+        rhs.data_, rhs.data_ + rhs.frames_count_
+    );
+}
+
+bool backend::operator==(const backend& rhs) const BOOST_NOEXCEPT {
+    if (hash_code_ != rhs.hash_code_ || frames_count_ != rhs.frames_count_) {
+        return false;
+    } else if (data_ == rhs.data_) {
+        return true;
+    }
+
+    return std::equal(
+        data_, data_ + frames_count_,
+        rhs.data_
+    );
+}
+
+}}}
+
+#endif // BOOST_STACKTRACE_DETAIL_BACKEND_COMMON_IPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/backend_linux.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/backend_linux.hpp
@@ -1,0 +1,249 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_BACKEND_LINUX_HPP
+#define BOOST_STACKTRACE_DETAIL_BACKEND_LINUX_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/core/demangle.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/stacktrace/detail/to_hex_array.hpp>
+#include <boost/lexical_cast/try_lexical_convert.hpp>
+
+#if defined(BOOST_STACKTRACE_USE_UNWIND)
+#include <unwind.h>
+#endif
+
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <cstdio>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+
+namespace boost { namespace stacktrace { namespace detail {
+
+class addr2line_pipe {
+    FILE* p;
+    pid_t pid;
+
+public:
+    explicit addr2line_pipe(const char *flag, const char* exec_path, const char* addr) BOOST_NOEXCEPT
+        : p(0)
+        , pid(0)
+    {
+        int pdes[2];
+        char prog_name[] = "addr2line";
+        char* argp[] = {
+            prog_name,
+            const_cast<char*>(flag),
+            const_cast<char*>(exec_path),
+            const_cast<char*>(addr),
+            0
+        };
+
+        if (pipe(pdes) < 0) {
+            return;
+        }
+
+        pid = fork();
+        switch (pid) {
+        case -1:
+            // failed
+            close(pdes[0]);
+            close(pdes[1]);
+            return;
+
+        case 0:
+            // we are the child
+            close(STDERR_FILENO);
+            close(pdes[0]);
+            if (pdes[1] != STDOUT_FILENO) {
+                dup2(pdes[1], STDOUT_FILENO);
+            }
+            execvp(prog_name, argp);
+            _exit(127);
+        }
+
+        p = fdopen(pdes[0], "r");
+        close(pdes[1]);
+    }
+
+    operator FILE*() const BOOST_NOEXCEPT {
+        return p;
+    }
+
+    ~addr2line_pipe() BOOST_NOEXCEPT {
+        if (p) {
+            fclose(p);
+            int pstat = 0;
+            kill(pid, SIGKILL);
+            waitpid(pid, &pstat, 0);
+        }
+    }
+};
+
+static inline std::string addr2line(const char* flag, const void* addr) {
+    std::string res;
+
+    Dl_info dli;
+    if (!!dladdr(addr, &dli) && dli.dli_fname) {
+        res = dli.dli_fname;
+    } else {
+        res.resize(16);
+        int rlin_size = readlink("/proc/self/exe", &res[0], res.size() - 1);
+        while (rlin_size == static_cast<int>(res.size() - 1)) {
+            res.resize(res.size() * 4);
+            rlin_size = readlink("/proc/self/exe", &res[0], res.size() - 1);
+        }
+        if (rlin_size == -1) {
+            res.clear();
+            return res;
+        }
+        res.resize(rlin_size);
+    }
+
+    addr2line_pipe p(flag, res.c_str(), to_hex_array(addr).data());
+    res.clear();
+
+    if (!p) {
+        return res;
+    }
+
+    char data[32];
+    while (!std::feof(p)) {
+        if (std::fgets(data, sizeof(data), p)) {
+            res += data;
+        } else {
+            break;
+        }
+    }
+
+    // Trimming
+    while (!res.empty() && (res[res.size() - 1] == '\n' || res[res.size() - 1] == '\r')) {
+        res.erase(res.size() - 1);
+    }
+
+    return res;
+}
+
+static inline std::string try_demangle(const char* mangled) {
+    std::string res;
+
+    boost::core::scoped_demangled_name demangled(mangled);
+    if (demangled.get()) {
+        res = demangled.get();
+    } else {
+        res = mangled;
+    }
+
+    return res;
+}
+
+
+
+
+#if defined(BOOST_STACKTRACE_USE_UNWIND)
+struct unwind_state {
+    void** current;
+    void** end;
+};
+
+inline _Unwind_Reason_Code unwind_callback(struct _Unwind_Context* context, void* arg) {
+    unwind_state* state = static_cast<unwind_state*>(arg);
+    *state->current = reinterpret_cast<void*>(
+        _Unwind_GetIP(context)
+    );
+
+    ++state->current;
+    if (!*(state->current - 1) || state->current == state->end) {
+        return _URC_END_OF_STACK;
+    }
+    return _URC_NO_REASON;
+}
+#endif
+
+
+
+
+backend::backend(void** memory, std::size_t size) BOOST_NOEXCEPT
+    : hash_code_(0)
+    , frames_count_(0)
+    , data_(memory)
+{
+    if (!size) {
+        return;
+    }
+#if defined(BOOST_STACKTRACE_USE_UNWIND)
+    unwind_state state = { data_, data_ + size };
+    _Unwind_Backtrace(&unwind_callback, &state);
+    frames_count_ = state.current - data_;
+#elif defined(BOOST_STACKTRACE_USE_BACKTRACE)
+    frames_count_ = ::backtrace(data_, size);
+#else
+#   error No stacktrace backend defined. Define BOOST_STACKTRACE_USE_UNWIND or BOOST_STACKTRACE_USE_BACKTRACE
+#endif
+    if (data_[frames_count_ - 1] == 0) {
+        -- frames_count_;
+    }
+
+    hash_code_ = boost::hash_range(data_, data_ + frames_count_);
+}
+
+std::string backend::get_name(const void* addr) {
+    std::string res;
+
+    Dl_info dli;
+    if (!!dladdr(addr, &dli) && dli.dli_sname) {
+        res = try_demangle(dli.dli_sname);
+    } else {
+        res = addr2line("-fe", addr);
+        res = res.substr(0, res.find_last_of('\n'));
+        res = try_demangle(res.c_str());
+    }
+
+    if (res == "??") {
+        res.clear();
+    }
+
+    return res;
+}
+
+std::string backend::get_source_file(const void* addr) {
+    std::string res = addr2line("-e", addr);
+    res = res.substr(0, res.find_last_of(':'));
+    if (res == "??") {
+        res.clear();
+    }
+    return res;
+}
+
+std::size_t backend::get_source_line(const void* addr) {
+    std::string res = addr2line("-e", addr);
+    const std::size_t last = res.find_last_of(':');
+    if (last == std::string::npos) {
+        return 0;
+    }
+    res = res.substr(last + 1);
+
+    std::size_t line_num = 0;
+    if (!boost::conversion::try_lexical_convert(res, line_num)) {
+        return 0;
+    }
+
+    return line_num;
+}
+
+}}} // namespace boost::stacktrace::detail
+
+#include <boost/stacktrace/detail/backend_common.ipp>
+
+#endif // BOOST_STACKTRACE_DETAIL_BACKEND_LINUX_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/backend_noop.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/backend_noop.hpp
@@ -1,0 +1,46 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_BACKEND_NOOP_HPP
+#define BOOST_STACKTRACE_DETAIL_BACKEND_NOOP_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+namespace boost { namespace stacktrace { namespace detail {
+
+
+backend::backend(void** /*memory*/, std::size_t /*size*/) BOOST_NOEXCEPT
+    : hash_code_(0)
+    , frames_count_(0)
+    , data_(0)
+{}
+
+std::string backend::get_name(const void* /*addr*/) {
+    return std::string();
+}
+
+std::string backend::get_source_file(const void* /*addr*/) {
+    return std::string();
+}
+
+std::size_t backend::get_source_line(const void* /*addr*/) {
+    return 0;
+}
+
+bool backend::operator< (const backend& /*rhs*/) const BOOST_NOEXCEPT {
+    return false;
+}
+
+bool backend::operator==(const backend& /*rhs*/) const BOOST_NOEXCEPT {
+    return true;
+}
+
+}}} // namespace boost::stacktrace::detail
+
+#endif // BOOST_STACKTRACE_DETAIL_BACKEND_LIBUNWIND_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/backend_windows.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/backend_windows.hpp
@@ -1,0 +1,221 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_BACKEND_WINDOWS_HPP
+#define BOOST_STACKTRACE_DETAIL_BACKEND_WINDOWS_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/core/noncopyable.hpp>
+#include <boost/functional/hash.hpp>
+
+#include <windows.h>
+#include "Dbgeng.h"
+
+#include <boost/detail/winapi/get_current_process.hpp>
+
+#pragma comment(lib, "ole32.lib")
+#pragma comment(lib, "Dbgeng.lib")
+
+namespace boost { namespace stacktrace { namespace detail {
+
+template <class T>
+class com_holder: boost::noncopyable {
+    T* holder_;
+
+public:
+    com_holder() BOOST_NOEXCEPT
+        : holder_(0)
+    {}
+
+    T* operator->() const BOOST_NOEXCEPT {
+        return holder_;
+    }
+
+    void** to_void_ptr_ptr() BOOST_NOEXCEPT {
+        return reinterpret_cast<void**>(&holder_);
+    }
+
+    bool is_inited() const BOOST_NOEXCEPT {
+        return !!holder_;
+    }
+
+    void reset() const BOOST_NOEXCEPT {
+        if (holder_) {
+            holder_->Release();
+        }
+    }
+
+    ~com_holder() BOOST_NOEXCEPT {
+        reset();
+    }
+};
+
+inline bool try_init_com(com_holder<IDebugSymbols>& idebug_) BOOST_NOEXCEPT {
+    if (idebug_.is_inited()) {
+        return true;
+    }
+
+    CoInitializeEx(0, COINIT_MULTITHREADED);
+
+    com_holder<IDebugClient> iclient;
+    DebugCreate(__uuidof(IDebugClient), iclient.to_void_ptr_ptr());
+
+    com_holder<IDebugControl> icontrol;
+    iclient->QueryInterface(__uuidof(IDebugControl), icontrol.to_void_ptr_ptr());
+
+    const bool res1 = (S_OK == iclient->AttachProcess(
+        0,
+        GetCurrentProcessId(),
+        DEBUG_ATTACH_NONINVASIVE | DEBUG_ATTACH_NONINVASIVE_NO_SUSPEND)
+    );
+    if (!res1) {
+        return false;
+    }
+
+    const bool res2 = (S_OK == icontrol->WaitForEvent(DEBUG_WAIT_DEFAULT, INFINITE));
+    if (!res2) {
+        return false;
+    }
+
+    const bool res = (S_OK == iclient->QueryInterface(__uuidof(IDebugSymbols), idebug_.to_void_ptr_ptr()));
+    if (!res) {
+        idebug_.reset();
+        return false;
+    }
+
+    return true;
+}
+
+
+
+
+backend::backend(void** memory, std::size_t size) BOOST_NOEXCEPT
+    : hash_code_(0)
+    , frames_count_(0)
+    , data_(memory)
+{
+    boost::detail::winapi::ULONG_ hc = 0;
+    frames_count_ = CaptureStackBackTrace(
+        0,
+        static_cast<boost::detail::winapi::ULONG_>(size),
+        data_,
+        &hc
+    );
+
+    boost::hash_combine(hash_code_, hc);
+}
+
+std::string backend::get_name(const void* addr) {
+    std::string result;
+    com_holder<IDebugSymbols> idebug_;
+    if (!try_init_com(idebug_)) {
+        return result;
+    }
+    const ULONG64 offset = reinterpret_cast<ULONG64>(addr);
+
+    char name[256];
+    name[0] = '\0';
+    ULONG size = 0;
+    bool res = (S_OK == idebug_->GetNameByOffset(
+        offset,
+        name,
+        sizeof(name),
+        &size,
+        0
+    ));
+
+    if (!res && size != 0) {
+        result.resize(size);
+        res = (S_OK == idebug_->GetNameByOffset(
+            offset,
+            &result[0],
+            static_cast<ULONG>(result.size()),
+            &size,
+            0
+        ));
+    } else if (res) {
+        result = name;
+    }
+
+    if (!res) {
+        result.clear();
+    }
+
+    return result;
+}
+
+std::string backend::get_source_file(const void* addr) {
+    std::string result;
+    com_holder<IDebugSymbols> idebug_;
+    if (!try_init_com(idebug_)) {
+        return result;
+    }
+    const ULONG64 offset = reinterpret_cast<ULONG64>(addr);
+
+    char name[256];
+    name[0] = 0;
+    ULONG size = 0;
+    bool res = (S_OK == idebug_->GetLineByOffset(
+        offset,
+        0,
+        name,
+        sizeof(name),
+        &size,
+        0
+    ));
+
+    if (!res && size != 0) {
+        result.resize(size);
+        res = (S_OK == idebug_->GetLineByOffset(
+            offset,
+            0,
+            &result[0],
+            static_cast<ULONG>(result.size()),
+            &size,
+            0
+        ));
+    } else if (res) {
+        result = name;
+    }
+
+
+    if (!res) {
+        result.clear();
+    }
+
+    return result;
+}
+
+std::size_t backend::get_source_line(const void* addr) {
+    ULONG line_num = 0;
+
+    com_holder<IDebugSymbols> idebug_;
+    if (!try_init_com(idebug_)) {
+        return 0;
+    }
+
+    const bool is_ok = (S_OK == idebug_->GetLineByOffset(
+        reinterpret_cast<ULONG64>(addr),
+        &line_num,
+        0,
+        0,
+        0,
+        0
+    ));
+
+    return (is_ok ? line_num : 0);
+}
+
+
+}}} // namespace boost::stacktrace::detail
+
+#include <boost/stacktrace/detail/backend_common.ipp>
+
+#endif // BOOST_STACKTRACE_DETAIL_BACKEND_LINUX_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/detail/to_hex_array.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/detail/to_hex_array.hpp
@@ -1,0 +1,54 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_STACKTRACE_TO_HEX_ARRAY_HPP
+#define BOOST_STACKTRACE_DETAIL_STACKTRACE_TO_HEX_ARRAY_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/array.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_pointer.hpp>
+#include <boost/type_traits/make_unsigned.hpp>
+
+namespace boost { namespace stacktrace { namespace detail {
+
+BOOST_STATIC_CONSTEXPR char to_hex_array_bytes[] = "0123456789ABCDEF";
+
+template <class T>
+inline boost::array<char, 2 + sizeof(void*) * 2 + 1> to_hex_array(T addr) BOOST_NOEXCEPT {
+    boost::array<char, 2 + sizeof(void*) * 2 + 1> ret = {"0x"};
+    ret.back() = '\0';
+    BOOST_STATIC_ASSERT_MSG(!boost::is_pointer<T>::value, "");
+
+    const std::size_t s = sizeof(T);
+
+    char* out = ret.data() + s * 2 + 1;
+
+    for (std::size_t i = 0; i < s; ++i) {
+        const unsigned char tmp_addr = (addr & 0xFFu);
+        *out = to_hex_array_bytes[tmp_addr & 0xF];
+        -- out;
+        *out = to_hex_array_bytes[tmp_addr >> 4];
+        -- out;
+        addr >>= 8;
+    }
+
+    return ret;
+}
+
+inline boost::array<char, 2 + sizeof(void*) * 2 + 1> to_hex_array(const void* addr) BOOST_NOEXCEPT {
+    return to_hex_array(
+        reinterpret_cast< boost::make_unsigned<std::ptrdiff_t>::type >(addr)
+    );
+}
+
+}}} // namespace boost::stacktrace::detail
+
+#endif // BOOST_STACKTRACE_DETAIL_STACKTRACE_TO_HEX_ARRAY_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/frame.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/frame.hpp
@@ -1,0 +1,157 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_FRAME_HPP
+#define BOOST_STACKTRACE_FRAME_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <iosfwd>
+#include <string>
+
+#include <boost/core/explicit_operator_bool.hpp>
+#include <boost/stacktrace/detail/backend.hpp>
+
+namespace boost { namespace stacktrace {
+
+/// Non-owning class that references the frame information stored inside the boost::stacktrace::stacktrace class.
+class frame {
+    /// @cond
+    const void* addr_;
+    /// @endcond
+
+public:
+    /// @brief Constructs frame that references NULL address.
+    /// Calls to source_file() and source_line() wil lreturn empty string.
+    /// Calls to source_line() will return 0.
+    ///
+    /// @b Complexity: O(1).
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    /// @throws Nothing.
+    frame() BOOST_NOEXCEPT
+        : addr_(0)
+    {}
+
+#ifdef BOOST_STACKTRACE_DOXYGEN_INVOKED
+    /// @brief Copy constructs frame.
+    ///
+    /// @b Complexity: O(1).
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    /// @throws Nothing.
+    frame(const frame&) = default;
+
+    /// @brief Copy assigns frame.
+    ///
+    /// @b Complexity: O(1).
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    /// @throws Nothing.
+    frame& operator=(const frame&) = default;
+#endif
+
+    /// @brief Constructs frame that can extract information from addr at runtime.
+    ///
+    /// @b Complexity: O(1).
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    /// @throws Nothing.
+    explicit frame(const void* addr) BOOST_NOEXCEPT
+        : addr_(addr)
+    {}
+
+    /// @returns Name of the frame (function name in a human readable form).
+    ///
+    /// @b Async-Handler-Safety: Unsafe.
+    /// @throws std::bad_alloc if not enough memory to construct resulting string.
+    std::string name() const {
+        return boost::stacktrace::detail::backend::get_name(address());
+    }
+
+    /// @returns Address of the frame function.
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    /// @throws Nothing.
+    const void* address() const BOOST_NOEXCEPT {
+        return addr_;
+    }
+
+    /// @returns Path to the source file, were the function of the frame is defined. Returns empty string
+    /// if this->source_line() == 0.
+    /// @throws std::bad_alloc if not enough memory to construct resulting string.
+    ///
+    /// @b Async-Handler-Safety: Unsafe.
+    std::string source_file() const {
+        return boost::stacktrace::detail::backend::get_source_file(address());
+    }
+
+    /// @returns Code line in the source file, were the function of the frame is defined.
+    /// @throws std::bad_alloc if not enough memory to construct string for internal needs.
+    ///
+    /// @b Async-Handler-Safety: Unsafe.
+    std::size_t source_line() const {
+        return boost::stacktrace::detail::backend::get_source_line(address());
+    }
+
+    /// @brief Checks that frame is not references NULL address.
+    /// @returns `true` if `this->address() != 0`
+    ///
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    BOOST_EXPLICIT_OPERATOR_BOOL_NOEXCEPT()
+
+    /// @brief Checks that frame references NULL address.
+    /// @returns `true` if `this->address() == 0`
+    ///
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    bool empty() const BOOST_NOEXCEPT { return !address(); }
+    
+    /// @cond
+    bool operator!() const BOOST_NOEXCEPT { return !address(); }
+    /// @endcond
+};
+
+/// Comparison operators that provide platform dependant ordering and have O(1) complexity; are Async-Handler-Safe.
+inline bool operator< (const frame& lhs, const frame& rhs) BOOST_NOEXCEPT { return lhs.address() < rhs.address(); }
+inline bool operator> (const frame& lhs, const frame& rhs) BOOST_NOEXCEPT { return rhs < lhs; }
+inline bool operator<=(const frame& lhs, const frame& rhs) BOOST_NOEXCEPT { return !(lhs > rhs); }
+inline bool operator>=(const frame& lhs, const frame& rhs) BOOST_NOEXCEPT { return !(lhs < rhs); }
+inline bool operator==(const frame& lhs, const frame& rhs) BOOST_NOEXCEPT { return lhs.address() == rhs.address(); }
+inline bool operator!=(const frame& lhs, const frame& rhs) BOOST_NOEXCEPT { return !(lhs == rhs); }
+
+/// Hashing support, O(1) complexity; Async-Handler-Safe.
+inline std::size_t hash_value(const frame& f) BOOST_NOEXCEPT {
+    return reinterpret_cast<std::size_t>(f.address());
+}
+
+/// Outputs stacktrace::frame in a human readable format to output stream; unsafe to use in async handlers.
+template <class CharT, class TraitsT>
+std::basic_ostream<CharT, TraitsT>& operator<<(std::basic_ostream<CharT, TraitsT>& os, const frame& f) {
+    std::string name = f.name();
+    if (!name.empty()) {
+        os << name;
+    } else {
+        os << f.address();
+    }
+
+    const std::size_t source_line = f.source_line();
+    if (source_line) {
+        os << " at " << f.source_file() << ':' << source_line;
+    }
+
+    return os;
+}
+
+}} // namespace boost::stacktrace
+
+#endif // BOOST_STACKTRACE_FRAME_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/stacktrace.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/stacktrace.hpp
@@ -1,0 +1,233 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_STACKTRACE_HPP
+#define BOOST_STACKTRACE_STACKTRACE_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <boost/core/explicit_operator_bool.hpp>
+
+#include <iosfwd>
+#include <string>
+
+#include <boost/stacktrace/stacktrace_fwd.hpp>
+#include <boost/stacktrace/detail/backend.hpp>
+#include <boost/stacktrace/frame.hpp>
+#include <boost/stacktrace/const_iterator.hpp>
+
+
+namespace boost { namespace stacktrace {
+
+/// Class that on construction copies minimal information about call stack into its internals and provides access to that information.
+/// @tparam Depth Max stack frames count that this class may hold. Equal to basic_stacktrace::max_depth.
+template <std::size_t Depth>
+class basic_stacktrace {
+    /// @cond
+    void* impl_[Depth ? Depth : 1];
+    boost::stacktrace::detail::backend back_;
+    /// @endcond
+
+public:
+    /// Max stack frames count that this class may hold. Equal to Depth template parameter.
+    BOOST_STATIC_CONSTEXPR std::size_t max_depth = Depth;
+
+    typedef frame                                   reference;
+
+    typedef boost::stacktrace::const_iterator       iterator;
+    typedef boost::stacktrace::const_iterator       const_iterator;
+    typedef std::reverse_iterator<iterator>         reverse_iterator;
+    typedef std::reverse_iterator<const_iterator>   const_reverse_iterator;
+
+    /// @brief Stores the current function call sequence inside the class.
+    ///
+    /// @b Complexity: O(N) where N is call sequence length, O(1) for noop backend.
+    ///
+    /// @b Async-Handler-Safety: Depends on backend, see "Build, Macros and Backends" section.
+    BOOST_FORCEINLINE basic_stacktrace() BOOST_NOEXCEPT
+        : impl_()
+        , back_(impl_, Depth)
+    {}
+
+    /// @b Complexity: O(st.size())
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    basic_stacktrace(const basic_stacktrace& st) BOOST_NOEXCEPT
+        : impl_()
+        , back_(st.back_, impl_)
+    {}
+
+    /// @b Complexity: O(st.size())
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    basic_stacktrace& operator=(const basic_stacktrace& st) BOOST_NOEXCEPT {
+        back_ = st.back_;
+
+        return *this;
+    }
+
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    ~basic_stacktrace() BOOST_NOEXCEPT {}
+
+    /// @returns Number of function names stored inside the class.
+    ///
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    std::size_t size() const BOOST_NOEXCEPT {
+        return back_.size();
+    }
+
+    /// @param frame_no Zero based index of frame to return. 0
+    /// is the function index where stacktrace was constructed and
+    /// index close to this->size() contains function `main()`.
+    /// @returns frame that references the actual frame info, stored inside *this.
+    ///
+    /// @b Complexity: Amortized O(1), O(1) for noop backend.
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    frame operator[](std::size_t frame_no) const BOOST_NOEXCEPT {
+        return *(cbegin() + frame_no);
+    }
+
+
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_iterator begin() const BOOST_NOEXCEPT { return const_iterator(&back_, 0); }
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_iterator cbegin() const BOOST_NOEXCEPT { return const_iterator(&back_, 0); }
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_iterator end() const BOOST_NOEXCEPT { return const_iterator(&back_, size()); }
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_iterator cend() const BOOST_NOEXCEPT { return const_iterator(&back_, size()); }
+
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_reverse_iterator rbegin() const BOOST_NOEXCEPT { return const_reverse_iterator( const_iterator(&back_, 0) ); }
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_reverse_iterator crbegin() const BOOST_NOEXCEPT { return const_reverse_iterator( const_iterator(&back_, 0) ); }
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_reverse_iterator rend() const BOOST_NOEXCEPT { return const_reverse_iterator( const_iterator(&back_, size()) ); }
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    const_reverse_iterator crend() const BOOST_NOEXCEPT { return const_reverse_iterator( const_iterator(&back_, size()) ); }
+
+
+    /// @brief Allows to check that stack trace capturing was successful.
+    /// @returns `true` if `this->size() != 0`
+    ///
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    BOOST_EXPLICIT_OPERATOR_BOOL_NOEXCEPT()
+
+
+    /// @brief Allows to check that stack trace failed.
+    /// @returns `true` if `this->size() == 0`
+    ///
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    bool empty() const BOOST_NOEXCEPT { return !size(); }
+
+    /// @brief Compares stacktraces for less, order is platform dependant.
+    ///
+    /// @b Complexity: Amortized O(1); worst case O(size())
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    bool operator< (const basic_stacktrace& rhs) const BOOST_NOEXCEPT {
+        return back_ < rhs.back_;
+    }
+
+    /// @brief Compares stacktraces for equality.
+    ///
+    /// @b Complexity: Amortized O(1); worst case O(size())
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    bool operator==(const basic_stacktrace& rhs) const BOOST_NOEXCEPT {
+        return back_ == rhs.back_;
+    }
+
+    /// @brief Returns hashed code of the stacktrace.
+    ///
+    /// @b Complexity: O(1)
+    ///
+    /// @b Async-Handler-Safety: Safe.
+    std::size_t hash_code() const BOOST_NOEXCEPT { return back_.hash_code(); }
+
+    /// @cond
+    bool operator!() const BOOST_NOEXCEPT { return !size(); }
+    /// @endcond
+};
+
+
+/// Comparison operators that provide platform dependant ordering and have amortized O(1) complexity; O(size()) worst case complexity; are Async-Handler-Safe.
+template <std::size_t Depth>
+bool operator> (const basic_stacktrace<Depth>& lhs, const basic_stacktrace<Depth>& rhs) BOOST_NOEXCEPT {
+    return rhs < lhs;
+}
+
+template <std::size_t Depth>
+bool operator<=(const basic_stacktrace<Depth>& lhs, const basic_stacktrace<Depth>& rhs) BOOST_NOEXCEPT {
+    return !(lhs > rhs);
+}
+
+template <std::size_t Depth>
+bool operator>=(const basic_stacktrace<Depth>& lhs, const basic_stacktrace<Depth>& rhs) BOOST_NOEXCEPT {
+    return !(lhs < rhs);
+}
+
+template <std::size_t Depth>
+bool operator!=(const basic_stacktrace<Depth>& lhs, const basic_stacktrace<Depth>& rhs) BOOST_NOEXCEPT {
+    return !(lhs == rhs);
+}
+
+/// Hashing support, O(1) complexity; Async-Handler-Safe.
+template <std::size_t Depth>
+std::size_t hash_value(const basic_stacktrace<Depth>& st) BOOST_NOEXCEPT {
+    return st.hash_code();
+}
+
+/// Outputs stacktrace in a human readable format to output stream; unsafe to use in async handlers.
+template <class CharT, class TraitsT, std::size_t Depth>
+std::basic_ostream<CharT, TraitsT>& operator<<(std::basic_ostream<CharT, TraitsT>& os, const basic_stacktrace<Depth>& bt) {
+    const std::streamsize w = os.width();
+    const std::size_t frames = bt.size();
+    for (std::size_t i = 0; i < frames; ++i) {
+        os.width(2);
+        os << i;
+        os.width(w);
+        os << "# ";
+        os << bt[i];
+        os << '\n';
+    }
+
+    return os;
+}
+
+typedef basic_stacktrace<BOOST_STACKTRACE_DEFAULT_MAX_DEPTH> stacktrace;
+
+}} // namespace boost::stacktrace
+
+#endif // BOOST_STACKTRACE_STACKTRACE_HPP

--- a/third_party/stacktrace/include/boost/stacktrace/stacktrace_fwd.hpp
+++ b/third_party/stacktrace/include/boost/stacktrace/stacktrace_fwd.hpp
@@ -1,0 +1,39 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_STACKTRACE_FWD_HPP
+#define BOOST_STACKTRACE_STACKTRACE_FWD_HPP
+
+#include <cstddef>
+
+/// @file stacktrace_fwd.hpp This header contains only forward declarations of
+/// boost::stacktrace::frame, boost::stacktrace::const_iterator, boost::stacktrace::basic_stacktrace
+/// and does not include any other Boost headers.
+
+
+#ifndef BOOST_STACKTRACE_DEFAULT_MAX_DEPTH
+/// You may define this macro to some positive integer to limit the max stack frames count for the boost::stacktrace::stacktrace class.
+/// This macro does not affect the boost::stacktrace::basic_stacktrace.
+///
+/// @b Default: 100
+#define BOOST_STACKTRACE_DEFAULT_MAX_DEPTH 100
+#endif
+
+namespace boost { namespace stacktrace {
+
+class frame;
+
+class const_iterator;
+
+template <std::size_t Depth>
+class basic_stacktrace;
+
+typedef basic_stacktrace<BOOST_STACKTRACE_DEFAULT_MAX_DEPTH> stacktrace;
+
+}} // namespace boost::stacktrace
+
+
+#endif // BOOST_STACKTRACE_STACKTRACE_FWD_HPP

--- a/third_party/stacktrace/meta/libraries.json
+++ b/third_party/stacktrace/meta/libraries.json
@@ -1,0 +1,14 @@
+{
+  "key": "stacktrace",
+  "name": "Stacktrace",
+  "authors": [
+    "Antony Polukhin"
+  ],
+  "maintainers": [
+    "Antony Polukhin <antoshkka -at- gmail.com>"
+  ],
+  "description": "Gather, store, copy and print backtraces.",
+  "category": [
+    "System", "Correctness"
+  ]
+}

--- a/third_party/stacktrace/src/backtrace.cpp
+++ b/third_party/stacktrace/src/backtrace.cpp
@@ -1,0 +1,10 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_STACKTRACE_INTERNAL_BUILD_LIBS
+#define BOOST_STACKTRACE_USE_BACKTRACE
+#define BOOST_STACKTRACE_LINK
+#include <boost/stacktrace/detail/backend.ipp>

--- a/third_party/stacktrace/src/noop.cpp
+++ b/third_party/stacktrace/src/noop.cpp
@@ -1,0 +1,10 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_STACKTRACE_INTERNAL_BUILD_LIBS
+#define BOOST_STACKTRACE_USE_NOOP
+#define BOOST_STACKTRACE_LINK
+#include <boost/stacktrace/detail/backend.ipp>

--- a/third_party/stacktrace/src/unwind.cpp
+++ b/third_party/stacktrace/src/unwind.cpp
@@ -1,0 +1,10 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_STACKTRACE_INTERNAL_BUILD_LIBS
+#define BOOST_STACKTRACE_USE_UNWIND
+#define BOOST_STACKTRACE_LINK
+#include <boost/stacktrace/detail/backend.ipp>

--- a/third_party/stacktrace/src/windbg.cpp
+++ b/third_party/stacktrace/src/windbg.cpp
@@ -1,0 +1,10 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_STACKTRACE_INTERNAL_BUILD_LIBS
+#define BOOST_STACKTRACE_USE_WINDBG
+#define BOOST_STACKTRACE_LINK
+#include <boost/stacktrace/detail/backend.ipp>

--- a/third_party/stacktrace/test/Jamfile.v2
+++ b/third_party/stacktrace/test/Jamfile.v2
@@ -1,0 +1,64 @@
+#  Copyright (C) 2016, Antony Polukhin.
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+
+lib dl : : <link>shared ;
+lib gcc_s ;
+lib Dbghelp ;
+
+project
+  : requirements
+    <toolset>msvc:<asynch-exceptions>on
+    <warnings>all
+    <debug-symbols>on
+    <test-info>always_show_run_output
+    <target-os>linux:<cxxflags>"-fvisibility=hidden"
+  ;
+
+
+local BT_DEPS   = <target-os>linux:<library>dl [ check-target-builds ../build//backtrace : : <build>no ] ;
+local UNWD_DEPS = <target-os>linux:<library>dl  [ check-target-builds ../build//unwind : : <build>no ] ;
+local WIND_DEPS = <library>Dbghelp [ check-target-builds ../build//WinDbg : : <build>no ] ;
+local NOOP_DEPS =  ;
+local AUTO_DEPS = <target-os>linux:<library>dl [ check-target-builds ../build//WinDbg : <library>Dbghelp ] ;
+
+local LINKSHARED_BT   = <link>shared <define>BOOST_STACKTRACE_DYN_LINK <library>/boost/stacktrace//boost_stacktrace_backtrace  $(BT_DEPS)   ;
+local LINKSHARED_UNWD = <link>shared <define>BOOST_STACKTRACE_DYN_LINK <library>/boost/stacktrace//boost_stacktrace_unwind     $(UNWD_DEPS) ;
+local LINKSHARED_WIND = <link>shared <define>BOOST_STACKTRACE_DYN_LINK <library>/boost/stacktrace//boost_stacktrace_windbg     $(WIND_DEPS) ;
+local LINKSHARED_NOOP = <link>shared <define>BOOST_STACKTRACE_DYN_LINK <library>/boost/stacktrace//boost_stacktrace_noop       $(NOOP_DEPS) ;
+
+lib test_impl_lib_backtrace : test_impl.cpp : $(LINKSHARED_BT) ;
+lib test_impl_lib_unwind    : test_impl.cpp : $(LINKSHARED_UNWD) ;
+lib test_impl_lib_windbg    : test_impl.cpp : $(LINKSHARED_WIND) ;
+lib test_impl_lib_noop      : test_impl.cpp : $(LINKSHARED_NOOP) ;
+
+test-suite stacktrace_tests
+  :
+    # Header only tests
+    [ run test.cpp test_impl.cpp        : : : <define>BOOST_STACKTRACE_USE_BACKTRACE $(BT_DEPS)   : backtrace_ho ]
+    [ run test.cpp test_impl.cpp        : : : <define>BOOST_STACKTRACE_USE_UNWIND $(UNWD_DEPS)   : unwind_ho ]
+    [ run test.cpp test_impl.cpp        : : : <define>BOOST_STACKTRACE_USE_WINDBG $(WIND_DEPS) : windbg_ho ]
+    [ run test_noop.cpp test_impl.cpp   : : : <define>BOOST_STACKTRACE_USE_NOOP $(NOOP_DEPS) : noop_ho ]
+    [ run test.cpp test_impl.cpp        : : : $(AUTO_DEPS) : autodetect_ho ]
+
+    # Test with shared linked backends
+    [ run test.cpp      : : : <library>.//test_impl_lib_backtrace $(LINKSHARED_BT)   : backtrace_lib ]
+    [ run test.cpp      : : : <library>.//test_impl_lib_unwind $(LINKSHARED_UNWD)   : unwind_lib ]
+    [ run test.cpp      : : : <library>.//test_impl_lib_windbg $(LINKSHARED_WIND) : windbg_lib ]
+    [ run test_noop.cpp : : : <library>.//test_impl_lib_noop $(LINKSHARED_NOOP) : noop_lib ]
+  ;
+
+# Assuring that examples compile and run. Adding sources from `examples` directory to the `type_index` test suite. 
+for local p in [ glob ../example/*.cpp ]
+{
+    stacktrace_tests += [ run $(p) : : : $(LINKSHARED_BT) : backtrace_$(p[1]:B) ] ;
+    stacktrace_tests += [ run $(p) : : : $(LINKSHARED_UNWD) : unwind_$(p[1]:B) ] ;
+    stacktrace_tests += [ run $(p) : : : $(LINKSHARED_WIND) : windbg_$(p[1]:B) ] ;
+    stacktrace_tests += [ run $(p) : : : $(LINKSHARED_NOOP) : noop_$(p[1]:B) ] ;
+    stacktrace_tests += [ run $(p) : : : $(AUTO_DEPS) : autodetect_$(p[1]:B) ] ;
+
+}
+

--- a/third_party/stacktrace/test/appveyor.yml
+++ b/third_party/stacktrace/test/appveyor.yml
@@ -1,0 +1,67 @@
+# Use, modification, and distribution are
+# subject to the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Copyright Antony Polukhin 2016.
+
+#
+# See https://svn.boost.org/trac/boost/wiki/TravisCoverals for description of this file
+# and how it can be used with Boost libraries.
+#
+# File revision #2
+
+init:
+    - set BRANCH_TO_TEST=%APPVEYOR_REPO_BRANCH%
+    - set BOOST_REMOVE=stacktrace
+
+os: Visual Studio 2015
+configuration: Debug
+platform: x64
+
+###############################################################################################################
+# From this point and below code is same for all the Boost libs
+###############################################################################################################
+
+version: 1.61.{build}-{branch}
+ 
+# branches to build
+branches:
+  except:
+    - gh-pages
+
+skip_tags: true
+
+before_build:
+    # Set this to the name of the library
+    - set PROJECT_TO_TEST=%APPVEYOR_PROJECT_NAME%
+    - echo "Testing %PROJECT_TO_TEST%"
+    # Cloning Boost libraries (fast nondeep cloning)
+    - set BOOST=C:/boost-local
+    - git init %BOOST%
+    - cd %BOOST%
+    - git remote add --no-tags -t %BRANCH_TO_TEST% origin https://github.com/boostorg/boost.git
+    - git fetch --depth=1
+    - git checkout %BRANCH_TO_TEST%
+    - git submodule update --init --merge
+    - git remote set-branches --add origin %BRANCH_TO_TEST%
+    - git pull --recurse-submodules
+    - git status
+    - rm -rf %BOOST%/libs/%BOOST_REMOVE%
+    - mv %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%PROJECT_TO_TEST%
+    - set TRAVIS_BUILD_DIR=%BOOST%/libs/%PROJECT_TO_TEST%
+
+build_script:
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+    - bootstrap.bat
+    - b2.exe headers
+    - cd %BOOST%/libs/%PROJECT_TO_TEST%/test
+
+after_build:
+before_test:
+test_script:
+  - ..\..\..\b2.exe address-model=64 architecture=x86 cxxflags="-DBOOST_TRAVISCI_BUILD" -sBOOST_BUILD_PATH=.
+
+after_test:
+on_success:
+on_failure:
+on_finish:

--- a/third_party/stacktrace/test/test.cpp
+++ b/third_party/stacktrace/test/test.cpp
@@ -1,0 +1,255 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/stacktrace/stacktrace_fwd.hpp>
+
+#include <boost/stacktrace.hpp>
+#include <stdexcept>
+#include <iostream>
+#include <sstream>
+#include <boost/core/lightweight_test.hpp>
+
+using boost::stacktrace::stacktrace;
+using boost::stacktrace::frame;
+
+#ifdef BOOST_STACKTRACE_DYN_LINK
+#   define BOOST_ST_API BOOST_SYMBOL_IMPORT
+#else
+#   define BOOST_ST_API
+#endif
+
+BOOST_ST_API std::pair<stacktrace, stacktrace> foo2(int i);
+BOOST_ST_API std::pair<stacktrace, stacktrace> foo1(int i);
+BOOST_ST_API stacktrace return_from_nested_namespaces();
+BOOST_ST_API boost::stacktrace::basic_stacktrace<4> bar1();
+BOOST_ST_API boost::stacktrace::basic_stacktrace<4> bar2();
+
+void test_deeply_nested_namespaces() {
+    std::stringstream ss;
+    ss << return_from_nested_namespaces();
+    std::cout << ss.str() << '\n';
+    BOOST_TEST(ss.str().find("main") != std::string::npos);
+
+#if defined(BOOST_STACKTRACE_DYN_LINK)
+    BOOST_TEST(ss.str().find("get_backtrace_from_nested_namespaces") != std::string::npos
+                || ss.str().find("return_from_nested_namespaces") != std::string::npos);
+#endif
+
+    stacktrace ns1 = return_from_nested_namespaces();
+    BOOST_TEST(ns1 != return_from_nested_namespaces()); // Different addresses in test_deeply_nested_namespaces() function
+}
+
+void test_nested() {
+
+    std::pair<stacktrace, stacktrace> res = foo2(15);
+
+    std::stringstream ss1, ss2;
+
+    ss1 << res.first;
+    ss2 << res.second;
+    std::cout << "'" << ss1.str() << "'\n\n" << ss2.str() << std::endl;
+    BOOST_TEST(!ss1.str().empty());
+    BOOST_TEST(!ss2.str().empty());
+
+    BOOST_TEST(ss1.str().find(" 0# ") != std::string::npos);
+    BOOST_TEST(ss2.str().find(" 0# ") != std::string::npos);
+
+    BOOST_TEST(ss1.str().find(" 1# ") != std::string::npos);
+    BOOST_TEST(ss2.str().find(" 1# ") != std::string::npos);
+
+    BOOST_TEST(ss1.str().find("main") != std::string::npos);
+    BOOST_TEST(ss2.str().find("main") != std::string::npos);
+
+#if defined(BOOST_STACKTRACE_DYN_LINK) || !defined(BOOST_STACKTRACE_USE_BACKTRACE)
+    BOOST_TEST(ss1.str().find("foo1") != std::string::npos);
+    BOOST_TEST(ss1.str().find("foo2") != std::string::npos);
+    BOOST_TEST(ss2.str().find("foo1") != std::string::npos);
+    BOOST_TEST(ss2.str().find("foo2") != std::string::npos);
+#endif
+    //BOOST_TEST(false);
+}
+
+template <class Bt>
+void test_comparisons_base(Bt nst, Bt st) {
+    Bt cst(st);
+    st = st;
+    cst = cst;
+    BOOST_TEST(nst);
+    BOOST_TEST(st);
+
+    BOOST_TEST(nst != st);
+    BOOST_TEST(st != nst);
+    BOOST_TEST(st == st);
+    BOOST_TEST(nst == nst);
+
+    BOOST_TEST(nst != cst);
+    BOOST_TEST(cst != nst);
+    BOOST_TEST(cst == st);
+    BOOST_TEST(cst == cst);
+
+    BOOST_TEST(nst < st || nst > st);
+    BOOST_TEST(st < nst || nst < st);
+    BOOST_TEST(st <= st);
+    BOOST_TEST(nst <= nst);
+    BOOST_TEST(st >= st);
+    BOOST_TEST(nst >= nst);
+
+    BOOST_TEST(nst < cst || cst < nst);
+    BOOST_TEST(nst > cst || cst > nst);
+
+
+    BOOST_TEST(hash_value(nst) == hash_value(nst));
+    BOOST_TEST(hash_value(cst) == hash_value(st));
+
+    BOOST_TEST(hash_value(nst) != hash_value(cst));
+    BOOST_TEST(hash_value(st) != hash_value(nst));
+}
+
+void test_comparisons() {
+    stacktrace nst = return_from_nested_namespaces();
+    stacktrace st;
+    test_comparisons_base(nst, st);
+}
+
+void test_iterators() {
+    stacktrace nst = return_from_nested_namespaces();
+    stacktrace st;
+
+    BOOST_TEST(nst.begin() != st.begin());
+    BOOST_TEST(nst.cbegin() != st.cbegin());
+    BOOST_TEST(nst.crbegin() != st.crbegin());
+    BOOST_TEST(nst.rbegin() != st.rbegin());
+
+    BOOST_TEST(st.begin() == st.begin());
+    BOOST_TEST(st.cbegin() == st.cbegin());
+    BOOST_TEST(st.crbegin() == st.crbegin());
+    BOOST_TEST(st.rbegin() == st.rbegin());
+
+    BOOST_TEST(++st.begin() == ++st.begin());
+    BOOST_TEST(++st.cbegin() == ++st.cbegin());
+    BOOST_TEST(++st.crbegin() == ++st.crbegin());
+    BOOST_TEST(++st.rbegin() == ++st.rbegin());
+
+    BOOST_TEST(st.begin() + 1 == st.begin() + 1);
+    BOOST_TEST(st.cbegin() + 1 == st.cbegin() + 1);
+    BOOST_TEST(st.crbegin() + 1 == st.crbegin() + 1);
+    BOOST_TEST(st.rbegin() + 1 == st.rbegin() + 1);
+
+    BOOST_TEST(nst.end() != st.end());
+    BOOST_TEST(nst.cend() != st.cend());
+    BOOST_TEST(nst.crend() != st.crend());
+    BOOST_TEST(nst.rend() != st.rend());
+
+    BOOST_TEST(st.end() == st.end());
+    BOOST_TEST(st.cend() == st.cend());
+    BOOST_TEST(st.crend() == st.crend());
+    BOOST_TEST(st.rend() == st.rend());
+
+    BOOST_TEST(--st.end() == --st.end());
+    BOOST_TEST(--st.cend() == --st.cend());
+    BOOST_TEST(--st.crend() == --st.crend());
+    BOOST_TEST(--st.rend() == --st.rend());
+
+
+    BOOST_TEST(st.end() > st.begin());
+    BOOST_TEST(st.end() > st.cbegin());
+    BOOST_TEST(st.cend() > st.cbegin());
+    BOOST_TEST(st.cend() > st.begin());
+
+
+    BOOST_TEST(st.size() == static_cast<std::size_t>(st.end() - st.begin()));
+    BOOST_TEST(st.size() == static_cast<std::size_t>(st.end() - st.cbegin()));
+    BOOST_TEST(st.size() == static_cast<std::size_t>(st.cend() - st.cbegin()));
+    BOOST_TEST(st.size() == static_cast<std::size_t>(st.cend() - st.begin()));
+
+    BOOST_TEST(st.size() == static_cast<std::size_t>(std::distance(st.rend(), st.rbegin())));
+    BOOST_TEST(st.size() == static_cast<std::size_t>(std::distance(st.rend(), st.crbegin())));
+    BOOST_TEST(st.size() == static_cast<std::size_t>(std::distance(st.crend(), st.crbegin())));
+    BOOST_TEST(st.size() == static_cast<std::size_t>(std::distance(st.crend(), st.rbegin())));
+
+
+    boost::stacktrace::stacktrace::iterator it = st.begin();
+    ++ it;
+    BOOST_TEST(it == st.begin() + 1);
+}
+
+void test_frame() {
+    stacktrace nst = return_from_nested_namespaces();
+    stacktrace st;
+
+    const std::size_t min_size = (nst.size() < st.size() ? nst.size() : st.size());
+    BOOST_TEST(min_size > 2);
+
+    for (std::size_t i = 0; i < min_size; ++i) {
+        BOOST_TEST(st[i] == st[i]);
+        BOOST_TEST(st[i].source_file() == st[i].source_file());
+        BOOST_TEST(st[i].source_line() == st[i].source_line());
+        BOOST_TEST(st[i] <= st[i]);
+        BOOST_TEST(st[i] >= st[i]);
+
+        frame fv = nst[2];
+        BOOST_TEST(fv);
+        if (i >= 2 && i < min_size - 3) { // Begin and end of the trace may match, skipping them
+            BOOST_TEST(st[i] != fv);
+            BOOST_TEST(st[i].name() != fv.name());
+            BOOST_TEST(st[i] != fv);
+            BOOST_TEST(st[i] < fv || st[i] > fv);
+            BOOST_TEST(hash_value(st[i]) != hash_value(fv));
+            BOOST_TEST(st[i].source_line() == 0 || st[i].source_file() != fv.source_file());
+            BOOST_TEST(st[i]);
+        }
+
+        fv = st[i];
+        BOOST_TEST(hash_value(st[i]) == hash_value(fv));
+    }
+
+    boost::stacktrace::frame empty_frame;
+    BOOST_TEST(!empty_frame);
+    BOOST_TEST(empty_frame.source_file() == "");
+    BOOST_TEST(empty_frame.name() == "");
+    BOOST_TEST(empty_frame.source_line() == 0);
+}
+
+void test_empty_basic_stacktrace() {
+    typedef boost::stacktrace::basic_stacktrace<0> st_t;
+    st_t st;
+
+    BOOST_TEST(!st);
+    BOOST_TEST(st.empty());
+    BOOST_TEST(st.size() == 0);
+    BOOST_TEST(st.begin() == st.end());
+    BOOST_TEST(st.cbegin() == st.end());
+    BOOST_TEST(st.cbegin() == st.cend());
+    BOOST_TEST(st.begin() == st.cend());
+
+    BOOST_TEST(st.rbegin() == st.rend());
+    BOOST_TEST(st.crbegin() == st.rend());
+    BOOST_TEST(st.crbegin() == st.crend());
+    BOOST_TEST(st.rbegin() == st.crend());
+
+    BOOST_TEST(hash_value(st) == hash_value(st_t()));
+    BOOST_TEST(st == st_t());
+    BOOST_TEST(!(st < st_t()));
+    BOOST_TEST(!(st > st_t()));
+}
+
+int main() {
+    test_deeply_nested_namespaces();
+    test_nested();
+    test_comparisons();
+    test_iterators();
+    test_frame();
+    test_empty_basic_stacktrace();
+
+    BOOST_TEST(&bar1 != &bar2);
+    boost::stacktrace::basic_stacktrace<4> b1 = bar1();
+    BOOST_TEST(b1.size() == 4);
+    boost::stacktrace::basic_stacktrace<4> b2 = bar2();
+    BOOST_TEST(b2.size() == 4);
+    test_comparisons_base(bar1(), bar2());
+
+    return boost::report_errors();
+}

--- a/third_party/stacktrace/test/test_impl.cpp
+++ b/third_party/stacktrace/test/test_impl.cpp
@@ -1,0 +1,78 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <boost/stacktrace.hpp>
+#include <stdexcept>
+
+using namespace boost::stacktrace;
+
+#ifdef BOOST_STACKTRACE_DYN_LINK
+#   define BOOST_ST_API BOOST_SYMBOL_EXPORT
+#else
+#   define BOOST_ST_API
+#endif
+
+BOOST_ST_API BOOST_NOINLINE std::pair<stacktrace, stacktrace> foo1(int i);
+BOOST_ST_API BOOST_NOINLINE std::pair<stacktrace, stacktrace> foo2(int i);
+
+std::pair<stacktrace, stacktrace> foo1(int i) {
+    if (i) {
+        return foo2(i - 1);
+    }
+
+    std::pair<stacktrace, stacktrace> ret;
+    try {
+        throw std::logic_error("test");
+    } catch (const std::logic_error& /*e*/) {
+        ret.second = stacktrace();
+        return ret;
+    }
+}
+
+std::pair<stacktrace, stacktrace> foo2(int i) {
+    if (i) {
+        return foo1(--i);
+    } else {
+        return foo1(i);
+    }
+}
+
+
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+namespace very_very_very_very_very_very_long_namespace {
+    BOOST_ST_API BOOST_NOINLINE stacktrace get_backtrace_from_nested_namespaces() {
+        return stacktrace();
+    }
+}}}}}}}}}}
+
+BOOST_ST_API BOOST_NOINLINE stacktrace return_from_nested_namespaces() {
+    using very_very_very_very_very_very_long_namespace::very_very_very_very_very_very_long_namespace::very_very_very_very_very_very_long_namespace
+        ::very_very_very_very_very_very_long_namespace::very_very_very_very_very_very_long_namespace::very_very_very_very_very_very_long_namespace
+        ::very_very_very_very_very_very_long_namespace::very_very_very_very_very_very_long_namespace::very_very_very_very_very_very_long_namespace
+        ::very_very_very_very_very_very_long_namespace::get_backtrace_from_nested_namespaces;
+
+    return get_backtrace_from_nested_namespaces();
+}
+
+BOOST_ST_API BOOST_NOINLINE boost::stacktrace::basic_stacktrace<4> bar1() {
+    boost::stacktrace::basic_stacktrace<4> result;
+    return result;
+}
+
+BOOST_ST_API BOOST_NOINLINE boost::stacktrace::basic_stacktrace<4> bar2() {
+    boost::stacktrace::basic_stacktrace<4> result;
+    return result;
+}
+

--- a/third_party/stacktrace/test/test_noop.cpp
+++ b/third_party/stacktrace/test/test_noop.cpp
@@ -1,0 +1,61 @@
+// Copyright Antony Polukhin, 2016.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <boost/stacktrace.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+using boost::stacktrace::stacktrace;
+BOOST_SYMBOL_IMPORT std::pair<stacktrace, stacktrace> foo2(int i);
+BOOST_SYMBOL_IMPORT std::pair<stacktrace, stacktrace> foo1(int i);
+BOOST_SYMBOL_IMPORT stacktrace return_from_nested_namespaces();
+
+void test_deeply_nested_namespaces() {
+    BOOST_TEST(return_from_nested_namespaces().size() == 0);
+    BOOST_TEST(return_from_nested_namespaces().begin()->name() == "");
+}
+
+void test_nested() {
+    std::pair<stacktrace, stacktrace> res = foo2(15);
+
+    BOOST_TEST(!res.first);
+    BOOST_TEST(res.first.size() == 0);
+    BOOST_TEST(res.first.begin()->name() == "");
+    BOOST_TEST(res.first.begin()->source_file() == "");
+    BOOST_TEST(res.first.begin()->source_line() == 0);
+    BOOST_TEST(!res.second);
+    BOOST_TEST(res.second.size() == 0);
+    BOOST_TEST(res.second.begin()->name() == "");
+    BOOST_TEST(res.second.begin()->source_file() == "");
+    BOOST_TEST(res.second.begin()->source_line() == 0);
+
+    BOOST_TEST(res.second[0].name() == "");
+    BOOST_TEST(res.second[0].source_file() == "");
+    BOOST_TEST(res.second[0].source_line() == 0);
+    BOOST_TEST(res.second[0].address() == 0);
+
+    BOOST_TEST(res.second <= res.first);
+    BOOST_TEST(res.second >= res.first);
+    BOOST_TEST(res.second == res.first);
+    BOOST_TEST(res.second == res.first);
+    BOOST_TEST(!(res.second > res.first));
+}
+
+void test_empty_frame() {
+    boost::stacktrace::frame empty_frame;
+    BOOST_TEST(!empty_frame);
+    BOOST_TEST(empty_frame.source_file() == "");
+    BOOST_TEST(empty_frame.name() == "");
+    BOOST_TEST(empty_frame.source_line() == 0);
+}
+
+int main() {
+    test_deeply_nested_namespaces();
+    test_nested();
+    test_empty_frame();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Header-only stacktrace library which is currently up for review to be
included in Boost. First try to include this as optional feature.

At the moment we register segfault and assertion handlers.

- http://lists.boost.org/boost-users/2016/12/86979.php
- https://github.com/apolukhin/stacktrace
- http://apolukhin.github.io/stacktrace/boost_stacktrace/getting_started.html

Tested on my Linux machine and produces nice stacktraces for both assertions as well as segfaults.

Needs some more testing for macOS (maybe a signal handler and support for Windows, but we mostly don't care there) and on our infrastructure.

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
