### PR TITLE
No longer require .data member attribute for StaticGraph edges

### DIFF
--- a/src/partition/dinic_max_flow.cpp
+++ b/src/partition/dinic_max_flow.cpp
@@ -276,7 +276,6 @@ std::vector<NodeID> DinicMaxFlow::GetAugmentingPath(LevelGraph &levels,
 
             // check if the edge is valid
             const auto has_capacity = flow[target].count(path.back()) == 0;
-
             const auto descends_level_graph = levels[target] + 1 == levels[path.back()];
 
             if (has_capacity && descends_level_graph)

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -28,21 +28,8 @@ namespace osrm
 namespace tools
 {
 
-struct TarjanEdgeData
-{
-    TarjanEdgeData() : distance(INVALID_EDGE_WEIGHT), name_id(INVALID_NAMEID) {}
-
-    TarjanEdgeData(std::uint32_t distance, std::uint32_t name_id)
-        : distance(distance), name_id(name_id)
-    {
-    }
-
-    std::uint32_t distance;
-    std::uint32_t name_id;
-};
-
-using TarjanGraph = util::StaticGraph<TarjanEdgeData>;
-using TarjanEdge = util::static_graph_details::SortableEdgeWithData<TarjanEdgeData>;
+using TarjanGraph = util::StaticGraph<void>;
+using TarjanEdge = util::static_graph_details::SortableEdgeWithData<void>;
 
 std::size_t loadGraph(const std::string &path,
                       std::vector<extractor::QueryNode> &coordinate_list,
@@ -68,18 +55,12 @@ std::size_t loadGraph(const std::string &path,
 
         if (input_edge.forward)
         {
-            graph_edge_list.emplace_back(input_edge.source,
-                                         input_edge.target,
-                                         (std::max)(input_edge.weight, 1),
-                                         input_edge.name_id);
+            graph_edge_list.emplace_back(input_edge.source, input_edge.target);
         }
 
         if (input_edge.backward)
         {
-            graph_edge_list.emplace_back(input_edge.target,
-                                         input_edge.source,
-                                         (std::max)(input_edge.weight, 1),
-                                         input_edge.name_id);
+            graph_edge_list.emplace_back(input_edge.target, input_edge.source);
         }
     }
 


### PR DESCRIPTION
Our `StaticGraph` requires edge member attributes `.target` and `.data`. The need for `.data` forces us to provide a dummy for each edge where we don't have meaningful data to assign to edges. This is completely unnecessary and the `StaticGraph` works just as fine without a `.data` member attribute.

This changeset uses introspection to check for a `.data` member attribute and - if available - provides the `GetEdgeData` member functions. If not available all the `.data` related functionality is SFINAE-ed out.

@MoKob 