### PR TITLE
Add own update thread and removed query mutexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
       - Removed the `./profile.lua -> ./profiles/car.lua` symlink. Use specific profiles from the `profiles` directory.
     - Infrastructure
       - Disabled link-time optimized (LTO) builds by default. Enable by passing `-DENABLE_LTO=ON` to `cmake` if you need the performance and know what you are doing.
-    - File handling
       - Datafile versioning is now based on OSRM semver values, rather than source code checksums.
         Datafiles are compatible between patch levels, but incompatible between minor version or higher bumps.
+      - libOSRM now creates an own watcher thread then used in shared memory mode to listen for data updates
 
 # 5.5.1
   - Changes from 5.5.0

--- a/features/lib/osrm_loader.js
+++ b/features/lib/osrm_loader.js
@@ -99,7 +99,6 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
             if (err) return callback(err);
             if (!this.osrmIsRunning()) this.launch(callback);
             else {
-                // some osrm-routed output prior this line can appear in the prevoius log file
                 this.scope.setupOutputLog(this.child, fs.createWriteStream(this.scope.scenarioLogFile, {'flags': 'a'}));
                 callback();
             }
@@ -109,10 +108,7 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
     loadData (callback) {
         this.scope.runBin('osrm-datastore', this.inputFile, this.scope.environment, (err) => {
             if (err) return callback(new Error('*** osrm-datastore exited with ' + err.code + ': ' + err));
-            // in case of false positive results with a dummy 1ms delay an stdout monitor
-            // this.child.stdout.on('data', facade_monitor) must be added and wait for
-            // "updated facade to region" in stdout
-            setTimeout(callback, 1);
+            callback();
         });
     }
 

