### PR TITLE
foot profile: fix missing tracktype/smothness settings

### DIFF
--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -95,6 +95,10 @@ surface_speeds = {
   sand =          walking_speed*0.5
 }
 
+tracktype_speeds = {}
+
+smoothness_speeds = {}
+
 leisure_speeds = {
   track = walking_speed
 }


### PR DESCRIPTION
# Issue

fixes #3617, where a missing setting in the refactored would cause the foot profile to choke tracktype=* or smoothness=*
