### PR TITLE
Allow build with Osmium from external location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,7 +530,9 @@ else()
 
   # note libosmium depends on expat and bzip2
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/cmake")
-  set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include")
+  if(NOT OSMIUM_INCLUDE_DIR)
+    set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include")
+  endif()
   find_package(Osmium REQUIRED COMPONENTS io)
   include_directories(SYSTEM ${OSMIUM_INCLUDE_DIR})
 


### PR DESCRIPTION
If `OSMIUM_INCLUDE_DIR` is specified in CMake command line, use Osmium from that location, instead of `/third_party`.

------

A non-intrusive change in CMake configuration to let override Osmium location.