--- a/features/lib/osrm_loader.js
+++ b/features/lib/osrm_loader.js
@@ -36,9 +36,8 @@ class OSRMBaseLoader{
 
     osrmDown (callback) {
         if (this.osrmIsRunning()) {
-            this.child.on('exit', (code, signal) => {callback();});
-            this.child.down = true;
-            this.child.kill();
+            this.child.on('exit', (code, signal) => { callback();});
+            this.child.kill('SIGINT');
         } else callback();
     }
 
@@ -79,7 +78,7 @@ class OSRMDirectLoader extends OSRMBaseLoader {
         if (this.osrmIsRunning()) return callback(new Error("osrm-routed already running!"));
 
         this.child = this.scope.runBin('osrm-routed', util.format("%s -p %d", this.inputFile, this.scope.OSRM_PORT), this.scope.environment, (err) => {
-          if (err && !this.child.down) {
+          if (err && err.signal !== 'SIGINT') {
               throw new Error(util.format('osrm-routed %s: %s', errorReason(err), err.cmd));
           }
         });
@@ -116,7 +115,7 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
         if (this.osrmIsRunning()) return callback();
 
         this.child = this.scope.runBin('osrm-routed', util.format('--shared-memory=1 -p %d', this.scope.OSRM_PORT), this.scope.environment, (err) => {
-            if (err && !this.child.down) {
+            if (err && err.signal !== 'SIGINT') {
                 throw new Error(util.format('osrm-routed %s: %s', errorReason(err), err.cmd));
             }
         });

--- a/features/lib/osrm_loader.js
+++ b/features/lib/osrm_loader.js
@@ -99,6 +99,7 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
             if (err) return callback(err);
             if (!this.osrmIsRunning()) this.launch(callback);
             else {
+                // some osrm-routed output prior this line can appear in the prevoius log file
                 this.scope.setupOutputLog(this.child, fs.createWriteStream(this.scope.scenarioLogFile, {'flags': 'a'}));
                 callback();
             }
@@ -108,7 +109,10 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
     loadData (callback) {
         this.scope.runBin('osrm-datastore', this.inputFile, this.scope.environment, (err) => {
             if (err) return callback(new Error('*** osrm-datastore exited with ' + err.code + ': ' + err));
-            callback();
+            // in case of false positive results with a dummy 1ms delay an stdout monitor
+            // this.child.stdout.on('data', facade_monitor) must be added and wait for
+            // "updated facade to region" in stdout
+            setTimeout(callback, 1);
         });
     }
 

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -27,10 +27,11 @@ module.exports = function () {
             return callback(new Error('*** '+stxxl_config+ 'does not exist'));
         }
 
+        this.PLATFORM_WINDOWS = process.platform.match(/^win.*/);
         this.DEFAULT_ENVIRONMENT = Object.assign({STXXLCFG: stxxl_config}, process.env);
         this.DEFAULT_PROFILE = 'bicycle';
         this.DEFAULT_INPUT_FORMAT = 'osm';
-        this.DEFAULT_LOAD_METHOD = 'datastore';
+        this.DEFAULT_LOAD_METHOD = this.PLATFORM_WINDOWS ? 'directly' : 'datastore';
         this.DEFAULT_ORIGIN = [1,1];
         this.OSM_USER = 'osrm';
         this.OSM_GENERATOR = 'osrm-test';
@@ -42,7 +43,7 @@ module.exports = function () {
         this.OSRM_PORT = process.env.OSRM_PORT && parseInt(process.env.OSRM_PORT) || 5000;
         this.HOST = 'http://127.0.0.1:' + this.OSRM_PORT;
 
-        if (process.platform.match(/^win.*/)) {
+        if (this.PLATFORM_WINDOWS) {
             this.TERMSIGNAL = 9;
             this.EXE = '.exe';
         } else {

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -13,6 +13,7 @@
 #include <boost/thread/shared_mutex.hpp>
 
 #include <memory>
+#include <thread>
 
 namespace osrm
 {
@@ -26,10 +27,17 @@ class DataWatchdog
 {
   public:
     DataWatchdog()
-        : shared_barriers{std::make_shared<storage::SharedBarriers>()},
-          shared_regions(storage::makeSharedMemory(storage::CURRENT_REGION)),
-          current_timestamp{storage::REGION_NONE, 0}
+        : active(true)
+        , timestamp(0)
     {
+        watcher = std::thread(&DataWatchdog::Run, this);
+    }
+
+    ~DataWatchdog()
+    {
+        active = false;
+        barrier.region_condition.notify_all();
+        watcher.join();
     }
 
     // Tries to connect to the shared memory containing the regions table
@@ -38,102 +46,44 @@ class DataWatchdog
         return storage::SharedMemory::RegionExists(storage::CURRENT_REGION);
     }
 
-    using RegionsLock =
-        boost::interprocess::sharable_lock<boost::interprocess::named_sharable_mutex>;
-    using LockAndFacade = std::pair<RegionsLock, std::shared_ptr<datafacade::BaseDataFacade>>;
-
-    // This will either update the contens of facade or just leave it as is
-    // if the update was already done by another thread
-    LockAndFacade GetDataFacade()
+    auto GetDataFacade() const
     {
-        const boost::interprocess::sharable_lock<boost::interprocess::named_upgradable_mutex> lock(
-            shared_barriers->current_region_mutex);
-
-        const auto shared_timestamp =
-            static_cast<const storage::SharedDataTimestamp *>(shared_regions->Ptr());
-
-        const auto get_locked_facade = [this, shared_timestamp](
-            const std::shared_ptr<datafacade::SharedMemoryDataFacade> &facade) {
-            if (current_timestamp.region == storage::REGION_1)
-            {
-                return std::make_pair(RegionsLock(shared_barriers->region_1_mutex), facade);
-            }
-            else
-            {
-                BOOST_ASSERT(current_timestamp.region == storage::REGION_2);
-                return std::make_pair(RegionsLock(shared_barriers->region_2_mutex), facade);
-            }
-        };
-
-        // this blocks handle the common case when there is no data update -> we will only need a
-        // shared lock
-        {
-            boost::shared_lock<boost::shared_mutex> facade_lock(facade_mutex);
-
-            if (shared_timestamp->timestamp == current_timestamp.timestamp)
-            {
-                if (auto facade = cached_facade.lock())
-                {
-                    BOOST_ASSERT(shared_timestamp->region == current_timestamp.region);
-                    return get_locked_facade(facade);
-                }
-            }
-        }
-
-        // if we reach this code there is a data update to be made. multiple
-        // requests can reach this, but only ever one goes through at a time.
-        boost::upgrade_lock<boost::shared_mutex> facade_lock(facade_mutex);
-
-        // we might get overtaken before we actually do the writing
-        // in that case we don't modify anything
-        if (shared_timestamp->timestamp == current_timestamp.timestamp)
-        {
-            if (auto facade = cached_facade.lock())
-            {
-                BOOST_ASSERT(shared_timestamp->region == current_timestamp.region);
-                return get_locked_facade(facade);
-            }
-        }
-
-        // this thread has won and can update the data
-        boost::upgrade_to_unique_lock<boost::upgrade_mutex> unique_facade_lock(facade_lock);
-
-        // if two threads try to enter this critical section one will loose
-        // and will find an up-to-date instance of the shared data facade
-        if (shared_timestamp->timestamp == current_timestamp.timestamp)
-        {
-            // if the thread that updated the facade finishes the query before
-            // we can aquire our handle here, we need to regenerate
-            if (auto facade = cached_facade.lock())
-            {
-                BOOST_ASSERT(shared_timestamp->region == current_timestamp.region);
-
-                return get_locked_facade(facade);
-            }
-        }
-        else
-        {
-            current_timestamp = *shared_timestamp;
-        }
-
-        auto new_facade = std::make_shared<datafacade::SharedMemoryDataFacade>(
-            shared_barriers, current_timestamp.region, current_timestamp.timestamp);
-        cached_facade = new_facade;
-
-        return get_locked_facade(new_facade);
+        return facade;
     }
 
   private:
-    // mutexes should be mutable even on const objects: This enables
-    // marking functions as logical const and thread-safe.
-    std::shared_ptr<storage::SharedBarriers> shared_barriers;
 
-    // shared memory table containing pointers to all shared regions
-    std::unique_ptr<storage::SharedMemory> shared_regions;
+    void Run()
+    {
+        boost::interprocess::scoped_lock<boost::interprocess::named_mutex>
+            current_region_lock(barrier.region_mutex);
 
-    mutable boost::shared_mutex facade_mutex;
-    std::weak_ptr<datafacade::SharedMemoryDataFacade> cached_facade;
-    storage::SharedDataTimestamp current_timestamp;
+        auto shared_memory = makeSharedMemory(storage::CURRENT_REGION);
+        auto current = static_cast<storage::SharedDataTimestamp *>(shared_memory->Ptr());
+
+        while (active)
+        {
+            if (timestamp != current->timestamp)
+            {
+                util::Log() << "updating facade to region " << storage::regionToString(current->region)
+                            << " with timestamp " << current->timestamp;
+                facade = std::make_shared<datafacade::SharedMemoryDataFacade>(current->region);
+                timestamp = current->timestamp;
+            }
+
+            barrier.region_condition.wait(current_region_lock);
+        }
+
+        facade.reset();
+
+        util::Log() << "DataWatchdog thread stopped";
+    }
+
+    storage::SharedBarriers barrier;
+    std::thread watcher;
+    bool active;
+    unsigned timestamp;
+    std::shared_ptr<datafacade::SharedMemoryDataFacade> facade;
 };
 }
 }

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -65,10 +65,10 @@ class DataWatchdog
         {
             if (timestamp != current->timestamp)
             {
-                util::Log() << "updating facade to region " << storage::regionToString(current->region)
-                            << " with timestamp " << current->timestamp;
                 facade = std::make_shared<datafacade::SharedMemoryDataFacade>(current->region);
                 timestamp = current->timestamp;
+                util::Log() << "updated facade to region " << storage::regionToString(current->region)
+                            << " with timestamp " << current->timestamp;
             }
 
             barrier.region_condition.wait(current_region_lock);

--- a/include/engine/datafacade/shared_memory_datafacade.hpp
+++ b/include/engine/datafacade/shared_memory_datafacade.hpp
@@ -30,9 +30,7 @@ class SharedMemoryDataFacade : public ContiguousInternalMemoryDataFacadeBase
     SharedMemoryDataFacade() {}
 
   public:
-
-    SharedMemoryDataFacade(storage::SharedDataType data_region)
-        : data_region(data_region)
+    SharedMemoryDataFacade(storage::SharedDataType data_region) : data_region(data_region)
     {
         util::Log(logDEBUG) << "Loading new data for region " << regionToString(data_region);
 

--- a/include/engine/datafacade/shared_memory_datafacade.hpp
+++ b/include/engine/datafacade/shared_memory_datafacade.hpp
@@ -25,57 +25,16 @@ class SharedMemoryDataFacade : public ContiguousInternalMemoryDataFacadeBase
 
   protected:
     std::unique_ptr<storage::SharedMemory> m_large_memory;
-    std::shared_ptr<storage::SharedBarriers> shared_barriers;
     storage::SharedDataType data_region;
-    unsigned shared_timestamp;
 
     SharedMemoryDataFacade() {}
 
   public:
-    // this function handle the deallocation of the shared memory it we can prove it will not be
-    // used anymore.  We crash hard here if something goes wrong (noexcept).
-    virtual ~SharedMemoryDataFacade() noexcept
+
+    SharedMemoryDataFacade(storage::SharedDataType data_region)
+        : data_region(data_region)
     {
-        // Now check if this is still the newest dataset
-        boost::interprocess::sharable_lock<boost::interprocess::named_upgradable_mutex>
-            current_regions_lock(shared_barriers->current_region_mutex,
-                                 boost::interprocess::defer_lock);
-
-        boost::interprocess::scoped_lock<boost::interprocess::named_sharable_mutex> exclusive_lock(
-            data_region == storage::REGION_1 ? shared_barriers->region_1_mutex
-                                             : shared_barriers->region_2_mutex,
-            boost::interprocess::defer_lock);
-
-        // if this returns false this is still in use
-        if (current_regions_lock.try_lock() && exclusive_lock.try_lock())
-        {
-            if (storage::SharedMemory::RegionExists(data_region))
-            {
-                auto shared_region = storage::makeSharedMemory(storage::CURRENT_REGION);
-                const auto current_timestamp =
-                    static_cast<const storage::SharedDataTimestamp *>(shared_region->Ptr());
-
-                // check if the memory region referenced by this facade needs cleanup
-                if (current_timestamp->region == data_region)
-                {
-                    util::Log(logDEBUG) << "Retaining data with shared timestamp "
-                                        << shared_timestamp;
-                }
-                else
-                {
-                    storage::SharedMemory::Remove(data_region);
-                }
-            }
-        }
-    }
-
-    SharedMemoryDataFacade(const std::shared_ptr<storage::SharedBarriers> &shared_barriers_,
-                           storage::SharedDataType data_region_,
-                           unsigned shared_timestamp_)
-        : shared_barriers(shared_barriers_), data_region(data_region_),
-          shared_timestamp(shared_timestamp_)
-    {
-        util::Log(logDEBUG) << "Loading new data with shared timestamp " << shared_timestamp;
+        util::Log(logDEBUG) << "Loading new data for region " << regionToString(data_region);
 
         BOOST_ASSERT(storage::SharedMemory::RegionExists(data_region));
         m_large_memory = storage::makeSharedMemory(data_region);

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -50,7 +50,7 @@ class Engine final
     Status Tile(const api::TileParameters &parameters, std::string &result) const;
 
   private:
-    std::unique_ptr<storage::SharedBarriers> lock;
+    //std::unique_ptr<storage::SharedBarriers> lock;
     std::unique_ptr<DataWatchdog> watchdog;
 
     const plugins::ViaRoutePlugin route_plugin;

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -1,7 +1,6 @@
 #ifndef ENGINE_HPP
 #define ENGINE_HPP
 
-#include "storage/shared_barriers.hpp"
 #include "engine/api/match_parameters.hpp"
 #include "engine/api/nearest_parameters.hpp"
 #include "engine/api/route_parameters.hpp"
@@ -23,7 +22,6 @@
 #include "util/json_container.hpp"
 
 #include <memory>
-#include <mutex>
 #include <string>
 
 namespace osrm
@@ -50,7 +48,6 @@ class Engine final
     Status Tile(const api::TileParameters &parameters, std::string &result) const;
 
   private:
-    //std::unique_ptr<storage::SharedBarriers> lock;
     std::unique_ptr<DataWatchdog> watchdog;
 
     const plugins::ViaRoutePlugin route_plugin;

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -59,7 +59,7 @@ class Engine final
 
     // note in case of shared memory this will be empty, since the watchdog
     // will provide us with the up-to-date facade
-    std::shared_ptr<datafacade::BaseDataFacade> immutable_data_facade;
+    std::shared_ptr<const datafacade::BaseDataFacade> immutable_data_facade;
 };
 }
 }

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -33,7 +33,7 @@ class MatchPlugin : public BasePlugin
     {
     }
 
-    Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+    Status HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const api::MatchParameters &parameters,
                          util::json::Object &json_result) const;
 

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -17,7 +17,7 @@ class NearestPlugin final : public BasePlugin
   public:
     explicit NearestPlugin(const int max_results);
 
-    Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+    Status HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const api::NearestParameters &params,
                          util::json::Object &result) const;
 

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -20,7 +20,7 @@ class TablePlugin final : public BasePlugin
   public:
     explicit TablePlugin(const int max_locations_distance_table);
 
-    Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+    Status HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const api::TableParameters &params,
                          util::json::Object &result) const;
 

--- a/include/engine/plugins/tile.hpp
+++ b/include/engine/plugins/tile.hpp
@@ -26,7 +26,7 @@ namespace plugins
 class TilePlugin final : public BasePlugin
 {
   public:
-    Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+    Status HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const api::TileParameters &parameters,
                          std::string &pbf_buffer) const;
 };

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -44,7 +44,7 @@ class TripPlugin final : public BasePlugin
     {
     }
 
-    Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+    Status HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const api::TripParameters &parameters,
                          util::json::Object &json_result) const;
 };

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -38,7 +38,7 @@ class ViaRoutePlugin final : public BasePlugin
   public:
     explicit ViaRoutePlugin(int max_locations_viaroute);
 
