### PR TITLE
Implements Zero-Copy String Views onto Contiguous Memory.

### DIFF
--- a/include/engine/api/base_api.hpp
+++ b/include/engine/api/base_api.hpp
@@ -51,12 +51,13 @@ class BaseAPI
         if (parameters.generate_hints)
         {
             return json::makeWaypoint(phantom.location,
-                                      facade.GetNameForID(phantom.name_id),
+                                      facade.GetNameForID(phantom.name_id).to_string(),
                                       Hint{phantom, facade.GetCheckSum()});
         }
         else
         {
-            return json::makeWaypoint(phantom.location, facade.GetNameForID(phantom.name_id));
+            return json::makeWaypoint(phantom.location,
+                                      facade.GetNameForID(phantom.name_id).to_string());
         }
     }
 

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -17,6 +17,7 @@
 #include "util/guidance/turn_lanes.hpp"
 #include "util/integer_range.hpp"
 #include "util/string_util.hpp"
+#include "util/string_view.hpp"
 #include "util/typedefs.hpp"
 
 #include "osrm/coordinate.hpp"
@@ -34,6 +35,7 @@ namespace engine
 namespace datafacade
 {
 
+using StringView = util::StringView;
 using EdgeRange = util::range<EdgeID>;
 
 class BaseDataFacade
@@ -74,10 +76,10 @@ class BaseDataFacade
                                     const std::function<bool(EdgeData)> filter) const = 0;
 
     // node and edge information access
-    virtual util::Coordinate GetCoordinateOfNode(const unsigned id) const = 0;
-    virtual OSMNodeID GetOSMNodeIDOfNode(const unsigned id) const = 0;
+    virtual util::Coordinate GetCoordinateOfNode(const NodeID id) const = 0;
+    virtual OSMNodeID GetOSMNodeIDOfNode(const NodeID id) const = 0;
 
-    virtual GeometryID GetGeometryIndexForEdgeID(const unsigned id) const = 0;
+    virtual GeometryID GetGeometryIndexForEdgeID(const EdgeID id) const = 0;
 
     virtual std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID id) const = 0;
 
@@ -91,16 +93,16 @@ class BaseDataFacade
 
     // Returns the data source ids that were used to supply the edge
     // weights.  Will return an empty array when only the base profile is used.
-    virtual std::vector<uint8_t> GetUncompressedForwardDatasources(const EdgeID id) const = 0;
-    virtual std::vector<uint8_t> GetUncompressedReverseDatasources(const EdgeID id) const = 0;
+    virtual std::vector<DatasourceID> GetUncompressedForwardDatasources(const EdgeID id) const = 0;
+    virtual std::vector<DatasourceID> GetUncompressedReverseDatasources(const EdgeID id) const = 0;
 
     // Gets the name of a datasource
-    virtual std::string GetDatasourceName(const uint8_t datasource_name_id) const = 0;
+    virtual StringView GetDatasourceName(const DatasourceID id) const = 0;
 
     virtual extractor::guidance::TurnInstruction
-    GetTurnInstructionForEdgeID(const unsigned id) const = 0;
+    GetTurnInstructionForEdgeID(const EdgeID id) const = 0;
 
-    virtual extractor::TravelMode GetTravelModeForEdgeID(const unsigned id) const = 0;
+    virtual extractor::TravelMode GetTravelModeForEdgeID(const EdgeID id) const = 0;
 
     virtual std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate south_west,
                                                  const util::Coordinate north_east) const = 0;
@@ -157,15 +159,15 @@ class BaseDataFacade
 
     virtual bool IsCoreNode(const NodeID id) const = 0;
 
-    virtual unsigned GetNameIndexFromEdgeID(const unsigned id) const = 0;
+    virtual NameID GetNameIndexFromEdgeID(const EdgeID id) const = 0;
 
