### PR TITLE
Makes Units in Profiles Explicit

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -6,6 +6,7 @@ local get_turn_lanes = require("lib/guidance").get_turn_lanes
 local Set = require('lib/set')
 local Sequence = require('lib/sequence')
 local Directional = require('lib/directional')
+local Units = require('lib/units')
 
 -- Begin of globals
 barrier_whitelist = Set {
@@ -188,16 +189,17 @@ maxspeed_table = {
 }
 
 -- set profile properties
-properties.u_turn_penalty                  = 20
-properties.traffic_signal_penalty          = 2
-properties.max_speed_for_map_matching      = 180/3.6 -- 180kmph -> m/s
+properties.u_turn_penalty                  = Units.Seconds(20)
+properties.traffic_signal_penalty          = Units.Seconds(2)
+properties.max_speed_for_map_matching      = Units.MetersPerSeconds(180/3.6)
 properties.use_turn_restrictions           = true
 properties.continue_straight_at_waypoint   = true
 properties.left_hand_driving               = false
 
 local side_road_speed_multiplier = 0.8
 
-local turn_penalty               = 7.5
+local turn_penalty               = Units.Seconds(7.5)
+
 -- Note: this biases right-side driving.  Should be
 -- inverted for left-driving countries.
 local turn_bias                  = properties.left_hand_driving and 1/1.075 or 1.075

--- a/profiles/lib/units.lua
+++ b/profiles/lib/units.lua
@@ -1,0 +1,12 @@
+-- Units.
+
+local Units = {}
+
+-- Time
+function Units.Seconds (v) return v end
+
+-- Speed
+function Units.KpH (v) return v end
+function Units.MetersPerSeconds (v) return v end
+
+return Units


### PR DESCRIPTION
Here's the deal. Lua is untyped. But at least we can be explicit about our units.

Why? Because time was once in deci-seconds. And now is in seconds.
And it's all very confusing and un-checked if you get things wrong.

@emiltin with my limited Lua knowledge this is the only way I could think of pulling it off. Is there a way to "fake types" so to speak? Maybe even checked via asserts?

It would be great to be explicit at least for time, speeds, etc. - not sure if it makes sense to have a `Key()`, `Value` and `Tag` "type" for our sets.