### PR TITLE
Penalize turns from non-local access only edges to local access only edges

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -119,12 +119,13 @@ Feature: Car - Restricted access
             | permissive   | x     |
             | designated   | x     |
             | no           |       |
-            | private      |       |
+            | private      | x     |
             | agricultural |       |
             | forestry     |       |
             | psv          |       |
-            | delivery     |       |
+            | delivery     | x     |
             | some_tag     | x     |
+            | destination  | x     |
 
 
     Scenario: Car - Access tags on nodes
@@ -134,11 +135,11 @@ Feature: Car - Restricted access
             | permissive   | x     |
             | designated   | x     |
             | no           |       |
-            | private      |       |
+            | private      | x     |
             | agricultural |       |
             | forestry     |       |
             | psv          |       |
-            | delivery     |       |
+            | delivery     | x     |
             | some_tag     | x     |
 
     Scenario: Car - Access tags on both node and way
@@ -156,15 +157,15 @@ Feature: Car - Restricted access
 
     Scenario: Car - Access combinations
         Then routability should be
-            | highway     | accesss      | vehicle    | motor_vehicle | motorcar    | bothw |
-            | runway      | private      |            |               | permissive  | x     |
-            | primary     | forestry     |            | yes           |             | x     |
-            | cycleway    |              |            | designated    |             | x     |
-            | residential |              | yes        | no            |             |       |
-            | motorway    | yes          | permissive |               | private     |       |
-            | trunk       | agricultural | designated | permissive    | no          |       |
-            | pedestrian  |              |            |               |             |       |
-            | pedestrian  |              |            |               | destination | x     |
+            | highway     | access       | vehicle    | motor_vehicle | motorcar    | forw | backw | # |
+            | runway      | private      |            |               | permissive  | x    | x     |   |
+            | primary     | forestry     |            | yes           |             | x    | x     |   |
+            | cycleway    |              |            | designated    |             | x    | x     |   |
+            | residential |              | yes        | no            |             |      |       |   |
+            | motorway    | yes          | permissive |               | private     | x    |       | implied oneway  |
+            | trunk       | agricultural | designated | permissive    | no          |      |       |   |
+            | pedestrian  |              |            |               |             |      |       |   |
+            | pedestrian  |              |            |               | destination | x    | x     |   |
 
     Scenario: Car - Ignore access tags for other modes
         Then routability should be
@@ -182,7 +183,7 @@ Feature: Car - Restricted access
     Scenario: Car - designated HOV ways are rated low
         Then routability should be
             | highway | hov        | bothw | forw_rate  | backw_rate  |
-            | primary | designated | x     | 2          | 2           |
+            | primary | designated | x     | 18         | 18          |
             | primary | yes        | x     | 18         | 18          |
             | primary | no         | x     | 18         | 18          |
 
@@ -193,28 +194,28 @@ Feature: Car - Restricted access
     Scenario: Car - I-66 use HOV-only roads with heavy penalty
         Then routability should be
             | highway  | hov         | hov:lanes                          | lanes | access     | oneway | forw | backw | forw_rate  |
-            | motorway | designated  | designated\|designated\|designated | 3     | hov        | yes    | x    |       | 3          |
+            | motorway | designated  | designated\|designated\|designated | 3     | hov        | yes    | x    |       | 25         |
             | motorway | lane        |                                    | 3     | designated | yes    | x    |       | 25         |
 
     @hov
     Scenario: Car - a way with all lanes HOV-designated is highly penalized by default (similar to hov=designated)
         Then routability should be
             | highway | hov:lanes:forward      | hov:lanes:backward     | hov:lanes              | oneway | forw | backw | forw_rate | backw_rate |
-            | primary | designated             | designated             |                        |        | x    | x     | 2         | 2          |
-            | primary |                        | designated             |                        |        | x    | x     | 18        | 2          |
-            | primary | designated             |                        |                        |        | x    | x     | 2         | 18         |
-            | primary | designated\|designated | designated\|designated |                        |        | x    | x     | 2         | 2          |
+            | primary | designated             | designated             |                        |        | x    | x     | 18        | 18         |
+            | primary |                        | designated             |                        |        | x    | x     | 18        | 18         |
+            | primary | designated             |                        |                        |        | x    | x     | 18        | 18         |
+            | primary | designated\|designated | designated\|designated |                        |        | x    | x     | 18        | 18         |
             | primary | designated\|no         | designated\|no         |                        |        | x    | x     | 18        | 18         |
             | primary | yes\|no                | yes\|no                |                        |        | x    | x     | 18        | 18         |
             | primary |                        |                        |                        |        | x    | x     | 18        | 18         |
             | primary | designated             |                        |                        | -1     |      | x     |           | 18         |
