### PR TITLE
Nearest Service #coordinates >=1

### DIFF
--- a/src/server/service/nearest_service.cpp
+++ b/src/server/service/nearest_service.cpp
@@ -31,11 +31,6 @@ std::string getWrongOptionHelp(const engine::api::NearestParameters &parameters)
         constrainParamSize(
             PARAMETER_SIZE_MISMATCH_MSG, "radiuses", parameters.radiuses, coord_size, help);
 
-    if (!param_size_mismatch && parameters.coordinates.size() < 2)
-    {
-        help = "Number of coordinates needs to be at least two.";
-    }
-
     return help;
 }
 } // anon. ns


### PR DESCRIPTION
Incorrect check inside getWrongOptionHelp function of NearestService. This condition is never satisfied effectively making it unreachable.
