### PR TITLE
cucumber: enable checking mode in routability tables

### DIFF
--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -7,193 +7,179 @@ Feature: Bike - Access tags on ways
 
     Scenario: Bike - Access tag hierarchy on ways
         Then routability should be
-            | highway | access | vehicle | bicycle | bothw |
-            |         |        |         |         | x     |
-            |         | yes    |         |         | x     |
-            |         | no     |         |         |       |
-            |         |        | yes     |         | x     |
-            |         |        | no      |         |       |
-            |         | no     | yes     |         | x     |
-            |         | yes    | no      |         |       |
-            |         |        |         | yes     | x     |
-            |         |        |         | no      |       |
-            |         | no     |         | yes     | x     |
-            |         | yes    |         | no      |       |
-            |         |        | no      | yes     | x     |
-            |         |        | yes     | no      |       |
-            | runway  |        |         |         |       |
-            | runway  | yes    |         |         | x     |
-            | runway  | no     |         |         |       |
-            | runway  |        | yes     |         | x     |
-            | runway  |        | no      |         |       |
-            | runway  | no     | yes     |         | x     |
-            | runway  | yes    | no      |         |       |
-            | runway  |        |         | yes     | x     |
-            | runway  |        |         | no      |       |
-            | runway  | no     |         | yes     | x     |
-            | runway  | yes    |         | no      |       |
-            | runway  |        | no      | yes     | x     |
-            | runway  |        | yes     | no      |       |
+            | highway | access | vehicle | bicycle | bothw   |
+            | primary |        |         |         | cycling |
+            | primary | yes    |         |         | cycling |
+            | primary | no     |         |         |         |
+            | primary |        | yes     |         | cycling |
+            | primary |        | no      |         |         |
+            | primary | no     | yes     |         | cycling |
+            | primary | yes    | no      |         |         |
+            | primary |        |         | yes     | cycling |
+            | primary |        |         | no      |         |
+            | primary | no     |         | yes     | cycling |
+            | primary | yes    |         | no      |         |
+            | primary |        | no      | yes     | cycling |
+            | primary |        | yes     | no      |         |
 
     @todo
     Scenario: Bike - Access tag in forward direction
         Then routability should be
-            | highway | access:forward | vehicle:forward | bicycle:forward | forw | backw |
-            |         |                |                 |                 | x    |       |
-            |         | yes            |                 |                 | x    |       |
-            |         | no             |                 |                 |      |       |
-            |         |                | yes             |                 | x    |       |
-            |         |                | no              |                 |      |       |
-            |         | no             | yes             |                 | x    |       |
-            |         | yes            | no              |                 |      |       |
-            |         |                |                 | yes             | x    |       |
-            |         |                |                 | no              |      |       |
-            |         | no             |                 | yes             | x    |       |
-            |         | yes            |                 | no              |      |       |
-            |         |                | no              | yes             | x    |       |
-            |         |                | yes             | no              |      |       |
-            | runway  |                |                 |                 | x    |       |
-            | runway  | yes            |                 |                 | x    |       |
-            | runway  | no             |                 |                 |      |       |
-            | runway  |                | yes             |                 | x    |       |
-            | runway  |                | no              |                 |      |       |
-            | runway  | no             | yes             |                 | x    |       |
-            | runway  | yes            | no              |                 |      |       |
-            | runway  |                |                 | yes             | x    |       |
-            | runway  |                |                 | no              |      |       |
-            | runway  | no             |                 | yes             | x    |       |
-            | runway  | yes            |                 | no              |      |       |
-            | runway  |                | no              | yes             | x    |       |
-            | runway  |                | yes             | no              |      |       |
+            | highway | access:forward | vehicle:forward | bicycle:forward | forw    | backw |
+            | primary |                |                 |                 | cycling |       |
+            | primary | yes            |                 |                 | cycling |       |
+            | primary | no             |                 |                 |         |       |
+            | primary |                | yes             |                 | cycling |       |
+            | primary |                | no              |                 |         |       |
+            | primary | no             | yes             |                 | cycling |       |
+            | primary | yes            | no              |                 |         |       |
+            | primary |                |                 | yes             | cycling |       |
+            | primary |                |                 | no              |         |       |
+            | primary | no             |                 | yes             | cycling |       |
+            | primary | yes            |                 | no              |         |       |
+            | primary |                | no              | yes             | cycling |       |
+            | primary |                | yes             | no              |         |       |
+            | runway  |                |                 |                 | cycling |       |
+            | runway  | yes            |                 |                 | cycling |       |
+            | runway  | no             |                 |                 |         |       |
+            | runway  |                | yes             |                 | cycling |       |
+            | runway  |                | no              |                 |         |       |
+            | runway  | no             | yes             |                 | cycling |       |
+            | runway  | yes            | no              |                 |         |       |
+            | runway  |                |                 | yes             | cycling |       |
+            | runway  |                |                 | no              |         |       |
+            | runway  | no             |                 | yes             | cycling |       |
+            | runway  | yes            |                 | no              |         |       |
+            | runway  |                | no              | yes             | cycling |       |
+            | runway  |                | yes             | no              |         |       |
 
     @todo
     Scenario: Bike - Access tag in backward direction
         Then routability should be
