### PR TITLE
Downgrade log levels for SHM detach messages

### DIFF
--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -151,7 +151,7 @@ class SharedMemory
 #else
     void WaitForDetach()
     {
-        util::Log(logWARNING)
+        util::Log(logDEBUG)
             << "Shared memory support for non-Linux systems does not wait for clients to "
                "dettach. Going to sleep for 50ms.";
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -245,8 +245,8 @@ class SharedMemory
     void WaitForDetach()
     {
         // FIXME this needs an implementation for Windows
-        util::Log(logWARNING) << "Shared memory support for Windows does not wait for clients to "
-                                 "dettach. Going to sleep for 50ms.";
+        util::Log(logDEBUG) << "Shared memory support for Windows does not wait for clients to "
+                               "dettach. Going to sleep for 50ms.";
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 


### PR DESCRIPTION
# Issue

We're logging a warning when `osrm-datastore` asks clients to detach from shared memory segments during a data update on non-Linux platforms.

```
[warn] Shared memory support for non-Linux systems does not wait for clients to dettach. Going to sleep for 50ms.
```

This isn't really a warning, it's expected and known behaviour.  This PR downgrades these messages to `logDEBUG` so that there aren't any scary warnings generated for `Release` builds under normal operating conditions.

## Tasklist
 - [x] review
 - [x] adjust for comments