-            | primary |                        | designated             |                        | -1     |      | x     |           | 2          |
-            | primary |                        |                        | designated             | yes    | x    |       | 2         |            |
-            | primary |                        |                        | designated             | -1     |      | x     |           | 2          |
+            | primary |                        | designated             |                        | -1     |      | x     |           | 18         |
+            | primary |                        |                        | designated             | yes    | x    |       | 18        |            |
+            | primary |                        |                        | designated             | -1     |      | x     |           | 18         |
             | primary |                        |                        | designated\|           | yes    | x    |       | 18        |            |
             | primary |                        |                        | designated\|           | -1     |      | x     |           | 18         |
-            | primary |                        |                        | designated\|designated | yes    | x    |       | 2         |            |
-            | primary |                        |                        | designated\|designated | -1     |      | x     |           | 2          |
+            | primary |                        |                        | designated\|designated | yes    | x    |       | 18        |            |
+            | primary |                        |                        | designated\|designated | -1     |      | x     |           | 18         |
             | primary |                        |                        | designated\|yes        | yes    | x    |       | 18        |            |
             | primary |                        |                        | designated\|no         | -1     |      | x     |           | 18         |
 
@@ -250,7 +251,7 @@ Feature: Car - Restricted access
             | gate         | yes        | x     |
             | gate         | permissive | x     |
             | gate         | designated | x     |
-            | gate         | private    |       |
+            | gate         | private    | x     |
             | gate         | garbagetag | x     |
 
     Scenario: Car - a way with conditional access

--- a/features/car/barrier.feature
+++ b/features/car/barrier.feature
@@ -29,14 +29,14 @@ Feature: Car - Barriers
             | gate         | permissive    | x     |
             | gate         | designated    | x     |
             | gate         | no            |       |
-            | gate         | private       |       |
+            | gate         | private       | x     |
             | gate         | agricultural  |       |
             | wall         |               |       |
             | wall         | yes           | x     |
             | wall         | permissive    | x     |
             | wall         | designated    | x     |
             | wall         | no            |       |
-            | wall         | private       |       |
+            | wall         | private       | x     |
             | wall         | agricultural  |       |
 
     Scenario: Car - Rising bollard exception for barriers

--- a/features/car/destination.feature
+++ b/features/car/destination.feature
@@ -1,4 +1,4 @@
-@routing @car @destination @todo
+@routing @car @destination
 Feature: Car - Destination only, no passing through
 
     Background:

--- a/features/car/hov.feature
+++ b/features/car/hov.feature
@@ -1,0 +1,36 @@
+@routing @car @hov
+Feature: Car - Handle driving
+
+    Background:
+        Given the profile "car"
+        And a grid size of 100 meters
+
+    Scenario: Car - Avoid hov when not on hov
+        Given the node map
+            """
+               b=========c========================e====j
+             ~            ~                         ~
+            a              ~                         f----m
+            |               i                        |
+            |               |        ----------------l
+            |               |       /
+            g_______________h______k_____n
+            """
+
+        And the ways
+            | nodes | highway       | hov           |
+            | ab    | motorway_link |               |
+            | bcej  | motorway      | designated    |
+            | ag    | primary       |               |
+            | ghkn  | primary       |               |
+            | ih    | primary       |               |
+            | kl    | secondary     |               |
+            | lf    | secondary     |               |
+            | ci    | motorway_link |               |
+            | ef    | motorway_link |               |
+            | fm    | secondary     |               |
+
+        When I route I should get
+            | from | to | route                |
+            | a    | m  | ag,ghkn,kl,lf,fm,fm  |
+            | c    | m  | bcej,ef,fm,fm        |

--- a/features/car/surface.feature
+++ b/features/car/surface.feature
@@ -40,13 +40,13 @@ Feature: Car - Surfaces
             | highway  | access       | tracktype | smoothness | surface | forw | backw |
             | motorway |              |           |            |         | x    |       |
             | motorway | no           | grade1    | excellent  | asphalt |      |       |