-            | highway | access:forward | vehicle:forward | bicycle:forward | forw | backw |
-            |         |                |                 |                 |      | x     |
-            |         | yes            |                 |                 |      | x     |
-            |         | no             |                 |                 |      |       |
-            |         |                | yes             |                 |      | x     |
-            |         |                | no              |                 |      |       |
-            |         | no             | yes             |                 |      | x     |
-            |         | yes            | no              |                 |      |       |
-            |         |                |                 | yes             |      | x     |
-            |         |                |                 | no              |      |       |
-            |         | no             |                 | yes             |      | x     |
-            |         | yes            |                 | no              |      |       |
-            |         |                | no              | yes             |      | x     |
-            |         |                | yes             | no              |      |       |
-            | runway  |                |                 |                 |      | x     |
-            | runway  | yes            |                 |                 |      | x     |
-            | runway  | no             |                 |                 |      |       |
-            | runway  |                | yes             |                 |      | x     |
-            | runway  |                | no              |                 |      |       |
-            | runway  | no             | yes             |                 |      | x     |
-            | runway  | yes            | no              |                 |      |       |
-            | runway  |                |                 | yes             |      | x     |
-            | runway  |                |                 | no              |      |       |
-            | runway  | no             |                 | yes             |      | x     |
-            | runway  | yes            |                 | no              |      |       |
-            | runway  |                | no              | yes             |      | x     |
-            | runway  |                | yes             | no              |      |       |
+            | highway | access:forward | vehicle:forward | bicycle:forward | forw | backw   |
+            | primary |                |                 |                 |      | cycling |
+            | primary | yes            |                 |                 |      | cycling |
+            | primary | no             |                 |                 |      |         |
+            | primary |                | yes             |                 |      | cycling |
+            | primary |                | no              |                 |      |         |
+            | primary | no             | yes             |                 |      | cycling |
+            | primary | yes            | no              |                 |      |         |
+            | primary |                |                 | yes             |      | cycling |
+            | primary |                |                 | no              |      |         |
+            | primary | no             |                 | yes             |      | cycling |
+            | primary | yes            |                 | no              |      |         |
+            | primary |                | no              | yes             |      | cycling |
+            | primary |                | yes             | no              |      |         |
+            | runway  |                |                 |                 |      | cycling |
+            | runway  | yes            |                 |                 |      | cycling |
+            | runway  | no             |                 |                 |      |         |
+            | runway  |                | yes             |                 |      | cycling |
+            | runway  |                | no              |                 |      |         |
+            | runway  | no             | yes             |                 |      | cycling |
+            | runway  | yes            | no              |                 |      |         |
+            | runway  |                |                 | yes             |      | cycling |
+            | runway  |                |                 | no              |      |         |
+            | runway  | no             |                 | yes             |      | cycling |
+            | runway  | yes            |                 | no              |      |         |
+            | runway  |                | no              | yes             |      | cycling |
+            | runway  |                | yes             | no              |      |         |
 
     Scenario: Bike - Overwriting implied acccess on ways
         Then routability should be
-            | highway  | access | vehicle | bicycle | bothw |
-            | cycleway |        |         |         | x     |
-            | runway   |        |         |         |       |
-            | cycleway | no     |         |         |       |
-            | cycleway |        | no      |         |       |
-            | cycleway |        |         | no      |       |
-            | runway   | yes    |         |         | x     |
-            | runway   |        | yes     |         | x     |
-            | runway   |        |         | yes     | x     |
+            | highway  | access | vehicle | bicycle | bothw   |
+            | cycleway |        |         |         | cycling |
+            | runway   |        |         |         |         |
+            | cycleway | no     |         |         |         |
+            | cycleway |        | no      |         |         |
+            | cycleway |        |         | no      |         |
+            | runway   | yes    |         |         | cycling |
+            | runway   |        | yes     |         | cycling |
+            | runway   |        |         | yes     | cycling |
 
     Scenario: Bike - Access tags on ways
         Then routability should be
