### PR TITLE
Allow routing on toll roads by default

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -224,12 +224,10 @@ Feature: Car - Restricted access
             | primary | no          | x     |
             | primary | snowmobile  | x     |
 
-     # To test this we need issue #2781
-     @todo
-     Scenario: Car - only toll=yes ways are ignored by default
+     Scenario: Car - toll=yes ways are enabled by default
         Then routability should be
             | highway | toll        | bothw |
-            | primary | yes         |       |
+            | primary | yes         | x     |
 
     Scenario: Car - directional access tags
         Then routability should be

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -96,7 +96,7 @@ local profile = {
 
   avoid = Set {
     'area',
-    'toll',
+    -- 'toll',    -- uncomment this to avoid tolls
     'reversible',
     'impassable',
     'hov_lanes',


### PR DESCRIPTION
This fixes #3711 and re-enables toll-road routing by default in the `car.lua` profile.  It also adds a regression test so we don't do this again.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments