### PR TITLE
Silences Clang warnings about unused arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,7 @@ endif()
 
 # Configuring compilers
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fPIC -fcolor-diagnostics -ftemplate-depth=1024")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fPIC -fcolor-diagnostics -ftemplate-depth=1024 -Wno-unused-command-line-argument")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(COLOR_FLAG "-fdiagnostics-color=auto")
   check_cxx_compiler_flag("-fdiagnostics-color=auto" HAS_COLOR_FLAG)


### PR DESCRIPTION
With local Clang 4.0 build I can see

```
...
[ 11%] Building CXX object CMakeFiles/UTIL.dir/src/util/guidance/entry_class.cpp.o
clang-4.0: warning: argument unused during compilation: '-I /tmp/osrm-backend/include' [-Wunused-command-line-argument]
clang-4.0: warning: argument unused during compilation: '-I /tmp/osrm-backend/build/include' [-Wunused-command-line-argument]
clang-4.0: warning: argument unused during compilation: '-isystem /tmp/osrm-backend/third_party/sol2' [-Wunused-command-line-argument]
clang-4.0: warning: argument unused during compilation: '-isystem /tmp/osrm-backend/third_party/variant/include' [-Wunused-command-line-argument]
clang-4.0: warning: argument unused during compilation: '-isystem /tmp/osrm-backend/third_party/libosmium/include' [-Wunused-command-line-argument]
...
```

Removes the noise.