### PR TITLE
Use internal logger instead of std stream

### DIFF
--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -179,8 +179,10 @@ catch (const std::bad_alloc &e)
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
+#ifdef _WIN32
 catch (const std::exception &e)
 {
-    std::cerr << "[exception] " << e.what();
+    util::Log(logERROR) << "[exception] " << e.what();
     return EXIT_FAILURE;
 }
+#endif

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -172,8 +172,10 @@ catch (const std::bad_alloc &e)
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
+#ifdef _WIN32
 catch (const std::exception &e)
 {
-    std::cerr << "[exception] " << e.what();
+    util::Log(logERROR) << "[exception] " << e.what() << std::endl;
     return EXIT_FAILURE;
 }
+#endif

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -350,8 +350,10 @@ catch (const std::bad_alloc &e)
     util::Log(logWARNING) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }
+#ifdef _WIN32
 catch (const std::exception &e)
 {
-    std::cerr << "[exception] " << e.what();
+    util::Log(logERROR) << "[exception] " << e.what();
     return EXIT_FAILURE;
 }
+#endif


### PR DESCRIPTION
# Issue

After f8499957fa1d5c696c0a91c78e4daefeae8427ea  incorrectly used std::cerr can lead to test fails that check output of stderr. The internal logger correctly adds EOL.

## Tasklist
 - [x] review
 - [x] adjust for comments
