### PR TITLE
[Trip] Support more parameter combinations of fixed start/end when requesting roundtrips

### DIFF
--- a/features/step_definitions/trip.js
+++ b/features/step_definitions/trip.js
@@ -151,12 +151,15 @@ module.exports = function () {
                         });
                         got = { waypoints: row.waypoints };
 
-                        if (row.source && row.destination) {
+                        if (row.source) {
                             params.source = got.source = row.source;
+                        } 
+                        
+                        if (row.destination) {
                             params.destination = got.destination = row.destination;
                         } 
 
-                        if (row.hasOwnProperty('roundtrip')) {
+                        if (row.hasOwnProperty('roundtrip')) { //roundtrip is a boolean so row.roundtrip alone doesn't work as a check here
                             params.roundtrip = got.roundtrip = row.roundtrip;
                         }
 

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -5,7 +5,7 @@ Feature: Basic trip planning
         Given the profile "testbot"
         Given a grid size of 10 meters
 
-    Scenario: Testbot - Roundtrip with waypoints <10
+    Scenario: Testbot - Trip: Roundtrip with waypoints <10
         Given the node map
             """
             a b
@@ -24,7 +24,7 @@ Feature: Basic trip planning
             | a,b,c,d   | abcda  | 7.6       |
             | d,b,c,a   | dbcad  | 7.6       |
 
-    Scenario: Testbot - Roundtrip waypoints >10
+    Scenario: Testbot - Trip: Roundtrip waypoints >10
         Given the node map
             """
             a b c d
@@ -51,9 +51,7 @@ Feature: Basic trip planning
             | waypoints               | trips         |
             | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba |
 
-    Scenario: Testbot - Roundtrip FS waypoints >10
-        Given the query options
-            | source | first  |
+    Scenario: Testbot - Trip: Roundtrip FS waypoints >10
         Given the node map
             """
             a b c d
@@ -77,10 +75,10 @@ Feature: Basic trip planning
             | la    |
 
         When I plan a trip I should get
-            | waypoints               | trips         |
-            | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba |
+            | waypoints               | trips         | source |
+            | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba | first  |
 
-    Scenario: Testbot - Roundtrip FE waypoints >10
+    Scenario: Testbot - Trip: Roundtrip FE waypoints >10
         Given the query options
             | source | last  |
         Given the node map
@@ -109,7 +107,7 @@ Feature: Basic trip planning
             | waypoints               | trips         |
             | a,b,c,d,e,f,g,h,i,j,k,l | lkjihgfedcbal |
 
-    Scenario: Testbot - Unroutable roundtrip with waypoints <10
+    Scenario: Testbot - Trip: Unroutable roundtrip with waypoints <10
         Given the node map
             """
             a b
@@ -127,7 +125,7 @@ Feature: Basic trip planning
             |  a,b,c,d      | NoTrips        | No trip visiting all destinations possible.  |
 
 
-    Scenario: Testbot - Unroutable roundtrip with waypoints >10
+    Scenario: Testbot - Trip: Unroutable roundtrip with waypoints >10
         Given the node map
             """
             a b c d
@@ -164,7 +162,7 @@ Feature: Basic trip planning
             | a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p | NoTrips        | No trip visiting all destinations possible.  |
 
 # Test TFSE
-    Scenario: Testbot - TFSE with errors
+    Scenario: Testbot - Trip: TFSE with errors
         Given the node map
             """
             a b
@@ -181,7 +179,7 @@ Feature: Basic trip planning
             |  waypoints    | source  | destination | roundtrip | status           | message                                       |
             |  a,b,c,d      | first   | last        | false     | NoTrips          | No trip visiting all destinations possible.   |
 
-    Scenario: Testbot - TFSE with waypoints <10
+    Scenario: Testbot - Trip: FSE with waypoints <10
         Given the node map
             """
             a  b
@@ -208,7 +206,7 @@ Feature: Basic trip planning
             |  a,b,d,e,c  | first  | last        | false    | abedc  | 8.200000000000001 | 81.6                   |
 
 
-    Scenario: Testbot - TFSE with waypoints >10
+    Scenario: Testbot - Trip: FSE with waypoints >10
         Given the node map
             """
             a b c d e f g h i j k
@@ -231,7 +229,7 @@ Feature: Basic trip planning
             |  waypoints              | source | destination | roundtrip |  trips       | durations  | distance  |
             |  a,b,c,d,e,h,i,j,k,g,f  | first  | last        | false     | abcdeghijkf  | 15         | 149.8     |
 
-    Scenario: Testbot - TFSE roundtrip with waypoints <10
+    Scenario: Testbot - Trip: FSE roundtrip with waypoints <10
         Given the node map
             """
             a  b
@@ -259,7 +257,7 @@ Feature: Basic trip planning
 
 
     # Test single node in each component #1850
-    Scenario: Testbot - Trip planning with less than 10 nodes
+    Scenario: Testbot - Trip: look at 
         Given the node map
             """
             a 1 b
@@ -276,7 +274,7 @@ Feature: Basic trip planning
             | waypoints | trips |
             | 1,2       |       |
 
-    Scenario: Testbot - Repeated Coordinate
+    Scenario: Testbot - Trip: Repeated Coordinate
         Given the node map
             """
             a   b
@@ -291,7 +289,7 @@ Feature: Basic trip planning
             | a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a |       |
 
 
-    Scenario: Testbot - Trip with geometry details of geojson
+    Scenario: Testbot - Trip: geometry details of geojson
         Given the query options
             | geometries | geojson  |
 
@@ -313,7 +311,7 @@ Feature: Basic trip planning
             | a,b,c,d   | abcda  | 7.6       | 1,1,1.00009,1,1,0.99991,1.00009,1,1,1,1.00009,0.99991,1,1              |
             | d,b,c,a   | dbcad  | 7.6       | 1.00009,0.99991,1,1,1.00009,1,1,0.99991,1.00009,1,1,1,1.00009,0.99991  |
 
-    Scenario: Testbot - Trip with geometry details of polyline
+    Scenario: Testbot - Trip: geometry details of polyline
         Given the query options
             | geometries | polyline  |
 
@@ -335,7 +333,7 @@ Feature: Basic trip planning
             | a,b,c,d   | abcda  | 7.6       | 1,1,1,1.00009,0.99991,1,1,1.00009,1,1,0.99991,1.00009,1,1             |
             | d,b,c,a   | dbcad  | 7.6       | 0.99991,1.00009,1,1,1,1.00009,0.99991,1,1,1.00009,1,1,0.99991,1.00009 |
 
-    Scenario: Testbot - Trip with geometry details of polyline6
+    Scenario: Testbot - Trip: geometry details of polyline6
         Given the query options
             | geometries | polyline6  |
 

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -51,6 +51,64 @@ Feature: Basic trip planning
             | waypoints               | trips         |
             | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba |
 
+    Scenario: Testbot - Roundtrip FS waypoints >10
+        Given the query options
+            | source | first  |
+        Given the node map
+            """
+            a b c d
+            l     e
+            k     f
+            j i h g
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | de    |
+            | ef    |
+            | fg    |
+            | gh    |
+            | hi    |
+            | ij    |
+            | jk    |
+            | kl    |
+            | la    |
+
+        When I plan a trip I should get
+            | waypoints               | trips         |
+            | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba |
+
+    Scenario: Testbot - Roundtrip FE waypoints >10
+        Given the query options
+            | source | last  |
+        Given the node map
+            """
+            a b c d
+            l     e
+            k     f
+            j i h g
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | de    |
+            | ef    |
+            | fg    |
+            | gh    |
+            | hi    |
+            | ij    |
+            | jk    |
+            | kl    |
+            | la    |
+
+        When I plan a trip I should get
+            | waypoints               | trips         |
+            | a,b,c,d,e,f,g,h,i,j,k,l | lkjihgfedcbal |
+
     Scenario: Testbot - Unroutable roundtrip with waypoints <10
         Given the node map
             """
@@ -122,7 +180,6 @@ Feature: Basic trip planning
          When I plan a trip I should get
             |  waypoints    | source  | destination | roundtrip | status           | message                                       |
             |  a,b,c,d      | first   | last        | false     | NoTrips          | No trip visiting all destinations possible.   |
-            |  a,b,c,d      | first   | last        | true      | NotImplemented   | This request is not implemented               |
 
     Scenario: Testbot - TFSE with waypoints <10
         Given the node map
@@ -173,6 +230,32 @@ Feature: Basic trip planning
         When I plan a trip I should get
             |  waypoints              | source | destination | roundtrip |  trips       | durations  | distance  |
             |  a,b,c,d,e,h,i,j,k,g,f  | first  | last        | false     | abcdeghijkf  | 15         | 149.8     |
+
+    Scenario: Testbot - TFSE roundtrip with waypoints <10
+        Given the node map
+            """
+            a  b
+
+                  c
+            e  d
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | ac    |
+            | ad    |
+            | ae    |
+            | bc    |
+            | bd    |
+            | be    |
+            | cd    |
+            | ce    |
+            | de    |
+
+        When I plan a trip I should get
+            |  waypoints  | source | destination | roundtrip | trips   |
+            |  a,b,d,e,c  | first  | last        | true      | abedca  |
 
 
     # Test single node in each component #1850

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -256,8 +256,7 @@ Feature: Basic trip planning
             |  a,b,d,e,c  | first  | last        | true      | abedca  |
 
 
-    # Test single node in each component #1850
-    Scenario: Testbot - Trip: look at 
+    Scenario: Testbot - Trip: midway points in isoldated roads should return no trips 
         Given the node map
             """
             a 1 b

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -60,6 +60,8 @@ using NameID = std::uint32_t;
 using EdgeWeight = std::int32_t;
 using TurnPenalty = std::int16_t; // turn penalty in 100ms units
 
+static const std::size_t INVALID_SIZE_T = std::numeric_limits<std::size_t>::max();
+
 using LaneID = std::uint8_t;
 static const LaneID INVALID_LANEID = std::numeric_limits<LaneID>::max();
 using LaneDataID = std::uint16_t;

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -167,7 +167,7 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
     bool fixed_start_and_end = fixed_start && fixed_end;
     if (!IsSupportedParameterCombination(fixed_start, fixed_end, parameters.roundtrip))
     {
-        return Error("NotImplemented", "This request is not implemented", json_result);
+        return Error("NotImplemented", "This request is not supported", json_result);
     }
 
     // enforce maximum number of locations for performance reasons

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -41,7 +41,7 @@ bool IsSupportedParameterCombination(const bool fixed_start,
     {
         return true;
     }
-    else if (!fixed_start && !fixed_end && roundtrip)
+    else if (roundtrip)
     {
         return true;
     }
@@ -51,6 +51,8 @@ bool IsSupportedParameterCombination(const bool fixed_start,
     }
 }
 
+// given the node order in which to visit, compute the actual route (with geometry, travel time and
+// so on) and return the result
 InternalRouteResult
 TripPlugin::ComputeRoute(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                          const std::vector<PhantomNode> &snapped_phantoms,
@@ -60,27 +62,22 @@ TripPlugin::ComputeRoute(const std::shared_ptr<const datafacade::BaseDataFacade>
     InternalRouteResult min_route;
     // given the final trip, compute total duration and return the route and location permutation
     PhantomNodes viapoint;
-    const auto start = std::begin(trip);
-    const auto end = std::end(trip);
+
     // computes a roundtrip from the nodes in trip
-    for (auto it = start; it != end; ++it)
+    for (auto node = trip.begin(); node < trip.end() - 1; ++node)
     {
-        const auto from_node = *it;
-
-        // if from_node is the last node and it is a fixed start and end trip,
-        // break out of this loop and return the route
-        if (!roundtrip && std::next(it) == end)
-            break;
-
-        // if from_node is the last node, compute the route from the last to the first location
-        const auto to_node = std::next(it) != end ? *std::next(it) : *start;
+        const auto from_node = *node;
+        const auto to_node = *std::next(node);
 
         viapoint = PhantomNodes{snapped_phantoms[from_node], snapped_phantoms[to_node]};
         min_route.segment_end_coordinates.emplace_back(viapoint);
     }
 
+    // return back to the first node if it is a round trip
     if (roundtrip)
     {
+        viapoint = PhantomNodes{snapped_phantoms[trip.back()], snapped_phantoms[trip.front()]};
+        min_route.segment_end_coordinates.emplace_back(viapoint);
         // trip comes out to be something like 0 1 4 3 2 0
         BOOST_ASSERT(min_route.segment_end_coordinates.size() == trip.size());
     }
@@ -91,7 +88,6 @@ TripPlugin::ComputeRoute(const std::shared_ptr<const datafacade::BaseDataFacade>
     }
 
     shortest_path(facade, min_route.segment_end_coordinates, {false}, min_route);
-
     BOOST_ASSERT_MSG(min_route.shortest_path_length < INVALID_EDGE_WEIGHT, "unroutable route");
     return min_route;
 }
@@ -241,9 +237,15 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
     }
 
     // rotate result such that roundtrip starts at node with index 0
-    if (parameters.roundtrip && !fixed_end)
+    if (!(fixed_end && !fixed_start_and_end))
     {
         auto desired_start_index = std::find(std::begin(trip), std::end(trip), 0);
+        BOOST_ASSERT(desired_start_index != std::end(trip));
+        std::rotate(std::begin(trip), desired_start_index, std::end(trip));
+    }
+    else if (fixed_end && !fixed_start_and_end && parameters.roundtrip)
+    {
+        auto desired_start_index = std::find(std::begin(trip), std::end(trip), destination_id);
         BOOST_ASSERT(desired_start_index != std::end(trip));
         std::rotate(std::begin(trip), desired_start_index, std::end(trip));
     }

--- a/unit_tests/library/trip.cpp
+++ b/unit_tests/library/trip.cpp
@@ -247,195 +247,81 @@ BOOST_AUTO_TEST_CASE(test_tfse_2)
     }
 }
 
