### PR TITLE
fix coordinate assertion for walking profile with steps

### DIFF
--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -1340,3 +1340,34 @@ Feature: Simple Turns
         When I route I should get
             | waypoints | route |
             | a,d       | ab,ab |
+
+    Scenario: Sharp Turn Onto A Bridge
+        Given the node map
+            """
+              e
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+              |
+            g a - - -b
+              f    /
+              d -c
+            """
+
+        And the ways
+            | nodes | oneway | lanes |
+            | gaf   | yes    | 1     |
+            | abcde | yes    | 1     |
+
+        When I route I should get
+            | waypoints | route       |
+            | g,e       | abcde,abcde |

--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -422,12 +422,24 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
         }
     }
 
-    // We use the locations on the regression line to offset the regression line onto the
-    // intersection.
     const auto result =
         ExtractCoordinateAtLength(LOOKAHEAD_DISTANCE_WITHOUT_LANES, coordinates, segment_distances);
-    BOOST_ASSERT(not_same_as_start(result));
-    return result;
+    // there are cases that loop back to the original node (e.g. a tiny circle travelling on steps).
+    // To compensate for these, we check if we got back to the start and, if so, return the first
+    // valid result
+    if (not_same_as_start(result))
+    {
+        return result;
+    }
+    else
+    {
+        const auto result_itr =
+            std::find_if(coordinates.begin(), coordinates.end(), not_same_as_start);
+        if (result_itr != coordinates.end())
+            return *result_itr;
+        else
+            return result;
+    }
 }
 
 util::Coordinate


### PR DESCRIPTION
# Issue

Fixes the assertion mentioned in https://github.com/Project-OSRM/osrm-backend/issues/3547#issuecomment-271538502. It turns out that if brides circle around in just the right way, the guidance code will run into a situation that can trigger the mentioned assertion (needs to loop over the start in exactly 10 meters).

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none