### PR TITLE
remove exit tag from arrive step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.5.2
+  - Changes from 5.5.1
+    - Bugfixes
+      - Fix #3475 removed an invalid `exit` field from the `arrive` maneuver
+
 # 5.5.1
   - Changes from 5.5.0
     - API:

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -259,6 +259,8 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
     BOOST_ASSERT(steps.back().intersections.front().lanes.first_lane_from_the_right ==
                  INVALID_LANEID);
     BOOST_ASSERT(steps.back().intersections.front().lane_description.empty());
+    // depart and arrive need to be trivial
+    BOOST_ASSERT(steps.front().maneuver.exit == 0 && steps.back().maneuver.exit == 0);
     return steps;
 }
 

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -29,6 +29,7 @@ inline void print(const engine::guidance::RouteStep &step)
               << " "
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
+              << " Exit: " << step.maneuver.exit
               << "\n\tIntersections: " << step.intersections.size() << " [";
 
     for (const auto &intersection : step.intersections)

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -147,10 +147,9 @@ void fixFinalRoundabout(std::vector<RouteStep> &steps)
          --propagation_index)
     {
         auto &propagation_step = steps[propagation_index];
+        propagation_step.maneuver.exit = 0;
         if (entersRoundabout(propagation_step.maneuver.instruction))
         {
-            propagation_step.maneuver.exit = 0;
-
             // remember the current name as rotary name in tha case we end in a rotary
             if (propagation_step.maneuver.instruction.type == TurnType::EnterRotary ||
                 propagation_step.maneuver.instruction.type == TurnType::EnterRotaryAtExit)
@@ -158,12 +157,13 @@ void fixFinalRoundabout(std::vector<RouteStep> &steps)
                 propagation_step.rotary_name = propagation_step.name;
                 propagation_step.rotary_pronunciation = propagation_step.pronunciation;
             }
-
             else if (propagation_step.maneuver.instruction.type ==
                          TurnType::EnterRoundaboutIntersection ||
                      propagation_step.maneuver.instruction.type ==
                          TurnType::EnterRoundaboutIntersectionAtExit)
+            {
                 propagation_step.maneuver.instruction.type = TurnType::EnterRoundabout;
+            }
 
             return;
         }


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/3475. It turns out that the front-end tries to make more out of invalid data we give out than there is. The issue here was that when we end in a roundabout, we don't emit any exit number on the roundabout instruction itself.
Due to the internal counting, there was a left-over `exit` on the arrive step.

Cutting a test for this is kind of difficult, I'd propose simply to assert that `arrive`/`depart` are trivial (in this case don't sport an `exit` field) and notice it this way, if we introduce a regression.

## Tasklist
 ~~- [ ] add regression / cucumber cases (see docs/testing.md)~~
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
