### PR TITLE
align cucumber diff tables

### DIFF
--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -63,7 +63,7 @@ module.exports = function () {
                             }
 
                             if (this.FuzzyMatch.match(outputRow[direction], want)) {
-                                outputRow[direction] = [usingShortcut ? usingShortcut : row[direction]];
+                                outputRow[direction] = usingShortcut ? usingShortcut : row[direction];
                             }
                         });
 


### PR DESCRIPTION
# Issue

When cucumber tables don't match, the output table is not aligned, which makes it hard to read. This PR fixes it.

Before:
```cucumber
1) Scenario: Car - Mode specific oneway - features/car/oneway.feature:18
   Step: Then routability should be - features/car/oneway.feature:19
   Step Definition: features/step_definitions/routability.js:6
   Message:
     Tables were not identical:
         highway |     oneway:motorcar |     oneway:motor_vehicle |     oneway:vehicle |     oneway |     forw |     backw
     |     primary |      |      |      |      |     x |     x | 
     | (-) primary | (-) no | (-)  | (-)  | (-)  | (-) x | (-)  | 
     | (+) primary | (+) no | (+)  | (+)  | (+)  | (+) x | (+) x | 
     |     primary |      |     yes |      |      |     x |      | 
     |     primary |      |     yes |     yes |      |     x |      | 
     |     primary |      |      |      |     yes |     x |      | 
     | (-) primary | (-) yes | (-) no | (-)  | (-)  | (-)  | (-)  | 
     | (+) primary | (+) yes | (+) no | (+)  | (+)  | (+) x | (+)  | 
     |     primary |      |     yes |     no |      |     x |      | 
     |     primary |      |      |     yes |     no |     x |      | 
     |     primary |      |      |      |     yes |     x |      | 
     |     primary |     no |     yes |      |      |     x |     x | 
     |     primary |      |     no |      |      |     x |     x | 
     |     primary |      |      |     no |     yes |     x |     x | 
```

After:
```cucumber
1) Scenario: Car - Mode specific oneway - features/car/oneway.feature:18
   Step: Then routability should be - features/car/oneway.feature:19
   Step Definition: features/step_definitions/routability.js:6
   Message:
     Tables were not identical:
     |     highway |     oneway:motorcar |     oneway:motor_vehicle |     oneway:vehicle |     oneway |     forw |     backw |
     |     primary |                     |                          |                    |            |     x    |     x     |
     | (-) primary | (-) no              | (-)                      | (-)                | (-)        | (-) x    | (-)       |
     | (+) primary | (+) no              | (+)                      | (+)                | (+)        | (+) x    | (+) x     |
     |     primary |                     |     yes                  |                    |            |     x    |           |
     |     primary |                     |     yes                  |     yes            |            |     x    |           |
     |     primary |                     |                          |                    |     yes    |     x    |           |
     | (-) primary | (-) yes             | (-) no                   | (-)                | (-)        | (-)      | (-)       |
     | (+) primary | (+) yes             | (+) no                   | (+)                | (+)        | (+) x    | (+)       |
     |     primary |                     |     yes                  |     no             |            |     x    |           |
     |     primary |                     |                          |     yes            |     no     |     x    |           |
     |     primary |                     |                          |                    |     yes    |     x    |           |
     |     primary |     no              |     yes                  |                    |            |     x    |     x     |
     |     primary |                     |     no                   |                    |            |     x    |     x     |
     |     primary |                     |                          |     no             |     yes    |     x    |     x     |
```

I discovered a bug in routability.js which was returning the forward/backward rows as arrays ['x'] instead of plain 'x'. This was causing problems with the table diffing, so fixed it.