### PR TITLE
don't emit invalid turns when having u-turns on ferries in harbours/dead ends

### DIFF
--- a/features/guidance/collapse-ferry.feature
+++ b/features/guidance/collapse-ferry.feature
@@ -141,3 +141,22 @@ Feature: Collapse
             | waypoints | route                                          | turns                                             |
             | a,d       | cursed-island,beagle,forker,forker             | depart,notification straight,turn straight,arrive |
             | a,e       | cursed-island,beagle,screw-me-not,screw-me-not | depart,notification straight,turn straight,arrive |
+
+    @uturn @dead-end @ferry @via
+    Scenario: U-Turn on a dead-end ferry
+        Given the node map
+            """
+            a - 1 - b ~ ~ ~ ~ ~ ~ ~ c
+            """
+
+        And the ways
+            | nodes | highway | route | name |
+            | ab    | primary |       | land |
+            | bc    |         | ferry | sea  |
+
+        # we actually cannot check the route here, since two possible routes are equally valid:
+        # (ab)(bcb1) and (abcb)(b1) are exactly the same. Luckily, we only want to check for
+        # not asserting here.
+        When I route I should get
+            | waypoints |
+            | a,b,1     |

--- a/src/extractor/guidance/suppress_mode_handler.cpp
+++ b/src/extractor/guidance/suppress_mode_handler.cpp
@@ -52,7 +52,7 @@ bool SuppressModeHandler::canProcess(const NodeID,
 Intersection SuppressModeHandler::
 operator()(const NodeID, const EdgeID, Intersection intersection) const
 {
-    const auto first = begin(intersection) + 1;
+    const auto first = begin(intersection);
     const auto last = end(intersection);
 
     std::for_each(first, last, [&](auto &road) {


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/3609

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 none