### PR TITLE
fix forks exiting a ferry, resolves #3536

### DIFF
--- a/features/guidance/collapse-ferry.feature
+++ b/features/guidance/collapse-ferry.feature
@@ -119,3 +119,25 @@ Feature: Collapse
         When I route I should get
             | waypoints | route                                   | turns                                                  |
             | g,e       | land-bottom,ferry,land-right,land-right | depart,notification straight,notification right,arrive |
+
+    @negative
+    Scenario: Don't Detect Suppressed/Obvious Forks on Ferries
+    Given the node map
+        """
+                           . . . . . . . . .d
+        a - b ~ ~ ~ ~ ~ c <
+                           ' ' ' ' ' ' ' ' 'e
+        """
+
+        And the ways
+            | nodes | highway | route | name          |
+            | ab    | primary |       | cursed-island |
+            | bc    |         | ferry | beagle        |
+            | cd    | service |       | forker        |
+            | ce    | primary |       | screw-me-not  |
+
+        #the turns here could be better, but intersection classification shows you if you go left or right. But we cannot fork here
+        When I route I should get
+            | waypoints | route                                          | turns                                             |
+            | a,d       | cursed-island,beagle,forker,forker             | depart,notification straight,turn straight,arrive |
+            | a,e       | cursed-island,beagle,screw-me-not,screw-me-not | depart,notification straight,turn straight,arrive |

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -29,7 +29,7 @@ inline void print(const engine::guidance::RouteStep &step)
               << " "
               << " Duration: " << step.duration << " Distance: " << step.distance
               << " Geometry: " << step.geometry_begin << " " << step.geometry_end
-              << " Exit: " << step.maneuver.exit
+              << " Exit: " << step.maneuver.exit << " Mode: " << (int)step.mode
               << "\n\tIntersections: " << step.intersections.size() << " [";
 
     for (const auto &intersection : step.intersections)

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -174,6 +174,14 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
         node_based_graph.GetEdgeData(left.eid).road_classification.IsLowPriorityRoadClass();
     const bool low_priority_right =
         node_based_graph.GetEdgeData(right.eid).road_classification.IsLowPriorityRoadClass();
+    const auto same_mode_left =
+        in_data.travel_mode == node_based_graph.GetEdgeData(left.eid).travel_mode;
+    const auto same_mode_right =
+        in_data.travel_mode == node_based_graph.GetEdgeData(right.eid).travel_mode;
+    const auto suppressed_left_type =
+        same_mode_left ? TurnType::Suppressed : TurnType::Notification;
+    const auto suppressed_right_type =
+        same_mode_right ? TurnType::Suppressed : TurnType::Notification;
     if ((angularDeviation(left.angle, STRAIGHT_ANGLE) < MAXIMAL_ALLOWED_NO_TURN_DEVIATION &&
          angularDeviation(right.angle, STRAIGHT_ANGLE) > FUZZY_ANGLE_DIFFERENCE))
     {
@@ -205,7 +213,7 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
         }
         else
         {
-            left.instruction = {TurnType::Suppressed, DirectionModifier::Straight};
+            left.instruction = {suppressed_left_type, DirectionModifier::Straight};
             right.instruction = {findBasicTurnType(via_edge, right),
                                  DirectionModifier::SlightRight};
         }
@@ -244,7 +252,7 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
             }
             else
             {
-                right.instruction = {TurnType::Suppressed, DirectionModifier::Straight};
+                right.instruction = {suppressed_right_type, DirectionModifier::Straight};
                 left.instruction = {findBasicTurnType(via_edge, left),
                                     DirectionModifier::SlightLeft};
             }
@@ -252,7 +260,7 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
     }
     // left side of fork
     if (low_priority_right && !low_priority_left)