-    Status HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+    Status HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const api::RouteParameters &route_parameters,
                          util::json::Object &json_result) const;
 };

--- a/include/storage/shared_barriers.hpp
+++ b/include/storage/shared_barriers.hpp
@@ -1,8 +1,8 @@
 #ifndef SHARED_BARRIERS_HPP
 #define SHARED_BARRIERS_HPP
 
-#include <boost/interprocess/sync/named_sharable_mutex.hpp>
-#include <boost/interprocess/sync/named_upgradable_mutex.hpp>
+#include <boost/interprocess/sync/named_condition.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
 
 namespace osrm
 {
@@ -13,22 +13,19 @@ struct SharedBarriers
 {
 
     SharedBarriers()
-        : current_region_mutex(boost::interprocess::open_or_create, "current_region"),
-          region_1_mutex(boost::interprocess::open_or_create, "region_1"),
-          region_2_mutex(boost::interprocess::open_or_create, "region_2")
+        : region_mutex(boost::interprocess::open_or_create, "osrm-region")
+        , region_condition(boost::interprocess::open_or_create, "osrm-region-cv")
     {
     }
 
-    static void resetCurrentRegion()
+    static void remove()
     {
-        boost::interprocess::named_sharable_mutex::remove("current_region");
+        boost::interprocess::named_mutex::remove("osrm-region");
+        boost::interprocess::named_condition::remove("osrm-region-cv");
     }
-    static void resetRegion1() { boost::interprocess::named_sharable_mutex::remove("region_1"); }
-    static void resetRegion2() { boost::interprocess::named_sharable_mutex::remove("region_2"); }
 
-    boost::interprocess::named_upgradable_mutex current_region_mutex;
-    boost::interprocess::named_sharable_mutex region_1_mutex;
-    boost::interprocess::named_sharable_mutex region_2_mutex;
+    boost::interprocess::named_mutex region_mutex;
+    boost::interprocess::named_condition region_condition;
 };
 }
 }

