### PR TITLE
MLD customization: fill weights in CellStorage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ configure_file(
 file(GLOB UtilGlob src/util/*.cpp src/util/*/*.cpp)
 file(GLOB ExtractorGlob src/extractor/*.cpp src/extractor/*/*.cpp)
 file(GLOB PartitionerGlob src/partition/*.cpp)
+file(GLOB CustomizerGlob src/customize/*.cpp)
 file(GLOB ContractorGlob src/contractor/*.cpp)
 file(GLOB StorageGlob src/storage/*.cpp)
 file(GLOB ServerGlob src/server/*.cpp src/server/**/*.cpp)
@@ -127,6 +128,7 @@ file(GLOB EngineGlob src/engine/*.cpp src/engine/**/*.cpp)
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})
 add_library(PARTITIONER OBJECT ${PartitionerGlob})
+add_library(CUSTOMIZER OBJECT ${CustomizerGlob})
 add_library(CONTRACTOR OBJECT ${ContractorGlob})
 add_library(STORAGE OBJECT ${StorageGlob})
 add_library(ENGINE OBJECT ${EngineGlob})
@@ -136,12 +138,14 @@ set_target_properties(UTIL PROPERTIES LINKER_LANGUAGE CXX)
 
 add_executable(osrm-extract src/tools/extract.cpp)
 add_executable(osrm-partition src/tools/partition.cpp)
+add_executable(osrm-customize src/tools/customize.cpp)
 add_executable(osrm-contract src/tools/contract.cpp)
 add_executable(osrm-routed src/tools/routed.cpp $<TARGET_OBJECTS:SERVER> $<TARGET_OBJECTS:UTIL>)
 add_executable(osrm-datastore src/tools/store.cpp $<TARGET_OBJECTS:UTIL>)
 add_library(osrm src/osrm/osrm.cpp $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:STORAGE>)
 add_library(osrm_extract $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_partition $<TARGET_OBJECTS:PARTITIONER> $<TARGET_OBJECTS:UTIL>)
