### PR TITLE
Fix internal edges for nodes not in the boundary

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 coverage:
 
   ignore:
-    - unit_tests/.*
     - third_party/.*
 
 comment: off

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -39,9 +39,9 @@ class CellCustomizer
                 const EdgeWeight weight = heap.GetKey(node);
 
                 if (level == 1)
-                    RelaxNode<true>(graph, cells, heap, level, id, node, weight);
+                    RelaxNode<true>(graph, cells, heap, level, node, weight);
                 else
-                    RelaxNode<false>(graph, cells, heap, level, id, node, weight);
+                    RelaxNode<false>(graph, cells, heap, level, node, weight);
 
                 destinations_set.erase(node);
             }
@@ -85,7 +85,6 @@ class CellCustomizer
                    const partition::CellStorage &cells,
                    Heap &heap,
                    LevelID level,
-                   CellID id,
                    NodeID node,
                    EdgeWeight weight) const
     {

--- a/include/partition/multi_level_graph.hpp
+++ b/include/partition/multi_level_graph.hpp
@@ -110,9 +110,17 @@ class MultiLevelGraph : public util::StaticGraph<EdgeDataT, UseSharedMemory>
         // which can be smaller then the total number of nodes.
         // this will save memory in case we sort the border nodes first
         if (index >= node_to_edge_offset.size() - 1)
-            return SuperT::BeginEdges(node);
+        {
+            // On level 0 all edges are border edges
+            if (level == 0)
+                return SuperT::BeginEdges(node);
+            else
+                return SuperT::EndEdges(node);
+        }
         else
+        {
             return SuperT::BeginEdges(node) + node_to_edge_offset[index + level];
+        }
     }
 
     // We save the level as sentinel at the end

--- a/unit_tests/partition/multi_level_graph.cpp
+++ b/unit_tests/partition/multi_level_graph.cpp
@@ -46,11 +46,11 @@ BOOST_AUTO_TEST_SUITE(multi_level_graph)
 
 BOOST_AUTO_TEST_CASE(check_edges_sorting)
 {
-    // node:                0  1  2  3  4  5  6  7  8  9 10 11 12
-    std::vector<CellID> l1{{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6}};
-    std::vector<CellID> l2{{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 4}};
-    std::vector<CellID> l3{{0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2}};
-    std::vector<CellID> l4{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
+    // node:                0  1  2  3  4  5  6  7  8  9 10 11 12 13
+    std::vector<CellID> l1{{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6}};
+    std::vector<CellID> l2{{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 4, 4}};
+    std::vector<CellID> l3{{0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2}};
+    std::vector<CellID> l4{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}};
     MultiLevelPartition mlp{{l1, l2, l3, l4}, {7, 5, 3, 2}};
 
     std::vector<MockEdge> edges = {
@@ -69,7 +69,8 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
         {9, 8},   //  i   i   i   i
         {10, 11}, //  i   i   i   i
         {11, 10}, //  i   i   i   i
-        {11, 12}  //  b   b   b   b
+        {11, 12}, //  b   b   b   b
+        {12, 13}  //  i   i   i   i
     };
 
     auto graph = makeGraph(mlp, edges);
@@ -97,7 +98,7 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
     // the union of border and internal edge needs to equal the adjacent edges
     for (auto level : util::irange<LevelID>(0, 4))
     {
-        for (auto node : util::irange<NodeID>(0, 13))
+        for (auto node : util::irange<NodeID>(0, 14))
         {
             const auto adjacent = graph.GetAdjacentEdgeRange(node);
             const auto border = graph.GetBorderEdgeRange(level, node);
@@ -122,6 +123,7 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(1, 10).size(), 0);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(1, 11).size(), 2);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(1, 12).size(), 1);
+    BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(1, 13).size(), 0);
 
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 0).size(), 1);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 1).size(), 0);
@@ -136,6 +138,7 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 10).size(), 0);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 11).size(), 2);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 12).size(), 1);
+    BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 13).size(), 0);
 
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 0).size(), 1);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 1).size(), 0);
@@ -150,6 +153,7 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 10).size(), 0);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 11).size(), 1);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 12).size(), 1);
+    BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 13).size(), 0);
 
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(4, 0).size(), 0);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(4, 1).size(), 0);
@@ -164,6 +168,7 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(4, 10).size(), 0);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(4, 11).size(), 1);
     BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(3, 12).size(), 1);
+    BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(4, 13).size(), 0);
 
     CHECK_EQUAL_RANGE(graph.GetBorderEdgeRange(1, 0), graph.FindEdge(0, 4));
     CHECK_EQUAL_RANGE(graph.GetBorderEdgeRange(1, 3), graph.FindEdge(3, 7));

--- a/unit_tests/partition/multi_level_graph.cpp
+++ b/unit_tests/partition/multi_level_graph.cpp
@@ -199,4 +199,25 @@ BOOST_AUTO_TEST_CASE(check_edges_sorting)
     CHECK_EQUAL_RANGE(graph.GetBorderEdgeRange(4, 12), graph.FindEdge(12, 11));
 }
 
+BOOST_AUTO_TEST_CASE(check_last_internal_edge)
+{
+    //                      a--b--c--d
+    std::vector<CellID> l1{{0, 0, 1, 1}};
+    std::vector<CellID> l2{{0, 0, 1, 1}};
+    MultiLevelPartition mlp{{l1, l2}, {2, 2}};
+
+    std::vector<MockEdge> edges = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2}};
+
+    auto graph = makeGraph(mlp, edges);
+
+    auto all_edges = graph.GetAdjacentEdgeRange(3);
+    CHECK_EQUAL_COLLECTIONS(graph.GetBorderEdgeRange(0, 3), all_edges);
+    BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(1, 3).size(), 0);
+    BOOST_CHECK_EQUAL(graph.GetBorderEdgeRange(2, 3).size(), 0);
+
+    BOOST_CHECK_EQUAL(graph.GetInternalEdgeRange(0, 3).size(), 0);
+    CHECK_EQUAL_COLLECTIONS(graph.GetInternalEdgeRange(1, 3), all_edges);
+    CHECK_EQUAL_COLLECTIONS(graph.GetInternalEdgeRange(2, 3), all_edges);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

@oxidase did the leg work for this in #3858 already. For the edge case of nodes that are not in the boundary and have a very high ID, `BeginBorderEdges` is broken.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Fixes the problem in #3858.