### PR TITLE
Enable building osrm-extract-conditionals on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_COVERAGE=ON BUILD_COMPONENTS=ON
+      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_COVERAGE=ON ENABLE_SANITIZER=ON BUILD_COMPONENTS=ON
 
     - os: linux
       compiler: "clang-3.9-debug"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,11 @@ add_definitions(-DOSRM_PROJECT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 # include_directories and add_definitions for both
 # this build and for sharing externally via pkg-config
 
-function(add_dependency_includes includes)
-  list(APPEND DEPENDENCIES_INCLUDE_DIRS "${includes}")
-  set(DEPENDENCIES_INCLUDE_DIRS "${DEPENDENCIES_INCLUDE_DIRS}" PARENT_SCOPE)
+function(add_dependency_includes)
+  if(${ARGC} GREATER 0)
+    list(APPEND DEPENDENCIES_INCLUDE_DIRS "${ARGV}")
+    set(DEPENDENCIES_INCLUDE_DIRS "${DEPENDENCIES_INCLUDE_DIRS}" PARENT_SCOPE)
+  endif()
 endfunction(add_dependency_includes)
 
 function(add_dependency_defines defines)
@@ -165,8 +167,8 @@ endif()
 
 # Disable LTO when mason+gcc is detected before testing for / setting any flags.
 # Mason builds libraries with Clang, mixing does not work in the context of lto.
-if(ENABLE_MASON AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(ENABLE_LTO Off)
+if(ENABLE_MASON AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND ENABLE_LTO)
+  set(ENABLE_LTO OFF)
   message(WARNING "Mason and GCC's LTO not work together. Disabling LTO.")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if(ENABLE_MASON)
   set(MASON_LUA_VERSION "5.2.4")
   set(MASON_BZIP2_VERSION "1.0.6")
   set(MASON_TBB_VERSION "2017_20161128")
+  set(MASON_LIBSHP_VERSION "1.3.0")
 
   message(STATUS "Enabling mason")
 
@@ -433,6 +434,10 @@ if(ENABLE_MASON)
   add_dependency_includes(${MASON_PACKAGE_tbb_INCLUDE_DIRS})
   set(TBB_LIBRARIES ${MASON_PACKAGE_tbb_LDFLAGS})
 
+  mason_use(libshp2 VERSION ${MASON_LIBSHP_VERSION})
+  set(LIBSHAPEFILE_INCLUDE_DIR ${MASON_PACKAGE_libshp2_INCLUDE_DIRS})
+  set(LIBSHAPEFILE_LIBRARY ${MASON_PACKAGE_libshp2_LDFLAGS})
+
   if(NOT MASON_PACKAGE_tbb_LIBRARY_DIRS)
     message(FATAL_ERROR "MASON_PACKAGE_tbb_LIBRARY_DIRS is empty, rpath will not work")
   endif()
@@ -652,10 +657,11 @@ if(BUILD_TOOLS)
   install(TARGETS osrm-io-benchmark DESTINATION bin)
 
   find_package(Shapefile) # package libshp-dev
-  if(Shapefile_FOUND)
+  if(SHAPEFILE_FOUND AND (Boost_VERSION VERSION_GREATER 106000 OR ENABLE_MASON))
     add_executable(osrm-extract-conditionals src/tools/extract-conditionals.cpp $<TARGET_OBJECTS:UTIL>)
     target_include_directories(osrm-extract-conditionals PRIVATE ${LIBSHAPEFILE_INCLUDE_DIR})
-    target_link_libraries(osrm-extract-conditionals ${OSMIUM_LIBRARIES} ${BOOST_BASE_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${LIBSHAPEFILE_LIBRARY})
+    target_link_libraries(osrm-extract-conditionals ${OSMIUM_LIBRARIES} ${BOOST_BASE_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARY}
+      ${LIBSHAPEFILE_LIBRARY} ${BZIP2_LIBRARIES} ${ZLIB_LIBRARY} ${EXPAT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     install(TARGETS osrm-extract-conditionals DESTINATION bin)
   endif()
 endif()

--- a/src/tools/extract-conditionals.cpp
+++ b/src/tools/extract-conditionals.cpp
@@ -198,15 +198,17 @@ struct LocatedConditionalRestriction
     ConditionalRestriction restriction;
 };
 
+// clang-format off
 BOOST_FUSION_ADAPT_ADT(LocatedConditionalRestriction,
-                       (obj.restriction.from, obj.restriction.from = val)           //
-                       (obj.restriction.via, obj.restriction.via = val)             //
-                       (obj.restriction.to, obj.restriction.to = val)               //
-                       (obj.restriction.tag, obj.restriction.tag = val)             //
-                       (obj.restriction.value, obj.restriction.value = val)         //
-                       (obj.restriction.condition, obj.restriction.condition = val) //
-                       (obj.location.lon(), obj.location.set_lon(val))              //
-                       (obj.location.lat(), obj.location.set_lat(val)))
+  (osmium::object_id_type, osmium::object_id_type, obj.restriction.from, obj.restriction.from = val)
+  (osmium::object_id_type, osmium::object_id_type, obj.restriction.via, obj.restriction.via = val)
+  (osmium::object_id_type, osmium::object_id_type, obj.restriction.to, obj.restriction.to = val)
+  (std::string, std::string const &, obj.restriction.tag, obj.restriction.tag = val)
+  (std::string, std::string const &, obj.restriction.value, obj.restriction.value = val)
+  (std::string, std::string const &, obj.restriction.condition, obj.restriction.condition = val)
+  (std::int32_t, std::int32_t, obj.location.lon(), obj.location.set_lon(val))
+  (std::int32_t, std::int32_t, obj.location.lat(), obj.location.set_lat(val)))
+// clang-format on
 
 // The first pass relations handler that collects conditional restrictions
 class ConditionalRestrictionsCollector : public osmium::handler::Handler
@@ -311,10 +313,11 @@ class ConditionalRestrictionsHandler : public osmium::handler::Handler
         const auto &nodes = way.nodes();
 
         if (related_vias.find(nodes.front().ref()) != related_vias.end())
-            via_adjacency.push_back({nodes.front().ref(), way.id(), nodes[1].ref()});
+            via_adjacency.push_back(std::make_tuple(nodes.front().ref(), way.id(), nodes[1].ref()));
 
         if (related_vias.find(nodes.back().ref()) != related_vias.end())
-            via_adjacency.push_back({nodes.back().ref(), way.id(), nodes[nodes.size() - 2].ref()});
+            via_adjacency.push_back(
+                std::make_tuple(nodes.back().ref(), way.id(), nodes[nodes.size() - 2].ref()));
     }
 
     template <typename Callback> void process(Callback callback)
@@ -457,14 +460,16 @@ struct LocatedConditionalSpeedLimit
     ConditionalSpeedLimit speed_limit;
 };
 
+// clang-format off
 BOOST_FUSION_ADAPT_ADT(LocatedConditionalSpeedLimit,
-                       (obj.speed_limit.from, obj.speed_limit.from = val)           //
-                       (obj.speed_limit.to, obj.speed_limit.to = val)               //
-                       (obj.speed_limit.tag, obj.speed_limit.tag = val)             //
-                       (obj.speed_limit.value, obj.speed_limit.value = val)         //
-                       (obj.speed_limit.condition, obj.speed_limit.condition = val) //
-                       (obj.location.lon(), obj.location.set_lon(val))              //
-                       (obj.location.lat(), obj.location.set_lat(val)))
+  (osmium::object_id_type, osmium::object_id_type, obj.speed_limit.from, obj.speed_limit.from = val)
+  (osmium::object_id_type, osmium::object_id_type, obj.speed_limit.to, obj.speed_limit.to = val)
+  (std::string, std::string const &, obj.speed_limit.tag, obj.speed_limit.tag = val)
+  (int, int, obj.speed_limit.value, obj.speed_limit.value = val)
+  (std::string, std::string const &, obj.speed_limit.condition, obj.speed_limit.condition = val)
+  (std::int32_t, std::int32_t, obj.location.lon(), obj.location.set_lon(val))
+  (std::int32_t, std::int32_t, obj.location.lat(), obj.location.set_lat(val)))
+// clang-format on
 
 class ConditionalSpeedLimitsCollector : public osmium::handler::Handler
 {


### PR DESCRIPTION
# Issue

PR #3415  did not include building on travis `osrm-extract-conditionals` and was tested only locally.
This PR adds installation of `libshp` and building `osrm-extract-conditionals` on travis.

/cc @karenzshea 

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
PR #3415 
https://github.com/mapbox/mason/pull/364