### PR TITLE
Add speed option to annotations parameter

### DIFF
--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -147,7 +147,7 @@ module.exports = function () {
                             // if header matches 'a:*', parse out the values for *
                             // and return in that header
                             headers.forEach((k) => {
-                                let whitelist = ['duration', 'distance', 'datasources', 'nodes', 'weight'];
+                                let whitelist = ['duration', 'distance', 'datasources', 'nodes', 'weight', 'speed'];
                                 if (k.match(/^a:/)) {
                                     let a_type = k.slice(2);
                                     if (whitelist.indexOf(a_type) == -1)

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -53,11 +53,11 @@ Feature: Weight tests
             | abc   |
 
         When I route I should get
-            | waypoints | route   | distances | weights | times   | a:distance          | a:duration | a:weight | a:speed            |
-            | s,t       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3          | 3        | 6.672562           |
-            | t,s       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3.1        | 3.1      | 6.457318           |
-            | s,e       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 30.026527:10.008842 | 3.1:1      | 3.1:1    | 9.685976:10.008842 |
-            | e,s       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 10.008842:30.026527 | 1:3.1      | 1:3.1    | 10.008842:9.685976 |
+            | waypoints | route   | distances | weights | times   | a:distance          | a:duration | a:weight | a:speed |
+            | s,t       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3          | 3        | 6.7     |
+            | t,s       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3.1        | 3.1      | 6.5     |
+            | s,e       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 30.026527:10.008842 | 3.1:1      | 3.1:1    | 9.7:10  |
+            | e,s       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 10.008842:30.026527 | 1:3.1      | 1:3.1    | 10:9.7  |
 
 
     Scenario: Step weights -- way_function: fail if no weight or weight_per_meter property

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -39,7 +39,7 @@ Feature: Weight tests
     # FIXME include/engine/guidance/assemble_geometry.hpp:95
     Scenario: Start and target on the same and adjacent edge
         Given the query options
-            | annotations | distance,duration,weight,nodes |
+            | annotations | distance,duration,weight,nodes,speed |
 
         Given the node map
             """
@@ -53,11 +53,11 @@ Feature: Weight tests
             | abc   |
 
         When I route I should get
-            | waypoints | route   | distances | weights | times   | a:distance          | a:duration | a:weight |
-            | s,t       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3          | 3        |
-            | t,s       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3.1        | 3.1      |
-            | s,e       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 30.026527:10.008842 | 3.1:1      | 3.1:1    |
-            | e,s       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 10.008842:30.026527 | 1:3.1      | 1:3.1    |
+            | waypoints | route   | distances | weights | times   | a:distance          | a:duration | a:weight | a:speed            |
+            | s,t       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3          | 3        | 6.672562           |
+            | t,s       | abc,abc | 20m,0m    | 2.1,0   | 2.1s,0s | 20.017685           | 3.1        | 3.1      | 6.457318           |
+            | s,e       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 30.026527:10.008842 | 3.1:1      | 3.1:1    | 9.685976:10.008842 |
+            | e,s       | abc,abc | 40m,0m    | 4.1,0   | 4.1s,0s | 10.008842:30.026527 | 1:3.1      | 1:3.1    | 10.008842:9.685976 |
 
 
     Scenario: Step weights -- way_function: fail if no weight or weight_per_meter property

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -235,6 +235,14 @@ class RouteAPI : public BaseAPI
                 auto &leg_geometry = leg_geometries[idx];
                 util::json::Object annotation;
 
+                if (parameters.annotations_type & RouteParameters::AnnotationsType::Speed)
+                {
+                    annotation.values["speed"] = GetAnnotations(
+                        leg_geometry, [](const guidance::LegGeometry::Annotation &anno) {
+                            return anno.distance / anno.duration;
+                        });
+                }
+
                 if (parameters.annotations_type & RouteParameters::AnnotationsType::Duration)
                 {
                     annotation.values["duration"] = GetAnnotations(

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -239,7 +239,7 @@ class RouteAPI : public BaseAPI
                 {
                     annotation.values["speed"] = GetAnnotations(
                         leg_geometry, [](const guidance::LegGeometry::Annotation &anno) {
-                            return anno.distance / anno.duration;
+                            return std::round(anno.distance / anno.duration * 10.) / 10.;
                         });
                 }
 

--- a/include/engine/api/route_parameters.hpp
+++ b/include/engine/api/route_parameters.hpp
@@ -75,7 +75,8 @@ struct RouteParameters : public BaseParameters
         Distance = 0x04,
         Weight = 0x08,
         Datasources = 0x10,
-        All = Duration | Nodes | Distance | Weight | Datasources
+        Speed = 0x20,
+        All = Duration | Nodes | Distance | Weight | Datasources | Speed
     };
 
     RouteParameters() = default;

--- a/include/server/api/route_parameters_grammar.hpp
+++ b/include/server/api/route_parameters_grammar.hpp
@@ -61,7 +61,8 @@ struct RouteParametersGrammar : public BaseParametersGrammar<Iterator, Signature
 
         annotations_type.add("duration", AnnotationsType::Duration)(
             "nodes", AnnotationsType::Nodes)("distance", AnnotationsType::Distance)(
-            "weight", AnnotationsType::Weight)("datasources", AnnotationsType::Datasources);
+            "weight", AnnotationsType::Weight)("datasources", AnnotationsType::Datasources)(
+            "speed", AnnotationsType::Speed);
 
         base_rule =
             BaseGrammar::base_rule(qi::_r1) |

--- a/include/server/api/route_parameters_grammar.hpp
+++ b/include/server/api/route_parameters_grammar.hpp
@@ -59,10 +59,10 @@ struct RouteParametersGrammar : public BaseParametersGrammar<Iterator, Signature
             "full", engine::api::RouteParameters::OverviewType::Full)(
             "false", engine::api::RouteParameters::OverviewType::False);
 
-        annotations_type.add("duration", AnnotationsType::Duration)(
-            "nodes", AnnotationsType::Nodes)("distance", AnnotationsType::Distance)(
-            "weight", AnnotationsType::Weight)("datasources", AnnotationsType::Datasources)(
-            "speed", AnnotationsType::Speed);
+        annotations_type.add("duration", AnnotationsType::Duration)("nodes",
+                                                                    AnnotationsType::Nodes)(
+            "distance", AnnotationsType::Distance)("weight", AnnotationsType::Weight)(
+            "datasources", AnnotationsType::Datasources)("speed", AnnotationsType::Speed);
 
         base_rule =
             BaseGrammar::base_rule(qi::_r1) |

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(speed_annotation_matches_duration_and_distance)
         auto speed = speeds[i].get<json::Number>().value;
         auto duration = durations[i].get<json::Number>().value;
         auto distance = distances[i].get<json::Number>().value;
-        BOOST_CHECK_EQUAL(speed, distance / duration);
+        BOOST_CHECK_EQUAL(speed, std::round(distance / duration * 10.) / 10.);
     }
 }
 

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -359,9 +359,10 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     BOOST_CHECK(result_speed);
     BOOST_CHECK_EQUAL(reference_speed.geometries, result_speed->geometries);
     BOOST_CHECK_EQUAL(reference_speed.overview, result_speed->overview);
-    BOOST_CHECK_EQUAL(result_speed->annotations_type == (RouteParameters::AnnotationsType::Duration |
-                          RouteParameters::AnnotationsType::Distance |
-                          RouteParameters::AnnotationsType::Speed),
+    BOOST_CHECK_EQUAL(result_speed->annotations_type ==
+                          (RouteParameters::AnnotationsType::Duration |
+                           RouteParameters::AnnotationsType::Distance |
+                           RouteParameters::AnnotationsType::Speed),
                       true);
     BOOST_CHECK_EQUAL(result_speed->annotations, true);
 

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -350,6 +350,21 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
                       true);
     BOOST_CHECK_EQUAL(result_15->annotations, true);
 
+    RouteParameters reference_speed{};
+    reference_speed.annotations_type = RouteParameters::AnnotationsType::Duration;
+    reference_speed.coordinates = coords_1;
+    auto result_speed =
+        parseParameters<RouteParameters>("1,2;3,4?geometries=polyline&"
+                                         "overview=simplified&annotations=duration,distance,speed");
+    BOOST_CHECK(result_speed);
+    BOOST_CHECK_EQUAL(reference_speed.geometries, result_speed->geometries);
+    BOOST_CHECK_EQUAL(reference_speed.overview, result_speed->overview);
+    BOOST_CHECK_EQUAL(result_speed->annotations_type == (RouteParameters::AnnotationsType::Duration |
+                          RouteParameters::AnnotationsType::Distance |
+                          RouteParameters::AnnotationsType::Speed),
+                      true);
+    BOOST_CHECK_EQUAL(result_speed->annotations, true);
+
     // parse multiple annotations correctly
     RouteParameters reference_16{};
     reference_16.annotations_type = RouteParameters::AnnotationsType::Duration |


### PR DESCRIPTION
# Issue

Closes https://github.com/Project-OSRM/osrm-backend/issues/3664

Adds convenience field of `speed` to annotations parameter to be returned for each edge.

## Tasklist
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
~~Will need to be rebased on/off https://github.com/Project-OSRM/osrm-backend/pull/3687 depending on what goes in first~~ Rebased
