### PR TITLE
Reduce memory consumption during extraction and flip backward segment coordinates

### DIFF
--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -388,21 +388,24 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
             BOOST_ASSERT(edge_iterator->source_coordinate.lon !=
                          util::FixedLongitude{std::numeric_limits<std::int32_t>::min()});
 
-            const util::Coordinate target_coord{node_iterator->lon, node_iterator->lat};
-            const double distance = util::coordinate_calculation::greatCircleDistance(
-                edge_iterator->source_coordinate, target_coord);
+            util::Coordinate source_coord(edge_iterator->source_coordinate);
+            util::Coordinate target_coord{node_iterator->lon, node_iterator->lat};
 
-            auto weight = edge_iterator->weight_data(distance);
-            auto duration = edge_iterator->duration_data(distance);
+            // flip source and target coordinates if segment is in backward direction only
+            if (!edge_iterator->result.forward && edge_iterator->result.backward)
+                std::swap(source_coord, target_coord);
 
-            ExtractionSegment extracted_segment(
-                edge_iterator->source_coordinate, target_coord, distance, weight, duration);
-            scripting_environment.ProcessSegment(extracted_segment);
+            const auto distance =
+                util::coordinate_calculation::greatCircleDistance(source_coord, target_coord);
+            const auto weight = edge_iterator->weight_data(distance);
+            const auto duration = edge_iterator->duration_data(distance);
+
+            ExtractionSegment segment(source_coord, target_coord, distance, weight, duration);
+            scripting_environment.ProcessSegment(segment);
 
             auto &edge = edge_iterator->result;
-            edge.weight =
-                std::max<EdgeWeight>(1, std::round(extracted_segment.weight * weight_multiplier));
-            edge.duration = std::max<EdgeWeight>(1, std::round(extracted_segment.duration * 10.));
+            edge.weight = std::max<EdgeWeight>(1, std::round(segment.weight * weight_multiplier));
+            edge.duration = std::max<EdgeWeight>(1, std::round(segment.duration * 10.));
 
             // assign new node id
             auto id_iter = external_to_internal_node_id_map.find(node_iterator->node_id);

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -330,7 +330,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                              (turn_lane_id_forward != turn_lane_id_backward));
 
     if (in_forward_direction)
-    {
+    { // add (forward) segments or (forward,backward) for non-split edges in backward direction
         util::for_each_pair(
             nodes.cbegin(),
             nodes.cend(),
@@ -355,8 +355,8 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
             });
     }
 
-    if (in_backward_direction || split_edge)
-    {
+    if (in_backward_direction && (!in_forward_direction || split_edge))
+    { // add (backward) segments for split edges or not in forward direction
         util::for_each_pair(
             nodes.cbegin(),
             nodes.cend(),


### PR DESCRIPTION
# Issue

PR solves two issues:
* unnecessarily duplication of backward segments if `in_forward_direction` is true and `split_edge` is false. This will reduce memory consumption during extraction, but will prohibit workaround as in #3869
* fixes #3861 by flipping source and target coordinates for backward edges

For #3869 i would suggest to add and additional flag `split_edge` in `way_function`'s `result` argument and use it at https://github.com/Project-OSRM/osrm-backend/blob/fix/segment-end-points/src/extractor/extractor_callbacks.cpp#L326-L330

The current workaround to split edges to use slightly different weights
```
  result.forward_speed = 15
  result.backward_speed = 15.01
```
## Tasklist
 - [x] review
 - [x] adjust for comments

