### PR TITLE
Return `NoTrips` if waypoints in trip request are not connected and not routable

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -313,8 +313,7 @@ All other properties might be undefined.
 
 The trip plugin solves the Traveling Salesman Problem using a greedy heuristic (farthest-insertion algorithm) for 10 or more waypoints and uses brute force for less than 10 waypoints.
 The returned path does not have to be the fastest path, as TSP is NP-hard it is only an approximation.
-Note that if the input coordinates can not be joined by a single trip (e.g. the coordinates are on several disconnected islands)
-multiple trips for each connected component are returned.
+Note that all input coordinates have to be connected. 
 
 ```endpoint
 GET /trip/v1/{profile}/{coordinates}?steps={true|false}&geometries={polyline|polyline6|geojson}&overview={simplified|full|false}&annotations={true|false}'
@@ -365,7 +364,7 @@ In case of error the following `code`s are supported in addition to the general 
 
 | Type              | Description         |
 |-------------------|---------------------|
-| `NoTrips`         | No trips found.     |
+| `NoTrips`         | No trips found because input coordinates are not connected.     |
 
 All other properties might be undefined.
 

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -60,7 +60,7 @@ Feature: Basic trip planning
                   c
             e  d
             """
- 
+
         And the ways
             | nodes |
             | ab    |
@@ -73,7 +73,7 @@ Feature: Basic trip planning
             | cd    |
             | ce    |
             | de    |
- 
+
         When I plan a trip I should get
             |  waypoints  | source | destination |roundtrip | trips  | durations         | distance               |
             |  a,b,c,d,e  | 4      | 4           | true     | abcdea | 10.3              | 103                    |
@@ -106,8 +106,6 @@ Feature: Basic trip planning
             |  a,b,c,d,e,f,g,h,i,j,k  | 4      | 4           | true      | abcdefghijka | 20         | 199.9     |
             |  a,b,c,d,e,f,g,h,i,j,k  | 0      | 5           | true      | abcdeghijkfa | 20         | 199.8     |
 
-
-
     Scenario: Testbot - Trip planning with multiple scc roundtrip
         Given the node map
             """
@@ -117,7 +115,7 @@ Feature: Basic trip planning
             j i h g
 
             q m n
-              p o
+            p o
             """
 
         And the ways
@@ -141,9 +139,25 @@ Feature: Basic trip planning
             | qm    |
 
         When I plan a trip I should get
-            | waypoints                       | trips               |
-            | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | abcdefghijkla,mnopm |
+            | waypoints                       | status         | message                                      |
+            | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | NoTrips        | No trip visiting all destinations possible.  |
 
+    Scenario: Testbot - Trip planning with unroutable waypoints
+        Given the node map
+            """
+            a b
+
+            d c
+            """
+
+         And the ways
+            | nodes |
+            | ab    |
+            | dc    |
+
+         When I plan a trip I should get
+            |  waypoints    | status         | message                                       |
+            |  a,b,c,d      | NoTrips        | No trip visiting all destinations possible.  |
 
     Scenario: Testbot - Trip planning with fixed start and end points errors
         Given the node map
@@ -160,7 +174,7 @@ Feature: Basic trip planning
 
          When I plan a trip I should get
             |  waypoints    | source  | destination | roundtrip | status         | message                                       |
-            |  a,b,c,d      | 0       | 3           | false     | NoTrips        | No route possible from source to destination  |
+            |  a,b,c,d      | 0       | 3           | false     | NoTrips        | No trip visiting all destinations possible.  |
             |  a,b,c,d      | -1      | 1           | false     | InvalidQuery   | Query string malformed close to position 123  |
             |  a,b,c,d      | 1       | -1          | false     | InvalidQuery   | Query string malformed close to position 137  |
             |  a,b,c,d      | 10      | 1           | false     | InvalidValue   | Invalid source or destination value.          |

--- a/include/engine/trip/trip_brute_force.hpp
+++ b/include/engine/trip/trip_brute_force.hpp
@@ -25,14 +25,15 @@ namespace trip
 EdgeWeight ReturnDistance(const util::DistTableWrapper<EdgeWeight> &dist_table,
                           const std::vector<NodeID> &location_order,
                           const EdgeWeight min_route_dist,
-                          const std::size_t component_size)
+                          const std::size_t number_of_locations)
 {
     EdgeWeight route_dist = 0;
     std::size_t i = 0;
     while (i < location_order.size() && (route_dist < min_route_dist))
     {
 
-        auto edge_weight = dist_table(location_order[i], location_order[(i + 1) % component_size]);
+        auto edge_weight =
+            dist_table(location_order[i], location_order[(i + 1) % number_of_locations]);
 
         // If the edge_weight is very large (INVALID_EDGE_WEIGHT) then the algorithm will not choose
         // this edge in final minimal path. So instead of computing all the permutations after this
@@ -47,9 +48,10 @@ EdgeWeight ReturnDistance(const util::DistTableWrapper<EdgeWeight> &dist_table,
         }
 
         // This boost assert should not be reached if TFSE table
-        BOOST_ASSERT_MSG(dist_table(location_order[i], location_order[(i + 1) % component_size]) !=
-                             INVALID_EDGE_WEIGHT,
-                         "invalid route found");
+        BOOST_ASSERT_MSG(
+            dist_table(location_order[i], location_order[(i + 1) % number_of_locations]) !=
+                INVALID_EDGE_WEIGHT,
+            "invalid route found");
         ++i;
     }
 
@@ -57,45 +59,43 @@ EdgeWeight ReturnDistance(const util::DistTableWrapper<EdgeWeight> &dist_table,
 }
 
 // computes the route by computing all permutations and selecting the shortest
-template <typename NodeIDIterator>
-std::vector<NodeID> BruteForceTrip(const NodeIDIterator start,
-                                   const NodeIDIterator end,
-                                   const std::size_t number_of_locations,
+std::vector<NodeID> BruteForceTrip(const std::size_t number_of_locations,
                                    const util::DistTableWrapper<EdgeWeight> &dist_table)
 {
-    (void)number_of_locations; // unused
-
-    const auto component_size = std::distance(start, end);
-
-    std::vector<NodeID> perm(start, end);
-    std::vector<NodeID> route = perm;
+    // set initial order in which nodes are visited to 0, 1, 2, 3, ...
+    std::vector<NodeID> node_order(number_of_locations);
+    std::iota(std::begin(node_order), std::end(node_order), 0);
+    std::vector<NodeID> route = node_order;
 
     EdgeWeight min_route_dist = INVALID_EDGE_WEIGHT;
 
     // check length of all possible permutation of the component ids
-
-    BOOST_ASSERT_MSG(perm.size() > 0, "no permutation given");
-    BOOST_ASSERT_MSG(*(std::max_element(std::begin(perm), std::end(perm))) < number_of_locations,
+    BOOST_ASSERT_MSG(node_order.size() > 0, "no order permutation given");
+    BOOST_ASSERT_MSG(*(std::max_element(std::begin(node_order), std::end(node_order))) <
+                         number_of_locations,
                      "invalid node id");
-    BOOST_ASSERT_MSG(*(std::min_element(std::begin(perm), std::end(perm))) >= 0, "invalid node id");
+    BOOST_ASSERT_MSG(*(std::min_element(std::begin(node_order), std::end(node_order))) >= 0,
+                     "invalid node id");
 
     do
     {
-        const auto new_distance = ReturnDistance(dist_table, perm, min_route_dist, component_size);
+        const auto new_distance =
+            ReturnDistance(dist_table, node_order, min_route_dist, number_of_locations);
         // we can use `<` instead of `<=` here, since all distances are `!=` INVALID_EDGE_WEIGHT
         // In case we really sum up to invalid edge weight for all permutations, keeping the very
         // first one is fine too.
         if (new_distance < min_route_dist)
         {
             min_route_dist = new_distance;
-            route = perm;
+            route = node_order;
         }
-    } while (std::next_permutation(std::begin(perm), std::end(perm)));
+    } while (std::next_permutation(std::begin(node_order), std::end(node_order)));
 
     return route;
 }
-}
-}
-}
+
+} // namespace trip
+} // namespace engine
+} // namespace osrm
 
 #endif // TRIP_BRUTE_FORCE_HPP

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -1,7 +1,5 @@
 #include "engine/plugins/trip.hpp"
 
-#include "extractor/tarjan_scc.hpp"
-
 #include "engine/api/trip_api.hpp"
 #include "engine/api/trip_parameters.hpp"
 #include "engine/trip/trip_brute_force.hpp"
@@ -29,89 +27,10 @@ namespace engine
 namespace plugins
 {
 
-// Object to hold all strongly connected components (scc) of a graph
-// to access all graphs with component ID i, get the iterators by:
-// auto start = std::begin(scc_component.component) + scc_component.range[i];
-// auto end = std::begin(scc_component.component) + scc_component.range[i+1];
-struct SCC_Component
+bool IsStronglyConnectedComponent(const util::DistTableWrapper<EdgeWeight> &result_table)
 {
-    // in_component: all NodeIDs sorted by component ID
-    // in_range: index where a new component starts
-    //
-    // example: NodeID 0, 1, 2, 4, 5 are in component 0
-    //          NodeID 3, 6, 7, 8    are in component 1
-    //          => in_component = [0, 1, 2, 4, 5, 3, 6, 7, 8]
-    //          => in_range = [0, 5]
-    SCC_Component(std::vector<NodeID> in_component_nodes, std::vector<size_t> in_range)
-        : component(std::move(in_component_nodes)), range(std::move(in_range))
-    {
-        BOOST_ASSERT_MSG(component.size() > 0, "there's no scc component");
-        BOOST_ASSERT_MSG(*std::max_element(range.begin(), range.end()) == component.size(),
-                         "scc component ranges are out of bound");
-        BOOST_ASSERT_MSG(*std::min_element(range.begin(), range.end()) == 0,
-                         "invalid scc component range");
-        BOOST_ASSERT_MSG(std::is_sorted(std::begin(range), std::end(range)),
-                         "invalid component ranges");
-    }
-
-    std::size_t GetNumberOfComponents() const
-    {
-        BOOST_ASSERT_MSG(range.size() > 0, "there's no range");
-        return range.size() - 1;
-    }
-
-    std::vector<NodeID> component;
-    std::vector<std::size_t> range;
-};
-
-// takes the number of locations and its duration matrix,
-// identifies and splits the graph in its strongly connected components (scc)
-// and returns an SCC_Component
-SCC_Component SplitUnaccessibleLocations(const std::size_t number_of_locations,
-                                         const util::DistTableWrapper<EdgeWeight> &result_table)
-{
-    if (std::find(std::begin(result_table), std::end(result_table), INVALID_EDGE_WEIGHT) ==
-        std::end(result_table))
-    {
-        // whole graph is one scc
-        std::vector<NodeID> location_ids(number_of_locations);
-        std::iota(std::begin(location_ids), std::end(location_ids), 0);
-        std::vector<size_t> range = {0, location_ids.size()};
-        return SCC_Component(std::move(location_ids), std::move(range));
-    }
-
-    // Run TarjanSCC
-    auto wrapper = std::make_shared<util::MatrixGraphWrapper<EdgeWeight>>(result_table.GetTable(),
-                                                                          number_of_locations);
-    auto scc = extractor::TarjanSCC<util::MatrixGraphWrapper<EdgeWeight>>(wrapper);
-    scc.Run();
-
-    const auto number_of_components = scc.GetNumberOfComponents();
-
-    std::vector<std::size_t> range_insertion;
-    std::vector<std::size_t> range;
-    range_insertion.reserve(number_of_components);
-    range.reserve(number_of_components);
-
-    std::vector<NodeID> components(number_of_locations, 0);
-
-    std::size_t prefix = 0;
-    for (std::size_t j = 0; j < number_of_components; ++j)
-    {
-        range_insertion.push_back(prefix);
-        range.push_back(prefix);
-        prefix += scc.GetComponentSize(j);
-    }
-    // senitel
-    range.push_back(components.size());
-
-    for (std::size_t i = 0; i < number_of_locations; ++i)
-    {
-        components[range_insertion[scc.GetComponentID(i)]] = i;
-        ++range_insertion[scc.GetComponentID(i)];
-    }
-
-    return SCC_Component(std::move(components), std::move(range));
+    return std::find(std::begin(result_table), std::end(result_table), INVALID_EDGE_WEIGHT) ==
+           std::end(result_table);
 }
 
 InternalRouteResult
@@ -145,12 +64,12 @@ TripPlugin::ComputeRoute(const std::shared_ptr<const datafacade::BaseDataFacade>
     if (roundtrip)
     {
         // trip comes out to be something like 0 1 4 3 2 0
-        // BOOST_ASSERT(min_route.segment_end_coordinates.size() == trip.size());
+        BOOST_ASSERT(min_route.segment_end_coordinates.size() == trip.size());
     }
     else
     {
         // trip comes out to be something like 0 1 4 3 2, so the sizes don't match
-        // BOOST_ASSERT(min_route.segment_end_coordinates.size() == trip.size() - 1);
+        BOOST_ASSERT(min_route.segment_end_coordinates.size() == trip.size() - 1);
     }
 
     shortest_path(facade, min_route.segment_end_coordinates, {false}, min_route);
@@ -216,8 +135,10 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
     BOOST_ASSERT_MSG(result_table.size() == number_of_locations * number_of_locations,
                      "Distance Table has wrong size");
 
-    // get scc components
-    SCC_Component scc = SplitUnaccessibleLocations(result_table.GetNumberOfNodes(), result_table);
+    if (!IsStronglyConnectedComponent(result_table))
+    {
+        return Error("NoTrips", "No trip visiting all destinations possible.", json_result);
+    }
 
     if (fixed_start_and_end)
     {
@@ -267,92 +188,34 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
         result_table.InvalidateRoute(parameters.source, parameters.destination);
 
         //*********  End of changes to table  *************************************
-
-        //*********  SCC related errors in tfse ***********************************
-        // if source and destination are in different sccs then return error
-        if (scc.GetNumberOfComponents() > 1)
-        {
-            std::size_t source_component_id = std::numeric_limits<std::size_t>::max();
-            std::size_t destination_component_id = std::numeric_limits<std::size_t>::max();
-
-            for (std::size_t k = 0; k < scc.GetNumberOfComponents(); ++k)
-            {
-                auto route_begin = std::begin(scc.component) + scc.range[k];
-                auto route_end = std::begin(scc.component) + scc.range[k + 1];
-
-                std::for_each(route_begin, route_end, [&](const NodeID &id) {
-                    if ((NodeID)parameters.source == id)
-                        source_component_id = k;
-                    if ((NodeID)parameters.destination == id)
-                        destination_component_id = k;
-                });
-            }
-
-            if (destination_component_id == std::numeric_limits<std::size_t>::max() ||
-                source_component_id == std::numeric_limits<std::size_t>::max() ||
-                source_component_id != destination_component_id)
-            {
-                return Error(
-                    "NoTrips", "No route possible from source to destination", json_result);
-            }
-        }
-        //*********  End of SCC related errors ************************************
     }
 
-    std::vector<std::vector<NodeID>> trips;
-    trips.reserve(scc.GetNumberOfComponents());
-    // run Trip computation for every SCC
-    for (std::size_t k = 0; k < scc.GetNumberOfComponents(); ++k)
+    std::vector<NodeID> trip;
+    trip.reserve(number_of_locations);
+    // get an optimized order in which the destinations should be visited
+    if (number_of_locations < BF_MAX_FEASABLE)
     {
-        const auto component_size = scc.range[k + 1] - scc.range[k];
-
-        BOOST_ASSERT_MSG(component_size > 0, "invalid component size");
-
-        std::vector<NodeID> scc_route;
-        auto route_begin = std::begin(scc.component) + scc.range[k];
-        auto route_end = std::begin(scc.component) + scc.range[k + 1];
-
-        if (component_size > 1)
-        {
-            if (component_size < BF_MAX_FEASABLE)
-            {
-                scc_route =
-                    trip::BruteForceTrip(route_begin, route_end, number_of_locations, result_table);
-            }
-            else
-            {
-                scc_route = trip::FarthestInsertionTrip(
-                    route_begin, route_end, number_of_locations, result_table);
-            }
-        }
-        else
-        {
-            scc_route = std::vector<NodeID>(route_begin, route_end);
-        }
-        // rotate result such that roundtrip starts at node with index 0
-        if (parameters.roundtrip)
-        {
-            auto start_index = std::find(scc_route.begin(), scc_route.end(), 0);
-            // @TODO: Find out whether there is always a 0 == Find out whether we return multiple
-            //        trips if there are more than one SCC
-            // BOOST_ASSERT(start_index != scc_route.end());
-            std::rotate(scc_route.begin(), start_index, scc_route.end());
-        }
-        trips.push_back(std::move(scc_route));
+        trip = trip::BruteForceTrip(number_of_locations, result_table);
     }
-    if (trips.empty())
+    else
     {
-        return Error("NoTrips", "Cannot find trips", json_result);
+        trip = trip::FarthestInsertionTrip(number_of_locations, result_table);
     }
 
-    // compute all round trip routes
-    std::vector<InternalRouteResult> routes;
-    routes.reserve(trips.size());
-    for (const auto &trip : trips)
+    // rotate result such that roundtrip starts at node with index 0
+    if (parameters.roundtrip)
     {
-        routes.push_back(ComputeRoute(facade, snapped_phantoms, trip, parameters.roundtrip));
+        auto desired_start_index = std::find(std::begin(trip), std::end(trip), 0);
+        BOOST_ASSERT(desired_start_index != std::end(trip));
+        std::rotate(std::begin(trip), desired_start_index, std::end(trip));
     }
 
+    // get the route when visiting all destinations in optimized order
+    InternalRouteResult route = ComputeRoute(facade, snapped_phantoms, trip, parameters.roundtrip);
+
+    // get api response
+    const std::vector<std::vector<NodeID>> trips = {{trip}};
+    const std::vector<InternalRouteResult> routes = {{route}};
     api::TripAPI trip_api{*facade, parameters};
     trip_api.MakeResponse(trips, routes, snapped_phantoms, json_result);
 

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -214,8 +214,8 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
     InternalRouteResult route = ComputeRoute(facade, snapped_phantoms, trip, parameters.roundtrip);
 
     // get api response
-    const std::vector<std::vector<NodeID>> trips = {{trip}};
-    const std::vector<InternalRouteResult> routes = {{route}};
+    const std::vector<std::vector<NodeID>> trips = {trip};
+    const std::vector<InternalRouteResult> routes = {route};
     api::TripAPI trip_api{*facade, parameters};
     trip_api.MakeResponse(trips, routes, snapped_phantoms, json_result);
 


### PR DESCRIPTION
# Issue

Fixing the bug issued in #3634 .
If waypoints in trip request are not connected and not in the same strongly connected component, return `NoTrips` error

(This PR removes so much ugly code, it makes me so happy I could cry 🎉🎉🎉)

## Tasklist
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review and merge by @ghoshkaj 

