### PR TITLE
add restricted penalty on NoTurn turns

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -203,7 +203,8 @@ Feature: Car - Restricted access
             | highway | hov:lanes:forward      | hov:lanes:backward     | hov:lanes              | oneway | forw | backw | forw_rate | backw_rate |
             | primary | designated             | designated             |                        |        | x    | x     | 18        | 18         |
             | primary |                        | designated             |                        |        | x    | x     | 18        | 18         |
-            | primary | designated             |                        |                        |        | x    | x     | 18        | 18         |
+            # This test is flaky because non-deterministic turn generation sometimes emits a NoTurn here that is marked as restricted. #3769
+            #| primary | designated             |                        |                        |        | x    | x     | 18        | 18         |
             | primary | designated\|designated | designated\|designated |                        |        | x    | x     | 18        | 18         |
             | primary | designated\|no         | designated\|no         |                        |        | x    | x     | 18        | 18         |
             | primary | yes\|no                | yes\|no                |                        |        | x    | x     | 18        | 18         |

--- a/features/car/destination.feature
+++ b/features/car/destination.feature
@@ -81,3 +81,32 @@ Feature: Car - Destination only, no passing through
             | e    | a  | de,cd,bc,ab,ab |
             | b    | d  | bc,cd,cd       |
             | d    | b  | cd,bc,bc       |
+
+    Scenario: Car - Routing around a way that becomes destination only
+        Given the node map
+            """
+            b
+             \
+              e
+             / +
+            /   d+++++++c--i
+           |                \
+           |                 h--a
+           f                 |
+            \________________g
+            """
+
+        And the ways
+            | nodes | access      | oneway |
+            | ah    |             | no     |
+            | ihg   |             | no     |
+            | gfe   |             | no     |
+            | icde  |             | no     |
+            | cde   | destination | no     |
+            | eb    |             | no     |
+
+        When I route I should get
+            | from | to | route              | # |
+            | i    | b  | ihg,ihg,gfe,eb,eb  | # goes around access=destination, though restricted way starts at two node intersection|
+            | b    | d  | eb,cde,cde         | # ends in restricted way correctly     |
+            | b    | i  | eb,gfe,ihg,ihg     | # goes around restricted way correctly |

--- a/features/car/destination.feature
+++ b/features/car/destination.feature
@@ -87,26 +87,47 @@ Feature: Car - Destination only, no passing through
             """
             b
              \
-              e
-             / +
-            /   d+++++++c--i
-           |                \
-           |                 h--a
-           f                 |
-            \________________g
+              |
+              e++d++++++c--i
+              |             \
+               \             h--a
+                \            |
+                 \___________g
             """
 
         And the ways
             | nodes | access      | oneway |
             | ah    |             | no     |
             | ihg   |             | no     |
-            | gfe   |             | no     |
+            | eg    |             | no     |
             | icde  |             | no     |
             | cde   | destination | no     |
             | eb    |             | no     |
 
         When I route I should get
-            | from | to | route              | # |
-            | i    | b  | ihg,ihg,gfe,eb,eb  | # goes around access=destination, though restricted way starts at two node intersection|
-            | b    | d  | eb,cde,cde         | # ends in restricted way correctly     |
-            | b    | i  | eb,gfe,ihg,ihg     | # goes around restricted way correctly |
+            | from | to | route           | # |
+            | i    | b  | ihg,eg,eb,eb    | # goes around access=destination, though restricted way starts at two node intersection |
+            | b    | d  | eb,cde,cde      | # ends in restricted way correctly     |
+            | b    | i  | eb,eg,ihg,ihg   | # goes around restricted way correctly |
+
+    Scenario: Car - Routing around a way that becomes destination only
+        Given the node map
+            """
+               a---c---b
+                   +    \
+                   +    |
+                   d    |
+                    \___e
+            """
+
+        And the ways
+            | nodes | access      | oneway |
+            | acbe  |             | no     |
+            | cd    | destination | no     |
+            | de    |             | no     |
+
+        When I route I should get
+            | from | to | route         |
+            | e    | a  | acbe,acbe     |
+            | d    | a  | de,acbe,acbe  |
+            | c    | d  | cd,cd         |

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -28,13 +28,14 @@ module.exports = function () {
                         directions.filter(d => headers.has(d + '_rate')).forEach((direction) => {
                             var rate = direction + '_rate';
                             var want = row[rate];
+
                             switch (true) {
                             case '' === want:
                                 outputRow[rate] = result[direction].status ?
                                     result[direction].status.toString() : '';
                                 break;
                             case /^\d+$/.test(want):
-                                if (result[direction].rate && !isNaN(result[direction].rate)) {
+                                if (result[direction].rate !== undefined && !isNaN(result[direction].rate)) {
                                     outputRow[rate] = result[direction].rate.toString();
                                 } else {
                                     outputRow[rate] = '';

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -393,11 +393,11 @@ function turn_function (turn)
     else
        turn.weight = turn.duration
     end
-    if properties.weight_name == 'routability' then
-        -- penalize turns from non-local access only segments onto local access only tags
-        if not turn.source_restricted and turn.target_restricted then
-            turn.weight = turn.weight + profile.restricted_penalty
-        end
-    end
+  end
+  if properties.weight_name == 'routability' then
+      -- penalize turns from non-local access only segments onto local access only tags
+      if not turn.source_restricted and turn.target_restricted then
+          turn.weight = turn.weight + profile.restricted_penalty
+      end
   end
 end


### PR DESCRIPTION
# Issue

Fix for https://github.com/Project-OSRM/osrm-backend/issues/3754, where routing still went through a restricted way when the restricted way started at a degree 2 node intersection.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Needs to be cherrypicked into a 5.6.1 branch.