-            | access       | vehicle      | bicycle      | bothw |
-            |              |              |              | x     |
-            | yes          |              |              | x     |
-            | permissive   |              |              | x     |
-            | designated   |              |              | x     |
-            | some_tag     |              |              | x     |
-            | no           |              |              |       |
-            | private      |              |              |       |
-            | agricultural |              |              |       |
-            | forestry     |              |              |       |
-            | delivery     |              |              |       |
-            |              | yes          |              | x     |
-            |              | permissive   |              | x     |
-            |              | designated   |              | x     |
-            |              | some_tag     |              | x     |
-            |              | no           |              |       |
-            |              | private      |              |       |
-            |              | agricultural |              |       |
-            |              | forestry     |              |       |
-            |              | delivery     |              |       |
-            |              |              | yes          | x     |
-            |              |              | permissive   | x     |
-            |              |              | designated   | x     |
-            |              |              | some_tag     | x     |
-            |              |              | no           |       |
-            |              |              | private      |       |
-            |              |              | agricultural |       |
-            |              |              | forestry     |       |
-            |              |              | delivery     |       |
+            | access       | vehicle      | bicycle      | bothw   |
+            |              |              |              | cycling |
+            | yes          |              |              | cycling |
+            | permissive   |              |              | cycling |
+            | designated   |              |              | cycling |
+            | some_tag     |              |              | cycling |
+            | no           |              |              |         |
+            | private      |              |              |         |
+            | agricultural |              |              |         |
+            | forestry     |              |              |         |
+            | delivery     |              |              |         |
+            |              | yes          |              | cycling |
+            |              | permissive   |              | cycling |
+            |              | designated   |              | cycling |
+            |              | some_tag     |              | cycling |
+            |              | no           |              |         |
+            |              | private      |              |         |
+            |              | agricultural |              |         |
+            |              | forestry     |              |         |
+            |              | delivery     |              |         |
+            |              |              | yes          | cycling |
+            |              |              | permissive   | cycling |
+            |              |              | designated   | cycling |
+            |              |              | some_tag     | cycling |
+            |              |              | no           |         |
+            |              |              | private      |         |
+            |              |              | agricultural |         |
+            |              |              | forestry     |         |
+            |              |              | delivery     |         |
 
     Scenario: Bike - Access tags on both node and way
         Then routability should be
-            | access   | node/access | bothw |
-            | yes      | yes         | x     |
-            | yes      | no          |       |
-            | yes      | some_tag    | x     |
-            | no       | yes         |       |
-            | no       | no          |       |
-            | no       | some_tag    |       |
-            | some_tag | yes         | x     |
-            | some_tag | no          |       |
-            | some_tag | some_tag    | x     |
+            | access   | node/access | bothw   |
+            | yes      | yes         | cycling |
+            | yes      | no          |         |
+            | yes      | some_tag    | cycling |
+            | no       | yes         |         |
+            | no       | no          |         |
+            | no       | some_tag    |         |
+            | some_tag | yes         | cycling |
+            | some_tag | no          |         |
+            | some_tag | some_tag    | cycling |
 
     Scenario: Bike - Access combinations
         Then routability should be
-            | highway     | access     | vehicle    | bicycle    | forw | backw |
-            | runway      | private    |            | yes        | x    | x     |
-            | footway     |            | no         | permissive | x    | x     |
-            | motorway    |            |            | yes        | x    |       |
-            | track       | forestry   |            | permissive | x    | x     |
-            | cycleway    | yes        | designated | no         |      |       |
-            | primary     |            | yes        | private    |      |       |
-            | residential | permissive |            | no         |      |       |
+            | highway     | access     | vehicle    | bicycle    | forw    | backw   |
+            | runway      | private    |            | yes        | cycling | cycling |
+            | footway     |            | no         | permissive | cycling | cycling |
+            | motorway    |            |            | yes        | cycling |         |
+            | track       | forestry   |            | permissive | cycling | cycling |
+            | cycleway    | yes        | designated | no         |         |         |
+            | primary     |            | yes        | private    |         |         |
+            | residential | permissive |            | no         |         |         |
 
     Scenario: Bike - Ignore access tags for other modes
         Then routability should be
-            | highway  | boat | motor_vehicle | moped | bothw |
-            | river    | yes  |               |       |       |
-            | cycleway | no   |               |       | x     |
-            | runway   |      | yes           |       |       |
-            | cycleway |      | no            |       | x     |
-            | runway   |      |               | yes   |       |
-            | cycleway |      |               | no    | x     |
+            | highway  | boat | motor_vehicle | moped | bothw   |
+            | river    | yes  |               |       |         |
+            | cycleway | no   |               |       | cycling |
+            | runway   |      | yes           |       |         |
+            | cycleway |      | no            |       | cycling |
+            | runway   |      |               | yes   |         |
+            | cycleway |      |               | no    | cycling |
 
     Scenario: Bike - Bridleways when access is explicit
         Then routability should be
-            | highway   | horse      | foot | bicycle | bothw |
-            | bridleway |            |      | yes     | x     |
-            | bridleway |            | yes  |         | x     |
-            | bridleway | designated |      |         |       |
-            | bridleway |            |      |         |       |
+            | highway   | horse      | foot | bicycle | bothw        |
+            | bridleway |            |      | yes     | cycling      |
+            | bridleway |            | yes  |         | pushing bike |
+            | bridleway | designated |      |         |              |
+            | bridleway |            |      |         |              |
 
     Scenario: Bike - Tram with oneway when access is implicit
         Then routability should be
-            | highway     | railway | access | oneway | bothw |
-            | residential | tram    |        | yes    | x     |
-            | service     | tram    | psv    | yes    | x     |
+            | highway     | railway | access | oneway | forw    | backw        |
+            | residential | tram    |        | yes    | cycling | pushing bike |
+            | service     | tram    | psv    | yes    | cycling | pushing bike |
 
     Scenario: Bike - Access combinations
         Then routability should be
