### PR TITLE
Tidying prarameter for the map matching plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Track preprocessing flag in the map matching plugin.
+
 # 5.7.0
   - Changes from 5.6
     - Internals

--- a/docs/http.md
+++ b/docs/http.md
@@ -280,7 +280,7 @@ In addition to the [general options](#general-options) the following options are
 |timestamps  |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamps for the input locations in seconds since UNIX epoch. Timestamps need to be monotonically increasing. |
 |radiuses    |`{radius};{radius}[;{radius} ...]`              |Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy.|
 |gaps        |`split` (default), `ignore`                     |Allows the input track splitting based on huge timestamp gaps between points.             |
-|tidying     |`true`, `false` (default)                       |Allows the input track modification to obtain better matching quality for noisy tracks.   |
+|tidy        |`true`, `false` (default)                       |Allows the input track modification to obtain better matching quality for noisy tracks.   |
 
 |Parameter   |Values                             |
 |------------|-----------------------------------|

--- a/docs/http.md
+++ b/docs/http.md
@@ -274,7 +274,7 @@ In addition to the [general options](#general-options) the following options are
 |Option      |Values                                          |Description                                                                               |
 |------------|------------------------------------------------|------------------------------------------------------------------------------------------|
 |steps       |`true`, `false` (default)                       |Return route steps for each route                                                         |
-|tidying     |`true` (default), `false`                       |Allows the input track modification to obtain better matching quality for noisy tracks.   |
+|preprocess  |`full`, `simple` (default), `false`             |Allows the input track modification to obtain better matching quality for noisy tracks.   |
 |geometries  |`polyline` (default), `polyline6`, `geojson`    |Returned route geometry format (influences overview and per step)                         |
 |annotations |`true`, `false` (default), `nodes`, `distance`, `duration`, `datasources`, `weight`, `speed`  |Returns additional metadata for each coordinate along the route geometry.                 |
 |overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
@@ -315,7 +315,7 @@ All other properties might be undefined.
 
 The trip plugin solves the Traveling Salesman Problem using a greedy heuristic (farthest-insertion algorithm) for 10 or more waypoints and uses brute force for less than 10 waypoints.
 The returned path does not have to be the fastest path. As TSP is NP-hard it only returns an approximation.
-Note that all input coordinates have to be connected for the trip service to work. 
+Note that all input coordinates have to be connected for the trip service to work.
 
 ```endpoint
 GET /trip/v1/{profile}/{coordinates}?roundtrip={true|false}&source{any|first}&destination{any|last}&steps={true|false}&geometries={polyline|polyline6|geojson}&overview={simplified|full|false}&annotations={true|false}'
@@ -335,7 +335,7 @@ In addition to the [general options](#general-options) the following options are
 
 **Fixing Start and End Points**
 
-It is possible to explicitely set the start or end coordinate of the trip. 
+It is possible to explicitely set the start or end coordinate of the trip.
 When source is set to `first`, the first coordinate is used as start coordinate of the trip in the output. When destination is set to `last`, the last coordinate will be used as destination of the trip in the returned output. If you specify `any`, any of the coordinates can be used as the first or last coordinate in the output.
 
 However, if `source=any&destination=any` the returned round-trip will still start at the first input coordinate by default.
@@ -345,7 +345,7 @@ Right now, the following combinations are possible:
 
 | roundtrip | source | destination | supported |
 | :-- | :-- | :-- | :-- |
-| true | first | last | **yes** | 
+| true | first | last | **yes** |
 | true | first | any | **yes** |
 | true | any | last | **yes** |
 | true | any | any | **yes** |

--- a/docs/http.md
+++ b/docs/http.md
@@ -274,12 +274,13 @@ In addition to the [general options](#general-options) the following options are
 |Option      |Values                                          |Description                                                                               |
 |------------|------------------------------------------------|------------------------------------------------------------------------------------------|
 |steps       |`true`, `false` (default)                       |Return route steps for each route                                                         |
-|preprocess  |`full`, `simple` (default), `false`             |Allows the input track modification to obtain better matching quality for noisy tracks.   |
 |geometries  |`polyline` (default), `polyline6`, `geojson`    |Returned route geometry format (influences overview and per step)                         |
 |annotations |`true`, `false` (default), `nodes`, `distance`, `duration`, `datasources`, `weight`, `speed`  |Returns additional metadata for each coordinate along the route geometry.                 |
 |overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|
 |timestamps  |`{timestamp};{timestamp}[;{timestamp} ...]`     |Timestamps for the input locations in seconds since UNIX epoch. Timestamps need to be monotonically increasing. |
 |radiuses    |`{radius};{radius}[;{radius} ...]`              |Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy.|
+|gaps        |`split` (default), `ignore`                     |Allows the input track splitting based on huge timestamp gaps between points.             |
+|tidying     |`true`, `false` (default)                       |Allows the input track modification to obtain better matching quality for noisy tracks.   |
 
 |Parameter   |Values                             |
 |------------|-----------------------------------|

--- a/docs/http.md
+++ b/docs/http.md
@@ -274,6 +274,7 @@ In addition to the [general options](#general-options) the following options are
 |Option      |Values                                          |Description                                                                               |
 |------------|------------------------------------------------|------------------------------------------------------------------------------------------|
 |steps       |`true`, `false` (default)                       |Return route steps for each route                                                         |
+|tidying     |`true` (default), `false`                       |Allows the input track modification to obtain better matching quality for noisy tracks.   |
 |geometries  |`polyline` (default), `polyline6`, `geojson`    |Returned route geometry format (influences overview and per step)                         |
 |annotations |`true`, `false` (default), `nodes`, `distance`, `duration`, `datasources`, `weight`, `speed`  |Returns additional metadata for each coordinate along the route geometry.                 |
 |overview    |`simplified` (default), `full`, `false`         |Add overview geometry either full, simplified according to highest zoom level it could be display on, or not at all.|

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -62,7 +62,7 @@ Feature: Basic Map Matching
         Given a grid size of 100 meters
 
         Given the query options
-            | tidying | true |
+            | tidy | true |
 
         Given the node map
             """
@@ -82,7 +82,7 @@ Feature: Basic Map Matching
         Given a grid size of 100 meters
 
         Given the query options
-            | tidying | true |
+            | tidy | true |
 
         Given the node map
             """
@@ -102,7 +102,7 @@ Feature: Basic Map Matching
         Given a grid size of 8 meters
 
         Given the query options
-            | tidying | true |
+            | tidy | true |
 
         Given the node map
             """

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -78,7 +78,7 @@ Feature: Basic Map Matching
             | trace | timestamps | matchings |
             | abcd | 0 10 20 30  | abcd      |
 
-    Scenario: Testbot - Map matching with trace tidying. Dirty case.
+    Scenario: Testbot - Map matching with trace tidying. Dirty case by ts.
         Given a grid size of 100 meters
 
         Given the query options
@@ -97,6 +97,26 @@ Feature: Basic Map Matching
         When I match I should get
             | trace | timestamps    | matchings |
             | abacd | 0 10 12 20 30 | abcd      |
+
+    Scenario: Testbot - Map matching with trace tidying. Dirty case by dist.
+        Given a grid size of 8 meters
+
+        Given the query options
+            | tidying | true |
+
+        Given the node map
+            """
+            a q b c d
+                e
+            """
+
+        And the ways
+            | nodes | oneway |
+            | aqbcd | no     |
+
+        When I match I should get
+            | trace | matchings |
+            | abcbd | abbd      |
 
     Scenario: Testbot - Map matching with core factor
         Given the contract extra arguments "--core 0.8"

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -40,6 +40,64 @@ Feature: Basic Map Matching
             | trace | timestamps | matchings |
             | abcd  | 0 1 62 63  | ab,cd     |
 
+    Scenario: Testbot - Map matching with trace splitting suppression
+        Given the query options
+            | gaps | ignore |
+
+        Given the node map
+            """
+            a b c d
+                e
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | timestamps | matchings |
+            | abcd  | 0 1 62 63  | abcd      |
+
+    Scenario: Testbot - Map matching with trace tidying. Clean case.
+        Given a grid size of 100 meters
+
+        Given the query options
+            | tidying | true |
+
+        Given the node map
+            """
+            a b c d
+                e
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | timestamps | matchings |
+            | abcd | 0 10 20 30  | abcd      |
+
+    Scenario: Testbot - Map matching with trace tidying. Dirty case.
+        Given a grid size of 100 meters
+
+        Given the query options
+            | tidying | true |
+
+        Given the node map
+            """
+            a b c d
+                e
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | timestamps    | matchings |
+            | abacd | 0 10 12 20 30 | abcd      |
+
     Scenario: Testbot - Map matching with core factor
         Given the contract extra arguments "--core 0.8"
         Given the node map

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -63,23 +63,20 @@ struct MatchParameters : public RouteParameters
                           RouteParameters::GeometriesType::Polyline,
                           RouteParameters::OverviewType::Simplified,
                           {}),
-          gaps_processing(GapsType::Split), use_tidying(false)
+          gaps(GapsType::Split), tidy(false)
     {
     }
 
     template <typename... Args>
-    MatchParameters(std::vector<unsigned> timestamps_,
-                    GapsType gaps_processing_,
-                    bool use_tidying_,
-                    Args... args_)
+    MatchParameters(std::vector<unsigned> timestamps_, GapsType gaps_, bool tidy_, Args... args_)
         : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)},
-          gaps_processing(gaps_processing_), use_tidying(use_tidying_)
+          gaps(gaps_), tidy(tidy_)
     {
     }
 
     std::vector<unsigned> timestamps;
-    GapsType gaps_processing;
-    bool use_tidying;
+    GapsType gaps;
+    bool tidy;
 
     bool IsValid() const
     {

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -63,13 +63,17 @@ struct MatchParameters : public RouteParameters
                           false,
                           RouteParameters::GeometriesType::Polyline,
                           RouteParameters::OverviewType::Simplified,
-                          {}), track_preprocessing(PreprocessingType::Simple)
+                          {}),
+          track_preprocessing(PreprocessingType::Simple)
     {
     }
 
     template <typename... Args>
-    MatchParameters(std::vector<unsigned> timestamps_, PreprocessingType track_preprocessing_, Args... args_)
-        : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)}, track_preprocessing(track_preprocessing_)
+    MatchParameters(std::vector<unsigned> timestamps_,
+                    PreprocessingType track_preprocessing_,
+                    Args... args_)
+        : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)},
+          track_preprocessing(track_preprocessing_)
     {
     }
 

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -50,24 +50,31 @@ namespace api
  */
 struct MatchParameters : public RouteParameters
 {
+    enum class PreprocessingType
+    {
+        False,
+        Simple,
+        Full
+    };
+
     MatchParameters()
         : RouteParameters(false,
                           false,
                           false,
                           RouteParameters::GeometriesType::Polyline,
                           RouteParameters::OverviewType::Simplified,
-                          {}), use_tidying(true)
+                          {}), track_preprocessing(PreprocessingType::Simple)
     {
     }
 
     template <typename... Args>
-    MatchParameters(std::vector<unsigned> timestamps_, bool use_tidying_, Args... args_)
-        : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)}, use_tidying(use_tidying_)
+    MatchParameters(std::vector<unsigned> timestamps_, PreprocessingType track_preprocessing_, Args... args_)
+        : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)}, track_preprocessing(track_preprocessing_)
     {
     }
 
     std::vector<unsigned> timestamps;
-    bool use_tidying;
+    PreprocessingType track_preprocessing;
 
     bool IsValid() const
     {

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -61,12 +61,13 @@ struct MatchParameters : public RouteParameters
     }
 
     template <typename... Args>
-    MatchParameters(std::vector<unsigned> timestamps_, Args... args_)
-        : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)}
+    MatchParameters(std::vector<unsigned> timestamps_, bool use_tidying_, Args... args_)
+        : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)}, use_tidying(use_tidying_)
     {
     }
 
     std::vector<unsigned> timestamps;
+    bool use_tidying = true;
     bool IsValid() const
     {
         return RouteParameters::IsValid() &&

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -50,11 +50,10 @@ namespace api
  */
 struct MatchParameters : public RouteParameters
 {
-    enum class PreprocessingType
+    enum class GapsType
     {
-        False,
-        Simple,
-        Full
+        Split,
+        Ignore
     };
 
     MatchParameters()
@@ -64,21 +63,23 @@ struct MatchParameters : public RouteParameters
                           RouteParameters::GeometriesType::Polyline,
                           RouteParameters::OverviewType::Simplified,
                           {}),
-          track_preprocessing(PreprocessingType::Simple)
+          gaps_processing(GapsType::Split), use_tidying(false)
     {
     }
 
     template <typename... Args>
     MatchParameters(std::vector<unsigned> timestamps_,
-                    PreprocessingType track_preprocessing_,
+                    GapsType gaps_processing_,
+                    bool use_tidying_,
                     Args... args_)
         : RouteParameters{std::forward<Args>(args_)...}, timestamps{std::move(timestamps_)},
-          track_preprocessing(track_preprocessing_)
+          gaps_processing(gaps_processing_), use_tidying(use_tidying_)
     {
     }
 
     std::vector<unsigned> timestamps;
-    PreprocessingType track_preprocessing;
+    GapsType gaps_processing;
+    bool use_tidying;
 
     bool IsValid() const
     {

--- a/include/engine/api/match_parameters.hpp
+++ b/include/engine/api/match_parameters.hpp
@@ -56,7 +56,7 @@ struct MatchParameters : public RouteParameters
                           false,
                           RouteParameters::GeometriesType::Polyline,
                           RouteParameters::OverviewType::Simplified,
-                          {})
+                          {}), use_tidying(true)
     {
     }
 
@@ -67,7 +67,8 @@ struct MatchParameters : public RouteParameters
     }
 
     std::vector<unsigned> timestamps;
-    bool use_tidying = true;
+    bool use_tidying;
+
     bool IsValid() const
     {
         return RouteParameters::IsValid() &&

--- a/include/engine/api/match_parameters_tidy.hpp
+++ b/include/engine/api/match_parameters_tidy.hpp
@@ -1,0 +1,138 @@
+#ifndef COORDINATE_TIDY
+#define COORDINATE_TIDY
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+
+#include "engine/api/match_parameters.hpp"
+#include "util/coordinate_calculation.hpp"
+
+#include <boost/assert.hpp>
+#include <boost/dynamic_bitset.hpp>
+
+namespace osrm
+{
+namespace engine
+{
+namespace api
+{
+namespace tidy
+{
+
+struct Thresholds
+{
+    double distance_in_meters;
+    std::int32_t duration_in_seconds;
+};
+
+using Mask = boost::dynamic_bitset<>;
+using Mapping = std::vector<std::size_t>;
+
+struct Result
+{
+    // Tidied parameters
+    MatchParameters parameters;
+    // Masking the MatchParameter parallel arrays for items which should be removed.
+    Mask can_be_removed;
+    // Maps the MatchParameter's original items to items which should not be removed.
+    Mapping original_to_tidied;
+};
+
+inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
+{
+    Result result;
+
+    result.can_be_removed.reserve(params.coordinates.size());
+    result.original_to_tidied.reserve(params.coordinates.size());
+
+    result.can_be_removed.push_back(false);
+    result.original_to_tidied.push_back(0);
+    std::size_t last_good = 0;
+
+    const auto uses_timestamps = !params.timestamps.empty();
+
+    Thresholds running{0., 0};
+
+    // Walk over adjacent (coord, ts)-pairs, with rhs being the candidate to discard or keep
+    for (std::size_t current = 0; current < params.coordinates.size() - 1; ++current)
+    {
+        const auto next = current + 1;
+
+        auto distance_delta = util::coordinate_calculation::haversineDistance(
+            params.coordinates[current], params.coordinates[next]);
+        running.distance_in_meters += distance_delta;
+        const auto over_distance = running.distance_in_meters >= cfg.distance_in_meters;
+
+        if (uses_timestamps)
+        {
+            auto duration_delta = params.timestamps[next] - params.timestamps[current];
+            running.duration_in_seconds += duration_delta;
+            const auto over_duration = running.duration_in_seconds >= cfg.duration_in_seconds;
+
+            if (over_distance && over_duration)
+            {
+                result.can_be_removed.push_back(false);
+                last_good = next;
+                running = {0., 0}; // reset running distance and time
+            }
+            else
+            {
+                result.can_be_removed.push_back(true);
+            }
+        }
+        else
+        {
+            if (over_distance)
+            {
+                result.can_be_removed.push_back(false);
+                last_good = next;
+                running = {0., 0}; // reset running distance and time
+            }
+            else
+            {
+                result.can_be_removed.push_back(true);
+            }
+        }
+
+        result.original_to_tidied.push_back(last_good);
+    }
+
+    BOOST_ASSERT(result.original_to_tidied.size() == params.coordinates.size());
+    BOOST_ASSERT(result.can_be_removed.size() == params.coordinates.size());
+    BOOST_ASSERT(std::is_sorted(begin(result.original_to_tidied), end(result.original_to_tidied)));
+
+    // We have to filter parallel arrays that may be empty or the exact same size.
+    // result.parameters contains an empty MatchParameters at this point: conditionally fill.
+
+    const auto to_keep = result.can_be_removed.size() - result.can_be_removed.count();
+
+    for (std::size_t i = 0; i < result.can_be_removed.size(); ++i)
+    {
+        if (!result.can_be_removed[i])
+        {
+            result.parameters.coordinates.push_back(params.coordinates[i]);
+
+            if (!params.hints.empty())
+                result.parameters.hints.push_back(params.hints[i]);
+
+            if (!params.radiuses.empty())
+                result.parameters.radiuses.push_back(params.radiuses[i]);
+
+            if (!params.bearings.empty())
+                result.parameters.bearings.push_back(params.bearings[i]);
+
+            if (!params.timestamps.empty())
+                result.parameters.timestamps.push_back(params.timestamps[i]);
+        }
+    }
+
+    return result;
+}
+
+} // ns tidy
+} // ns api
+} // ns engine
+} // ns osrm
+
+#endif

--- a/include/engine/api/match_parameters_tidy.hpp
+++ b/include/engine/api/match_parameters_tidy.hpp
@@ -43,10 +43,10 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
 {
     Result result;
 
-    result.can_be_removed.reserve(params.coordinates.size());
+    result.can_be_removed.resize(params.coordinates.size(), false);
     result.original_to_tidied.reserve(params.coordinates.size());
 
-    result.can_be_removed.push_back(false);
+    result.can_be_removed.set(0, false);
     result.original_to_tidied.push_back(0);
     std::size_t last_good = 0;
 
@@ -72,26 +72,26 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
 
             if (over_distance && over_duration)
             {
-                result.can_be_removed.push_back(false);
+                result.can_be_removed.set(next, false);
                 last_good = next;
                 running = {0., 0}; // reset running distance and time
             }
             else
             {
-                result.can_be_removed.push_back(true);
+                result.can_be_removed.set(next, true);
             }
         }
         else
         {
             if (over_distance)
             {
-                result.can_be_removed.push_back(false);
+                result.can_be_removed.set(next, false);
                 last_good = next;
                 running = {0., 0}; // reset running distance and time
             }
             else
             {
-                result.can_be_removed.push_back(true);
+                result.can_be_removed.set(next, true);
             }
         }
 

--- a/include/engine/api/match_parameters_tidy.hpp
+++ b/include/engine/api/match_parameters_tidy.hpp
@@ -84,7 +84,6 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
 
     result.can_be_removed.resize(params.coordinates.size(), false);
 
-    result.can_be_removed.set(0, false);
     result.tidied_to_original.push_back(0);
     std::size_t last_good = 0;
 
@@ -110,7 +109,6 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
 
             if (over_distance && over_duration)
             {
-                result.can_be_removed.set(next, false);
                 last_good = next;
                 result.tidied_to_original.push_back(next);
                 running = {0., 0}; // reset running distance and time
@@ -124,7 +122,6 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
         {
             if (over_distance)
             {
-                result.can_be_removed.set(next, false);
                 last_good = next;
                 result.tidied_to_original.push_back(next);
                 running = {0., 0}; // reset running distance and time

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -80,12 +80,12 @@ template <typename AlgorithmT> class RoutingAlgorithms final : public RoutingAlg
                      const std::vector<std::size_t> &source_indices,
                      const std::vector<std::size_t> &target_indices) const final override;
 
-    routing_algorithms::SubMatchingList MapMatching(
-        const routing_algorithms::CandidateLists &candidates_list,
-        const std::vector<util::Coordinate> &trace_coordinates,
-        const std::vector<unsigned> &trace_timestamps,
-        const std::vector<boost::optional<double>> &trace_gps_precision,
-        const bool use_tidying) const final override;
+    routing_algorithms::SubMatchingList
+    MapMatching(const routing_algorithms::CandidateLists &candidates_list,
+                const std::vector<util::Coordinate> &trace_coordinates,
+                const std::vector<unsigned> &trace_timestamps,
+                const std::vector<boost::optional<double>> &trace_gps_precision,
+                const bool use_tidying) const final override;
 
     std::vector<routing_algorithms::TurnData>
     GetTileTurns(const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &edges,
@@ -168,8 +168,13 @@ inline routing_algorithms::SubMatchingList RoutingAlgorithms<AlgorithmT>::MapMat
     const std::vector<boost::optional<double>> &trace_gps_precision,
     const bool use_tidying) const
 {
-    return routing_algorithms::mapMatching(
-        heaps, facade, candidates_list, trace_coordinates, trace_timestamps, trace_gps_precision, use_tidying);
+    return routing_algorithms::mapMatching(heaps,
+                                           facade,
+                                           candidates_list,
+                                           trace_coordinates,
+                                           trace_timestamps,
+                                           trace_gps_precision,
+                                           use_tidying);
 }
 
 template <typename AlgorithmT>

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -38,7 +38,8 @@ class RoutingAlgorithmsInterface
     MapMatching(const routing_algorithms::CandidateLists &candidates_list,
                 const std::vector<util::Coordinate> &trace_coordinates,
                 const std::vector<unsigned> &trace_timestamps,
-                const std::vector<boost::optional<double>> &trace_gps_precision) const = 0;
+                const std::vector<boost::optional<double>> &trace_gps_precision,
+                const bool use_tidying) const = 0;
 
     virtual std::vector<routing_algorithms::TurnData>
     GetTileTurns(const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &edges,
@@ -83,7 +84,8 @@ template <typename AlgorithmT> class RoutingAlgorithms final : public RoutingAlg
         const routing_algorithms::CandidateLists &candidates_list,
         const std::vector<util::Coordinate> &trace_coordinates,
         const std::vector<unsigned> &trace_timestamps,
-        const std::vector<boost::optional<double>> &trace_gps_precision) const final override;
+        const std::vector<boost::optional<double>> &trace_gps_precision,
+        const bool use_tidying) const final override;
 
     std::vector<routing_algorithms::TurnData>
     GetTileTurns(const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &edges,
@@ -163,10 +165,11 @@ inline routing_algorithms::SubMatchingList RoutingAlgorithms<AlgorithmT>::MapMat
     const routing_algorithms::CandidateLists &candidates_list,
     const std::vector<util::Coordinate> &trace_coordinates,
     const std::vector<unsigned> &trace_timestamps,
-    const std::vector<boost::optional<double>> &trace_gps_precision) const
+    const std::vector<boost::optional<double>> &trace_gps_precision,
+    const bool use_tidying) const
 {
     return routing_algorithms::mapMatching(
-        heaps, facade, candidates_list, trace_coordinates, trace_timestamps, trace_gps_precision);
+        heaps, facade, candidates_list, trace_coordinates, trace_timestamps, trace_gps_precision, use_tidying);
 }
 
 template <typename AlgorithmT>
@@ -214,7 +217,8 @@ inline routing_algorithms::SubMatchingList
 RoutingAlgorithms<algorithm::MLD>::MapMatching(const routing_algorithms::CandidateLists &,
                                                const std::vector<util::Coordinate> &,
                                                const std::vector<unsigned> &,
-                                               const std::vector<boost::optional<double>> &) const
+                                               const std::vector<boost::optional<double>> &,
+                                               const bool) const
 {
     throw util::exception("MapMatching is not implemented");
 }

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -39,7 +39,7 @@ class RoutingAlgorithmsInterface
                 const std::vector<util::Coordinate> &trace_coordinates,
                 const std::vector<unsigned> &trace_timestamps,
                 const std::vector<boost::optional<double>> &trace_gps_precision,
-                const bool use_tidying) const = 0;
+                const bool allow_splitting) const = 0;
 
     virtual std::vector<routing_algorithms::TurnData>
     GetTileTurns(const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &edges,
@@ -85,7 +85,7 @@ template <typename AlgorithmT> class RoutingAlgorithms final : public RoutingAlg
                 const std::vector<util::Coordinate> &trace_coordinates,
                 const std::vector<unsigned> &trace_timestamps,
                 const std::vector<boost::optional<double>> &trace_gps_precision,
-                const bool use_tidying) const final override;
+                const bool allow_splitting) const final override;
 
     std::vector<routing_algorithms::TurnData>
     GetTileTurns(const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &edges,
@@ -166,7 +166,7 @@ inline routing_algorithms::SubMatchingList RoutingAlgorithms<AlgorithmT>::MapMat
     const std::vector<util::Coordinate> &trace_coordinates,
     const std::vector<unsigned> &trace_timestamps,
     const std::vector<boost::optional<double>> &trace_gps_precision,
-    const bool use_tidying) const
+    const bool allow_splitting) const
 {
     return routing_algorithms::mapMatching(heaps,
                                            facade,
@@ -174,7 +174,7 @@ inline routing_algorithms::SubMatchingList RoutingAlgorithms<AlgorithmT>::MapMat
                                            trace_coordinates,
                                            trace_timestamps,
                                            trace_gps_precision,
-                                           use_tidying);
+                                           allow_splitting);
 }
 
 template <typename AlgorithmT>

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -28,7 +28,8 @@ mapMatching(SearchEngineData &engine_working_data,
             const CandidateLists &candidates_list,
             const std::vector<util::Coordinate> &trace_coordinates,
             const std::vector<unsigned> &trace_timestamps,
-            const std::vector<boost::optional<double>> &trace_gps_precision);
+            const std::vector<boost::optional<double>> &trace_gps_precision,
+            const bool use_tidying);
 
 SubMatchingList
 mapMatching(SearchEngineData &engine_working_data,
@@ -36,7 +37,8 @@ mapMatching(SearchEngineData &engine_working_data,
             const CandidateLists &candidates_list,
             const std::vector<util::Coordinate> &trace_coordinates,
             const std::vector<unsigned> &trace_timestamps,
-            const std::vector<boost::optional<double>> &trace_gps_precision);
+            const std::vector<boost::optional<double>> &trace_gps_precision,
+            const bool use_tidying);
 }
 }
 }

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -29,7 +29,7 @@ mapMatching(SearchEngineData &engine_working_data,
             const std::vector<util::Coordinate> &trace_coordinates,
             const std::vector<unsigned> &trace_timestamps,
             const std::vector<boost::optional<double>> &trace_gps_precision,
-            const bool use_tidying);
+            const bool allow_splitting);
 
 SubMatchingList
 mapMatching(SearchEngineData &engine_working_data,
@@ -38,7 +38,7 @@ mapMatching(SearchEngineData &engine_working_data,
             const std::vector<util::Coordinate> &trace_coordinates,
             const std::vector<unsigned> &trace_timestamps,
             const std::vector<boost::optional<double>> &trace_gps_precision,
-            const bool use_tidying);
+            const bool allow_splitting);
 }
 }
 }

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -38,14 +38,12 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
 
         root_rule =
             BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
-            -('?' >
-              (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) |
-               (qi::lit("gaps=") >
-                gaps_type[ph::bind(&engine::api::MatchParameters::gaps_processing, qi::_r1) =
-                              qi::_1]) |
-               (qi::lit("tidying=") > qi::bool_[ph::bind(&engine::api::MatchParameters::use_tidying,
-                                                         qi::_r1) = qi::_1])) %
-                  '&');
+            -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) |
+                     (qi::lit("gaps=") >
+                      gaps_type[ph::bind(&engine::api::MatchParameters::gaps, qi::_r1) = qi::_1]) |
+                     (qi::lit("tidy=") >
+                      qi::bool_[ph::bind(&engine::api::MatchParameters::tidy, qi::_r1) = qi::_1])) %
+                        '&');
     }
 
   private:

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -34,7 +34,9 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
              ';')[ph::bind(&engine::api::MatchParameters::timestamps, qi::_r1) = qi::_1];
 
         root_rule = BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
-                    -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1)) % '&');
+                    -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) | (
+                    qi::lit("tidying=") > qi::bool_[ph::bind(&engine::api::MatchParameters::use_tidying,
+                    qi::_r1) = qi::_1])) % '&');
     }
 
   private:

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -33,17 +33,18 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
             (qi::uint_ %
              ';')[ph::bind(&engine::api::MatchParameters::timestamps, qi::_r1) = qi::_1];
 
-        preprocessing_type.add("simple", engine::api::MatchParameters::PreprocessingType::Simple)(
-            "full", engine::api::MatchParameters::PreprocessingType::Full)(
-            "false", engine::api::MatchParameters::PreprocessingType::False);
+        gaps_type.add("split", engine::api::MatchParameters::GapsType::Split)(
+            "ignore", engine::api::MatchParameters::GapsType::Ignore);
 
         root_rule =
             BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
             -('?' >
               (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) |
-               (qi::lit("preprocess=") >
-                preprocessing_type[ph::bind(&engine::api::MatchParameters::track_preprocessing,
-                                            qi::_r1) = qi::_1])) %
+               (qi::lit("gaps=") >
+                gaps_type[ph::bind(&engine::api::MatchParameters::gaps_processing, qi::_r1) =
+                              qi::_1]) |
+               (qi::lit("tidying=") > qi::bool_[ph::bind(&engine::api::MatchParameters::use_tidying,
+                                                         qi::_r1) = qi::_1])) %
                   '&');
     }
 
@@ -51,7 +52,7 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
     qi::rule<Iterator, Signature> root_rule;
     qi::rule<Iterator, Signature> timestamps_rule;
 
-    qi::symbols<char, engine::api::MatchParameters::PreprocessingType> preprocessing_type;
+    qi::symbols<char, engine::api::MatchParameters::GapsType> gaps_type;
 };
 }
 }

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -34,14 +34,17 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
              ';')[ph::bind(&engine::api::MatchParameters::timestamps, qi::_r1) = qi::_1];
 
         preprocessing_type.add("simple", engine::api::MatchParameters::PreprocessingType::Simple)(
-                               "full", engine::api::MatchParameters::PreprocessingType::Full)(
-                               "false", engine::api::MatchParameters::PreprocessingType::False);
+            "full", engine::api::MatchParameters::PreprocessingType::Full)(
+            "false", engine::api::MatchParameters::PreprocessingType::False);
 
-
-        root_rule = BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
-                    -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) | (
-                    qi::lit("preprocess=") > preprocessing_type[ph::bind(&engine::api::MatchParameters::track_preprocessing, qi::_r1) = qi::_1])
-                    ) % '&');
+        root_rule =
+            BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
+            -('?' >
+              (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) |
+               (qi::lit("preprocess=") >
+                preprocessing_type[ph::bind(&engine::api::MatchParameters::track_preprocessing,
+                                            qi::_r1) = qi::_1])) %
+                  '&');
     }
 
   private:

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -33,15 +33,22 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
             (qi::uint_ %
              ';')[ph::bind(&engine::api::MatchParameters::timestamps, qi::_r1) = qi::_1];
 
+        preprocessing_type.add("simple", engine::api::MatchParameters::PreprocessingType::Simple)(
+                               "full", engine::api::MatchParameters::PreprocessingType::Full)(
+                               "false", engine::api::MatchParameters::PreprocessingType::False);
+
+
         root_rule = BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
                     -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) | (
-                    qi::lit("tidying=") > qi::bool_[ph::bind(&engine::api::MatchParameters::use_tidying,
-                    qi::_r1) = qi::_1])) % '&');
+                    qi::lit("preprocess=") > preprocessing_type[ph::bind(&engine::api::MatchParameters::track_preprocessing, qi::_r1) = qi::_1])
+                    ) % '&');
     }
 
   private:
     qi::rule<Iterator, Signature> root_rule;
     qi::rule<Iterator, Signature> timestamps_rule;
+
+    qi::symbols<char, engine::api::MatchParameters::PreprocessingType> preprocessing_type;
 };
 }
 }

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -148,7 +148,7 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
 
     SubMatchingList sub_matchings;
     api::tidy::Result tidied;
-    if (parameters.use_tidying)
+    if (parameters.tidy)
     {
         // Transparently tidy match parameters, do map matching on tidied parameters.
         // Then use the mapping to restore the original <-> tidied relationship.
@@ -207,7 +207,7 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
                                tidied.parameters.coordinates,
                                tidied.parameters.timestamps,
                                tidied.parameters.radiuses,
-                               parameters.gaps_processing == api::MatchParameters::GapsType::Split);
+                               parameters.gaps == api::MatchParameters::GapsType::Split);
 
     if (sub_matchings.size() == 0)
     {

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -175,7 +175,7 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
     }
 
     SubMatchingList sub_matchings;
-    if (parameters.track_preprocessing == api::MatchParameters::PreprocessingType::Full)
+    if (parameters.use_tidying)
     {
         // Transparently tidy match parameters, do map matching on tidied parameters.
         // Then use the mapping to restore the original <-> tidied relationship.
@@ -197,12 +197,12 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
         }
 
         // call the actual map matching
-        sub_matchings = algorithms.MapMatching(
-            candidates_lists,
-            tidied.parameters.coordinates,
-            tidied.parameters.timestamps,
-            tidied.parameters.radiuses,
-            !(parameters.track_preprocessing == api::MatchParameters::PreprocessingType::False));
+        sub_matchings = algorithms.MapMatching(candidates_lists,
+                                               tidied.parameters.coordinates,
+                                               tidied.parameters.timestamps,
+                                               tidied.parameters.radiuses,
+                                               parameters.gaps_processing ==
+                                                   api::MatchParameters::GapsType::Split);
     }
     else
     {
@@ -222,12 +222,12 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
         }
 
         // call the actual map matching
-        sub_matchings = algorithms.MapMatching(
-            candidates_lists,
-            parameters.coordinates,
-            parameters.timestamps,
-            parameters.radiuses,
-            !(parameters.track_preprocessing == api::MatchParameters::PreprocessingType::False));
+        sub_matchings = algorithms.MapMatching(candidates_lists,
+                                               parameters.coordinates,
+                                               parameters.timestamps,
+                                               parameters.radiuses,
+                                               parameters.gaps_processing ==
+                                                   api::MatchParameters::GapsType::Split);
     }
 
     if (sub_matchings.size() == 0)

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -189,7 +189,7 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
 
     // call the actual map matching
     SubMatchingList sub_matchings = algorithms.MapMatching(
-        candidates_lists, parameters.coordinates, parameters.timestamps, parameters.radiuses);
+        candidates_lists, parameters.coordinates, parameters.timestamps, parameters.radiuses, parameters.use_tidying);
 
     if (sub_matchings.size() == 0)
     {

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -177,32 +177,32 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
     SubMatchingList sub_matchings;
     if (parameters.track_preprocessing == api::MatchParameters::PreprocessingType::Full)
     {
-    // Transparently tidy match parameters, do map matching on tidied parameters.
-    // Then use the mapping to restore the original <-> tidied relationship.
-    auto tidied = api::tidy::tidy(parameters);
+        // Transparently tidy match parameters, do map matching on tidied parameters.
+        // Then use the mapping to restore the original <-> tidied relationship.
+        auto tidied = api::tidy::tidy(parameters);
 
-    // TODO is search radiuses still actual
-    auto candidates_lists = GetPhantomNodesInRange(facade, tidied.parameters, search_radiuses);
+        // TODO is search radiuses still actual
+        auto candidates_lists = GetPhantomNodesInRange(facade, tidied.parameters, search_radiuses);
 
-    filterCandidates(tidied.parameters.coordinates, candidates_lists);
-    if (std::all_of(candidates_lists.begin(),
-                    candidates_lists.end(),
-                    [](const std::vector<PhantomNodeWithDistance> &candidates) {
-                        return candidates.empty();
-                    }))
-    {
-        return Error("NoSegment",
-                     std::string("Could not find a matching segment for any coordinate."),
-                     json_result);
-    }
+        filterCandidates(tidied.parameters.coordinates, candidates_lists);
+        if (std::all_of(candidates_lists.begin(),
+                        candidates_lists.end(),
+                        [](const std::vector<PhantomNodeWithDistance> &candidates) {
+                            return candidates.empty();
+                        }))
+        {
+            return Error("NoSegment",
+                         std::string("Could not find a matching segment for any coordinate."),
+                         json_result);
+        }
 
-    // call the actual map matching
-    sub_matchings = algorithms.MapMatching(
-                                                 candidates_lists,
-                                                 tidied.parameters.coordinates,
-                                                 tidied.parameters.timestamps,
-                                                 tidied.parameters.radiuses,
-                                                !(parameters.track_preprocessing == api::MatchParameters::PreprocessingType::False));
+        // call the actual map matching
+        sub_matchings = algorithms.MapMatching(
+            candidates_lists,
+            tidied.parameters.coordinates,
+            tidied.parameters.timestamps,
+            tidied.parameters.radiuses,
+            !(parameters.track_preprocessing == api::MatchParameters::PreprocessingType::False));
     }
     else
     {
@@ -223,11 +223,11 @@ Status MatchPlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
 
         // call the actual map matching
         sub_matchings = algorithms.MapMatching(
-                                               candidates_lists,
-                                               parameters.coordinates,
-                                               parameters.timestamps,
-                                               parameters.radiuses,
-                                               !(parameters.track_preprocessing == api::MatchParameters::PreprocessingType::False));
+            candidates_lists,
+            parameters.coordinates,
+            parameters.timestamps,
+            parameters.radiuses,
+            !(parameters.track_preprocessing == api::MatchParameters::PreprocessingType::False));
     }
 
     if (sub_matchings.size() == 0)

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -55,7 +55,7 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
                 const std::vector<util::Coordinate> &trace_coordinates,
                 const std::vector<unsigned> &trace_timestamps,
                 const std::vector<boost::optional<double>> &trace_gps_precision,
-                const bool use_tidying)
+                const bool allow_splitting)
 {
     map_matching::MatchingConfidence confidence;
     map_matching::EmissionLogProbability default_emission_log_probability(DEFAULT_GPS_PRECISION);
@@ -159,11 +159,7 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
 
         const bool gap_in_trace = [&]() {
             // do not determine split if wasn't asked about it
-            if (!use_tidying)
-            {
-                return false;
-            }
-            else
+            if (allow_splitting)
             {
                 // use temporal information if available to determine a split
                 if (use_timestamps)
@@ -175,6 +171,10 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
                 {
                     return t - prev_unbroken_timestamps.back() > MAX_BROKEN_STATES;
                 }
+            }
+            else
+            {
+                return false;
             }
         }();
 

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -169,7 +169,7 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
                 if (use_timestamps)
                 {
                     return trace_timestamps[t] - trace_timestamps[prev_unbroken_timestamps.back()] >
-                        max_broken_time;
+                           max_broken_time;
                 }
                 else
                 {

--- a/unit_tests/engine/tidy.cpp
+++ b/unit_tests/engine/tidy.cpp
@@ -29,12 +29,12 @@ BOOST_AUTO_TEST_CASE(two_item_trace_already_tidied_test)
     auto result = tidy::tidy(params, thresholds);
 
     BOOST_CHECK_EQUAL(result.can_be_removed.size(), 2);
-    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), 2);
+    BOOST_CHECK_EQUAL(result.tidied_to_original.size(), 2);
 
     BOOST_CHECK(result.can_be_removed[0] == false);
     BOOST_CHECK(result.can_be_removed[1] == false);
-    BOOST_CHECK_EQUAL(result.original_to_tidied[0], 0);
-    BOOST_CHECK_EQUAL(result.original_to_tidied[1], 1);
+    BOOST_CHECK_EQUAL(result.tidied_to_original[0], 0);
+    BOOST_CHECK_EQUAL(result.tidied_to_original[1], 1);
 }
 
 BOOST_AUTO_TEST_CASE(two_item_trace_needs_tidiying_test)
@@ -53,12 +53,11 @@ BOOST_AUTO_TEST_CASE(two_item_trace_needs_tidiying_test)
     auto result = tidy::tidy(params, thresholds);
 
     BOOST_CHECK_EQUAL(result.can_be_removed.size(), 2);
-    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), 2);
+    BOOST_CHECK_EQUAL(result.tidied_to_original.size(), 1);
 
     BOOST_CHECK_EQUAL(result.can_be_removed[0], false);
     BOOST_CHECK_EQUAL(result.can_be_removed[1], true);
-    BOOST_CHECK_EQUAL(result.original_to_tidied[0], 0);
-    BOOST_CHECK_EQUAL(result.original_to_tidied[1], 0);
+    BOOST_CHECK_EQUAL(result.tidied_to_original[0], 0);
 }
 
 BOOST_AUTO_TEST_CASE(two_blobs_in_traces_needs_tidiying_test)
@@ -88,27 +87,16 @@ BOOST_AUTO_TEST_CASE(two_blobs_in_traces_needs_tidiying_test)
     auto result = tidy::tidy(params, thresholds);
 
     BOOST_CHECK_EQUAL(result.can_be_removed.size(), params.coordinates.size());
-    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), params.coordinates.size());
+    BOOST_CHECK_EQUAL(result.tidied_to_original.size(), 2);
 
-    auto valid = [](auto index) { return index == 0 || index == 3; };
-    auto ok = std::all_of(begin(result.original_to_tidied), end(result.original_to_tidied), valid);
-    BOOST_CHECK(ok);
-
-    BOOST_CHECK(std::is_sorted(begin(result.original_to_tidied), end(result.original_to_tidied)));
+    BOOST_CHECK_EQUAL(result.tidied_to_original[0], 0);
+    BOOST_CHECK_EQUAL(result.tidied_to_original[1], 3);
 
     const auto redundant = result.can_be_removed.count();
     BOOST_CHECK_EQUAL(redundant, params.coordinates.size() - 2);
 
     BOOST_CHECK_EQUAL(result.can_be_removed[0], false);
     BOOST_CHECK_EQUAL(result.can_be_removed[3], false);
-
-    auto second_blob_start = std::partition_point(begin(result.original_to_tidied),
-                                                  end(result.original_to_tidied),
-                                                  [](auto index) { return index == 0; });
-
-    BOOST_CHECK(begin(result.original_to_tidied) < second_blob_start);
-    BOOST_CHECK(second_blob_start < end(result.original_to_tidied));
-    BOOST_CHECK(second_blob_start == begin(result.original_to_tidied) + 3); // 3 in first blob
 }
 
 BOOST_AUTO_TEST_CASE(two_blobs_in_traces_needs_tidiying_no_timestamps_test)
@@ -130,27 +118,15 @@ BOOST_AUTO_TEST_CASE(two_blobs_in_traces_needs_tidiying_no_timestamps_test)
     auto result = tidy::tidy(params, thresholds);
 
     BOOST_CHECK_EQUAL(result.can_be_removed.size(), params.coordinates.size());
-    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), params.coordinates.size());
-
-    auto valid = [](auto index) { return index == 0 || index == 3; };
-    auto ok = std::all_of(begin(result.original_to_tidied), end(result.original_to_tidied), valid);
-    BOOST_CHECK(ok);
-
-    BOOST_CHECK(std::is_sorted(begin(result.original_to_tidied), end(result.original_to_tidied)));
+    BOOST_CHECK_EQUAL(result.tidied_to_original.size(), 2);
+    BOOST_CHECK_EQUAL(result.tidied_to_original[0], 0);
+    BOOST_CHECK_EQUAL(result.tidied_to_original[1], 3);
 
     const auto redundant = result.can_be_removed.count();
     BOOST_CHECK_EQUAL(redundant, params.coordinates.size() - 2);
 
     BOOST_CHECK_EQUAL(result.can_be_removed[0], false);
     BOOST_CHECK_EQUAL(result.can_be_removed[3], false);
-
-    auto second_blob_start = std::partition_point(begin(result.original_to_tidied),
-                                                  end(result.original_to_tidied),
-                                                  [](auto index) { return index == 0; });
-
-    BOOST_CHECK(begin(result.original_to_tidied) < second_blob_start);
-    BOOST_CHECK(second_blob_start < end(result.original_to_tidied));
-    BOOST_CHECK(second_blob_start == begin(result.original_to_tidied) + 3); // 3 in first blob
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/engine/tidy.cpp
+++ b/unit_tests/engine/tidy.cpp
@@ -1,0 +1,156 @@
+#include "engine/api/match_parameters_tidy.hpp"
+
+#include <boost/test/test_case_template.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(tidy_test)
+
+using namespace osrm;
+using namespace osrm::util;
+using namespace osrm::engine::api;
+
+BOOST_AUTO_TEST_CASE(two_item_trace_already_tidied_test)
+{
+    MatchParameters params;
+    params.coordinates.emplace_back(FloatLongitude{13.207993}, FloatLatitude{52.446379});
+    params.coordinates.emplace_back(FloatLongitude{13.231658}, FloatLatitude{52.465416});
+
+    params.timestamps.emplace_back(1477090402);
+    params.timestamps.emplace_back(1477090663);
+
+    tidy::Thresholds thresholds;
+    thresholds.distance_in_meters = 15.;
+    thresholds.duration_in_seconds = 5;
+
+    auto result = tidy::tidy(params, thresholds);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed.size(), 2);
+    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), 2);
+
+    BOOST_CHECK(result.can_be_removed[0] == false);
+    BOOST_CHECK(result.can_be_removed[1] == false);
+    BOOST_CHECK_EQUAL(result.original_to_tidied[0], 0);
+    BOOST_CHECK_EQUAL(result.original_to_tidied[1], 1);
+}
+
+BOOST_AUTO_TEST_CASE(two_item_trace_needs_tidiying_test)
+{
+    MatchParameters params;
+    params.coordinates.emplace_back(FloatLongitude{13.207993}, FloatLatitude{52.446379});
+    params.coordinates.emplace_back(FloatLongitude{13.231658}, FloatLatitude{52.465416});
+
+    params.timestamps.emplace_back(1477090402);
+    params.timestamps.emplace_back(1477090663);
+
+    tidy::Thresholds thresholds;
+    thresholds.distance_in_meters = 5000;
+    thresholds.duration_in_seconds = 5 * 60;
+
+    auto result = tidy::tidy(params, thresholds);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed.size(), 2);
+    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), 2);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed[0], false);
+    BOOST_CHECK_EQUAL(result.can_be_removed[1], true);
+    BOOST_CHECK_EQUAL(result.original_to_tidied[0], 0);
+    BOOST_CHECK_EQUAL(result.original_to_tidied[1], 0);
+}
+
+BOOST_AUTO_TEST_CASE(two_blobs_in_traces_needs_tidiying_test)
+{
+    MatchParameters params;
+
+    params.coordinates.emplace_back(FloatLongitude{13.207993}, FloatLatitude{52.446379});
+    params.coordinates.emplace_back(FloatLongitude{13.207994}, FloatLatitude{52.446380});
+    params.coordinates.emplace_back(FloatLongitude{13.207995}, FloatLatitude{52.446381});
+
+    params.coordinates.emplace_back(FloatLongitude{13.231658}, FloatLatitude{52.465416});
+    params.coordinates.emplace_back(FloatLongitude{13.231659}, FloatLatitude{52.465417});
+    params.coordinates.emplace_back(FloatLongitude{13.231660}, FloatLatitude{52.465417});
+
+    params.timestamps.emplace_back(1477090402);
+    params.timestamps.emplace_back(1477090403);
+    params.timestamps.emplace_back(1477090404);
+
+    params.timestamps.emplace_back(1477090661);
+    params.timestamps.emplace_back(1477090662);
+    params.timestamps.emplace_back(1477090663);
+
+    tidy::Thresholds thresholds;
+    thresholds.distance_in_meters = 15;
+    thresholds.duration_in_seconds = 5;
+
+    auto result = tidy::tidy(params, thresholds);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed.size(), params.coordinates.size());
+    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), params.coordinates.size());
+
+    auto valid = [](auto index) { return index == 0 || index == 3; };
+    auto ok = std::all_of(begin(result.original_to_tidied), end(result.original_to_tidied), valid);
+    BOOST_CHECK(ok);
+
+    BOOST_CHECK(std::is_sorted(begin(result.original_to_tidied), end(result.original_to_tidied)));
+
+    const auto redundant = result.can_be_removed.count();
+    BOOST_CHECK_EQUAL(redundant, params.coordinates.size() - 2);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed[0], false);
+    BOOST_CHECK_EQUAL(result.can_be_removed[3], false);
+
+    auto second_blob_start = std::partition_point(begin(result.original_to_tidied),
+                                                  end(result.original_to_tidied),
+                                                  [](auto index) { return index == 0; });
+
+    BOOST_CHECK(begin(result.original_to_tidied) < second_blob_start);
+    BOOST_CHECK(second_blob_start < end(result.original_to_tidied));
+    BOOST_CHECK(second_blob_start == begin(result.original_to_tidied) + 3); // 3 in first blob
+}
+
+BOOST_AUTO_TEST_CASE(two_blobs_in_traces_needs_tidiying_no_timestamps_test)
+{
+    MatchParameters params;
+
+    params.coordinates.emplace_back(FloatLongitude{13.207993}, FloatLatitude{52.446379});
+    params.coordinates.emplace_back(FloatLongitude{13.207994}, FloatLatitude{52.446380});
+    params.coordinates.emplace_back(FloatLongitude{13.207995}, FloatLatitude{52.446381});
+
+    params.coordinates.emplace_back(FloatLongitude{13.231658}, FloatLatitude{52.465416});
+    params.coordinates.emplace_back(FloatLongitude{13.231659}, FloatLatitude{52.465417});
+    params.coordinates.emplace_back(FloatLongitude{13.231660}, FloatLatitude{52.465417});
+
+    tidy::Thresholds thresholds;
+    thresholds.distance_in_meters = 15;
+    thresholds.duration_in_seconds = 5;
+
+    auto result = tidy::tidy(params, thresholds);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed.size(), params.coordinates.size());
+    BOOST_CHECK_EQUAL(result.original_to_tidied.size(), params.coordinates.size());
+
+    auto valid = [](auto index) { return index == 0 || index == 3; };
+    auto ok = std::all_of(begin(result.original_to_tidied), end(result.original_to_tidied), valid);
+    BOOST_CHECK(ok);
+
+    BOOST_CHECK(std::is_sorted(begin(result.original_to_tidied), end(result.original_to_tidied)));
+
+    const auto redundant = result.can_be_removed.count();
+    BOOST_CHECK_EQUAL(redundant, params.coordinates.size() - 2);
+
+    BOOST_CHECK_EQUAL(result.can_be_removed[0], false);
+    BOOST_CHECK_EQUAL(result.can_be_removed[3], false);
+
+    auto second_blob_start = std::partition_point(begin(result.original_to_tidied),
+                                                  end(result.original_to_tidied),
+                                                  [](auto index) { return index == 0; });
+
+    BOOST_CHECK(begin(result.original_to_tidied) < second_blob_start);
+    BOOST_CHECK(second_blob_start < end(result.original_to_tidied));
+    BOOST_CHECK(second_blob_start == begin(result.original_to_tidied) + 3); // 3 in first blob
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

#3778

Adds special parameter to turn off track splitting. I think this parameter will be useful also in other tidying functions, like in #3149 
Default value does not change current map matching behavior.

## Tasklist
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] review
 - [x] adjust for comments