### PR TITLE
Fix JSON syntax error in HTTP API docs

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -701,7 +701,7 @@ location of the StepManeuver. Further intersections are listed for every cross-w
     "in":0,
     "out":2,
     "bearings":[60,150,240,330],
-    "entry":["false","true","true","true"]
+    "entry":["false","true","true","true"],
     "lanes":{
         "indications": ["left", "straight"],
         "valid": "false"


### PR DESCRIPTION
The syntax highlighting in GitHub (of http.md) and on the web page were broken for "Intersection object" by the missing comma, this pull request corrects the syntax in the response example.

Apologies if I've skipped part of your contributing process, most didn't seem to apply to something so minor.