-            | highway    | access     | bothw |
-            | primary    | permissive | x     |
-            | steps      | permissive | x     |
-            | footway    | permissive | x     |
-            | garbagetag | permissive | x     |
-
+            | highway    | access     | bothw   |
+            | primary    | permissive | cycling |
+            | steps      | permissive | cycling |
+            | footway    | permissive | cycling |
+            | garbagetag | permissive | cycling |

--- a/features/bicycle/access_node.feature
+++ b/features/bicycle/access_node.feature
@@ -7,62 +7,62 @@ Feature: Bike - Access tags on nodes
 
     Scenario: Bike - Access tag hierarchy on nodes
         Then routability should be
-            | node/access | node/vehicle | node/bicycle | node/highway  | bothw |
-            |             |              |              |               | x     |
-            | yes         |              |              |               | x     |
-            | no          |              |              |               |       |
-            |             | yes          |              |               | x     |
-            |             | no           |              |               |       |
-            | no          | yes          |              |               | x     |
-            | yes         | no           |              |               |       |
-            |             |              | yes          |               | x     |
-            |             |              | no           |               |       |
-            |             |              | no           | crossing      | x     |
-            | no          |              | yes          |               | x     |
-            | yes         |              | no           |               |       |
-            |             | no           | yes          |               | x     |
-            |             | yes          | no           |               |       |
+            | node/access | node/vehicle | node/bicycle | node/highway | bothw   |
+            |             |              |              |              | cycling |
+            | yes         |              |              |              | cycling |
+            | no          |              |              |              |         |
+            |             | yes          |              |              | cycling |
+            |             | no           |              |              |         |
+            | no          | yes          |              |              | cycling |
+            | yes         | no           |              |              |         |
+            |             |              | yes          |              | cycling |
+            |             |              | no           |              |         |
+            |             |              | no           | crossing     | cycling |
+            | no          |              | yes          |              | cycling |
+            | yes         |              | no           |              |         |
+            |             | no           | yes          |              | cycling |
+            |             | yes          | no           |              |         |
 
     Scenario: Bike - Overwriting implied acccess on nodes doesn't overwrite way
         Then routability should be
-            | highway  | node/access | node/vehicle | node/bicycle | bothw |
-            | cycleway |             |              |              | x     |
-            | runway   |             |              |              |       |
-            | cycleway | no          |              |              |       |
-            | cycleway |             | no           |              |       |
-            | cycleway |             |              | no           |       |
-            | runway   | yes         |              |              |       |
-            | runway   |             | yes          |              |       |
-            | runway   |             |              | yes          |       |
+            | highway  | node/access | node/vehicle | node/bicycle | bothw   |
+            | cycleway |             |              |              | cycling |
+            | runway   |             |              |              |         |
+            | cycleway | no          |              |              |         |
+            | cycleway |             | no           |              |         |
+            | cycleway |             |              | no           |         |
+            | runway   | yes         |              |              |         |
+            | runway   |             | yes          |              |         |
+            | runway   |             |              | yes          |         |
 
     Scenario: Bike - Access tags on nodes
         Then routability should be
-            | node/access  | node/vehicle | node/bicycle | bothw |
-            |              |              |              | x     |
-            | yes          |              |              | x     |
-            | permissive   |              |              | x     |
-            | designated   |              |              | x     |
-            | some_tag     |              |              | x     |
-            | no           |              |              |       |
-            | private      |              |              |       |
-            | agricultural |              |              |       |
-            | forestry     |              |              |       |
-            | delivery     |              |              |       |
-            |              | yes          |              | x     |
-            |              | permissive   |              | x     |
-            |              | designated   |              | x     |
-            |              | some_tag     |              | x     |
-            |              | no           |              |       |
-            |              | private      |              |       |
-            |              | agricultural |              |       |
-            |              | forestry     |              |       |
-            |              | delivery     |              |       |
-            |              |              | yes          | x     |
-            |              |              | permissive   | x     |
-            |              |              | designated   | x     |
-            |              |              | some_tag     | x     |
-            |              |              | no           |       |
-            |              |              | private      |       |
-            |              |              | agricultural |       |
-            |              |              | forestry     |       |
-            |              |              | delivery     |       |
+            | node/access  | node/vehicle | node/bicycle | bothw   |
+            |              |              |              | cycling |
+            | yes          |              |              | cycling |
+            | permissive   |              |              | cycling |
+            | designated   |              |              | cycling |
+            | some_tag     |              |              | cycling |
+            | no           |              |              |         |
+            | private      |              |              |         |
+            | agricultural |              |              |         |
+            | forestry     |              |              |         |
+            | delivery     |              |              |         |
+            |              | yes          |              | cycling |
+            |              | permissive   |              | cycling |
+            |              | designated   |              | cycling |
+            |              | some_tag     |              | cycling |
+            |              | no           |              |         |
+            |              | private      |              |         |
+            |              | agricultural |              |         |
+            |              | forestry     |              |         |
+            |              | delivery     |              |         |
+            |              |              | yes          | cycling |
+            |              |              | permissive   | cycling |
+            |              |              | designated   | cycling |
+            |              |              | some_tag     | cycling |
+            |              |              | no           |         |
+            |              |              | private      |         |
+            |              |              | agricultural |         |
+            |              |              | forestry     |         |
+            |              |              | delivery     |         |

