### PR TITLE
Fix spelling of access=customer_s_ and add to the restricted list

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -292,14 +292,15 @@ Feature: Car - Restricted access
             | service    | private    |       |
             | cycleway   | private    |       |
             | track      | private    |       |
+            | footway    | customers  |       |
 
     Scenario: Car - Access blacklist
         Then routability should be
             | highway    | access       | bothw |
             | primary    |              |   x   |
-            | primary    | customer     |       |
             | primary    | emergency    |       |
             | primary    | forestry     |       |
             | primary    | agricultural |       |
             | primary    | psv          |       |
             | primary    | no           |       |
+            | primary    | customers    |   x   |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -75,7 +75,7 @@ local profile = {
     'forestry',
     'emergency',
     'psv',
-    'customer',
+    'customers',
     'private',
     'delivery',
     'destination'
@@ -84,7 +84,8 @@ local profile = {
   restricted_access_tag_list = Set {
     'private',
     'delivery',
-    'destination'
+    'destination',
+    'customers',
   },
 
   access_tags_hierarchy = Sequence {


### PR DESCRIPTION
# Issue

Fixes the following routing bug in Tiergarten Berlin:

![broken](https://cloud.githubusercontent.com/assets/606968/23578392/b68ec408-00cd-11e7-803f-9d94b4d97e70.png)

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
