### PR TITLE
Added bus_trap and sump_buster to barrier whitelist for bicycle profile

### DIFF
--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -39,6 +39,8 @@ local profile = {
   },
 
   barrier_whitelist = Set {
+    'sump_buster',
+    'bus_trap',
     'cycle_barrier',
     'bollard',
     'entrance',


### PR DESCRIPTION
I have been using OSRM a lot for creating cycling routes. I noticed some segments weren't working. After closer inspection I noticed these specific segments had barriers not whitelisted in the bicycle profile.

https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dbus_trap
https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dsump_buster

On those specific pages they even mention that cyclers are allowed. 
I hope this is enough information. Let me know if you need anything else.