-            | motorway | private      | grade1    | excellent  | asphalt |      |       |
+            | motorway | private      | grade1    | excellent  | asphalt | x    |       |
             | motorway | agricultural | grade1    | excellent  | asphalt |      |       |
             | motorway | forestry     | grade1    | excellent  | asphalt |      |       |
             | motorway | emergency    | grade1    | excellent  | asphalt |      |       |
             | primary  |              |           |            |         | x    | x     |
+            | primary  | private      | grade1    | excellent  | asphalt | x    | x     |
             | primary  | no           | grade1    | excellent  | asphalt |      |       |
-            | primary  | private      | grade1    | excellent  | asphalt |      |       |
             | primary  | agricultural | grade1    | excellent  | asphalt |      |       |
             | primary  | forestry     | grade1    | excellent  | asphalt |      |       |
             | primary  | emergency    | grade1    | excellent  | asphalt |      |       |

--- a/include/extractor/extraction_turn.hpp
+++ b/include/extractor/extraction_turn.hpp
@@ -17,7 +17,8 @@ struct ExtractionTurn
     ExtractionTurn(const guidance::ConnectedRoad &turn, bool has_traffic_light)
         : angle(180. - turn.angle), turn_type(turn.instruction.type),
           direction_modifier(turn.instruction.direction_modifier),
-          has_traffic_light(has_traffic_light), weight(0.), duration(0.)
+          has_traffic_light(has_traffic_light), weight(0.), duration(0.), source_restricted(false),
+          target_restricted(false)
     {
     }
 
@@ -27,6 +28,8 @@ struct ExtractionTurn
     const bool has_traffic_light;
     double weight;
     double duration;
+    bool source_restricted;
+    bool target_restricted;
 };
 }
 }

--- a/include/extractor/extraction_way.hpp
+++ b/include/extractor/extraction_way.hpp
@@ -58,6 +58,8 @@ struct ExtractionWay
         turn_lanes_forward.clear();
         turn_lanes_backward.clear();
         road_classification = guidance::RoadClassification();
+        backward_restricted = false;
+        forward_restricted = false;
     }
 
     // These accessors exists because it's not possible to take the address of a bitfield,
@@ -106,6 +108,8 @@ struct ExtractionWay
     bool roundabout;
     bool circular;
     bool is_startpoint;
+    bool backward_restricted;
+    bool forward_restricted;
     TravelMode forward_travel_mode : 4;
     TravelMode backward_travel_mode : 4;
     guidance::RoadClassification road_classification;

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -70,8 +70,9 @@ struct InternalExtractorEdge
                  false, // roundabout
                  false, // circular
                  true,  // can be startpoint
+                 false, // local access only
+                 false, // split edge
                  TRAVEL_MODE_INACCESSIBLE,
-                 false,
                  guidance::TurnLaneType::empty,
                  guidance::RoadClassification()),
           weight_data(), duration_data()
@@ -88,8 +89,9 @@ struct InternalExtractorEdge
                                    bool roundabout,
                                    bool circular,
                                    bool startpoint,
-                                   TravelMode travel_mode,
+                                   bool restricted,
                                    bool is_split,
+                                   TravelMode travel_mode,
                                    LaneDescriptionID lane_description,
                                    guidance::RoadClassification road_classification,
                                    util::Coordinate source_coordinate)
@@ -103,8 +105,9 @@ struct InternalExtractorEdge
                  roundabout,
                  circular,
                  startpoint,
-                 travel_mode,
+                 restricted,
                  is_split,
+                 travel_mode,
                  lane_description,
                  std::move(road_classification)),
           weight_data(std::move(weight_data)), duration_data(std::move(duration_data)),
@@ -134,8 +137,9 @@ struct InternalExtractorEdge
                                      false, // roundabout
                                      false, // circular
                                      true,  // can be startpoint
+                                     false, // local access only
+                                     false, // split edge
                                      TRAVEL_MODE_INACCESSIBLE,
-                                     false,
                                      INVALID_LANE_DESCRIPTIONID,
                                      guidance::RoadClassification(),
                                      util::Coordinate());
@@ -152,8 +156,9 @@ struct InternalExtractorEdge
                                      false, // roundabout
                                      false, // circular
                                      true,  // can be startpoint
+                                     false, // local access only
+                                     false, // split edge
                                      TRAVEL_MODE_INACCESSIBLE,
