### PR TITLE
[WIP] direct testing of LUA profiles

### DIFF
--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -5,65 +5,71 @@ var classes = require('../support/data_classes');
 module.exports = function () {
     this.Then(/^routability should be$/, (table, callback) => {
         this.buildWaysFromTable(table, () => {
-            var directions = ['forw','backw','bothw'],
-                headers = new Set(Object.keys(table.hashes()[0]));
+            var directions = ['forw','backw','bothw']
+            var headers = table.raw()[0]
 
-            if (!directions.some(k => !!headers.has(k))) {
+            if (!directions.some(d => headers.indexOf(d) != -1)) {
                 throw new Error('*** routability table must contain either "forw", "backw" or "bothw" column');
             }
 
             this.reprocessAndLoadData((e) => {
                 if (e) return callback(e);
                 var testRow = (row, i, cb) => {
-                    var outputRow = Object.assign({}, row);
+                    var outputRow = Object.assign([], row);
 
                     testRoutabilityRow(i, (err, result) => {
                         if (err) return cb(err);
-                        directions.filter(d => headers.has(d)).forEach((direction) => {
-                            var usingShortcut = false,
-                                want = row[direction];
-                            // shortcuts are when a test has mapped a value like `foot` to
-                            // a value like `5 km/h`, to represent the speed that one
-                            // can travel by foot. we check for these and use the mapped to
-                            // value for later comparison.
-                            if (this.shortcutsHash[row[direction]]) {
-                                want = this.shortcutsHash[row[direction]];
-                                usingShortcut = row[direction];
-                            }
+                        //directions.filter(d => headers.has(d)).forEach((direction,i) => 
+                        headers.forEach( (header,i) =>          // loop through columns
+                        {
+                            if (directions.indexOf(header) != -1) {     // should this column be checked?
+                                var usingShortcut = false
+                                var want = row[i]
+                                var direction = headers[i]
 
-                            switch (true) {
-                            case '' === want:
-                            case 'x' === want:
-                                outputRow[direction] = result[direction].status ?
-                                    result[direction].status.toString() : '';
-                                break;
-                            case /^[\d\.]+ s/.test(want):
-                                // the result here can come back as a non-number value like
-                                // `diff`, but we only want to apply the unit when it comes
-                                // back as a number, for tableDiff's literal comparison
-                                if (result[direction].time) {
-                                    outputRow[direction] = !isNaN(result[direction].time) ?
-                                        result[direction].time.toString()+' s' :
-                                        result[direction].time.toString() || '';
-                                } else {
-                                    outputRow[direction] = '';
+                                // shortcuts are when a test has mapped a value like `foot` to
+                                // a value like `5 km/h`, to represent the speed that one
+                                // can travel by foot. we check for these and use the mapped to
+                                // value for later comparison.
+                                if (this.shortcutsHash[row[i]]) {
+                                    want = this.shortcutsHash[row[i]];
+                                    usingShortcut = row[i];
                                 }
-                                break;
-                            case /^\d+ km\/h/.test(want):
-                                if (result[direction].speed) {
-                                    outputRow[direction] = !isNaN(result[direction].speed) ?
-                                        result[direction].speed.toString()+' km/h' :
-                                        result[direction].speed.toString() || '';
-                                } else {
-                                    outputRow[direction] = '';
-                                }
-                                break;
-                            default:
-                                throw new Error(util.format('*** Unknown expectation format: %s', want));
-                            }
 
-                            if (this.FuzzyMatch.match(outputRow[direction], want)) {
-                                outputRow[direction] = usingShortcut ? usingShortcut : row[direction];
+                                switch (true) {
+                                case '' === want:
+                                case 'x' === want:
+                                    outputRow[i] = result[direction].status ?
+                                        result[direction].status.toString() : '';
+                                    break;
+                                case /^[\d\.]+ s/.test(want):
+                                    // the result here can come back as a non-number value like
+                                    // `diff`, but we only want to apply the unit when it comes
+                                    // back as a number, for tableDiff's literal comparison
+                                    if (result[direction].time) {
+                                        outputRow[direction] = !isNaN(result[direction].time) ?
+                                            result[direction].time.toString()+' s' :
+                                            result[direction].time.toString() || '';
+                                    } else {
+                                        outputRow[i] = '';
+                                    }
+                                    break;
+                                case /^\d+ km\/h/.test(want):
+                                    if (result[direction].speed) {
+                                        outputRow[i] = !isNaN(result[direction].speed) ?
+                                            result[direction].speed.toString()+' km/h' :
+                                            result[direction].speed.toString() || '';
+                                    } else {
+                                        outputRow[i] = '';
+                                    }
+                                    break;
+                                default:
+                                    throw new Error(util.format('*** Unknown expectation format: %s', want));
+                                }
+
+                                if (this.FuzzyMatch.match(outputRow[i], want)) {
+                                    outputRow[i] = usingShortcut ? usingShortcut : row[i];
+                                }
                             }
                         });
 

--- a/features/step_definitions/tags.js
+++ b/features/step_definitions/tags.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var d3 = require('d3-queue');
+const tableDiff = require('../lib/table_diff');
+
+
+module.exports = function () {
+
+    this.When(/^processing way tags I should get$/, (table, callback) => {
+        
+        // determine split point
+        var headers = table.raw()[0]
+        var split
+        headers.forEach((key,i) => {
+            if (key == '>') {
+                split = i
+            }
+        });
+        
+        // process rows
+        var resultTable = []
+        table.rows().forEach((row, i) => {
+            // fetch input tags and expected tags
+            var input = {}
+            var expected = {}
+            row.forEach((v,j) => {
+                if (j<split && v)
+                    input[ headers[j] ] = v
+                else if (j>split && v)
+                    expected[ headers[j] ] = v
+            })
+            
+            // call profile
+            var json = this.processWayTags( input )
+            
+            // prepare row for later table diff 
+            var actual = []
+            row.forEach((value,j) => {
+                if (j <= split) {
+                    actual[ j ] = value                     // input tags are simply copied
+                } else if (j > split) {
+                    if (json[ headers[j] ] == null)
+                        actual[ j ] = ''                    // treat '' as null 
+                    else
+                        actual[ j ] = json[ headers[j] ]    // output tags from profile output
+                }
+            })
+            
+            // store row
+            resultTable.push( actual )
+        })
+
+        // compare expected and actual tables
+        var diff = tableDiff(table, resultTable)
+        callback(diff)
+    });
+}

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -243,7 +243,7 @@ module.exports = function () {
     this.processRowsAndDiff = (table, fn, callback) => {
         var q = d3.queue(1);
 
-        table.hashes().forEach((row, i) => { q.defer(fn, row, i); });
+        table.rows().forEach((row, i) => { q.defer(fn, row, i); });
 
         q.awaitAll((err, actual) => {
             if (err) return callback(err);

--- a/features/support/tags.js
+++ b/features/support/tags.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const fs = require('fs');
+const util = require('util');
+const d3 = require('d3-queue');
+const classes = require('./data_classes');
+const tableDiff = require('../lib/table_diff');
+var child_process = require('child_process');
+var path = require('path')
+
+
+module.exports = function () {
+  
+  this.processWayTags = (tags) => {
+    var args = []
+
+    for (var key in tags) {
+      args.push("\"" + key + "\"")
+      args.push("\"" + tags[key] + "\"")
+    }
+    
+    var oldDir = process.cwd()
+    process.chdir('profiles')
+    
+    var lua = 'lua5.1'
+    var profile = 'bicycle'
+    var script  = './lib/testing.lua'
+    var cmd = [lua,script,profile,args.join(' ')].join(' ')
+    var output = child_process.execSync(cmd).toString()
+
+    process.chdir(oldDir)
+
+    return JSON.parse(output)
+   };
+};

--- a/features/tags/name.feature
+++ b/features/tags/name.feature
@@ -1,0 +1,29 @@
+@tags @bicycle
+Feature: Bicycle - profile tag parsing
+
+Background:
+Given the profile "bicycle"
+
+Scenario: Bike - name tag
+When processing way tags I should get  
+| name  | highway   | > | name  |
+| Linea | cycleway  |   | Linea |
+| Linea |           |   |       |
+|       | cycleway  |   |       |
+|       |           |   |       |
+
+Scenario: Bike - highway and oneway tags
+When processing way tags I should get  
+| highway  | oneway | > | forward_mode | backward_mode |
+| cycleway |        |   | 2            | 2             |
+| cycleway | yes    |   | 2            | 6             |
+| footway  |        |   | 6            | 6             |
+| footway  | yes    |   | 6            | 6             |
+
+Scenario: Bike - surface tags           
+When processing way tags I should get  
+| highway  | surface   | smoothness | > | forward_speed | backward_speed |
+| cycleway |           |            |   | 15            | 15             |
+| cycleway | compacted |            |   | 10            | 10             |
+| footway  |           | bad        |   | 6             | 6              |
+| footway  | compacted | bad        |   | 6             | 6              |

--- a/profiles/lib/json.lua
+++ b/profiles/lib/json.lua
@@ -1,0 +1,480 @@
+--[[
+The MIT License (MIT)
+
+Copyright (c) 2014 Ted Dobyns
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+
+local tokens = {}
+
+tokens.quote = '\"'
+tokens.comma = ','
+tokens.colon = ':'
+tokens.leftBracket = '['
+tokens.rightBracket = ']'
+tokens.leftBrace = '{'
+tokens.rightBrace = '}'
+
+local types = {
+    none = 0,
+    syntax = 1,
+    number = 2,
+    string = 3,
+    boolean = 4
+}
+
+local table_types = {
+    array = 0,
+    object = 1
+}
+
+local function print_error(err)
+    print(string.format("Error parsing JSON: %s", err))
+end
+
+local function gen_error(err, index)
+    return string.format("%s at index %d.", err, index)
+end
+
+local function toboolean(v)
+    return (type(v) == "string" and v == "true") or
+           (type(v) == "number" and v ~= 0) or
+           (type(v) == "boolean" and v)
+end
+
+local function is_whitespace(str)
+    local c = 0
+    for w in str:gmatch("%S+") do c = c + 1 end
+    return c == 0
+end
+
+local function is_token(str)
+    for k, v in pairs(tokens) do
+        if str == v then
+            return true, v
+        end
+    end
+
+    return false, nil
+end
+
+local function is_char(str)
+    local s = str:lower()
+    local alphabet = "abcdefghijklmnopqrstuvwxyz"
+    return alphabet:find(s) ~= nil
+end
+
+local function is_num(str)
+    local num_chars = "0123456789-."
+    return num_chars:find(str) ~= nil
+end
+
+local function is_valid_string_char(str)
+    return str ~= tokens.quote and str ~= tokens.comma and not is_whitespace(str)
+end
+
+local function next_token(str, index, forceStr)
+    local len = string.len(str)
+
+    local frontIndex = index
+    local backIndex = index
+
+    local is_char_func = is_char
+
+    if forceStr then
+        is_char_func = is_valid_string_char
+    end
+
+    while frontIndex <= len do
+        local front = str:sub(frontIndex, backIndex)
+
+        if is_token(front) then
+            return { value = front, __type = types.syntax }, frontIndex + 1
+        elseif is_char_func(front) then
+            while backIndex <= len and
+                  is_valid_string_char(str:sub(backIndex, backIndex)) do
+                backIndex = backIndex + 1
+            end
+            backIndex = backIndex - 1
+            local token = str:sub(frontIndex, backIndex)
+            local tokenType = types.string
+            if token == "true" or token == "false" then
+                token = toboolean(token)
+                tokenType = types.boolean
+            end
+            return { value = token, __type = tokenType }, backIndex + 1
+        elseif is_num(front) then
+            while backIndex <= len and is_num(str:sub(backIndex, backIndex)) do
+                backIndex = backIndex + 1
+            end
+            backIndex = backIndex - 1
+            local token = tonumber(str:sub(frontIndex, backIndex))
+            return { value = token, __type = types.number }, backIndex + 1
+        elseif is_whitespace(front) then
+            frontIndex = frontIndex + 1
+            backIndex = backIndex + 1
+        else
+            return nil, nil, gen_error("Unexpected character", front)
+        end
+    end
+
+    return nil, frontIndex
+end
+
+local function parse_string(str, index)
+    local lquote, index, err = next_token(str, index)
+
+    if err ~= nil then return nil, nil, err end
+
+    if lquote.value ~= tokens.quote then
+        return nil, nil, gen_error("Expected opening quote", index)
+    end
+
+    local strToken, index, err = next_token(str, index, true)
+
+    if err ~= nil then return nil, nil, err end
+    if strToken.__type ~= types.string then
+        return nil, nil, gen_error("Expected string", index)
+    end
+
+    local rquote, index, err = next_token(str, index)
+
+    if err ~= nil then return nil, nil, err end
+
+    if rquote.value ~= tokens.quote then
+        return nil, nil, gen_error("Expected closing quote", index)
+    end
+
+    return strToken.value, index
+end
+
+local function parse_value(str, index)
+    local token, i, err = next_token(str, index)
+
+    if err ~= nil then return nil, nil, err end
+
+    if token.__type == types.syntax then
+        if token.value == tokens.quote then
+            token, i, err = parse_string(str, index)
+
+            if err ~= nil then return nil, nil, err end
+        else
+            return nil, nil, gen_error("Not a valid value token", index)
+        end
+    end
+
+    return token.value, i
+end
+
+local function parse_array(str, index)
+    local result = {}
+    local foundComma = true
+
+    while true do
+        local token, i, err = next_token(str, index)
+
+        if err ~= nil then return nil, nil, err end
+
+        if token.value == tokens.comma then
+            index = i
+            foundComma = true
+        elseif token.value == tokens.rightBracket then
+
+            -- REMOVE THIS TO IGNORE TRALING COMMAS
+            if foundComma then
+                return nil, nil, gen_error("Trailing comma", index)
+            end
+
+            index = i
+            return result, i
+        else
+            if not foundComma then
+                return nil, nil, gen_error("Expected comma", index)
+            end
+
+            foundComma = false
+
+            local next, i, err = next_token(str, index)
+            local value = nil
+            if next.__type == types.syntax then
+                if next.value == tokens.leftBracket then
+                    value, index, err = parse_array(str, index)
+                elseif next.value == tokesn.leftBrace then
+                    value, index, err = parse_object(str, index)
+                else
+                    return nil, nil, gen_error("Unexpected symbol", index)
+                end
+            else
+                value, index, err = parse_value(str, index)
+            end
+
+            if err ~= nil then return nil, nil, err end
+
+            table.insert(result, value)
+        end
+    end
+end
+
+local function parse_object(str, index)
+    local result = {}
+    local foundComma = true
+
+    while true do
+        local token, i, err = next_token(str, index)
+
+        if err ~= nil then return nil, nil, err end
+
+        if token.value == tokens.comma then
+            index = i
+            foundComma = true
+        elseif token.value == tokens.rightBrace then
+
+            -- REMOVE THIS TO IGNORE TRALING COMMAS
+            if foundComma then
+                return nil, nil, gen_error("Trailing comma", index)
+            end
+
+            index = i
+            return result, i
+        else
+            if not foundComma then
+                return nil, nil, gen_error("Expected comma", index)
+            end
+
+            foundComma = false
+
+            local key = nil
+            key, index, err = parse_string(str, index)
+
+            if err ~= nil then return nil, nil, err end
+
+            local colon = nil
+            colon, index, err = next_token(str, index)
+            if err ~= nil then return nil, nil, err end
+            if colon.value ~= tokens.colon then
+                return nil, nil, gen_error("Expected colon", index)
+            end
+
+            local next, i, err = next_token(str, index)
+            local value = nil
+            if next.__type == types.syntax then
+                if next.value == tokens.leftBracket then
+                    value, index, err = parse_array(str, i)
+                elseif next.value == tokens.leftBrace then
+                    value, index, err = parse_object(str, i)
+                elseif next.value == tokens.quote then
+                    value, index, err = parse_string(str, index)
+                else
+                    return nil, nil, gen_error("Unexpected symbol "..next.value, index)
+                end
+            else
+                value, index, err = parse_value(str, index)
+            end
+
+            if err ~= nil then return nil, nil, err end
+
+            result[key] = value
+        end
+    end
+end
+
+local function count_table_items(table)
+    local count = 0
+    for _ in pairs(table) do count = count + 1 end
+    return count
+end
+
+local function encode_spaces(output, count, minify)
+    if minify then return output end
+
+    for i = 1, count do
+        output = output .. ' '
+    end
+
+    return output
+end
+
+local function encode_return(output, minify, tabIndex)
+    if minify then return output end
+
+    output = output .. '\n'
+    output = encode_spaces(output, tabIndex * 4, minify)
+
+    return output
+end
+
+local function encode_number(output, number, minify, tabIndex)
+    output = output .. tostring(number)
+    return output
+end
+
+local function encode_boolean(output, boolean, minify, tabIndex)
+    output = output .. tostring(boolean)
+    return output
+end
+
+local function encode_string(output, string, minify, tabIndex)
+    output = output .. '\"' .. string .. '\"'
+    return output
+end
+
+local function encode_keyvalue(output, key, value, minify, tabIndex)
+    output = encode_string(output, key, minify, tabIndex)
+
+    output = encode_spaces(output, 1, minify)
+
+    output = output .. ':'
+
+    output = encode_spaces(output, 1, minify)
+
+    output = encode_value(output, value, minify, tabIndex)
+
+    return output
+end
+
+local function encode_object(output, object, minify, tabIndex)
+    output = output .. '{'
+
+    tabIndex = tabIndex + 1
+    output = encode_return(output, minify, tabIndex)
+
+    local count = count_table_items(object)
+
+    local encoded = 0
+    for k, value in pairs(object) do
+        output = encode_keyvalue(output, k, value, minify, tabIndex)
+
+        encoded = encoded + 1
+
+        if encoded < count then
+            output = output .. ','
+        else
+            tabIndex = tabIndex - 1
+        end
+
+        output = encode_return(output, minify, tabIndex)
+    end
+
+    output = output .. '}'
+
+    return output
+end
+
+local function encode_array(output, array, minify, tabIndex)
+    output = output .. '['
+
+    tabIndex = tabIndex + 1
+    output = encode_return(output, minify, tabIndex)
+
+    for i, value in ipairs(array) do
+        output = encode_value(output, value, minify, tabIndex)
+
+        if i < #array then
+            output = output .. ','
+        else
+            tabIndex = tabIndex - 1
+        end
+
+        output = encode_return(output, minify, tabIndex)
+    end
+
+    output = output .. ']'
+
+    return output
+end
+
+local function table_type(table)
+    if #table > 0 then
+        return table_types.array
+    else
+        return table_types.object
+    end
+end
+
+local function encode_table(output, table, minify, tabIndex)
+    if table_type(table) == table_types.array then
+        output = encode_array(output, table, minify, tabIndex)
+    else
+        output = encode_object(output, table, minify, tabIndex)
+    end
+
+    return output
+end
+
+function encode_value(output, value, minify, tabIndex)
+    local t = type(value)
+    if t == "table" then
+        output = encode_table(output, value, minify, tabIndex)
+    elseif t == "number" then
+        output = encode_number(output, value, minify, tabIndex)
+    elseif t == "string" then
+        output = encode_string(output, value, minify, tabIndex)
+    elseif t == "boolean" then
+        output = encode_boolean(output, value, minify, tabIndex)
+    end
+
+    return output
+end
+
+local function decode(jsonstr)
+    token, index, err = next_token(jsonstr, 1)
+
+    if err ~= nil then
+        print_error(err)
+        return nil
+    end
+
+    result = nil
+
+    if token.__type == types.syntax then
+        if token.value == tokens.leftBrace then
+            result, index, err = parse_object(jsonstr, 2)
+        elseif token.value == tokens.leftBracket then
+            result, index, err = parse_array(jsonstr, 2)
+        end
+    else
+        print_error("Not a valid JSON object.")
+    end
+
+    if err ~= nil then
+        print_error(err)
+        return nil
+    end
+
+    return result
+end
+
+local function encode(table, minify)
+    assert(type(table) == "table", "JSON encoding requires a table.")
+
+    local output = ""
+
+    output = encode_table(output, table, minify, 0)
+
+    return output
+end
+
+return {
+    encode = encode,
+    decode = decode,
+
+    -- aliases
+    parse = decode
+}

--- a/profiles/lib/test_server.lua
+++ b/profiles/lib/test_server.lua
@@ -1,0 +1,93 @@
+-- lua tag test server, communicating via tcp port 7878.
+-- it can speed up the execution of large number of tag tests,
+-- because you don't have to launch the lua interpreter for each test.
+-- instead you launch the tag test server and keep it running.
+-- for each test you send it some tags which are processed by a
+-- profile. the values computed by the profile are returned and can
+-- be used to validate against expected values.
+
+-- the general flow of events is:
+--
+-- 1. it receives a set of osm tags, encoded as json
+-- 2. it uses the specified profile to process the tags
+-- 3. it returns the resulting values encoded as json
+--
+-- example usage:
+--
+-- first start the test server:
+--   > cd profiles
+--   > lua lib/test_server.lua
+--   Starting tag test server on port 7878
+--
+-- then use eg. netcat to send tags and get back values:
+--   > nc 127.0.0.1 7878
+--   {"highway":"primary"}
+--   {
+--       "forward_speed" : 36,
+--       "duration" : 0,
+--       "road_classification" : {
+--           },
+--       "forward_mode" : 1,
+--       "backward_mode" : 1,
+--       "backward_speed" : 36
+--   }
+--
+-- for use in eg. cucumber testing, the cucumber support code would interface
+-- with the test server instead of netcat.
+
+
+
+local Debug = require('lib/profile_debugger')
+local pprint = require('lib/pprint')
+json = require 'lib/json'
+
+
+
+
+
+-- load profile
+Debug.load_profile('testbot')
+
+
+
+
+-- load namespace
+local socket = require("socket")
+
+-- create a TCP socket and bind it to the local host, at any port
+local server = assert(socket.bind("*", 7878))
+
+-- find out which port the OS chose for us
+local ip, port = server:getsockname()
+
+-- print a message informing what's up
+print("Starting tag test server on port " .. port)
+
+
+
+-- wait for a connection from any client
+local client = server:accept()
+
+-- make sure we don't block waiting for this client's line
+--client:settimeout(10)
+
+-- loop forever waiting for clients
+while 1 do
+  -- receive the line
+  local line, err = client:receive()
+  -- if there was no error, send it back to the client
+  if not err then
+  	local way = json.parse(line)
+		local result = {}
+		Debug.way_function(way,result)
+  	client:send(json.encode(result) .. "\n")
+  else
+  	break
+ 	end
+end
+
+print("Starting tag test server on port " .. port)
+
+  -- done with client, close the object
+  --client:close()
+

--- a/profiles/lib/testing.lua
+++ b/profiles/lib/testing.lua
@@ -1,0 +1,55 @@
+-- Script for testing lua profiles
+--
+-- You pass in osm tags, and get the result table.
+-- This makes it possible to test tag parsing in profiles directly,
+-- Without having to go use osrm binaries or osm files
+--
+-- The script accepts the profile name and a hash of key/values as arguments,
+-- and outputs a formattet result table. Example usage:
+--
+-- > cd profiles
+-- > lua5.1 ./lib/testing.lua bicycle highway primary oneway yes
+-- { 
+--   backward_mode = 6,
+--   backward_rate = 1.6666666666667,
+--   backward_speed = 6,
+--   duration = 0,
+--   forward_mode = 2,
+--   forward_rate = 4.1666666666667,
+--   forward_speed = 15,
+--   road_classification = { 
+--     may_be_ignored = false,
+--     road_priority_class = 4 
+--   } 
+-- }
+-- 
+
+local Debug = require('lib/profile_debugger')
+local pprint = require('lib/pprint')
+
+
+function parse_command_arguments()
+  local key = nil
+  local data = {}
+  local profile
+  for i, v in ipairs(arg) do
+    if i==1 then
+      profile = v
+    else
+      if key then
+        data[key] = v
+        key = nil
+      else
+        key = v
+      end
+    end
+  end
+  return profile,data
+end
+
+
+local profile, way = parse_command_arguments()
+Debug.load_profile(profile)     -- load profile
+local result = {}               -- results go here
+Debug.way_function(way,result)  -- call way function
+pprint(result)                  -- and print output

--- a/profiles/lib/testing.lua
+++ b/profiles/lib/testing.lua
@@ -26,6 +26,7 @@
 
 local Debug = require('lib/profile_debugger')
 local pprint = require('lib/pprint')
+json = require 'lib/json'
 
 
 function parse_command_arguments()
@@ -52,4 +53,4 @@ local profile, way = parse_command_arguments()
 Debug.load_profile(profile)     -- load profile
 local result = {}               -- results go here
 Debug.way_function(way,result)  -- call way function
-pprint(result)                  -- and print output
+print(json.encode(result))      -- and print output as json

--- a/profiles/lib/testing.lua
+++ b/profiles/lib/testing.lua
@@ -23,6 +23,9 @@
 --   } 
 -- }
 -- 
+-- a lua tcp service requires the module luasocket. to install this on lua 5.2 see:
+-- https://stackoverflow.com/questions/39760619/lua-cannot-find-installed-luarocks-on-ubuntu
+
 
 local Debug = require('lib/profile_debugger')
 local pprint = require('lib/pprint')


### PR DESCRIPTION
# Issue
Begins to address #3131, with a LUA script for testing profiles directly. No osrm binaries or OSM files are involved.

The way it works is simple. You call the script form the command line, passing the name of the profile, and some input tags. The profile processes the way and the result table is printed. Example:

```
~/code/osrm-backend/profiles$  lua5.1 ./lib/testing.lua car maxspeed 30 highway primary oneway yes name 'Linea Lane'
{ 
  backward_mode = 0,
  backward_speed = 24,
  destinations = '',
  forward_mode = 1,
  forward_speed = 24,
  is_startpoint = true,
  name = 'Linea Lane',
  road_classification = { 
    may_be_ignored = false,
    road_priority_class = 4 
  } 
}
```

With a bit of cucumber js support code we could then write cucumber test like this:
```gherkin
@tags @car
Feature: Car - Speed tags

  Background:
    Given the profile "car"

  Scenario: Car - parsing of maxspeed tags    
    Given the way
      | highway  | primary    |
      | name     | Linea Lane |
      | maxspeed | 30         |
    When I process the way 
    Then I should get
      | name           | Linea Lane |
      | forward_mode   | driving    |
      | forward_speed  | 24         |
      | backward_mode  | 0          |
      | backward_speed | 0          |
      | is_startpoint  | true       |
```

I think these tests would be very fast to run, since there are no OSM files or binaries to run.
 
There a a few c++ helper functions that profiles can call, these would have to be rewritten in lua to test things that uses these helpers.

## Tasklist
 - [ ] Is this a good idea?
 - [ ] Reimplement C++ helper functions in LUA
 - [ ] Add cucumber.js support code
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

