### PR TITLE
remove unsigned >= 0 checks, unused constnat

### DIFF
--- a/include/engine/trip/trip_brute_force.hpp
+++ b/include/engine/trip/trip_brute_force.hpp
@@ -74,8 +74,6 @@ std::vector<NodeID> BruteForceTrip(const std::size_t number_of_locations,
     BOOST_ASSERT_MSG(*(std::max_element(std::begin(node_order), std::end(node_order))) <
                          number_of_locations,
                      "invalid node id");
-    BOOST_ASSERT_MSG(*(std::min_element(std::begin(node_order), std::end(node_order))) >= 0,
-                     "invalid node id");
 
     do
     {

--- a/include/engine/trip/trip_farthest_insertion.hpp
+++ b/include/engine/trip/trip_farthest_insertion.hpp
@@ -167,8 +167,6 @@ std::vector<NodeID> FarthestInsertionTrip(const std::size_t number_of_locations,
     NodeID max_from = index_of_farthest_distance / number_of_locations;
     NodeID max_to = index_of_farthest_distance % number_of_locations;
 
-    BOOST_ASSERT(max_from >= 0);
-    BOOST_ASSERT(max_to >= 0);
     BOOST_ASSERT_MSG(static_cast<std::size_t>(max_from) < number_of_locations, "start node");
     BOOST_ASSERT_MSG(static_cast<std::size_t>(max_to) < number_of_locations, "start node");
     return FindRoute(number_of_locations, dist_table, max_from, max_to);

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -112,8 +112,6 @@ namespace osrm
 namespace extractor
 {
 
-static const int WRITE_BLOCK_BUFFER_SIZE = 8000;
-
 ExtractionContainers::ExtractionContainers()
 {
     // Check if stxxl can be instantiated


### PR DESCRIPTION
# Issue

Fixes a few compiler warnings due to unsigned >= 0 comparisons and unused constant.

## Tasklist
 - [x] review
 - [x] adjust for comments