### PR TITLE
Add logic to penalize certain roads in the car profile

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -179,12 +179,12 @@ Feature: Car - Restricted access
             | primary |      |         |     | no        | x     |
 
     @hov
-    Scenario: Car - only designated HOV ways are ignored by default
+    Scenario: Car - designated HOV ways are rated low
         Then routability should be
             | highway | hov        | bothw | forw_rate  |
-            | primary | designated | x     | 52.63 km/h |
-            | primary | yes        | x     |            |
-            | primary | no         | x     |            |
+            | primary | designated | x     | 2          |
+            | primary | yes        | x     | 18         |
+            | primary | no         | x     | 18         |
 
     @hov
     Scenario: Car - a way with all lanes HOV-designated is inaccessible by default (similar to hov=designated)

--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -181,10 +181,10 @@ Feature: Car - Restricted access
     @hov
     Scenario: Car - only designated HOV ways are ignored by default
         Then routability should be
-            | highway | hov        | bothw |
-            | primary | designated |       |
-            | primary | yes        | x     |
-            | primary | no         | x     |
+            | highway | hov        | bothw | forw_rate  |
+            | primary | designated | x     | 52.63 km/h |
+            | primary | yes        | x     |            |
+            | primary | no         | x     |            |
 
     @hov
     Scenario: Car - a way with all lanes HOV-designated is inaccessible by default (similar to hov=designated)

--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -181,32 +181,42 @@ Feature: Car - Restricted access
     @hov
     Scenario: Car - designated HOV ways are rated low
         Then routability should be
-            | highway | hov        | bothw | forw_rate  |
-            | primary | designated | x     | 2          |
-            | primary | yes        | x     | 18         |
-            | primary | no         | x     | 18         |
+            | highway | hov        | bothw | forw_rate  | backw_rate  |
+            | primary | designated | x     | 2          | 2           |
+            | primary | yes        | x     | 18         | 18          |
+            | primary | no         | x     | 18         | 18          |
+
+    # Models:
+    # https://www.openstreetmap.org/way/124891268
+    # https://www.openstreetmap.org/way/237173472
+    @hov
+    Scenario: Car - I-66 use HOV-only roads with heavy penalty
+        Then routability should be
+            | highway  | hov         | hov:lanes                          | lanes | access     | oneway | forw | backw | forw_rate  |
+            | motorway | designated  | designated\|designated\|designated | 3     | hov        | yes    | x    |       | 3          |
+            | motorway | lane        |                                    | 3     | designated | yes    | x    |       | 25         |
 
     @hov
-    Scenario: Car - a way with all lanes HOV-designated is inaccessible by default (similar to hov=designated)
+    Scenario: Car - a way with all lanes HOV-designated is highly penalized by default (similar to hov=designated)
         Then routability should be
-            | highway | hov:lanes:forward      | hov:lanes:backward     | hov:lanes              | oneway | forw | backw |
-            | primary | designated             | designated             |                        |        |      |       |
-            | primary |                        | designated             |                        |        | x    |       |
-            | primary | designated             |                        |                        |        |      | x     |
-            | primary | designated\|designated | designated\|designated |                        |        |      |       |
-            | primary | designated\|no         | designated\|no         |                        |        | x    | x     |
-            | primary | yes\|no                | yes\|no                |                        |        | x    | x     |
-            | primary |                        |                        |                        |        | x    | x     |
-            | primary | designated             |                        |                        | -1     |      | x     |
-            | primary |                        | designated             |                        | -1     |      |       |
-            | primary |                        |                        | designated             | yes    |      |       |
-            | primary |                        |                        | designated             | -1     |      |       |
-            | primary |                        |                        | designated\|           | yes    | x    |       |
-            | primary |                        |                        | designated\|           | -1     |      | x     |
-            | primary |                        |                        | designated\|designated | yes    |      |       |
-            | primary |                        |                        | designated\|designated | -1     |      |       |
-            | primary |                        |                        | designated\|yes        | yes    | x    |       |
-            | primary |                        |                        | designated\|no         | -1     |      | x     |
+            | highway | hov:lanes:forward      | hov:lanes:backward     | hov:lanes              | oneway | forw | backw | forw_rate | backw_rate |
+            | primary | designated             | designated             |                        |        | x    | x     | 2         | 2          |
+            | primary |                        | designated             |                        |        | x    | x     | 18        | 2          |
+            | primary | designated             |                        |                        |        | x    | x     | 2         | 18         |
+            | primary | designated\|designated | designated\|designated |                        |        | x    | x     | 2         | 2          |
+            | primary | designated\|no         | designated\|no         |                        |        | x    | x     | 18        | 18         |
+            | primary | yes\|no                | yes\|no                |                        |        | x    | x     | 18        | 18         |
+            | primary |                        |                        |                        |        | x    | x     | 18        | 18         |
+            | primary | designated             |                        |                        | -1     |      | x     |           | 18         |
+            | primary |                        | designated             |                        | -1     |      | x     |           | 2          |
+            | primary |                        |                        | designated             | yes    | x    |       | 2         |            |
+            | primary |                        |                        | designated             | -1     |      | x     |           | 2          |
+            | primary |                        |                        | designated\|           | yes    | x    |       | 18        |            |
+            | primary |                        |                        | designated\|           | -1     |      | x     |           | 18         |
+            | primary |                        |                        | designated\|designated | yes    | x    |       | 2         |            |
+            | primary |                        |                        | designated\|designated | -1     |      | x     |           | 2          |
+            | primary |                        |                        | designated\|yes        | yes    | x    |       | 18        |            |
+            | primary |                        |                        | designated\|no         | -1     |      | x     |           | 18         |
 
      Scenario: Car - these toll roads always work
         Then routability should be

--- a/features/car/bridge.feature
+++ b/features/car/bridge.feature
@@ -29,6 +29,27 @@ Feature: Car - Handle driving
             | c    | f  | cde,efg,efg     | driving,driving,driving         |
             | c    | g  | cde,efg,efg     | driving,driving,driving         |
 
+    Scenario: Car - Control test without durations, osrm uses movable bridge speed to calculate duration
+        Given the node map
+            """
+            a b c
+                d
+                e f g
+            """
+
+        And the ways
+            | nodes | highway | bridge  |
+            | abc   | primary |         |
+            | cde   |         | movable |
+            | efg   | primary |         |
+
+        When I route I should get
+            | from | to | route           | modes                           | speed   | time     |
+            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 12 km/h | 173s +-1 |
+            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 9 km/h  | 162s +-1 |
+            | c    | e  | cde,cde         | driving,driving                 | 5 km/h  | 146s +-1 |
+            | e    | c  | cde,cde         | driving,driving                 | 5 km/h  | 149s +-1 |
+
     Scenario: Car - Properly handle durations
         Given the node map
             """
@@ -45,7 +66,7 @@ Feature: Car - Handle driving
 
         When I route I should get
             | from | to | route           | modes                           | speed  |
-            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 6 km/h |
-            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 4 km/h |
+            | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 7 km/h |
+            | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 5 km/h |
             | c    | e  | cde,cde         | driving,driving                 | 2 km/h |
             | e    | c  | cde,cde         | driving,driving                 | 2 km/h |

--- a/features/car/ferry.feature
+++ b/features/car/ferry.feature
@@ -29,6 +29,27 @@ Feature: Car - Handle ferry routes
             | c    | f  | cde,efg,efg     | ferry,driving,driving         |
             | c    | g  | cde,efg,efg     | ferry,driving,driving         |
 
+
+    Scenario: Car - Use default speeds to calculate duration if no duration given
+        Given the node map
+            """
+            a b c
+                d
+                e f g
+            """
+
+        And the ways
+            | nodes | highway | route |
+            | abc   | primary |       |
+            | cde   |         | ferry |
+            | efg   | primary |       |
+
+        When I route I should get
+            | from | to | route           | modes                         | speed   | time    |
+            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 12 km/h | 173.4s  |
+            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 9 km/h  | 162.4s  |
+            | c    | e  | cde,cde         | ferry,ferry                   | 5 km/h  | 151.4s  |
+            | e    | c  | cde,cde         | ferry,ferry                   | 5 km/h  | 151.4s  |
     Scenario: Car - Properly handle simple durations
         Given the node map
             """