--- a/include/storage/shared_barriers.hpp
+++ b/include/storage/shared_barriers.hpp
@@ -4,6 +4,8 @@
 #include <boost/interprocess/sync/named_condition.hpp>
 #include <boost/interprocess/sync/named_mutex.hpp>
 
+#include "util/retry_lock.hpp"
+
 namespace osrm
 {
 namespace storage
@@ -13,8 +15,8 @@ struct SharedBarriers
 {
 
     SharedBarriers()
-        : region_mutex(boost::interprocess::open_or_create, "osrm-region")
-        , region_condition(boost::interprocess::open_or_create, "osrm-region-cv")
+        : region_mutex(boost::interprocess::open_or_create, "osrm-region"),
+          region_condition(boost::interprocess::open_or_create, "osrm-region-cv")
     {
     }
 
@@ -22,6 +24,11 @@ struct SharedBarriers
     {
         boost::interprocess::named_mutex::remove("osrm-region");
         boost::interprocess::named_condition::remove("osrm-region-cv");
+    }
+
+    static RetryLock getLockWithRetry(int timeout_seconds)
+    {
+        return RetryLock(timeout_seconds, "osrm-region");
     }
 
     boost::interprocess::named_mutex region_mutex;

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -19,7 +19,6 @@
 #include <sys/shm.h>
 #endif
 
-// #include <cstring>
 #include <cstdint>
 
 #include <algorithm>
@@ -150,25 +149,23 @@ class SharedMemory
 
     SharedMemory(const boost::filesystem::path &lock_file,
                  const int id,
-                 const uint64_t size = 0,
-                 bool read_write = false)
+                 const uint64_t size = 0)
     {
         sprintf(key, "%s.%d", "osrm.lock", id);
-        auto access = read_write ? boost::interprocess::read_write : boost::interprocess::read_only;
         if (0 == size)
         { // read_only
             shm = boost::interprocess::shared_memory_object(
                 boost::interprocess::open_only,
                 key,
-                read_write ? boost::interprocess::read_write : boost::interprocess::read_only);
-            region = boost::interprocess::mapped_region(shm, access);
+                boost::interprocess::read_only);
+            region = boost::interprocess::mapped_region(shm, boost::interprocess::read_only);
         }
         else
         { // writeable pointer
             shm = boost::interprocess::shared_memory_object(
                 boost::interprocess::open_or_create, key, boost::interprocess::read_write);
             shm.truncate(size);
-            region = boost::interprocess::mapped_region(shm, access);
+            region = boost::interprocess::mapped_region(shm, boost::interprocess::read_write);
 
             util::Log(logDEBUG) << "writeable memory allocated " << size << " bytes";
         }

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -52,12 +52,9 @@ class SharedMemory
     template <typename IdentifierT>
     SharedMemory(const boost::filesystem::path &lock_file,
                  const IdentifierT id,
-                 const uint64_t size = 0,
-                 bool read_write = false)
+                 const uint64_t size = 0)
         : key(lock_file.string().c_str(), id)
     {
-        const auto access =
-            read_write ? boost::interprocess::read_write : boost::interprocess::read_only;
         // open only
         if (0 == size)
         {
@@ -65,7 +62,7 @@ class SharedMemory
 
             util::Log(logDEBUG) << "opening " << shm.get_shmid() << " from id " << id;
 
-            region = boost::interprocess::mapped_region(shm, access);
+            region = boost::interprocess::mapped_region(shm, boost::interprocess::read_only);
         }
         // open or create
         else
@@ -83,7 +80,7 @@ class SharedMemory
                 }
             }
 #endif
