### PR TITLE
Removes distance field from v5 Waypoint object docs

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -721,7 +721,6 @@ Object used to describe waypoint on a route.
 
 - `name` Name of the street the coordinate snapped to
 - `location` Array that contains the `[longitude, latitude]` pair of the snapped coordinate
-- `distance` The distance of the snapped point from the original
 - `hint` Unique internal identifier of the segment (ephemeral, not constant over data updates)
    This can be used on subsequent request to significantly speed up the query and to connect multiple services.
    E.g. you can use the `hint` value obtained by the `nearest` query as `hint` values for `route` inputs.

--- a/docs/http.md
+++ b/docs/http.md
@@ -638,12 +638,8 @@ step.
 | `turn`                 | `modifier` indicates the change in direction accomplished through the turn                                                |
 | `depart`/`arrive`      | `modifier` indicates the position of departure point and arrival point in relation to the current direction of travel      |
 
-- `exit` An optional `integer` indicating number of the exit to take. The property exists for the following `type` property:
-
-| `type`                 | Description                                                                                                               |
-|------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `roundabout`/`rotary`         | Number of the roundabout exit to take. If exit is `undefined` the destination is on the roundabout.                       |
-| else                   | Indicates the number of intersections passed until the turn. Example instruction: `at the fourth intersection, turn left` |
+- `exit` An optional `integer` indicating number of the exit to take. The property exists for the `roundabout` / `rotary` property:
+  Number of the roundabout exit to take. If exit is `undefined` the destination is on the roundabout.
 
 
 New properties (potentially depending on `type`) may be introduced in the future without an API version change.


### PR DESCRIPTION
Waypoint objects have
- name
- location
- hint

fields. The only API adding `distance` to waypoints is the Nearest
plugin. And it documents this behavior independently.

The docs are wrong here from what I can tell. See:
- https://github.com/Project-OSRM/osrm-backend/blob/5.5/src/engine/api/json_factory.cpp#L290-L297
- https://github.com/Project-OSRM/osrm-backend/blob/5.5/include/engine/api/nearest_api.hpp#L37-L44