--- a/features/bicycle/mode.feature
+++ b/features/bicycle/mode.feature
@@ -159,7 +159,7 @@ Feature: Bike - Mode flag
     	 | c    | a  | bc,ab,ab    | pushing bike,cycling,cycling         |
     	 | d    | b  | cd,bc,bc    | cycling,pushing bike,pushing bike    |
     	 | a    | c  | ab,bc,bc    | cycling,pushing bike,pushing bike    |
-         | b    | d  | bc,cd,cd    | pushing bike,cycling,cycling         |
+         | b    | d  | bc,cd,cd  | pushing bike,cycling,cycling         |
 
     Scenario: Bicycle - Modes when starting on forward oneway
         Given the node map

--- a/features/bicycle/oneway.feature
+++ b/features/bicycle/oneway.feature
@@ -8,13 +8,15 @@ Feature: Bike - Oneway streets
 
     Scenario: Bike - Simple oneway
         Then routability should be
-            | highway | foot | oneway | forw | backw |
-            | primary | no   | yes    | x    |       |
+            | highway | foot | oneway | forw    | backw        |
+            | primary | no   | yes    | cycling |              |
+            | primary |      | yes    | cycling | pushing bike |
 
     Scenario: Simple reverse oneway
         Then routability should be
-            | highway | foot | oneway | forw | backw |
-            | primary | no   | -1     |      | x     |
+            | highway | foot | oneway | forw         | backw   |
+            | primary | no   | -1     |              | cycling |
+            | primary |      | -1     | pushing bike | cycling |
 
     Scenario: Bike - Around the Block
         Given the node map
@@ -39,83 +41,83 @@ Feature: Bike - Oneway streets
 
     Scenario: Bike - Handle various oneway tag values
         Then routability should be
-            | foot | oneway   | forw | backw |
-            | no   |          | x    | x     |
-            | no   | nonsense | x    | x     |
-            | no   | no       | x    | x     |
-            | no   | false    | x    | x     |
-            | no   | 0        | x    | x     |
-            | no   | yes      | x    |       |
-            | no   | true     | x    |       |
-            | no   | 1        | x    |       |
-            | no   | -1       |      | x     |
+            | foot | oneway   | forw    | backw   |
+            | no   |          | cycling | cycling |
+            | no   | nonsense | cycling | cycling |
+            | no   | no       | cycling | cycling |
+            | no   | false    | cycling | cycling |
+            | no   | 0        | cycling | cycling |
+            | no   | yes      | cycling |         |
+            | no   | true     | cycling |         |
+            | no   | 1        | cycling |         |
+            | no   | -1       |         | cycling |
 
     Scenario: Bike - Implied oneways
         Then routability should be
-            | highway         | foot | bicycle | junction   | forw | backw | #                     |
-            |                 | no   |         |            | x    | x     |                       |
-            |                 | no   |         | roundabout | x    |       |                       |
-            | motorway        | no   | yes     |            | x    |       |                       |
-            | motorway_link   | no   | yes     |            | x    | x     | does not imply oneway |
-            | motorway        | no   | yes     | roundabout | x    |       |                       |
-            | motorway_link   | no   | yes     | roundabout | x    |       |                       |
+            | highway       | foot | bicycle | junction   | forw    | backw   | #                     |
+            |               | no   |         |            | cycling | cycling |                       |
+            |               | no   |         | roundabout | cycling |         |                       |
+            | motorway      | no   | yes     |            | cycling |         |                       |
+            | motorway_link | no   | yes     |            | cycling | cycling | does not imply oneway |
+            | motorway      | no   | yes     | roundabout | cycling |         |                       |
+            | motorway_link | no   | yes     | roundabout | cycling |         |                       |
 
     Scenario: Bike - Overriding implied oneways
         Then routability should be
-            | highway         | foot | junction   | oneway | forw | backw |
-            | primary         | no   | roundabout | no     | x    | x     |
-            | primary         | no   | roundabout | yes    | x    |       |
-            | motorway_link   | no   |            | -1     |      |       |
-            | trunk_link      | no   |            | -1     |      |       |
-            | primary         | no   | roundabout | -1     |      | x     |
+            | highway       | foot | junction   | oneway | forw    | backw   |
+            | primary       | no   | roundabout | no     | cycling | cycling |
+            | primary       | no   | roundabout | yes    | cycling |         |
+            | motorway_link | no   |            | -1     |         |         |
+            | trunk_link    | no   |            | -1     |         |         |
+            | primary       | no   | roundabout | -1     |         | cycling |
 
     Scenario: Bike - Oneway:bicycle should override normal oneways tags
         Then routability should be
