### PR TITLE
Revert "Integrate internal cell scan into customizer"

### DIFF
--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -116,11 +116,11 @@ class CellCustomizer
         }
 
         // Relax base graph edges if a sub-cell border edge
-        for (auto edge : graph.GetInternalEdgeRange(level, node))
+        for (auto edge : graph.GetAdjacentEdgeRange(node))
         {
             const NodeID to = graph.GetTarget(edge);
             const auto &data = graph.GetEdgeData(edge);
-            if (data.forward &&
+            if (data.forward && partition.GetCell(level, to) == id &&
                 (first_level ||
                  partition.GetCell(level - 1, node) != partition.GetCell(level - 1, to)))
             {


### PR DESCRIPTION
# Issue

This reverts commit b085add97362764ee8fb54c8f97d0ecb3ae150d2.

Fixes missing overlay shortcuts if a shortcut contains border edges of higher levels than the current customization level. 

Customization uses both internal and border edges on all levels.

Missing overlay edges lead to non-optimal paths like in #3857
![mld](https://cloud.githubusercontent.com/assets/4421046/24335094/369a96f8-1277-11e7-9d19-e84cc0dbac66.png)
instead of
![ch](https://cloud.githubusercontent.com/assets/4421046/24335084/214c977e-1277-11e7-81a5-f531e30dc9b0.png)

/cc @TheMarex 

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