-            region = boost::interprocess::mapped_region(shm, access);
+            region = boost::interprocess::mapped_region(shm, boost::interprocess::read_write);
         }
     }
 
@@ -232,7 +229,7 @@ class SharedMemory
 
 template <typename IdentifierT, typename LockFileT = OSRMLockFile>
 std::unique_ptr<SharedMemory>
-makeSharedMemory(const IdentifierT &id, const uint64_t size = 0, bool read_write = false)
+makeSharedMemory(const IdentifierT &id, const uint64_t size = 0)
 {
     try
     {
@@ -248,7 +245,7 @@ makeSharedMemory(const IdentifierT &id, const uint64_t size = 0, bool read_write
                 boost::filesystem::ofstream ofs(lock_file());
             }
         }
-        return std::make_unique<SharedMemory>(lock_file(), id, size, read_write);
+        return std::make_unique<SharedMemory>(lock_file(), id, size);
     }
     catch (const boost::interprocess::interprocess_exception &e)
     {

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -205,6 +205,13 @@ class SharedMemory
         return Remove(k);
     }
 
+    void WaitForDetach()
+    {
+        // FIXME this needs an implementation for Windows
+        util::Log(logWARNING)
+            << "Shared memory support for Windows does not wait for clients to dettach.";
+    }
+
   private:
     static void build_key(int id, char *key) { sprintf(key, "%s.%d", "osrm.lock", id); }
 

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -111,10 +111,35 @@ class SharedMemory
     {
         auto shmid = shm.get_shmid();
         ::shmid_ds xsi_ds;
+        const auto errorToMessage = [](int error) -> std::string {
+            switch (error)
+            {
+            case EPERM:
+                return "EPERM";
+                break;
+            case EACCES:
+                return "ACCESS";
+                break;
+            case EINVAL:
+                return "EINVAL";
+                break;
+            case EFAULT:
+                return "EFAULT";
+                break;
+            default:
+                return "Unknown Error " + std::to_string(error);
+                break;
+            }
+        };
+
         do
         {
             int ret = ::shmctl(shmid, IPC_STAT, &xsi_ds);
-            (void)ret; // no unused warning
+            if (ret < 0)
+            {
+                throw util::exception("shmctl encountered an error: " + errorToMessage(ret) +
+                                      SOURCE_REF);
+            }
             BOOST_ASSERT(ret >= 0);
 
             std::this_thread::sleep_for(std::chrono::microseconds(100));

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -208,8 +208,9 @@ class SharedMemory
     void WaitForDetach()
     {
         // FIXME this needs an implementation for Windows
-        util::Log(logWARNING)
-            << "Shared memory support for Windows does not wait for clients to dettach.";
+        util::Log(logWARNING) << "Shared memory support for Windows does not wait for clients to "
+                                 "dettach. Going to sleep for 50ms.";
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
   private:

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "storage/shared_datatype.hpp"
 #include "storage/storage_config.hpp"
 
+#include <boost/interprocess/sync/named_mutex.hpp>
 #include <boost/filesystem/path.hpp>
 
 #include <string>
@@ -44,20 +45,14 @@ class Storage
   public:
     Storage(StorageConfig config);
 
-    enum ReturnCode
-    {
-        Ok,
-        Error,
-        Retry
-    };
-
-    ReturnCode Run(int max_wait);
+    int Run();
 
     void PopulateLayout(DataLayout &layout);
     void PopulateData(const DataLayout &layout, char *memory_ptr);
 
   private:
     StorageConfig config;
+    boost::interprocess::named_mutex datastore_mutex;
 };
 }
 }

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "storage/shared_datatype.hpp"
 #include "storage/storage_config.hpp"
 
