### PR TITLE
fix emitting invalid turn types

### DIFF
--- a/features/guidance/dedicated-turn-roads.feature
+++ b/features/guidance/dedicated-turn-roads.feature
@@ -892,3 +892,40 @@ Feature: Slipways and Dedicated Turn Lanes
         When I route I should get
             | waypoints | route            | turns                                            | locations |
             | z,t       | through,,out,out | depart,off ramp slight right,round-exit-3,arrive | z,s,c,t   |
+
+    Scenario: Sliproad before a roundabout
+        Given the node map
+            """
+                      e
+            a - b - - c - d
+                    'f|l'
+                      m
+                      g
+                      |
+                     .h-_
+                k - i    |
+                     '.j.'
+
+            """
+
+        And the ways
+            | nodes | junction   | oneway | highway   | name |
+            | ab    |            | yes    | primary   | road |
+            | bc    |            | yes    | primary   | road |
+            | cd    |            | yes    | primary   | road |
+            | ec    |            | yes    | secondary |      |
+            | cm    |            | yes    | secondary |      |
+            | mg    |            | yes    | primary   |      |
+            | gh    |            | no     | primary   |      |
+            | hijh  | roundabout | yes    | primary   |      |
+            | ik    |            | yes    | primary   |      |
+            | bfm   |            | yes    | primary   |      |
+            | gld   |            | yes    | primary   |      |
+
+		And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | bc       | cd     | c        | only_straight |
+
+        When I route I should get
+            | waypoints | route     | turns                                                     | locations |
+            | a,k       | road,,,   | depart,continue right,roundabout turn right exit-1,arrive | a,b,h,k   |

--- a/include/extractor/guidance/intersection.hpp
+++ b/include/extractor/guidance/intersection.hpp
@@ -39,6 +39,14 @@ struct IntersectionShapeData
 inline auto makeCompareShapeDataByBearing(const double base_bearing)
 {
     return [base_bearing](const auto &lhs, const auto &rhs) {
+        return util::angularDeviation(lhs.bearing, base_bearing) <
+               util::angularDeviation(rhs.bearing, base_bearing);
+    };
+}
+
+inline auto makeCompareShapeDataAngleToBearing(const double base_bearing)
+{
+    return [base_bearing](const auto &lhs, const auto &rhs) {
         return util::bearing::angleBetween(lhs.bearing, base_bearing) <
                util::bearing::angleBetween(rhs.bearing, base_bearing);
     };

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -998,7 +998,8 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps)
         if (one_back_step.maneuver.instruction.type == TurnType::Sliproad)
         {
             if (current_step.maneuver.instruction.type == TurnType::Suppressed &&
-                compatible(one_back_step, current_step))
+                compatible(one_back_step, current_step) && current_step.intersections.size() == 1 &&
+                current_step.intersections.front().entry.size() == 2)
             {
                 // Traffic light on the sliproad, the road itself will be handled in the next
                 // iteration, when one-back-index again points to the sliproad.

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -140,8 +140,9 @@ IntersectionGenerator::ComputeIntersectionShape(const NodeID node_at_center_of_i
             }
             return util::bearing::reverse(intersection.begin()->bearing);
         }();
-        std::sort(
-            intersection.begin(), intersection.end(), makeCompareShapeDataByBearing(base_bearing));
+        std::sort(intersection.begin(),
+                  intersection.end(),
+                  makeCompareShapeDataAngleToBearing(base_bearing));
     }
     return intersection;
 }


### PR DESCRIPTION
resolves https://github.com/Project-OSRM/osrm-backend/issues/3535,

In combination with obvious discovery, sliproads and roundabouts, we still emit invalid turn instructions. This PR fixes the invalid collapsing of anything other than traffic lights when looking at a sliproad.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none
