### PR TITLE
Matching alternatives count output

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -298,7 +298,7 @@ The area to search is chosen such that the correct candidate should be considere
   Each `Waypoint` object has the following additional properties:
   - `matchings_index`: Index to the `Route` object in `matchings` the sub-trace was matched to.
   - `waypoint_index`: Index of the waypoint inside the matched route.
-  - `alternatives_count`: number of routes leading to the destination from this trace point. 1 means there are no other routes reaching destination. Greater values mean that there are different routes available and different route can be selected if you provide more coordinates.
+  - `alternatives_count`: number of alternative routes leading to the destination from this trace point. 0 means there are no other routes reaching destination. Greater values mean that there are different routes available and different route can be selected if you provide more coordinates.
 - `matchings`: An array of `Route` objects that assemble the trace. Each `Route` object has the following additional properties:
   - `confidence`: Confidence of the matching. `float` value between 0 and 1. 1 is very confident that the matching is correct.
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -298,6 +298,7 @@ The area to search is chosen such that the correct candidate should be considere
   Each `Waypoint` object has the following additional properties:
   - `matchings_index`: Index to the `Route` object in `matchings` the sub-trace was matched to.
   - `waypoint_index`: Index of the waypoint inside the matched route.
+  - `alternatives_count`: number of routes leading to the destination from this trace point. 1 means there are no other routes reaching destination. Greater values mean that there are different routes available and different route can be selected if you provide more coordinates.
 - `matchings`: An array of `Route` objects that assemble the trace. Each `Route` object has the following additional properties:
   - `confidence`: Confidence of the matching. `float` value between 0 and 1. 1 is very confident that the matching is correct.
 

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -39,7 +39,8 @@ module.exports = function () {
                         duration = '',
                         annotation = '',
                         geometry = '',
-                        OSMIDs = '';
+                        OSMIDs = '',
+                        alternatives = '';
 
 
                     if (res.statusCode === 200) {
@@ -95,6 +96,10 @@ module.exports = function () {
                             if (json.matchings.length != 1) throw new Error('*** Checking geometry only supported for matchings with one subtrace');
                             geometry = json.matchings[0].geometry;
                         }
+
+                        if (headers.has('alternatives')) {
+                            alternatives = this.alternativesList(json);
+                        }
                     }
 
                     if (headers.has('turns')) {
@@ -137,6 +142,9 @@ module.exports = function () {
                         got['OSM IDs'] = OSMIDs;
                     }
 
+                    if (headers.has('alternatives')) {
+                        got['alternatives'] = alternatives;
+                    }
                     var ok = true;
                     var encodedResult = '',
                         extendedTarget = '';

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -180,6 +180,11 @@ module.exports = function () {
         return merged;
     };
 
+    this.alternativesList = (instructions) => {
+        // alternatives_count come from tracepoints list
+        return instructions.tracepoints.map(t => t.alternatives_count.toString()).join(',');
+    };
+
     this.lanesList = (instructions) => {
         return this.extractInstructionList(instructions, instruction => {
             if( 'lanes' in instruction.intersections[0] )

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -263,6 +263,22 @@ Feature: Basic Map Matching
             | trace | matchings | geometry                                |
             | abd   | abd       | 1,1,1,1.00009,1,1.00009,0.99991,1.00009 |
 
+    Scenario: Testbot - Matching alternatives count test
+        Given the node map
+            """
+            a b c d e f
+                  g h i
+            """
+
+        And the ways
+            | nodes  | oneway |
+            | abcdef | yes    |
+            | dghi   | yes    |
+
+        When I match I should get
+            | trace  | matchings | alternatives         |
+            | abcdef | abcde     | 1,1,1,1,2,2          |
+
     Scenario: Testbot - Speed greater than speed threshhold
         Given a grid size of 10 meters
         Given the query options

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -277,7 +277,7 @@ Feature: Basic Map Matching
 
         When I match I should get
             | trace  | matchings | alternatives         |
-            | abcdef | abcde     | 1,1,1,1,2,2          |
+            | abcdef | abcde     | 0,0,0,0,1,1          |
 
     Scenario: Testbot - Speed greater than speed threshhold
         Given a grid size of 10 meters

--- a/include/engine/api/match_api.hpp
+++ b/include/engine/api/match_api.hpp
@@ -101,6 +101,9 @@ class MatchAPI final : public RouteAPI
             auto waypoint = BaseAPI::MakeWaypoint(phantom);
             waypoint.values["matchings_index"] = matching_index.sub_matching_index;
             waypoint.values["waypoint_index"] = matching_index.point_index;
+            waypoint.values["alternatives_count"] =
+                sub_matchings[matching_index.sub_matching_index]
+                    .alternatives_count[matching_index.point_index];
             waypoints.values.push_back(std::move(waypoint));
         }
 

--- a/include/engine/map_matching/hidden_markov_model.hpp
+++ b/include/engine/map_matching/hidden_markov_model.hpp
@@ -51,6 +51,7 @@ struct TransitionLogProbability
 template <class CandidateLists> struct HiddenMarkovModel
 {
     std::vector<std::vector<double>> viterbi;
+    std::vector<std::vector<bool>> viterbi_reachable;
     std::vector<std::vector<std::pair<unsigned, unsigned>>> parents;
     std::vector<std::vector<float>> path_distances;
     std::vector<std::vector<bool>> pruned;
@@ -65,6 +66,7 @@ template <class CandidateLists> struct HiddenMarkovModel
           emission_log_probabilities(emission_log_probabilities)
     {
         viterbi.resize(candidates_list.size());
+        viterbi_reachable.resize(candidates_list.size());
         parents.resize(candidates_list.size());
         path_distances.resize(candidates_list.size());
         pruned.resize(candidates_list.size());
@@ -76,6 +78,7 @@ template <class CandidateLists> struct HiddenMarkovModel
             if (num_candidates > 0)
             {
                 viterbi[i].resize(num_candidates);
+                viterbi_reachable[i].resize(num_candidates);
                 parents[i].resize(num_candidates);
                 path_distances[i].resize(num_candidates);
                 pruned[i].resize(num_candidates);
@@ -93,6 +96,7 @@ template <class CandidateLists> struct HiddenMarkovModel
         for (const auto t : util::irange(initial_timestamp, viterbi.size()))
         {
             std::fill(viterbi[t].begin(), viterbi[t].end(), IMPOSSIBLE_LOG_PROB);
+            std::fill(viterbi_reachable[t].begin(), viterbi_reachable[t].end(), false);
             std::fill(parents[t].begin(), parents[t].end(), std::make_pair(0u, 0u));
             std::fill(path_distances[t].begin(), path_distances[t].end(), 0);
             std::fill(pruned[t].begin(), pruned[t].end(), true);

--- a/include/engine/map_matching/sub_matching.hpp
+++ b/include/engine/map_matching/sub_matching.hpp
@@ -16,6 +16,7 @@ struct SubMatching
 {
     std::vector<PhantomNode> nodes;
     std::vector<unsigned> indices;
+    std::vector<unsigned> alternatives_count;
     double confidence;
 };
 }

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -371,10 +371,13 @@ operator()(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
 
             matching.indices.push_back(timestamp_index);
             matching.nodes.push_back(candidates_list[timestamp_index][location_index].phantom_node);
-            matching.alternatives_count.push_back(
+            auto const routes_count =
                 std::accumulate(model.viterbi_reachable[timestamp_index].begin(),
                                 model.viterbi_reachable[timestamp_index].end(),
-                                0));
+                                0);
+            BOOST_ASSERT(routes_count > 0);
+            // we don't count the current route in the "alternatives_count" parameter
+            matching.alternatives_count.push_back(routes_count - 1);
             matching_distance += model.path_distances[timestamp_index][location_index];
         }
         util::for_each_pair(


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/3508

Possible way to determine degree of "finality" of the solution is how many ways that points to final HMM state lefts in the current layer. If there is only one candidate, that has link with final candidates set, than we can't change this candidate in future, even we obtain additional points after the last one. So we can save all matching results for points without alternatives and match only a part of the track when we obtain additional points. 

## Tasklist
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
