### PR TITLE
Fix trip response such that it starts at the first coordinate

### DIFF
--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -49,7 +49,7 @@ Feature: Basic trip planning
 
         When I plan a trip I should get
             | waypoints               | trips         |
-            | a,b,c,d,e,f,g,h,i,j,k,l | cbalkjihgfedc |
+            | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba |
 
 
     Scenario: Testbot - Trip planning with less than 10 waypoints tfse
@@ -140,7 +140,7 @@ Feature: Basic trip planning
 
         When I plan a trip I should get
             | waypoints                       | trips               |
-            | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | defghijklabcd,mnopm |
+            | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | abcdefghijkla,mnopm |
 
 
     Scenario: Testbot - Trip planning with fixed start and end points errors

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -328,7 +328,15 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
         {
             scc_route = std::vector<NodeID>(route_begin, route_end);
         }
-
+        // rotate result such that roundtrip starts at node with index 0
+        if (roundtrip)
+        {
+            auto start_index = std::find(scc_route.begin(), scc_route.end(), 0);
+            // @TODO: Find out whether there is always a 0 == Find out whether we return multiple
+            //        trips if there are more than one SCC
+            // BOOST_ASSERT(start_index != scc_route.end());
+            std::rotate(scc_route.begin(), start_index, scc_route.end());
+        }
         trips.push_back(std::move(scc_route));
     }
     if (trips.empty())


### PR DESCRIPTION
# Issue

Currently, the response for roundtrips will return a roundtrip starting at an arbitrary location. 
This means that 
* if a roundtrip between `n0, n1, n2, n3, n4, n5` is requested
* the response could start anywhere e.g. `n4, n2, n1, n3, n0, n5, n4`

This PR will solve this such that the roundtrip starts (and ends) at the first location given in the request:

* if a roundtrip between `n0, n1, n2, n3, n4, n5` is requested
* the response will start at n0 e.g. `n0, n5, n4, n2, n1, n3, n0`

This will solve
#1939
#3067

and partially #3650

## Tasklist
 - [ ] Remove or add assertion of finding zero index depending on the answer [here](https://github.com/Project-OSRM/osrm-backend/issues/3634#issuecomment-277690675)
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki) & API docs
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
