### PR TITLE
remove 4 bytes packing of NodeBasedEdgeWithOSM due to alignment fails

### DIFF
--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -48,7 +48,6 @@ struct NodeBasedEdge
     guidance::RoadClassification road_classification;
 };
 
-#pragma pack(push, 4)
 struct NodeBasedEdgeWithOSM : NodeBasedEdge
 {
     NodeBasedEdgeWithOSM(OSMNodeID source,
@@ -69,7 +68,6 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
     OSMNodeID osm_source_id;
     OSMNodeID osm_target_id;
 };
-#pragma pack(pop)
 
 // Impl.
 


### PR DESCRIPTION
# Issue

Fixes #3653 that was introduced in c48fc58 via 4-bytes packing of `NodeBasedEdgeWithOSM`. 
Rearrangement of members will not help (28, 8, 8 bytes) to get 8 bytes alignment in `NodeBasedEdgeWithOSM`and `InternalExtractorEdge`
PR makes size of `NodeBasedEdgeWithOSM` again 48 bytes with 4 bytes padding and `InternalExtractorEdge` 64 bytes as it was before merging #2399.

## Tasklist
 - [x] review
 - [x] adjust for comments
