### PR TITLE
Add read-only max_turn_weight in ProfileProperties

### DIFF
--- a/features/options/profiles/version1.feature
+++ b/features/options/profiles/version1.feature
@@ -13,6 +13,9 @@ properties.max_speed_for_map_matching      = 180/3.6
 properties.use_turn_restrictions           = true
 properties.continue_straight_at_waypoint   = true
 properties.weight_name                     = 'test_version1'
+properties.weight_precision                = 2
+
+assert(properties.max_turn_weight == 327.67)
 
 function node_function (node, result)
   print ('node_function ' .. node:id())

--- a/include/extractor/profile_properties.hpp
+++ b/include/extractor/profile_properties.hpp
@@ -1,6 +1,8 @@
 #ifndef PROFILE_PROPERTIES_HPP
 #define PROFILE_PROPERTIES_HPP
 
+#include "util/typedefs.hpp"
+
 #include <algorithm>
 #include <boost/assert.hpp>
 #include <boost/numeric/conversion/cast.hpp>
@@ -65,6 +67,11 @@ struct ProfileProperties
     }
 
     double GetWeightMultiplier() const { return std::pow(10., weight_precision); }
+
+    double GetMaxTurnWeight() const
+    {
+        return std::numeric_limits<TurnPenalty>::max() / GetWeightMultiplier();
+    }
 
     //! penalty to cross a traffic light in deci-seconds
     std::int32_t traffic_signal_penalty;

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -245,7 +245,9 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "weight_precision",
         &ProfileProperties::weight_precision,
         "weight_name",
-        sol::property(&ProfileProperties::SetWeightName, &ProfileProperties::GetWeightName));
+        sol::property(&ProfileProperties::SetWeightName, &ProfileProperties::GetWeightName),
+        "max_turn_weight",
+        sol::property(&ProfileProperties::GetMaxTurnWeight));
 
     context.state.new_usertype<std::vector<std::string>>(
         "vector",


### PR DESCRIPTION
# Issue

`max_turn_weight` can be useful in profiles to avoid some turns by setting maximum possible turn weight.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
