### PR TITLE
fix order of parameter initialisation for route parameters

### DIFF
--- a/include/engine/api/route_parameters.hpp
+++ b/include/engine/api/route_parameters.hpp
@@ -120,9 +120,9 @@ struct RouteParameters : public BaseParameters
                     const boost::optional<bool> continue_straight_,
                     Args... args_)
         : BaseParameters{std::forward<Args>(args_)...}, steps{steps_}, alternatives{alternatives_},
-          annotations_type{annotations_},
           annotations{annotations_ == AnnotationsType::None ? false : true},
-          geometries{geometries_}, overview{overview_}, continue_straight{continue_straight_}
+          annotations_type{annotations_}, geometries{geometries_}, overview{overview_},
+          continue_straight{continue_straight_}
     {
     }
 


### PR DESCRIPTION
# Issue

Fixes compiler warnings:

```
engine/project-osrm/osrm-backend/include/engine/api/route_parameters.hpp:123:11: warning: field 'annotations_type' will be initialized after field 'annotations' [-Wreorder]
          annotations_type{annotations_}
```

## Tasklist
 - [x] review
 - [x] adjust for comments
