### PR TITLE
Make edge weights and durations strongly defined

### DIFF
--- a/include/contractor/contractor_dijkstra.hpp
+++ b/include/contractor/contractor_dijkstra.hpp
@@ -21,7 +21,7 @@ class ContractorDijkstra
     // search the graph up
     void Run(const unsigned number_of_targets,
              const int node_limit,
-             const int weight_limit,
+             const EdgeWeight weight_limit,
              const NodeID forbidden_node,
              const ContractorGraph &graph);
 
@@ -37,7 +37,7 @@ class ContractorDijkstra
 
   private:
     void RelaxNode(const NodeID node,
-                   const int node_weight,
+                   const EdgeWeight node_weight,
                    const NodeID forbidden_node,
                    const ContractorGraph &graph);
 

--- a/include/contractor/contractor_graph.hpp
+++ b/include/contractor/contractor_graph.hpp
@@ -12,12 +12,12 @@ namespace contractor
 struct ContractorEdgeData
 {
     ContractorEdgeData()
-        : weight(0), duration(0), id(0), originalEdges(0), shortcut(0), forward(0), backward(0),
+        : weight{0}, duration{0}, id(0), originalEdges(0), shortcut(0), forward(0), backward(0),
           is_original_via_node_ID(false)
     {
     }
     ContractorEdgeData(EdgeWeight weight,
-                       EdgeWeight duration,
+                       EdgeDuration duration,
                        unsigned original_edges,
                        unsigned id,
                        bool shortcut,
@@ -29,7 +29,7 @@ struct ContractorEdgeData
     {
     }
     EdgeWeight weight;
-    EdgeWeight duration;
+    EdgeDuration duration;
     unsigned id;
     unsigned originalEdges : 28;
     bool shortcut : 1;

--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -134,7 +134,7 @@ class GraphContractor
                     BOOST_ASSERT_MSG(SPECIAL_NODEID != new_edge.source, "Source id invalid");
                     BOOST_ASSERT_MSG(SPECIAL_NODEID != new_edge.target, "Target id invalid");
                     new_edge.data.weight = data.weight;
-                    new_edge.data.duration = data.duration;
+                    new_edge.data.duration = static_cast<EdgeDuration::value_type>(data.duration);
                     new_edge.data.shortcut = data.shortcut;
                     if (!data.is_original_via_node_ID && !orig_node_id_from_new_node_id_map.empty())
                     {
@@ -200,8 +200,8 @@ class GraphContractor
             }
 
             dijkstra.Clear();
-            dijkstra.Insert(source, 0, ContractorHeapData{});
-            EdgeWeight max_weight = 0;
+            dijkstra.Insert(source, EdgeWeight{0}, ContractorHeapData{});
+            EdgeWeight max_weight{0};
             unsigned number_of_targets = 0;
 
             for (auto out_edge : contractor_graph->GetAdjacentEdgeRange(node))
@@ -229,7 +229,7 @@ class GraphContractor
                             // CAREFUL: This only works due to the independent node-setting. This
                             // guarantees that source is not connected to another node that is
                             // contracted
-                            node_weights[source] = path_weight + 1;
+                            node_weights[source] = path_weight + EdgeWeight{1};
                             BOOST_ASSERT(stats != nullptr);
                             stats->edges_added_count += 2;
                             stats->original_edges_added_count +=

--- a/include/contractor/graph_contractor_adaptors.hpp
+++ b/include/contractor/graph_contractor_adaptors.hpp
@@ -21,19 +21,17 @@ std::vector<ContractorEdge> adaptToContractorInput(InputEdgeContainer input_edge
     for (const auto &input_edge : input_edge_list)
     {
 #ifndef NDEBUG
-        const unsigned int constexpr DAY_IN_DECI_SECONDS = 24 * 60 * 60 * 10;
-        if (static_cast<unsigned int>(std::max(input_edge.weight, 1)) > DAY_IN_DECI_SECONDS)
+        if (input_edge.duration > 24 * 60 * 60 * 10)
         {
-            util::Log(logWARNING) << "Edge weight large -> "
-                                  << static_cast<unsigned int>(std::max(input_edge.weight, 1))
-                                  << " : " << static_cast<unsigned int>(input_edge.source) << " -> "
-                                  << static_cast<unsigned int>(input_edge.target);
+            util::Log(logWARNING) << "Edge duration large -> " << input_edge.duration << ", weight "
+                                  << input_edge.weight << " : " << input_edge.source << " -> "
+                                  << input_edge.target;
         }
 #endif
         edges.emplace_back(input_edge.source,
                            input_edge.target,
-                           std::max(input_edge.weight, 1),
-                           input_edge.duration,
+                           std::max(input_edge.weight, EdgeWeight{1}),
+                           EdgeDuration{input_edge.duration},
                            1,
                            input_edge.edge_id,
                            false,
@@ -42,8 +40,8 @@ std::vector<ContractorEdge> adaptToContractorInput(InputEdgeContainer input_edge
 
         edges.emplace_back(input_edge.target,
                            input_edge.source,
-                           std::max(input_edge.weight, 1),
-                           input_edge.duration,
+                           std::max(input_edge.weight, EdgeWeight{1}),
+                           EdgeDuration{input_edge.duration},
                            1,
                            input_edge.edge_id,
                            false,

--- a/include/contractor/query_edge.hpp
+++ b/include/contractor/query_edge.hpp
@@ -17,14 +17,14 @@ struct QueryEdge
     struct EdgeData
     {
         explicit EdgeData()
-            : id(0), shortcut(false), weight(0), duration(0), forward(false), backward(false)
+            : id(0), shortcut(false), weight{0}, duration{0}, forward(false), backward(false)
         {
         }
 
         template <class OtherT> EdgeData(const OtherT &other)
         {
             weight = other.weight;
-            duration = other.duration;
+            duration = static_cast<std::int32_t>(other.duration); // TODO check 30 bit
             shortcut = other.shortcut;
             id = other.id;
             forward = other.forward;
@@ -36,7 +36,7 @@ struct QueryEdge
         NodeID id : 31;
         bool shortcut : 1;
         EdgeWeight weight;
-        EdgeWeight duration : 30;
+        std::int32_t duration : 30;
         std::uint32_t forward : 1;
         std::uint32_t backward : 1;
     } data;

--- a/include/engine/api/table_api.hpp
+++ b/include/engine/api/table_api.hpp
@@ -36,7 +36,7 @@ class TableAPI final : public BaseAPI
     {
     }
 
-    virtual void MakeResponse(const std::vector<EdgeWeight> &durations,
+    virtual void MakeResponse(const std::vector<EdgeDuration> &durations,
                               const std::vector<PhantomNode> &phantoms,
                               util::json::Object &response) const
     {
@@ -98,7 +98,7 @@ class TableAPI final : public BaseAPI
         return json_waypoints;
     }
 
-    virtual util::json::Array MakeTable(const std::vector<EdgeWeight> &values,
+    virtual util::json::Array MakeTable(const std::vector<EdgeDuration> &values,
                                         std::size_t number_of_rows,
                                         std::size_t number_of_columns) const
     {
@@ -112,12 +112,13 @@ class TableAPI final : public BaseAPI
             std::transform(row_begin_iterator,
                            row_end_iterator,
                            json_row.values.begin(),
-                           [](const EdgeWeight duration) {
+                           [](const EdgeDuration duration) {
                                if (duration == MAXIMAL_EDGE_DURATION)
                                {
                                    return util::json::Value(util::json::Null());
                                }
-                               return util::json::Value(util::json::Number(duration / 10.));
+                               return util::json::Value(util::json::Number(
+                                   static_cast<EdgeDuration::value_type>(duration) / 10.));
                            });
             json_table.values.push_back(std::move(json_row));
         }

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -86,8 +86,8 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
     util::ShM<NodeID, true>::vector m_geometry_node_list;
     util::ShM<EdgeWeight, true>::vector m_geometry_fwd_weight_list;
     util::ShM<EdgeWeight, true>::vector m_geometry_rev_weight_list;
-    util::ShM<EdgeWeight, true>::vector m_geometry_fwd_duration_list;
-    util::ShM<EdgeWeight, true>::vector m_geometry_rev_duration_list;
+    util::ShM<EdgeDuration, true>::vector m_geometry_fwd_duration_list;
+    util::ShM<EdgeDuration, true>::vector m_geometry_rev_duration_list;
     util::ShM<bool, true>::vector m_is_core_node;
     util::ShM<DatasourceID, true>::vector m_datasource_list;
     util::ShM<std::uint32_t, true>::vector m_lane_description_offsets;
@@ -358,16 +358,16 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
             datasources_list_ptr, data_layout.num_entries[storage::DataLayout::DATASOURCES_LIST]);
         m_datasource_list = std::move(datasources_list);
 
-        auto geometries_fwd_duration_list_ptr = data_layout.GetBlockPtr<EdgeWeight>(
+        auto geometries_fwd_duration_list_ptr = data_layout.GetBlockPtr<EdgeDuration>(
             memory_block, storage::DataLayout::GEOMETRIES_FWD_DURATION_LIST);
-        util::ShM<EdgeWeight, true>::vector geometry_fwd_duration_list(
+        util::ShM<EdgeDuration, true>::vector geometry_fwd_duration_list(
             geometries_fwd_duration_list_ptr,
             data_layout.num_entries[storage::DataLayout::GEOMETRIES_FWD_DURATION_LIST]);
         m_geometry_fwd_duration_list = std::move(geometry_fwd_duration_list);
 
-        auto geometries_rev_duration_list_ptr = data_layout.GetBlockPtr<EdgeWeight>(
+        auto geometries_rev_duration_list_ptr = data_layout.GetBlockPtr<EdgeDuration>(
             memory_block, storage::DataLayout::GEOMETRIES_REV_DURATION_LIST);
-        util::ShM<EdgeWeight, true>::vector geometry_rev_duration_list(
+        util::ShM<EdgeDuration, true>::vector geometry_rev_duration_list(
             geometries_rev_duration_list_ptr,
             data_layout.num_entries[storage::DataLayout::GEOMETRIES_REV_DURATION_LIST]);
         m_geometry_rev_duration_list = std::move(geometry_rev_duration_list);
@@ -560,7 +560,7 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
         return result_nodes;
     }
 
-    virtual std::vector<EdgeWeight>
+    virtual std::vector<EdgeDuration>
     GetUncompressedForwardDurations(const EdgeID id) const override final
     {
         /*
@@ -573,7 +573,7 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
         const auto begin = m_geometry_indices.at(id) + 1;
         const auto end = m_geometry_indices.at(id + 1);
 
-        std::vector<EdgeWeight> result_durations;
+        std::vector<EdgeDuration> result_durations;
         result_durations.reserve(end - begin);
 
         std::copy(m_geometry_fwd_duration_list.begin() + begin,
@@ -583,7 +583,7 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
         return result_durations;
     }
 
-    virtual std::vector<EdgeWeight>
+    virtual std::vector<EdgeDuration>
     GetUncompressedReverseDurations(const EdgeID id) const override final
     {
         /*
@@ -598,7 +598,7 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
         const auto begin = m_geometry_indices.at(id);
         const auto end = m_geometry_indices.at(id + 1) - 1;
 
-        std::vector<EdgeWeight> result_durations;
+        std::vector<EdgeDuration> result_durations;
         result_durations.reserve(end - begin);
 
         std::reverse_copy(m_geometry_rev_duration_list.begin() + begin,
@@ -661,16 +661,16 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
         return m_via_geometry_list.at(id);
     }
 
-    virtual TurnPenalty GetWeightPenaltyForEdgeID(const unsigned id) const override final
+    virtual EdgeWeight GetWeightPenaltyForEdgeID(const unsigned id) const override final
     {
         BOOST_ASSERT(m_turn_weight_penalties.size() > id);
-        return m_turn_weight_penalties[id];
+        return EdgeWeight{static_cast<TurnPenalty::value_type>(m_turn_weight_penalties[id])};
     }
 
-    virtual TurnPenalty GetDurationPenaltyForEdgeID(const unsigned id) const override final
+    virtual EdgeDuration GetDurationPenaltyForEdgeID(const unsigned id) const override final
     {
         BOOST_ASSERT(m_turn_duration_penalties.size() > id);
-        return m_turn_duration_penalties[id];
+        return EdgeDuration{static_cast<TurnDuration::value_type>(m_turn_duration_penalties[id])};
     }
 
     extractor::guidance::TurnInstruction

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -85,9 +85,9 @@ class BaseDataFacade
 
     virtual std::vector<NodeID> GetUncompressedReverseGeometry(const EdgeID id) const = 0;
 
-    virtual TurnPenalty GetWeightPenaltyForEdgeID(const unsigned id) const = 0;
+    virtual EdgeWeight GetWeightPenaltyForEdgeID(const unsigned id) const = 0;
 
-    virtual TurnPenalty GetDurationPenaltyForEdgeID(const unsigned id) const = 0;
+    virtual EdgeDuration GetDurationPenaltyForEdgeID(const unsigned id) const = 0;
 
     // Gets the weight values for each segment in an uncompressed geometry.
     // Should always be 1 shorter than GetUncompressedGeometry
@@ -96,8 +96,8 @@ class BaseDataFacade
 
     // Gets the duration values for each segment in an uncompressed geometry.
     // Should always be 1 shorter than GetUncompressedGeometry
-    virtual std::vector<EdgeWeight> GetUncompressedForwardDurations(const EdgeID id) const = 0;
-    virtual std::vector<EdgeWeight> GetUncompressedReverseDurations(const EdgeID id) const = 0;
+    virtual std::vector<EdgeDuration> GetUncompressedForwardDurations(const EdgeID id) const = 0;
+    virtual std::vector<EdgeDuration> GetUncompressedReverseDurations(const EdgeID id) const = 0;
 
     // Returns the data source ids that were used to supply the edge
     // weights.  Will return an empty array when only the base profile is used.

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -369,18 +369,18 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         // Find the node-based-edge that this belongs to, and directly
         // calculate the forward_weight, forward_offset, reverse_weight, reverse_offset
 
-        EdgeWeight forward_weight_offset = 0, forward_weight = 0;
-        EdgeWeight reverse_weight_offset = 0, reverse_weight = 0;
-        EdgeWeight forward_duration_offset = 0, forward_duration = 0;
-        EdgeWeight reverse_duration_offset = 0, reverse_duration = 0;
+        EdgeWeight forward_weight_offset{0}, forward_weight{0};
+        EdgeWeight reverse_weight_offset{0}, reverse_weight{0};
+        EdgeDuration forward_duration_offset{0}, forward_duration{0};
+        EdgeDuration reverse_duration_offset{0}, reverse_duration{0};
 
         const std::vector<EdgeWeight> forward_weight_vector =
             datafacade.GetUncompressedForwardWeights(data.packed_geometry_id);
         const std::vector<EdgeWeight> reverse_weight_vector =
             datafacade.GetUncompressedReverseWeights(data.packed_geometry_id);
-        const std::vector<EdgeWeight> forward_duration_vector =
+        const std::vector<EdgeDuration> forward_duration_vector =
             datafacade.GetUncompressedForwardDurations(data.packed_geometry_id);
-        const std::vector<EdgeWeight> reverse_duration_vector =
+        const std::vector<EdgeDuration> reverse_duration_vector =
             datafacade.GetUncompressedReverseDurations(data.packed_geometry_id);
 
         for (std::size_t i = 0; i < data.fwd_segment_position; i++)
@@ -407,13 +407,13 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         ratio = std::min(1.0, std::max(0.0, ratio));
         if (data.forward_segment_id.id != SPECIAL_SEGMENTID)
         {
-            forward_weight = static_cast<EdgeWeight>(forward_weight * ratio);
-            forward_duration = static_cast<EdgeWeight>(forward_duration * ratio);
+            forward_weight = forward_weight * ratio;
+            forward_duration = forward_duration * ratio;
         }
         if (data.reverse_segment_id.id != SPECIAL_SEGMENTID)
         {
-            reverse_weight -= static_cast<EdgeWeight>(reverse_weight * ratio);
-            reverse_duration -= static_cast<EdgeWeight>(reverse_duration * ratio);
+            reverse_weight -= reverse_weight * ratio;
+            reverse_duration -= reverse_duration * ratio;
         }
 
         auto transformed = PhantomNodeWithDistance{PhantomNode{data,

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -75,11 +75,13 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         }
 
         prev_coordinate = coordinate;
-        geometry.annotations.emplace_back(
-            LegGeometry::Annotation{current_distance,
-                                    path_point.duration_until_turn / 10.,
-                                    path_point.weight_until_turn / facade.GetWeightMultiplier(),
-                                    path_point.datasource_id});
+        geometry.annotations.emplace_back(LegGeometry::Annotation{
+            current_distance,
+            static_cast<EdgeDuration::value_type>(path_point.duration_until_turn) /
+                10., // TODO: make over lambdas
+            static_cast<EdgeWeight::value_type>(path_point.weight_until_turn) /
+                facade.GetWeightMultiplier(),
+            path_point.datasource_id});
         geometry.locations.push_back(std::move(coordinate));
         geometry.osm_node_ids.push_back(facade.GetOSMNodeIDOfNode(path_point.turn_via_node));
     }
@@ -97,8 +99,11 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     // testbot/weight.feature:Start and target on the same and adjacent edge
     geometry.annotations.emplace_back(LegGeometry::Annotation{
         current_distance,
-        (reversed_target ? target_node.reverse_duration : target_node.forward_duration) / 10.,
-        (reversed_target ? target_node.reverse_weight : target_node.forward_weight) /
+        static_cast<EdgeDuration::value_type>(reversed_target ? target_node.reverse_duration
+                                                              : target_node.forward_duration) /
+            10.,
+        static_cast<EdgeWeight::value_type>(reversed_target ? target_node.reverse_weight
+                                                            : target_node.forward_weight) /
             facade.GetWeightMultiplier(),
         forward_datasources[target_node.fwd_segment_position]});
 

--- a/include/engine/guidance/assemble_leg.hpp
+++ b/include/engine/guidance/assemble_leg.hpp
@@ -33,7 +33,7 @@ namespace detail
 const constexpr std::size_t MAX_USED_SEGMENTS = 2;
 struct NamedSegment
 {
-    EdgeWeight duration;
+    EdgeDuration duration;
     std::uint32_t position;
     std::uint32_t name_id;
 };
@@ -80,7 +80,7 @@ std::array<std::uint32_t, SegmentNumber> summarizeRoute(const std::vector<PathDa
         });
     const auto target_duration =
         target_traversed_in_reverse ? target_node.reverse_duration : target_node.forward_duration;
-    if (target_duration > 1)
+    if (target_duration > EdgeDuration{1})
         segments.push_back({target_duration, index++, target_node.name_id});
     // this makes sure that the segment with the lowest position comes first
     std::sort(
@@ -137,13 +137,15 @@ inline RouteLeg assembleLeg(const datafacade::BaseDataFacade &facade,
     auto distance = std::accumulate(
         leg_geometry.segment_distances.begin(), leg_geometry.segment_distances.end(), 0.);
     auto duration = std::accumulate(
-        route_data.begin(), route_data.end(), 0, [](const double sum, const PathData &data) {
-            return sum + data.duration_until_turn;
-        });
+        route_data.begin(),
+        route_data.end(),
+        EdgeDuration{0},
+        [](const auto sum, const PathData &data) { return sum + data.duration_until_turn; });
     auto weight = std::accumulate(
-        route_data.begin(), route_data.end(), 0, [](const double sum, const PathData &data) {
-            return sum + data.weight_until_turn;
-        });
+        route_data.begin(),
+        route_data.end(),
+        EdgeWeight{0},
+        [](const auto sum, const PathData &data) { return sum + data.weight_until_turn; });
 
     //                 s
     //                 |
@@ -206,8 +208,8 @@ inline RouteLeg assembleLeg(const datafacade::BaseDataFacade &facade,
     }
 
     return RouteLeg{std::round(distance * 10.) / 10.,
-                    duration / 10.,
-                    weight / facade.GetWeightMultiplier(),
+                    static_cast<EdgeDuration::value_type>(duration) / 10.,
+                    static_cast<EdgeWeight::value_type>(weight) / facade.GetWeightMultiplier(),
                     summary,
                     {}};
 }

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -27,7 +27,7 @@ struct PathData
     // weight that is traveled on the segment until the turn is reached
     EdgeWeight weight_until_turn;
     // duration that is traveled on the segment until the turn is reached
-    EdgeWeight duration_until_turn;
+    EdgeDuration duration_until_turn;
     // instruction to execute at the turn
     extractor::guidance::TurnInstruction turn_instruction;
     // turn lane data
@@ -55,8 +55,8 @@ struct InternalRouteResult
     std::vector<bool> target_traversed_in_reverse;
     std::vector<bool> alt_source_traversed_in_reverse;
     std::vector<bool> alt_target_traversed_in_reverse;
-    int shortest_path_length;
-    int alternative_path_length;
+    EdgeWeight shortest_path_length;
+    EdgeWeight alternative_path_length;
 
     bool is_valid() const { return INVALID_EDGE_WEIGHT != shortest_path_length; }
 
@@ -68,7 +68,7 @@ struct InternalRouteResult
     }
 
     InternalRouteResult()
-        : shortest_path_length(INVALID_EDGE_WEIGHT), alternative_path_length(INVALID_EDGE_WEIGHT)
+        : shortest_path_length{INVALID_EDGE_WEIGHT}, alternative_path_length{INVALID_EDGE_WEIGHT}
     {
     }
 };

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -53,10 +53,10 @@ struct PhantomNode
                 EdgeWeight reverse_weight,
                 EdgeWeight forward_weight_offset,
                 EdgeWeight reverse_weight_offset,
-                EdgeWeight forward_duration,
-                EdgeWeight reverse_duration,
-                EdgeWeight forward_duration_offset,
-                EdgeWeight reverse_duration_offset,
+                EdgeDuration forward_duration,
+                EdgeDuration reverse_duration,
+                EdgeDuration forward_duration_offset,
+                EdgeDuration reverse_duration_offset,
                 unsigned packed_geometry_id_,
                 bool is_tiny_component,
                 unsigned component_id,
@@ -81,11 +81,12 @@ struct PhantomNode
         : forward_segment_id{SPECIAL_SEGMENTID, false},
           reverse_segment_id{SPECIAL_SEGMENTID, false},
           name_id(std::numeric_limits<unsigned>::max()), forward_weight(INVALID_EDGE_WEIGHT),
-          reverse_weight(INVALID_EDGE_WEIGHT), forward_weight_offset(0), reverse_weight_offset(0),
-          forward_duration(MAXIMAL_EDGE_DURATION), reverse_duration(MAXIMAL_EDGE_DURATION),
-          forward_duration_offset(0), reverse_duration_offset(0),
-          packed_geometry_id(SPECIAL_GEOMETRYID), component{INVALID_COMPONENTID, false},
-          fwd_segment_position(0), forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
+          reverse_weight(INVALID_EDGE_WEIGHT), forward_weight_offset(EdgeWeight{0}),
+          reverse_weight_offset(EdgeWeight{0}), forward_duration(MAXIMAL_EDGE_DURATION),
+          reverse_duration(MAXIMAL_EDGE_DURATION), forward_duration_offset(EdgeDuration{0}),
+          reverse_duration_offset(EdgeDuration{0}), packed_geometry_id(SPECIAL_GEOMETRYID),
+          component{INVALID_COMPONENTID, false}, fwd_segment_position(0),
+          forward_travel_mode(TRAVEL_MODE_INACCESSIBLE),
           backward_travel_mode(TRAVEL_MODE_INACCESSIBLE)
     {
     }
@@ -102,13 +103,13 @@ struct PhantomNode
         return reverse_weight_offset + reverse_weight;
     }
 
-    EdgeWeight GetForwardDuration() const
+    EdgeDuration GetForwardDuration() const
     {
         BOOST_ASSERT(forward_segment_id.enabled);
         return forward_duration + forward_duration_offset;
     }
 
-    EdgeWeight GetReverseDuration() const
+    EdgeDuration GetReverseDuration() const
     {
         BOOST_ASSERT(reverse_segment_id.enabled);
         return reverse_duration + reverse_duration_offset;
@@ -142,10 +143,10 @@ struct PhantomNode
                          EdgeWeight reverse_weight,
                          EdgeWeight forward_weight_offset,
                          EdgeWeight reverse_weight_offset,
-                         EdgeWeight forward_duration,
-                         EdgeWeight reverse_duration,
-                         EdgeWeight forward_duration_offset,
-                         EdgeWeight reverse_duration_offset,
+                         EdgeDuration forward_duration,
+                         EdgeDuration reverse_duration,
+                         EdgeDuration forward_duration_offset,
+                         EdgeDuration reverse_duration_offset,
                          const util::Coordinate location,
                          const util::Coordinate input_location)
         : forward_segment_id{other.forward_segment_id},
@@ -170,10 +171,10 @@ struct PhantomNode
     EdgeWeight reverse_weight;
     EdgeWeight forward_weight_offset; // TODO: try to remove -> requires path unpacking changes
     EdgeWeight reverse_weight_offset; // TODO: try to remove -> requires path unpacking changes
-    EdgeWeight forward_duration;
-    EdgeWeight reverse_duration;
-    EdgeWeight forward_duration_offset; // TODO: try to remove -> requires path unpacking changes
-    EdgeWeight reverse_duration_offset; // TODO: try to remove -> requires path unpacking changes
+    EdgeDuration forward_duration;
+    EdgeDuration reverse_duration;
+    EdgeDuration forward_duration_offset; // TODO: try to remove -> requires path unpacking changes
+    EdgeDuration reverse_duration_offset; // TODO: try to remove -> requires path unpacking changes
     unsigned packed_geometry_id;
     struct ComponentType
     {

--- a/include/engine/routing_algorithms/shortest_path.hpp
+++ b/include/engine/routing_algorithms/shortest_path.hpp
@@ -48,9 +48,9 @@ class ShortestPathRouting final : public BasicRoutingInterface
                          const bool search_to_reverse_node,
                          const PhantomNode &source_phantom,
                          const PhantomNode &target_phantom,
-                         const int total_weight_to_forward,
-                         const int total_weight_to_reverse,
-                         int &new_total_weight,
+                         const EdgeWeight total_weight_to_forward,
+                         const EdgeWeight total_weight_to_reverse,
+                         EdgeWeight &new_total_weight,
                          std::vector<NodeID> &leg_packed_path) const;
 
     // searches shortest path between:
@@ -67,10 +67,10 @@ class ShortestPathRouting final : public BasicRoutingInterface
                 const bool search_to_reverse_node,
                 const PhantomNode &source_phantom,
                 const PhantomNode &target_phantom,
-                const int total_weight_to_forward,
-                const int total_weight_to_reverse,
-                int &new_total_weight_to_forward,
-                int &new_total_weight_to_reverse,
+                const EdgeWeight total_weight_to_forward,
+                const EdgeWeight total_weight_to_reverse,
+                EdgeWeight &new_total_weight_to_forward,
+                EdgeWeight &new_total_weight_to_reverse,
                 std::vector<NodeID> &leg_packed_path_forward,
                 std::vector<NodeID> &leg_packed_path_reverse) const;
 
@@ -78,7 +78,7 @@ class ShortestPathRouting final : public BasicRoutingInterface
                     const std::vector<PhantomNodes> &phantom_nodes_vector,
                     const std::vector<NodeID> &total_packed_path,
                     const std::vector<std::size_t> &packed_leg_begin,
-                    const int shortest_path_length,
+                    const EdgeWeight shortest_path_length,
                     InternalRouteResult &raw_route_data) const;
 
     void operator()(const std::shared_ptr<const datafacade::BaseDataFacade> facade,

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -19,8 +19,8 @@ struct HeapData
 
 struct ManyToManyHeapData : HeapData
 {
-    EdgeWeight duration;
-    ManyToManyHeapData(NodeID p, EdgeWeight duration) : HeapData(p), duration(duration) {}
+    EdgeDuration duration;
+    ManyToManyHeapData(NodeID p, EdgeDuration duration) : HeapData(p), duration(duration) {}
 };
 
 struct SearchEngineData

--- a/include/extractor/compressed_edge_container.hpp
+++ b/include/extractor/compressed_edge_container.hpp
@@ -19,9 +19,9 @@ class CompressedEdgeContainer
     struct OnewayCompressedEdge
     {
       public:
-        NodeID node_id;      // refers to an internal node-based-node
-        EdgeWeight weight;   // the weight of the edge leading to this node
-        EdgeWeight duration; // the duration of the edge leading to this node
+        NodeID node_id;        // refers to an internal node-based-node
+        EdgeWeight weight;     // the weight of the edge leading to this node
+        EdgeDuration duration; // the duration of the edge leading to this node
     };
 
     using OnewayEdgeBucket = std::vector<OnewayCompressedEdge>;
@@ -33,13 +33,13 @@ class CompressedEdgeContainer
                       const NodeID target_node,
                       const EdgeWeight weight1,
                       const EdgeWeight weight2,
-                      const EdgeWeight duration1,
-                      const EdgeWeight duration2);
+                      const EdgeDuration duration1,
+                      const EdgeDuration duration2);
 
     void AddUncompressedEdge(const EdgeID edge_id,
                              const NodeID target_node,
                              const EdgeWeight weight,
-                             const EdgeWeight duration);
+                             const EdgeDuration duration);
 
     void InitializeBothwayVector();
     unsigned ZipEdges(const unsigned f_edge_pos, const unsigned r_edge_pos);
@@ -67,8 +67,8 @@ class CompressedEdgeContainer
     std::vector<NodeID> m_compressed_geometry_nodes;
     std::vector<EdgeWeight> m_compressed_geometry_fwd_weights;
     std::vector<EdgeWeight> m_compressed_geometry_rev_weights;
-    std::vector<EdgeWeight> m_compressed_geometry_fwd_durations;
-    std::vector<EdgeWeight> m_compressed_geometry_rev_durations;
+    std::vector<EdgeDuration> m_compressed_geometry_fwd_durations;
+    std::vector<EdgeDuration> m_compressed_geometry_rev_durations;
     std::vector<unsigned> m_free_list;
     std::unordered_map<EdgeID, unsigned> m_edge_id_to_list_index_map;
     std::unordered_map<EdgeID, unsigned> m_forward_edge_id_to_zipped_index_map;

--- a/include/extractor/edge_based_edge.hpp
+++ b/include/extractor/edge_based_edge.hpp
@@ -21,7 +21,7 @@ struct EdgeBasedEdge
                   const NodeID target,
                   const NodeID edge_id,
                   const EdgeWeight weight,
-                  const EdgeWeight duration,
+                  const EdgeDuration duration,
                   const bool forward,
                   const bool backward);
 
@@ -31,7 +31,7 @@ struct EdgeBasedEdge
     NodeID target;
     NodeID edge_id;
     EdgeWeight weight;
-    EdgeWeight duration : 30;
+    std::int32_t duration : 30;
     std::uint32_t forward : 1;
     std::uint32_t backward : 1;
 };
@@ -43,7 +43,7 @@ static_assert(sizeof(extractor::EdgeBasedEdge) == 20,
 // Impl.
 
 inline EdgeBasedEdge::EdgeBasedEdge()
-    : source(0), target(0), edge_id(0), weight(0), duration(0), forward(false), backward(false)
+    : source(0), target(0), edge_id(0), weight{0}, duration{0}, forward(false), backward(false)
 {
 }
 
@@ -51,7 +51,7 @@ inline EdgeBasedEdge::EdgeBasedEdge(const NodeID source,
                                     const NodeID target,
                                     const NodeID edge_id,
                                     const EdgeWeight weight,
-                                    const EdgeWeight duration,
+                                    const EdgeDuration duration,
                                     const bool forward,
                                     const bool backward)
     : source(source), target(target), edge_id(edge_id), weight(weight), duration(duration),

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -61,7 +61,7 @@ struct SegmentBlock
     OSMNodeID this_osm_node_id;
     double segment_length;
     EdgeWeight segment_weight;
-    EdgeWeight segment_duration;
+    EdgeDuration segment_duration;
 };
 #pragma pack(pop)
 static_assert(sizeof(SegmentBlock) == 24, "SegmentBlock is not packed correctly");

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -63,8 +63,8 @@ struct InternalExtractorEdge
         : result(MIN_OSM_NODEID,
                  MIN_OSM_NODEID,
                  SPECIAL_NODEID,
-                 0,
-                 0,
+                 EdgeWeight{0},
+                 EdgeDuration{0},
                  false, // forward
                  false, // backward
                  false, // roundabout
@@ -96,8 +96,8 @@ struct InternalExtractorEdge
         : result(source,
                  target,
                  name_id,
-                 0,
-                 0,
+                 EdgeWeight{0},
+                 EdgeDuration{0},
                  forward,
                  backward,
                  roundabout,

--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -19,7 +19,7 @@ struct NodeBasedEdge
                   NodeID target,
                   NodeID name_id,
                   EdgeWeight weight,
-                  EdgeWeight duration,
+                  EdgeDuration duration,
                   bool forward,
                   bool backward,
                   bool roundabout,
@@ -36,7 +36,7 @@ struct NodeBasedEdge
     NodeID target;
     NodeID name_id;
     EdgeWeight weight;
-    EdgeWeight duration;
+    EdgeDuration duration; // TODO: repack
     std::uint8_t forward : 1;
     std::uint8_t backward : 1;
     std::uint8_t roundabout : 1;
@@ -54,7 +54,7 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
                          OSMNodeID target,
                          NodeID name_id,
                          EdgeWeight weight,
-                         EdgeWeight duration,
+                         EdgeDuration duration,
                          bool forward,
                          bool backward,
                          bool roundabout,
@@ -72,7 +72,7 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
 // Impl.
 
 inline NodeBasedEdge::NodeBasedEdge()
-    : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight(0), duration(0),
+    : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight{0}, duration{0},
       forward(false), backward(false), roundabout(false), circular(false), startpoint(true),
       is_split(false), travel_mode(TRAVEL_MODE_INACCESSIBLE),
       lane_description_id(INVALID_LANE_DESCRIPTIONID)
@@ -83,7 +83,7 @@ inline NodeBasedEdge::NodeBasedEdge(NodeID source,
                                     NodeID target,
                                     NodeID name_id,
                                     EdgeWeight weight,
-                                    EdgeWeight duration,
+                                    EdgeDuration duration,
                                     bool forward,
                                     bool backward,
                                     bool roundabout,
@@ -121,7 +121,7 @@ inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM(OSMNodeID source,
                                                   OSMNodeID target,
                                                   NodeID name_id,
                                                   EdgeWeight weight,
-                                                  EdgeWeight duration,
+                                                  EdgeDuration duration,
                                                   bool forward,
                                                   bool backward,
                                                   bool roundabout,

--- a/include/util/dist_table_wrapper.hpp
+++ b/include/util/dist_table_wrapper.hpp
@@ -34,7 +34,7 @@ template <typename T> class DistTableWrapper
 
     std::size_t size() const { return table_.size(); }
 
-    EdgeWeight operator()(NodeID from, NodeID to) const
+    T operator()(NodeID from, NodeID to) const
     {
         BOOST_ASSERT_MSG(from < number_of_nodes_, "from ID is out of bound");
         BOOST_ASSERT_MSG(to < number_of_nodes_, "to ID is out of bound");
@@ -46,7 +46,7 @@ template <typename T> class DistTableWrapper
         return table_[index];
     }
 
-    void SetValue(NodeID from, NodeID to, EdgeWeight value)
+    void SetValue(NodeID from, NodeID to, EdgeDuration value)
     {
         BOOST_ASSERT_MSG(from < number_of_nodes_, "from ID is out of bound");
         BOOST_ASSERT_MSG(to < number_of_nodes_, "to ID is out of bound");

--- a/include/util/graph_loader.hpp
+++ b/include/util/graph_loader.hpp
@@ -119,7 +119,7 @@ inline NodeID loadEdgesFromFile(storage::io::FileReader &file_reader,
         const auto &edge = edge_list[i];
         const auto &prev_edge = edge_list[i - 1];
 
-        BOOST_ASSERT_MSG(edge.weight > 0, "loaded null weight");
+        BOOST_ASSERT_MSG(edge.weight > EdgeWeight{0}, "loaded null weight");
         BOOST_ASSERT_MSG(edge.forward, "edge must be oriented in forward direction");
         BOOST_ASSERT_MSG(edge.travel_mode != TRAVEL_MODE_INACCESSIBLE, "loaded non-accessible");
 

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -18,7 +18,7 @@ namespace util
 struct NodeBasedEdgeData
 {
     NodeBasedEdgeData()
-        : weight(INVALID_EDGE_WEIGHT), duration(INVALID_EDGE_WEIGHT), edge_id(SPECIAL_NODEID),
+        : weight{INVALID_EDGE_WEIGHT}, duration{MAXIMAL_EDGE_DURATION}, edge_id(SPECIAL_NODEID),
           name_id(std::numeric_limits<unsigned>::max()), reversed(false), roundabout(false),
           circular(false), travel_mode(TRAVEL_MODE_INACCESSIBLE),
           lane_description_id(INVALID_LANE_DESCRIPTIONID)
@@ -26,7 +26,7 @@ struct NodeBasedEdgeData
     }
 
     NodeBasedEdgeData(EdgeWeight weight,
-                      EdgeWeight duration,
+                      EdgeDuration duration,
                       unsigned edge_id,
                       unsigned name_id,
                       bool reversed,
@@ -42,7 +42,7 @@ struct NodeBasedEdgeData
     }
 
     EdgeWeight weight;
-    EdgeWeight duration;
+    EdgeDuration duration;
     unsigned edge_id;
     unsigned name_id;
     bool reversed : 1;
@@ -90,8 +90,8 @@ NodeBasedDynamicGraphFromEdges(NodeID number_of_nodes,
             output_edge.data.road_classification = input_edge.road_classification;
             output_edge.data.lane_description_id = input_edge.lane_description_id;
 
-            BOOST_ASSERT(output_edge.data.weight > 0);
-            BOOST_ASSERT(output_edge.data.duration > 0);
+            BOOST_ASSERT(output_edge.data.weight > EdgeWeight{0});
+            BOOST_ASSERT(output_edge.data.duration > EdgeDuration{0});
         });
 
     tbb::parallel_sort(edges_list.begin(), edges_list.end());

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -67,8 +67,8 @@ struct RectangleInt2D
         Coordinate centroid;
         // The coordinates of the midpoints are given by:
         // x = (x1 + x2) /2 and y = (y1 + y2) /2.
-        centroid.lon = (min_lon + max_lon) / FixedLongitude{2};
-        centroid.lat = (min_lat + max_lat) / FixedLatitude{2};
+        centroid.lon = (min_lon + max_lon) / 2.;
+        centroid.lat = (min_lat + max_lat) / 2.;
         return centroid;
     }
 

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -34,7 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 
 // OpenStreetMap node ids are higher than 2^32
 OSRM_STRONG_TYPEDEF(std::uint64_t, OSMNodeID)
@@ -57,8 +56,19 @@ using OSMEdgeID_weak = std::uint64_t;
 using NodeID = std::uint32_t;
 using EdgeID = std::uint32_t;
 using NameID = std::uint32_t;
-using EdgeWeight = std::int32_t;
-using TurnPenalty = std::int16_t; // turn penalty in 100ms units
+OSRM_STRONG_TYPEDEF(std::int32_t, EdgeWeight)
+OSRM_STRONG_TYPEDEF(std::int16_t, TurnPenalty)
+OSRM_STRONG_TYPEDEF(std::int32_t, EdgeDuration)
+OSRM_STRONG_TYPEDEF(std::int16_t, TurnDuration)
+OSRM_STRONG_TYPEDEF_LIMITS(EdgeWeight,
+                           std::numeric_limits<std::int32_t>::min(),
+                           std::numeric_limits<std::int32_t>::max())
+OSRM_STRONG_TYPEDEF_LIMITS(EdgeDuration, std::numeric_limits<std::int32_t>::min(), (1 << 30) - 1)
+OSRM_STRONG_TYPEDEF_LIMITS(TurnPenalty,
+                           std::numeric_limits<std::int16_t>::min(),
+                           std::numeric_limits<std::int16_t>::max())
+OSRM_STRONG_TYPEDEF_HASHABLE(std::int32_t, EdgeWeight)
+OSRM_STRONG_TYPEDEF_HASHABLE(std::int32_t, EdgeDuration)
 
 static const std::size_t INVALID_INDEX = std::numeric_limits<std::size_t>::max();
 
@@ -86,7 +96,7 @@ static const NameID INVALID_NAMEID = std::numeric_limits<NameID>::max();
 static const NameID EMPTY_NAMEID = 0;
 static const unsigned INVALID_COMPONENTID = 0;
 static const EdgeWeight INVALID_EDGE_WEIGHT = std::numeric_limits<EdgeWeight>::max();
-static const EdgeWeight MAXIMAL_EDGE_DURATION = std::numeric_limits<EdgeWeight>::max();
+static const EdgeDuration MAXIMAL_EDGE_DURATION = std::numeric_limits<EdgeDuration>::max();
 static const TurnPenalty INVALID_TURN_PENALTY = std::numeric_limits<TurnPenalty>::max();
 
 using DatasourceID = std::uint8_t;

--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -60,7 +60,7 @@ GraphContractor::GraphContractor(int nodes,
         // merge edges (s,t) and (t,s) into bidirectional edge
         if (forward_edge.data.weight == reverse_edge.data.weight)
         {
-            if ((int)forward_edge.data.weight != INVALID_EDGE_WEIGHT)
+            if (forward_edge.data.weight != INVALID_EDGE_WEIGHT)
             {
                 forward_edge.data.backward = true;
                 edges[edge++] = forward_edge;
@@ -68,11 +68,11 @@ GraphContractor::GraphContractor(int nodes,
         }
         else
         { // insert seperate edges
-            if (((int)forward_edge.data.weight) != INVALID_EDGE_WEIGHT)
+            if ((forward_edge.data.weight) != INVALID_EDGE_WEIGHT)
             {
                 edges[edge++] = forward_edge;
             }
-            if ((int)reverse_edge.data.weight != INVALID_EDGE_WEIGHT)
+            if (reverse_edge.data.weight != INVALID_EDGE_WEIGHT)
             {
                 edges[edge++] = reverse_edge;
             }

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -27,9 +27,9 @@ namespace engine
 namespace plugins
 {
 
-bool IsStronglyConnectedComponent(const util::DistTableWrapper<EdgeWeight> &result_table)
+bool IsStronglyConnectedComponent(const util::DistTableWrapper<EdgeDuration> &result_table)
 {
-    return std::find(std::begin(result_table), std::end(result_table), INVALID_EDGE_WEIGHT) ==
+    return std::find(std::begin(result_table), std::end(result_table), MAXIMAL_EDGE_DURATION) ==
            std::end(result_table);
 }
 
@@ -94,7 +94,7 @@ TripPlugin::ComputeRoute(const std::shared_ptr<const datafacade::BaseDataFacade>
 
 void ManipulateTableForFSE(const std::size_t source_id,
                            const std::size_t destination_id,
-                           util::DistTableWrapper<EdgeWeight> &result_table)
+                           util::DistTableWrapper<EdgeDuration> &result_table)
 {
     // ****************** Change Table *************************
     // The following code manipulates the table and produces the new table for
@@ -120,7 +120,7 @@ void ManipulateTableForFSE(const std::size_t source_id,
     {
         if (i == source_id)
             continue;
-        result_table.SetValue(i, source_id, INVALID_EDGE_WEIGHT);
+        result_table.SetValue(i, source_id, MAXIMAL_EDGE_DURATION);
     }
 
     // change parameters.destination row
@@ -130,16 +130,16 @@ void ManipulateTableForFSE(const std::size_t source_id,
     {
         if (i == destination_id)
             continue;
-        result_table.SetValue(destination_id, i, INVALID_EDGE_WEIGHT);
+        result_table.SetValue(destination_id, i, MAXIMAL_EDGE_DURATION);
     }
 
     // set destination->source to zero so rountrip treats source and
     // destination as one location
-    result_table.SetValue(destination_id, source_id, 0);
+    result_table.SetValue(destination_id, source_id, EdgeDuration{0});
 
     // set source->destination as very high number so algorithm is forced
     // to find another path to get to destination
-    result_table.SetValue(source_id, destination_id, INVALID_EDGE_WEIGHT);
+    result_table.SetValue(source_id, destination_id, MAXIMAL_EDGE_DURATION);
 
     //*********  End of changes to table  *************************************
 }
@@ -201,7 +201,7 @@ Status TripPlugin::HandleRequest(const std::shared_ptr<const datafacade::BaseDat
     BOOST_ASSERT(snapped_phantoms.size() == number_of_locations);
 
     // compute the duration table of all phantom nodes
-    auto result_table = util::DistTableWrapper<EdgeWeight>(
+    auto result_table = util::DistTableWrapper<EdgeDuration>(
         duration_table(facade, snapped_phantoms, {}, {}), number_of_locations);
 
     if (result_table.size() == 0)

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -62,7 +62,7 @@ operator()(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
                             target_phantom.reverse_segment_id.id);
     }
 
-    int weight = INVALID_EDGE_WEIGHT;
+    auto weight = INVALID_EDGE_WEIGHT;
     std::vector<NodeID> packed_leg;
 
     const bool constexpr DO_NOT_FORCE_LOOPS =

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -157,9 +157,9 @@ operator()(const std::shared_ptr<const datafacade::BaseDataFacade> facade,
 
             const auto haversine_distance = util::coordinate_calculation::haversineDistance(
                 prev_coordinate, current_coordinate);
-            // assumes minumum of 0.1 m/s
-            const int duration_upper_bound =
-                ((haversine_distance + max_distance_delta) * 0.25) * 10;
+            // TODO: duration used as weight assumes minumum of 0.1 m/s
+            const EdgeWeight duration_upper_bound = EdgeWeight{static_cast<EdgeWeight::value_type>(
+                ((haversine_distance + max_distance_delta) * 0.25) * 10)};
 
             // compute d_t for this timestamp and the next one
             for (const auto s : util::irange<std::size_t>(0UL, prev_viterbi.size()))

--- a/src/engine/routing_algorithms/routing_base.cpp
+++ b/src/engine/routing_algorithms/routing_base.cpp
@@ -32,7 +32,7 @@ void BasicRoutingInterface::RoutingStep(
                 (force_loop_reverse && reverse_heap.GetData(node).parent == node) ||
                 // in this case we are looking at a bi-directional way where the source
                 // and target phantom are on the same edge based node
-                new_weight < 0)
+                new_weight < EdgeWeight{0})
             {
                 // check whether there is a loop present at the node
                 for (const auto edge : facade->GetAdjacentEdgeRange(node))
@@ -46,7 +46,7 @@ void BasicRoutingInterface::RoutingStep(
                         {
                             const EdgeWeight edge_weight = data.weight;
                             const EdgeWeight loop_weight = new_weight + edge_weight;
-                            if (loop_weight >= 0 && loop_weight < upper_bound)
+                            if (loop_weight >= EdgeWeight{0} && loop_weight < upper_bound)
                             {
                                 middle_node_id = node;
                                 upper_bound = loop_weight;
@@ -57,7 +57,7 @@ void BasicRoutingInterface::RoutingStep(
             }
             else
             {
-                BOOST_ASSERT(new_weight >= 0);
+                BOOST_ASSERT(new_weight >= EdgeWeight{0});
 
                 middle_node_id = node;
                 upper_bound = new_weight;
@@ -67,7 +67,7 @@ void BasicRoutingInterface::RoutingStep(
 
     // make sure we don't terminate too early if we initialize the weight
     // for the nodes in the forward heap with the forward/reverse offset
-    BOOST_ASSERT(min_edge_offset <= 0);
+    BOOST_ASSERT(min_edge_offset <= EdgeWeight{0});
     if (weight + min_edge_offset > upper_bound)
     {
         forward_heap.DeleteAll();
@@ -86,7 +86,7 @@ void BasicRoutingInterface::RoutingStep(
                 const NodeID to = facade->GetTarget(edge);
                 const EdgeWeight edge_weight = data.weight;
 
-                BOOST_ASSERT_MSG(edge_weight > 0, "edge_weight invalid");
+                BOOST_ASSERT_MSG(edge_weight > EdgeWeight{0}, "edge_weight invalid");
 
                 if (forward_heap.WasInserted(to))
                 {
@@ -108,7 +108,7 @@ void BasicRoutingInterface::RoutingStep(
             const NodeID to = facade->GetTarget(edge);
             const EdgeWeight edge_weight = data.weight;
 
-            BOOST_ASSERT_MSG(edge_weight > 0, "edge_weight invalid");
+            BOOST_ASSERT_MSG(edge_weight > EdgeWeight{0}, "edge_weight invalid");
             const EdgeWeight to_weight = weight + edge_weight;
 
             // New Node discovered -> Add to Heap + Node Info Storage
@@ -206,10 +206,10 @@ void BasicRoutingInterface::Search(const std::shared_ptr<const datafacade::BaseD
     weight = weight_upper_bound;
 
     // get offset to account for offsets on phantom nodes on compressed edges
-    const auto min_edge_offset = std::min(0, forward_heap.MinKey());
-    BOOST_ASSERT(min_edge_offset <= 0);
+    const auto min_edge_offset = std::min(EdgeWeight{0}, forward_heap.MinKey());
+    BOOST_ASSERT(min_edge_offset <= EdgeWeight{0});
     // we only every insert negative offsets for nodes in the forward heap
-    BOOST_ASSERT(reverse_heap.MinKey() >= 0);
+    BOOST_ASSERT(reverse_heap.MinKey() >= EdgeWeight{0});
 
     // run two-Target Dijkstra routing step.
     const constexpr bool STALLING_ENABLED = true;
@@ -295,9 +295,9 @@ void BasicRoutingInterface::SearchWithCore(
     std::vector<CoreEntryPoint> reverse_entry_points;
 
     // get offset to account for offsets on phantom nodes on compressed edges
-    const auto min_edge_offset = std::min(0, forward_heap.MinKey());
+    const auto min_edge_offset = std::min(EdgeWeight{0}, forward_heap.MinKey());
     // we only every insert negative offsets for nodes in the forward heap
-    BOOST_ASSERT(reverse_heap.MinKey() >= 0);
+    BOOST_ASSERT(reverse_heap.MinKey() >= EdgeWeight{0});
 
     const constexpr bool STALLING_ENABLED = true;
     // run two-Target Dijkstra routing step.
@@ -372,16 +372,16 @@ void BasicRoutingInterface::SearchWithCore(
     }
 
     // get offset to account for offsets on phantom nodes on compressed edges
-    EdgeWeight min_core_edge_offset = 0;
+    EdgeWeight min_core_edge_offset{0};
     if (forward_core_heap.Size() > 0)
     {
         min_core_edge_offset = std::min(min_core_edge_offset, forward_core_heap.MinKey());
     }
-    if (reverse_core_heap.Size() > 0 && reverse_core_heap.MinKey() < 0)
+    if (reverse_core_heap.Size() > 0 && reverse_core_heap.MinKey() < EdgeWeight{0})
     {
         min_core_edge_offset = std::min(min_core_edge_offset, reverse_core_heap.MinKey());
     }
-    BOOST_ASSERT(min_core_edge_offset <= 0);
+    BOOST_ASSERT(min_core_edge_offset <= EdgeWeight{0});
 
     // run two-target Dijkstra routing step on core with termination criterion
     const constexpr bool STALLING_DISABLED = false;

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -21,9 +21,9 @@ void ShortestPathRouting::SearchWithUTurn(
     const bool search_to_reverse_node,
     const PhantomNode &source_phantom,
     const PhantomNode &target_phantom,
-    const int total_weight_to_forward,
-    const int total_weight_to_reverse,
-    int &new_total_weight,
+    const EdgeWeight total_weight_to_forward,
+    const EdgeWeight total_weight_to_reverse,
+    EdgeWeight &new_total_weight,
     std::vector<NodeID> &leg_packed_path) const
 {
     forward_heap.Clear();
@@ -111,10 +111,10 @@ void ShortestPathRouting::Search(const std::shared_ptr<const datafacade::BaseDat
                                  const bool search_to_reverse_node,
                                  const PhantomNode &source_phantom,
                                  const PhantomNode &target_phantom,
-                                 const int total_weight_to_forward,
-                                 const int total_weight_to_reverse,
-                                 int &new_total_weight_to_forward,
-                                 int &new_total_weight_to_reverse,
+                                 const EdgeWeight total_weight_to_forward,
+                                 const EdgeWeight total_weight_to_reverse,
+                                 EdgeWeight &new_total_weight_to_forward,
+                                 EdgeWeight &new_total_weight_to_reverse,
                                  std::vector<NodeID> &leg_packed_path_forward,
                                  std::vector<NodeID> &leg_packed_path_reverse) const
 {
@@ -227,7 +227,7 @@ void ShortestPathRouting::UnpackLegs(const std::shared_ptr<const datafacade::Bas
                                      const std::vector<PhantomNodes> &phantom_nodes_vector,
                                      const std::vector<NodeID> &total_packed_path,
                                      const std::vector<std::size_t> &packed_leg_begin,
-                                     const int shortest_path_length,
+                                     const EdgeWeight shortest_path_length,
                                      InternalRouteResult &raw_route_data) const
 {
     raw_route_data.unpacked_path_segments.resize(packed_leg_begin.size() - 1);
@@ -270,8 +270,8 @@ void ShortestPathRouting::operator()(const std::shared_ptr<const datafacade::Bas
     QueryHeap &forward_core_heap = *(engine_working_data.forward_heap_2);
     QueryHeap &reverse_core_heap = *(engine_working_data.reverse_heap_2);
 
-    int total_weight_to_forward = 0;
-    int total_weight_to_reverse = 0;
+    EdgeWeight total_weight_to_forward{0};
+    EdgeWeight total_weight_to_reverse{0};
     bool search_from_forward_node =
         phantom_nodes_vector.front().source_phantom.forward_segment_id.enabled;
     bool search_from_reverse_node =
@@ -290,8 +290,8 @@ void ShortestPathRouting::operator()(const std::shared_ptr<const datafacade::Bas
     // a list of vias
     for (const auto &phantom_node_pair : phantom_nodes_vector)
     {
-        int new_total_weight_to_forward = INVALID_EDGE_WEIGHT;
-        int new_total_weight_to_reverse = INVALID_EDGE_WEIGHT;
+        auto new_total_weight_to_forward = INVALID_EDGE_WEIGHT;
+        auto new_total_weight_to_reverse = INVALID_EDGE_WEIGHT;
 
         std::vector<NodeID> packed_leg_to_forward;
         std::vector<NodeID> packed_leg_to_reverse;

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -126,8 +126,8 @@ void CompressedEdgeContainer::CompressEdge(const EdgeID edge_id_1,
                                            const NodeID target_node_id,
                                            const EdgeWeight weight1,
                                            const EdgeWeight weight2,
-                                           const EdgeWeight duration1,
-                                           const EdgeWeight duration2)
+                                           const EdgeDuration duration1,
+                                           const EdgeDuration duration2)
 {
     // remove super-trivial geometries
     BOOST_ASSERT(SPECIAL_EDGEID != edge_id_1);
@@ -210,7 +210,7 @@ void CompressedEdgeContainer::CompressEdge(const EdgeID edge_id_1,
 void CompressedEdgeContainer::AddUncompressedEdge(const EdgeID edge_id,
                                                   const NodeID target_node_id,
                                                   const EdgeWeight weight,
-                                                  const EdgeWeight duration)
+                                                  const EdgeDuration duration)
 {
     // remove super-trivial geometries
     BOOST_ASSERT(SPECIAL_EDGEID != edge_id);
@@ -278,7 +278,7 @@ unsigned CompressedEdgeContainer::ZipEdges(const EdgeID f_edge_id, const EdgeID 
     m_compressed_geometry_nodes.emplace_back(first_node.node_id);
     m_compressed_geometry_fwd_weights.emplace_back(INVALID_EDGE_WEIGHT);
     m_compressed_geometry_rev_weights.emplace_back(first_node.weight);
-    m_compressed_geometry_fwd_durations.emplace_back(INVALID_EDGE_WEIGHT);
+    m_compressed_geometry_fwd_durations.emplace_back(MAXIMAL_EDGE_DURATION);
     m_compressed_geometry_rev_durations.emplace_back(first_node.duration);
 
     for (std::size_t i = 0; i < forward_bucket.size() - 1; ++i)
@@ -301,7 +301,7 @@ unsigned CompressedEdgeContainer::ZipEdges(const EdgeID f_edge_id, const EdgeID 
     m_compressed_geometry_fwd_weights.emplace_back(last_node.weight);
     m_compressed_geometry_rev_weights.emplace_back(INVALID_EDGE_WEIGHT);
     m_compressed_geometry_fwd_durations.emplace_back(last_node.duration);
-    m_compressed_geometry_rev_durations.emplace_back(INVALID_EDGE_WEIGHT);
+    m_compressed_geometry_rev_durations.emplace_back(MAXIMAL_EDGE_DURATION);
 
     return zipped_geometry_id;
 }

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -368,7 +368,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
     // FIXME these need to be tuned in pre-allocated size
     std::vector<TurnPenalty> turn_weight_penalties;
-    std::vector<TurnPenalty> turn_duration_penalties;
+    std::vector<TurnDuration> turn_duration_penalties;
 
     const auto weight_multiplier =
         scripting_environment.GetProfileProperties().GetWeightMultiplier();
@@ -530,10 +530,11 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
 
                     // turn penalties are limited to [-2^15, 2^15) which roughly
                     // translates to 54 minutes and fits signed 16bit deci-seconds
-                    auto weight_penalty =
-                        boost::numeric_cast<TurnPenalty>(extracted_turn.weight * weight_multiplier);
+                    auto weight_penalty = TurnPenalty{boost::numeric_cast<TurnPenalty::value_type>(
+                        extracted_turn.weight * weight_multiplier)};
                     auto duration_penalty =
-                        boost::numeric_cast<TurnPenalty>(extracted_turn.duration * 10.);
+                        TurnDuration{boost::numeric_cast<TurnDuration::value_type>(
+                            extracted_turn.duration * 10.)};
 
                     BOOST_ASSERT(SPECIAL_NODEID != edge_data1.edge_id);
                     BOOST_ASSERT(SPECIAL_NODEID != edge_data2.edge_id);
@@ -543,9 +544,11 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                                  std::numeric_limits<NodeID>::max());
                     auto turn_id = m_edge_based_edge_list.size();
                     auto weight =
-                        boost::numeric_cast<EdgeWeight>(edge_data1.weight + weight_penalty);
+                        EdgeWeight{static_cast<EdgeWeight::value_type>(edge_data1.weight) +
+                                   static_cast<TurnPenalty::value_type>(weight_penalty)};
                     auto duration =
-                        boost::numeric_cast<EdgeWeight>(edge_data1.duration + duration_penalty);
+                        EdgeDuration{static_cast<EdgeDuration::value_type>(edge_data1.duration) +
+                                     static_cast<TurnDuration::value_type>(duration_penalty)};
                     m_edge_based_edge_list.emplace_back(edge_data1.edge_id,
                                                         edge_data2.edge_id,
                                                         turn_id,

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -402,9 +402,10 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
             scripting_environment.ProcessSegment(extracted_segment);
 
             auto &edge = edge_iterator->result;
-            edge.weight =
-                std::max<EdgeWeight>(1, std::round(extracted_segment.weight * weight_multiplier));
-            edge.duration = std::max<EdgeWeight>(1, std::round(extracted_segment.duration * 10.));
+            edge.weight = EdgeWeight{std::max<EdgeWeight::value_type>(
+                1, std::round(extracted_segment.weight * weight_multiplier))};
+            edge.duration = EdgeDuration{std::max<EdgeDuration::value_type>(
+                1, std::round(extracted_segment.duration * 10.))};
 
             // assign new node id
             auto id_iter = external_to_internal_node_id_map.find(node_iterator->node_id);
@@ -470,10 +471,8 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
         NodeID source = all_edges_list[i].result.source;
         NodeID target = all_edges_list[i].result.target;
 
-        auto min_forward = std::make_pair(std::numeric_limits<EdgeWeight>::max(),
-                                          std::numeric_limits<EdgeWeight>::max());
-        auto min_backward = std::make_pair(std::numeric_limits<EdgeWeight>::max(),
-                                           std::numeric_limits<EdgeWeight>::max());
+        auto min_forward = std::make_pair(INVALID_EDGE_WEIGHT, MAXIMAL_EDGE_DURATION);
+        auto min_backward = std::make_pair(INVALID_EDGE_WEIGHT, MAXIMAL_EDGE_DURATION);
         std::size_t min_forward_idx = std::numeric_limits<std::size_t>::max();
         std::size_t min_backward_idx = std::numeric_limits<std::size_t>::max();
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -325,7 +325,7 @@ void Extractor::FindComponents(unsigned max_edge_id,
 {
     struct UncontractedEdgeData
     {
-        EdgeWeight duration;
+        EdgeDuration duration;
     };
     struct InputEdge
     {
@@ -349,8 +349,7 @@ void Extractor::FindComponents(unsigned max_edge_id,
 
     for (const auto &edge : input_edge_list)
     {
-        BOOST_ASSERT_MSG(static_cast<unsigned int>(std::max(edge.weight, 1)) > 0,
-                         "edge distance < 1");
+        BOOST_ASSERT_MSG(edge.weight > EdgeWeight{0}, "edge weight < 1");
         BOOST_ASSERT(edge.source <= max_edge_id);
         BOOST_ASSERT(edge.target <= max_edge_id);
         if (edge.forward)

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -122,19 +122,19 @@ void GraphCompressor::Compress(const std::unordered_set<NodeID> &barrier_nodes,
                 // Get weights before graph is modified
                 const EdgeWeight forward_weight1 = fwd_edge_data1.weight;
                 const EdgeWeight forward_weight2 = fwd_edge_data2.weight;
-                const EdgeWeight forward_duration1 = fwd_edge_data1.duration;
-                const EdgeWeight forward_duration2 = fwd_edge_data2.duration;
+                const EdgeDuration forward_duration1 = fwd_edge_data1.duration;
+                const EdgeDuration forward_duration2 = fwd_edge_data2.duration;
 
-                BOOST_ASSERT(0 != forward_weight1);
-                BOOST_ASSERT(0 != forward_weight2);
+                BOOST_ASSERT(forward_weight1 != EdgeWeight{0});
+                BOOST_ASSERT(forward_weight2 != EdgeWeight{0});
 
                 const EdgeWeight reverse_weight1 = rev_edge_data1.weight;
                 const EdgeWeight reverse_weight2 = rev_edge_data2.weight;
-                const EdgeWeight reverse_duration1 = rev_edge_data1.duration;
-                const EdgeWeight reverse_duration2 = rev_edge_data2.duration;
+                const EdgeDuration reverse_duration1 = rev_edge_data1.duration;
+                const EdgeDuration reverse_duration2 = rev_edge_data2.duration;
 
-                BOOST_ASSERT(0 != reverse_weight1);
-                BOOST_ASSERT(0 != reverse_weight2);
+                BOOST_ASSERT(reverse_weight1 != EdgeWeight{0});
+                BOOST_ASSERT(reverse_weight2 != EdgeWeight{0});
 
                 // add weight of e2's to e1
                 graph.GetEdgeData(forward_e1).weight += forward_weight2;

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -32,13 +32,10 @@ struct TarjanEdgeData
 {
     TarjanEdgeData() : distance(INVALID_EDGE_WEIGHT), name_id(INVALID_NAMEID) {}
 
-    TarjanEdgeData(std::uint32_t distance, std::uint32_t name_id)
-        : distance(distance), name_id(name_id)
-    {
-    }
+    TarjanEdgeData(EdgeWeight distance, NameID name_id) : distance(distance), name_id(name_id) {}
 
-    std::uint32_t distance;
-    std::uint32_t name_id;
+    EdgeWeight distance;
+    NameID name_id;
 };
 
 using TarjanGraph = util::StaticGraph<TarjanEdgeData>;
@@ -68,18 +65,16 @@ std::size_t loadGraph(const std::string &path,
 
         if (input_edge.forward)
         {
-            graph_edge_list.emplace_back(input_edge.source,
-                                         input_edge.target,
-                                         (std::max)(input_edge.weight, 1),
-                                         input_edge.name_id);
+            BOOST_ASSERT(input_edge.weight > EdgeWeight{0});
+            graph_edge_list.emplace_back(
+                input_edge.source, input_edge.target, input_edge.weight, input_edge.name_id);
         }
 
         if (input_edge.backward)
         {
-            graph_edge_list.emplace_back(input_edge.target,
-                                         input_edge.source,
-                                         (std::max)(input_edge.weight, 1),
-                                         input_edge.name_id);
+            BOOST_ASSERT(input_edge.weight > EdgeWeight{0});
+            graph_edge_list.emplace_back(
+                input_edge.target, input_edge.source, input_edge.weight, input_edge.name_id);
         }
     }
 

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -120,8 +120,8 @@ Coordinate centroid(const Coordinate lhs, const Coordinate rhs)
     Coordinate centroid;
     // The coordinates of the midpoints are given by:
     // x = (x1 + x2) /2 and y = (y1 + y2) /2.
-    centroid.lon = (lhs.lon + rhs.lon) / FixedLongitude{2};
-    centroid.lat = (lhs.lat + rhs.lat) / FixedLatitude{2};
+    centroid.lon = (lhs.lon + rhs.lon) / 2.;
+    centroid.lat = (lhs.lat + rhs.lat) / 2.;
     return centroid;
 }
 

--- a/unit_tests/extractor/compressed_edge_container.cpp
+++ b/unit_tests/extractor/compressed_edge_container.cpp
@@ -16,7 +16,8 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     CompressedEdgeContainer container;
 
     // compress 0---1---2 to 0---2
-    container.CompressEdge(0, 1, 1, 2, 1, 1, 11, 11);
+    container.CompressEdge(
+        0, 1, 1, 2, EdgeWeight{1}, EdgeWeight{1}, EdgeDuration{11}, EdgeDuration{11});
     BOOST_CHECK(container.HasEntryForID(0));
     BOOST_CHECK(!container.HasEntryForID(1));
     BOOST_CHECK(!container.HasEntryForID(2));
@@ -25,7 +26,8 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     BOOST_CHECK_EQUAL(container.GetLastEdgeSourceID(0), 1);
 
     // compress 2---3---4 to 2---4
-    container.CompressEdge(2, 3, 3, 4, 1, 1, 11, 11);
+    container.CompressEdge(
+        2, 3, 3, 4, EdgeWeight{1}, EdgeWeight{1}, EdgeDuration{11}, EdgeDuration{11});
     BOOST_CHECK(container.HasEntryForID(0));
     BOOST_CHECK(!container.HasEntryForID(1));
     BOOST_CHECK(container.HasEntryForID(2));
@@ -34,7 +36,8 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     BOOST_CHECK_EQUAL(container.GetLastEdgeSourceID(2), 3);
 
     // compress 0---2---4 to 0---4
-    container.CompressEdge(0, 2, 2, 4, 2, 2, 22, 22);
+    container.CompressEdge(
+        0, 2, 2, 4, EdgeWeight{2}, EdgeWeight{2}, EdgeDuration{22}, EdgeDuration{22});
     BOOST_CHECK(container.HasEntryForID(0));
     BOOST_CHECK(!container.HasEntryForID(1));
     BOOST_CHECK(!container.HasEntryForID(2));
@@ -54,7 +57,8 @@ BOOST_AUTO_TEST_CASE(t_crossing)
     CompressedEdgeContainer container;
 
     // compress 0---1---2 to 0---2
-    container.CompressEdge(0, 1, 1, 2, 1, 1, 11, 11);
+    container.CompressEdge(
+        0, 1, 1, 2, EdgeWeight{1}, EdgeWeight{1}, EdgeDuration{11}, EdgeDuration{11});
     BOOST_CHECK(container.HasEntryForID(0));
     BOOST_CHECK(!container.HasEntryForID(1));
     BOOST_CHECK(!container.HasEntryForID(2));
@@ -65,7 +69,8 @@ BOOST_AUTO_TEST_CASE(t_crossing)
     BOOST_CHECK_EQUAL(container.GetLastEdgeSourceID(0), 1);
 
     // compress 2---5---6 to 2---6
-    container.CompressEdge(4, 5, 5, 6, 1, 1, 11, 11);
+    container.CompressEdge(
+        4, 5, 5, 6, EdgeWeight{1}, EdgeWeight{1}, EdgeDuration{11}, EdgeDuration{11});
     BOOST_CHECK(container.HasEntryForID(0));
     BOOST_CHECK(!container.HasEntryForID(1));
     BOOST_CHECK(!container.HasEntryForID(2));
@@ -76,7 +81,8 @@ BOOST_AUTO_TEST_CASE(t_crossing)
     BOOST_CHECK_EQUAL(container.GetLastEdgeSourceID(4), 5);
 
     // compress 2---3---4 to 2---4
-    container.CompressEdge(2, 3, 3, 4, 1, 1, 11, 11);
+    container.CompressEdge(
+        2, 3, 3, 4, EdgeWeight{1}, EdgeWeight{1}, EdgeDuration{11}, EdgeDuration{11});
     BOOST_CHECK(container.HasEntryForID(0));
     BOOST_CHECK(!container.HasEntryForID(1));
     BOOST_CHECK(container.HasEntryForID(2));

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -25,10 +25,10 @@ inline InputEdge MakeUnitEdge(const NodeID from, const NodeID to)
     // src, tgt, dist, edge_id, name_id, fwd, bkwd, roundabout, circular, travel_mode
     return {from,
             to,
+            EdgeWeight{1},
+            EdgeDuration{1},
             1,
             SPECIAL_EDGEID,
-            0,
-            0,
             false,
             false,
             false,

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    BOOST_CHECK_EQUAL(result.size(), 113824);
+    BOOST_CHECK_EQUAL(result.size(), 113769);
 
     protozero::pbf_reader tile_message(result);
     tile_message.next();

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -68,13 +68,13 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     {
         return GeometryID{SPECIAL_GEOMETRYID, false};
     }
-    TurnPenalty GetWeightPenaltyForEdgeID(const unsigned /* id */) const override final
+    EdgeWeight GetWeightPenaltyForEdgeID(const unsigned /* id */) const override final
     {
-        return 0;
+        return EdgeWeight{0};
     }
-    TurnPenalty GetDurationPenaltyForEdgeID(const unsigned /* id */) const override final
+    EdgeDuration GetDurationPenaltyForEdgeID(const unsigned /* id */) const override final
     {
-        return 0;
+        return EdgeDuration{0};
     }
     std::vector<NodeID> GetUncompressedForwardGeometry(const EdgeID /* id */) const override
     {
@@ -86,22 +86,19 @@ class MockDataFacade final : public engine::datafacade::BaseDataFacade
     }
     std::vector<EdgeWeight> GetUncompressedForwardWeights(const EdgeID /* id */) const override
     {
-        std::vector<EdgeWeight> result_weights;
-        result_weights.resize(1);
-        result_weights[0] = 1;
-        return result_weights;
+        return std::vector<EdgeWeight>(1, EdgeWeight{1});
     }
     std::vector<EdgeWeight> GetUncompressedReverseWeights(const EdgeID id) const override
     {
         return GetUncompressedForwardWeights(id);
     }
-    std::vector<EdgeWeight> GetUncompressedForwardDurations(const EdgeID id) const override
+    std::vector<EdgeDuration> GetUncompressedForwardDurations(const EdgeID /* id */) const override
     {
-        return GetUncompressedForwardWeights(id);
+        return std::vector<EdgeDuration>(1, EdgeDuration{1});
     }
-    std::vector<EdgeWeight> GetUncompressedReverseDurations(const EdgeID id) const override
+    std::vector<EdgeDuration> GetUncompressedReverseDurations(const EdgeID id) const override
     {
-        return GetUncompressedForwardWeights(id);
+        return GetUncompressedForwardDurations(id);
     }
     std::vector<DatasourceID> GetUncompressedForwardDatasources(const EdgeID /*id*/) const override
     {


### PR DESCRIPTION
# Issue

For #3601 PR defines `EdgeWeight`, `TurnPenalty`, `EdgeDuration`, `TurnDuration` as strong types. Also fixes #3677 by defining 30 bits size for duration that roughly corresponds to 621 days in deciseconds. 

## Tasklist
 - [ ] Fix TODOs in the PR
 - [ ] Fix fallback to durations in traffic speed updates
 - [ ] Refine explicit `static_cast` by defining operators
 - [ ] review
 - [ ] adjust for comments

