### PR TITLE
Quick-n-dirty error handling for file writes on 5.6 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 
+# 5.6.4
+  - Changes from 5.6.3
+    - Bugfixes
+      - Fix #3838 throws errors if write streams have failed
+
 # 5.6.3
-  - Changes from 5.6.0
+  - Changes from 5.6.2
     - Bugfixes
       - #3790 Fix incorrect speed values in tile plugin
 
 # 5.6.2
-  - Changes from 5.6.0
+  - Changes from 5.6.1
     - Bugfixes
       - Fix incorrect forward datasources getter in facade
       - Fix include `access=private` non-car roads in the car profile

--- a/include/util/range_table.hpp
+++ b/include/util/range_table.hpp
@@ -2,6 +2,7 @@
 #define RANGE_TABLE_HPP
 
 #include "storage/io.hpp"
+#include "util/exception_utils.hpp"
 #include "util/integer_range.hpp"
 #include "util/shared_memory_vector_wrapper.hpp"
 
@@ -221,12 +222,34 @@ std::ostream &operator<<(std::ostream &out, const RangeTable<BLOCK_SIZE, USE_SHA
     // write number of block
     const unsigned number_of_blocks = table.diff_blocks.size();
     out.write((char *)&number_of_blocks, sizeof(unsigned));
+    if (!out)
+    {
+        throw util::exception(
+            std::string("Error writing block size of range table to shared memory: ") + SOURCE_REF);
+    }
     // write total length
     out.write((char *)&table.sum_lengths, sizeof(unsigned));
+    if (!out)
+    {
+        throw util::exception(
+            std::string("Error writing total length of range table to shared memory: ") +
+            SOURCE_REF);
+    }
     // write block offsets
     out.write((char *)table.block_offsets.data(), sizeof(unsigned) * table.block_offsets.size());
+    if (!out)
+    {
+        throw util::exception(
+            std::string("Error writing block offsets of range table to shared memory: ") +
+            SOURCE_REF);
+    }
     // write blocks
     out.write((char *)table.diff_blocks.data(), BLOCK_SIZE * table.diff_blocks.size());
+    if (!out)
+    {
+        throw util::exception(
+            std::string("Error writing blocks of range table to shared memory: ") + SOURCE_REF);
+    }
 
     return out;
 }

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -263,6 +263,12 @@ class StaticRTree
 
                 // write leaf_node to leaf node file
                 leaf_node_file.write((char *)&current_leaf, sizeof(current_leaf));
+                if (!leaf_node_file)
+                {
+                    throw util::exception(std::string("Error in static_rtree, writing leaf_node to "
+                                                      "leaf node file (`.fileIndex`): ") +
+                                          SOURCE_REF);
+                }
             }
 
             tree_nodes_in_level.emplace_back(current_node);
@@ -336,7 +342,19 @@ class StaticRTree
         std::uint64_t size_of_tree = m_search_tree.size();
         BOOST_ASSERT_MSG(0 < size_of_tree, "tree empty");
         tree_node_file.write((char *)&size_of_tree, sizeof(size_of_tree));
+        if (!tree_node_file)
+        {
+            throw util::exception(
+                std::string("Error in static_rtree, writing size of tree in `.fileIndex` file: ") +
+                SOURCE_REF);
+        }
         tree_node_file.write((char *)&m_search_tree[0], sizeof(TreeNode) * size_of_tree);
+        if (!tree_node_file)
+        {
+            throw util::exception(
+                std::string("Error in static_rtree, writing tree data in `.fileIndex` file: ") +
+                SOURCE_REF);
+        }
 
         MapLeafNodesFile(leaf_node_filename);
     }

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -1,4 +1,6 @@
 #include "extractor/compressed_edge_container.hpp"
+#include "util/exception.hpp"
+#include "util/exception_utils.hpp"
 #include "util/log.hpp"
 
 #include <boost/assert.hpp>
@@ -109,6 +111,13 @@ void CompressedEdgeContainer::SerializeInternalVector(const std::string &path) c
     // write compressed geometry reverse durations
     geometry_out_stream.write((char *)(m_compressed_geometry_rev_durations.data()),
                               sizeof(EdgeWeight) * m_compressed_geometry_rev_durations.size());
+
+    if (!geometry_out_stream)
+    {
+        throw util::exception(std::string("Error in CompressedEdgeContainer, writing compressed "
+                                          "geometry to `.geometry` file: ") +
+                              SOURCE_REF);
+    }
 }
 
 // Adds info for a compressed edge to the container.   edge_id_2

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -158,6 +158,13 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
     file_out_stream.open(output_file_name.c_str(), std::ios::binary);
     const util::FingerPrint fingerprint = util::FingerPrint::GetValid();
     file_out_stream.write((char *)&fingerprint, sizeof(util::FingerPrint));
+    if (!file_out_stream)
+    {
+        throw util::exception(
+            std::string(
+                "Error writing fingerprint during extraction containers data preparation: ") +
+            SOURCE_REF);
+    }
 
     FlushVectors();
 