+void ResetParams(const Locations &locations, osrm::TripParameters &params)
+{
+    params = osrm::TripParameters();
+    params.coordinates.push_back(locations.at(0));
+    params.coordinates.push_back(locations.at(1));
+    params.coordinates.push_back(locations.at(2));
+}
+void CheckNotImplemented(const osrm::OSRM &osrm, osrm::TripParameters &params)
+{
+    osrm::json::Object result;
+    auto rc = osrm.Trip(params, result);
+    BOOST_REQUIRE(rc == osrm::Status::Error);
+    auto code = result.values.at("code").get<osrm::json::String>().value;
+    BOOST_CHECK_EQUAL(code, "NotImplemented");
+}
+
+void CheckOk(const osrm::OSRM &osrm, osrm::TripParameters &params)
+{
+    osrm::json::Object result;
+    auto rc = osrm.Trip(params, result);
+    BOOST_REQUIRE(rc == osrm::Status::Ok);
+    auto code = result.values.at("code").get<osrm::json::String>().value;
+    BOOST_CHECK_EQUAL(code, "Ok");
+}
+
 BOOST_AUTO_TEST_CASE(test_tfse_illegal_parameters)
 {
     const auto args = get_args();
     auto osrm = getOSRM(args.at(0));
-
     using namespace osrm;
 
     const auto locations = get_locations_in_big_component();
+    auto params = osrm::TripParameters();
 
     // one parameter set
-    TripParameters params;
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.roundtrip = false;
-    json::Object result;
-    auto rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    auto code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.source = TripParameters::SourceType::First;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.destination = TripParameters::DestinationType::Last;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    // two parameters set
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.source = TripParameters::SourceType::First;
-    params.destination = TripParameters::DestinationType::Any;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.source = TripParameters::SourceType::Any;
-    params.destination = TripParameters::DestinationType::Last;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.source = TripParameters::SourceType::First;
-    params.destination = TripParameters::DestinationType::Last;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    // two parameter set
+    ResetParams(locations, params);
     params.source = TripParameters::SourceType::Any;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.source = TripParameters::SourceType::First;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.source = TripParameters::SourceType::First;
-    params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.destination = TripParameters::DestinationType::Any;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    params.destination = TripParameters::DestinationType::Last;
-    params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
     // three parameters set
     params.source = TripParameters::SourceType::Any;
     params.destination = TripParameters::DestinationType::Any;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
     params.source = TripParameters::SourceType::Any;
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params.source = TripParameters::SourceType::Any;
-    params.destination = TripParameters::DestinationType::Last;
-    params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 
     params.source = TripParameters::SourceType::First;
     params.destination = TripParameters::DestinationType::Any;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params.source = TripParameters::SourceType::First;
-    params.destination = TripParameters::DestinationType::Any;
-    params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
-
-    params.source = TripParameters::SourceType::First;
-    params.destination = TripParameters::DestinationType::Last;
-    params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Error);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "NotImplemented");
+    CheckNotImplemented(osrm, params);
 }
 
 BOOST_AUTO_TEST_CASE(test_tfse_legal_parameters)