@@ -44,11 +65,11 @@ Feature: Car - Handle ferry routes
             | efg   | primary |       |          |
 
         When I route I should get
-            | from | to | route           | modes                         | speed   |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 23 km/h |
-            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h |
-            | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h |
-            | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h |
+            | from | to | route           | modes                         | speed   | time  |
+            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 24 km/h | 89.4s |
+            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h | 78.4s |
+            | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
+            | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
 
     Scenario: Car - Properly handle ISO 8601 durations
         Given the node map
@@ -65,8 +86,8 @@ Feature: Car - Handle ferry routes
             | efg   | primary |       |          |
 
         When I route I should get
-            | from | to | route           | modes                         | speed   |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 23 km/h |
-            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h |
-            | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h |
-            | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h |
+            | from | to | route           | modes                         | speed   | time  |
+            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 24 km/h | 89.4s |
+            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h | 78.4s |
+            | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
+            | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |

--- a/features/car/maxspeed.feature
+++ b/features/car/maxspeed.feature
@@ -86,54 +86,54 @@ OSRM will use 4/5 of the projected free-flow speed.
         Then routability should be
 
             | highway | maxspeed | width | maxspeed:forward | maxspeed:backward | forw    | backw   | forw_rate | backw_rate |
-            | primary |          |       |                  |                   | 64 km/h | 64 km/h | 65 km/h   | 65 km/h    |
-            | primary |          |   3   |                  |                   | 64 km/h | 64 km/h | 32 km/h   | 32 km/h    |
-            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h | 48 km/h   | 48 km/h    |
-            | primary | 60       |   3   |                  |                   | 47 km/h | 47 km/h | 24 km/h   | 24 km/h    |
-            | primary |          |       | 60               |                   | 47 km/h | 64 km/h | 48 km/h   | 65 km/h    |
-            | primary |          |   3   | 60               |                   | 47 km/h | 64 km/h | 24 km/h   | 32 km/h    |
-            | primary |          |       |                  | 60                | 64 km/h | 47 km/h | 65 km/h   | 48 km/h    |
-            | primary |          |   3   |                  | 60                | 64 km/h | 47 km/h | 32 km/h   | 24 km/h    |
-            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h | 48 km/h   | 12 km/h    |
-            | primary | 15       |   3   | 60               |                   | 48 km/h | 12 km/h | 24 km/h   | 6 km/h     |
-            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h | 12 km/h   | 48 km/h    |
-            | primary | 15       |   3   |                  | 60                | 12 km/h | 47 km/h | 6 km/h    | 24 km/h    |
-            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h | 24 km/h   | 48 km/h    |
-            | primary | 15       |   3   | 30               | 60                | 23 km/h | 47 km/h | 12 km/h   | 24 km/h    |
+            | primary |          |       |                  |                   | 64 km/h | 64 km/h | 18        | 18         |
+            | primary |          |   3   |                  |                   | 64 km/h | 64 km/h | 9         | 9          |
+            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h | 13        | 13         |
+            | primary | 60       |   3   |                  |                   | 47 km/h | 47 km/h | 7         | 7          |
+            | primary |          |       | 60               |                   | 47 km/h | 64 km/h | 13        | 18         |
+            | primary |          |   3   | 60               |                   | 47 km/h | 64 km/h | 7         | 9          |
+            | primary |          |       |                  | 60                | 64 km/h | 47 km/h | 18        | 13         |
+            | primary |          |   3   |                  | 60                | 64 km/h | 47 km/h | 9         | 7          |
+            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h | 13        | 3          |
+            | primary | 15       |   3   | 60               |                   | 48 km/h | 12 km/h | 7         | 2          |
+            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h | 3         | 13         |
+            | primary | 15       |   3   |                  | 60                | 12 km/h | 47 km/h | 2         | 7          |
+            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h | 7         | 13         |
+            | primary | 15       |   3   | 30               | 60                | 23 km/h | 47 km/h | 3         | 7          |
 
     Scenario: Car - Single lane streets be ignored or incur a penalty
         Then routability should be
 
             | highway | maxspeed | lanes | maxspeed:forward | maxspeed:backward | forw    | backw   | forw_rate | backw_rate |
-            | primary |          |       |                  |                   | 64 km/h | 64 km/h | 65 km/h   | 65 km/h    |
-            | primary |          |   1   |                  |                   | 64 km/h | 64 km/h | 32 km/h   | 32 km/h    |
-            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h | 48 km/h   | 48 km/h    |
-            | primary | 60       |   1   |                  |                   | 47 km/h | 47 km/h | 24 km/h   | 24 km/h    |
-            | primary |          |       | 60               |                   | 47 km/h | 64 km/h | 48 km/h   | 65 km/h    |
-            | primary |          |   1   | 60               |                   | 47 km/h | 64 km/h | 24 km/h   | 32 km/h    |
-            | primary |          |       |                  | 60                | 64 km/h | 47 km/h | 65 km/h   | 48 km/h    |
-            | primary |          |   1   |                  | 60                | 64 km/h | 47 km/h | 32 km/h   | 24 km/h    |
-            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h | 48 km/h   | 12 km/h    |
-            | primary | 15       |   1   | 60               |                   | 48 km/h | 12 km/h | 24 km/h   | 6 km/h     |
-            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h | 12 km/h   | 48 km/h    |
-            | primary | 15       |   1   |                  | 60                | 12 km/h | 47 km/h | 6 km/h    | 24 km/h    |
-            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h | 24 km/h   | 48 km/h    |
-            | primary | 15       |   1   | 30               | 60                | 23 km/h | 47 km/h | 12 km/h   | 24 km/h    |
+            | primary |          |       |                  |                   | 64 km/h | 64 km/h | 18        | 18         |
+            | primary |          |   1   |                  |                   | 64 km/h | 64 km/h | 9         | 9          |
+            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h | 13        | 13         |
+            | primary | 60       |   1   |                  |                   | 47 km/h | 47 km/h | 7         | 7          |
+            | primary |          |       | 60               |                   | 47 km/h | 64 km/h | 13        | 18         |
+            | primary |          |   1   | 60               |                   | 47 km/h | 64 km/h | 7         | 9          |
+            | primary |          |       |                  | 60                | 64 km/h | 47 km/h | 18        | 13         |
+            | primary |          |   1   |                  | 60                | 64 km/h | 47 km/h | 9         | 7          |
+            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h | 13        | 3          |
+            | primary | 15       |   1   | 60               |                   | 48 km/h | 12 km/h | 7         | 2          |
+            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h | 3         | 13         |
+            | primary | 15       |   1   |                  | 60                | 12 km/h | 47 km/h | 2         | 7          |
+            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h | 7         | 13         |
+            | primary | 15       |   1   | 30               | 60                | 23 km/h | 47 km/h | 3         | 7          |
 
     Scenario: Car - Single lane streets only incur a penalty for two-way streets
         Then routability should be
             | highway | maxspeed | lanes  | oneway | forw    | backw   | forw_rate | backw_rate |
-            | primary |   30     |   1    | yes    | 23 km/h |         | 24 km/h   |            |
-            | primary |   30     |   1    | -1     |         | 23 km/h |           | 24 km/h    |
-            | primary |   30     |   1    |        | 23 km/h | 23 km/h | 12 km/h   | 12 km/h    |
-            | primary |   30     |   2    |        | 23 km/h | 23 km/h | 24 km/h   | 24 km/h    |
+            | primary |   30     |   1    | yes    | 23 km/h |         | 7         |            |
+            | primary |   30     |   1    | -1     |         | 23 km/h |           | 7          |
+            | primary |   30     |   1    |        | 23 km/h | 23 km/h | 3         | 3          |
+            | primary |   30     |   2    |        | 23 km/h | 23 km/h | 7         | 7          |
 
     Scenario: Car - Forward/backward maxspeed on reverse oneways
         Then routability should be
             | highway | maxspeed | maxspeed:forward | maxspeed:backward | oneway | forw    | backw   | forw_rate | backw_rate |
