### PR TITLE
Fix Win tests by copying data explicitly to test/data

### DIFF
--- a/appveyor-build.bat
+++ b/appveyor-build.bat
@@ -141,15 +141,21 @@ SET test_osm=%test_region%.osm.pbf
 IF NOT EXIST %test_osm% powershell Invoke-WebRequest https://s3.amazonaws.com/mapbox/osrm/testing/monaco.osm.pbf -OutFile %test_osm%
 %Configuration%\osrm-extract.exe -p ../profiles/car.lua %test_osm%
 MKDIR ch
-XCOPY %test_region%.osrm %test_region%.osrm.* ch\
+XCOPY %test_region%.osrm.* ch\
+XCOPY %test_region%.osrm ch\
 MKDIR corech
-XCOPY %test_region%.osrm %test_region%.osrm.* corech\
+XCOPY %test_region%.osrm.* corech\
+XCOPY %test_region%.osrm corech\
 MKDIR mld
-XCOPY %test_region%.osrm %test_region%.osrm.* mld\
+XCOPY %test_region%.osrm.* mld\
+XCOPY %test_region%.osrm mld\
 %Configuration%\osrm-contract.exe %test_region_ch%.osrm
 %Configuration%\osrm-contract.exe --core 0.8 %test_region_corech%.osrm
 %Configuration%\osrm-partition.exe %test_region_mld%.osrm
 %Configuration%\osrm-customize.exe %test_region_mld%.osrm
+XCOPY /Y ch\*.* ..\test\data\ch\
+XCOPY /Y corech\*.* ..\test\data\corech\
+XCOPY /Y mld\*.* ..\test\data\mld\
 unit_tests\%Configuration%\library-tests.exe
 
 IF NOT "%APPVEYOR_REPO_BRANCH%"=="master" GOTO DONE


### PR DESCRIPTION
# Issue

Local Win builds weren't working anymore due to two issues:
- XCOPY can't handle multiple files
- files didn't get copied to `./test/data` and stayed in `./build instead`

## Tasklist
 - [ ] review
 - [ ] adjust for comments
