### PR TITLE
Fix Lua static library linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ else()
     ENDIF()
   ENDIF()
 
-  set(USED_LUA_LIBRARIES ${LUA_LIBRARY})
+  set(USED_LUA_LIBRARIES ${LUA_LIBRARIES})
   add_dependency_includes(${LUA_INCLUDE_DIR})
 
   # add a target to generate API documentation with Doxygen
@@ -776,4 +776,3 @@ foreach(header ${headers_to_check})
 endforeach()
 add_library(check-headers STATIC EXCLUDE_FROM_ALL ${sources})
 set_target_properties(check-headers PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${check_headers_dir})
-

--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -172,12 +172,18 @@ if (LUA_LIBRARY)
     if (UNIX AND NOT APPLE AND NOT BEOS)
         find_library(LUA_MATH_LIBRARY m)
         set(LUA_LIBRARIES "${LUA_LIBRARY};${LUA_MATH_LIBRARY}")
+
+        # include dl library for statically-linked Lua library
+        get_filename_component(LUA_LIB_EXT ${LUA_LIBRARY} EXT)
+        if(LUA_LIB_EXT STREQUAL CMAKE_STATIC_LIBRARY_SUFFIX)
+          list(APPEND LUA_LIBRARIES ${CMAKE_DL_LIBS})
+        endif()
+
     # For Windows and Mac, don't need to explicitly include the math library
     else ()
         set(LUA_LIBRARIES "${LUA_LIBRARY}")
     endif ()
 endif ()
-
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LUA_FOUND to TRUE if
 # all listed variables are TRUE

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -245,8 +245,9 @@ module.exports = function () {
             text += data + '\n';
         } else {
             text += 'local f = assert(io.open("' + lua_profiles_path + '/' + profile + '.lua", "r"))\n';
-            text += 'local m = assert(loadstring(f:read("*all") .. [[\n' + data + '\n]]))\n';
+            text += 'local s = f:read("*all") .. [[\n' + data + '\n]]\n';
             text += 'f:close()\n';
+            text += 'local m = assert(loadstring and loadstring(s) or load(s))\n';
             text += 'm()\n';
         }
         this.profileFile = this.profileCacheFile;


### PR DESCRIPTION
# Issue

If a Lua library is compiled from source as liblua.a linking of dl library is required
Also updated Lua profile generation: in 5.3 `loadstring` function has been renamed to `load`

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations

Was reported in #3572