### PR TITLE
Installs profiles to /usr/local/share/osrm by default, resolves #3670

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,11 @@ install(TARGETS osrm_extract DESTINATION lib)
 install(TARGETS osrm_contract DESTINATION lib)
 install(TARGETS osrm_store DESTINATION lib)
 
+
+# Install profiles and support library to /usr/local/share/osrm/profiles by default
+set(DefaultProfilesDir profiles)
+install(DIRECTORY ${DefaultProfilesDir} DESTINATION share/osrm)
+
 # Setup exporting variables for pkgconfig and subproject
 #
 


### PR DESCRIPTION
For #3670. I see no reason not to install profiles by default.

    sudo make install

and

    sudo make uninstall

will now take profiles into account.