-            | foot | oneway:bicycle | oneway | junction   | forw | backw |
-            | no   | yes            |        |            | x    |       |
-            | no   | yes            | yes    |            | x    |       |
-            | no   | yes            | no     |            | x    |       |
-            | no   | yes            | -1     |            | x    |       |
-            | no   | yes            |        | roundabout | x    |       |
-            | no   | no             |        |            | x    | x     |
-            | no   | no             | yes    |            | x    | x     |
-            | no   | no             | no     |            | x    | x     |
-            | no   | no             | -1     |            | x    | x     |
-            | no   | no             |        | roundabout | x    | x     |
-            | no   | -1             |        |            |      | x     |
-            | no   | -1             | yes    |            |      | x     |
-            | no   | -1             | no     |            |      | x     |
-            | no   | -1             | -1     |            |      | x     |
-            | no   | -1             |        | roundabout |      | x     |
+            | foot | oneway:bicycle | oneway | junction   | forw    | backw   |
+            | no   | yes            |        |            | cycling |         |
+            | no   | yes            | yes    |            | cycling |         |
+            | no   | yes            | no     |            | cycling |         |
+            | no   | yes            | -1     |            | cycling |         |
+            | no   | yes            |        | roundabout | cycling |         |
+            | no   | no             |        |            | cycling | cycling |
+            | no   | no             | yes    |            | cycling | cycling |
+            | no   | no             | no     |            | cycling | cycling |
+            | no   | no             | -1     |            | cycling | cycling |
+            | no   | no             |        | roundabout | cycling | cycling |
+            | no   | -1             |        |            |         | cycling |
+            | no   | -1             | yes    |            |         | cycling |
+            | no   | -1             | no     |            |         | cycling |
+            | no   | -1             | -1     |            |         | cycling |
+            | no   | -1             |        | roundabout |         | cycling |
 
     Scenario: Bike - Contra flow
         Then routability should be
-            | foot | oneway | cycleway       | forw | backw |
-            | no   | yes    | opposite       | x    | x     |
-            | no   | yes    | opposite_track | x    | x     |
-            | no   | yes    | opposite_lane  | x    | x     |
-            | no   | -1     | opposite       | x    | x     |
-            | no   | -1     | opposite_track | x    | x     |
-            | no   | -1     | opposite_lane  | x    | x     |
-            | no   | no     | opposite       | x    | x     |
-            | no   | no     | opposite_track | x    | x     |
-            | no   | no     | opposite_lane  | x    | x     |
+            | foot | oneway | cycleway       | forw    | backw   |
+            | no   | yes    | opposite       | cycling | cycling |
+            | no   | yes    | opposite_track | cycling | cycling |
+            | no   | yes    | opposite_lane  | cycling | cycling |
+            | no   | -1     | opposite       | cycling | cycling |
+            | no   | -1     | opposite_track | cycling | cycling |
+            | no   | -1     | opposite_lane  | cycling | cycling |
+            | no   | no     | opposite       | cycling | cycling |
+            | no   | no     | opposite_track | cycling | cycling |
+            | no   | no     | opposite_lane  | cycling | cycling |
 
     Scenario: Bike - Should not be affected by car tags
         Then routability should be
-            | foot | junction   | oneway | oneway:car | forw | backw |
-            | no   |            | yes    | yes        | x    |       |
-            | no   |            | yes    | no         | x    |       |
-            | no   |            | yes    | -1         | x    |       |
-            | no   |            | no     | yes        | x    | x     |
-            | no   |            | no     | no         | x    | x     |
-            | no   |            | no     | -1         | x    | x     |
-            | no   |            | -1     | yes        |      | x     |
-            | no   |            | -1     | no         |      | x     |
-            | no   |            | -1     | -1         |      | x     |
-            | no   | roundabout |        | yes        | x    |       |
-            | no   | roundabout |        | no         | x    |       |
-            | no   | roundabout |        | -1         | x    |       |
+            | foot | junction   | oneway | oneway:car | forw    | backw   |
+            | no   |            | yes    | yes        | cycling |         |
+            | no   |            | yes    | no         | cycling |         |
+            | no   |            | yes    | -1         | cycling |         |
+            | no   |            | no     | yes        | cycling | cycling |
+            | no   |            | no     | no         | cycling | cycling |
+            | no   |            | no     | -1         | cycling | cycling |
+            | no   |            | -1     | yes        |         | cycling |
+            | no   |            | -1     | no         |         | cycling |
+            | no   |            | -1     | -1         |         | cycling |
+            | no   | roundabout |        | yes        | cycling |         |
+            | no   | roundabout |        | no         | cycling |         |
+            | no   | roundabout |        | -1         | cycling |         |
 
     Scenario: Bike - Two consecutive oneways
         Given the node map

--- a/features/bicycle/pushing.feature
+++ b/features/bicycle/pushing.feature
@@ -3,34 +3,30 @@ Feature: Bike - Accessability of different way types
 
     Background:
         Given the profile "bicycle"
-        Given the shortcuts
-            | key  | value        |
-            | bike | 15 km/h ~20% |
-            | foot | 5 km/h ~20%  |
 
     Scenario: Bike - Pushing bikes on pedestrian-only ways
         Then routability should be