@@ -571,7 +578,14 @@ void ExtractionContainers::WriteEdges(std::ofstream &file_out_stream) const
             // class of NodeBasedEdgeWithOSM
             NodeBasedEdge tmp = edge.result;
             file_out_stream.write((char *)&tmp, sizeof(NodeBasedEdge));
+
             used_edges_counter++;
+        }
+
+        if (!file_out_stream)
+        {
+            throw util::exception(std::string("Error writing edges in extraction containers: ") +
+                                  SOURCE_REF);
         }
 
         if (used_edges_counter > std::numeric_limits<unsigned>::max())
@@ -591,6 +605,13 @@ void ExtractionContainers::WriteEdges(std::ofstream &file_out_stream) const
         file_out_stream.seekp(start_position);
         file_out_stream.write((char *)&used_edges_counter_buffer,
                               sizeof(used_edges_counter_buffer));
+
+        if (!file_out_stream)
+        {
+            throw util::exception(
+                std::string("Error writing number of used edges in extraction containers: ") +
+                SOURCE_REF);
+        }
         log << "ok";
     }
 
@@ -632,6 +653,12 @@ void ExtractionContainers::WriteNodes(std::ofstream &file_out_stream) const
             BOOST_ASSERT(*node_id_iterator == node_iterator->node_id);
 
             file_out_stream.write((char *)&(*node_iterator), sizeof(ExternalMemoryNode));
+            if (!file_out_stream)
+            {
+                throw util::exception(
+                    std::string("Error writing size of edges buffer in extraction containers: ") +
+                    SOURCE_REF);
+            }
 
             ++node_id_iterator;
             ++node_iterator;
@@ -651,6 +678,7 @@ void ExtractionContainers::WriteRestrictions(const std::string &path) const
     restrictions_out_stream.open(path.c_str(), std::ios::binary);
     const util::FingerPrint fingerprint = util::FingerPrint::GetValid();
     restrictions_out_stream.write((char *)&fingerprint, sizeof(util::FingerPrint));
+
     const auto count_position = restrictions_out_stream.tellp();
     restrictions_out_stream.write((char *)&written_restriction_count, sizeof(unsigned));
 
@@ -665,8 +693,14 @@ void ExtractionContainers::WriteRestrictions(const std::string &path) const
             ++written_restriction_count;
         }
     }
+
     restrictions_out_stream.seekp(count_position);
     restrictions_out_stream.write((char *)&written_restriction_count, sizeof(unsigned));
+    if (!restrictions_out_stream)
+    {
+        throw util::exception(std::string("Error writing restrictions in extraction containers: ") +
+                              SOURCE_REF);
+    }
     util::Log() << "usable restrictions: " << written_restriction_count;
 }
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -166,6 +166,12 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
         boost::filesystem::ofstream timestamp_out(config.timestamp_file_name);
         timestamp_out.write(timestamp.c_str(), timestamp.length());
 
+        if (!timestamp_out)
+        {
+            throw util::exception(std::string("Error writing timestamp in extractor: ") +
+                                  SOURCE_REF);
+        }
+
         // initialize vectors holding parsed objects
         tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> resulting_nodes;
         tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> resulting_ways;
@@ -317,6 +323,12 @@ void Extractor::WriteProfileProperties(const std::string &output_path,
     }
 
     out_stream.write(reinterpret_cast<const char *>(&properties), sizeof(properties));
+
+    if (!out_stream)
+    {
+        throw util::exception(std::string("Error writing profile properties in extractor: ") +
+                              SOURCE_REF);
+    }
 }
 
 void Extractor::FindComponents(unsigned max_edge_id,
@@ -536,6 +548,11 @@ void Extractor::WriteNodeMapping(const std::vector<QueryNode> &internal_to_exter
         node_stream.write((char *)internal_to_external_node_map.data(),
                           size_of_mapping * sizeof(QueryNode));
     }
+    if (!node_stream)
+    {
+        throw util::exception(std::string("Error writing node mapping in extractor: ") +
+                              SOURCE_REF);
+    }
 }
 
 /**
@@ -608,6 +625,12 @@ void Extractor::WriteEdgeBasedGraph(
         file_out_stream.write((char *)&edge, sizeof(EdgeBasedEdge));
     }
 
+    if (!file_out_stream)
+    {
+        throw util::exception(std::string("Error writing edge based graph in extractor: ") +
+                              SOURCE_REF);
+    }
+
     TIMER_STOP(write_edges);
     util::Log() << "ok, after " << TIMER_SEC(write_edges) << "s";
 
@@ -647,6 +670,14 @@ void Extractor::WriteIntersectionClassificationData(
     file_out_stream << bearing_class_range_table;
 
     file_out_stream.write(reinterpret_cast<const char *>(&total_bearings), sizeof(total_bearings));
+
+    if (!file_out_stream)
+    {
+        throw util::exception(
+            std::string("Error in writing interestction classification data in extractor: ") +
+            SOURCE_REF);
+    }
+
     for (const auto &bearing_class : bearing_classes)
     {
         const auto &bearings = bearing_class.getAvailableBearings();


### PR DESCRIPTION
# Issue
https://github.com/Project-OSRM/osrm-backend/issues/3838 related to failures seen in production environments.

## Tasklist
 - [ ] throw errors to all file writes

