### PR TITLE
Join LAYOUT and DATA shared memory blocks into REGION

### DIFF
--- a/include/storage/shared_barriers.hpp
+++ b/include/storage/shared_barriers.hpp
@@ -13,22 +13,22 @@ struct SharedBarriers
 {
 
     SharedBarriers()
-        : current_regions_mutex(boost::interprocess::open_or_create, "current_regions"),
-          regions_1_mutex(boost::interprocess::open_or_create, "regions_1"),
-          regions_2_mutex(boost::interprocess::open_or_create, "regions_2")
+        : current_region_mutex(boost::interprocess::open_or_create, "current_region"),
+          region_1_mutex(boost::interprocess::open_or_create, "region_1"),
+          region_2_mutex(boost::interprocess::open_or_create, "region_2")
     {
     }
 
-    static void resetCurrentRegions()
+    static void resetCurrentRegion()
     {
-        boost::interprocess::named_sharable_mutex::remove("current_regions");
+        boost::interprocess::named_sharable_mutex::remove("current_region");
     }
-    static void resetRegions1() { boost::interprocess::named_sharable_mutex::remove("regions_1"); }
-    static void resetRegions2() { boost::interprocess::named_sharable_mutex::remove("regions_2"); }
+    static void resetRegion1() { boost::interprocess::named_sharable_mutex::remove("region_1"); }
+    static void resetRegion2() { boost::interprocess::named_sharable_mutex::remove("region_2"); }
 
-    boost::interprocess::named_upgradable_mutex current_regions_mutex;
-    boost::interprocess::named_sharable_mutex regions_1_mutex;
-    boost::interprocess::named_sharable_mutex regions_2_mutex;
+    boost::interprocess::named_upgradable_mutex current_region_mutex;
+    boost::interprocess::named_sharable_mutex region_1_mutex;
+    boost::interprocess::named_sharable_mutex region_2_mutex;
 };
 }
 }

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -192,19 +192,15 @@ struct DataLayout
 
 enum SharedDataType
 {
-    CURRENT_REGIONS,
-    LAYOUT_1,
-    DATA_1,
-    LAYOUT_2,
-    DATA_2,
-    LAYOUT_NONE,
-    DATA_NONE
+    CURRENT_REGION,
+    REGION_1,
+    REGION_2,
+    REGION_NONE
 };
 
 struct SharedDataTimestamp
 {
-    SharedDataType layout;
-    SharedDataType data;
+    SharedDataType region;
     unsigned timestamp;
 };
 
@@ -212,20 +208,14 @@ inline std::string regionToString(const SharedDataType region)
 {
     switch (region)
     {
-    case CURRENT_REGIONS:
-        return "CURRENT_REGIONS";
-    case LAYOUT_1:
-        return "LAYOUT_1";
-    case DATA_1:
-        return "DATA_1";
-    case LAYOUT_2:
-        return "LAYOUT_2";
-    case DATA_2:
-        return "DATA_2";
-    case LAYOUT_NONE:
-        return "LAYOUT_NONE";
-    case DATA_NONE:
-        return "DATA_NONE";
+    case CURRENT_REGION:
+        return "CURRENT_REGION";
+    case REGION_1:
+        return "REGION_1";
+    case REGION_2:
+        return "REGION_2";
+    case REGION_NONE:
+        return "REGION_NONE";
     default:
         return "INVALID_REGION";
     }

--- a/src/tools/springclean.cpp
+++ b/src/tools/springclean.cpp
@@ -19,20 +19,14 @@ void deleteRegion(const SharedDataType region)
         const std::string name = [&] {
             switch (region)
             {
-            case CURRENT_REGIONS:
+            case CURRENT_REGION:
                 return "CURRENT_REGIONS";
-            case LAYOUT_1:
-                return "LAYOUT_1";
-            case DATA_1:
-                return "DATA_1";
-            case LAYOUT_2:
-                return "LAYOUT_2";
-            case DATA_2:
-                return "DATA_2";
-            case LAYOUT_NONE:
-                return "LAYOUT_NONE";
-            default: // DATA_NONE:
-                return "DATA_NONE";
+            case REGION_1:
+                return "REGION_1";
+            case REGION_2:
+                return "REGION_2";
+            default: // REGION_NONE:
+                return "REGION_NONE";
             }
         }();
 
@@ -44,11 +38,9 @@ void deleteRegion(const SharedDataType region)
 void springclean()
 {
     util::Log() << "spring-cleaning all shared memory regions";
-    deleteRegion(DATA_1);
-    deleteRegion(LAYOUT_1);
-    deleteRegion(DATA_2);
-    deleteRegion(LAYOUT_2);
-    deleteRegion(CURRENT_REGIONS);
+    deleteRegion(REGION_1);
+    deleteRegion(REGION_2);
+    deleteRegion(CURRENT_REGION);
 }
 }
 }

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -93,7 +93,7 @@ bool generateDataStoreOptions(const int argc,
 
 [[ noreturn ]] void CleanupSharedBarriers(int signum)
 { // Here the lock state of named mutexes is unknown, make a hard cleanup
-    osrm::storage::SharedBarriers::resetCurrentRegions();
+    osrm::storage::SharedBarriers::resetCurrentRegion();
     std::_Exit(128 + signum);
 }
 

--- a/src/tools/unlock_all_mutexes.cpp
+++ b/src/tools/unlock_all_mutexes.cpp
@@ -8,9 +8,9 @@ int main()
     osrm::util::LogPolicy::GetInstance().Unmute();
     osrm::util::Log() << "Releasing all locks";
 
-    osrm::storage::SharedBarriers::resetCurrentRegions();
-    osrm::storage::SharedBarriers::resetRegions1();
-    osrm::storage::SharedBarriers::resetRegions2();
+    osrm::storage::SharedBarriers::resetCurrentRegion();
+    osrm::storage::SharedBarriers::resetRegion1();
+    osrm::storage::SharedBarriers::resetRegion2();
 
     return 0;
 }


### PR DESCRIPTION
# Issue

PR for #3489
Joined LAYOUT and DATA regions and changed to REGION. Variables and enums are renamed to singular `region`. 

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Should reduce number of syscalls by factor 2 in #3485 