-#include <boost/interprocess/sync/named_mutex.hpp>
 #include <boost/filesystem/path.hpp>
 
 #include <string>
@@ -45,14 +44,13 @@ class Storage
   public:
     Storage(StorageConfig config);
 
-    int Run();
+    int Run(int max_wait);
 
     void PopulateLayout(DataLayout &layout);
     void PopulateData(const DataLayout &layout, char *memory_ptr);
 
   private:
     StorageConfig config;
-    boost::interprocess::named_mutex datastore_mutex;
 };
 }
 }

--- a/include/util/retry_lock.hpp
+++ b/include/util/retry_lock.hpp
@@ -1,0 +1,49 @@
+#ifndef OSRM_RETRY_TIMED_LOCK_HPP
+#define OSRM_RETRY_TIMED_LOCK_HPP
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/interprocess/exceptions.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+class RetryLock
+{
+  public:
+    RetryLock(int timeout_seconds, const char *name)
+        : timeout_seconds(timeout_seconds), name(name),
+          mutex(std::make_unique<boost::interprocess::named_mutex>(
+              boost::interprocess::open_or_create, name)),
+          internal_lock(*mutex, boost::interprocess::defer_lock)
+    {
+    }
+
+    bool TryLock()
+    {
+        if (timeout_seconds >= 0)
+        {
+            return internal_lock.timed_lock(boost::posix_time::microsec_clock::universal_time() +
+                                            boost::posix_time::seconds(timeout_seconds));
+        }
+        else
+        {
+            internal_lock.lock();
+            return true;
+        }
+    }
+
+    void ForceLock()
+    {
+        mutex.reset();
+        boost::interprocess::named_mutex::remove(name);
+        mutex = std::make_unique<boost::interprocess::named_mutex>(
+            boost::interprocess::open_or_create, name);
+    }
+
+  private:
+    int timeout_seconds;
+    const char *name;
+    std::unique_ptr<boost::interprocess::named_mutex> mutex;
+    boost::interprocess::scoped_lock<boost::interprocess::named_mutex> internal_lock;
+};
+
+#endif

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -27,7 +27,7 @@ elif type clang-format 2> /dev/null ; then
     V=$(clang-format --version)
     if [[ $V != *3.8* ]] ; then
         echo "clang-format is not 3.8 (returned ${V})"
