### PR TITLE
Unit testing docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ See the library tests for how to add new dataset dependent tests.
 
 To prepare the test data simply `cd test/data/` and then run `make`.
 
-## Running Tests
+### Running Tests
 
 To build the unit tests:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,29 @@ This dataset is a small extract and may not even contain all tags or edge cases.
 Furthermore this dataset is not in sync with what you see in up-to-date OSM maps or on the demo server.
 See the library tests for how to add new dataset dependent tests.
 
+To prepare the test data simply `cd test/data/` and then run `make`.
+
+## Running Tests
+
+To build the unit tests:
+
+```
+cd build
+cmake ..
+make tests
+```
+
+You should see the compiled binaries in `build/unit_tests`, you can then run each suite individually:
+
+```
+./engine-tests
+```
+
+For `library-tests` you will need to provide a path to the test data:
+
+```
+./library-tests ../../test/data/monaco.osrm
+```
 
 ## Cucumber
 

--- a/unit_tests/library/args.hpp
+++ b/unit_tests/library/args.hpp
@@ -3,12 +3,18 @@
 
 #include <string>
 #include <vector>
+#include <iostream>
 
 inline std::vector<std::string> get_args()
 {
     // Split off argv[0], store actual positional arguments in args
     const auto argc = boost::unit_test::framework::master_test_suite().argc - 1;
     const auto argv = boost::unit_test::framework::master_test_suite().argv + 1;
+
+    if (argc == 0)
+    {
+        std::cout << "You must provide a path to the test data, please see the unit testing docs" << std::endl;
+    }
 
     return {argv, argv + argc};
 }


### PR DESCRIPTION
# Issue

This is a fix for issue #3697.

## Tasklist
 - [x] Update docs with info on how to build and run the unit tests
 - [x] Add check to get_args() in library-tests to supply a meaningful error message when no path is supplied