### PR TITLE
Fix incorrect forward datasources getter in facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
     - Internals
       - Shared memory notification via conditional variables on Linux or semaphore queue on OS X and Windows with a limit of 128 OSRM Engine instances
 
+# 5.6.2
+  - Changes from 5.6.0
+    - Bugfixes
+      - Fix incorrect forward datasources getter in facade
+
+# 5.6.1
+  - Changes from 5.6.0
+    - Bugfixes
+      - Fix #3754 add restricted penalty on NoTurn turns
+
 # 5.6.0
   - Changes from 5.5
     - Bugfixes

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -36,15 +36,18 @@ Feature: Traffic - speeds
         1,4,27
         4,1,27
         """
-        And I route I should get
-          | from | to | route       | speed   | weights              |
-          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 |
-          | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       |
-          | b    | c  | bc,bc       | 27 km/h | 741.5,0              |
-          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             |
-          | d    | c  | dc,dc       | 36 km/h | 956.8,0              |
-          | g    | b  | fb,fb       | 36 km/h | 164.7,0              |
-          | a    | g  | ad,df,fb,fb | 30 km/h | 1275.7,487.5,304.7,0 |
+        And the query options
+          | annotations | datasources |
+
+        When I route I should get
+          | from | to | route       | speed   | weights              | a:datasources |
+          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0:0       |
+          | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       | 1:0           |
+          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1:0           |
+          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1:0           |
+          | d    | c  | dc,dc       | 36 km/h | 956.8,0              | 0             |
+          | g    | b  | fb,fb       | 36 km/h | 164.7,0              | 0             |
+          | a    | g  | ad,df,fb,fb | 30 km/h | 1275.7,487.5,304.7,0 | 1:0:0         |
 
 
     Scenario: Weighting based on speed file weights, ETA based on file durations
@@ -58,15 +61,18 @@ Feature: Traffic - speeds
         1,4,27,1275.7
         4,1,27,1275.7
         """
-        And I route I should get
-          | from | to | route       | speed   | weights              |
-          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 |
-          | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       |
-          | b    | c  | bc,bc       | 27 km/h | 741.5,0              |
-          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             |
-          | d    | c  | dc,dc       | 36 km/h | 956.8,0              |
-          | g    | b  | ab,ab       | 1 km/h  | 10010.4,0            |
-          | a    | g  | ab,ab       | 1 km/h  | 10010.3,0            |
+        And the query options
+          | annotations | datasources |
+
+        When I route I should get
+          | from | to | route       | speed   | weights              | a:datasources |
+          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0:0       |
+          | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       | 1:0           |
+          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1:0           |
+          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1:0           |
+          | d    | c  | dc,dc       | 36 km/h | 956.8,0              | 0             |
+          | g    | b  | ab,ab       | 1 km/h  | 10010.4,0            | 1:0           |
+          | a    | g  | ab,ab       | 1 km/h  | 10010.3,0            | 1             |
 
 
     Scenario: Weighting based on speed file weights, ETA based on file durations
@@ -87,16 +93,19 @@ Feature: Traffic - speeds
         1,4,1,34445.12
         4,1,1,34445.3
         """
-        And I route I should get
-          | from | to | route       | speed   | weights                     |
-          | a    | b  | ab,ab       | 1 km/h  | 20020.789,0                 |
-          | a    | c  | ab,bc,bc    | 2 km/h  | 20020.789,741.568,0         |
-          | b    | c  | bc,bc       | 27 km/h | 741.568,0                   |
-          | a    | d  | ab,eb,de,de | 2 km/h  | 20020.789,378.169,400.415,0 |
-          | d    | c  | dc,dc       | 36 km/h | 956.805,0                   |
-          | g    | b  | ab,ab       | 1 km/h  | 10010.392,0                 |
-          | a    | g  | ab,ab       | 1 km/h  | 10010.397,0                 |
-          | g    | a  | ab,ab       | 1 km/h  | 10010.064,0                 |
+        And the query options
+          | annotations | datasources |
+
+        When I route I should get
+          | from | to | route       | speed   | weights                     | a:datasources |
+          | a    | b  | ab,ab       | 1 km/h  | 20020.789,0                 | 1:0           |
+          | a    | c  | ab,bc,bc    | 2 km/h  | 20020.789,741.568,0         | 1:1:0         |
+          | b    | c  | bc,bc       | 27 km/h | 741.568,0                   | 1:0           |
+          | a    | d  | ab,eb,de,de | 2 km/h  | 20020.789,378.169,400.415,0 | 1:0:0         |
+          | d    | c  | dc,dc       | 36 km/h | 956.805,0                   | 0             |
+          | g    | b  | ab,ab       | 1 km/h  | 10010.392,0                 | 1:0           |
+          | a    | g  | ab,ab       | 1 km/h  | 10010.397,0                 | 1             |
+          | g    | a  | ab,ab       | 1 km/h  | 10010.064,0                 | 1:1           |
 
 
     Scenario: Speeds that isolate a single node (a)
@@ -113,15 +122,18 @@ Feature: Traffic - speeds
         1,4,0
         4,1,0
         """
-        And I route I should get
-          | from | to | route    | speed   | weights       |
-          | a    | b  | fb,fb    | 36 km/h | 329.4,0       |
-          | a    | c  | fb,bc,bc | 30 km/h | 329.4,741.5,0 |
-          | b    | c  | bc,bc    | 27 km/h | 741.5,0       |
-          | a    | d  | fb,df,df | 36 km/h | 140,487.5,0   |
-          | d    | c  | dc,dc    | 36 km/h | 956.8,0       |
-          | g    | b  | fb,fb    | 36 km/h | 164.7,0       |
-          | a    | g  | fb,fb    | 36 km/h | 164.7,0       |
+        And the query options
+          | annotations | true |
+
+        When I route I should get
+          | from | to | route    | speed   | weights       | a:datasources |
+          | a    | b  | fb,fb    | 36 km/h | 329.4,0       | 0             |
+          | a    | c  | fb,bc,bc | 30 km/h | 329.4,741.5,0 | 0:1:0         |
+          | b    | c  | bc,bc    | 27 km/h | 741.5,0       | 1:0           |
+          | a    | d  | fb,df,df | 36 km/h | 140,487.5,0   | 0:0:0         |
+          | d    | c  | dc,dc    | 36 km/h | 956.8,0       | 0             |
+          | g    | b  | fb,fb    | 36 km/h | 164.7,0       | 0             |
+          | a    | g  | fb,fb    | 36 km/h | 164.7,0       | 0             |
 
 
     Scenario: Verify that negative values cause an error, they're not valid at all

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -864,7 +864,6 @@ class ContiguousInternalMemoryDataFacade : public BaseDataFacade
         }
         else
         {
-            result_datasources.resize(end - begin);
             std::copy(m_datasource_list.begin() + begin,
                       m_datasource_list.begin() + end,
                       std::back_inserter(result_datasources));


### PR DESCRIPTION
# Issue

Forward datasources vector is incorrectly resized, that is a "copy-paste" regression from 3e2db47cc8739098ef8fea0670d3e513134490c3

## Tasklist
 - [x] add regression test
 - [x] review
 - [x] adjust for comments

