### PR TITLE
add kerb to foot.profile barrier whitelist

### DIFF
--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -33,6 +33,7 @@ local profile = {
     'sally_port',
     'gate',
     'no',
+    'kerb',
     'block'
   },
 


### PR DESCRIPTION
# Issue

`kerb` is currently blacklisted for foot profile, whilst it is routable the same way as highway=steps. PR aims to whitelist it.

## Tasklist
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
