### PR TITLE
Documents `null` in Table response if no route can be found

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -247,7 +247,7 @@ curl 'http://router.project-osrm.org/table/v1/driving/polyline(egs_Iq_aqAppHzbHu
 
 - `code` if the request was successful `Ok` otherwise see the service dependent and general status codes.
 - `durations` array of arrays that stores the matrix in row-major order. `durations[i][j]` gives the travel time from
-  the i-th waypoint to the j-th waypoint. Values are given in seconds.
+  the i-th waypoint to the j-th waypoint. Values are given in seconds. Can be `null` if no route between `i` and `j` can be found.
 - `sources` array of `Waypoint` objects describing all sources in order
 - `destinations` array of `Waypoint` objects describing all destinations in order
 


### PR DESCRIPTION
Documents `null` in the table response when no route between `i` and `j` can be found:

https://github.com/Project-OSRM/osrm-backend/blob/5.6/include/engine/api/table_api.hpp#L118

The API here is horrible and probably 99% of all users will run into the following issue:
- The user requests a `n x n` table
- We find routes between all locations except between location `i` and `j`
- `table[i][j]` is now `null`
- Javascript happily implicitly converts `null` to `0` in arithmetic contexts
- Code such as `table[i][j] + 42` becomes now `42` even if `table[i][j] === null`

=> The user has to explicitly check for `null` in the response.

cc @ghoshkaj you need to check this.