### PR TITLE
Use boost d-ary heap for MLD routing

### DIFF
--- a/include/contractor/contractor_heap.hpp
+++ b/include/contractor/contractor_heap.hpp
@@ -1,7 +1,7 @@
 #ifndef OSRM_CONTRACTOR_CONTRACTOR_HEAP_HPP_
 #define OSRM_CONTRACTOR_CONTRACTOR_HEAP_HPP_
 
-#include "util/binary_heap.hpp"
+#include "util/query_heap.hpp"
 #include "util/typedefs.hpp"
 #include "util/xor_fast_hash_storage.hpp"
 
@@ -18,11 +18,11 @@ struct ContractorHeapData
     bool target = false;
 };
 
-using ContractorHeap = util::BinaryHeap<NodeID,
-                                        NodeID,
-                                        EdgeWeight,
-                                        ContractorHeapData,
-                                        util::XORFastHashStorage<NodeID, NodeID>>;
+using ContractorHeap = util::QueryHeap<NodeID,
+                                       NodeID,
+                                       EdgeWeight,
+                                       ContractorHeapData,
+                                       util::XORFastHashStorage<NodeID, NodeID>>;
 
 } // namespace contractor
 } // namespace osrm

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -3,7 +3,7 @@
 
 #include "partition/cell_storage.hpp"
 #include "partition/multi_level_partition.hpp"
-#include "util/binary_heap.hpp"
+#include "util/query_heap.hpp"
 
 #include <tbb/enumerable_thread_specific.h>
 
@@ -24,7 +24,7 @@ class CellCustomizer
 
   public:
     using Heap =
-        util::BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::ArrayStorage<NodeID, int>>;
+        util::QueryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::ArrayStorage<NodeID, int>>;
     using HeapPtr = tbb::enumerable_thread_specific<Heap>;
 
     CellCustomizer(const partition::MultiLevelPartition &partition) : partition(partition) {}

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -4,7 +4,7 @@
 #include <boost/thread/tss.hpp>
 
 #include "engine/algorithm.hpp"
-#include "util/binary_heap.hpp"
+#include "util/query_heap.hpp"
 #include "util/typedefs.hpp"
 
 namespace osrm
@@ -14,8 +14,7 @@ namespace engine
 
 // Algorithm-dependent heaps
 // - CH algorithms use CH heaps
-// - CoreCH algorithms use CoreCH heaps that can be upcasted to CH heaps when CH algorithms reused
-//    by CoreCH at calling ch::routingStep, ch::retrievePackedPathFromSingleHeap and ch::unpackPath
+// - CoreCH algorithms use CH
 // - MLD algorithms use MLD heaps
 
 template <typename Algorithm> struct SearchEngineData
