### PR TITLE
remove assertions that could be triggered by bad data

### DIFF
--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -1314,3 +1314,29 @@ Feature: Simple Turns
         When I route I should get
             | waypoints | route              | intersections                                |
             | a,g       | ab,bcdefgh,bcdefgh | true:90;true:45 false:180 false:270;true:180 |
+
+    #https://github.com/Project-OSRM/osrm-backend/pull/3469#issuecomment-270806580
+    Scenario: Oszillating Lower Priority Road
+		#Given the node map
+	#		"""
+	#		a -db    c
+    #           f
+    #   	"""
+        Given the node locations
+            | node | lat                | lon                | #          |
+            | a    | 1.0                | 1.0                |            |
+            | b    | 1.0000179813587253 | 1.0                |            |
+            | c    | 1.0000204580571323 | 1.0                |            |
+            | d    | 1.0000179813587253 | 1.0                | same as b  |
+            | f    | 1.0000179813587253 | 1.0000179813587253 |            |
+
+        And the ways
+            | nodes | oneway | lanes | highway |
+            | ab    | yes    | 1     | primary |
+            | bf    | yes    | 1     | primary |
+            | bcd   | yes    | 1     | service |
+
+        # we don't care for turn instructions, this is a coordinate extraction bug check
+        When I route I should get
+            | waypoints | route |
+            | a,d       | ab,ab |

--- a/include/extractor/guidance/coordinate_extractor.hpp
+++ b/include/extractor/guidance/coordinate_extractor.hpp
@@ -28,7 +28,8 @@ class CoordinateExtractor
     /* Find a interpolated coordinate a long the compressed geometries. The desired coordinate
      * should be in a certain distance. This method is dedicated to find representative coordinates
      * at turns.
-     * Since we are computing the length of the segment anyhow, we also return it.
+     * Note: The segment between intersection and turn coordinate can be zero, if the OSM modelling
+     * is unfortunate. See https://github.com/Project-OSRM/osrm-backend/issues/3470
      */
     OSRM_ATTR_WARN_UNUSED
     util::Coordinate GetCoordinateAlongRoad(const NodeID intersection_node,

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -5,8 +5,10 @@
 
 #include "util/bearing.hpp"
 #include "util/coordinate_calculation.hpp"
+#include "util/log.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <functional> // mem_fn
 #include <limits>
 #include <numeric>
@@ -105,6 +107,19 @@ IntersectionGenerator::ComputeIntersectionShape(const NodeID node_at_center_of_i
 
         bearing =
             util::coordinate_calculation::bearing(turn_coordinate, coordinate_along_edge_leaving);
+
+        // OSM data sometimes contains duplicated nodes with identical coordinates, or
+        // because of coordinate precision rounding, end up at the same coordinate.
+        // It's impossible to calculate a bearing between these, so we log a warning
+        // that the data should be checked.
+        // The bearing calculation should return 0 in these cases, which may not be correct,
+        // but is at least not random.
+        if (turn_coordinate == coordinate_along_edge_leaving)
+        {
+            util::Log(logDEBUG) << "Zero length segment at " << coordinate_along_edge_leaving
+                                << " could cause invalid intersection exit bearing.";
+            BOOST_ASSERT(std::abs(bearing) <= 0.1);
+        }
 
         intersection.push_back({edge_connected_to_intersection, bearing, segment_length});
     }

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -204,6 +204,20 @@ bool RoundaboutHandler::qualifiesAsRoundaboutIntersection(
 
                 result.push_back(
                     util::coordinate_calculation::bearing(src_coordinate, next_coordinate));
+
+                // OSM data sometimes contains duplicated nodes with identical coordinates, or
+                // because of coordinate precision rounding, end up at the same coordinate.
+                // It's impossible to calculate a bearing between these, so we log a warning
+                // that the data should be checked.
+                // The bearing calculation should return 0 in these cases, which may not be correct,
+                // but is at least not random.
+                if (src_coordinate == next_coordinate)
+                {
+                    util::Log(logDEBUG) << "Zero length segment at " << next_coordinate
+                                        << " could cause invalid roundabout exit bearings";
+                    BOOST_ASSERT(std::abs(result.back()) <= 0.1);
+                }
+
                 break;
             }
         }

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -145,6 +145,11 @@ double bearing(const Coordinate first_coordinate, const Coordinate second_coordi
     {
         result -= 360.0;
     }
+    // If someone gives us two identical coordinates, then the concept of a bearing
+    // makes no sense.  However, because it sometimes happens, we'll at least
+    // return a consistent value of 0 so that the behaviour isn't random.
+    BOOST_ASSERT(first_coordinate != second_coordinate || result == 0.);
+
     return result;
 }
 

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    BOOST_CHECK_EQUAL(result.size(), 114091);
+    BOOST_CHECK_EQUAL(result.size(), 114098);
 
     protozero::pbf_reader tile_message(result);
     tile_message.next();

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -378,4 +378,15 @@ BOOST_AUTO_TEST_CASE(parallel_lines_slight_offset)
     BOOST_CHECK(are_parallel);
 }
 
+BOOST_AUTO_TEST_CASE(consistent_invalid_bearing_result)
+{
+    const auto pos1 = Coordinate(util::FloatLongitude{0.}, util::FloatLatitude{0.});
+    const auto pos2 = Coordinate(util::FloatLongitude{5.}, util::FloatLatitude{5.});
+    const auto pos3 = Coordinate(util::FloatLongitude{-5.}, util::FloatLatitude{-5.});
+
+    BOOST_CHECK_EQUAL(0., util::coordinate_calculation::bearing(pos1, pos1));
+    BOOST_CHECK_EQUAL(0., util::coordinate_calculation::bearing(pos2, pos2));
+    BOOST_CHECK_EQUAL(0., util::coordinate_calculation::bearing(pos3, pos3));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Some of the assertions in various coordinate extraction steps are not correct.  It's possible for valid OSM geometry to contain nodes that are at the same coordinate (either via users placing duplicate coordinates, or decimal rounding snapping nearby points to the same place).  We are currently asserting that this can't happen, even though it can.

This PR disables those assertions.

In addition, because there is no definition of "bearing" between two identical points, the current behaviour is undefined.  This PR also adds some tests that when we encounter this situation, we return 0 for the bearing.  Although still incorrect, at least it's consistent and testable.

A full fix for this requires #3470 which is more complex, this PR is just to unblock the demo server updates.  We will live with #3470 being a known issue for now.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Related to: https://github.com/Project-OSRM/osrm-backend/issues/3470
