### PR TITLE
reduce verbosity of use-lane in combination with lane-anticipation

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -818,3 +818,37 @@ Feature: Turn Lane Guidance
        When I route I should get
             | waypoints | route               | turns                                   | lanes                                                                        |
             | a,e       | MySt,MySt,MySt,MySt | depart,continue right,turn right,arrive | ,straight:false straight:false right:false right:true,left:false right:true, |
+
+    @anticipate
+    Scenario: Don't Overdo It
+        Given the node map
+            """
+                                  q                     r                     s                     t                     u                     v
+                                  |                     |                     |                     |                     |                     |
+            a - - - - - - - - - - b - - - - - - - - - - c - - - - - - - - - - d - - - - - - - - - - e - - - - - - - - - - f - - - - - - - - - - g - h - i
+                                  |                     |                     |                     |                     |                     |   |
+                                  p                     o                     n                     m                     l                     k   j
+            """
+
+        And the ways
+            | nodes | name | turn:lanes:forward | oneway |
+            | ab    | road | left\|\|\|         | yes    |
+            | bc    | road | left\|\|\|         | yes    |
+            | cd    | road | left\|\|\|         | yes    |
+            | de    | road | left\|\|\|         | yes    |
+            | ef    | road | left\|\|\|         | yes    |
+            | fg    | road | left\|\|\|         | yes    |
+            | gh    | road | \|\|right          | yes    |
+            | hi    | road |                    | yes    |
+            | qbp   | 1st  |                    | no     |
+            | rco   | 2nd  |                    | no     |
+            | sdn   | 3rd  |                    | no     |
+            | tem   | 4th  |                    | no     |
+            | ufl   | 5th  |                    | no     |
+            | vgk   | 6th  |                    | no     |
+            | hj    | 7th  |                    | no     |
+
+        When I route I should get
+            | waypoints | route             | turns                                      | locations | lanes                                                                         |
+            | a,i       | road,road,road    | depart,use lane straight,arrive            | a,g,i     | ,left:false none:true none:true none:false,                                   |
+            | a,j       | road,road,7th,7th | depart,use lane straight,turn right,arrive | a,f,h,j   | ,left:false none:false none:false none:true,none:false none:false right:true, |

--- a/include/engine/guidance/lane_processing.hpp
+++ b/include/engine/guidance/lane_processing.hpp
@@ -20,7 +20,7 @@ namespace guidance
 // as separate maneuvers.
 OSRM_ATTR_WARN_UNUSED
 std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
-                                            const double min_duration_needed_for_lane_change = 15);
+                                            const double min_duration_needed_for_lane_change = 10);
 
 } // namespace guidance
 } // namespace engine

--- a/include/engine/guidance/post_processing.hpp
+++ b/include/engine/guidance/post_processing.hpp
@@ -28,6 +28,7 @@ std::vector<RouteStep> collapseTurns(std::vector<RouteStep> steps);
 
 // A check whether two instructions can be treated as one. This is only the case for very short
 // maneuvers that can, in some form, be seen as one. Lookahead of one step.
+// This is only a pre-check and does not necessarily allow collapsing turns!!!
 bool collapsable(const RouteStep &step, const RouteStep &next);
 
 // trim initial/final segment of very short length.


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/3571.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
none

Changes the results from the issue to:

<img width="1223" alt="screen shot 2017-02-13 at 16 37 37" src="https://cloud.githubusercontent.com/assets/12932279/22889848/cc8153a6-f20a-11e6-95c3-3eb51ec4df8f.png">

The remaining use-lane is a result of the following use-lane which is 2 of 2 lanes but the 2 leftmost. The rightmost lanes becomes a turn right, which is now a reason to call out early for keeping left.

