### PR TITLE
Only allow restricted access for road of certain highway type

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -165,7 +165,7 @@ Feature: Car - Restricted access
             | motorway    | yes          | permissive |               | private     | x    |       | implied oneway  |
             | trunk       | agricultural | designated | permissive    | no          |      |       |   |
             | pedestrian  |              |            |               |             |      |       |   |
-            | pedestrian  |              |            |               | destination | x    | x     |   |
+            | pedestrian  |              |            |               | destination |      |       | temporary disabled #3773 |
 
     Scenario: Car - Ignore access tags for other modes
         Then routability should be
@@ -262,9 +262,11 @@ Feature: Car - Restricted access
 
     Scenario: Car - a way with a list of tags
         Then routability should be
-            | highway | motor_vehicle            | motor_vehicle:forward | motor_vehicle:backward | forw | backw |
-            | footway |                          |                       | destination            |      | x     |
-            | track   | destination;agricultural | destination           |                        | x    | x     |
+            | highway | motor_vehicle            | motor_vehicle:forward | motor_vehicle:backward | forw | backw | # |
+            | primary |                          | no                    | destination            |      | x     |   |
+            | primary | destination;agricultural | destination           |                        | x    | x     |   |
+            | footway |                          |                       | destination            |      |       | temporary #3373 |
+            | track   | destination;agricultural | destination           |                        |      | x     | temporary #3373 |
 
     Scenario: Car - Don't route over steps even if marked as accessible
         Then routability should be
@@ -280,3 +282,24 @@ Feature: Car - Restricted access
             | steps      | permissive |       |
             | footway    | permissive | x     |
             | garbagetag | permissive | x     |
+
+    Scenario: Car - Access private blacklist
+        Then routability should be
+            | highway    | access     | bothw |
+            | footway    | yes        |   x   |
+            | pedestrian | private    |       |
+            | footway    | private    |       |
+            | service    | private    |       |
+            | cycleway   | private    |       |
+            | track      | private    |       |
+
+    Scenario: Car - Access blacklist
+        Then routability should be
+            | highway    | access       | bothw |
+            | primary    |              |   x   |
+            | primary    | customer     |       |
+            | primary    | emergency    |       |
+            | primary    | forestry     |       |
+            | primary    | agricultural |       |
+            | primary    | psv          |       |
+            | primary    | no           |       |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -67,6 +67,8 @@ local profile = {
 
   restricted_access_tag_list = Set { },
 
+  restricted_highway_whitelist = Set { },
+
   access_tags_hierarchy = Sequence {
   	'bicycle',
   	'vehicle',

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -74,7 +74,11 @@ local profile = {
     'agricultural',
     'forestry',
     'emergency',
-    'psv'
+    'psv',
+    'customer',
+    'private',
+    'delivery',
+    'destination'
   },
 
   restricted_access_tag_list = Set {
@@ -135,6 +139,21 @@ local profile = {
     driveway          = 0.5,
     ["drive-through"] = 0.5,
     ["drive-thru"] = 0.5
+  },
+
+ restricted_highway_whitelist = Set {
+      'motorway',
+      'motorway_link',
+      'trunk',
+      'trunk_link',
+      'primary',
+      'primary_link',
+      'secondary',
+      'secondary_link',
+      'tertiary',
+      'tertiary_link',
+      'residential',
+      'living_street',
   },
 
   route_speeds = {
@@ -259,7 +278,7 @@ function node_function (node, result)
   -- parse access and barrier tags
   local access = find_access_tag(node, profile.access_tags_hierarchy)
   if access then
-    if profile.access_tag_blacklist[access] then
+    if profile.access_tag_blacklist[access] and not profile.restricted_access_tag_list[access] then
       result.barrier = true
     end
   else

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -53,6 +53,8 @@ local profile = {
 
   restricted_access_tag_list = Set { },
 
+  restricted_highway_whitelist = Set { },
+
   access_tags_hierarchy = Sequence {
     'foot',
     'access'

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -212,24 +212,27 @@ function Handlers.handle_access(way,result,data,profile)
   data.forward_access, data.backward_access =
     Tags.get_forward_backward_by_set(way,data,profile.access_tags_hierarchy)
 
-  if profile.access_tag_blacklist[data.forward_access] then
+  -- only allow a subset of roads that are marked as restricted
+  if profile.restricted_highway_whitelist[data.highway] then
+      if profile.restricted_access_tag_list[data.forward_access] then
+          result.forward_restricted = true
+      end
+
+      if profile.restricted_access_tag_list[data.backward_access] then
+          result.backward_restricted = true
+      end
+  end
+
+  if profile.access_tag_blacklist[data.forward_access] and not result.forward_restricted then
     result.forward_mode = mode.inaccessible
   end
 
-  if profile.access_tag_blacklist[data.backward_access] then
+  if profile.access_tag_blacklist[data.backward_access] and not result.backward_restricted then
     result.backward_mode = mode.inaccessible
   end
 
   if result.forward_mode == mode.inaccessible and result.backward_mode == mode.inaccessible then
     return false
-  end
-
-  if profile.restricted_access_tag_list[data.forward_access] then
-      result.forward_restricted = true
-  end
-
-  if profile.restricted_access_tag_list[data.backward_access] then
-      result.backward_restricted = true
   end
 end
 

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_tile)
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    BOOST_CHECK(result.size() > 115000);
+    BOOST_CHECK(result.size() > 114000);
 
     protozero::pbf_reader tile_message(result);
     tile_message.next();


### PR DESCRIPTION
# Issue

This resolves the issue that we were routing on a lot of footpaths and service roads that were tagged as private. This creates some problems when the access tag actually means to allow access there, we would need #3773 for that.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