-        left.instruction = {TurnType::Suppressed, DirectionModifier::SlightLeft};
+        left.instruction = {suppressed_left_type, DirectionModifier::SlightLeft};
     else
     {
         if (low_priority_left && !low_priority_right)
@@ -267,7 +275,7 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
 
     // right side of fork
     if (low_priority_left && !low_priority_right)
-        right.instruction = {TurnType::Suppressed, DirectionModifier::SlightLeft};
+        right.instruction = {suppressed_right_type, DirectionModifier::SlightLeft};
     else
     {
         if (low_priority_right && !low_priority_left)
@@ -287,6 +295,12 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
                                      ConnectedRoad &right) const
 {
     // TODO handle low priority road classes in a reasonable way
+    const auto suppressed_type = [&](const ConnectedRoad &road) {
+        const auto in_mode = node_based_graph.GetEdgeData(via_edge).travel_mode;
+        const auto out_mode = node_based_graph.GetEdgeData(road.eid).travel_mode;
+        return in_mode == out_mode ? TurnType::Suppressed : TurnType::Notification;
+    };
+
     if (left.entry_allowed && center.entry_allowed && right.entry_allowed)
     {
         left.instruction = {TurnType::Fork, DirectionModifier::SlightLeft};
@@ -300,7 +314,7 @@ void IntersectionHandler::assignFork(const EdgeID via_edge,
             }
             else
             {
-                center.instruction = {TurnType::Suppressed, DirectionModifier::Straight};
+                center.instruction = {suppressed_type(center), DirectionModifier::Straight};
             }
         }
         else

--- a/src/extractor/guidance/suppress_mode_handler.cpp
+++ b/src/extractor/guidance/suppress_mode_handler.cpp
@@ -39,7 +39,7 @@ bool SuppressModeHandler::canProcess(const NodeID,
     const auto in_mode = node_based_graph.GetEdgeData(via_eid).travel_mode;
     const auto suppress_in_mode = std::find(begin(suppressed), end(suppressed), in_mode);
 
-    const auto first = begin(intersection) + 1;
+    const auto first = begin(intersection);
     const auto last = end(intersection);
 
     const auto all_share_mode = std::all_of(first, last, [this, &in_mode](const auto &road) {

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -650,8 +650,14 @@ boost::optional<TurnHandler::Fork> TurnHandler::findFork(const EdgeID via_edge,
         const bool only_valid_entries =
             intersection.hasAllValidEntries(fork->right, fork->left + 1);
 
+        const auto has_compatible_modes =
+            std::all_of(fork->right, fork->left + 1, [&](const auto &road) {
+                return node_based_graph.GetEdgeData(road.eid).travel_mode ==
+                       node_based_graph.GetEdgeData(via_edge).travel_mode;
+            });
+
         if (separated_at_left_side && separated_at_right_side && !has_obvious &&
-            has_compatible_classes && only_valid_entries)
+            has_compatible_classes && only_valid_entries && has_compatible_modes)
         {
             return fork;
         }


### PR DESCRIPTION
# Issue

This PR introduces a problem introduced in our fork refactor (https://github.com/Project-OSRM/osrm-backend/pull/3264) /cc @chaupow 

<img width="481" alt="screen shot 2017-01-11 at 11 22 13" src="https://cloud.githubusercontent.com/assets/12932279/21844789/423eaefc-d7f0-11e6-8f93-32f52130d235.png">

The error occurs on this [node](http://www.openstreetmap.org/node/1587892816#map=18/54.50270/11.22937) where a ferry enters a fork.

I cannot pin-point the exact location in the code that is responsible for this change, but I think it might be related to road-classification comparisons.

I've fixed multiple locations in the code:
  - the fork detection does not trigger on invalid mode combinations anymore
  - in the fork handler, we don't assign a suppressed-turn if it should turn out one of the `fork` entries is obvious due to the road class (the fork handler is currently miss-used to give better instructions than `turn straight` for both turns).

Possible additional changes could be to incorporate the layer of the road, since we here see an intersection that technically is no intersection. I don't know how serious this problem is, though? Is this something worth ticketing? (Single Intersection with ferry, two roads, different layers of the ferry exiting).

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none