-            | primary |          |                  |                   | -1     |         | 64 km/h |           | 65 km/h    |
-            | primary | 30       |                  |                   | -1     |         | 23 km/h |           | 24 km/h    |
-            | primary |          | 30               |                   | -1     |         | 64 km/h |           | 65 km/h    |
-            | primary |          |                  | 30                | -1     |         | 23 km/h |           | 24 km/h    |
-            | primary | 20       | 30               |                   | -1     |         | 15 km/h |           | 16 km/h    |
-            | primary | 20       |                  | 30                | -1     |         | 23 km/h |           | 24 km/h    |
+            | primary |          |                  |                   | -1     |         | 64 km/h |           | 18         |
+            | primary | 30       |                  |                   | -1     |         | 23 km/h |           | 7          |
+            | primary |          | 30               |                   | -1     |         | 64 km/h |           | 18         |
+            | primary |          |                  | 30                | -1     |         | 23 km/h |           | 7          |
+            | primary | 20       | 30               |                   | -1     |         | 15 km/h |           | 4          |
+            | primary | 20       |                  | 30                | -1     |         | 23 km/h |           | 7          |

--- a/features/car/maxspeed.feature
+++ b/features/car/maxspeed.feature
@@ -37,26 +37,30 @@ OSRM will use 4/5 of the projected free-flow speed.
             """
 
         And the ways
-            | nodes | highway       | maxspeed |
-            | ab    | residential   |          |
-            | bc    | residential   | 90       |
-            | cd    | living_street | FR:urban |
+            | nodes | highway       | maxspeed | # |
+            | ab    | residential   |          | default residential speed is 25 |
+            | bc    | residential   | 90       |   |
+            | cd    | living_street | FR:urban |   |
 
         When I route I should get
             | from | to | route | speed   |
-            | a    | b  | ab,ab | 20 km/h |
+            | a    | b  | ab,ab | 25 km/h |
+                                            # default residential speed is 25, don't mess with this
             | b    | c  | bc,bc | 72 km/h |
+                                            # parsed maxspeeds are scaled by profile's speed_reduction value
             | c    | d  | cd,cd | 40 km/h |
+                                            # symbolic posted speeds without explicit exceptions are parsed
+                                            # from the profile's maxspeed_table_default table
 
-    Scenario: Car - Forward/backward maxspeed
+    Scenario: Car - Forward/backward maxspeed are scaled by profile's speed_reduction if explicitly set
         Given a grid size of 100 meters
 
         Then routability should be
             | highway | maxspeed | maxspeed:forward | maxspeed:backward | forw    | backw   |
-            | primary |          |                  |                   | 52 km/h | 52 km/h |
+            | primary |          |                  |                   | 65 km/h | 65 km/h |
             | primary | 60       |                  |                   | 48 km/h | 48 km/h |
-            | primary |          | 60               |                   | 48 km/h | 52 km/h |
-            | primary |          |                  | 60                | 52 km/h | 48 km/h |
+            | primary |          | 60               |                   | 48 km/h | 65 km/h |
+            | primary |          |                  | 60                | 65 km/h | 48 km/h |
             | primary | 15       | 60               |                   | 48 km/h | 12 km/h |
             | primary | 15       |                  | 60                | 12 km/h | 48 km/h |
             | primary | 15       | 30               | 60                | 24 km/h | 48 km/h |
@@ -81,55 +85,55 @@ OSRM will use 4/5 of the projected free-flow speed.
     Scenario: Car - Too narrow streets should be ignored or incur a penalty
         Then routability should be
 
-            | highway | maxspeed | width | maxspeed:forward | maxspeed:backward | forw    | backw   |
-            | primary |          |       |                  |                   | 52 km/h | 52 km/h |
-            | primary |          |   3   |                  |                   | 32 km/h | 32 km/h |
-            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h |
-            | primary | 60       |   3   |                  |                   | 29 km/h | 29 km/h |
-            | primary |          |       | 60               |                   | 47 km/h | 52 km/h |
-            | primary |          |   3   | 60               |                   | 29 km/h | 32 km/h |
-            | primary |          |       |                  | 60                | 52 km/h | 47 km/h |
-            | primary |          |   3   |                  | 60                | 32 km/h | 29 km/h |
-            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h |
-            | primary | 15       |   3   | 60               |                   | 30 km/h |  7 km/h |
-            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h |
-            | primary | 15       |   3   |                  | 60                |  7 km/h | 29 km/h |
-            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h |
-            | primary | 15       |   3   | 30               | 60                | 15 km/h | 29 km/h |
+            | highway | maxspeed | width | maxspeed:forward | maxspeed:backward | forw    | backw   | forw_rate | backw_rate |
+            | primary |          |       |                  |                   | 64 km/h | 64 km/h | 65 km/h   | 65 km/h    |
+            | primary |          |   3   |                  |                   | 64 km/h | 64 km/h | 32 km/h   | 32 km/h    |
+            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h | 48 km/h   | 48 km/h    |
+            | primary | 60       |   3   |                  |                   | 47 km/h | 47 km/h | 24 km/h   | 24 km/h    |
+            | primary |          |       | 60               |                   | 47 km/h | 64 km/h | 48 km/h   | 65 km/h    |
+            | primary |          |   3   | 60               |                   | 47 km/h | 64 km/h | 24 km/h   | 32 km/h    |
+            | primary |          |       |                  | 60                | 64 km/h | 47 km/h | 65 km/h   | 48 km/h    |
+            | primary |          |   3   |                  | 60                | 64 km/h | 47 km/h | 32 km/h   | 24 km/h    |
+            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h | 48 km/h   | 12 km/h    |
+            | primary | 15       |   3   | 60               |                   | 48 km/h | 12 km/h | 24 km/h   | 6 km/h     |
+            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h | 12 km/h   | 48 km/h    |
+            | primary | 15       |   3   |                  | 60                | 12 km/h | 47 km/h | 6 km/h    | 24 km/h    |
+            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h | 24 km/h   | 48 km/h    |
+            | primary | 15       |   3   | 30               | 60                | 23 km/h | 47 km/h | 12 km/h   | 24 km/h    |
 
     Scenario: Car - Single lane streets be ignored or incur a penalty
         Then routability should be
 
-            | highway | maxspeed | lanes | maxspeed:forward | maxspeed:backward | forw    | backw   |
-            | primary |          |       |                  |                   | 52 km/h | 52 km/h |
-            | primary |          |   1   |                  |                   | 32 km/h | 32 km/h |
-            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h |
-            | primary | 60       |   1   |                  |                   | 29 km/h | 29 km/h |
-            | primary |          |       | 60               |                   | 47 km/h | 52 km/h |
-            | primary |          |   1   | 60               |                   | 29 km/h | 32 km/h |
-            | primary |          |       |                  | 60                | 52 km/h | 47 km/h |
-            | primary |          |   1   |                  | 60                | 32 km/h | 29 km/h |
-            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h |
-            | primary | 15       |   1   | 60               |                   | 30 km/h |  7 km/h |
-            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h |
-            | primary | 15       |   1   |                  | 60                |  7 km/h | 29 km/h |
-            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h |
-            | primary | 15       |   1   | 30               | 60                | 15 km/h | 29 km/h |
+            | highway | maxspeed | lanes | maxspeed:forward | maxspeed:backward | forw    | backw   | forw_rate | backw_rate |
+            | primary |          |       |                  |                   | 64 km/h | 64 km/h | 65 km/h   | 65 km/h    |
+            | primary |          |   1   |                  |                   | 64 km/h | 64 km/h | 32 km/h   | 32 km/h    |
+            | primary | 60       |       |                  |                   | 47 km/h | 47 km/h | 48 km/h   | 48 km/h    |
+            | primary | 60       |   1   |                  |                   | 47 km/h | 47 km/h | 24 km/h   | 24 km/h    |
+            | primary |          |       | 60               |                   | 47 km/h | 64 km/h | 48 km/h   | 65 km/h    |
+            | primary |          |   1   | 60               |                   | 47 km/h | 64 km/h | 24 km/h   | 32 km/h    |
+            | primary |          |       |                  | 60                | 64 km/h | 47 km/h | 65 km/h   | 48 km/h    |
+            | primary |          |   1   |                  | 60                | 64 km/h | 47 km/h | 32 km/h   | 24 km/h    |
+            | primary | 15       |       | 60               |                   | 47 km/h | 11 km/h | 48 km/h   | 12 km/h    |
+            | primary | 15       |   1   | 60               |                   | 48 km/h | 12 km/h | 24 km/h   | 6 km/h     |
+            | primary | 15       |       |                  | 60                | 12 km/h | 47 km/h | 12 km/h   | 48 km/h    |
+            | primary | 15       |   1   |                  | 60                | 12 km/h | 47 km/h | 6 km/h    | 24 km/h    |
+            | primary | 15       |       | 30               | 60                | 23 km/h | 47 km/h | 24 km/h   | 48 km/h    |
+            | primary | 15       |   1   | 30               | 60                | 23 km/h | 47 km/h | 12 km/h   | 24 km/h    |
 
-    Scenario: Car - Single lane streets only incure a penalty for two-way streets
+    Scenario: Car - Single lane streets only incur a penalty for two-way streets
         Then routability should be
-            | highway | maxspeed | lanes  | oneway | forw    | backw   |
-            | primary |   30     |   1    | yes    | 23 km/h |         |
-            | primary |   30     |   1    | -1     |         | 23 km/h |
-            | primary |   30     |   1    |        | 15 km/h | 15 km/h |
-            | primary |   30     |   2    |        | 23 km/h | 23 km/h |
+            | highway | maxspeed | lanes  | oneway | forw    | backw   | forw_rate | backw_rate |
+            | primary |   30     |   1    | yes    | 23 km/h |         | 24 km/h   |            |
+            | primary |   30     |   1    | -1     |         | 23 km/h |           | 24 km/h    |
+            | primary |   30     |   1    |        | 23 km/h | 23 km/h | 12 km/h   | 12 km/h    |
+            | primary |   30     |   2    |        | 23 km/h | 23 km/h | 24 km/h   | 24 km/h    |
 
-    Scenario: Car - Forwward/backward maxspeed on reverse oneways
+    Scenario: Car - Forward/backward maxspeed on reverse oneways
         Then routability should be
-            | highway | maxspeed | maxspeed:forward | maxspeed:backward | oneway | forw    | backw   |
-            | primary |          |                  |                   | -1     |         | 52 km/h |
-            | primary | 30       |                  |                   | -1     |         | 23 km/h |
-            | primary |          | 30               |                   | -1     |         | 52 km/h |
-            | primary |          |                  | 30                | -1     |         | 23 km/h |
-            | primary | 20       | 30               |                   | -1     |         | 15 km/h |
-            | primary | 20       |                  | 30                | -1     |         | 23 km/h |
+            | highway | maxspeed | maxspeed:forward | maxspeed:backward | oneway | forw    | backw   | forw_rate | backw_rate |
+            | primary |          |                  |                   | -1     |         | 64 km/h |           | 65 km/h    |
+            | primary | 30       |                  |                   | -1     |         | 23 km/h |           | 24 km/h    |
+            | primary |          | 30               |                   | -1     |         | 64 km/h |           | 65 km/h    |
+            | primary |          |                  | 30                | -1     |         | 23 km/h |           | 24 km/h    |
+            | primary | 20       | 30               |                   | -1     |         | 15 km/h |           | 16 km/h    |
+            | primary | 20       |                  | 30                | -1     |         | 23 km/h |           | 24 km/h    |

--- a/features/car/maxspeed.feature
+++ b/features/car/maxspeed.feature
@@ -6,7 +6,7 @@ OSRM will use 4/5 of the projected free-flow speed.
         Given the profile "car"
         Given a grid size of 1000 meters
 
-    Scenario: Car - Respect maxspeeds when lower that way type speed
+    Scenario: Car - Respect maxspeeds when lower than way type speed
         Given the node map
             """
             a b c d e f g