-                                     false,
                                      INVALID_LANE_DESCRIPTIONID,
                                      guidance::RoadClassification(),
                                      util::Coordinate());

--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -25,27 +25,29 @@ struct NodeBasedEdge
                   bool roundabout,
                   bool circular,
                   bool startpoint,
-                  TravelMode travel_mode,
+                  bool restricted,
                   bool is_split,
+                  TravelMode travel_mode,
                   const LaneDescriptionID lane_description_id,
                   guidance::RoadClassification road_classification);
 
     bool operator<(const NodeBasedEdge &other) const;
 
-    NodeID source;
-    NodeID target;
-    NodeID name_id;
-    EdgeWeight weight;
-    EdgeWeight duration;
-    std::uint8_t forward : 1;
-    std::uint8_t backward : 1;
-    std::uint8_t roundabout : 1;
-    std::uint8_t circular : 1;
-    std::uint8_t startpoint : 1;
-    std::uint8_t is_split : 1;
-    TravelMode travel_mode : 4;
-    LaneDescriptionID lane_description_id;
-    guidance::RoadClassification road_classification;
+    NodeID source;                                    // 32 4
+    NodeID target;                                    // 32 4
+    NodeID name_id;                                   // 32 4
+    EdgeWeight weight;                                // 32 4
+    EdgeWeight duration;                              // 32 4
+    std::uint8_t forward : 1;                         // 1
+    std::uint8_t backward : 1;                        // 1
+    std::uint8_t roundabout : 1;                      // 1
+    std::uint8_t circular : 1;                        // 1
+    std::uint8_t startpoint : 1;                      // 1
+    std::uint8_t restricted : 1;                      // 1
+    std::uint8_t is_split : 1;                        // 1
+    TravelMode travel_mode : 4;                       // 4
+    LaneDescriptionID lane_description_id;            // 16 2
+    guidance::RoadClassification road_classification; // 16 2
 };
 
 struct NodeBasedEdgeWithOSM : NodeBasedEdge
@@ -60,8 +62,9 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
                          bool roundabout,
                          bool circular,
                          bool startpoint,
-                         TravelMode travel_mode,
+                         bool restricted,
                          bool is_split,
+                         TravelMode travel_mode,
                          const LaneDescriptionID lane_description_id,
                          guidance::RoadClassification road_classification);
 
@@ -74,7 +77,7 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
 inline NodeBasedEdge::NodeBasedEdge()
     : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight(0), duration(0),
       forward(false), backward(false), roundabout(false), circular(false), startpoint(true),
-      is_split(false), travel_mode(TRAVEL_MODE_INACCESSIBLE),
+      restricted(false), is_split(false), travel_mode(TRAVEL_MODE_INACCESSIBLE),
       lane_description_id(INVALID_LANE_DESCRIPTIONID)
 {
 }
@@ -89,13 +92,14 @@ inline NodeBasedEdge::NodeBasedEdge(NodeID source,
                                     bool roundabout,
                                     bool circular,
                                     bool startpoint,
-                                    TravelMode travel_mode,
+                                    bool restricted,
                                     bool is_split,
+                                    TravelMode travel_mode,
                                     const LaneDescriptionID lane_description_id,
                                     guidance::RoadClassification road_classification)
     : source(source), target(target), name_id(name_id), weight(weight), duration(duration),
       forward(forward), backward(backward), roundabout(roundabout), circular(circular),
-      startpoint(startpoint), is_split(is_split), travel_mode(travel_mode),
+      startpoint(startpoint), restricted(restricted), is_split(is_split), travel_mode(travel_mode),
       lane_description_id(lane_description_id), road_classification(std::move(road_classification))
 {
 }
@@ -127,8 +131,9 @@ inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM(OSMNodeID source,
                                                   bool roundabout,
                                                   bool circular,
                                                   bool startpoint,
-                                                  TravelMode travel_mode,
+                                                  bool restricted,
                                                   bool is_split,
+                                                  TravelMode travel_mode,
                                                   const LaneDescriptionID lane_description_id,
                                                   guidance::RoadClassification road_classification)
     : NodeBasedEdge(SPECIAL_NODEID,
@@ -141,8 +146,9 @@ inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM(OSMNodeID source,
                     roundabout,
                     circular,
                     startpoint,
-                    travel_mode,
+                    restricted,
                     is_split,
+                    travel_mode,
                     lane_description_id,
                     std::move(road_classification)),
       osm_source_id(std::move(source)), osm_target_id(std::move(target))

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -33,11 +33,12 @@ struct NodeBasedEdgeData
                       bool roundabout,
                       bool circular,
                       bool startpoint,
+                      bool restricted,
                       extractor::TravelMode travel_mode,
                       const LaneDescriptionID lane_description_id)
         : weight(weight), duration(duration), edge_id(edge_id), name_id(name_id),
           reversed(reversed), roundabout(roundabout), circular(circular), startpoint(startpoint),
