### PR TITLE
Removed unused structure and fixed "multi-line comment" warning

### DIFF
--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -340,7 +340,7 @@ double findTotalTurnAngle(const RouteStep &entry_step, const RouteStep &exit_ste
         // both angles are in the same direction, the total turn gets increased
         //
         // a ---- b
-        //           \
+        //           \ 
         //              c
         //              |
         //              d

--- a/src/extractor/guidance/turn_classification.cpp
+++ b/src/extractor/guidance/turn_classification.cpp
@@ -11,19 +11,6 @@ namespace extractor
 namespace guidance
 {
 
-struct TurnPossibility
-{
-    TurnPossibility(bool entry_allowed, double bearing)
-        : entry_allowed(entry_allowed), bearing(std::move(bearing))
-    {
-    }
-
-    TurnPossibility() : entry_allowed(false), bearing(0) {}
-
-    bool entry_allowed;
-    double bearing;
-};
-
 std::pair<util::guidance::EntryClass, util::guidance::BearingClass>
 classifyIntersection(Intersection intersection)
 {


### PR DESCRIPTION
# Issue

Removed unused `TurnPossibility` and added NO-BREAK SPACE that is a whitespace that is not removed as a trailing whitespace by clang format. Unlocks `-Werror` option.


## Tasklist
 - [x] review
 - [x] adjust for comments