@@ -23,7 +23,7 @@ OSRM will use 4/5 of the projected free-flow speed.
 
         When I route I should get
             | from | to | route | speed   |
-            | a    | b  | ab,ab | 68 km/h |
+            | a    | b  | ab,ab | 85 km/h |
             | b    | c  | bc,bc | 48 km/h |
             | c    | d  | cd,cd | 40 km/h |
             | d    | e  | de,de | 64 km/h |

--- a/features/car/service.feature
+++ b/features/car/service.feature
@@ -4,11 +4,11 @@ Feature: Car - Surfaces
     Background:
         Given the profile "car"
 
-    Scenario: Car - Surface should reduce speed
+    Scenario: Car - Ways tagged service should reduce speed
         Then routability should be
-            | highway  | service           | forw       | backw       |
-            | service  | alley             | 5 km/h +-1 | 5 km/h +-1  |
-            | service  | emergency_access  |            |             |
-            | service  | driveway          | 5 km/h +-1 | 5 km/h +-1  |
-            | service  | drive-through     | 5 km/h +-1 | 5 km/h +-1  |
-            | service  | parking           | 5 km/h +-1 | 5 km/h +-1  |
+            | highway  | service           | forw        | backw        | forw_rate  |
+            | service  | alley             | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
+            | service  | emergency_access  |             |              |            |
+            | service  | driveway          | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
+            | service  | drive-through     | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
+            | service  | parking           | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |

--- a/features/car/service.feature
+++ b/features/car/service.feature
@@ -7,8 +7,8 @@ Feature: Car - Surfaces
     Scenario: Car - Ways tagged service should reduce speed
         Then routability should be
             | highway  | service           | forw        | backw        | forw_rate  |
-            | service  | alley             | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
+            | service  | alley             | 15 km/h +-1 | 15 km/h +-1  | 2          |
             | service  | emergency_access  |             |              |            |
-            | service  | driveway          | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
-            | service  | drive-through     | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
-            | service  | parking           | 15 km/h +-1 | 15 km/h +-1  | 12.05 km/h |
+            | service  | driveway          | 15 km/h +-1 | 15 km/h +-1  | 2          |
+            | service  | drive-through     | 15 km/h +-1 | 15 km/h +-1  | 2          |
+            | service  | parking           | 15 km/h +-1 | 15 km/h +-1  | 2          |

--- a/features/car/side_bias.feature
+++ b/features/car/side_bias.feature
@@ -28,8 +28,8 @@ Feature: Testbot - side bias
 
         When I route I should get
             | from | to | route    | time       |
-            | d    | a  | bd,ab,ab | 29s +-1    |
-            | d    | c  | bd,bc,bc | 33s +-1    |
+            | d    | a  | bd,ab,ab | 24s +-1    |
+            | d    | c  | bd,bc,bc | 27s +-1    |
 
     Scenario: Right hand bias
         Given the profile file "car" extended with
@@ -51,8 +51,9 @@ Feature: Testbot - side bias
 
         When I route I should get
             | from | to | route    | time       |
-            | d    | a  | bd,ab,ab | 33s +-1    |
-            | d    | c  | bd,bc,bc | 29s +-1    |
+            | d    | a  | bd,ab,ab | 27s +-1    |
+                                            # should be inverse of left hand bias
+            | d    | c  | bd,bc,bc | 24s +-1    |
 
     Scenario: Roundabout exit counting for left sided driving
         And a grid size of 10 meters

--- a/features/car/speed.feature
+++ b/features/car/speed.feature
@@ -5,42 +5,43 @@ Feature: Car - speeds
         Given the profile "car"
         And a grid size of 1000 meters
 
+    # should more or less match default speeds in car profile, but may be different due to rounding errors
     Scenario: Car - speed of various way types
         Then routability should be
             | highway        | oneway | bothw   |
