### PR TITLE
Configure Dockerfile for integration with Docker Cloud/Dockerhub for

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,15 @@
 FROM alpine:3.5
 
+ARG DOCKER_TAG
+
 RUN mkdir /src
 COPY . /src
 
 RUN mkdir /opt
 WORKDIR /opt
 RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
+    case ${DOCKER_TAG} in *"-debug"*) BUILD_TYPE="Debug";; *) BUILD_TYPE="Release";; esac && \
+    \
     echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk update && \
     apk upgrade && \
@@ -21,11 +25,11 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     make -j${NPROC} && \
     make install && \
     \
-    echo "Building OSRM" &&\
+    echo "Building OSRM ${DOCKER_TAG}" && \
     cd /src && \
     mkdir build && \
     cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=On .. && \
+    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_LTO=On .. && \
     make -j${NPROC} install && \
     cd ../profiles && \
     cp -r * /opt && \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# We've placed the Dockerfile under docker/ so that the generically named
+# hooks/ directory doesn't pollute the main directory.  Because we need to
+# COPY the source into the container, we need to use some -f gymnastics to
+# ensure that "COPY . /src" is referring to the repo root, not the directory
+# that contains the Dockerfile.
+# This script gets executed with a pwd of wherever the Dockerfile is.
+docker build --build-arg DOCKER_TAG=${DOCKER_TAG} -t $IMAGE_NAME -f Dockerfile ..


### PR DESCRIPTION
This adds a Dockerfile and hook scripts to enable automated Docker image builds on Docker Cloud/Dockerhub.

Dockerhub watches for changes to `master` and new tags, and kicks off builds using these scripts.

Images can then be installed with:

```
docker run -t -i osrm/osrm-backend:latest
```

which will get you the latest build from `master`, or

```
docker run -t -i osrm/osrm-backend:v5.6.3
```

## Tasklist
 - [x] review
 - [x] adjust for comments