### PR TITLE
Fix copying vector on std::sort comparator

### DIFF
--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -370,7 +370,7 @@ Status TilePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacad
     // as the sort condition
     std::sort(sorted_edge_indexes.begin(),
               sorted_edge_indexes.end(),
-              [edges](const std::size_t &left, const std::size_t &right) -> bool {
+              [&edges](const std::size_t &left, const std::size_t &right) -> bool {
                   return (edges[left].u != edges[right].u) ? edges[left].u < edges[right].u
                                                            : edges[left].v < edges[right].v;
               });


### PR DESCRIPTION
# Issue

This PR is targeting following issue: https://github.com/Project-OSRM/osrm-backend/issues/3503
It seems that large std::vector is copied for each std::sort comparator call. Fix the issue by capturing the vector by reference.

Here's log from `osrm-routed` daemon, after applying the patch

```
[info] 30-12-2016 02:13:40 14.5274ms 10.86.14.154 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 200
/tile/v1/car/tile(13968,6346,14).mvt
[info] 30-12-2016 02:13:40 42.9931ms 10.86.14.154 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 200
/tile/v1/car/tile(13969,6346,14).mvt
[info] 30-12-2016 02:13:40 40.6375ms 10.86.14.154 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 200
/tile/v1/car/tile(13970,6346,14).mvt
[info] 30-12-2016 02:13:41 18.0215ms 10.86.14.154 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 200
/tile/v1/car/tile(13971,6347,14).mvt
[info] 30-12-2016 02:13:41 39.6929ms 10.86.14.154 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 200
/tile/v1/car/tile(13971,6346,14).mvt
[info] 30-12-2016 02:13:41 22.3632ms 10.86.14.154 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 200
/tile/v1/car/tile(13971,6348,14).mvt
```