### PR TITLE
Mason clang format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
    - CASHER_TIME_OUT=599 # one second less than 10m to avoid 10m timeout error: https://github.com/Project-OSRM/osrm-backend/issues/2742
    - CCACHE_VERSION=3.3.1
    - CMAKE_VERSION=3.6.2
+   - MASON="$(pwd)/third_party/mason/mason"
 
 matrix:
   fast_finish: true
@@ -49,7 +50,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['libstdc++-5-dev', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: CLANG_VERSION='3.8.1' BUILD_TYPE='Debug' RUN_CLANG_FORMAT=ON BUILD_COMPONENTS=ON CUCUMBER_TIMEOUT=60000
+      env: CLANG_VERSION='3.8.1' BUILD_TYPE='Debug' BUILD_COMPONENTS=ON CUCUMBER_TIMEOUT=60000
 
     - os: osx
       osx_image: xcode8.2
@@ -64,7 +65,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['libstdc++-5-dev']
-      env: CLANG_VERSION='3.8.1' BUILD_TYPE='Release' ENABLE_MASON=ON
+      env: CLANG_VERSION='3.8.1' BUILD_TYPE='Release' ENABLE_MASON=ON RUN_CLANG_FORMAT=ON
 
     - os: linux
       compiler: "gcc-6-release"
@@ -122,6 +123,10 @@ before_install:
       export JOBS=$((`nproc` + 1))
     fi
   - |
+    if [ -n "${RUN_CLANG_FORMAT}" ]; then
+      ${MASON} install clang-format 3.8.0 && PATH=$(${MASON} prefix clang-format 3.8.0)/bin:${PATH} ./scripts/format.sh
+    fi
+  - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       export JOBS=$((`sysctl -n hw.ncpu` + 1))
       sudo mdutil -i off /
@@ -130,22 +135,18 @@ before_install:
   - source ./scripts/install_node.sh 4
   - npm install -g "npm@>=3" # Upgrade to npm >v2 to reduce size of downloaded dependencies
   - npm install
-  - ./third_party/mason/mason install ccache ${CCACHE_VERSION}
-  - export PATH=$(./third_party/mason/mason prefix ccache ${CCACHE_VERSION})/bin:${PATH}
-  - ./third_party/mason/mason install cmake ${CMAKE_VERSION}
-  - export PATH=$(./third_party/mason/mason prefix cmake ${CMAKE_VERSION})/bin:${PATH}
+  - ${MASON} install ccache ${CCACHE_VERSION} && export PATH=$(${MASON} prefix ccache ${CCACHE_VERSION})/bin:${PATH}
+  - ${MASON} install cmake ${CMAKE_VERSION} && export PATH=$(${MASON} prefix cmake ${CMAKE_VERSION})/bin:${PATH}
   - |
     if [[ ! -z ${CLANG_VERSION} ]]; then
       export CCOMPILER='clang'
       export CXXCOMPILER='clang++'
-      ./third_party/mason/mason install clang++ ${CLANG_VERSION}
-      export PATH=$(./third_party/mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
+      ${MASON} install clang++ ${CLANG_VERSION} && export PATH=$(${MASON} prefix clang++ ${CLANG_VERSION})/bin:${PATH}
       # we only enable lto for release builds
       # and therefore don't need to us ld.gold or llvm tools for linking
       # for debug builds
       if [[ ${BUILD_TYPE} == 'Release' ]]; then
-        ./third_party/mason/mason install binutils 2.27
-        export PATH=$(./third_party/mason/mason prefix binutils 2.27)/bin:${PATH}
+        ${MASON} install binutils 2.27 && export PATH=$(${MASON} prefix binutils 2.27)/bin:${PATH}
       fi
     fi
   - ccache --max-size=256M  # limiting the cache's size to roughly the previous job's object sizes
@@ -195,10 +196,6 @@ script:
   - npm test
 
 after_success:
-  - |
-    if [ -n "${RUN_CLANG_FORMAT}" ]; then
-      ./scripts/format.sh # we don't want to fail just yet
-    fi
   - |
     if [ -n "${ENABLE_COVERAGE}" ]; then
       bash <(curl -s https://codecov.io/bash)

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -52,7 +52,6 @@ class DataWatchdog
         const auto shared_timestamp =
             static_cast<const storage::SharedDataTimestamp *>(shared_regions->Ptr());
 
-
         const auto get_locked_facade = [this, shared_timestamp](
             const std::shared_ptr<datafacade::SharedMemoryDataFacade> &facade) {
             if (current_timestamp.region == storage::REGION_1)
@@ -117,10 +116,8 @@ class DataWatchdog
             current_timestamp = *shared_timestamp;
         }
 
-        auto new_facade =
-            std::make_shared<datafacade::SharedMemoryDataFacade>(shared_barriers,
-                                                                 current_timestamp.region,
-                                                                 current_timestamp.timestamp);
+        auto new_facade = std::make_shared<datafacade::SharedMemoryDataFacade>(
+            shared_barriers, current_timestamp.region, current_timestamp.timestamp);
         cached_facade = new_facade;
 
         return get_locked_facade(new_facade);

--- a/include/engine/datafacade/shared_memory_datafacade.hpp
+++ b/include/engine/datafacade/shared_memory_datafacade.hpp
@@ -72,7 +72,8 @@ class SharedMemoryDataFacade : public ContiguousInternalMemoryDataFacadeBase
     SharedMemoryDataFacade(const std::shared_ptr<storage::SharedBarriers> &shared_barriers_,
                            storage::SharedDataType data_region_,
                            unsigned shared_timestamp_)
-        : shared_barriers(shared_barriers_), data_region(data_region_), shared_timestamp(shared_timestamp_)
+        : shared_barriers(shared_barriers_), data_region(data_region_),
+          shared_timestamp(shared_timestamp_)
     {
         util::Log(logDEBUG) << "Loading new data with shared timestamp " << shared_timestamp;
 
@@ -80,7 +81,8 @@ class SharedMemoryDataFacade : public ContiguousInternalMemoryDataFacadeBase
         m_large_memory = storage::makeSharedMemory(data_region);
 
         InitializeInternalPointers(*reinterpret_cast<storage::DataLayout *>(m_large_memory->Ptr()),
-                                   reinterpret_cast<char *>(m_large_memory->Ptr()) + sizeof(storage::DataLayout));
+                                   reinterpret_cast<char *>(m_large_memory->Ptr()) +
+                                       sizeof(storage::DataLayout));
     }
 };
 }

