### PR TITLE
Make DataWatchdog spawn its own thread and listen for updates

### DIFF
--- a/include/engine/datafacade/shared_memory_datafacade.hpp
+++ b/include/engine/datafacade/shared_memory_datafacade.hpp
@@ -37,7 +37,7 @@ class SharedMemoryDataFacade : public ContiguousInternalMemoryDataFacadeBase
     virtual ~SharedMemoryDataFacade() noexcept
     {
         // Now check if this is still the newest dataset
-        boost::interprocess::sharable_lock<boost::interprocess::named_upgradable_mutex>
+        boost::interprocess::scoped_lock<boost::interprocess::named_mutex>
             current_regions_lock(shared_barriers->current_region_mutex,
                                  boost::interprocess::defer_lock);
 

--- a/include/storage/shared_barriers.hpp
+++ b/include/storage/shared_barriers.hpp
@@ -2,6 +2,7 @@
 #define SHARED_BARRIERS_HPP
 
 #include <boost/interprocess/sync/named_sharable_mutex.hpp>
+#include <boost/interprocess/sync/named_condition.hpp>
 #include <boost/interprocess/sync/named_upgradable_mutex.hpp>
 
 namespace osrm
@@ -13,7 +14,8 @@ struct SharedBarriers
 {
 
     SharedBarriers()
-        : current_region_mutex(boost::interprocess::open_or_create, "current_region"),
+        : new_dataset_condition(boost::interprocess::open_or_create, "new_dataset_condition"),
+          current_region_mutex(boost::interprocess::open_or_create, "current_region"),
           region_1_mutex(boost::interprocess::open_or_create, "region_1"),
           region_2_mutex(boost::interprocess::open_or_create, "region_2")
     {
@@ -21,12 +23,13 @@ struct SharedBarriers
 
     static void resetCurrentRegion()
     {
-        boost::interprocess::named_sharable_mutex::remove("current_region");
+        boost::interprocess::named_mutex::remove("current_region");
     }
     static void resetRegion1() { boost::interprocess::named_sharable_mutex::remove("region_1"); }
     static void resetRegion2() { boost::interprocess::named_sharable_mutex::remove("region_2"); }
 
-    boost::interprocess::named_upgradable_mutex current_region_mutex;
+    boost::interprocess::named_condition new_dataset_condition;
+    boost::interprocess::named_mutex current_region_mutex;
     boost::interprocess::named_sharable_mutex region_1_mutex;
     boost::interprocess::named_sharable_mutex region_2_mutex;
 };


### PR DESCRIPTION
## Issue 

This makes DataWatchdog spawn its own thread that checks for data
updates. This addresses an issue where libOSRM instances would not
notice a data update and thus never dettach from shared memory regions.

## Tasklist
 - [ ] Investigate behavior when query segfaults
 - [ ] Use timed mutexes in osrm-datastore for aquiring exclusive locks
 - [ ] Review
 - [ ] Adjust for comments

## Requirements / Relations

This is an alternative to #3485