-    virtual std::string GetNameForID(const unsigned name_id) const = 0;
+    virtual StringView GetNameForID(const NameID id) const = 0;
 
-    virtual std::string GetRefForID(const unsigned name_id) const = 0;
+    virtual StringView GetRefForID(const NameID id) const = 0;
 
-    virtual std::string GetPronunciationForID(const unsigned name_id) const = 0;
+    virtual StringView GetPronunciationForID(const NameID id) const = 0;
 
-    virtual std::string GetDestinationsForID(const unsigned name_id) const = 0;
+    virtual StringView GetDestinationsForID(const NameID id) const = 0;
 
     virtual std::size_t GetCoreSize() const = 0;
 

--- a/include/engine/guidance/assemble_leg.hpp
+++ b/include/engine/guidance/assemble_leg.hpp
@@ -186,11 +186,11 @@ inline RouteLeg assembleLeg(const datafacade::BaseDataFacade &facade,
         const auto name_id_to_string = [&](const NameID name_id) {
             const auto name = facade.GetNameForID(name_id);
             if (!name.empty())
-                return name;
+                return name.to_string();
             else
             {
                 const auto ref = facade.GetRefForID(name_id);
-                return ref;
+                return ref.to_string();
             }
         };
 

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -105,10 +105,10 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                 const auto distance = leg_geometry.segment_distances[segment_index];
 
                 steps.push_back(RouteStep{step_name_id,
-                                          std::move(name),
-                                          std::move(ref),
-                                          std::move(pronunciation),
-                                          std::move(destinations),
+                                          name.to_string(),
+                                          ref.to_string(),
+                                          pronunciation.to_string(),
+                                          destinations.to_string(),
                                           NO_ROTARY_NAME,
                                           NO_ROTARY_NAME,
                                           segment_duration / 10.0,
@@ -179,10 +179,10 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
         const int duration = segment_duration + target_duration;
         BOOST_ASSERT(duration >= 0);
         steps.push_back(RouteStep{step_name_id,
-                                  facade.GetNameForID(step_name_id),
-                                  facade.GetRefForID(step_name_id),
-                                  facade.GetPronunciationForID(step_name_id),
-                                  facade.GetDestinationsForID(step_name_id),
+                                  facade.GetNameForID(step_name_id).to_string(),
+                                  facade.GetRefForID(step_name_id).to_string(),
+                                  facade.GetPronunciationForID(step_name_id).to_string(),
+                                  facade.GetDestinationsForID(step_name_id).to_string(),
                                   NO_ROTARY_NAME,
                                   NO_ROTARY_NAME,
                                   duration / 10.,
@@ -206,10 +206,10 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
         BOOST_ASSERT(duration >= 0);
 
         steps.push_back(RouteStep{source_node.name_id,
-                                  facade.GetNameForID(source_node.name_id),
-                                  facade.GetRefForID(source_node.name_id),
-                                  facade.GetPronunciationForID(source_node.name_id),
-                                  facade.GetDestinationsForID(source_node.name_id),
+                                  facade.GetNameForID(source_node.name_id).to_string(),
+                                  facade.GetRefForID(source_node.name_id).to_string(),
+                                  facade.GetPronunciationForID(source_node.name_id).to_string(),
+                                  facade.GetDestinationsForID(source_node.name_id).to_string(),
                                   NO_ROTARY_NAME,
                                   NO_ROTARY_NAME,
                                   duration / 10.,
@@ -243,10 +243,10 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
 
     BOOST_ASSERT(!leg_geometry.locations.empty());
     steps.push_back(RouteStep{target_node.name_id,
-                              facade.GetNameForID(target_node.name_id),
-                              facade.GetRefForID(target_node.name_id),
-                              facade.GetPronunciationForID(target_node.name_id),
-                              facade.GetDestinationsForID(target_node.name_id),
+                              facade.GetNameForID(target_node.name_id).to_string(),
+                              facade.GetRefForID(target_node.name_id).to_string(),
+                              facade.GetPronunciationForID(target_node.name_id).to_string(),
+                              facade.GetDestinationsForID(target_node.name_id).to_string(),
                               NO_ROTARY_NAME,
                               NO_ROTARY_NAME,
                               ZERO_DURATION,

--- a/include/extractor/suffix_table.hpp
+++ b/include/extractor/suffix_table.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <unordered_set>
 
+#include "util/string_view.hpp"
+
 namespace osrm
 {
 namespace extractor
@@ -21,9 +23,20 @@ class SuffixTable final
 
     // check whether a string is part of the know suffix list
     bool isSuffix(const std::string &possible_suffix) const;
+    bool isSuffix(util::StringView possible_suffix) const;
 
   private:
-    std::unordered_set<std::string> suffix_set;
+    // Store lower-cased strings in SuffixTable and a set of StringViews for quick membership
+    // checks.
+    //
+    // Why not uset<StringView>? StringView is non-owning, the vector<string> holds the string
+    // contents, the set<StringView> only holds [first,last) pointers into the vector.
+    //
+    // Then why not simply uset<string>? Because membership tests against StringView keys would
+    // require us to first convert StringViews into strings (allocation), do the membership,
+    // and destroy the StringView again.
+    std::vector<std::string> suffixes;
+    std::unordered_set<util::StringView> suffix_set;
 };
 
 } /* namespace extractor */

--- a/include/util/guidance/name_announcements.hpp
+++ b/include/util/guidance/name_announcements.hpp
@@ -159,13 +159,14 @@ inline bool requiresNameAnnounced(const NameID from_name_id,
     if (from_name_id == to_name_id)
         return false;
     else
-        return requiresNameAnnounced(name_table.GetNameForID(from_name_id),
-                                     name_table.GetRefForID(from_name_id),
-                                     name_table.GetPronunciationForID(from_name_id),
-                                     name_table.GetNameForID(to_name_id),
-                                     name_table.GetRefForID(to_name_id),
-                                     name_table.GetPronunciationForID(to_name_id),
+        return requiresNameAnnounced(name_table.GetNameForID(from_name_id).to_string(),
+                                     name_table.GetRefForID(from_name_id).to_string(),
+                                     name_table.GetPronunciationForID(from_name_id).to_string(),
+                                     name_table.GetNameForID(to_name_id).to_string(),
+                                     name_table.GetRefForID(to_name_id).to_string(),
+                                     name_table.GetPronunciationForID(to_name_id).to_string(),
                                      suffix_table);
+    // FIXME: converts StringViews to strings since the name change heuristics mutates in place
 }
 
 inline bool requiresNameAnnounced(const NameID from_name_id,
@@ -175,12 +176,13 @@ inline bool requiresNameAnnounced(const NameID from_name_id,
     if (from_name_id == to_name_id)
         return false;
     else
-        return requiresNameAnnounced(name_table.GetNameForID(from_name_id),
-                                     name_table.GetRefForID(from_name_id),
-                                     name_table.GetPronunciationForID(from_name_id),
-                                     name_table.GetNameForID(to_name_id),
-                                     name_table.GetRefForID(to_name_id),
-                                     name_table.GetPronunciationForID(to_name_id));
+        return requiresNameAnnounced(name_table.GetNameForID(from_name_id).to_string(),
+                                     name_table.GetRefForID(from_name_id).to_string(),
+                                     name_table.GetPronunciationForID(from_name_id).to_string(),
+                                     name_table.GetNameForID(to_name_id).to_string(),
+                                     name_table.GetRefForID(to_name_id).to_string(),
+                                     name_table.GetPronunciationForID(to_name_id).to_string());
+    // FIXME: converts StringViews to strings since the name change heuristics mutates in place
 }
 
 } // namespace guidance

--- a/include/util/name_table.hpp
+++ b/include/util/name_table.hpp
@@ -3,6 +3,8 @@
 
 #include "util/range_table.hpp"
 #include "util/shared_memory_vector_wrapper.hpp"
+#include "util/string_view.hpp"
+#include "util/typedefs.hpp"
 
 #include <string>
 
@@ -28,9 +30,9 @@ class NameTable
     // The following functions are a subset of what is available.
     // See the data facades for they provide full access to this serialized string data.
     // (at time of writing this: get{Name,Ref,Pronunciation,Destinations}ForID(name_id);)
-    std::string GetNameForID(const unsigned name_id) const;
-    std::string GetRefForID(const unsigned name_id) const;
-    std::string GetPronunciationForID(const unsigned name_id) const;
+    util::StringView GetNameForID(const NameID id) const;
+    util::StringView GetRefForID(const NameID id) const;
+    util::StringView GetPronunciationForID(const NameID id) const;
 };
 } // namespace util
 } // namespace osrm

--- a/include/util/string_view.hpp
+++ b/include/util/string_view.hpp
@@ -1,0 +1,34 @@
+#ifndef OSRM_STRING_VIEW_HPP
+#define OSRM_STRING_VIEW_HPP
+
+#include <boost/functional/hash.hpp>
+#include <boost/utility/string_ref.hpp>
+
+namespace osrm
+{
+namespace util
+{
+// Convenience typedef: boost::string_ref, boost::string_view or C++17's string_view
+using StringView = boost::string_ref;
+
+} // namespace util
+} // namespace osrm
+
+// Specializing hash<> for user-defined type in std namespace, this is standard conforming.
+namespace std
+{
+template <> struct hash<::osrm::util::StringView> final
+{
+    std::size_t operator()(::osrm::util::StringView v) const noexcept
+    {
+        // Bring into scope and call un-qualified for ADL:
+        // remember we want to be able to switch impl. above.
+        using std::begin;
+        using std::end;
+
+        return boost::hash_range(begin(v), end(v));
+    }
+};
+} // namespace std
+
+#endif /* OSRM_STRING_VIEW_HPP */

--- a/src/extractor/suffix_table.cpp
+++ b/src/extractor/suffix_table.cpp
@@ -1,6 +1,8 @@
 #include "extractor/suffix_table.hpp"
-
 #include "extractor/scripting_environment.hpp"
+
+#include <algorithm>
+#include <iterator>
 
 #include <boost/algorithm/string.hpp>
 
@@ -11,13 +13,22 @@ namespace extractor
 
 SuffixTable::SuffixTable(ScriptingEnvironment &scripting_environment)
 {
-    std::vector<std::string> suffixes_vector = scripting_environment.GetNameSuffixList();
-    for (auto &suffix : suffixes_vector)
+    suffixes = scripting_environment.GetNameSuffixList();
+
+    for (auto &suffix : suffixes)
         boost::algorithm::to_lower(suffix);
-    suffix_set.insert(std::begin(suffixes_vector), std::end(suffixes_vector));
+
+    auto into = std::inserter(suffix_set, end(suffix_set));
+    auto to_view = [](const auto &s) { return util::StringView{s}; };
+    std::transform(begin(suffixes), end(suffixes), into, to_view);
 }
 
 bool SuffixTable::isSuffix(const std::string &possible_suffix) const
+{
+    return isSuffix(util::StringView{possible_suffix});
+}
+
+bool SuffixTable::isSuffix(util::StringView possible_suffix) const
 {
     return suffix_set.count(possible_suffix) > 0;
 }

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -19,6 +19,8 @@ namespace test
 
 class MockDataFacade final : public engine::datafacade::BaseDataFacade
 {
+    using StringView = util::StringView;
+
   private:
     EdgeData foo;
 
@@ -56,13 +58,13 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     {
         return SPECIAL_EDGEID;
     }
-    util::Coordinate GetCoordinateOfNode(const unsigned /* id */) const override
+    util::Coordinate GetCoordinateOfNode(const NodeID /* id */) const override
     {
         return {util::FixedLongitude{0}, util::FixedLatitude{0}};
     }
-    OSMNodeID GetOSMNodeIDOfNode(const unsigned /* id */) const override { return OSMNodeID{0}; }
-    bool EdgeIsCompressed(const unsigned /* id */) const { return false; }
-    GeometryID GetGeometryIndexForEdgeID(const unsigned /* id */) const override
+    OSMNodeID GetOSMNodeIDOfNode(const NodeID /* id */) const override { return OSMNodeID{0}; }
+    bool EdgeIsCompressed(const EdgeID /* id */) const { return false; }
+    GeometryID GetGeometryIndexForEdgeID(const EdgeID /* id */) const override
     {
         return GeometryID{SPECIAL_GEOMETRYID, false};
     }
@@ -88,24 +90,23 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
         result_weights[0] = 1;
         return result_weights;
     }
-    std::vector<uint8_t> GetUncompressedForwardDatasources(const EdgeID /*id*/) const override
+    std::vector<DatasourceID> GetUncompressedForwardDatasources(const EdgeID /*id*/) const override
     {
         return {};
     }
-    std::vector<uint8_t> GetUncompressedReverseDatasources(const EdgeID /*id*/) const override
+    std::vector<DatasourceID> GetUncompressedReverseDatasources(const EdgeID /*id*/) const override
     {
         return {};
     }
-    std::string GetDatasourceName(const uint8_t /*datasource_name_id*/) const override
-    {
-        return "";
-    }
+
+    StringView GetDatasourceName(const DatasourceID) const override final { return {}; }
+
     extractor::guidance::TurnInstruction
-    GetTurnInstructionForEdgeID(const unsigned /* id */) const override
+    GetTurnInstructionForEdgeID(const EdgeID /* id */) const override
     {
         return extractor::guidance::TurnInstruction::NO_TURN();
     }
-    extractor::TravelMode GetTravelModeForEdgeID(const unsigned /* id */) const override
+    extractor::TravelMode GetTravelModeForEdgeID(const EdgeID /* id */) const override
     {
         return TRAVEL_MODE_INACCESSIBLE;
     }
@@ -198,11 +199,14 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
 
     unsigned GetCheckSum() const override { return 0; }
     bool IsCoreNode(const NodeID /* id */) const override { return false; }
-    unsigned GetNameIndexFromEdgeID(const unsigned /* id */) const override { return 0; }
-    std::string GetNameForID(const unsigned /* name_id */) const override { return ""; }
-    std::string GetRefForID(const unsigned /* name_id */) const override { return ""; }
-    std::string GetPronunciationForID(const unsigned /* name_id */) const override { return ""; }
-    std::string GetDestinationsForID(const unsigned /* name_id */) const override { return ""; }
+
+    NameID GetNameIndexFromEdgeID(const EdgeID /* id */) const override { return 0; }
+
+    StringView GetNameForID(const NameID) const override final { return {}; }
+    StringView GetRefForID(const NameID) const override final { return {}; }
+    StringView GetPronunciationForID(const NameID) const override final { return {}; }
+    StringView GetDestinationsForID(const NameID) const override final { return {}; }
+
     std::size_t GetCoreSize() const override { return 0; }
     std::string GetTimestamp() const override { return ""; }
     bool GetContinueStraightDefault() const override { return true; }


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/3265. Work in progress. This is harder than I thought, mostly because call sites often mutate the string which would mean we have to make a copy.

Also cleans up some type aliases on the way.

## Tasklist
 - [x] re-write call sites using string views
 - [x] rip out old-style string interface
 - [x] review
 - [x] adjust for comments

References:

- http://www.boost.org/doc/libs/1_61_0/libs/utility/doc/html/string_ref.html
- http://en.cppreference.com/w/cpp/string/basic_string_view