-            | motorway       | no     | 71 km/h |
-            | motorway_link  | no     | 35 km/h |
-            | trunk          | no     | 68 km/h |
-            | trunk_link     | no     | 31 km/h |
-            | primary        | no     | 52 km/h |
-            | primary_link   | no     | 23 km/h |
-            | secondary      | no     | 44 km/h |
-            | secondary_link | no     | 19 km/h |
-            | tertiary       | no     | 31 km/h |
-            | tertiary_link  | no     | 16 km/h |
-            | unclassified   | no     | 19 km/h |
-            | residential    | no     | 19 km/h |
-            | living_street  | no     | 8 km/h  |
-            | service        | no     | 12 km/h |
+            | motorway       | no     | 89 km/h |
+            | motorway_link  | no     | 44 km/h |
+            | trunk          | no     | 85 km/h |
+            | trunk_link     | no     | 39 km/h |
+            | primary        | no     | 64 km/h |
+            | primary_link   | no     | 29 km/h |
+            | secondary      | no     | 55 km/h |
+            | secondary_link | no     | 24 km/h |
+            | tertiary       | no     | 39 km/h |
+            | tertiary_link  | no     | 20 km/h |
+            | unclassified   | no     | 24 km/h |
+            | residential    | no     | 24 km/h |
+            | living_street  | no     | 9 km/h  |
+            | service        | no     | 15 km/h |
 
-    # Alternating oneways have to take average waiting time into account.
+    # Alternating oneways scale rates but not speeds
     Scenario: Car - scaled speeds for oneway=alternating
         Then routability should be
             | highway        | oneway      | junction   | forw    | backw   | #              |
-            | tertiary       |             |            | 31 km/h | 31 km/h |                |
-            | tertiary       | alternating |            | 12 km/h | 12 km/h |                |
-            | motorway       |             |            | 71 km/h |         | implied oneway |
-            | motorway       | alternating |            | 28 km/h |         | implied oneway |
+            | tertiary       |             |            | 39 km/h | 39 km/h |                |
+            | tertiary       | alternating |            | 39 km/h | 39 km/h |                |
+            | motorway       |             |            | 89 km/h |         | implied oneway |
+            | motorway       | alternating |            | 89 km/h |         | implied oneway |
             | motorway       | reversible  |            |         |         | unroutable     |
-            | primary        |             | roundabout | 52 km/h |         | implied oneway |
-            | primary        | alternating | roundabout | 20 km/h |         | implied oneway |
+            | primary        |             | roundabout | 64 km/h |         | implied oneway |
+            | primary        | alternating | roundabout | 64 km/h |         | implied oneway |
             | primary        | reversible  | roundabout |         |         | unroutable     |
 
     Scenario: Car - Check roundoff errors
         Then routability should be
 
             | highway | maxspeed | forw    | backw    |
-            | primary |          | 52 km/h | 52 km/h  |
+            | primary |          | 64 km/h | 64 km/h  |
             | primary | 60       | 47 km/h | 47 km/h  |
             | primary | 60       | 47 km/h | 47 km/h  |
             | primary | 60       | 47 km/h | 47 km/h  |

--- a/features/car/surface.feature
+++ b/features/car/surface.feature
@@ -64,64 +64,65 @@ Feature: Car - Surfaces
     Scenario: Car - Surface should reduce speed
         Then routability should be
             | highway  | oneway | surface         | forw        | backw       |
-            | motorway | no     |                 | 72 km/h     | 72 km/h     |
-            | motorway | no     | asphalt         | 72 km/h     | 72 km/h +-1 |
-            | motorway | no     | concrete        | 72 km/h +-1 | 72 km/h +-1 |
-            | motorway | no     | concrete:plates | 72 km/h +-1 | 72 km/h +-1 |
-            | motorway | no     | concrete:lanes  | 72 km/h +-1 | 72 km/h +-1 |
-            | motorway | no     | paved           | 72 km/h +-1 | 72 km/h +-1 |
-            | motorway | no     | cement          | 64 km/h +-1 | 64 km/h +-1 |
-            | motorway | no     | compacted       | 64 km/h +-1 | 64 km/h +-1 |
-            | motorway | no     | fine_gravel     | 64 km/h +-1 | 64 km/h +-1 |
-            | motorway | no     | paving_stones   | 48 km/h +-1 | 48 km/h +-1 |
-            | motorway | no     | metal           | 48 km/h +-1 | 48 km/h +-1 |
-            | motorway | no     | bricks          | 48 km/h +-1 | 48 km/h +-1 |
-            | motorway | no     | grass           | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | wood            | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | sett            | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | grass_paver     | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | gravel          | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | unpaved         | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | ground          | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | dirt            | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | pebblestone     | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | tartan          | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | cobblestone     | 24 km/h +-1 | 24 km/h +-1 |
-            | motorway | no     | clay            | 24 km/h +-1 | 24 km/h +-1 |
-            | motorway | no     | earth           | 16 km/h +-1 | 16 km/h +-1 |
-            | motorway | no     | stone           | 16 km/h +-1 | 16 km/h +-1 |
-            | motorway | no     | rocky           | 16 km/h +-1 | 16 km/h +-1 |
-            | motorway | no     | sand            | 16 km/h +-1 | 16 km/h +-1 |
+            | motorway | no     |                 | 90 km/h     | 90 km/h     |
+            | motorway | no     | asphalt         | 90 km/h     | 90 km/h +-1 |
+            | motorway | no     | concrete        | 90 km/h +-1 | 90 km/h +-1 |
+            | motorway | no     | concrete:plates | 90 km/h +-1 | 90 km/h +-1 |
+            | motorway | no     | concrete:lanes  | 90 km/h +-1 | 90 km/h +-1 |
+            | motorway | no     | paved           | 90 km/h +-1 | 90 km/h +-1 |
+            | motorway | no     | cement          | 80 km/h +-1 | 80 km/h +-1 |
+            | motorway | no     | compacted       | 80 km/h +-1 | 80 km/h +-1 |
+            | motorway | no     | fine_gravel     | 80 km/h +-1 | 80 km/h +-1 |
+            | motorway | no     | paving_stones   | 60 km/h +-1 | 60 km/h +-1 |
+            | motorway | no     | metal           | 60 km/h +-1 | 60 km/h +-1 |
+            | motorway | no     | bricks          | 60 km/h +-1 | 60 km/h +-1 |
+            | motorway | no     | grass           | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | wood            | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | sett            | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | grass_paver     | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | gravel          | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | unpaved         | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | ground          | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | dirt            | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | pebblestone     | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | tartan          | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | cobblestone     | 30 km/h +-1 | 30 km/h +-1 |
+            | motorway | no     | clay            | 30 km/h +-1 | 30 km/h +-1 |
+            | motorway | no     | earth           | 20 km/h +-1 | 20 km/h +-1 |
+            | motorway | no     | stone           | 20 km/h +-1 | 20 km/h +-1 |
+            | motorway | no     | rocky           | 20 km/h +-1 | 20 km/h +-1 |
+            | motorway | no     | sand            | 20 km/h +-1 | 20 km/h +-1 |
+            | motorway | no     | mud             | 10 km/h +-1 | 10 km/h +-1 |
 
     Scenario: Car - Tracktypes should reduce speed
         Then routability should be
             | highway  | oneway | tracktype | forw        | backw       |
-            | motorway | no     |           | 72 km/h     | 72 km/h     |
-            | motorway | no     | grade1    | 48 km/h +-1 | 48 km/h +-1 |
-            | motorway | no     | grade2    | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | grade3    | 24 km/h +-1 | 24 km/h +-1 |
-            | motorway | no     | grade4    | 20 km/h +-1 | 20 km/h +-1 |
-            | motorway | no     | grade5    | 16 km/h +-1 | 16 km/h +-1 |
+            | motorway | no     |           | 90 km/h     | 90 km/h     |
+            | motorway | no     | grade1    | 60 km/h +-1 | 60 km/h +-1 |
+            | motorway | no     | grade2    | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | grade3    | 30 km/h +-1 | 30 km/h +-1 |
+            | motorway | no     | grade4    | 25 km/h +-1 | 25 km/h +-1 |
+            | motorway | no     | grade5    | 20 km/h +-1 | 20 km/h +-1 |
 
     Scenario: Car - Smoothness should reduce speed
         Then routability should be
             | highway  | oneway | smoothness    | forw        | backw       |
