### PR TITLE
sliproad roundabouts

### DIFF
--- a/features/guidance/dedicated-turn-roads.feature
+++ b/features/guidance/dedicated-turn-roads.feature
@@ -875,20 +875,20 @@ Feature: Slipways and Dedicated Turn Lanes
             | ab    | through | trunk      | yes    |            |                      |
             | bx    | through | trunk      | yes    |            |                      |
             | ac    | round   | primary    | yes    | roundabout |                      |
-			| cdy   | round   | primary    | yes    | roundabout |                      |
+            | cdy   | round   | primary    | yes    | roundabout |                      |
             | yb    | round   | primary    | yes    | roundabout |                      |
             | be    | round   | primary    | yes    | roundabout |                      |
             | ea    | round   | primary    | yes    | roundabout |                      |
             | et    | out     | primary    | yes    |            | the extraterrestrial |
             | sc    |         | trunk_link | yes    |            |                      |
-			| yx	| right   | trunk_link | yes    |			 |						|
+            | yx    | right   | trunk_link | yes    |            |                      |
 
-		And the relations
+        And the relations
             | type        | way:from | way:to | node:via | restriction   |
             | restriction | sa       | ab     | a        | only_straight |
             | restriction | ab       | bx     | b        | only_straight |
             | restriction | yb       | be     | b        | only_straight |
 
         When I route I should get
-            | waypoints | route | turns | locations |
-            | z,t       | through,out,out | depart,roundabout-exit-2,arrive | |
+            | waypoints | route            | turns                                            | locations |
+            | z,t       | through,,out,out | depart,off ramp slight right,round-exit-3,arrive | z,s,c,t   |

--- a/src/extractor/guidance/sliproad_handler.cpp
+++ b/src/extractor/guidance/sliproad_handler.cpp
@@ -271,7 +271,8 @@ operator()(const NodeID /*nid*/, const EdgeID source_edge_id, Intersection inter
             continue;
         }
 
-        // The turn off of the Sliproad has to be obvious and a narrow turn
+        // The turn off of the Sliproad has to be obvious and a narrow turn and must not be a
+        // roundabout
         {
             const auto index = findObviousTurn(sliproad_edge, target_intersection);
 
@@ -285,6 +286,13 @@ operator()(const NodeID /*nid*/, const EdgeID source_edge_id, Intersection inter
             const auto is_narrow_turn = angle_deviation <= 2 * NARROW_TURN_ANGLE;
 
             if (!is_narrow_turn)
+            {
+                continue;
+            }
+
+            const auto &onto_data = node_based_graph.GetEdgeData(onto.eid);
+
+            if (onto_data.roundabout)
             {
                 continue;
             }


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/3540.
Sliproads can be detected currently on roads entering roundabouts. This can lead to a combined failure in roundabout post-processing.

/cc @daniel-j-h 

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