@@ -37,14 +36,14 @@ struct ManyToManyHeapData : HeapData
 template <> struct SearchEngineData<routing_algorithms::ch::Algorithm>
 {
     using QueryHeap = util::
-        BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::UnorderedMapStorage<NodeID, int>>;
+        QueryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::UnorderedMapStorage<NodeID, int>>;
     using SearchEngineHeapPtr = boost::thread_specific_ptr<QueryHeap>;
 
-    using ManyToManyQueryHeap = util::BinaryHeap<NodeID,
-                                                 NodeID,
-                                                 EdgeWeight,
-                                                 ManyToManyHeapData,
-                                                 util::UnorderedMapStorage<NodeID, int>>;
+    using ManyToManyQueryHeap = util::QueryHeap<NodeID,
+                                                NodeID,
+                                                EdgeWeight,
+                                                ManyToManyHeapData,
+                                                util::UnorderedMapStorage<NodeID, int>>;
 
     using ManyToManyHeapPtr = boost::thread_specific_ptr<ManyToManyQueryHeap>;
 
@@ -81,11 +80,11 @@ struct MultiLayerDijkstraHeapData
 
 template <> struct SearchEngineData<routing_algorithms::mld::Algorithm>
 {
-    using QueryHeap = util::BinaryHeap<NodeID,
-                                       NodeID,
-                                       EdgeWeight,
-                                       MultiLayerDijkstraHeapData,
-                                       util::UnorderedMapStorage<NodeID, int>>;
+    using QueryHeap = util::QueryHeap<NodeID,
+                                      NodeID,
+                                      EdgeWeight,
+                                      MultiLayerDijkstraHeapData,
+                                      util::UnorderedMapStorage<NodeID, int>>;
 
     using SearchEngineHeapPtr = boost::thread_specific_ptr<QueryHeap>;
 

--- a/include/util/binary_heap.hpp
+++ b/include/util/binary_heap.hpp
@@ -156,7 +156,7 @@ class BinaryHeap
     {
         const auto index = static_cast<Key>(inserted_nodes.size());
         const auto handle = heap.push(std::make_pair(weight, index));
-        inserted_nodes.emplace_back(node, handle, weight, data);
+        inserted_nodes.emplace_back(HeapNode{handle, node, weight, data});
         node_index[node] = index;
     }
 
@@ -241,16 +241,10 @@ class BinaryHeap
                                                   boost::heap::compare<std::greater<HeapData>>>;
     using HeapHandle = typename HeapContainer::handle_type;
 
-    class HeapNode
+    struct HeapNode
     {
-      public:
-        HeapNode(NodeID n, HeapHandle h, Weight w, Data d)
-            : node(n), handle(h), weight(w), data(std::move(d))
-        {
-        }
-
-        NodeID node;
         HeapHandle handle;
+        NodeID node;
         Weight weight;
         Data data;
     };

--- a/include/util/query_heap.hpp
+++ b/include/util/query_heap.hpp
@@ -1,14 +1,12 @@
-#ifndef BINARY_HEAP_H
-#define BINARY_HEAP_H
+#ifndef OSRM_UTIL_QUERY_HEAP_HPP
+#define OSRM_UTIL_QUERY_HEAP_HPP
 
 #include <boost/assert.hpp>
 #include <boost/heap/d_ary_heap.hpp>
 
 #include <algorithm>
-#include <cstddef>
 #include <limits>
 #include <map>
-#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -133,13 +131,13 @@ template <typename NodeID,
           typename Weight,
           typename Data,
           typename IndexStorage = ArrayStorage<NodeID, NodeID>>
-class BinaryHeap
+class QueryHeap
 {
   public:
     using WeightType = Weight;
     using DataType = Data;
 
-    explicit BinaryHeap(std::size_t maxID) : node_index(maxID) { Clear(); }
+    explicit QueryHeap(std::size_t maxID) : node_index(maxID) { Clear(); }
 
     void Clear()
     {
@@ -256,4 +254,4 @@ class BinaryHeap
 }
 }
 
-#endif // BINARY_HEAP_H
+#endif // OSRM_UTIL_QUERY_HEAP_HPP

--- a/scripts/osrm-runner.js
+++ b/scripts/osrm-runner.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const http = require('http');
+const process = require('process');
+const cla = require('command-line-args');
+const clu = require('command-line-usage');
+const ansi = require('ansi-escape-sequences');
+const turf = require('turf');
+const util = require('util');
+const jp = require('jsonpath');
+
+const run_query = (query_options, filters, callback) => {
+    let tic = () => 0.;
+    let req = http.request(query_options, function (res) {
+        let body = '', ttfb = tic();
+        if (res.statusCode != 200)
+            return callback(query_options.path, res.statusCode, ttfb);
+
+        res.setEncoding('utf8');
+        res.on('data', function (chunk) {
+            body += chunk;
+        });
+        res.on('end', function () {
+            const elapsed = tic();
+            const json = JSON.parse(body);
+            Promise.all(filters.map(filter => jp.query(json, filter)))
+                .then(values => callback(query_options.path, res.statusCode, ttfb, elapsed, values));
+        });
+    }).on('socket', function (res) {
+        tic = ((toc) => { return () => process.hrtime(toc)[1] / 1000000; })(process.hrtime());
+    }).on('error', function (res) {
+        callback(query_options.path, res.code);
+    }).end();
+}
+
+function generate_points(polygon, number) {
+    let query_points = [];
+    while (query_points.length < number) {
+    var chunk = turf
+        .random('points', number, { bbox: turf.bbox(polygon)})
+        .features
+        .map(x => x.geometry.coordinates)
+        .filter(pt => turf.inside(pt, polygon));
+        query_points = query_points.concat(chunk);
+    }
+    return query_points.slice(0, number);
+}
+
+function generate_queries(options, query_points, coordinates_number) {
+    let queries = [];
+    for (let chunk = 0; chunk < query_points.length; chunk += coordinates_number)
+    {
+        let points = query_points.slice(chunk, chunk + coordinates_number);
+        let query = options.path.replace(/{}/g, x =>  points.pop().join(','));
+        queries.push(query);
+    }
+    return queries;
+}
+
+// Command line arguments
+function ServerDetails(x) {
+    if (!(this instanceof ServerDetails)) return new ServerDetails(x);
+    const v = x.split(':');
+    this.hostname = (v[0].length > 0) ? v[0] : '';
+    this.port = (v.length > 1) ? Number(v[1]) : 80;
+}
+function BoundingBox(x) {
+    if (!(this instanceof BoundingBox)) return new BoundingBox(x);
+    const v = x.match(/[+-]?\d+(?:\.\d*)?|\.\d+/g);
+    this.poly = turf.bboxPolygon(v.slice(0,4).map(x => Number(x)));
+}
+const optionsList = [
+    {name: 'help', alias: 'h', type: Boolean, description: 'Display this usage guide.', defaultValue: false},
+    {name: 'server', alias: 's', type: ServerDetails, defaultValue: ServerDetails('localhost:5000'),
+     description: 'OSRM routing server', typeLabel: '[underline]{hostname[:port]}'},
+    {name: 'path', alias: 'p', type: String, defaultValue: '/route/v1/driving/{};{}',
+     description: 'OSRM query path with {} coordinate placeholders, default /route/v1/driving/{};{}', typeLabel: '[underline]{path}'},
+    {name: 'filter', alias: 'f', type: String, defaultValue: ['$.routes[0].weight'], multiple: true,
+     description: 'JSONPath filters, default "$.routes[0].weight"', typeLabel: '[underline]{filter}'},
+    {name: 'bounding-box', alias: 'b', type: BoundingBox, defaultValue: BoundingBox('5.86442,47.2654,15.0508,55.1478'), multiple: true,
+     description: 'queries bounding box, default "5.86442,47.2654,15.0508,55.1478"', typeLabel: '[underline]{west,south,east,north}'},
+    {name: 'max-sockets', alias: 'm', type: Number, defaultValue: 1,
+     description: 'how many concurrent sockets the agent can have open per origin, default 1', typeLabel: '[underline]{number}'},
+    {name: 'number', alias: 'n', type: Number, defaultValue: 10,
+     description: 'number of query points, default 10', typeLabel: '[underline]{number}'},
+    {name: 'queries-files', alias: 'q', type: String,
+     description: 'CSV file with queries in the first row', typeLabel: '[underline]{file}'}];
+const options = cla(optionsList);
+if (options.help) {
+    const banner = '╔═╗╔═╗╦═╗╔╦╗      \n║ ║╚═╗╠╦╝║║║      \n╚═╝╚═╝╩╚═╩ ╩      \n┬─┐┬ ┬┌┐┌┌┐┌┌─┐┬─┐\n├┬┘│ │││││││├┤ ├┬┘\n┴└─└─┘┘└┘┘└┘└─┘┴└─';
+    const usage = clu([
+        { content: ansi.format(banner, 'green'), raw: true },
+        { header: 'Run OSRM queries and collect results'/*, content: 'Generates something [italic]{very} important.'*/ },
+        { header: 'Options', optionList: optionsList }
+    ]);
+    console.log(usage);
+    process.exit(0);
+}
+
+// read or generate random queries
+let queries = [];
+if (options.hasOwnProperty('queries-files')) {
+    queries = fs.readFileSync(options['queries-files'])
+        .toString()
+        .split('\n')
+        .map(r => { const match = /^"([^+]+)"/.exec(r); return match ? match[1] : null; })
+        .filter(q => q);
+} else {
+    const polygon = options['bounding-box'].map(x => x.poly).reduce((x,y) => turf.union(x, y));
+    const coordinates_number = (options.path.match(/{}/g) || []).length;
+    const query_points = generate_points(polygon, coordinates_number * options.number);
+    queries = generate_queries(options, query_points, coordinates_number);
+}
+queries = queries.map(q => { return {hostname: options.server.hostname, port: options.server.port, path: q}; });
+
+// run queries
+http.globalAgent.maxSockets = options['max-sockets'];
+queries.map(query => {
+    run_query(query, options.filter, (query, code, ttfb, total, results) => {
+        let str = `"${query}",${code}`;
+        if (ttfb !== undefined) str += `,${ttfb}`;
+        if (total !== undefined) str += `,${total}`;
+        if (typeof results === 'object' && results.length > 0)
+            str += ',' + results.map(x => isNaN(x) ? '"' + JSON.stringify(x).replace(/\n/g, ';').replace(/"/g, "'") + '"' : Number(x)).join(',');
+        console.log(str);
+    });
+});

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -1,7 +1,5 @@
 #include "engine/search_engine_data.hpp"
 
-#include "util/binary_heap.hpp"
-
 namespace osrm
 {
 namespace engine

--- a/unit_tests/util/query_heap.cpp
+++ b/unit_tests/util/query_heap.cpp
@@ -1,4 +1,4 @@
-#include "util/binary_heap.hpp"
+#include "util/query_heap.hpp"
 #include "util/typedefs.hpp"
 
 #include <boost/mpl/list.hpp>
@@ -56,7 +56,7 @@ constexpr unsigned NUM_NODES = 100;
 
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(insert_test, T, storage_types, RandomDataFixture<NUM_NODES>)
 {
-    BinaryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(NUM_NODES);
+    QueryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(NUM_NODES);
 
     TestWeight min_weight = std::numeric_limits<TestWeight>::max();
     TestNodeID min_id;
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(insert_test, T, storage_types, RandomDataFixtur
 
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(delete_min_test, T, storage_types, RandomDataFixture<NUM_NODES>)
 {
-    BinaryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(NUM_NODES);
+    QueryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(NUM_NODES);
 
     for (unsigned idx : order)
     {
@@ -111,7 +111,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(delete_min_test, T, storage_types, RandomDataFi
 
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(delete_all_test, T, storage_types, RandomDataFixture<NUM_NODES>)
 {
-    BinaryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(NUM_NODES);
+    QueryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(NUM_NODES);
 
     for (unsigned idx : order)
     {
@@ -125,7 +125,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(delete_all_test, T, storage_types, RandomDataFi
 
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(decrease_key_test, T, storage_types, RandomDataFixture<10>)
 {
-    BinaryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(10);
+    QueryHeap<TestNodeID, TestKey, TestWeight, TestData, T> heap(10);
 
     for (unsigned idx : order)
     {


### PR DESCRIPTION
# Issue

For #3764 can be used `boost::heap::d_ary_heap` as a 4-ary heap. The PR adds `SearchHeap` that internally uses `boost::heap::d_ary_heap` with `boost::heap::arity<4>`. In general on a small dataset like `bayern-latest` the difference between 2-ary and 4-ary heaps is not statistically relevant, but the difference wrt to `BinaryHeap` is for 1000 queries `http://localhost:5000/route/v1/driving/11.575395,48.137132;9.932966,49.792450`
```
	Welch Two Sample t-test

data:  before$V1 and after$V1
t = 13.672, df = 1274.7, p-value < 2.2e-16
alternative hypothesis: true difference in means is not equal to 0
95 percent confidence interval:
 0.001313073 0.001753019
sample estimates:
  mean of x   mean of y 
0.010305615 0.008772569 
```

Data summary of MLD routing  with `BinaryHeap`  (red on histogram) is
```
    Min.  1st Qu.   Median     Mean  3rd Qu.     Max. 
0.007715 0.008152 0.008602 0.010310 0.011940 0.039360 
```
and  for the new `SearchHeap` (blue on histogram) is
```
    Min.  1st Qu.   Median     Mean  3rd Qu.     Max. 
0.007814 0.008083 0.008232 0.008773 0.008688 0.014980 
```

![heaps](https://cloud.githubusercontent.com/assets/4421046/23865350/b1d55298-0815-11e7-9e52-98b0f423bda2.png)


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