--- a/include/extractor/guidance/intersection.hpp
+++ b/include/extractor/guidance/intersection.hpp
@@ -14,9 +14,9 @@
 
 #include "extractor/guidance/turn_instruction.hpp"
 
-#include <boost/range/algorithm/min_element.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/count_if.hpp>
+#include <boost/range/algorithm/find_if.hpp>
+#include <boost/range/algorithm/min_element.hpp>
 
 namespace osrm
 {
@@ -133,8 +133,7 @@ template <typename Self> struct EnableShapeOps
     // search a given eid in the intersection
     auto FindEid(const EdgeID eid) const
     {
-        return boost::range::find_if(
-            *self(), [eid](const auto &road) { return road.eid == eid; });
+        return boost::range::find_if(*self(), [eid](const auto &road) { return road.eid == eid; });
     }
 
     // find the maximum value based on a conversion operator
@@ -247,8 +246,8 @@ template <typename Self> struct EnableIntersectionOps
     auto findClosestTurn(const double angle, const UnaryPredicate filter) const
     {
         BOOST_ASSERT(!self()->empty());
-        const auto candidate = boost::range::min_element(
-            *self(), [angle, &filter](const auto &lhs, const auto &rhs) {
+        const auto candidate =
+            boost::range::min_element(*self(), [angle, &filter](const auto &lhs, const auto &rhs) {
                 const auto filtered_lhs = filter(lhs), filtered_rhs = filter(rhs);
                 const auto deviation_lhs = util::angularDeviation(lhs.angle, angle),
                            deviation_rhs = util::angularDeviation(rhs.angle, angle);

--- a/include/extractor/guidance/mergable_road_detector.hpp
+++ b/include/extractor/guidance/mergable_road_detector.hpp
@@ -13,10 +13,10 @@
 namespace osrm
 {
 
-//FWD declarations
+// FWD declarations
 namespace util
 {
-    class NameTable;
+class NameTable;
 } // namespace util
 
 namespace extractor
@@ -29,7 +29,6 @@ namespace guidance
 {
 class IntersectionGenerator;
 class CoordinateExtractor;
-
 
 class MergableRoadDetector
 {

--- a/src/extractor/guidance/mergable_road_detector.cpp
+++ b/src/extractor/guidance/mergable_road_detector.cpp
@@ -312,7 +312,7 @@ bool MergableRoadDetector::HaveSameDirection(const NodeID intersection_node,
      */
     const auto prune = [](auto &data_vector) {
         BOOST_ASSERT(data_vector.size() >= 3);
-        //erase the first third of the vector
+        // erase the first third of the vector
         data_vector.erase(data_vector.begin(), data_vector.begin() + data_vector.size() / 3);
     };
 

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -4,8 +4,8 @@
 #include "util/coordinate_calculation.hpp"
 #include "util/guidance/name_announcements.hpp"
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <limits>
 

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -1,5 +1,5 @@
-#include "extractor/guidance/constants.hpp"
 #include "extractor/guidance/turn_handler.hpp"
+#include "extractor/guidance/constants.hpp"
 
 #include "util/bearing.hpp"
 #include "util/guidance/name_announcements.hpp"

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -308,12 +308,12 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
     context.has_segment_function = segment_function.valid();
     auto maybe_version = context.state.get<sol::optional<int>>("api_version");
     if (maybe_version)
-     {
-         context.api_version = *maybe_version;
-     }
+    {
+        context.api_version = *maybe_version;
+    }
 
     if (context.api_version < SUPPORTED_MIN_API_VERSION ||
-        context.api_version > SUPPORTED_MAX_API_VERSION )
+        context.api_version > SUPPORTED_MAX_API_VERSION)
     {
         throw util::exception("Invalid profile API version " + std::to_string(context.api_version) +
                               " only versions from " + std::to_string(SUPPORTED_MIN_API_VERSION) +

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -73,10 +73,8 @@ RegionsLayout getRegionsLayout(SharedBarriers &barriers)
             static_cast<const SharedDataTimestamp *>(shared_region->Ptr());
         if (shared_timestamp->region == REGION_1)
         {
-            return RegionsLayout{REGION_1,
-                                 barriers.region_1_mutex,
-                                 REGION_2,
-                                 barriers.region_2_mutex};
+            return RegionsLayout{
+                REGION_1, barriers.region_1_mutex, REGION_2, barriers.region_2_mutex};
         }
 
         BOOST_ASSERT(shared_timestamp->region == REGION_2);

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -179,7 +179,7 @@ catch (const std::bad_alloc &e)
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
-catch (const std::exception& e)
+catch (const std::exception &e)
 {
     std::cerr << "[exception] " << e.what();
     return EXIT_FAILURE;

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -167,7 +167,7 @@ catch (const std::bad_alloc &e)
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
-catch (const std::exception& e)
+catch (const std::exception &e)
 {
     std::cerr << "[exception] " << e.what();
     return EXIT_FAILURE;

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -373,7 +373,7 @@ catch (const std::bad_alloc &e)
     util::Log(logWARNING) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
-catch (const std::exception& e)
+catch (const std::exception &e)
 {
     std::cerr << "[exception] " << e.what();
     return EXIT_FAILURE;

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -91,7 +91,7 @@ bool generateDataStoreOptions(const int argc,
     return true;
 }
 
-[[ noreturn ]] void CleanupSharedBarriers(int signum)
+[[noreturn]] void CleanupSharedBarriers(int signum)
 { // Here the lock state of named mutexes is unknown, make a hard cleanup
     osrm::storage::SharedBarriers::resetCurrentRegion();
     std::_Exit(128 + signum);


### PR DESCRIPTION
# Issue

Resolves #3512: added `./scripts/format.sh` to `mason-linux-release` job. The script call is moved from `after_success` section where exit code is ignored to `before_install` to fail earlier. Also the mason script path is parametrized in MASON envar.

## Tasklist
 - [x] install clang-tidy via mason (https://github.com/mapbox/mason/tree/master/scripts/clang-format)
 - [x] make sure the Clang build on Travis detects it and runs it (fails the build). Example of a failing job https://travis-ci.org/oxidase/osrm-backend/jobs/188654943
 - [x] format the code base once and then have the check enabled for all prs
 - [x] review
 - [x] adjust for comments
