### PR TITLE
Routing Engine / SCC Engine are disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
       - Fix #3515 adjusted number of `nodes` in `annotation`
       - Fix #3605 Fixed a bug that could lead to turns at the end of the road to be suppressed
       - Fix #2844 handle up to 16777215 code units in OSM names
+      - Fix #3689 fix a snapping issue related to small components
     - Infrastructure
       - Support building rpm packages.
     - Guidance

--- a/features/testbot/snap.feature
+++ b/features/testbot/snap.feature
@@ -180,3 +180,33 @@ Feature: Snap start/end point to the nearest way
             | x    | n  | xf,xf |
             | x    | o  | xg,xg |
             | x    | p  | xh,xh |
+
+    Scenario: Snapping in viaroute
+        Given the extract extra arguments "--small-component-size 2"
+        Given the node map
+            """
+            a - - b - - c
+            |           |
+            d - -1e - - f
+            |     |     |
+            g - - h - - i
+            """
+
+        And the ways
+            | nodes | name  | oneway |
+            | abc   | round | yes    |
+            | cf    | round | yes    |
+            | fi    | round | yes    |
+            | ihgda | round | yes    |
+            | he    | in    | yes    |
+            | ed    | left  | yes    |
+            | ef    | right | no     |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction   |
+            | restriction | cf       | fi     | f        | only_straight |
+            | restriction | he       | ef     | e        | only_right    |
+
+        When I route I should get
+            | waypoints | route       |
+            | i,1       | round,in,in |

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -364,26 +364,14 @@ void Extractor::FindComponents(unsigned max_edge_id,
         }
     }
 
-    // connect forward and backward nodes of each edge
-    for (const auto &node : input_nodes)
-    {
-        if (node.reverse_segment_id.enabled)
-        {
-            BOOST_ASSERT(node.forward_segment_id.id <= max_edge_id);
-            BOOST_ASSERT(node.reverse_segment_id.id <= max_edge_id);
-            edges.push_back({node.forward_segment_id.id, node.reverse_segment_id.id, {}});
-            edges.push_back({node.reverse_segment_id.id, node.forward_segment_id.id, {}});
-        }
-    }
-
     tbb::parallel_sort(edges.begin(), edges.end());
     auto new_end = std::unique(edges.begin(), edges.end());
     edges.resize(new_end - edges.begin());
 
-    auto uncontractor_graph = std::make_shared<UncontractedGraph>(max_edge_id + 1, edges);
+    auto uncontracted_graph = std::make_shared<UncontractedGraph>(max_edge_id + 1, edges);
 
     TarjanSCC<UncontractedGraph> component_search(
-        std::const_pointer_cast<const UncontractedGraph>(uncontractor_graph));
+        std::const_pointer_cast<const UncontractedGraph>(uncontracted_graph));
     component_search.Run();
 
     for (auto &node : input_nodes)

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -376,10 +376,11 @@ void Extractor::FindComponents(unsigned max_edge_id,
 
     for (auto &node : input_nodes)
     {
+        // the component IDs here don't necessarily match for forward and backward edge. Since we
+        // only store a single component ID, the edge itself can end up in either of both
+        // components. Snapping will behave more or less randomly around it.
+        // https://github.com/Project-OSRM/osrm-backend/issues/3689
         auto forward_component = component_search.GetComponentID(node.forward_segment_id.id);
-        BOOST_ASSERT(!node.reverse_segment_id.enabled ||
-                     forward_component ==
-                         component_search.GetComponentID(node.reverse_segment_id.id));
 
         const unsigned component_size = component_search.GetComponentSize(forward_component);
         node.component.is_tiny = component_size < config.small_component_size;


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/3689

It turns out that the `FindComponents` function added u-turn functionality for all edges which caused the disconnect between the routing graph and the graph used for SCC calculation.

Turns out this is even deeper: In the edge based graph edges can be of different components, even though they are the same road.

e.g. `a-b` with u-turns disabled on both ends will have a component for `a-b` and a component for `b-a`. So either we allow turning around on all segments, or we would require a component ID for all forward/backward edges and adjust snapping accordingly.

## Tasklist
 - [ ] find and fix the actual issue
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