@@ -448,95 +334,96 @@ BOOST_AUTO_TEST_CASE(test_tfse_legal_parameters)
     TripParameters params;
 
     // no parameter set
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
-    auto rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    auto code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    ResetParams(locations, params);
+    CheckOk(osrm, params);
 
     // one parameter set
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
+    params.source = TripParameters::SourceType::First;
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
     params.source = TripParameters::SourceType::Any;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.destination = TripParameters::DestinationType::Any;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
+    params.destination = TripParameters::DestinationType::Last;
+    CheckOk(osrm, params);
 
     // two parameter set
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
+    params.destination = TripParameters::DestinationType::Last;
+    params.roundtrip = true;
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
+    params.source = TripParameters::SourceType::First;
+    params.roundtrip = true;
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
+    params.source = TripParameters::SourceType::First;
+    params.destination = TripParameters::DestinationType::Any;
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
+    params.source = TripParameters::SourceType::Any;
+    params.destination = TripParameters::DestinationType::Last;
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
+    params.source = TripParameters::SourceType::First;
+    params.destination = TripParameters::DestinationType::Last;
+    CheckOk(osrm, params);
+
+    ResetParams(locations, params);
     params.source = TripParameters::SourceType::Any;
     params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.destination = TripParameters::DestinationType::Any;
     params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
 
