### PR TITLE
Fix of an assertion in bicycle profile

### DIFF
--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -185,6 +185,7 @@ Feature: Bike - Access tags on ways
 
     Scenario: Bike - Tram with oneway when access is implicit
         Then routability should be
-            | highway     | railway | oneway | bothw |
-            | residential | tram    | yes    | x     |
+            | highway     | railway | access | oneway | bothw |
+            | residential | tram    |        | yes    | x     |
+            | service     | tram    | psv    | yes    | x     |
 

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -338,10 +338,8 @@ function way_function (way, result)
     result.forward_mode = mode.train
     result.backward_mode = mode.train
     -- railways
-    if (not access and data.highway) or (access and not profile.access_tag_blacklist[access]) then
-      result.forward_speed = profile.railway_speeds[railway]
-      result.backward_speed = profile.railway_speeds[railway]
-    end
+    result.forward_speed = profile.railway_speeds[railway]
+    result.backward_speed = profile.railway_speeds[railway]
   elseif amenity and profile.amenity_speeds[amenity] then
     -- parking areas
     result.forward_speed = profile.amenity_speeds[amenity]
@@ -350,7 +348,7 @@ function way_function (way, result)
     -- regular ways
     result.forward_speed = profile.bicycle_speeds[data.highway]
     result.backward_speed = profile.bicycle_speeds[data.highway]
-  elseif access and not profile.access_tag_blacklist[access]  then
+  elseif access and profile.access_tag_whitelist[access]  then
     -- unknown way, but valid access tag
     result.forward_speed = default_speed
     result.backward_speed = default_speed

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -325,19 +325,18 @@ function way_function (way, result)
        result.forward_speed = profile.route_speeds[route]
        result.backward_speed = profile.route_speeds[route]
     end
-  -- public transport
-  elseif profile.use_public_transport and railway and profile.platform_speeds[railway] then
-    -- railway platforms (old tagging scheme)
+  -- railway platforms (old tagging scheme)
+  elseif railway and profile.platform_speeds[railway] then
     result.forward_speed = profile.platform_speeds[railway]
     result.backward_speed = profile.platform_speeds[railway]
-  elseif profile.use_public_transport and profile.platform_speeds[public_transport] then
-    -- public_transport platforms (new tagging platform)
+  -- public_transport platforms (new tagging platform)
+  elseif public_transport and profile.platform_speeds[public_transport] then
     result.forward_speed = profile.platform_speeds[public_transport]
     result.backward_speed = profile.platform_speeds[public_transport]
-  elseif profile.use_public_transport and railway and profile.railway_speeds[railway] then
+  -- railways
+  elseif profile.use_public_transport and railway and profile.railway_speeds[railway] and profile.access_tag_whitelist[access] then
     result.forward_mode = mode.train
     result.backward_mode = mode.train
-    -- railways
     result.forward_speed = profile.railway_speeds[railway]
     result.backward_speed = profile.railway_speeds[railway]
   elseif amenity and profile.amenity_speeds[amenity] then

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -338,7 +338,7 @@ function way_function (way, result)
     result.forward_mode = mode.train
     result.backward_mode = mode.train
     -- railways
-    if (not access and data.highway) or profile.access_tag_whitelist[access] then
+    if (not access and data.highway) or (access and not profile.access_tag_blacklist[access]) then
       result.forward_speed = profile.railway_speeds[railway]
       result.backward_speed = profile.railway_speeds[railway]
     end
@@ -350,7 +350,7 @@ function way_function (way, result)
     -- regular ways
     result.forward_speed = profile.bicycle_speeds[data.highway]
     result.backward_speed = profile.bicycle_speeds[data.highway]
-  elseif access and profile.access_tag_whitelist[access] then
+  elseif access and not profile.access_tag_blacklist[access]  then
     -- unknown way, but valid access tag
     result.forward_speed = default_speed
     result.backward_speed = default_speed


### PR DESCRIPTION
# Issue

In bicycle profile there is a possibility to have some accessible edges with undefined speed. The problem is that union of `access_tag_whitelist` and `access_tag_blacklist` sets is not the universal set of OSM access tags. 

PR changes `access_tag_whitelist` to a complement of `access_tag_blacklist`. Another possibility would be to list all access tags in `access_tag_whitelist` and `access_tag_blacklist`.

/cc @emiltin 

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
PR is rebased on top of #3654 and #3653 to check bicycle.lua on the planet size OSM network.