+add_library(osrm_customize $<TARGET_OBJECTS:CUSTOMIZER> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_contract $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
 
@@ -591,6 +595,7 @@ set(BOOST_ENGINE_LIBRARIES
 target_link_libraries(osrm-datastore osrm_store ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-extract osrm_extract ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-partition osrm_partition ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(osrm-customize osrm_customize ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-contract osrm_contract ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
 
@@ -613,6 +618,12 @@ set(PARTITIONER_LIBRARIES
     ${MAYBE_RT_LIBRARY}
     ${MAYBE_COVERAGE_LIBRARIES}
     ${ZLIB_LIBRARY})
+  set(CUSTOMIZER_LIBRARIES
+    ${BOOST_ENGINE_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${TBB_LIBRARIES}
+    ${MAYBE_RT_LIBRARY}
+    ${MAYBE_COVERAGE_LIBRARIES})
 set(CONTRACTOR_LIBRARIES
     ${BOOST_BASE_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
@@ -645,6 +656,7 @@ target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES})
 target_link_libraries(osrm_extract ${EXTRACTOR_LIBRARIES})
 target_link_libraries(osrm_partition ${PARTITIONER_LIBRARIES})
+target_link_libraries(osrm_customize ${CUSTOMIZER_LIBRARIES})
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
 
 # BUILD_COMPONENTS

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -10,7 +10,7 @@
 
 namespace osrm
 {
-namespace customizer
+namespace customize
 {
 
 class CellCustomizer

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -1,0 +1,148 @@
+#ifndef OSRM_CELLS_CUSTOMIZER_HPP
+#define OSRM_CELLS_CUSTOMIZER_HPP
+
+#include "partition/cell_storage.hpp"
+#include "partition/multi_level_partition.hpp"
+#include "util/binary_heap.hpp"
+
+#include <boost/thread/tss.hpp>
+#include <unordered_set>
+
+namespace osrm
+{
+namespace customizer
+{
+
+class CellCustomizer
+{
+
+  public:
+    CellCustomizer(const partition::MultiLevelPartition &partition) : partition(partition) {}
+
+    template <typename GraphT>
+    void Customize(const GraphT &graph,
+                   partition::CellStorage &cells,
+                   partition::LevelID level,
+                   partition::CellID id)
+    {
+        auto cell = cells.GetCell(level, id);
+        auto destinations = cell.GetDestinationNodes();
+
+        // for each source do forward search
+        for (auto source : cell.GetSourceNodes())
+        {
+            std::unordered_set<NodeID> destinations_set(destinations.begin(), destinations.end());
+            Heap heap(graph.GetNumberOfNodes());
+            heap.Insert(source, 0, {});
+
+            // explore search space
+            while (!heap.Empty() && !destinations_set.empty())
+            {
+                const NodeID node = heap.DeleteMin();
+                const EdgeWeight weight = heap.GetKey(node);
+
+                if (level == 1)
+                    RelaxNode<true>(graph, cells, heap, level, id, node, weight);
+                else
+                    RelaxNode<false>(graph, cells, heap, level, id, node, weight);
+
+                destinations_set.erase(node);
+            }
+
+            // fill a map of destination nodes to placeholder pointers
+            auto destination_iter = destinations.begin();
+            for (auto &weight : cell.GetOutWeight(source))
+            {
+                BOOST_ASSERT(destination_iter != destinations.end());
+                const auto destination = *destination_iter++;
+                weight =
+                    heap.WasInserted(destination) ? heap.GetKey(destination) : INVALID_EDGE_WEIGHT;
+            }
+        }
+    }
+
+    template <typename GraphT> void Customize(const GraphT &graph, partition::CellStorage &cells)
+    {
+        for (std::size_t level = 1; level < partition.GetNumberOfLevels(); ++level)
+        {
+            tbb::parallel_for(tbb::blocked_range<std::size_t>(0, partition.GetNumberOfCells(level)),
+                              [&](const tbb::blocked_range<std::size_t> &range) {
+                                  for (auto id = range.begin(), end = range.end(); id != end; ++id)
+                                  {
+                                      Customize(graph, cells, level, id);
+                                  }
+                              });
+        }
+    }
+
+  private:
+    struct HeapData
+    {
+    };
+    using Heap = util::
+        BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::UnorderedMapStorage<NodeID, int>>;
+    using HeapPtr = boost::thread_specific_ptr<Heap>;
+
+    template <bool first_level, typename GraphT>
+    void RelaxNode(const GraphT &graph,
+                   const partition::CellStorage &cells,
+                   Heap &heap,
+                   partition::LevelID level,
+                   partition::CellID id,
+                   NodeID node,
+                   EdgeWeight weight) const
+    {
+        if (!first_level)
+        {
+            // Relax sub-cell nodes
+            auto subcell_id = partition.GetCell(level - 1, node);
+            auto subcell = cells.GetCell(level - 1, subcell_id);
+            auto subcell_destination = subcell.GetDestinationNodes().begin();
+            for (auto subcell_weight : subcell.GetOutWeight(node))
+            {
+                if (subcell_weight != INVALID_EDGE_WEIGHT)
+                {
+                    const NodeID to = *subcell_destination;
+                    const EdgeWeight to_weight = subcell_weight + weight;
+                    if (!heap.WasInserted(to))
+                    {
+                        heap.Insert(to, to_weight, {});
+                    }
+                    else if (to_weight < heap.GetKey(to))
+                    {
+                        heap.DecreaseKey(to, to_weight);
+                    }
+                }
+
+                ++subcell_destination;
+            }
+        }
+
+        // Relax base graph edges if a sub-cell border edge
+        for (auto edge : graph.GetAdjacentEdgeRange(node))
+        {
+            const NodeID to = graph.GetTarget(edge);
+            const auto &data = graph.GetEdgeData(edge);
+            if (data.forward && partition.GetCell(level, to) == id &&
+                (first_level ||
+                 partition.GetCell(level - 1, node) != partition.GetCell(level - 1, to)))
+            {
+                const EdgeWeight to_weight = data.weight + weight;
+                if (!heap.WasInserted(to))
+                {
+                    heap.Insert(to, to_weight, {});
+                }
+                else if (to_weight < heap.GetKey(to))
+                {
+                    heap.DecreaseKey(to, to_weight);
+                }
+            }
+        }
+    }
+
+    const partition::MultiLevelPartition &partition;
+};
+}
+}
+
+#endif // OSRM_CELLS_CUSTOMIZER_HPP

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -20,10 +20,7 @@ class CellCustomizer
     CellCustomizer(const partition::MultiLevelPartition &partition) : partition(partition) {}
 
     template <typename GraphT>
-    void Customize(const GraphT &graph,
-                   partition::CellStorage &cells,
-                   partition::LevelID level,
-                   partition::CellID id)
+    void Customize(const GraphT &graph, partition::CellStorage &cells, LevelID level, CellID id)
     {
         auto cell = cells.GetCell(level, id);
         auto destinations = cell.GetDestinationNodes();
@@ -87,8 +84,8 @@ class CellCustomizer
     void RelaxNode(const GraphT &graph,
                    const partition::CellStorage &cells,
                    Heap &heap,
-                   partition::LevelID level,
-                   partition::CellID id,
+                   LevelID level,
+                   CellID id,
                    NodeID node,
                    EdgeWeight weight) const
     {

--- a/include/customizer/customizer.hpp
+++ b/include/customizer/customizer.hpp
@@ -1,0 +1,20 @@
+#ifndef OSRM_CUSTOMIZE_CUSTOMIZER_HPP
+#define OSRM_CUSTOMIZE_CUSTOMIZER_HPP
+
+#include "customizer/customizer_config.hpp"
+
+namespace osrm
+{
+namespace customize
+{
+
+class Customizer
+{
+  public:
+    int Run(const CustomizationConfig &config);
+};
+
+} // namespace customize
+} // namespace osrm
+
+#endif // OSRM_CUSTOMIZE_CUSTOMIZER_HPP

--- a/include/customizer/customizer_config.hpp
+++ b/include/customizer/customizer_config.hpp
@@ -1,0 +1,49 @@
+#ifndef OSRM_CUSTOMIZE_CUSTOMIZER_CONFIG_HPP
+#define OSRM_CUSTOMIZE_CUSTOMIZER_CONFIG_HPP
+
+#include <boost/filesystem/path.hpp>
+
+#include <array>
+#include <string>
+
+namespace osrm
+{
+namespace customize
+{
+
+struct CustomizationConfig
+{
+    CustomizationConfig() : requested_num_threads(0) {}
+
+    void UseDefaults()
+    {
+        std::string basepath = base_path.string();
+
+        const std::string ext = ".osrm";
+        const auto pos = basepath.find(ext);
+        if (pos != std::string::npos)
+        {
+            basepath.replace(pos, ext.size(), "");
+        }
+        else
+        {
+            // unknown extension
+        }
+
+        edge_based_graph_path = basepath + ".osrm.ebg";
+        mld_partition_path = basepath + ".osrm.partition";
+        mld_storage_path = basepath + ".osrm.cells";
+    }
+
+    // might be changed to the node based graph at some point
+    boost::filesystem::path base_path;
+    boost::filesystem::path edge_based_graph_path;
+    boost::filesystem::path mld_partition_path;
+    boost::filesystem::path mld_storage_path;
+
+    unsigned requested_num_threads;
+};
+}
+}
+
+#endif // OSRM_CUSTOMIZE_CUSTOMIZER_CONFIG_HPP

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -1110,19 +1110,19 @@ class ContiguousInternalMemoryAlgorithmDataFacade<algorithm::MLD>
                 *data_layout.GetBlockPtr<partition::MultiLevelPartitionView::LevelData>(
                     memory_block, storage::DataLayout::MLD_LEVEL_DATA);
 
-            auto mld_partition_ptr = data_layout.GetBlockPtr<partition::PartitionID>(
+            auto mld_partition_ptr = data_layout.GetBlockPtr<PartitionID>(
                 memory_block, storage::DataLayout::MLD_PARTITION);
             auto partition_entries_count =
                 data_layout.GetBlockEntries(storage::DataLayout::MLD_PARTITION);
-            util::ShM<partition::PartitionID, true>::vector partition(mld_partition_ptr,
-                                                                      partition_entries_count);
+            util::ShM<PartitionID, true>::vector partition(mld_partition_ptr,
+                                                           partition_entries_count);
 
-            auto mld_chilren_ptr = data_layout.GetBlockPtr<partition::CellID>(
+            auto mld_chilren_ptr = data_layout.GetBlockPtr<CellID>(
                 memory_block, storage::DataLayout::MLD_CELL_TO_CHILDREN);
             auto children_entries_count =
                 data_layout.GetBlockEntries(storage::DataLayout::MLD_CELL_TO_CHILDREN);
-            util::ShM<partition::CellID, true>::vector cell_to_children(mld_chilren_ptr,
-                                                                        children_entries_count);
+            util::ShM<CellID, true>::vector cell_to_children(mld_chilren_ptr,
+                                                             children_entries_count);
 
             mld_partition =
                 partition::MultiLevelPartitionView{level_data, partition, cell_to_children};

--- a/include/partition/cell_storage.hpp
+++ b/include/partition/cell_storage.hpp
@@ -33,6 +33,9 @@ using CellStorageView = detail::CellStorageImpl<true>;
 namespace io
 {
 template <bool UseShareMemory>
+inline void read(const boost::filesystem::path &path,
+                 detail::CellStorageImpl<UseShareMemory> &storage);
+template <bool UseShareMemory>
 inline void write(const boost::filesystem::path &path,
                   const detail::CellStorageImpl<UseShareMemory> &storage);
 }
@@ -346,6 +349,8 @@ template <bool UseShareMemory> class CellStorageImpl
             cells[cell_index], weights.data(), source_boundary.data(), destination_boundary.data()};
     }
 
+    friend void io::read<UseShareMemory>(const boost::filesystem::path &path,
+                                         detail::CellStorageImpl<UseShareMemory> &storage);
     friend void io::write<UseShareMemory>(const boost::filesystem::path &path,
                                           const detail::CellStorageImpl<UseShareMemory> &storage);
 

--- a/include/partition/cell_storage.hpp
+++ b/include/partition/cell_storage.hpp
@@ -177,7 +177,7 @@ template <bool UseShareMemory> class CellStorageImpl
         }
     };
 
-    std::size_t LevelIDToIndex(partition::LevelID level) const { return level - 1; }
+    std::size_t LevelIDToIndex(LevelID level) const { return level - 1; }
 
   public:
     using Cell = CellImpl<EdgeWeight>;
@@ -190,7 +190,7 @@ template <bool UseShareMemory> class CellStorageImpl
     {
         // pre-allocate storge for CellData so we can have random access to it by cell id
         unsigned number_of_cells = 0;
-        for (partition::LevelID level = 1u; level < partition.GetNumberOfLevels(); ++level)
+        for (LevelID level = 1u; level < partition.GetNumberOfLevels(); ++level)
         {
             level_to_cell_offset.push_back(number_of_cells);
             number_of_cells += partition.GetNumberOfCells(level);
@@ -198,12 +198,12 @@ template <bool UseShareMemory> class CellStorageImpl
         level_to_cell_offset.push_back(number_of_cells);
         cells.resize(number_of_cells);
 
-        std::vector<std::pair<partition::CellID, NodeID>> level_source_boundary;
-        std::vector<std::pair<partition::CellID, NodeID>> level_destination_boundary;
+        std::vector<std::pair<CellID, NodeID>> level_source_boundary;
+        std::vector<std::pair<CellID, NodeID>> level_destination_boundary;
 
         std::size_t number_of_unconneced = 0;
 
-        for (partition::LevelID level = 1u; level < partition.GetNumberOfLevels(); ++level)
+        for (LevelID level = 1u; level < partition.GetNumberOfLevels(); ++level)
         {
             auto level_offset = level_to_cell_offset[LevelIDToIndex(level)];
 
@@ -212,7 +212,7 @@ template <bool UseShareMemory> class CellStorageImpl
 
             for (auto node = 0u; node < base_graph.GetNumberOfNodes(); ++node)
             {
-                const partition::CellID cell_id = partition.GetCell(level, node);
+                const CellID cell_id = partition.GetCell(level, node);
                 bool is_source_node = false;
                 bool is_destination_node = false;
                 bool is_boundary_node = false;
@@ -324,7 +324,7 @@ template <bool UseShareMemory> class CellStorageImpl
     {
     }
 
-    ConstCell GetCell(partition::LevelID level, partition::CellID id) const
+    ConstCell GetCell(LevelID level, CellID id) const
     {
         const auto level_index = LevelIDToIndex(level);
         BOOST_ASSERT(level_index < level_to_cell_offset.size());
@@ -335,8 +335,7 @@ template <bool UseShareMemory> class CellStorageImpl
             cells[cell_index], weights.data(), source_boundary.data(), destination_boundary.data()};
     }
 
-    template <typename = std::enable_if<!UseShareMemory>>
-    Cell GetCell(partition::LevelID level, partition::CellID id)
+    template <typename = std::enable_if<!UseShareMemory>> Cell GetCell(LevelID level, CellID id)
     {
         const auto level_index = LevelIDToIndex(level);
         BOOST_ASSERT(level_index < level_to_cell_offset.size());

--- a/include/partition/io.hpp
+++ b/include/partition/io.hpp
@@ -1,8 +1,8 @@
 #ifndef OSRM_PARTITION_IO_HPP
 #define OSRM_PARTITION_IO_HPP
 
-#include "partition/cell_storage.hpp"
 #include "partition/multi_level_partition.hpp"
+#include "partition/cell_storage.hpp"
 
 #include "storage/io.hpp"
 
@@ -13,8 +13,17 @@ namespace partition
 namespace io
 {
 
-template <>
-inline void write(const boost::filesystem::path &path, const partition::MultiLevelPartition &mlp)
+template <> inline void read(const boost::filesystem::path &path, MultiLevelPartition &mlp)
+{
+    const auto fingerprint = storage::io::FileReader::VerifyFingerprint;
+    storage::io::FileReader reader{path, fingerprint};
+
+    reader.ReadInto<MultiLevelPartition::LevelData>(mlp.level_data);
+    reader.DeserializeVector(mlp.partition);
+    reader.DeserializeVector(mlp.cell_to_children);
+}
+
+template <> inline void write(const boost::filesystem::path &path, const MultiLevelPartition &mlp)
 {
     const auto fingerprint = storage::io::FileWriter::GenerateFingerprint;
     storage::io::FileWriter writer{path, fingerprint};
@@ -24,8 +33,7 @@ inline void write(const boost::filesystem::path &path, const partition::MultiLev
     writer.SerializeVector(mlp.cell_to_children);
 }
 
-template <>
-inline void write(const boost::filesystem::path &path, const partition::CellStorage &storage)
+template <> inline void write(const boost::filesystem::path &path, const CellStorage &storage)
 {
     const auto fingerprint = storage::io::FileWriter::GenerateFingerprint;
     storage::io::FileWriter writer{path, fingerprint};
@@ -36,6 +44,7 @@ inline void write(const boost::filesystem::path &path, const partition::CellStor
     writer.SerializeVector(storage.cells);
     writer.SerializeVector(storage.level_to_cell_offset);
 }
+
 }
 }
 }

--- a/include/partition/io.hpp
+++ b/include/partition/io.hpp
@@ -33,6 +33,18 @@ template <> inline void write(const boost::filesystem::path &path, const MultiLe
     writer.SerializeVector(mlp.cell_to_children);
 }
 
+template <> inline void read(const boost::filesystem::path &path, CellStorage &storage)
+{
+    const auto fingerprint = storage::io::FileReader::VerifyFingerprint;
+    storage::io::FileReader reader{path, fingerprint};
+
+    reader.DeserializeVector(storage.weights);
+    reader.DeserializeVector(storage.source_boundary);
+    reader.DeserializeVector(storage.destination_boundary);
+    reader.DeserializeVector(storage.cells);
+    reader.DeserializeVector(storage.level_to_cell_offset);
+}
+
 template <> inline void write(const boost::filesystem::path &path, const CellStorage &storage)
 {
     const auto fingerprint = storage::io::FileWriter::GenerateFingerprint;

--- a/include/partition/io.hpp
+++ b/include/partition/io.hpp
@@ -1,8 +1,8 @@
 #ifndef OSRM_PARTITION_IO_HPP
 #define OSRM_PARTITION_IO_HPP
 
-#include "partition/multi_level_partition.hpp"
 #include "partition/cell_storage.hpp"
+#include "partition/multi_level_partition.hpp"
 
 #include "storage/io.hpp"
 
@@ -44,7 +44,6 @@ template <> inline void write(const boost::filesystem::path &path, const CellSto
     writer.SerializeVector(storage.cells);
     writer.SerializeVector(storage.level_to_cell_offset);
 }
-
 }
 }
 }

--- a/include/partition/multi_level_partition.hpp
+++ b/include/partition/multi_level_partition.hpp
@@ -33,12 +33,11 @@ using MultiLevelPartitionView = detail::MultiLevelPartitionImpl<true>;
 namespace io
 {
 template <bool UseShareMemory>
+void read(const boost::filesystem::path &file,
+          detail::MultiLevelPartitionImpl<UseShareMemory> &mlp);
+template <bool UseShareMemory>
 void write(const boost::filesystem::path &file,
            const detail::MultiLevelPartitionImpl<UseShareMemory> &mlp);
-}
-
-namespace detail
-{
 }
 
 using LevelID = std::uint8_t;
@@ -141,6 +140,8 @@ template <bool UseShareMemory> class MultiLevelPartitionImpl final
         return cell_to_children[offset + cell + 1];
     }
 
+    friend void io::read<UseShareMemory>(const boost::filesystem::path &file,
+                                         MultiLevelPartitionImpl &mlp);
     friend void io::write<UseShareMemory>(const boost::filesystem::path &file,
                                           const MultiLevelPartitionImpl &mlp);
 

--- a/include/partition/multi_level_partition.hpp
+++ b/include/partition/multi_level_partition.hpp
@@ -40,12 +40,6 @@ void write(const boost::filesystem::path &file,
            const detail::MultiLevelPartitionImpl<UseShareMemory> &mlp);
 }
 
-using LevelID = std::uint8_t;
-using CellID = std::uint32_t;
-using PartitionID = std::uint64_t;
-
-static constexpr CellID INVALID_CELL_ID = std::numeric_limits<CellID>::max();
-
 namespace detail
 {
 

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -61,7 +61,6 @@ using EdgeWeight = std::int32_t;
 using TurnPenalty = std::int16_t; // turn penalty in 100ms units
 
 static const std::size_t INVALID_INDEX = std::numeric_limits<std::size_t>::max();
-using BisectionID = std::uint32_t;
 
 using LaneID = std::uint8_t;
 static const LaneID INVALID_LANEID = std::numeric_limits<LaneID>::max();
@@ -98,6 +97,14 @@ static const TurnPenalty INVALID_TURN_PENALTY = std::numeric_limits<TurnPenalty>
 static const EdgeWeight MAXIMAL_EDGE_DURATION_INT_30 = (1 << 29) - 1;
 
 using DatasourceID = std::uint8_t;
+
+using BisectionID = std::uint32_t;
+using LevelID = std::uint8_t;
+using CellID = std::uint32_t;
+using PartitionID = std::uint64_t;
+
+static constexpr auto INVALID_LEVEL_ID = std::numeric_limits<LevelID>::max();
+static constexpr auto INVALID_CELL_ID = std::numeric_limits<CellID>::max();
 
 struct SegmentID
 {

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -74,10 +74,11 @@ int Customizer::Run(const CustomizationConfig &config)
                 << edge_based_graph->GetNumberOfEdges() << " edges, "
                 << edge_based_graph->GetNumberOfNodes() << " nodes";
 
-    osrm::partition::MultiLevelPartition mlp;
+    partition::MultiLevelPartition mlp;
     partition::io::read(config.mld_partition_path, mlp);
 
-    partition::CellStorage storage(mlp, *edge_based_graph);
+    partition::CellStorage storage;
+    partition::io::read(config.mld_storage_path, storage);
     TIMER_STOP(loading_data);
     util::Log() << "Loading partition data took " << TIMER_SEC(loading_data) << " seconds";
 

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -1,0 +1,47 @@
+#include "customizer/customizer.hpp"
+#include "customizer/cell_customizer.hpp"
+#include "partition/edge_based_graph_reader.hpp"
+#include "partition/io.hpp"
+
+#include "partition/cell_storage.hpp"
+#include "partition/io.hpp"
+#include "partition/multi_level_partition.hpp"
+#include "util/log.hpp"
+#include "util/timing_util.hpp"
+
+namespace osrm
+{
+namespace customize
+{
+
+int Customizer::Run(const CustomizationConfig &config)
+{
+    TIMER_START(loading_data);
+    auto edge_based_graph = partition::LoadEdgeBasedGraph(config.edge_based_graph_path.string());
+    util::Log() << "Loaded edge based graph for mapping partition ids: "
+                << edge_based_graph->GetNumberOfEdges() << " edges, "
+                << edge_based_graph->GetNumberOfNodes() << " nodes";
+
+    osrm::partition::MultiLevelPartition mlp;
+    partition::io::read(config.mld_partition_path, mlp);
+
+    partition::CellStorage storage(mlp, *edge_based_graph);
+    TIMER_STOP(loading_data);
+    util::Log() << "Loading partition data took " << TIMER_SEC(loading_data) << " seconds";
+
+    TIMER_START(cell_customize);
+    CellCustomizer customizer(mlp);
+    customizer.Customize(*edge_based_graph, storage);
+    TIMER_STOP(cell_customize);
+    util::Log() << "Cells customization took " << TIMER_SEC(cell_customize) << " seconds";
+
+    TIMER_START(writing_mld_data);
+    partition::io::write(config.mld_storage_path, storage);
+    TIMER_STOP(writing_mld_data);
+    util::Log() << "MLD customization writing took " << TIMER_SEC(writing_mld_data) << " seconds";
+
+    return 0;
+}
+
+} // namespace customize
+} // namespace osrm

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -23,7 +23,7 @@ void CellStorageStatistics(const Graph &graph,
 
     for (std::size_t level = 1; level < partition.GetNumberOfLevels(); ++level)
     {
-        std::unordered_map<partition::CellID, std::size_t> cell_nodes;
+        std::unordered_map<CellID, std::size_t> cell_nodes;
         for (auto node : util::irange(0u, graph.GetNumberOfNodes()))
         {
             ++cell_nodes[partition.GetCell(level, node)];
@@ -55,14 +55,14 @@ void CellStorageStatistics(const Graph &graph,
         }
 
         util::Log() << "Level " << level << " #cells " << cell_nodes.size() << " #nodes " << total
-                    << ",   source nodes: average " << source
-                    << " (" << (100. * source / total) << "%)"
-                    << " invalid " << invalid_sources
-                    << " (" << (100. * invalid_sources / total) << "%)"
-                    << ",   destination nodes: average " << destination
-                    << " (" << (100. * destination / total) << "%)"
-                    << " invalid " << invalid_destinations
-                    << " (" << (100. * invalid_destinations / total) << "%)";
+                    << ",   source nodes: average " << source << " (" << (100. * source / total)
+                    << "%)"
+                    << " invalid " << invalid_sources << " (" << (100. * invalid_sources / total)
+                    << "%)"
+                    << ",   destination nodes: average " << destination << " ("
+                    << (100. * destination / total) << "%)"
+                    << " invalid " << invalid_destinations << " ("
+                    << (100. * invalid_destinations / total) << "%)";
     }
 }
 

--- a/src/partition/partitioner.cpp
+++ b/src/partition/partitioner.cpp
@@ -181,14 +181,8 @@ int Partitioner::Run(const PartitionConfig &config)
     TIMER_STOP(packed_mlp);
     util::Log() << "MultiLevelPartition constructed in " << TIMER_SEC(packed_mlp) << " seconds";
 
-    TIMER_START(cell_storage);
-    CellStorage storage(mlp, *edge_based_graph);
-    TIMER_STOP(cell_storage);
-    util::Log() << "CellStorage constructed in " << TIMER_SEC(cell_storage) << " seconds";
-
     TIMER_START(writing_mld_data);
     io::write(config.mld_partition_path, mlp);
-    io::write(config.mld_storage_path, storage);
     TIMER_STOP(writing_mld_data);
     util::Log() << "MLD data writing took " << TIMER_SEC(writing_mld_data) << " seconds";
 

--- a/src/partition/partitioner.cpp
+++ b/src/partition/partitioner.cpp
@@ -1,6 +1,7 @@
 #include "partition/partitioner.hpp"
 #include "partition/bisection_graph.hpp"
 #include "partition/bisection_to_partition.hpp"
+#include "partition/cell_storage.hpp"
 #include "partition/compressed_node_based_graph_reader.hpp"
 #include "partition/edge_based_graph_reader.hpp"
 #include "partition/io.hpp"
@@ -17,7 +18,6 @@
 
 #include <algorithm>
 #include <iterator>
-#include <unordered_set>
 #include <vector>
 
 #include <boost/assert.hpp>

--- a/src/partition/partitioner.cpp
+++ b/src/partition/partitioner.cpp
@@ -181,8 +181,14 @@ int Partitioner::Run(const PartitionConfig &config)
     TIMER_STOP(packed_mlp);
     util::Log() << "MultiLevelPartition constructed in " << TIMER_SEC(packed_mlp) << " seconds";
 
+    TIMER_START(cell_storage);
+    CellStorage storage(mlp, *edge_based_graph);
+    TIMER_STOP(cell_storage);
+    util::Log() << "CellStorage constructed in " << TIMER_SEC(cell_storage) << " seconds";
+
     TIMER_START(writing_mld_data);
     io::write(config.mld_partition_path, mlp);
+    io::write(config.mld_storage_path, storage);
     TIMER_STOP(writing_mld_data);
     util::Log() << "MLD data writing took " << TIMER_SEC(writing_mld_data) << " seconds";
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -427,19 +427,17 @@ void Storage::PopulateLayout(DataLayout &layout)
             reader.Skip<partition::MultiLevelPartition::LevelData>(1);
             layout.SetBlockSize<partition::MultiLevelPartition::LevelData>(
                 DataLayout::MLD_LEVEL_DATA, 1);
-            const auto partition_entries_count = reader.ReadVectorSize<partition::PartitionID>();
-            layout.SetBlockSize<partition::PartitionID>(DataLayout::MLD_PARTITION,
-                                                        partition_entries_count);
-            const auto children_entries_count = reader.ReadVectorSize<partition::CellID>();
-            layout.SetBlockSize<partition::CellID>(DataLayout::MLD_CELL_TO_CHILDREN,
-                                                   children_entries_count);
+            const auto partition_entries_count = reader.ReadVectorSize<PartitionID>();
+            layout.SetBlockSize<PartitionID>(DataLayout::MLD_PARTITION, partition_entries_count);
+            const auto children_entries_count = reader.ReadVectorSize<CellID>();
+            layout.SetBlockSize<CellID>(DataLayout::MLD_CELL_TO_CHILDREN, children_entries_count);
         }
         else
         {
             layout.SetBlockSize<partition::MultiLevelPartition::LevelData>(
                 DataLayout::MLD_LEVEL_DATA, 0);
-            layout.SetBlockSize<partition::PartitionID>(DataLayout::MLD_PARTITION, 0);
-            layout.SetBlockSize<partition::CellID>(DataLayout::MLD_CELL_TO_CHILDREN, 0);
+            layout.SetBlockSize<PartitionID>(DataLayout::MLD_PARTITION, 0);
+            layout.SetBlockSize<CellID>(DataLayout::MLD_CELL_TO_CHILDREN, 0);
         }
 
         if (boost::filesystem::exists(config.mld_storage_path))
@@ -964,10 +962,10 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
             auto mld_level_data_ptr =
                 layout.GetBlockPtr<partition::MultiLevelPartition::LevelData, true>(
                     memory_ptr, DataLayout::MLD_LEVEL_DATA);
-            auto mld_partition_ptr = layout.GetBlockPtr<partition::PartitionID, true>(
-                memory_ptr, DataLayout::MLD_PARTITION);
-            auto mld_chilren_ptr = layout.GetBlockPtr<partition::CellID, true>(
-                memory_ptr, DataLayout::MLD_CELL_TO_CHILDREN);
+            auto mld_partition_ptr =
+                layout.GetBlockPtr<PartitionID, true>(memory_ptr, DataLayout::MLD_PARTITION);
+            auto mld_chilren_ptr =
+                layout.GetBlockPtr<CellID, true>(memory_ptr, DataLayout::MLD_CELL_TO_CHILDREN);
 
             io::FileReader reader(config.mld_partition_path, io::FileReader::VerifyFingerprint);
 

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -1,0 +1,152 @@
+#include "customizer/customizer.hpp"
+
+#include "util/log.hpp"
+#include "util/meminfo.hpp"
+#include "util/version.hpp"
+
+#include <tbb/task_scheduler_init.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+#include <iostream>
+
+using namespace osrm;
+
+enum class return_code : unsigned
+{
+    ok,
+    fail,
+    exit
+};
+
+return_code
+parseArguments(int argc, char *argv[], customize::CustomizationConfig &customization_config)
+{
+    // declare a group of options that will be allowed only on command line
+    boost::program_options::options_description generic_options("Options");
+    generic_options.add_options()("version,v", "Show version")("help,h", "Show this help message");
+
+    // declare a group of options that will be allowed both on command line
+    boost::program_options::options_description config_options("Configuration");
+    config_options.add_options()
+        //
+        ("threads,t",
+         boost::program_options::value<unsigned int>(&customization_config.requested_num_threads)
+             ->default_value(tbb::task_scheduler_init::default_num_threads()),
+         "Number of threads to use");
+
+    // hidden options, will be allowed on command line, but will not be
+    // shown to the user
+    boost::program_options::options_description hidden_options("Hidden options");
+    hidden_options.add_options()(
+        "input,i",
+        boost::program_options::value<boost::filesystem::path>(&customization_config.base_path),
+        "Input file in .osrm format");
+
+    // positional option
+    boost::program_options::positional_options_description positional_options;
+    positional_options.add("input", 1);
+
+    // combine above options for parsing
+    boost::program_options::options_description cmdline_options;
+    cmdline_options.add(generic_options).add(config_options).add(hidden_options);
+
+    const auto *executable = argv[0];
+    boost::program_options::options_description visible_options(
+        boost::filesystem::path(executable).filename().string() + " <input.osrm> [options]");
+    visible_options.add(generic_options).add(config_options);
+
+    // parse command line options
+    boost::program_options::variables_map option_variables;
+    try
+    {
+        boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
+                                          .options(cmdline_options)
+                                          .positional(positional_options)
+                                          .run(),
+                                      option_variables);
+    }
+    catch (const boost::program_options::error &e)
+    {
+        util::Log(logERROR) << e.what();
+        return return_code::fail;
+    }
+
+    if (option_variables.count("version"))
+    {
+        std::cout << OSRM_VERSION << std::endl;
+        return return_code::exit;
+    }
+
+    if (option_variables.count("help"))
+    {
+        std::cout << visible_options;
+        return return_code::exit;
+    }
+
+    boost::program_options::notify(option_variables);
+
+    if (!option_variables.count("input"))
+    {
+        std::cout << visible_options;
+        return return_code::exit;
+    }
+
+    return return_code::ok;
+}
+
+int main(int argc, char *argv[]) try
+{
+    util::LogPolicy::GetInstance().Unmute();
+    customize::CustomizationConfig customization_config;
+
+    const auto result = parseArguments(argc, argv, customization_config);
+
+    if (return_code::fail == result)
+    {
+        return EXIT_FAILURE;
+    }
+
+    if (return_code::exit == result)
+    {
+        return EXIT_SUCCESS;
+    }
+
+    // set the default in/output names
+    customization_config.UseDefaults();
+
+    if (1 > customization_config.requested_num_threads)
+    {
+        util::Log(logERROR) << "Number of threads must be 1 or larger";
+        return EXIT_FAILURE;
+    }
+
+    if (!boost::filesystem::is_regular_file(customization_config.base_path))
+    {
+        util::Log(logERROR) << "Input file " << customization_config.base_path.string()
+                            << " not found!";
+        return EXIT_FAILURE;
+    }
+
+    tbb::task_scheduler_init init(customization_config.requested_num_threads);
+
+    auto exitcode = customize::Customizer().Run(customization_config);
+
+    util::DumpMemoryStats();
+
+    return exitcode;
+}
+catch (const std::bad_alloc &e)
+{
+    util::Log(logERROR) << "[exception] " << e.what();
+    util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
+    return EXIT_FAILURE;
+}
+#ifdef _WIN32
+catch (const std::exception &e)
+{
+    util::Log(logERROR) << "[exception] " << e.what() << std::endl;
+    return EXIT_FAILURE;
+}
+#endif

--- a/unit_tests/common/range_tools.hpp
+++ b/unit_tests/common/range_tools.hpp
@@ -1,0 +1,20 @@
+#ifndef UNIT_TESTS_RANGE_TOOLS_HPP
+#define UNIT_TESTS_RANGE_TOOLS_HPP
+
+#include <boost/test/unit_test.hpp>
+
+#define REQUIRE_SIZE_RANGE(range, ref) BOOST_REQUIRE_EQUAL(range.size(), ref)
+#define CHECK_EQUAL_RANGE(range, ...)                                                              \
+    do                                                                                             \
+    {                                                                                              \
+        const auto &lhs = range;                                                                   \
+        const auto &rhs = {__VA_ARGS__};                                                           \
+        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
+    } while (0)
+#define CHECK_EQUAL_COLLECTIONS(lhs, rhs)                                                          \
+    do                                                                                             \
+    {                                                                                              \
+        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
+    } while (0)
+
+#endif // UNIT_TESTS_RANGE_TOOLS_HPP

--- a/unit_tests/partition/cell_storage.cpp
+++ b/unit_tests/partition/cell_storage.cpp
@@ -16,6 +16,8 @@
 using namespace osrm;
 using namespace osrm::partition;
 
+namespace
+{
 struct MockEdge
 {
     NodeID start;
@@ -40,6 +42,7 @@ auto makeGraph(const std::vector<MockEdge> &mock_edges)
     }
     std::sort(edges.begin(), edges.end());
     return util::StaticGraph<EdgeData>(max_id + 1, edges);
+}
 }
 
 BOOST_AUTO_TEST_SUITE(cell_storage_tests)

--- a/unit_tests/partition/cell_storage.cpp
+++ b/unit_tests/partition/cell_storage.cpp
@@ -1,17 +1,8 @@
-#include <boost/numeric/conversion/cast.hpp>
+#include "common/range_tools.hpp"
 #include <boost/test/unit_test.hpp>
 
 #include "partition/cell_storage.hpp"
 #include "util/static_graph.hpp"
-
-#define CHECK_SIZE_RANGE(range, ref) BOOST_CHECK_EQUAL(range.end() - range.begin(), ref)
-#define CHECK_EQUAL_RANGE(range, ref)                                                              \
-    do                                                                                             \
-    {                                                                                              \
-        const auto &lhs = range;                                                                   \
-        const auto &rhs = ref;                                                                     \
-        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
-    } while (0)
 
 using namespace osrm;
 using namespace osrm::partition;
@@ -111,10 +102,10 @@ BOOST_AUTO_TEST_CASE(mutable_cell_storage)
     fill_range(out_range_1_3_6, {2});
     fill_range(out_range_1_5_11, {3});
 
-    CHECK_EQUAL_RANGE(in_range_1_1_3, std::vector<EdgeWeight>{});
-    CHECK_EQUAL_RANGE(in_range_1_2_5, std::vector<EdgeWeight>{1});
-    CHECK_EQUAL_RANGE(in_range_1_3_7, std::vector<EdgeWeight>{2});
-    CHECK_EQUAL_RANGE(in_range_1_5_11, std::vector<EdgeWeight>{3});
+    CHECK_EQUAL_COLLECTIONS(in_range_1_1_3, std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(in_range_1_2_5, 1);
+    CHECK_EQUAL_RANGE(in_range_1_3_7, 2);
+    CHECK_EQUAL_RANGE(in_range_1_5_11, 3);
 
     // Level 2
     auto cell_2_0 = storage.GetCell(2, 0);
@@ -137,10 +128,10 @@ BOOST_AUTO_TEST_CASE(mutable_cell_storage)
     fill_range(out_range_2_1_4, {2, 3});
     fill_range(out_range_2_3_11, {4});
 
-    CHECK_EQUAL_RANGE(in_range_2_0_3, std::vector<EdgeWeight>{1});
-    CHECK_EQUAL_RANGE(in_range_2_1_4, std::vector<EdgeWeight>{2});
-    CHECK_EQUAL_RANGE(in_range_2_1_7, std::vector<EdgeWeight>{3});
-    CHECK_EQUAL_RANGE(in_range_2_3_11, std::vector<EdgeWeight>{4});
+    CHECK_EQUAL_RANGE(in_range_2_0_3, 1);
+    CHECK_EQUAL_RANGE(in_range_2_1_4, 2);
+    CHECK_EQUAL_RANGE(in_range_2_1_7, 3);
+    CHECK_EQUAL_RANGE(in_range_2_3_11, 4);
 
     // Level 3
     auto cell_3_0 = storage.GetCell(3, 0);
@@ -158,9 +149,9 @@ BOOST_AUTO_TEST_CASE(mutable_cell_storage)
     fill_range(out_range_3_1_4, {2, 3});
     fill_range(out_range_3_1_7, {4, 5});
 
-    CHECK_EQUAL_RANGE(in_range_3_0_3, std::vector<EdgeWeight>({1}));
-    CHECK_EQUAL_RANGE(in_range_3_1_4, std::vector<EdgeWeight>({2, 4}));
-    CHECK_EQUAL_RANGE(in_range_3_1_7, std::vector<EdgeWeight>({3, 5}));
+    CHECK_EQUAL_RANGE(in_range_3_0_3, 1);
+    CHECK_EQUAL_RANGE(in_range_3_1_4, 2, 4);
+    CHECK_EQUAL_RANGE(in_range_3_1_7, 3, 5);
 }
 
 BOOST_AUTO_TEST_CASE(immutable_cell_storage)
@@ -236,19 +227,19 @@ BOOST_AUTO_TEST_CASE(immutable_cell_storage)
     auto const_cell_1_4 = const_storage.GetCell(1, 4);
     auto const_cell_1_5 = const_storage.GetCell(1, 5);
 
-    CHECK_EQUAL_RANGE(const_cell_1_0.GetSourceNodes(), std::vector<NodeID>({0}));
-    CHECK_EQUAL_RANGE(const_cell_1_1.GetSourceNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_1_2.GetSourceNodes(), std::vector<NodeID>({4}));
-    CHECK_EQUAL_RANGE(const_cell_1_3.GetSourceNodes(), std::vector<NodeID>({6}));
-    CHECK_EQUAL_RANGE(const_cell_1_4.GetSourceNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_1_5.GetSourceNodes(), std::vector<NodeID>({11}));
+    CHECK_EQUAL_RANGE(const_cell_1_0.GetSourceNodes(), 0);
+    CHECK_EQUAL_COLLECTIONS(const_cell_1_1.GetSourceNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(const_cell_1_2.GetSourceNodes(), 4);
+    CHECK_EQUAL_RANGE(const_cell_1_3.GetSourceNodes(), 6);
+    CHECK_EQUAL_COLLECTIONS(const_cell_1_4.GetSourceNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(const_cell_1_5.GetSourceNodes(), 11);
 
-    CHECK_EQUAL_RANGE(const_cell_1_0.GetDestinationNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_1_1.GetDestinationNodes(), std::vector<NodeID>({3}));
-    CHECK_EQUAL_RANGE(const_cell_1_2.GetDestinationNodes(), std::vector<NodeID>({5}));
-    CHECK_EQUAL_RANGE(const_cell_1_3.GetDestinationNodes(), std::vector<NodeID>({7}));
-    CHECK_EQUAL_RANGE(const_cell_1_4.GetDestinationNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_1_5.GetDestinationNodes(), std::vector<NodeID>({11}));
+    CHECK_EQUAL_COLLECTIONS(const_cell_1_0.GetDestinationNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(const_cell_1_1.GetDestinationNodes(), 3);
+    CHECK_EQUAL_RANGE(const_cell_1_2.GetDestinationNodes(), 5);
+    CHECK_EQUAL_RANGE(const_cell_1_3.GetDestinationNodes(), 7);
+    CHECK_EQUAL_COLLECTIONS(const_cell_1_4.GetDestinationNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(const_cell_1_5.GetDestinationNodes(), 11);
 
     auto out_const_range_1_0_0 = const_cell_1_0.GetOutWeight(0);
     auto out_const_range_1_2_4 = const_cell_1_2.GetOutWeight(4);
@@ -260,15 +251,15 @@ BOOST_AUTO_TEST_CASE(immutable_cell_storage)
     auto in_const_range_1_3_7 = const_cell_1_3.GetInWeight(7);
     auto in_const_range_1_5_11 = const_cell_1_5.GetInWeight(11);
 
-    CHECK_SIZE_RANGE(out_const_range_1_0_0, 0);
-    CHECK_SIZE_RANGE(out_const_range_1_2_4, 1);
-    CHECK_SIZE_RANGE(out_const_range_1_3_6, 1);
-    CHECK_SIZE_RANGE(out_const_range_1_5_11, 1);
+    REQUIRE_SIZE_RANGE(out_const_range_1_0_0, 0);
+    REQUIRE_SIZE_RANGE(out_const_range_1_2_4, 1);
+    REQUIRE_SIZE_RANGE(out_const_range_1_3_6, 1);
+    REQUIRE_SIZE_RANGE(out_const_range_1_5_11, 1);
 
-    CHECK_SIZE_RANGE(in_const_range_1_1_3, 0);
-    CHECK_SIZE_RANGE(in_const_range_1_2_5, 1);
-    CHECK_SIZE_RANGE(in_const_range_1_3_7, 1);
-    CHECK_SIZE_RANGE(in_const_range_1_5_11, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_1_1_3, 0);
+    REQUIRE_SIZE_RANGE(in_const_range_1_2_5, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_1_3_7, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_1_5_11, 1);
 
     // Level 2
     auto const_cell_2_0 = const_storage.GetCell(2, 0);
@@ -276,15 +267,15 @@ BOOST_AUTO_TEST_CASE(immutable_cell_storage)
     auto const_cell_2_2 = const_storage.GetCell(2, 2);
     auto const_cell_2_3 = const_storage.GetCell(2, 3);
 
-    CHECK_EQUAL_RANGE(const_cell_2_0.GetSourceNodes(), std::vector<NodeID>({0}));
-    CHECK_EQUAL_RANGE(const_cell_2_1.GetSourceNodes(), std::vector<NodeID>({4}));
-    CHECK_EQUAL_RANGE(const_cell_2_2.GetSourceNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_2_3.GetSourceNodes(), std::vector<NodeID>({11}));
+    CHECK_EQUAL_RANGE(const_cell_2_0.GetSourceNodes(), 0);
+    CHECK_EQUAL_RANGE(const_cell_2_1.GetSourceNodes(), 4);
+    CHECK_EQUAL_COLLECTIONS(const_cell_2_2.GetSourceNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(const_cell_2_3.GetSourceNodes(), 11);
 
-    CHECK_EQUAL_RANGE(const_cell_2_0.GetDestinationNodes(), std::vector<NodeID>({3}));
-    CHECK_EQUAL_RANGE(const_cell_2_1.GetDestinationNodes(), std::vector<NodeID>({4, 7}));
-    CHECK_EQUAL_RANGE(const_cell_2_2.GetDestinationNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_2_3.GetDestinationNodes(), std::vector<NodeID>({11}));
+    CHECK_EQUAL_RANGE(const_cell_2_0.GetDestinationNodes(), 3);
+    CHECK_EQUAL_RANGE(const_cell_2_1.GetDestinationNodes(), 4, 7);
+    CHECK_EQUAL_COLLECTIONS(const_cell_2_2.GetDestinationNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_RANGE(const_cell_2_3.GetDestinationNodes(), 11);
 
     auto out_const_range_2_0_0 = const_cell_2_0.GetOutWeight(0);
     auto out_const_range_2_1_4 = const_cell_2_1.GetOutWeight(4);
@@ -295,24 +286,24 @@ BOOST_AUTO_TEST_CASE(immutable_cell_storage)
     auto in_const_range_2_1_7 = const_cell_2_1.GetInWeight(7);
     auto in_const_range_2_3_7 = const_cell_2_3.GetInWeight(11);
 
-    CHECK_SIZE_RANGE(out_const_range_2_0_0, 1);
-    CHECK_SIZE_RANGE(out_const_range_2_1_4, 2);
-    CHECK_SIZE_RANGE(out_const_range_2_3_11, 1);
+    REQUIRE_SIZE_RANGE(out_const_range_2_0_0, 1);
+    REQUIRE_SIZE_RANGE(out_const_range_2_1_4, 2);
+    REQUIRE_SIZE_RANGE(out_const_range_2_3_11, 1);
 
-    CHECK_SIZE_RANGE(in_const_range_2_0_3, 1);
-    CHECK_SIZE_RANGE(in_const_range_2_1_4, 1);
-    CHECK_SIZE_RANGE(in_const_range_2_1_7, 1);
-    CHECK_SIZE_RANGE(in_const_range_2_3_7, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_2_0_3, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_2_1_4, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_2_1_7, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_2_3_7, 1);
 
     // Level 3
     auto const_cell_3_0 = const_storage.GetCell(3, 0);
     auto const_cell_3_1 = const_storage.GetCell(3, 1);
 
-    CHECK_EQUAL_RANGE(const_cell_3_0.GetSourceNodes(), std::vector<NodeID>({0}));
-    CHECK_EQUAL_RANGE(const_cell_3_1.GetSourceNodes(), std::vector<NodeID>({4, 7}));
+    CHECK_EQUAL_RANGE(const_cell_3_0.GetSourceNodes(), 0);
+    CHECK_EQUAL_RANGE(const_cell_3_1.GetSourceNodes(), 4, 7);
 
-    CHECK_EQUAL_RANGE(const_cell_3_0.GetDestinationNodes(), std::vector<NodeID>({3}));
-    CHECK_EQUAL_RANGE(const_cell_3_1.GetDestinationNodes(), std::vector<NodeID>({4, 7}));
+    CHECK_EQUAL_RANGE(const_cell_3_0.GetDestinationNodes(), 3);
+    CHECK_EQUAL_RANGE(const_cell_3_1.GetDestinationNodes(), 4, 7);
 
     auto out_const_range_3_0_0 = const_cell_3_0.GetOutWeight(0);
     auto out_const_range_3_1_4 = const_cell_3_1.GetOutWeight(4);
@@ -322,17 +313,17 @@ BOOST_AUTO_TEST_CASE(immutable_cell_storage)
     auto in_const_range_3_1_4 = const_cell_3_1.GetInWeight(4);
     auto in_const_range_3_1_7 = const_cell_3_1.GetInWeight(7);
 
-    CHECK_SIZE_RANGE(out_const_range_3_0_0, 1);
-    CHECK_SIZE_RANGE(out_const_range_3_1_4, 2);
-    CHECK_SIZE_RANGE(out_const_range_3_1_7, 2);
+    REQUIRE_SIZE_RANGE(out_const_range_3_0_0, 1);
+    REQUIRE_SIZE_RANGE(out_const_range_3_1_4, 2);
+    REQUIRE_SIZE_RANGE(out_const_range_3_1_7, 2);
 
-    CHECK_SIZE_RANGE(in_const_range_3_0_3, 1);
-    CHECK_SIZE_RANGE(in_const_range_3_1_4, 2);
-    CHECK_SIZE_RANGE(in_const_range_3_1_7, 2);
+    REQUIRE_SIZE_RANGE(in_const_range_3_0_3, 1);
+    REQUIRE_SIZE_RANGE(in_const_range_3_1_4, 2);
+    REQUIRE_SIZE_RANGE(in_const_range_3_1_7, 2);
 
     auto const_cell_4_0 = const_storage.GetCell(4, 0);
-    CHECK_EQUAL_RANGE(const_cell_4_0.GetSourceNodes(), std::vector<NodeID>({}));
-    CHECK_EQUAL_RANGE(const_cell_4_0.GetDestinationNodes(), std::vector<NodeID>({}));
+    CHECK_EQUAL_COLLECTIONS(const_cell_4_0.GetSourceNodes(), std::vector<EdgeWeight>{});
+    CHECK_EQUAL_COLLECTIONS(const_cell_4_0.GetDestinationNodes(), std::vector<EdgeWeight>{});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/cell_customization.cpp
+++ b/unit_tests/util/cell_customization.cpp
@@ -2,7 +2,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include "customizer/cell_customizer.hpp"
-#include "partition/cell_storage.hpp"
 #include "partition/multi_level_partition.hpp"
 #include "util/static_graph.hpp"
 
@@ -21,7 +20,7 @@
     } while (0)
 
 using namespace osrm;
-using namespace osrm::customizer;
+using namespace osrm::customize;
 using namespace osrm::partition;
 using namespace osrm::util;
 

--- a/unit_tests/util/cell_customization.cpp
+++ b/unit_tests/util/cell_customization.cpp
@@ -1,0 +1,277 @@
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "customizer/cell_customizer.hpp"
+#include "partition/cell_storage.hpp"
+#include "partition/multi_level_partition.hpp"
+#include "util/static_graph.hpp"
+
+#define REQUIRE_SIZE_RANGE(range, ref) BOOST_REQUIRE_EQUAL(range.size(), ref)
+#define CHECK_EQUAL_RANGE(range, ...)                                                              \
+    do                                                                                             \
+    {                                                                                              \
+        const auto &lhs = range;                                                                   \
+        const auto &rhs = {__VA_ARGS__};                                                           \
+        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
+    } while (0)
+#define CHECK_EQUAL_COLLECTIONS(lhs, rhs)                                                          \
+    do                                                                                             \
+    {                                                                                              \
+        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
+    } while (0)
+
+using namespace osrm;
+using namespace osrm::customizer;
+using namespace osrm::partition;
+using namespace osrm::util;
+
+namespace
+{
+struct MockEdge
+{
+    NodeID start;
+    NodeID target;
+    EdgeWeight weight;
+};
+
+auto makeGraph(const std::vector<MockEdge> &mock_edges)
+{
+    struct EdgeData
+    {
+        EdgeWeight weight;
+        bool forward;
+        bool backward;
+    };
+    using Edge = static_graph_details::SortableEdgeWithData<EdgeData>;
+    std::vector<Edge> edges;
+    std::size_t max_id = 0;
+    for (const auto &m : mock_edges)
+    {
+        max_id = std::max<std::size_t>(max_id, std::max(m.start, m.target));
+        edges.push_back(Edge{m.start, m.target, m.weight, true, false});
+        edges.push_back(Edge{m.target, m.start, m.weight, false, true});
+    }
+    std::sort(edges.begin(), edges.end());
+    return util::StaticGraph<EdgeData>(max_id + 1, edges);
+}
+}
+
+BOOST_AUTO_TEST_SUITE(cell_customization_tests)
+
+BOOST_AUTO_TEST_CASE(two_level_test)
+{
+    // node:                0  1  2  3
+    std::vector<CellID> l1{{0, 0, 1, 1}};
+    MultiLevelPartition mlp{{l1}, {2}};
+
+    BOOST_REQUIRE_EQUAL(mlp.GetNumberOfLevels(), 2);
+
+    std::vector<MockEdge> edges = {{0, 1, 1}, {0, 2, 1}, {2, 3, 1}, {3, 1, 1}, {3, 2, 1}};
+
+    auto graph = makeGraph(edges);
+
+    CellStorage storage(mlp, graph);
+    CellCustomizer customizer(mlp);
+
+    auto cell_1_0 = storage.GetCell(1, 0);
+    auto cell_1_1 = storage.GetCell(1, 1);
+
+    REQUIRE_SIZE_RANGE(cell_1_0.GetSourceNodes(), 1);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetDestinationNodes(), 1);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetSourceNodes(), 2);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetDestinationNodes(), 2);
+
+    CHECK_EQUAL_RANGE(cell_1_0.GetSourceNodes(), 0);
+    CHECK_EQUAL_RANGE(cell_1_0.GetDestinationNodes(), 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetSourceNodes(), 2, 3);
+    CHECK_EQUAL_RANGE(cell_1_1.GetDestinationNodes(), 2, 3);
+
+    REQUIRE_SIZE_RANGE(cell_1_0.GetOutWeight(0), 1);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetOutWeight(1), 0);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetInWeight(1), 1);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetInWeight(0), 0);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetOutWeight(2), 2);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetInWeight(3), 2);
+
+    customizer.Customize(graph, storage, 1, 0);
+    customizer.Customize(graph, storage, 1, 1);
+
+    // cell 0
+    // check row source -> destination
+    CHECK_EQUAL_RANGE(cell_1_0.GetOutWeight(0), 1);
+    // check column destination -> source
+    CHECK_EQUAL_RANGE(cell_1_0.GetInWeight(1), 1);
+
+    // cell 1
+    // check row source -> destination
+    CHECK_EQUAL_RANGE(cell_1_1.GetOutWeight(2), 0, 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetOutWeight(3), 1, 0);
+    // check column destination -> source
+    CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(2), 0, 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(3), 1, 0);
+}
+
+BOOST_AUTO_TEST_CASE(four_levels_test)
+{
+    // node:                0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+    std::vector<CellID> l1{{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}};
+    std::vector<CellID> l2{{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1}};
+    std::vector<CellID> l3{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+    MultiLevelPartition mlp{{l1, l2, l3}, {4, 2, 1}};
+
+    BOOST_REQUIRE_EQUAL(mlp.GetNumberOfLevels(), 4);
+
+    std::vector<MockEdge> edges = {
+        {0, 1, 1}, // cell (0, 0, 0)
+        {0, 2, 1},    {3, 1, 1},   {3, 2, 1},
+
+        {4, 5, 1}, // cell (1, 0, 0)
+        {4, 6, 1},    {4, 7, 1},   {5, 4, 1}, {5, 6, 1}, {5, 7, 1}, {6, 4, 1},
+        {6, 5, 1},    {6, 7, 1},   {7, 4, 1}, {7, 5, 1}, {7, 6, 1},
+
+        {9, 11, 1}, // cell (2, 1, 0)
+        {10, 8, 1},   {11, 10, 1},
+
+        {13, 12, 10}, // cell (3, 1, 0)
+        {15, 14, 1},
+
+        {2, 4, 1},  // edge between cells (0, 0, 0) -> (1, 0, 0)
+        {5, 12, 1}, // edge between cells (1, 0, 0) -> (3, 1, 0)
+        {8, 3, 1},  // edge between cells (2, 1, 0) -> (0, 0, 0)
+        {9, 3, 1},  // edge between cells (2, 1, 0) -> (0, 0, 0)
+        {12, 5, 1}, // edge between cells (3, 1, 0) -> (1, 0, 0)
+        {13, 7, 1}, // edge between cells (3, 1, 0) -> (1, 0, 0)
+        {14, 9, 1}, // edge between cells (2, 1, 0) -> (0, 0, 0)
+        {14, 11, 1} // edge between cells (2, 1, 0) -> (0, 0, 0)
+    };
+
+    auto graph = makeGraph(edges);
+
+    CellStorage storage(mlp, graph);
+
+    auto cell_1_0 = storage.GetCell(1, 0);
+    auto cell_1_1 = storage.GetCell(1, 1);
+    auto cell_1_2 = storage.GetCell(1, 2);
+    auto cell_1_3 = storage.GetCell(1, 3);
+    auto cell_2_0 = storage.GetCell(2, 0);
+    auto cell_2_1 = storage.GetCell(2, 1);
+    auto cell_3_0 = storage.GetCell(3, 0);
+
+    REQUIRE_SIZE_RANGE(cell_1_0.GetSourceNodes(), 1);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetDestinationNodes(), 1);
+    CHECK_EQUAL_RANGE(cell_1_0.GetSourceNodes(), 3);
+    CHECK_EQUAL_RANGE(cell_1_0.GetDestinationNodes(), 2);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetOutWeight(3), 1);
+    REQUIRE_SIZE_RANGE(cell_1_0.GetInWeight(2), 1);
+
+    REQUIRE_SIZE_RANGE(cell_1_1.GetSourceNodes(), 3);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetDestinationNodes(), 3);
+    CHECK_EQUAL_RANGE(cell_1_1.GetSourceNodes(), 4, 5, 7);
+    CHECK_EQUAL_RANGE(cell_1_1.GetDestinationNodes(), 4, 5, 7);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetOutWeight(4), 3);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetOutWeight(5), 3);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetOutWeight(7), 3);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetInWeight(4), 3);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetInWeight(5), 3);
+    REQUIRE_SIZE_RANGE(cell_1_1.GetInWeight(7), 3);
+
+    REQUIRE_SIZE_RANGE(cell_1_2.GetSourceNodes(), 2);
+    REQUIRE_SIZE_RANGE(cell_1_2.GetDestinationNodes(), 2);
+    CHECK_EQUAL_RANGE(cell_1_2.GetSourceNodes(), 9, 11);
+    CHECK_EQUAL_RANGE(cell_1_2.GetDestinationNodes(), 8, 11);
+    REQUIRE_SIZE_RANGE(cell_1_2.GetOutWeight(9), 2);
+    REQUIRE_SIZE_RANGE(cell_1_2.GetOutWeight(11), 2);
+    REQUIRE_SIZE_RANGE(cell_1_2.GetInWeight(8), 2);
+    REQUIRE_SIZE_RANGE(cell_1_2.GetInWeight(11), 2);
+
+    REQUIRE_SIZE_RANGE(cell_1_3.GetSourceNodes(), 1);
+    REQUIRE_SIZE_RANGE(cell_1_3.GetDestinationNodes(), 2);
+    CHECK_EQUAL_RANGE(cell_1_3.GetSourceNodes(), 13);
+    CHECK_EQUAL_RANGE(cell_1_3.GetDestinationNodes(), 12, 14);
+    REQUIRE_SIZE_RANGE(cell_1_3.GetOutWeight(13), 2);
+    REQUIRE_SIZE_RANGE(cell_1_3.GetInWeight(12), 1);
+    REQUIRE_SIZE_RANGE(cell_1_3.GetInWeight(14), 1);
+
+    REQUIRE_SIZE_RANGE(cell_2_0.GetSourceNodes(), 3);
+    REQUIRE_SIZE_RANGE(cell_2_0.GetDestinationNodes(), 2);
+    CHECK_EQUAL_RANGE(cell_2_0.GetSourceNodes(), 3, 5, 7);
+    CHECK_EQUAL_RANGE(cell_2_0.GetDestinationNodes(), 5, 7);
+    REQUIRE_SIZE_RANGE(cell_2_0.GetOutWeight(3), 2);
+    REQUIRE_SIZE_RANGE(cell_2_0.GetOutWeight(5), 2);
+    REQUIRE_SIZE_RANGE(cell_2_0.GetOutWeight(7), 2);
+    REQUIRE_SIZE_RANGE(cell_2_0.GetInWeight(5), 3);
+    REQUIRE_SIZE_RANGE(cell_2_0.GetInWeight(7), 3);
+
+    REQUIRE_SIZE_RANGE(cell_2_1.GetSourceNodes(), 2);
+    REQUIRE_SIZE_RANGE(cell_2_1.GetDestinationNodes(), 3);
+    CHECK_EQUAL_RANGE(cell_2_1.GetSourceNodes(), 9, 13);
+    CHECK_EQUAL_RANGE(cell_2_1.GetDestinationNodes(), 8, 9, 12);
+    REQUIRE_SIZE_RANGE(cell_2_1.GetOutWeight(9), 3);
+    REQUIRE_SIZE_RANGE(cell_2_1.GetOutWeight(13), 3);
+    REQUIRE_SIZE_RANGE(cell_2_1.GetInWeight(8), 2);
+    REQUIRE_SIZE_RANGE(cell_2_1.GetInWeight(9), 2);
+    REQUIRE_SIZE_RANGE(cell_2_1.GetInWeight(12), 2);
+
+    REQUIRE_SIZE_RANGE(cell_3_0.GetSourceNodes(), 0);
+    REQUIRE_SIZE_RANGE(cell_3_0.GetDestinationNodes(), 0);
+
+    CellCustomizer customizer(mlp);
+
+    customizer.Customize(graph, storage, 1, 0);
+    customizer.Customize(graph, storage, 1, 1);
+    customizer.Customize(graph, storage, 1, 2);
+    customizer.Customize(graph, storage, 1, 3);
+
+    customizer.Customize(graph, storage, 2, 0);
+    customizer.Customize(graph, storage, 2, 1);
+
+    // level 1
+    // cell 0
+    CHECK_EQUAL_RANGE(cell_1_0.GetOutWeight(3), 1);
+    CHECK_EQUAL_RANGE(cell_1_0.GetInWeight(2), 1);
+
+    // cell 1
+    CHECK_EQUAL_RANGE(cell_1_1.GetOutWeight(4), 0, 1, 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetOutWeight(5), 1, 0, 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetOutWeight(7), 1, 1, 0);
+    CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(4), 0, 1, 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(5), 1, 0, 1);
+    CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(7), 1, 1, 0);
+
+    // cell 2
+    CHECK_EQUAL_RANGE(cell_1_2.GetOutWeight(9), 3, 1);
+    CHECK_EQUAL_RANGE(cell_1_2.GetOutWeight(11), 2, 0);
+    CHECK_EQUAL_RANGE(cell_1_2.GetInWeight(8), 3, 2);
+    CHECK_EQUAL_RANGE(cell_1_2.GetInWeight(11), 1, 0);
+
+    // cell 3
+    CHECK_EQUAL_RANGE(cell_1_3.GetOutWeight(13), 10, INVALID_EDGE_WEIGHT);
+    CHECK_EQUAL_RANGE(cell_1_3.GetInWeight(12), 10);
+    CHECK_EQUAL_RANGE(cell_1_3.GetInWeight(14), INVALID_EDGE_WEIGHT);
+
+    // level 2
+    // cell 0
+    CHECK_EQUAL_RANGE(cell_2_0.GetOutWeight(3), 3, 3);
+    CHECK_EQUAL_RANGE(cell_2_0.GetOutWeight(5), 0, 1);
+    CHECK_EQUAL_RANGE(cell_2_0.GetOutWeight(7), 1, 0);
+    CHECK_EQUAL_RANGE(cell_2_0.GetInWeight(5), 3, 0, 1);
+    CHECK_EQUAL_RANGE(cell_2_0.GetInWeight(7), 3, 1, 0);
+
+    // cell 1
+    CHECK_EQUAL_RANGE(cell_2_1.GetOutWeight(9), 3, 0, INVALID_EDGE_WEIGHT);
+    CHECK_EQUAL_RANGE(cell_2_1.GetOutWeight(13), INVALID_EDGE_WEIGHT, INVALID_EDGE_WEIGHT, 10);
+    CHECK_EQUAL_RANGE(cell_2_1.GetInWeight(8), 3, INVALID_EDGE_WEIGHT);
+    CHECK_EQUAL_RANGE(cell_2_1.GetInWeight(9), 0, INVALID_EDGE_WEIGHT);
+    CHECK_EQUAL_RANGE(cell_2_1.GetInWeight(12), INVALID_EDGE_WEIGHT, 10);
+
+    CellStorage storage_rec(mlp, graph);
+    customizer.Customize(graph, storage_rec);
+
+    CHECK_EQUAL_COLLECTIONS(cell_2_1.GetOutWeight(9), storage_rec.GetCell(2, 1).GetOutWeight(9));
+    CHECK_EQUAL_COLLECTIONS(cell_2_1.GetOutWeight(13), storage_rec.GetCell(2, 1).GetOutWeight(13));
+    CHECK_EQUAL_COLLECTIONS(cell_2_1.GetInWeight(8), storage_rec.GetCell(2, 1).GetInWeight(8));
+    CHECK_EQUAL_COLLECTIONS(cell_2_1.GetInWeight(9), storage_rec.GetCell(2, 1).GetInWeight(9));
+    CHECK_EQUAL_COLLECTIONS(cell_2_1.GetInWeight(12), storage_rec.GetCell(2, 1).GetInWeight(12));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/cell_customization.cpp
+++ b/unit_tests/util/cell_customization.cpp
@@ -1,23 +1,9 @@
-#include <boost/numeric/conversion/cast.hpp>
+#include "common/range_tools.hpp"
 #include <boost/test/unit_test.hpp>
 
 #include "customizer/cell_customizer.hpp"
 #include "partition/multi_level_partition.hpp"
 #include "util/static_graph.hpp"
-
-#define REQUIRE_SIZE_RANGE(range, ref) BOOST_REQUIRE_EQUAL(range.size(), ref)
-#define CHECK_EQUAL_RANGE(range, ...)                                                              \
-    do                                                                                             \
-    {                                                                                              \
-        const auto &lhs = range;                                                                   \
-        const auto &rhs = {__VA_ARGS__};                                                           \
-        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
-    } while (0)
-#define CHECK_EQUAL_COLLECTIONS(lhs, rhs)                                                          \
-    do                                                                                             \
-    {                                                                                              \
-        BOOST_CHECK_EQUAL_COLLECTIONS(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());             \
-    } while (0)
 
 using namespace osrm;
 using namespace osrm::customize;


### PR DESCRIPTION
# Issue

PR partially addresses #3350: filling weights in CellStorage.

## Tasklist
 - [x] add a simple one-to-many Dijkstra cell customizer
 - [x] add `osrm-customize` tool
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Required PRs: #3724, #3730