-            | motorway | no     |               | 72 km/h     | 72 km/h     |
-            | motorway | no     | intermediate  | 64 km/h     | 64 km/h     |
-            | motorway | no     | bad           | 32 km/h +-1 | 32 km/h +-1 |
-            | motorway | no     | very_bad      | 16 km/h +-1 | 16 km/h +-1 |
-            | motorway | no     | horrible      |  8 km/h +-1 |  8 km/h +-1 |
-            | motorway | no     | very_horrible |  4 km/h +-1 |  4 km/h +-1 |
+            | motorway | no     |               | 90 km/h     | 90 km/h     |
+            | motorway | no     | intermediate  | 80 km/h     | 80 km/h     |
+            | motorway | no     | bad           | 40 km/h +-1 | 40 km/h +-1 |
+            | motorway | no     | very_bad      | 20 km/h +-1 | 20 km/h +-1 |
+            | motorway | no     | horrible      |  10 km/h +-1 |  10 km/h +-1 |
+            | motorway | no     | very_horrible |  5 km/h +-1 |  5 km/h +-1 |
 
     Scenario: Car - Combination of surface tags should use lowest speed
         Then routability should be
-            | highway  | oneway | tracktype | surface | smoothness    | backw   | forw    |
-            | motorway | no     |           |         |               | 72 km/h | 72 km/h |
-            | service  | no     | grade1    | asphalt | excellent     | 12 km/h | 12 km/h |
-            | motorway | no     | grade5    | asphalt | excellent     | 16 km/h | 16 km/h |
-            | motorway | no     | grade1    | mud     | excellent     |  8 km/h |  8 km/h |
-            | motorway | no     | grade1    | asphalt | very_horrible |  4 km/h |  4 km/h |
-            | service  | no     | grade5    | mud     | very_horrible |  4 km/h |  4 km/h |
+            | highway  | oneway | tracktype | surface | smoothness    | bothw   |
+            | motorway | no     |           |         |               | 90 km/h |
+            | service  | no     | grade1    | asphalt | excellent     | 15 km/h |
+            | motorway | no     | grade5    | asphalt | excellent     | 20 km/h |
+            | motorway | no     | grade1    | mud     | excellent     | 10 km/h |
+            | motorway | no     | grade1    | asphalt | very_horrible |  5 km/h |
+            | service  | no     | grade5    | mud     | very_horrible |  5 km/h |
 
     Scenario: Car - Surfaces should not affect oneway direction
         Then routability should be

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -52,23 +52,23 @@ Feature: Traffic - turn penalties
 
     Scenario: Weighting not based on turn penalty file
         When I route I should get
-            | from | to | route           | speed   | time      |
-            | a    | h  | ad,dhk,dhk      | 65 km/h | 11s +-1   |
-                                                                  # straight
-            | i    | g  | fim,fg,fg       | 55 km/h | 13s +-1 |
-                                                                  # right
-            | a    | e  | ad,def,def      | 44 km/h | 16.3s +-1 |
-                                                                  # left
-            | c    | g  | cd,def,fg,fg    | 65 km/h | 22s +-1   |
-                                                                  # double straight
-            | p    | g  | mp,fim,fg,fg    | 60 km/h | 24s +-1   |
-                                                                  # straight-right
-            | a    | l  | ad,dhk,klm,klm  | 53 km/h | 27s +-1   |
-                                                                  # straight-left
-            | l    | e  | klm,dhk,def,def | 55 km/h | 26s +-1   |
-                                                                  # double right
-            | g    | n  | fg,fim,mn,mn    | 44 km/h | 32s +-1   |
-                                                                  # double left
+            | from | to | route           | speed   | weight    | time      |
+            | a    | h  | ad,dhk,dhk      | 65 km/h | 11s +-1   | 11s +-1   |
+                                                                                # straight
+            | i    | g  | fim,fg,fg       | 55 km/h | 13s +-1   | 13s +-1   |
+                                                                                # right
+            | a    | e  | ad,def,def      | 44 km/h | 16.3s +-1 | 16.3s +-1 |
+                                                                                # left
+            | c    | g  | cd,def,fg,fg    | 65 km/h | 22s +-1   | 22s +-1   |
+                                                                                # double straight
+            | p    | g  | mp,fim,fg,fg    | 60 km/h | 24s +-1   | 24s +-1   |
+                                                                                # straight-right
+            | a    | l  | ad,dhk,klm,klm  | 53 km/h | 27s +-1   | 27s +-1   |
+                                                                                # straight-left
+            | l    | e  | klm,dhk,def,def | 55 km/h | 26s +-1   | 26s +-1   |
+                                                                                # double right
+            | g    | n  | fg,fim,mn,mn    | 44 km/h | 32s +-1   | 32s +-1   |
+                                                                                # double left
 
     Scenario: Weighting based on turn penalty file
         Given the turn penalty file
@@ -88,25 +88,25 @@ Feature: Traffic - turn penalties
             # ade left turn
         And the contract extra arguments "--turn-penalty-file {penalties_file}"
         When I route I should get
-            | from | to | route                 | speed   | time      |
-            | a    | h  | ad,dhk,dhk            | 65 km/h | 11s +-1   |
-                                                                              # straight
-            | i    | g  | fim,fg,fg             | 56 km/h | 15s +-1   |
-                                                                              # right - ifg penalty
-            | a    | e  | ad,def,def            | 53 km/h | 14s +-1   |
-                                                                              # left - faster because of negative ade penalty
-            | c    | g  | cd,def,fg,fg          | 52 km/h | 27s +-1   |
-                                                                              # double straight
-            | p    | g  | mp,fim,fg,fg          | 49 km/h | 29s +-1   |
-                                                                              # straight-right - ifg penalty
-            | a    | l  | ad,def,fim,klm,klm    | 48 km/h | 45s +-1   |
-                                                                              # was straight-left - forced around by hkl penalty
-            | l    | e  | klm,fim,def,def       | 38 km/h | 38s +-1   |
-                                                                              # double right - forced left by lkh penalty
-            | g    | n  | fg,fim,mn,mn          | 25 km/h | 57s +-1   |
-                                                                              # double left - imn penalty
-            | j    | c  | jk,klm,fim,def,cd,cd  | 44 km/h | 65.8s +-1 |
-                                                                              # double left - hdc penalty ever so slightly higher than imn; forces all the way around
+            | from | to | route                 | speed   | weight  | time      |
+            | a    | h  | ad,dhk,dhk            | 65 km/h | 11      | 11s +-1   |
+                                                                                # straight
+            | i    | g  | fim,fg,fg             | 56 km/h | 12.8    | 12s +-1   |
+                                                                                # right - ifg penalty
+            | a    | e  | ad,def,def            | 67 km/h | 10.8    | 10s +-1   |
+                                                                                # left - faster because of negative ade penalty
+            | c    | g  | cd,def,fg,fg          | 65 km/h | 22      | 22s +-1   |
+                                                                                # double straight
+            | p    | g  | mp,fim,fg,fg          | 61 km/h | 23.8    | 23s +-1   |
+                                                                                # straight-right - ifg penalty
+            | a    | l  | ad,def,fim,klm,klm    | 58 km/h | 37      | 37s +-1   |
+                                                                                # was straight-left - forced around by hkl penalty
+            | l    | e  | klm,fim,def,def       | 44 km/h | 32.6    | 32s +-1   |
+                                                                                # double right - forced left by lkh penalty
+            | g    | n  | fg,fim,mn,mn          | 28 km/h | 51.8    | 51s +-1   |
+                                                                                 # double left - imn penalty
+            | j    | c  | jk,klm,fim,def,cd,cd  | 53 km/h | 54.6    | 54s +-1   |
+                                                                                  # double left - hdc penalty ever so slightly higher than imn; forces all the way around
 
     Scenario: Too-negative penalty clamps, but does not fail
         Given the contract extra arguments "--turn-penalty-file {penalties_file}"

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -53,21 +53,21 @@ Feature: Traffic - turn penalties
     Scenario: Weighting not based on turn penalty file
         When I route I should get
             | from | to | route           | speed   | time      |
