### PR TITLE
Consider number of lanes to cross, resolves #3025.

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -783,3 +783,38 @@ Feature: Turn Lane Guidance
             | waypoints | route                                  | turns                                                  | lanes                                                                                                                                                               |
             | a,f       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,turn right,arrive | ,left:false left:true none:false none:false,left:false left:true none:false none:false,left:false left:true none:false none:false,left:false left:false right:true, |
             | a,g       | start,first,second,third,fourth,fourth | depart,turn left,turn left,turn left,turn left,arrive  | ,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true none:false none:false,left:true left:true right:false,     |
+
+    @anticipate
+    Scenario: Complex lane scenarios scale threshold for triggering Lane Anticipation
+        Given the node map
+            """
+            a – b – x
+                |
+                |
+                |
+                |
+                |
+                |
+                |
+                |
+                |
+                |
+                c
+                |
+            e – d – y
+            """
+        # With a grid size of 20m the duration is ~20s but our default threshold for Lane Anticipation is 15s.
+        # The additional lanes left and right of the turn scale the threshold up so that Lane Anticipation still triggers.
+
+        And the ways
+            | nodes | turn:lanes:forward             | name |
+            | ab    | through\|through\|right\|right | MySt |
+            | bx    |                                | XSt  |
+            | bc    |                                | MySt |
+            | cd    | left\|right                    | MySt |
+            | de    |                                | MySt |
+            | dy    |                                | YSt  |
+
+       When I route I should get
+            | waypoints | route               | turns                                   | lanes                                                                        |
+            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,turn right,arrive | ,straight:false straight:false right:false right:true,left:false right:true, |


### PR DESCRIPTION
For #3025.

Lane Anticipation currently triggers on quick steps with lanes. This
changeset makes the "quick" part more dynamic by taking lanes left and
right of the turn into account. The reasoning for this is as follows.

The user can drive on the leftmost or rightmost lane and has to cross
all lanes left or right of the turn, respecitvely.

We scale our threshold appropriately, which now means the threshold
describes the duration the user needs for crossing _a single lane_.

Note: this is a heuristic and assumes the worst case. Which in my
opinion is fine to do since triggering Lane Anticipation in complex
scenarios is desirable.

## Tasklist
 - [x] review
 - [x] adjust for comments