### PR TITLE
Allow empty segment speed files when parsing

### DIFF
--- a/features/options/contract/datasources.feature
+++ b/features/options/contract/datasources.feature
@@ -28,3 +28,11 @@ Feature: osrm-contract command line options: datasources
         When I run "osrm-contract --segment-speed-file {speeds_file} {processed_file}"
         Then datasource names should contain "lua profile,27_osrmcontract_passing_base_file_speeds"
         And it should exit successfully
+
+    Scenario: osrm-contract - Passing base file
+        Given the speed file
+        """
+        """
+        And the data has been extracted
+        When I run "osrm-contract --segment-speed-file {speeds_file} {processed_file}"
+        Then it should exit successfully

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -268,7 +268,7 @@ template <typename Key, typename Value> struct CSVFilesParser
         qi::rule<Iterator, std::pair<Key, Value>()> csv_line =
             (key_rule >> ',' >> value_source) >> -(',' >> *(qi::char_ - qi::eol));
         std::vector<std::pair<Key, Value>> result;
-        const auto ok = qi::parse(first, last, (csv_line % qi::eol) >> *qi::eol, result);
+        const auto ok = qi::parse(first, last, -(csv_line % qi::eol) >> *qi::eol, result);
 
         if (!ok || first != last)
         {


### PR DESCRIPTION
# Issue

Fixes regression of erroring on empty speed files. Closes https://github.com/Project-OSRM/osrm-backend/issues/3702

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Should go out with 5.6
cc @TheMarex @oxidase 