-            | a    | h  | ad,dhk,dhk      | 52 km/h | 14s +-1   |
+            | a    | h  | ad,dhk,dhk      | 65 km/h | 11s +-1   |
                                                                   # straight
-            | i    | g  | fim,fg,fg       | 45 km/h | 16s +-1   |
+            | i    | g  | fim,fg,fg       | 55 km/h | 13s +-1 |
                                                                   # right
-            | a    | e  | ad,def,def      | 38 km/h | 19s +-1   |
+            | a    | e  | ad,def,def      | 44 km/h | 16.3s +-1 |
                                                                   # left
-            | c    | g  | cd,def,fg,fg    | 52 km/h | 27s +-1   |
+            | c    | g  | cd,def,fg,fg    | 65 km/h | 22s +-1   |
                                                                   # double straight
-            | p    | g  | mp,fim,fg,fg    | 48 km/h | 29s +-1   |
+            | p    | g  | mp,fim,fg,fg    | 60 km/h | 24s +-1   |
                                                                   # straight-right
-            | a    | l  | ad,dhk,klm,klm  | 44 km/h | 33s +-1   |
+            | a    | l  | ad,dhk,klm,klm  | 53 km/h | 27s +-1   |
                                                                   # straight-left
-            | l    | e  | klm,dhk,def,def | 45 km/h | 32s +-1   |
+            | l    | e  | klm,dhk,def,def | 55 km/h | 26s +-1   |
                                                                   # double right
-            | g    | n  | fg,fim,mn,mn    | 38 km/h | 38s +-1   |
+            | g    | n  | fg,fim,mn,mn    | 44 km/h | 32s +-1   |
                                                                   # double left
 
     Scenario: Weighting based on turn penalty file

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -89,9 +89,9 @@ Feature: Traffic - turn penalties
         And the contract extra arguments "--turn-penalty-file {penalties_file}"
         When I route I should get
             | from | to | route                 | speed   | time      |
-            | a    | h  | ad,dhk,dhk            | 52 km/h | 14s +-1   |
+            | a    | h  | ad,dhk,dhk            | 65 km/h | 11s +-1   |
                                                                               # straight
-            | i    | g  | fim,fg,fg             | 46 km/h | 15s +-1   |
+            | i    | g  | fim,fg,fg             | 56 km/h | 15s +-1   |
                                                                               # right - ifg penalty
             | a    | e  | ad,def,def            | 53 km/h | 14s +-1   |
                                                                               # left - faster because of negative ade penalty

--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -80,6 +80,12 @@ Feature: Traffic - turn penalties
             8,11,12,23
             1,4,5,-0.2
             """
+            # ifg right turn
+            # imn left turn
+            # hdc left turn
+            # lkh right turn
+            # hkl left turn
+            # ade left turn
         And the contract extra arguments "--turn-penalty-file {penalties_file}"
         When I route I should get
             | from | to | route                 | speed   | time      |

--- a/features/car/weight.feature
+++ b/features/car/weight.feature
@@ -20,9 +20,9 @@ Feature: Car - weights
             | cg    | tertiary    |
             | bdf   | service     |
         When I route I should get
-            | from | to | route          | speed   |
-            | a    | e  | abc,cg,efg,efg | 23 km/h |
-            | a    | d  | abc,bdf,bdf    | 14 km/h |
+            | from | to | route          | speed   | weight |
+            | a    | e  | abc,cg,efg,efg | 28 km/h | 38 +-1 |
+            | a    | d  | abc,bdf,bdf    | 18 km/h | 21 +-1 |
 
     Scenario: Does not jump off the highway to go down service road
         Given the node map
@@ -37,20 +37,27 @@ Feature: Car - weights
             |
             d
             """
+        And the nodes
+            | node | id |
+            | a    | 1  |
+            | b    | 2  |
+            | c    | 3  |
+            | d    | 4  |
+            | e    | 5  |
         And the ways
-            | nodes | highway |
-            | ab    | primary |
-            | bc    | primary |
-            | cd    | primary |
-            | be    | service |
-            | ec    | service |
+            | nodes | highway | oneway |
+            | ab    | primary | yes    |
+            | bc    | primary | yes    |
+            | cd    | primary | yes    |
+            | be    | service | yes    |
+            | ec    | service | yes    |
         And the extract extra arguments "--generate-edge-lookup"
         And the contract extra arguments "--segment-speed-file {speeds_file}"
         And the speed file
             """
-            2,4,8
+            2,5,8
             """
         When I route I should get
-            | from | to | route       | speed   |
-            | a    | d  | ab,bc,cd,cd | 14 km/h |
-            | a    | e  | ab,be,be    | 19 km/h |
+            | from | to | route       | speed   | weight |
+            | a    | d  | ab,bc,cd,cd | 65 km/h | 12 +-1 |
+            | a    | e  | ab,be,be    | 14 km/h | 104    |

--- a/features/car/weight.feature
+++ b/features/car/weight.feature
@@ -1,0 +1,56 @@
+@routing @car @weight
+Feature: Car - weights
+
+    Background: Use specific speeds
+        Given the profile "car"
+
+    Scenario: Only routes down service road when that's the destination
+        Given the node map
+            """
+            a--b--c
+               |
+               d
+               |
+            e--f--g
+            """
+        And the ways
+            | nodes | highway     |
+            | abc   | residential |
+            | efg   | residential |
+            | cg    | tertiary    |
+            | bdf   | service     |
+        When I route I should get
+            | from | to | route          | speed   |
+            | a    | e  | abc,cg,efg,efg | 23 km/h |
+            | a    | d  | abc,bdf,bdf    | 14 km/h |
+
+    Scenario: Does not jump off the highway to go down service road
+        Given the node map
+            """
+            a
+            |
+            b
+            |\
+            | e
+            |/
+            c
+            |
+            d
+            """
+        And the ways
+            | nodes | highway |
+            | ab    | primary |
+            | bc    | primary |
+            | cd    | primary |
+            | be    | service |
+            | ec    | service |
+        And the extract extra arguments "--generate-edge-lookup"
+        And the contract extra arguments "--segment-speed-file {speeds_file}"
+        And the speed file
+            """
+            2,4,8
+            """
+        When I route I should get
+            | from | to | route       | speed   |
+            | a    | d  | ab,bc,cd,cd | 14 km/h |
+            | a    | e  | ab,be,be    | 19 km/h |

--- a/features/car/weight.feature
+++ b/features/car/weight.feature
@@ -21,8 +21,8 @@ Feature: Car - weights
             | bdf   | service     |
         When I route I should get
             | from | to | route          | speed   | weight |
-            | a    | e  | abc,cg,efg,efg | 28 km/h | 38 +-1 |
-            | a    | d  | abc,bdf,bdf    | 18 km/h | 21 +-1 |
+            | a    | e  | abc,cg,efg,efg | 28 km/h | 126.6  |
+            | a    | d  | abc,bdf,bdf    | 18 km/h | 71.7   |
 
     Scenario: Does not jump off the highway to go down service road
         Given the node map