-          travel_mode(travel_mode), lane_description_id(lane_description_id)
+          restricted(restricted), travel_mode(travel_mode), lane_description_id(lane_description_id)
     {
     }
 
@@ -49,6 +50,7 @@ struct NodeBasedEdgeData
     bool roundabout : 1;
     bool circular : 1;
     bool startpoint : 1;
+    bool restricted : 1;
     extractor::TravelMode travel_mode : 4;
     LaneDescriptionID lane_description_id;
     extractor::guidance::RoadClassification road_classification;
@@ -58,7 +60,8 @@ struct NodeBasedEdgeData
         return (reversed == other.reversed) && (roundabout == other.roundabout) &&
                (circular == other.circular) && (startpoint == other.startpoint) &&
                (travel_mode == other.travel_mode) &&
-               (road_classification == other.road_classification);
+               (road_classification == other.road_classification) &&
+               (restricted == other.restricted);
     }
 
     bool CanCombineWith(const NodeBasedEdgeData &other) const
@@ -87,6 +90,7 @@ NodeBasedDynamicGraphFromEdges(NodeID number_of_nodes,
             output_edge.data.name_id = input_edge.name_id;
             output_edge.data.travel_mode = input_edge.travel_mode;
             output_edge.data.startpoint = input_edge.startpoint;
+            output_edge.data.restricted = input_edge.restricted;
             output_edge.data.road_classification = input_edge.road_classification;
             output_edge.data.lane_description_id = input_edge.lane_description_id;
 

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -65,6 +65,8 @@ local profile = {
    	'delivery'
   },
 
+  restricted_access_tag_list = Set { },
+
   access_tags_hierarchy = Sequence {
   	'bicycle',
   	'vehicle',
@@ -520,5 +522,11 @@ function turn_function(turn)
 
   if turn.has_traffic_light then
      turn.duration = turn.duration + profile.traffic_light_penalty
+  end
+  if properties.weight_name == 'cyclability' then
+      -- penalize turns from non-local access only segments onto local access only tags
+      if not turn.source_restricted and turn.target_restricted then
+          turn.weight = turn.weight + 3000
+      end
   end
 end

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -12,6 +12,7 @@ properties.max_speed_for_map_matching    = 40/3.6 -- kmph -> m/s
 properties.use_turn_restrictions         = false
 properties.continue_straight_at_waypoint = false
 properties.weight_name                   = 'duration'
+--properties.weight_name                   = 'routability'
 
 local walking_speed = 5
 
@@ -44,11 +45,13 @@ local profile = {
 
   access_tag_blacklist = Set {
     'no',
-    'private',
     'agricultural',
     'forestry',
-    'delivery'
+    'private',
+    'delivery',
   },
+
+  restricted_access_tag_list = Set { },
 
   access_tags_hierarchy = Sequence {
     'foot',
@@ -243,5 +246,11 @@ function turn_function (turn)
 
   if turn.has_traffic_light then
      turn.duration = profile.traffic_light_penalty
+  end
+  if properties.weight_name == 'routability' then
+      -- penalize turns from non-local access only segments onto local access only tags
+      if not turn.source_restricted and turn.target_restricted then
+          turn.weight = turn.weight + 3000
+      end
   end
 end

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -526,6 +526,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                     // compute weight and duration penalties
                     auto is_traffic_light = m_traffic_lights.count(node_at_center_of_intersection);
                     ExtractionTurn extracted_turn(turn, is_traffic_light);
+                    extracted_turn.source_restricted = edge_data1.restricted;
+                    extracted_turn.target_restricted = edge_data2.restricted;
                     scripting_environment.ProcessTurn(extracted_turn);
 
                     // turn penalties are limited to [-2^15, 2^15) which roughly

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -121,6 +121,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
 
     const auto toValueByEdgeOrByMeter = [&nodes](const double by_way, const double by_meter) {
         using Value = detail::ByEdgeOrByMeterValue;
+        // get value by weight per edge
         if (by_way >= 0)
         {
             // FIXME We divide by the number of edges here, but should rather consider
@@ -132,6 +133,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
         }
         else
         {
+            // get value by deriving weight from speed per edge
             return Value(Value::by_meter, by_meter);
         }
     };
@@ -320,6 +322,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
          parsed_way.weight > 0) &&
         (parsed_way.backward_travel_mode != TRAVEL_MODE_INACCESSIBLE);
 
+    // split an edge into two edges if forwards/backwards behavior differ
     const bool split_edge = in_forward_direction && in_backward_direction &&
                             ((parsed_way.forward_rate != parsed_way.backward_rate) ||
                              (parsed_way.forward_speed != parsed_way.backward_speed) ||
@@ -343,8 +346,9 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                           parsed_way.roundabout,
                                           parsed_way.circular,
                                           parsed_way.is_startpoint,
-                                          parsed_way.forward_travel_mode,
+                                          parsed_way.forward_restricted,
                                           split_edge,
+                                          parsed_way.forward_travel_mode,
                                           turn_lane_id_forward,
                                           road_classification,
                                           {}));
@@ -368,8 +372,9 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                           parsed_way.roundabout,
                                           parsed_way.circular,
                                           parsed_way.is_startpoint,
-                                          parsed_way.backward_travel_mode,
+                                          parsed_way.backward_restricted,
                                           split_edge,
+                                          parsed_way.backward_travel_mode,
                                           turn_lane_id_backward,
                                           road_classification,
                                           {}));

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -343,7 +343,11 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "forward_mode",
         sol::property(&ExtractionWay::get_forward_mode, &ExtractionWay::set_forward_mode),
         "backward_mode",
