### PR TITLE
Minor fixes

### DIFF
--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -47,7 +47,7 @@ class GraphContractor
                            bool shortcut,
                            bool forward,
                            bool backward)
-            : weight(weight), id(id), originalEdges(std::min((unsigned)1 << 28, original_edges)),
+            : weight(weight), id(id), originalEdges(std::min((1u << 28) - 1u, original_edges)),
               shortcut(shortcut), forward(forward), backward(backward),
               is_original_via_node_ID(false)
         {

--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -336,15 +336,15 @@ class GraphContractor
     void Run(double core_factor = 1.0)
     {
         // for the preperation we can use a big grain size, which is much faster (probably cache)
-        const constexpr size_t InitGrainSize = 100000;
-        const constexpr size_t PQGrainSize = 100000;
+        constexpr size_t InitGrainSize = 100000;
+        constexpr size_t PQGrainSize = 100000;
         // auto_partitioner will automatically increase the blocksize if we have
         // a lot of data. It is *important* for the last loop iterations
         // (which have a very small dataset) that it is devisible.
-        const constexpr size_t IndependentGrainSize = 1;
-        const constexpr size_t ContractGrainSize = 1;
-        const constexpr size_t NeighboursGrainSize = 1;
-        const constexpr size_t DeleteGrainSize = 1;
+        constexpr size_t IndependentGrainSize = 1;
+        constexpr size_t ContractGrainSize = 1;
+        constexpr size_t NeighboursGrainSize = 1;
+        constexpr size_t DeleteGrainSize = 1;
 
         const NodeID number_of_nodes = contractor_graph->GetNumberOfNodes();
 
@@ -770,11 +770,11 @@ class GraphContractor
         ContractorHeap &heap = data->heap;
         std::size_t inserted_edges_size = data->inserted_edges.size();
         std::vector<ContractorEdge> &inserted_edges = data->inserted_edges;
-        const constexpr bool SHORTCUT_ARC = true;
-        const constexpr bool FORWARD_DIRECTION_ENABLED = true;
-        const constexpr bool FORWARD_DIRECTION_DISABLED = false;
-        const constexpr bool REVERSE_DIRECTION_ENABLED = true;
-        const constexpr bool REVERSE_DIRECTION_DISABLED = false;
+        constexpr bool SHORTCUT_ARC = true;
+        constexpr bool FORWARD_DIRECTION_ENABLED = true;
+        constexpr bool FORWARD_DIRECTION_DISABLED = false;
+        constexpr bool REVERSE_DIRECTION_ENABLED = true;
+        constexpr bool REVERSE_DIRECTION_DISABLED = false;
 
         for (auto in_edge : contractor_graph->GetAdjacentEdgeRange(node))
         {
@@ -867,12 +867,12 @@ class GraphContractor
 
             if (RUNSIMULATION)
             {
-                const int constexpr SIMULATION_SEARCH_SPACE_SIZE = 1000;
+                constexpr int SIMULATION_SEARCH_SPACE_SIZE = 1000;
                 Dijkstra(max_weight, number_of_targets, SIMULATION_SEARCH_SPACE_SIZE, *data, node);
             }
             else
             {
-                const int constexpr FULL_SEARCH_SPACE_SIZE = 2000;
+                constexpr int FULL_SEARCH_SPACE_SIZE = 2000;
                 Dijkstra(max_weight, number_of_targets, FULL_SEARCH_SPACE_SIZE, *data, node);
             }
             for (auto out_edge : contractor_graph->GetAdjacentEdgeRange(node))

--- a/include/util/deallocating_vector.hpp
+++ b/include/util/deallocating_vector.hpp
@@ -356,8 +356,8 @@ class DeallocatingVector
 
     ElementT &back() const
     {
-        const std::size_t _bucket = current_size / ELEMENTS_PER_BLOCK;
-        const std::size_t _index = current_size % ELEMENTS_PER_BLOCK;
+        const std::size_t _bucket = (current_size - 1) / ELEMENTS_PER_BLOCK;
+        const std::size_t _index = (current_size - 1) % ELEMENTS_PER_BLOCK;
         return (bucket_list[_bucket][_index]);
     }
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -173,10 +173,11 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         // setup restriction parser
         const RestrictionParser restriction_parser(scripting_environment);
 
-        while (const osmium::memory::Buffer buffer = reader.read())
+        // create a vector of iterators into the buffer
+        for (std::vector<osmium::memory::Buffer::const_iterator> osm_elements;
+             const osmium::memory::Buffer buffer = reader.read();
+             osm_elements.clear())
         {
-            // create a vector of iterators into the buffer
-            std::vector<osmium::memory::Buffer::const_iterator> osm_elements;
             for (auto iter = std::begin(buffer), end = std::end(buffer); iter != end; ++iter)
             {
                 osm_elements.push_back(iter);

--- a/src/storage/storage_config.cpp
+++ b/src/storage/storage_config.cpp
@@ -32,7 +32,7 @@ bool StorageConfig::IsValid() const
                                                       core_data_path,
                                                       geometries_path,
                                                       timestamp_path,
-                                                      datasource_indexes_path,
+                                                      datasource_names_path,
                                                       datasource_indexes_path,
                                                       names_data_path,
                                                       properties_path,


### PR DESCRIPTION
I provide fixes for some minor issues, including a bug in DeallocatingVector::back, a possible integer overflow in GraphContractor::ContractorEdgeData, the adding of duplicate edges in GraphContractor::Run and a bug in StorageConfig::IsValid.
I also cleaned up some misleading if-statements and added a few comments, where I found the code unclear.