-        exit 1
+        #exit 1
     fi
 else
     echo "No appropriate clang-format found (expected clang-format-3.8, or clang-format)"

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -27,22 +27,22 @@ namespace
 template <typename ParameterT, typename PluginT, typename ResultT>
 osrm::engine::Status
 RunQuery(const std::unique_ptr<osrm::engine::DataWatchdog> &watchdog,
-         const std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &facade,
+         const std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &immutable_facade,
          const ParameterT &parameters,
          PluginT &plugin,
          ResultT &result)
 {
     if (watchdog)
     {
-        BOOST_ASSERT(!facade);
+        BOOST_ASSERT(!immutable_facade);
         auto facade = watchdog->GetDataFacade();
 
         return plugin.HandleRequest(facade, parameters, result);
     }
 
-    BOOST_ASSERT(facade);
+    BOOST_ASSERT(immutable_facade);
 
-    return plugin.HandleRequest(facade, parameters, result);
+    return plugin.HandleRequest(immutable_facade, parameters, result);
 }
 
 } // anon. ns

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -35,9 +35,9 @@ RunQuery(const std::unique_ptr<osrm::engine::DataWatchdog> &watchdog,
     if (watchdog)
     {
         BOOST_ASSERT(!facade);
-        auto lock_and_facade = watchdog->GetDataFacade();
+        auto facade = watchdog->GetDataFacade();
 
-        return plugin.HandleRequest(lock_and_facade.second, parameters, result);
+        return plugin.HandleRequest(facade, parameters, result);
     }
 
     BOOST_ASSERT(facade);
@@ -53,9 +53,7 @@ namespace engine
 {
 
 Engine::Engine(const EngineConfig &config)
-    : lock(config.use_shared_memory ? std::make_unique<storage::SharedBarriers>()
-                                    : std::unique_ptr<storage::SharedBarriers>()),
-      route_plugin(config.max_locations_viaroute),       //
+    : route_plugin(config.max_locations_viaroute),       //
       table_plugin(config.max_locations_distance_table), //
       nearest_plugin(config.max_results_nearest),        //
       trip_plugin(config.max_locations_trip),            //

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -27,7 +27,7 @@ namespace
 template <typename ParameterT, typename PluginT, typename ResultT>
 osrm::engine::Status
 RunQuery(const std::unique_ptr<osrm::engine::DataWatchdog> &watchdog,
-         const std::shared_ptr<osrm::engine::datafacade::BaseDataFacade> &immutable_facade,
+         const std::shared_ptr<const osrm::engine::datafacade::BaseDataFacade> &immutable_facade,
          const ParameterT &parameters,
          PluginT &plugin,
          ResultT &result)
@@ -81,7 +81,7 @@ Engine::Engine(const EngineConfig &config)
             throw util::exception("Invalid file paths given!" + SOURCE_REF);
         }
         immutable_data_facade =
-            std::make_shared<datafacade::ProcessMemoryDataFacade>(config.storage_config);
+            std::make_shared<const datafacade::ProcessMemoryDataFacade>(config.storage_config);
     }
 }
 

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -108,7 +108,7 @@ void filterCandidates(const std::vector<util::Coordinate> &coordinates,
     }
 }
 