-            | highway    | oneway | forw | backw |
-            | (nil)      |        |      |       |
-            | cycleway   |        | bike | bike  |
-            | primary    |        | bike | bike  |
-            | pedestrian |        | foot | foot  |
-            | footway    |        | foot | foot  |
-            | primary    | yes    | bike | foot  |
+            | highway    | oneway | forw         | backw        |
+            | (nil)      |        |              |              |
+            | cycleway   |        | cycling      | cycling      |
+            | primary    |        | cycling      | cycling      |
+            | pedestrian |        | pushing bike | pushing bike |
+            | cycleway   |        | cycling      | cycling      |
+            | primary    | yes    | cycling      | pushing bike |
 
     Scenario: Bike - Pushing bikes against normal oneways
         Then routability should be
-            | highway    | oneway | forw | backw |
-            | (nil)      |        |      |       |
-            | primary    | yes    | bike | foot  |
-            | pedestrian | yes    | foot | foot  |
+            | highway    | oneway | forw         | backw        |
+            | (nil)      |        |              |              |
+            | primary    | yes    | cycling      | pushing bike |
+            | pedestrian | yes    | pushing bike | pushing bike |
 
     Scenario: Bike - Pushing bikes against reverse oneways
         Then routability should be
-            | highway    | oneway | forw | backw |
-            | (nil)      |        |      |       |
-            | primary    | -1     | foot | bike  |
-            | pedestrian | -1     | foot | foot  |
+            | highway    | oneway | forw         | backw        |
+            | (nil)      |        |              |              |
+            | primary    | -1     | pushing bike | cycling      |
+            | pedestrian | -1     | pushing bike | pushing bike |
 
     @square
     Scenario: Bike - Push bikes on pedestrian areas
@@ -47,7 +43,7 @@ Feature: Bike - Accessability of different way types
             | abcda | yes  | pedestrian |
 
         When I route I should get
-            | from | to | route |
+            | from | to | route       |
             | a    | b  | abcda,abcda |
             | a    | d  | abcda,abcda |
             | b    | c  | abcda,abcda |
@@ -59,19 +55,19 @@ Feature: Bike - Accessability of different way types
 
     Scenario: Bike - Pushing bikes on ways with foot=yes
         Then routability should be
-            | highway  | foot | forw | backw |
-            | motorway |      |      |       |
-            | motorway | yes  | foot |       |
-            | runway   |      |      |       |
-            | runway   | yes  | foot | foot  |
+            | highway  | foot | forw         | backw        |
+            | motorway |      |              |              |
+            | motorway | yes  | pushing bike |              |
+            | runway   |      |              |              |
+            | runway   | yes  | pushing bike | pushing bike |
 
     @todo
     Scenario: Bike - Pushing bikes on ways with foot=yes in one direction
         Then routability should be
-            | highway  | foot:forward | foot:backward | forw | backw |
-            | motorway |              |               |      |       |
-            | motorway | yes          |               | foot |       |
-            | motorway |              | yes           |      | foot  |
+            | highway  | foot:forward | foot:backward | forw         | backw        |
+            | motorway |              |               |              |              |
+            | motorway | yes          |               | pushing bike |              |
+            | motorway |              | yes           |              | pushing bike |
 
     @construction
     Scenario: Bike - Don't allow routing on ways still under construction
@@ -104,11 +100,11 @@ Feature: Bike - Accessability of different way types
             | cf    | primary |        |
 
         When I route I should get
-            | from | to | route       | modes                                   |
-            | a    | d  | ab,bc,cd,cd | cycling,cycling,cycling,cycling         |
-            | d    | a  | cd,bc,ab,ab | cycling,pushing bike,cycling,cycling    |
-            | c    | a  | bc,ab,ab    | pushing bike,cycling,cycling            |
-            | d    | b  | cd,bc,bc    | cycling,pushing bike,pushing bike       |
+            | from | to | route       | modes                                |
+            | a    | d  | ab,bc,cd,cd | cycling,cycling,cycling,cycling      |
+            | d    | a  | cd,bc,ab,ab | cycling,pushing bike,cycling,cycling |
+            | c    | a  | bc,ab,ab    | pushing bike,cycling,cycling         |
+            | d    | b  | cd,bc,bc    | cycling,pushing bike,pushing bike    |
 
     Scenario: Bike - Instructions when pushing bike on footway/pedestrian, etc.
         Given the node map

--- a/features/bicycle/train.feature
+++ b/features/bicycle/train.feature
@@ -7,33 +7,33 @@ Feature: Bike - Handle ferry routes
 
     Scenario: Bike - Bringing bikes on trains
         Then routability should be
