### PR TITLE
Add benchmarking tool for the table plugin

### DIFF
--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB RTreeBenchmarkSources static_rtree.cpp)
 file(GLOB MatchBenchmarkSources match.cpp)
+file(GLOB TableBenchmarkSources table.cpp)
 
 add_executable(rtree-bench
 	EXCLUDE_FROM_ALL
@@ -11,7 +12,7 @@ target_include_directories(rtree-bench
 	${PROJECT_SOURCE_DIR}/unit_tests)
 
 target_link_libraries(rtree-bench
-	${BOOST_BASE_LIBRARIES}
+	${Boost_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
 	${TBB_LIBRARIES})
 
@@ -20,13 +21,25 @@ add_executable(match-bench
 	${MatchBenchmarkSources}
 	$<TARGET_OBJECTS:UTIL>)
 
+add_executable(table-bench
+	EXCLUDE_FROM_ALL
+	${TableBenchmarkSources}
+	$<TARGET_OBJECTS:UTIL>)
+
 target_link_libraries(match-bench
 	osrm
-	${BOOST_BASE_LIBRARIES}
+	${Boost_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
+	${TBB_LIBRARIES})
+
+target_link_libraries(table-bench
+	osrm
+	${Boost_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
 	${TBB_LIBRARIES})
 
 add_custom_target(benchmarks
 	DEPENDS
 	rtree-bench
-	match-bench)
+	match-bench
+	table-bench)

--- a/src/benchmarks/table.cpp
+++ b/src/benchmarks/table.cpp
@@ -1,0 +1,87 @@
+#include "util/timing_util.hpp"
+
+#include "osrm/table_parameters.hpp"
+
+#include "storage/io.hpp"
+#include "storage/serialization.hpp"
+#include "osrm/coordinate.hpp"
+#include "osrm/engine_config.hpp"
+#include "osrm/json_container.hpp"
+
+#include "osrm/osrm.hpp"
+#include "osrm/status.hpp"
+
+#include <boost/assert.hpp>
+
+#include <exception>
+#include <iostream>
+#include <random>
+#include <string>
+#include <utility>
+
+#include <cstdlib>
+
+int main(int argc, const char *argv[]) try
+{
+    if (argc < 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " data.osrm\n";
+        return EXIT_FAILURE;
+    }
+
+    using namespace osrm;
+
+    std::vector<util::Coordinate> coordinates;
+    // Loading list of coordinates
+    {
+        using namespace osrm::storage;
+        io::FileReader nodes_file(std::string(argv[1]) + ".nodes",
+                                  io::FileReader::VerifyFingerprint);
+        storage::serialization::read(nodes_file, coordinates);
+    }
+
+    // Configure based on a .osrm base path, and no datasets in shared mem from osrm-datastore
+    EngineConfig config;
+    config.storage_config = {argv[1]};
+    config.use_shared_memory = false;
+
+    // Routing machine with several services (such as Route, Table, Nearest, Trip, Match)
+    OSRM osrm{config};
+
+    auto runtest = [&](const int coordcount) -> void {
+        auto r = std::mt19937();
+
+        TIMER_START(routes);
+        auto NUM = 10;
+        for (int i = 0; i < NUM; ++i)
+        {
+            TableParameters params;
+            // Select a random sample
+            for (int i = 0; i < coordcount; i++)
+            {
+                params.coordinates.push_back(coordinates[r() % coordinates.size()]);
+            }
+            json::Object result;
+            const auto rc = osrm.Table(params, result);
+            if (rc != Status::Ok)
+            {
+                return;
+            }
+        }
+        TIMER_STOP(routes);
+        std::cout << coordcount << "," << (TIMER_MSEC(routes) / 1000. / NUM) << std::endl;
+    };
+
+    std::cout << "Coordinates,Duration" << std::endl;
+    for (int i = 10; i < 3000; i += 10)
+    {
+        runtest(i);
+    }
+
+    return EXIT_SUCCESS;
+}
+catch (const std::exception &e)
+{
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
# Issue

Adds a simple tool to benchmark the `table` plugin.  Usage is similar to the `match` benchmark, except that the tool will work with any OSRM datafile (not coupled to Monaco).

## Tasklist
 - [ ] review
 - [ ] adjust for comments