### PR TITLE
Rewrites the osrm-components tool to dump GeoJSON, resolves #2176 #1738 #1602

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,10 +435,6 @@ if(ENABLE_MASON)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKER_FLAGS}")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 
-  if(BUILD_COMPONENTS)
-    message(FATAL_ERROR "BUILD_COMPONENTS is not supported with ENABLE_MASON")
-  endif()
-
   # current mason packages target -D_GLIBCXX_USE_CXX11_ABI=0
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
 
@@ -468,10 +464,6 @@ else()
 
   find_package(BZip2 REQUIRED)
   add_dependency_includes(${BZIP2_INCLUDE_DIR})
-
-  if(BUILD_COMPONENTS)
-    find_package(GDAL)
-  endif()
 
   FIND_PACKAGE(Lua 5.2 EXACT)
   IF (LUA_FOUND)
@@ -622,15 +614,9 @@ target_link_libraries(osrm_extract ${EXTRACTOR_LIBRARIES})
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
 
 if(BUILD_COMPONENTS)
-  if(GDAL_FOUND)
-    add_executable(osrm-components src/tools/components.cpp $<TARGET_OBJECTS:UTIL>)
-    target_link_libraries(osrm-components ${TBB_LIBRARIES})
-    include_directories(SYSTEM ${GDAL_INCLUDE_DIR})
-    target_link_libraries(osrm-components ${GDAL_LIBRARIES} ${BOOST_BASE_LIBRARIES})
-    install(TARGETS osrm-components DESTINATION bin)
-  else()
-    message(WARNING "libgdal and/or development headers not found")
-  endif()
+  add_executable(osrm-components src/tools/components.cpp $<TARGET_OBJECTS:UTIL>)
+  target_link_libraries(osrm-components ${TBB_LIBRARIES} ${BOOST_BASE_LIBRARIES})
+  install(TARGETS osrm-components DESTINATION bin)
 endif()
 
 if(BUILD_TOOLS)


### PR DESCRIPTION
Resolves #2176 #1738 #1602.
Unblocks `node-osrm` from bundling `osrm-components` https://github.com/Project-OSRM/node-osrm/issues/283.

On Monaco, unstyled raw dump: http://bl.ocks.org/d/9d6265b064c0f29a71503e0f6527769d

Would love some input here: at the moment I expose OSM ids as properties for the `LineString`'s from and to node. Is this helpful and are these use-cases where osm node ids help here? Otherwise I would remove it, since it bloats the file quite a bit.

cc @MoKob @geohacker @planemad @srividyacb @oini

## Tasklist
 - [x] review
 - [x] adjust for comments
 - [x] decide on node osm id properties
 - [x] check on planet how large the new geojson file will get (~2 GB, ~100 MB compressed)
 - [x] adapt demo server integration
 - [x] notify Fred from Geofabrik and figure out new integration with them