### PR TITLE
Fix clang format for "Add max-cell-sizes option to partitioner" and review

### DIFF
--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -136,7 +136,8 @@ return_code parseArguments(int argc, char *argv[], partition::PartitionConfig &c
 
     if (!std::is_sorted(config.max_cell_sizes.begin(), config.max_cell_sizes.end()))
     {
-        util::Log(logERROR) << "The maximum cell sizes array must be sorted in non-descending order.";
+        util::Log(logERROR)
+            << "The maximum cell sizes array must be sorted in non-descending order.";
         return return_code::fail;
     }
 


### PR DESCRIPTION
# Issue

For #3847 and proper testing of MLD partitioning sizes of cells must be configurable.
PR removes `min-cell-size` and adds `max-cell-sizes` options. `min-cell-size` value is the first entry of `max-cell-sizes`

Sorry, i have already "merged" to master, so please consider also 3dcc7132b65520c67e71d667980192b6645c3379  for review in this PR.
All review requests i will add to this PR

/cc @TheMarex 

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
