### PR TITLE
Reduce memory in stxxl

### DIFF
--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -48,6 +48,7 @@ struct NodeBasedEdge
     guidance::RoadClassification road_classification;
 };
 
+#pragma pack(push, 4)
 struct NodeBasedEdgeWithOSM : NodeBasedEdge
 {
     NodeBasedEdgeWithOSM(OSMNodeID source,
@@ -68,6 +69,7 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
     OSMNodeID osm_source_id;
     OSMNodeID osm_target_id;
 };
+#pragma pack(pop)
 
 // Impl.
 

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -427,10 +427,8 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
             const double distance = util::coordinate_calculation::greatCircleDistance(
                 edge_iterator->source_coordinate, target_coord);
 
-            double weight = static_cast<double>(mapbox::util::apply_visitor(
-                detail::ToValueByEdge(distance), edge_iterator->weight_data));
-            double duration = static_cast<double>(mapbox::util::apply_visitor(
-                detail::ToValueByEdge(distance), edge_iterator->duration_data));
+            auto weight = edge_iterator->weight_data(distance);
+            auto duration = edge_iterator->duration_data(distance);
 
             ExtractionSegment extracted_segment(
                 edge_iterator->source_coordinate, target_coord, distance, weight, duration);

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -119,20 +119,20 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
     InternalExtractorEdge::WeightData forward_weight_data;
     InternalExtractorEdge::WeightData backward_weight_data;
 
-    const auto toValueByEdgeOrByMeter =
-        [&nodes](const double by_way, const double by_meter) -> detail::ByEdgeOrByMeterValue {
-        if (by_way > 0)
+    const auto toValueByEdgeOrByMeter = [&nodes](const double by_way, const double by_meter) {
+        using Value = detail::ByEdgeOrByMeterValue;
+        if (by_way >= 0)
         {
             // FIXME We divide by the number of edges here, but should rather consider
             // the length of each segment. We would either have to compute the length
             // of the whole way here (we can't: no node coordinates) or push that back
             // to the container and keep a reference to the way.
-            const unsigned num_edges = (nodes.size() - 1);
-            return detail::ValueByEdge{by_way / num_edges};
+            const std::size_t num_edges = (nodes.size() - 1);
+            return Value(Value::by_edge, by_way / num_edges);
         }
         else
         {
-            return detail::ValueByMeter{by_meter};
+            return Value(Value::by_meter, by_meter);
         }
     };
 


### PR DESCRIPTION
# Issue

Issue #77 introduced a regression in memory consumption in [`InternalExtractorEdge`](https://github.com/Project-OSRM/osrm-backend/blob/9d2628b74f9ba7742955cd178c42a1bd09a55523/include/extractor/internal_extractor_edge.hpp#L23-L41). This PR aimed to reduce memory consumption by using float type for the value and avoid the variant type. The float type can be used with assumption that initial edge weights and duration values from profiles have  24 significant bits (about 7 decimal digits). This is pretty safe assumption, because these values are used as 31 significant bits integers and summing up without precision loss 128 maximum possible values will lead to signed integer overflow. To route for over 128 edges without risk of the integer overflow  edge weights should have less than 24 significant bits.
The variant type introduces 8 bytes overhead by `std::size_t type_index` and results to sizeof(mapbox::util::variant<osrm::extractor::detail::ValueByEdge, osrm::extractor::detail::ValueByMeter>)
= 16 bytes per `WeightData` or 32 bytes per edge. Because there are only two types `ValueByEdge` that is always non-negative and  `ValueByMeter` that is always strictly positive the sign bit can be used to encode the value type in a single value without values domains overlap.

Structure sizes:
* before merging #2399 was 
```
sizeof(osrm::extractor::InternalExtractorEdge::WeightData) = 16
sizeof(osrm::extractor::NodeBasedEdgeWithOSM) = 40
sizeof(osrm::extractor::InternalExtractorEdge) = 64
ptype osrm::extractor::InternalExtractorEdge
type = struct osrm::extractor::InternalExtractorEdge {
    osrm::extractor::NodeBasedEdgeWithOSM result;
    osrm::extractor::InternalExtractorEdge::WeightData weight_data;
    osrm::util::Coordinate source_coordinate;
```
* after merging #2399
```
sizeof(osrm::extractor::InternalExtractorEdge::WeightData) = 16
sizeof(osrm::extractor::NodeBasedEdgeWithOSM) = 48
sizeof(osrm::extractor::InternalExtractorEdge) = 88
ptype osrm::extractor::InternalExtractorEdge
type = struct osrm::extractor::InternalExtractorEdge {
    osrm::extractor::NodeBasedEdgeWithOSM result;
    WeightData weight_data;
    WeightData duration_data;
    osrm::util::Coordinate source_coordinate;
```
* with the PR
```
sizeof(osrm::extractor::InternalExtractorEdge::WeightData) = 4
sizeof(osrm::extractor::NodeBasedEdgeWithOSM) = 44
sizeof(osrm::extractor::InternalExtractorEdge) = 60
ptype osrm::extractor::InternalExtractorEdge
type = struct osrm::extractor::InternalExtractorEdge {
    osrm::extractor::NodeBasedEdgeWithOSM result;
    WeightData weight_data;
    WeightData duration_data;
    osrm::util::Coordinate source_coordinate;
```

So PR saves 28 bytes per edge wrt to the current master (>11GB) and 4 bytes wrt master before #2399 merge (1.6GB) for raw 392418286 input ways.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
The PR is rebased on top of #3629, so only e6c884d commit is relevant for review.