-    params = TripParameters();
-    params.coordinates.push_back(locations.at(0));
-    params.coordinates.push_back(locations.at(1));
-    params.coordinates.push_back(locations.at(2));
+    ResetParams(locations, params);
     params.source = TripParameters::SourceType::Any;
     params.destination = TripParameters::DestinationType::Any;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
 
     // three parameter set
     params.source = TripParameters::SourceType::Any;
     params.destination = TripParameters::DestinationType::Any;
     params.roundtrip = true;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
 
     params.source = TripParameters::SourceType::First;
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
-    rc = osrm.Trip(params, result);
-    BOOST_REQUIRE(rc == Status::Ok);
-    code = result.values.at("code").get<json::String>().value;
-    BOOST_CHECK_EQUAL(code, "Ok");
+    CheckOk(osrm, params);
+
+    params.source = TripParameters::SourceType::Any;
+    params.destination = TripParameters::DestinationType::Last;
+    params.roundtrip = true;
+    CheckOk(osrm, params);
+
+    params.source = TripParameters::SourceType::First;
+    params.destination = TripParameters::DestinationType::Any;
+    params.roundtrip = true;
+    CheckOk(osrm, params);
+
+    params.source = TripParameters::SourceType::First;
+    params.destination = TripParameters::DestinationType::Last;
+    params.roundtrip = true;
+    CheckOk(osrm, params);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue
This PR implements all supported parameter combinations tagged as `Shouldn't be too hard to extend to`

|  | Roundtrip | NoRoundtrip |
| :-- | :-- | :-- |
| Fixed Start&End (FSE) |Shouldn't be too hard to extend to|Already Implemented|
| Fixed Start (FS)  |Shouldn't be too hard to extend to| Won't do this for now|
| Fixed End (FE)  |Shouldn't be too hard to extend to|Won't do this for now|
| Nothing fixed  | Already Implemented |Won't do this for now||


## Tasklist
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
based on #3408 
based on #3675 
