### PR TITLE
Removes Profile Symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
       - Fix #3475 removed an invalid `exit` field from the `arrive` maneuver
     - Guidance
       - No longer emitting turns on ferries, if a ferry should use multiple docking locations
+    - Profiles
+      - Removed the `./profile.lua -> ./profiles/car.lua` symlink. Use specific profiles from the `profiles` directory.
 
 # 5.5.1
   - Changes from 5.5.0

--- a/profile.lua
+++ b/profile.lua
@@ -1,1 +1,0 @@
-profiles/car.lua


### PR DESCRIPTION
Removes the `./profiles.lua` symlink from the root dir.