### PR TITLE
Document all options available to Lua profiles

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -35,6 +35,7 @@ left_hand_driving             | Boolean  | Are vehicles assumed to drive on the 
 use_turn_restrictions         | Boolean  | Are turn instructions followed?
 continue_straight_at_waypoint | Boolean  | Must the route continue straight on at a via point, or are U-turns allowed?
 max_speed_for_map_matching    | Float    | Maximum vehicle speed to be assumed in matching (in m/s)
+max_turn_weight               | Float    | Maximum turn penalty weight
 
 ## way_function
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -58,9 +58,9 @@ duration                                | Float    | Alternative setter for dura
 weight                                  | Float    | Alternative setter for weight of the whole way in both directions
 turn_lanes_forward                      | String   | Directions for individual lanes (normalised OSM turn:lanes value)
 turn_lanes_backward                     | String   |  "   "
-forward_restricted                      | Boolean  | Is this a restricted access road? (e.g. private, deliveries only)
+forward_restricted                      | Boolean  | Is this a restricted access road? (e.g. private, or deliveries only; used to enable high turn penalty, so that way is only chosen for start/end of route)
 backward_restricted                     | Boolean  |  "   "
-is_startpoint                           | Boolean  | Can a journey start on this way?
+is_startpoint                           | Boolean  | Can a journey start on this way? (e.g. ferry; if false, prevents snapping the start point to this way)
 roundabout                              | Boolean  | Is this part of a roundabout?
 circular                                | Boolean  | Is this part of a non-roundabout circular junction?
 name                                    | String   | Name of the way

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -115,5 +115,9 @@ Attribute          | Read/write? | Type    | Notes
 -------------------|-------------|---------|------------------------------------------------------
 direction_modifier | Read        | Enum    | Geometry of turn. Defined in include/extractor/guidance/turn_instruction.hpp
 turn_type          | Read        | Enum    | Priority of turn. Defined in include/extractor/guidance/turn_instruction.hpp
-has_traffic_light  | Read        | Boolean | Traffic light present at this turn
-duration           | Write       | Float   | Penalty to be applied for this turn (s)
+has_traffic_light  | Read        | Boolean | Is a traffic light present at this turn?
+source_restricted  | Read        | Boolean | Is it from a restricted access road? (See definition in way_function)
+target_restricted  | Read        | Boolean | Is it to a restricted access road? (See definition in way_function)
+angle              | Read        | Float   | Angle of turn in degrees (0-360: 0=u-turn, 180=straight on)
+duration           | Read/write  | Float   | Penalty to be applied for this turn (duration in deciseconds)
+weight             | Read/write  | Float   | Penalty to be applied for this turn (routing weight)

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -49,10 +49,10 @@ The following attributes can be set on the result in way_function:
 
 Attribute                               | Type     | Notes
 ----------------------------------------|----------|--------------------------------------------------------------------------
-forward_rate                            | Float    | Routing weight on this way per metre
-backward_rate                           | Float    |  "   "
 forward_speed                           | Float    | Speed on this way in km/h
 backward_speed                          | Float    |  "   "
+forward_rate                            | Float    | Routing weight, expressed as meters/*weight* (e.g. for a fastest-route weighting, you would want this to be meters/second, so set it to forward_speed/3.6)
+backward_rate                           | Float    |  "   "
 forward_mode                            | Enum     | Mode of travel (e.g. car, ferry). Defined in include/extractor/travel_mode.hpp
 backward_mode                           | Enum     |  "   "
 duration                                | Float    | Alternative setter for duration of the whole way in both directions


### PR DESCRIPTION
Recent improvements to OSRM have led to a lot of changes to the Lua scripting interface, and refactoring of the default profiles makes them slightly more abstract and difficult to grok for those writing profiles from scratch.

This is therefore an attempt to fully document the attributes that can be read and set from Lua profiles. I've done it from my own understanding and from reading the source, but I may well have missed things or mistaken them!