### PR TITLE
Add MSVC flag /bigobj to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   # using Visual Studio C++
   set(BOOST_COMPONENTS ${BOOST_COMPONENTS} zlib)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # avoid compiler error C1128 from scripting_environment_lua.cpp
   add_dependency_defines(-DBOOST_LIB_DIAGNOSTIC)
   add_dependency_defines(-D_CRT_SECURE_NO_WARNINGS)
   add_dependency_defines(-DNOMINMAX) # avoid min and max macros that can break compilation


### PR DESCRIPTION
Fix fatal error [C1128](https://msdn.microsoft.com/en-us/library/8578y171.aspx): number of sections exceeded object file format limit while compiling `src/extractor/scripting_environment_lua.cpp`

------

I noticed the issue when building OSRM with MSVC in Debug configuration only.
Is it preferred to modify the `CMAKE_CXX_FLAGS_DEBUG` only?