### PR TITLE
Explicitly copy way.nodes() into vector to have proper table meta functions

### DIFF
--- a/features/options/extract/lua.feature
+++ b/features/options/extract/lua.feature
@@ -1,0 +1,28 @@
+@extract
+Feature: osrm-extract lua ways:get_nodes()
+
+    Background:
+        Given the node map
+            """
+            a b
+            """
+        And the ways
+            | nodes |
+            | ab    |
+        And the data has been saved to disk
+
+    Scenario: osrm-extract - Passing base file
+        Given the profile file "testbot" extended with
+        """
+        function way_function(way, result)
+          for _, node in ipairs(way:get_nodes()) do
+            print('node id ' .. node:id())
+          end
+          result.forward_mode = mode.driving
+          result.forward_speed = 1
+        end
+        """
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
+        Then it should exit successfully
+        And stdout should contain "node id 1"
+        And stdout should contain "node id 2"


### PR DESCRIPTION
# Issue

For #3452 added index, length and call metafunctions to WayNodeList, so it is possible to  access  node references in lua as 
```
  local nodes = way:get_nodes()
  for index = 1, #nodes do
     print (nodes[index]:id())
  end
```
or 
```
  for i,node in ipairs(way:get_nodes()()) do
     print (i, node:id())
  end
```

The return value of `call` is a table, so `for node in way:get_nodes() do` does not work. It should be checked what `call` should return to have an "iterable" object.

EDIT: the original commit defines explicitly meta functions for `WayNodeList`.  Also `__pairs` and `__ipairs` functions can not be explicitly defined for a usertype. Just copying `NodeRef` to vector solves the issue by using implicitly  `container_usertype_metatable`.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
