### PR TITLE
Correct a typo in the docs

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -483,9 +483,9 @@ Represents a route between two waypoints.
 - `distance`: The distance traveled by this route leg, in `float` meters.
 - `duration`: The estimated travel time, in `float` number of seconds.
 - `weight`: The calculated weight of the route leg.
-- `summary`: Summary of the route taken as `string`. Depends on the `steps` parameter:
+- `summary`: Summary of the route taken as `string`. Depends on the `summary` parameter:
 
-| steps        |                                                                       |
+| summary      |                                                                       |
 |--------------|-----------------------------------------------------------------------|
 | true         | Names of the two major roads used. Can be empty if route is too short.|
 | false        | empty `string`                                                        |


### PR DESCRIPTION
Fix the typo of `summary` parameter table that was mislabeled `steps`.