-        sol::property(&ExtractionWay::get_backward_mode, &ExtractionWay::set_backward_mode));
+        sol::property(&ExtractionWay::get_backward_mode, &ExtractionWay::set_backward_mode),
+        "forward_restricted",
+        &ExtractionWay::forward_restricted,
+        "backward_restricted",
+        &ExtractionWay::backward_restricted);
 
     context.state.new_usertype<ExtractionSegment>("ExtractionSegment",
                                                   "source",
@@ -369,7 +373,11 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                "weight",
                                                &ExtractionTurn::weight,
                                                "duration",
-                                               &ExtractionTurn::duration);
+                                               &ExtractionTurn::duration,
+                                               "source_restricted",
+                                               &ExtractionTurn::source_restricted,
+                                               "target_restricted",
+                                               &ExtractionTurn::target_restricted);
 
     // Keep in mind .location is undefined since we're not using libosmium's location cache
     context.state.new_usertype<osmium::NodeRef>("NodeRef", "id", &osmium::NodeRef::ref);

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -22,13 +22,15 @@ namespace
 // creates a default edge of unit weight
 inline InputEdge MakeUnitEdge(const NodeID from, const NodeID to)
 {
-    // src, tgt, dist, edge_id, name_id, fwd, bkwd, roundabout, circular, travel_mode
+    // src, tgt, dist, edge_id, name_id, fwd, bkwd, roundabout, circular, startpoint, local access,
+    // split edge, travel_mode
     return {from,
             to,
             1,
             SPECIAL_EDGEID,
             0,
             0,
+            false,
             false,
             false,
             false,

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    BOOST_CHECK_EQUAL(result.size(), 113824);
+    BOOST_CHECK(result.size() > 115000);
 
     protozero::pbf_reader tile_message(result);
     tile_message.next();
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     }
 
     BOOST_CHECK_EQUAL(number_of_turn_keys, 3);
-    BOOST_CHECK_EQUAL(number_of_turns_found, 732);
+    BOOST_CHECK(number_of_turns_found > 700);
 }
 
 BOOST_AUTO_TEST_CASE(test_tile_turns)


### PR DESCRIPTION
# Issue

Closes https://github.com/Project-OSRM/osrm-backend/issues/156

Instead of completely removing ways tagged with local access only or routing over them with impunity, this pr adds a heavy penalty on turn maneuvers from non-local access only edges to local access only edges. This allows routing onto a local access only, but only if the destination of the route ends on the way.

"Local access only" is defined in the `local_access_tag_list` set in the car lua profile. The default profile includes ways tagged like
- delivery
- private
- destination
- hov

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