-            | highway | railway    | bicycle | bothw |
-            | primary |            |         | x     |
-            | (nil)   | train      |         |       |
-            | (nil)   | train      | no      |       |
-            | (nil)   | train      | yes     | x     |
-            | (nil)   | railway    |         |       |
-            | (nil)   | railway    | no      |       |
-            | (nil)   | railway    | yes     | x     |
-            | (nil)   | subway     |         |       |
-            | (nil)   | subway     | no      |       |
-            | (nil)   | subway     | yes     | x     |
-            | (nil)   | tram       |         |       |
-            | (nil)   | tram       | no      |       |
-            | (nil)   | tram       | yes     | x     |
-            | (nil)   | light_rail |         |       |
-            | (nil)   | light_rail | no      |       |
-            | (nil)   | light_rail | yes     | x     |
-            | (nil)   | monorail   |         |       |
-            | (nil)   | monorail   | no      |       |
-            | (nil)   | monorail   | yes     | x     |
-            | (nil)   | some_tag   |         |       |
-            | (nil)   | some_tag   | no      |       |
-            | (nil)   | some_tag   | yes     | x     |
+            | highway | railway    | bicycle | bothw   |
+            | primary |            |         | cycling |
+            | (nil)   | train      |         |         |
+            | (nil)   | train      | no      |         |
+            | (nil)   | train      | yes     | train   |
+            | (nil)   | railway    |         |         |
+            | (nil)   | railway    | no      |         |
+            | (nil)   | railway    | yes     | train   |
+            | (nil)   | subway     |         |         |
+            | (nil)   | subway     | no      |         |
+            | (nil)   | subway     | yes     | train   |
+            | (nil)   | tram       |         |         |
+            | (nil)   | tram       | no      |         |
+            | (nil)   | tram       | yes     | train   |
+            | (nil)   | light_rail |         |         |
+            | (nil)   | light_rail | no      |         |
+            | (nil)   | light_rail | yes     | train   |
+            | (nil)   | monorail   |         |         |
+            | (nil)   | monorail   | no      |         |
+            | (nil)   | monorail   | yes     | train   |
+            | (nil)   | some_tag   |         |         |
+            | (nil)   | some_tag   | no      |         |
+            | (nil)   | some_tag   | yes     | cycling |
 
     @construction
     Scenario: Bike - Don't route on railways under construction
         Then routability should be
-            | highway | railway      | bicycle | bothw |
-            | primary |              |         | x     |
-            | (nil)   | construction | yes     |       |
+            | highway | railway      | bicycle | bothw   |
+            | primary |              |         | cycling |
+            | (nil)   | construction | yes     |         |

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -62,9 +62,12 @@ module.exports = function () {
                             // rename forw/backw to forw/backw_speed
                             switch (true) {
                             case '' === want:
-                            case 'x' === want:
                                 outputRow[direction] = result[direction].status ?
                                     result[direction].mode : '';
+                                break;
+                            case 'x' === want:
+                                outputRow[direction] = result[direction].status ?
+                                    'x' : '';
                                 break;
                             case /^[\d\.]+ s/.test(want):
                                 // the result here can come back as a non-number value like
@@ -88,7 +91,7 @@ module.exports = function () {
                                 }
                                 break;
                             default:
-                                outputRow[direction] = result[direction].mode || ''
+                                outputRow[direction] = result[direction].mode || '';
                             }
 
                             if (this.FuzzyMatch.match(outputRow[direction], want)) {
@@ -138,7 +141,7 @@ module.exports = function () {
                         // for routability table test, we can assume the mode is the same throughout the route,
                         // since the route is just a single way
                         if( r.json.routes[0].legs[0] && r.json.routes[0].legs[0].steps[0] ) {
-                            r.mode = r.json.routes[0].legs[0].steps[0].mode
+                            r.mode = r.json.routes[0].legs[0].steps[0].mode;
                         }
                     } else {
                         r.status = null;

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -64,7 +64,7 @@ module.exports = function () {
                             case '' === want:
                             case 'x' === want:
                                 outputRow[direction] = result[direction].status ?
-                                    result[direction].status.toString() : '';
+                                    result[direction].mode : '';
                                 break;
                             case /^[\d\.]+ s/.test(want):
                                 // the result here can come back as a non-number value like


### PR DESCRIPTION
# Issue

This PR makes it possible to check for the travel mode in cucumber routability table tests.

Instead of:

```gherking
Scenario: Bike - Pushing bikes on pedestrian-only ways
    Then routability should be
        | highway    | oneway | forw | backw |
        | (nil)      |        |      |       |
        | cycleway   |        | x    | x     |
        | primary    |        | x    | x     |
        | pedestrian |        | x    | x     |
        | cycleway   |        | x    | x     |
        | primary    | yes    | x    | x     |
```

which uses 'x' to check that the direction is routable (by whatever mode), you can now directly specify the mode:

```gherkin
Scenario: Bike - Pushing bikes on pedestrian-only ways
    Then routability should be
        | highway    | oneway | forw         | backw        |
        | (nil)      |        |              |              |
        | cycleway   |        | cycling      | cycling      |
        | primary    |        | cycling      | cycling      |
        | pedestrian |        | pushing bike | pushing bike |
        | cycleway   |        | cycling      | cycling      |
        | primary    | yes    | cycling      | pushing bike |
```

Using 'x' is still supported and works as before.

It make it possible to specify the expected behaviour more accurately in cucumber tests, and is a preparation for further refactoring of the bicycle lua profile, including proper support for bicycle:forward/backward and foot:forward/backward.
 
The PR updates the relevant bicycle tests.

## Tasklist
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