@@ -59,5 +59,5 @@ Feature: Car - weights
             """
         When I route I should get
             | from | to | route       | speed   | weight |
-            | a    | d  | ab,bc,cd,cd | 65 km/h | 12 +-1 |
-            | a    | e  | ab,be,be    | 14 km/h | 104    |
+            | a    | d  | ab,bc,cd,cd | 65 km/h | 44.4   |
+            | a    | e  | ab,be,be    | 14 km/h | 112    |

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -34,10 +34,8 @@ module.exports = function () {
                                     result[direction].status.toString() : '';
                                 break;
                             case /^\d+$/.test(want):
-                                if (result[direction].rate) {
-                                    outputRow[rate] = !isNaN(result[direction].rate) ?
-                                        result[direction].rate.toString() :
-                                        result[direction].rate.toString() || '';
+                                if (result[direction].rate && !isNaN(result[direction].rate)) {
+                                    outputRow[rate] = result[direction].rate.toString();
                                 } else {
                                     outputRow[rate] = '';
                                 }

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -117,7 +117,7 @@ module.exports = function () {
                     if (r.route.split(',')[0] === util.format('w%d', i)) {
                         r.time = r.json.routes[0].duration;
                         r.distance = r.json.routes[0].distance;
-                        r.rate = Math.round(r.distance / r.json.routes[0].weight)
+                        r.rate = Math.round(r.distance / r.json.routes[0].weight);
                         r.speed = r.time > 0 ? parseInt(3.6 * r.distance / r.time) : null;
                     } else {
                         r.status = null;

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -92,7 +92,8 @@ module.exports = function () {
                             }
 
                             var distance = hasRoute && json.routes[0].distance,
-                                time = hasRoute && json.routes[0].duration;
+                                time = hasRoute && json.routes[0].duration,
+                                weight = hasRoute && json.routes[0].weight;
 
                             if (headers.has('distance')) {
                                 if (row.distance.length) {
@@ -101,6 +102,16 @@ module.exports = function () {
                                     got.distance = instructions ? util.format('%dm', distance) : '';
                                 } else {
                                     got.distance = '';
+                                }
+                            }
+
+                            if (headers.has('weight')) {
+                                if (row.weight.length) {
+                                    if (!row.weight.match(/[\d\.]+/))
+                                        return cb(new Error('*** Weight must be specified as a numeric value. (ex: 8)'));
+                                    got.weight = instructions ? util.format('%dm', weight) : '';
+                                } else {
+                                    got.weight = '';
                                 }
                             }
 
@@ -161,6 +172,7 @@ module.exports = function () {
                             putValue('destinations', destinations);
                             putValue('weight_name', weight_name);
                             putValue('weights', weights);
+                            putValue('weight', weight);
                         }
 
                         for (var key in row) {

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -109,7 +109,7 @@ module.exports = function () {
                                 if (row.weight.length) {
                                     if (!row.weight.match(/[\d\.]+/))
                                         return cb(new Error('*** Weight must be specified as a numeric value. (ex: 8)'));
-                                    got.weight = instructions ? util.format('%dm', weight) : '';
+                                    got.weight = instructions ? util.format('%d', weight) : '';
                                 } else {
                                     got.weight = '';
                                 }

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -117,7 +117,7 @@ local profile = {
       unclassified    = 25,
       residential     = 25,
       living_street   = 10,
-      service         = 15,
+      service         = 15
     }
   },
 
@@ -126,7 +126,8 @@ local profile = {
     parking           = 0.5,
     parking_aisle     = 0.5,
     driveway          = 0.5,
-    ["drive-through"] = 0.5
+    ["drive-through"] = 0.5,
+    ["drive-thru"] = 0.5
   },
 
   route_speeds = {

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -17,7 +17,7 @@ properties.max_speed_for_map_matching      = 180/3.6 -- 180kmph -> m/s
 properties.use_turn_restrictions           = true
 properties.continue_straight_at_waypoint   = true
 properties.left_hand_driving               = false
--- For routing based on duration, but weighted for prefering certain roads
+-- For routing based on duration, but weighted for preferring certain roads
 properties.weight_name                     = 'routability'
 -- For shortest duration without penalties for accessibility
 --properties.weight_name                     = 'duration'
@@ -316,10 +316,10 @@ function way_function(way, result)
     -- access tags, e.g: motorcar, motor_vehicle, vehicle
     'handle_access',
 
-    -- check whether forward/backward directons are routable
+    -- check whether forward/backward directions are routable
     'handle_oneway',
 
-    -- check whether forward/backward directons are routable
+    -- check whether forward/backward directions are routable
     'handle_destinations',
 
     -- check whether we're using a special transport mode
@@ -334,11 +334,9 @@ function way_function(way, result)
 
     -- compute speed taking into account way type, maxspeed tags, etc.
     'handle_speed',
-    'handle_side_roads',
     'handle_surface',
     'handle_maxspeed',
     'handle_penalties',
-    'handle_alternating_speed',
 
     -- handle turn lanes and road classification, used for guidance
     'handle_turn_lanes',

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -63,7 +63,8 @@ local profile = {
     'vehicle',
     'permissive',
     'designated',
-    'destination'
+    'destination',
+    'hov' -- we might filter hov out later depending on the avoid settings or add penalties
   },
 
   access_tag_blacklist = Set {

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -486,16 +486,6 @@ function Handlers.run(handlers,way,result,data,profile)
   for i,handler in ipairs(handlers) do
     if Handlers[handler](way,result,data,profile) == false then
       return false
-    else
-      if handler == 'handle_penalties' then
---        io.write('handler: ', handler, '\n')
---        io.write('weight ', result.weight, '\n')
---        io.write('rate ', result.forward_rate, '\n')
---        io.write('duration ', result.duration, '\n')
---        io.write('speed ', result.forward_speed, '\n')
-        io.write('forward speed ', result.forward_speed)
-        io.write('forward rate ', result.forward_rate)
-      end
     end
   end
 end

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -320,10 +320,10 @@ function Handlers.handle_penalties(way,result,data,profile)
 
   if properties.weight_name == 'routability' then
     if result.forward_speed > 0 then
-      result.forward_rate = result.forward_speed * penalty
+      result.forward_rate = (result.forward_speed * penalty) / 3.6
     end
     if result.backward_speed > 0 then
-      result.backward_rate = result.backward_speed * penalty
+      result.backward_rate = (result.backward_speed * penalty) / 3.6
     end
     if result.duration > 0 then
       result.weight = result.duration / penalty

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -305,17 +305,17 @@ function Handlers.handle_penalties(way,result,data,profile)
   local sideroad_penalty = 1.0
   data.sideroad = way:get_value_by_key("side_road")
   if "yes" == data.sideroad or "rotary" == data.sideroad then
-    sideroad_penalty = side_road_multipler;
+    sideroad_penalty = side_road_multiplier;
   end
 
   local penalty = service_penalty * width_penalty * alternating_penalty * sideroad_penalty
 
   if properties.weight_name == 'routability' then
     if result.forward_speed > 0 then
-      result.forward_rate = result.forward_speed * penalty
+      result.forward_rate = result.forward_speed * profile.speed_reduction
     end
     if result.backward_speed > 0 then
-      result.backward_rate = result.backward_speed * penalty
+      result.backward_rate = result.backward_speed * profile.speed_reduction
     end
     if result.duration > 0 then
       result.weight = result.duration / penalty
@@ -331,11 +331,11 @@ function Handlers.handle_maxspeed(way,result,data,profile)
   backward = Handlers.parse_maxspeed(backward,profile)
 
   if forward and forward > 0 then
-    result.forward_speed = forward * speed_scaling
+    result.forward_speed = forward * profile.speed_reduction
   end
 
   if backward and backward > 0 then
-    result.backward_speed = backward * speed_scaling
+    result.backward_speed = backward * profile.speed_reduction
   end
 end
 

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
               {{"distance", 0.},
                {"duration", 0.},
                {"weight", 0.},
-               {"weight_name", "duration"},
+               {"weight_name", "routability"},
                {"geometry", "yw_jGupkl@??"},
                {"legs",
                 json::Array{{json::Object{

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    BOOST_CHECK_EQUAL(result.size(), 114033);
+    BOOST_CHECK_EQUAL(result.size(), 113824);
 
     protozero::pbf_reader tile_message(result);
     tile_message.next();


### PR DESCRIPTION
Continuation of https://github.com/Project-OSRM/osrm-backend/pull/3276 against the right branch.

# Issue

In the past we have used penalties on the speed to make routing over certain types of roads less appealing to the routing engine. However this screws with the ETAs when you actually need to go over those penalized roads.

This PR changes this speed penalties to weight penalties which was unlocked by fixing #77. 

This means certain tests that test for applying the penalties in the car profile will fail now. They need to be adapted to test if the speed is unchanged while the rate/weight is adjusted for the penalty.

## Tasklist
-  [x] port hov handler into penalty handler to heavily penalize HOV tagged ways
-  [x] use min applicable penalty rather than a multiplied aggregate penalty value
-  [x] Add support for new cucumber test headers: `rate` and `weight`
-  [x] Update tests to test for more important values, e.g. weight rather than speed
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
