### PR TITLE
Disables link-time optimization unless -DENABLE_LTO=ON is passed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
       - No longer emitting turns on ferries, if a ferry should use multiple docking locations
     - Profiles
       - Removed the `./profile.lua -> ./profiles/car.lua` symlink. Use specific profiles from the `profiles` directory.
+    - Infrastructure
+      - Disabled link-time optimized (LTO) builds by default. Enable by passing `-DENABLE_LTO=ON` to `cmake` if you need the performance and know what you are doing.
 
 # 5.5.1
   - Changes from 5.5.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(BUILD_COMPONENTS "Build osrm-components" OFF)
 option(ENABLE_ASSERTIONS "Use assertions in release mode" OFF)
 option(ENABLE_COVERAGE "Build with coverage instrumentalisation" OFF)
 option(ENABLE_SANITIZER "Use memory sanitizer for Debug build" OFF)
-option(ENABLE_LTO "Use LTO if available" ON)
+option(ENABLE_LTO "Use LTO if available" OFF)
 option(ENABLE_FUZZING "Fuzz testing using LLVM's libFuzzer" OFF)
 option(ENABLE_GOLD_LINKER "Use GNU gold linker if available" ON)
 


### PR DESCRIPTION
This disables the `-flto` LTO flag by default since we're seeing
segfaults in compiler lto plugins, binutils and linker errors again and
again for various clang / gcc / binutils combinations.

You can pass `-DNEBALE_LTO` to `cmake` in order to re-enable LTO.

LTO situation in short:
- LTO does not work at all for gcc<4.9
- With gcc>=4.9 the "slim" LTO format is getting used dumping IR
- Older binutils need LTO plugins which know how to read this IR
- Recent binutils handle this format all by themselves
- LLVM is more or less the same with some Clang versions segfaulting

If you need the performance benefit of LTO, make sure your compiler and
binutils are up to date and see for yourself if LTO builds work for you.

References:
- https://gcc.gnu.org/wiki/LinkTimeOptimizationFAQ
- https://github.com/Project-OSRM/osrm-backend/pull/3481#issuecomment-270618997
- https://github.com/Project-OSRM/osrm-backend/issues/3501
- https://github.com/Project-OSRM/osrm-backend/issues/3441

(and a ton of other LTO tickets if you search for them)
