### PR TITLE
Simpler cucumber error output

### DIFF
--- a/features/lib/table_diff.js
+++ b/features/lib/table_diff.js
@@ -50,5 +50,5 @@ module.exports = function (expected, actual) {
         s.push(rowString);
     });
 
-    return s.join('\n') + '\nTODO this is a temp workaround waiting for https://github.com/cucumber/cucumber-js/issues/534';
+    return s.join('\n');
 };

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -248,7 +248,7 @@ module.exports = function () {
         q.awaitAll((err, actual) => {
             if (err) return callback(err);
             let diff = tableDiff(table, actual);
-            if (diff) callback(new Error(diff));
+            if (diff) callback(diff);
             else callback();
         });
     };


### PR DESCRIPTION
We don't need to log a stack trace when we encounter a table diff (unexpected test results) during a `cucumberjs` run.  This PR logs the table differences in the normal way, but removes the stack trace.

Test-run errors change from this:
<img width="801" alt="screen shot 2017-01-30 at 3 11 10 pm" src="https://cloud.githubusercontent.com/assets/1892250/22445865/74cf66b4-e6fe-11e6-9084-5650c134d63c.png">

to this:
<img width="547" alt="screen shot 2017-01-30 at 3 11 36 pm" src="https://cloud.githubusercontent.com/assets/1892250/22445866/766e0084-e6fe-11e6-9eac-db19b19bab31.png">

which is much easier on the eye.  The stack trace wasn't helpful for the actual errors anyway, it was a trace inside the cucumberjs framework.

## Tasklist
 - [x] review
 - [x] adjust for comments