-Status MatchPlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+Status MatchPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                                   const api::MatchParameters &parameters,
                                   util::json::Object &json_result) const
 {

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -19,7 +19,7 @@ namespace plugins
 
 NearestPlugin::NearestPlugin(const int max_results_) : max_results{max_results_} {}
 
-Status NearestPlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+Status NearestPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                                     const api::NearestParameters &params,
                                     util::json::Object &json_result) const
 {

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -28,7 +28,7 @@ TablePlugin::TablePlugin(const int max_locations_distance_table)
 {
 }
 
-Status TablePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+Status TablePlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                                   const api::TableParameters &params,
                                   util::json::Object &result) const
 {

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -248,7 +248,7 @@ FixedPoint coordinatesToTilePoint(const util::Coordinate point, const BBox &tile
 
 } // namespace
 
-Status TilePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+Status TilePlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                                  const api::TileParameters &parameters,
                                  std::string &pbf_buffer) const
 {

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -141,7 +141,7 @@ InternalRouteResult TripPlugin::ComputeRoute(const datafacade::BaseDataFacade &f
     return min_route;
 }
 
-Status TripPlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                                  const api::TripParameters &parameters,
                                  util::json::Object &json_result) const
 {

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -27,7 +27,7 @@ ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute)
 {
 }
 
-Status ViaRoutePlugin::HandleRequest(const std::shared_ptr<datafacade::BaseDataFacade> facade,
+Status ViaRoutePlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                                      const api::RouteParameters &route_parameters,
                                      util::json::Object &json_result) const
 {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -100,6 +100,8 @@ int Storage::Run()
             storage::SharedMemory::Remove(next_region);
         }
 
+        util::Log() << "Loading data into " << regionToString(next_region) << " timestamp " << next_timestamp;
+
         // Populate a memory layout into stack memory
         DataLayout layout;
         PopulateLayout(layout);

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -175,14 +175,14 @@ Storage::ReturnCode Storage::Run(int max_wait)
     // Allocate shared memory block
     auto regions_size = sizeof(layout) + layout.GetSizeOfLayout();
     util::Log() << "allocating shared memory of " << regions_size << " bytes";
-    auto shared_memory = makeSharedMemory(data_region, regions_size, true);
+    auto shared_memory = makeSharedMemory(data_region, regions_size);
 
     // Copy memory layout to shared memory and populate data
     char *shared_memory_ptr = static_cast<char *>(shared_memory->Ptr());
     memcpy(shared_memory_ptr, &layout, sizeof(layout));
     PopulateData(layout, shared_memory_ptr + sizeof(layout));
 
-    auto data_type_memory = makeSharedMemory(CURRENT_REGION, sizeof(SharedDataTimestamp), true);
+    auto data_type_memory = makeSharedMemory(CURRENT_REGION, sizeof(SharedDataTimestamp));
     SharedDataTimestamp *data_timestamp_ptr =
         static_cast<SharedDataTimestamp *>(data_type_memory->Ptr());
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -66,7 +66,7 @@ int Storage::Run(int max_wait)
         boost::filesystem::ofstream ofs(lock_path);
     }
 
-    boost::interprocess::file_lock file_lock(lock_path.c_str());
+    boost::interprocess::file_lock file_lock(lock_path.string().c_str());
     boost::interprocess::scoped_lock<boost::interprocess::file_lock> datastore_lock(
         file_lock, boost::interprocess::defer_lock);
 

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -90,7 +90,6 @@ bool generateDataStoreOptions(const int argc,
     if (option_variables.count("remove-locks"))
     {
         osrm::storage::SharedBarriers::remove();
-        boost::interprocess::named_mutex::remove("osrm-datastore");
         return false;
     }
 

--- a/src/tools/unlock_all_mutexes.cpp
+++ b/src/tools/unlock_all_mutexes.cpp
@@ -8,9 +8,7 @@ int main()
     osrm::util::LogPolicy::GetInstance().Unmute();
     osrm::util::Log() << "Releasing all locks";
 
-    osrm::storage::SharedBarriers::resetCurrentRegion();
-    osrm::storage::SharedBarriers::resetRegion1();
-    osrm::storage::SharedBarriers::resetRegion2();
+    osrm::storage::SharedBarriers::remove();
 
     return 0;
 }

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -1,5 +1,5 @@
-#include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
+#include "util/coordinate.hpp"
 #include "util/trigonometry_table.hpp"
 #include "util/web_mercator.hpp"
 


### PR DESCRIPTION
# Issue

This makes DataWatchdog spawn its own thread that checks for data
updates. This addresses an issue where libOSRM instances would not
notice a data update and thus never dettach from shared memory regions.

Replaces #3497 by using the implementation from @oxidase and adjusting some functionality.

## Tasklist
 - [x] add changelog entry that we are now launching our own thread
 - [x] review
 - [x] adjust for comments

## Requirements / Relations

Replaces #3497 
