### PR TITLE
Clamp annotation speed values

### DIFF
--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -19,6 +19,7 @@
 
 #include "util/coordinate.hpp"
 #include "util/integer_range.hpp"
+#include "util/json_util.hpp"
 
 #include <iterator>
 #include <vector>
@@ -249,7 +250,8 @@ class RouteAPI : public BaseAPI
                 {
                     annotation.values["speed"] = GetAnnotations(
                         leg_geometry, [](const guidance::LegGeometry::Annotation &anno) {
-                            return std::round(anno.distance / anno.duration * 10.) / 10.;
+                            auto val = std::round(anno.distance / anno.duration * 10.) / 10.;
+                            return util::json::clamp_float(val);
                         });
                 }
 


### PR DESCRIPTION
# Issue

Closes https://github.com/Project-OSRM/osrm-backend/issues/3742

This clamps `speed` annotations when that value comes out as `infinite` (i.e. when duration is `0` for whatever reason) so that the JSON parsing upstream can handle the values properly.

I'm having trouble recreating the conditions for this in a cucumber test, likely because `0` durations are the result of some slippery phantom node snapping conditions at the beginning and ends of routes.

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Needed for 5.6 release
