### PR TITLE
Provides OSRM_ASSERT_WITH_LOC macros for asserting with location, resolves #3533

### DIFF
--- a/include/util/assert.hpp
+++ b/include/util/assert.hpp
@@ -1,0 +1,45 @@
+#ifndef OSRM_UTIL_ASSERT_HPP
+#define OSRM_UTIL_ASSERT_HPP
+
+#include <iostream>
+#include <string>
+
+#include "util/coordinate.hpp"
+
+#include <boost/assert.hpp>
+
+// Enhances BOOST_ASSERT / BOOST_ASSERT_MSG with convenience location printing
+// - OSRM_ASSERT(cond, coordinate)
+// - OSRM_ASSERT_MSG(cond, coordinate, msg)
+
+#ifdef BOOST_ENABLE_ASSERT_HANDLER
+
+#define OSRM_ASSERT_MSG(cond, loc, msg)                                                            \
+    do                                                                                             \
+    {                                                                                              \
+        if (!static_cast<bool>(cond))                                                              \
+        {                                                                                          \
+            ::osrm::util::FloatCoordinate c_(loc);                                                 \
+            std::cerr << "[Location] "                                                             \
+                      << "http://www.openstreetmap.org/?mlat=" << c_.lat << "&mlon=" << c_.lon     \
+                      << "#map=19/" << c_.lat << "/" << c_.lon << '\n';                            \
+        }                                                                                          \
+        BOOST_ASSERT_MSG(cond, msg);                                                               \
+    } while (0)
+
+#define OSRM_ASSERT(cond, loc) OSRM_ASSERT_MSG(cond, loc, "")
+
+#else
+
+#define OSRM_ASSERT_MSG(cond, coordinate, msg)                                                     \
+    do                                                                                             \
+    {                                                                                              \
+        (void)cond;                                                                                \
+        (void)coordinate;                                                                          \
+        (void)msg;                                                                                 \
+    } while (0)
+#define OSRM_ASSERT(cond, coordinate) OSRM_ASSERT_MSG(cond, coordinate, "")
+
+#endif
+
+#endif


### PR DESCRIPTION
For #3533.

Assertions now log a clickable location url:

> [Location] http://www.openstreetmap.org/?mlat=52.5396&mlon=13.2954#map=19/52.5396/13.2954
> [assert] /tmp/osrm-backend/src/extractor/guidance/sliproad_handler.cpp:322 in: virtual osrm::extractor::guidance::Intersection osrm::extractor::guidance::SliproadHandler::operator()(NodeID, EdgeID, osrm::extractor::guidance::Intersection) const: false

## Tasklist
 - [x] review
 - [x] adjust for comments