### PR TITLE
Logs the current thread's id in assertions and for requests, resolves #3534

### DIFF
--- a/src/server/request_handler.cpp
+++ b/src/server/request_handler.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <iterator>
 #include <string>
+#include <thread>
 
 namespace osrm
 {
@@ -46,13 +47,16 @@ void RequestHandler::HandleRequest(const http::request &current_request, http::r
         return;
     }
 
+    const auto tid = std::this_thread::get_id();
+
     // parse command
     try
     {
         TIMER_START(request_duration);
         std::string request_string;
         util::URIDecode(current_request.uri, request_string);
-        util::Log(logDEBUG) << "req: " << request_string;
+
+        util::Log(logDEBUG) << "[req][" << tid << "] " << request_string;
 
         auto api_iterator = request_string.begin();
         auto maybe_parsed_url = api::parseURL(api_iterator, request_string.end());
@@ -158,7 +162,7 @@ void RequestHandler::HandleRequest(const http::request &current_request, http::r
     catch (const std::exception &e)
     {
         current_reply = http::reply::stock_reply(http::reply::internal_server_error);
-        util::Log(logWARNING) << "[server error] code: " << e.what()
+        util::Log(logWARNING) << "[server error][" << tid << "] code: " << e.what()
                               << ", uri: " << current_request.uri;
     }
 }

--- a/src/util/assert.cpp
+++ b/src/util/assert.cpp
@@ -2,6 +2,7 @@
 
 #include <exception>
 #include <iostream>
+#include <thread>
 
 namespace
 {
@@ -9,7 +10,10 @@ namespace
 [[noreturn]] void assertion_failed_msg_helper(
     char const *expr, char const *msg, char const *function, char const *file, long line)
 {
-    std::cerr << "[assert] " << file << ":" << line << "\nin: " << function << ": " << expr << "\n"
+    const auto tid = std::this_thread::get_id();
+
+    std::cerr << "[assert][" << tid << "] " << file << ":" << line << "\nin: " << function << ": "
+              << expr << "\n"
               << msg;
     std::terminate();
 }


### PR DESCRIPTION
For #3534: prints tids for assertions and requests.
This lets us connect requests with assertions in a multi-threaded context.

Output will be

> [req][1267] get cheese
> [assert][1267] we're out of cheese


## Tasklist
 - [x] review
 - [x] adjust for comments