### PR TITLE
Bump SOL2 to e1329d24 to fix OSX compilation problems.

### DIFF
--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -19,7 +19,7 @@ MASON_REPO="https://github.com/mapbox/mason.git"
 MASON_TAG=v0.3.0
 
 SOL_REPO="https://github.com/ThePhD/sol2.git"
-SOL_TAG=v2.15.4
+SOL_TAG=v2.15.5
 
 VARIANT_LATEST=$(curl "https://api.github.com/repos/mapbox/variant/releases/latest" | jq ".tag_name")
 OSMIUM_LATEST=$(curl "https://api.github.com/repos/osmcode/libosmium/releases/latest" | jq ".tag_name")


### PR DESCRIPTION
Our shiny new use of the `sol2` Lua interface library had a bug that prevented it from compiling properly under OSX - see https://github.com/ThePhD/sol2/issues/300

This bumps to the e1329d244a79c95f467eaec97e06e058f492bcde version which fixes compilation under OSX.  There are a couple of other unrelated bugfixes in the newer release that don't seem bad to bring along.

I grabbed the raw file from github with `wget` - not sure why it's marked every line as a change, @karenzshea how did you import the original?

## Tasklist
 - [ ] review
 - [ ] adjust for comments

/cc @MoKob 