### PR TITLE
Pulls parameters through to make them configurable from the outside

### DIFF
--- a/include/partition/partition_config.hpp
+++ b/include/partition/partition_config.hpp
@@ -42,6 +42,11 @@ struct PartitionConfig
     boost::filesystem::path partition_path;
 
     unsigned requested_num_threads;
+
+    std::size_t maximum_cell_size;
+    double balance;
+    double boundary_factor;
+    std::size_t num_optimizing_cuts;
 };
 }
 }

--- a/include/partition/recursive_bisection.hpp
+++ b/include/partition/recursive_bisection.hpp
@@ -19,6 +19,7 @@ class RecursiveBisection
     RecursiveBisection(std::size_t maximum_cell_size,
                        double balance,
                        double boundary_factor,
+                       std::size_t num_optimizing_cuts,
                        BisectionGraph &bisection_graph);
 
     const std::vector<RecursiveBisectionState::BisectionID> &BisectionIDs() const;

--- a/src/partition/partitioner.cpp
+++ b/src/partition/partitioner.cpp
@@ -7,6 +7,7 @@
 
 #include <iterator>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <boost/assert.hpp>
@@ -84,8 +85,7 @@ void LogGeojson(const std::string &filename, const std::vector<std::uint32_t> &b
         return level;
     };
 
-    const auto reverse_bits = [](std::uint32_t x)
-    {
+    const auto reverse_bits = [](std::uint32_t x) {
         x = ((x >> 1) & 0x55555555u) | ((x & 0x55555555u) << 1);
         x = ((x >> 2) & 0x33333333u) | ((x & 0x33333333u) << 2);
         x = ((x >> 4) & 0x0f0f0f0fu) | ((x & 0x0f0f0f0fu) << 4);
@@ -150,7 +150,11 @@ int Partitioner::Run(const PartitionConfig &config)
         makeBisectionGraph(compressed_node_based_graph.coordinates,
                            adaptToBisectionEdge(std::move(compressed_node_based_graph.edges)));
 
-    RecursiveBisection recursive_bisection(8096, 1.1, 0.35, graph);
+    RecursiveBisection recursive_bisection(config.maximum_cell_size,
+                                           config.balance,
+                                           config.boundary_factor,
+                                           config.num_optimizing_cuts,
+                                           graph);
 
     LogGeojson(config.compressed_node_based_graph_path.string(),
                recursive_bisection.BisectionIDs());

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -57,7 +57,7 @@ return_code parseArguments(int argc, char *argv[], extractor::ExtractorConfig &e
         "Number of nodes required before a strongly-connected-componennt is considered big "
         "(affects nearest neighbor snapping)")(
         "with-osm-metadata",
-        boost::program_options::value<bool>(&extractor_config.use_metadata)
+        boost::program_options::bool_switch(&extractor_config.use_metadata)
             ->implicit_value(true)
             ->default_value(false),
         "Use metada during osm parsing (This can affect the extraction performance).");

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -28,11 +28,31 @@ return_code parseArguments(int argc, char *argv[], partition::PartitionConfig &p
 
     // declare a group of options that will be allowed both on command line
     boost::program_options::options_description config_options("Configuration");
-    config_options.add_options()(
-        "threads,t",
-        boost::program_options::value<unsigned int>(&partition_config.requested_num_threads)
-            ->default_value(tbb::task_scheduler_init::default_num_threads()),
-        "Number of threads to use");
+    config_options.add_options()
+        //
+        ("threads,t",
+         boost::program_options::value<unsigned int>(&partition_config.requested_num_threads)
+             ->default_value(tbb::task_scheduler_init::default_num_threads()),
+         "Number of threads to use")
+        //
+        ("max-cell-size",
+         boost::program_options::value<std::size_t>(&partition_config.maximum_cell_size)
+             ->default_value(4096),
+         "Bisection termination citerion based on cell size")
+        //
+        ("balance",
+         boost::program_options::value<double>(&partition_config.balance)->default_value(1.2),
+         "Balance for left and right side in single bisection")
+        //
+        ("boundary",
+         boost::program_options::value<double>(&partition_config.boundary_factor)
+             ->default_value(0.25),
+         "Percentage of embedded nodes to contract as sources and sinks")
+        //
+        ("optimizing-cuts",
+         boost::program_options::value<std::size_t>(&partition_config.num_optimizing_cuts)
+             ->default_value(10),
+         "Number of cuts to use for optimizing a single bisection");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/pull/3603. Defaults are equivalent to:

    ./osrm-partition \
      berlin-latest.osrm \
      --max-cell-size 4096 \
      --balance 1.2 \
      --boundary 0.25 \
      --optimizing-cuts 10

Should make it easier to play with parameters and auto-tune it later on from the outside.