### PR TITLE
Added missing backward_speed for cycleways

### DIFF
--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -369,10 +369,13 @@ function way_function (way, result)
   -- cycleways
   if cycleway and cycleway_tags[cycleway] then
     result.forward_speed = bicycle_speeds["cycleway"]
+    result.backward_speed = bicycle_speeds["cycleway"]
   elseif cycleway_left and cycleway_tags[cycleway_left] then
     result.forward_speed = bicycle_speeds["cycleway"]
+    result.backward_speed = bicycle_speeds["cycleway"]
   elseif cycleway_right and cycleway_tags[cycleway_right] then
     result.forward_speed = bicycle_speeds["cycleway"]
+    result.backward_speed = bicycle_speeds["cycleway"]
   end
 
   -- dismount


### PR DESCRIPTION
# Issue

PR #2399 contains a fix for cycleway `backward_speed` values, but it must be merged before to have proper commit history for bisecting.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
#2399
