### PR TITLE
Refactor `struct Fork` in turn_handler

### DIFF
--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -49,10 +49,21 @@ class TurnHandler : public IntersectionHandler
   private:
     struct Fork
     {
-        const Intersection::iterator right;
-        const Intersection::iterator left;
+        const Intersection::iterator intersection_base;
+        const Intersection::iterator begin;
+        const Intersection::iterator end;
         const std::size_t size;
-        Fork(const Intersection::iterator right, const Intersection::iterator left);
+        Fork(const Intersection::iterator intersection_base,
+             const Intersection::iterator begin,
+             const Intersection::iterator end);
+        ConnectedRoad &getRight() const;
+        ConnectedRoad &getLeft() const;
+        ConnectedRoad &getMiddle() const;
+        ConnectedRoad &getRight();
+        ConnectedRoad &getLeft();
+        ConnectedRoad &getMiddle();
+        std::size_t getRightIndex() const;
+        std::size_t getLeftIndex() const;
     };
 
     bool isObviousOfTwo(const EdgeID via_edge,


### PR DESCRIPTION
# Issue

Works towards #3457 to refactor the `struct Fork` that represents a Fork:
Before it was:
```
struct Fork
{
    const Intersection::iterator right;
    const Intersection::iterator left;
    const std::size_t size;
};
```
where `*right` and `*left` returned the `ConnectedRoad` that are the left or the right roads in a fork. Now the struct is as follows:
```
struct Fork
{
    const Intersection::iterator begin;
    const Intersection::iterator end;
    const std::size_t size;
};
```
where `*begin` returns the right road in a fork and `*(end-1)` returns the left road in a fork.

Reason: `begin` and `end` are more intuitive when talking about iterators and more std::lib conform.

I kind of think this is a sensible change. Sometimes not sure whether this is over-engineering or really needed though? Also, most of the times a Fork only consists of left and right in which case and begin and end iterator is not that intuitive? But using iterators it is often not necessary to differentiate Forks with two or three roads.

@MoKob @daniel-j-h 🙇‍♀️  

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
