### PR TITLE
Guards against no lanes for lanes left and right of turn, resolves #3518

### DIFF
--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -145,6 +145,16 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                     path_point.lane_data.second != INVALID_LANE_DESCRIPTIONID
                         ? facade.GetTurnDescription(path_point.lane_data.second)
                         : extractor::guidance::TurnLaneDescription();
+
+                // Lanes in turn are bound by total number of lanes at the location
+                BOOST_ASSERT(intersection.lanes.lanes_in_turn <=
+                             intersection.lane_description.size());
+                // No lanes at location and no turn lane or lanes at location and lanes in turn
+                BOOST_ASSERT((intersection.lane_description.empty() &&
+                              intersection.lanes.lanes_in_turn == 0) ||
+                             (!intersection.lane_description.empty() &&
+                              intersection.lanes.lanes_in_turn != 0));
+
                 std::copy(bearing_data.begin(),
                           bearing_data.end(),
                           std::back_inserter(intersection.bearings));

--- a/include/util/guidance/turn_lanes.hpp
+++ b/include/util/guidance/turn_lanes.hpp
@@ -69,7 +69,7 @@ class LaneTuple
     bool operator!=(const LaneTuple other) const;
 
     LaneID lanes_in_turn;
-    LaneID first_lane_from_the_right;
+    LaneID first_lane_from_the_right; // is INVALID_LANEID when no lanes present
 
     friend std::size_t hash_value(const LaneTuple &tup)
     {


### PR DESCRIPTION
For #3518.

In case the total lane count is zero we subtract the invalid lane id marker, wrap around and return garbage values. Instead we should return zero for lanes left / right of turn.

## Tasklist
 - [x] review
 - [x] adjust for comments