### PR TITLE
MLD shortest path plugin

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -3,5 +3,5 @@ module.exports = {
     verify: '--strict --tags ~@stress --tags ~@todo -f progress --require features/support --require features/step_definitions',
     todo: '--strict --tags @todo --require features/support --require features/step_definitions',
     all: '--strict --require features/support --require features/step_definitions',
-    mld: '--strict --tags ~@stress --tags ~@todo --tags ~@match --tags ~@alternative --tags ~@matrix --tags ~@trip --tags ~@via --require features/support --require features/step_definitions -f progress'
+    mld: '--strict --tags ~@stress --tags ~@todo --tags ~@match --tags ~@alternative --tags ~@matrix --tags ~@trip --require features/support --require features/step_definitions -f progress'
 }

--- a/include/engine/algorithm.hpp
+++ b/include/engine/algorithm.hpp
@@ -96,6 +96,9 @@ template <> struct HasGetTileTurns<corech::Algorithm> final : std::true_type
 template <> struct HasDirectShortestPathSearch<mld::Algorithm> final : std::true_type
 {
 };
+template <> struct HasShortestPathSearch<mld::Algorithm> final : std::true_type
+{
+};
 }
 }
 }

--- a/include/engine/algorithm.hpp
+++ b/include/engine/algorithm.hpp
@@ -78,6 +78,7 @@ template <> struct HasGetTileTurns<ch::Algorithm> final : std::true_type
 };
 
 // Algorithms supported by Contraction Hierarchies with core
+// the rest is disabled because of performance reasons
 template <> struct HasShortestPathSearch<corech::Algorithm> final : std::true_type
 {
 };
@@ -90,31 +91,9 @@ template <> struct HasMapMatching<corech::Algorithm> final : std::true_type
 template <> struct HasGetTileTurns<corech::Algorithm> final : std::true_type
 {
 };
-// disbaled because of perfomance reasons
-template <> struct HasAlternativePathSearch<corech::Algorithm> final : std::false_type
-{
-};
-template <> struct HasManyToManySearch<corech::Algorithm> final : std::false_type
-{
-};
 
 // Algorithms supported by Multi-Level Dijkstra
 template <> struct HasDirectShortestPathSearch<mld::Algorithm> final : std::true_type
-{
-};
-template <> struct HasMapMatching<mld::Algorithm> final : std::false_type
-{
-};
-template <> struct HasAlternativePathSearch<mld::Algorithm> final : std::false_type
-{
-};
-template <> struct HasManyToManySearch<mld::Algorithm> final : std::false_type
-{
-};
-template <> struct HasShortestPathSearch<mld::Algorithm> final : std::false_type
-{
-};
-template <> struct HasGetTileTurns<mld::Algorithm> final : std::false_type
 {
 };
 }

--- a/include/engine/algorithm.hpp
+++ b/include/engine/algorithm.hpp
@@ -7,30 +7,36 @@ namespace osrm
 {
 namespace engine
 {
-namespace algorithm
+namespace routing_algorithms
 {
 
 // Contraction Hiearchy
-struct CH final
+namespace ch
+{
+struct Algorithm final
 {
 };
+}
 // Contraction Hiearchy with core
-struct CoreCH final
+namespace corech
+{
+struct Algorithm final
 {
 };
+}
 // Multi-Level Dijkstra
-struct MLD final
+namespace mld
+{
+struct Algorithm final
 {
 };
-
-template <typename AlgorithmT> const char *name();
-template <> inline const char *name<CH>() { return "CH"; }
-template <> inline const char *name<CoreCH>() { return "CoreCH"; }
-template <> inline const char *name<MLD>() { return "MLD"; }
 }
 
-namespace algorithm_trais
-{
+// Algorithm names
+template <typename AlgorithmT> const char *name();
+template <> inline const char *name<ch::Algorithm>() { return "CH"; }
+template <> inline const char *name<corech::Algorithm>() { return "CoreCH"; }
+template <> inline const char *name<mld::Algorithm>() { return "MLD"; }
 
 template <typename AlgorithmT> struct HasAlternativePathSearch final : std::false_type
 {
@@ -51,62 +57,64 @@ template <typename AlgorithmT> struct HasGetTileTurns final : std::false_type
 {
 };
 
-template <> struct HasAlternativePathSearch<algorithm::CH> final : std::true_type
+// Algorithms supported by Contraction Hierarchies
+template <> struct HasAlternativePathSearch<ch::Algorithm> final : std::true_type
 {
 };
-template <> struct HasShortestPathSearch<algorithm::CH> final : std::true_type
+template <> struct HasShortestPathSearch<ch::Algorithm> final : std::true_type
 {
 };
-template <> struct HasDirectShortestPathSearch<algorithm::CH> final : std::true_type
+template <> struct HasDirectShortestPathSearch<ch::Algorithm> final : std::true_type
 {
 };
-template <> struct HasMapMatching<algorithm::CH> final : std::true_type
+template <> struct HasMapMatching<ch::Algorithm> final : std::true_type
 {
 };
-template <> struct HasManyToManySearch<algorithm::CH> final : std::true_type
+template <> struct HasManyToManySearch<ch::Algorithm> final : std::true_type
 {
 };
-template <> struct HasGetTileTurns<algorithm::CH> final : std::true_type
-{
-};
-
-// disbaled because of perfomance reasons
-template <> struct HasAlternativePathSearch<algorithm::CoreCH> final : std::false_type
-{
-};
-template <> struct HasManyToManySearch<algorithm::CoreCH> final : std::false_type
-{
-};
-template <> struct HasShortestPathSearch<algorithm::CoreCH> final : std::true_type
-{
-};
-template <> struct HasDirectShortestPathSearch<algorithm::CoreCH> final : std::true_type
-{
-};
-template <> struct HasMapMatching<algorithm::CoreCH> final : std::true_type
-{
-};
-template <> struct HasGetTileTurns<algorithm::CoreCH> final : std::true_type
+template <> struct HasGetTileTurns<ch::Algorithm> final : std::true_type
 {
 };
 
+// Algorithms supported by Contraction Hierarchies with core
+template <> struct HasShortestPathSearch<corech::Algorithm> final : std::true_type
+{
+};
+template <> struct HasDirectShortestPathSearch<corech::Algorithm> final : std::true_type
+{
+};
+template <> struct HasMapMatching<corech::Algorithm> final : std::true_type
+{
+};
+template <> struct HasGetTileTurns<corech::Algorithm> final : std::true_type
+{
+};
 // disbaled because of perfomance reasons
-template <> struct HasAlternativePathSearch<algorithm::MLD> final : std::false_type
+template <> struct HasAlternativePathSearch<corech::Algorithm> final : std::false_type
 {
 };
-template <> struct HasManyToManySearch<algorithm::MLD> final : std::false_type
+template <> struct HasManyToManySearch<corech::Algorithm> final : std::false_type
 {
 };
-template <> struct HasShortestPathSearch<algorithm::MLD> final : std::false_type
+
+// Algorithms supported by Multi-Level Dijkstra
+template <> struct HasDirectShortestPathSearch<mld::Algorithm> final : std::true_type
 {
 };
-template <> struct HasDirectShortestPathSearch<algorithm::MLD> final : std::true_type
+template <> struct HasMapMatching<mld::Algorithm> final : std::false_type
 {
 };
-template <> struct HasMapMatching<algorithm::MLD> final : std::false_type
+template <> struct HasAlternativePathSearch<mld::Algorithm> final : std::false_type
 {
 };
-template <> struct HasGetTileTurns<algorithm::MLD> final : std::false_type
+template <> struct HasManyToManySearch<mld::Algorithm> final : std::false_type
+{
+};
+template <> struct HasShortestPathSearch<mld::Algorithm> final : std::false_type
+{
+};
+template <> struct HasGetTileTurns<mld::Algorithm> final : std::false_type
 {
 };
 }

--- a/include/engine/api/match_parameters_tidy.hpp
+++ b/include/engine/api/match_parameters_tidy.hpp
@@ -85,7 +85,6 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
     result.can_be_removed.resize(params.coordinates.size(), false);
 
     result.tidied_to_original.push_back(0);
-    std::size_t last_good = 0;
 
     const auto uses_timestamps = !params.timestamps.empty();
 
@@ -109,7 +108,6 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
 
             if (over_distance && over_duration)
             {
-                last_good = next;
                 result.tidied_to_original.push_back(next);
                 running = {0., 0}; // reset running distance and time
             }
@@ -122,7 +120,6 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
         {
             if (over_distance)
             {
-                last_good = next;
                 result.tidied_to_original.push_back(next);
                 running = {0., 0}; // reset running distance and time
             }

--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -17,11 +17,16 @@ namespace engine
 namespace datafacade
 {
 
+// Namespace local aliases for algorithms
+using CH = routing_algorithms::ch::Algorithm;
+using CoreCH = routing_algorithms::corech::Algorithm;
+using MLD = routing_algorithms::mld::Algorithm;
+
 using EdgeRange = util::range<EdgeID>;
 
 template <typename AlgorithmT> class AlgorithmDataFacade;
 
-template <> class AlgorithmDataFacade<algorithm::CH>
+template <> class AlgorithmDataFacade<CH>
 {
   public:
     using EdgeData = contractor::QueryEdge::EdgeData;
@@ -56,7 +61,7 @@ template <> class AlgorithmDataFacade<algorithm::CH>
                                     const std::function<bool(EdgeData)> filter) const = 0;
 };
 
-template <> class AlgorithmDataFacade<algorithm::CoreCH>
+template <> class AlgorithmDataFacade<CoreCH>
 {
   public:
     using EdgeData = contractor::QueryEdge::EdgeData;
@@ -64,7 +69,7 @@ template <> class AlgorithmDataFacade<algorithm::CoreCH>
     virtual bool IsCoreNode(const NodeID id) const = 0;
 };
 
-template <> class AlgorithmDataFacade<algorithm::MLD>
+template <> class AlgorithmDataFacade<MLD>
 {
   public:
     using EdgeData = extractor::EdgeBasedEdge::EdgeData;

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -58,8 +58,7 @@ namespace datafacade
 template <typename AlgorithmT> class ContiguousInternalMemoryAlgorithmDataFacade;
 
 template <>
-class ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CH>
-    : public datafacade::AlgorithmDataFacade<algorithm::CH>
+class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::AlgorithmDataFacade<CH>
 {
   private:
     using QueryGraph = util::StaticGraph<EdgeData, storage::Ownership::View>;
@@ -151,8 +150,8 @@ class ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CH>
 };
 
 template <>
-class ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CoreCH>
-    : public datafacade::AlgorithmDataFacade<algorithm::CoreCH>
+class ContiguousInternalMemoryAlgorithmDataFacade<CoreCH>
+    : public datafacade::AlgorithmDataFacade<CoreCH>
 {
   private:
     util::vector_view<bool> m_is_core_node;
@@ -869,36 +868,34 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 template <typename AlgorithmT> class ContiguousInternalMemoryDataFacade;
 
 template <>
-class ContiguousInternalMemoryDataFacade<algorithm::CH>
+class ContiguousInternalMemoryDataFacade<CH>
     : public ContiguousInternalMemoryDataFacadeBase,
-      public ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CH>
+      public ContiguousInternalMemoryAlgorithmDataFacade<CH>
 {
   public:
     ContiguousInternalMemoryDataFacade(std::shared_ptr<ContiguousBlockAllocator> allocator)
         : ContiguousInternalMemoryDataFacadeBase(allocator),
-          ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CH>(allocator)
+          ContiguousInternalMemoryAlgorithmDataFacade<CH>(allocator)
 
     {
     }
 };
 
 template <>
-class ContiguousInternalMemoryDataFacade<algorithm::CoreCH> final
-    : public ContiguousInternalMemoryDataFacade<algorithm::CH>,
-      public ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CoreCH>
+class ContiguousInternalMemoryDataFacade<CoreCH> final
+    : public ContiguousInternalMemoryDataFacade<CH>,
+      public ContiguousInternalMemoryAlgorithmDataFacade<CoreCH>
 {
   public:
     ContiguousInternalMemoryDataFacade(std::shared_ptr<ContiguousBlockAllocator> allocator)
-        : ContiguousInternalMemoryDataFacade<algorithm::CH>(allocator),
-          ContiguousInternalMemoryAlgorithmDataFacade<algorithm::CoreCH>(allocator)
+        : ContiguousInternalMemoryDataFacade<CH>(allocator),
+          ContiguousInternalMemoryAlgorithmDataFacade<CoreCH>(allocator)
 
     {
     }
 };
 
-template <>
-class ContiguousInternalMemoryAlgorithmDataFacade<algorithm::MLD>
-    : public datafacade::AlgorithmDataFacade<algorithm::MLD>
+template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public AlgorithmDataFacade<MLD>
 {
     // MLD data
     partition::MultiLevelPartitionView mld_partition;
@@ -1065,15 +1062,15 @@ class ContiguousInternalMemoryAlgorithmDataFacade<algorithm::MLD>
 };
 
 template <>
-class ContiguousInternalMemoryDataFacade<algorithm::MLD> final
+class ContiguousInternalMemoryDataFacade<MLD> final
     : public ContiguousInternalMemoryDataFacadeBase,
-      public ContiguousInternalMemoryAlgorithmDataFacade<algorithm::MLD>
+      public ContiguousInternalMemoryAlgorithmDataFacade<MLD>
 {
   private:
   public:
     ContiguousInternalMemoryDataFacade(std::shared_ptr<ContiguousBlockAllocator> allocator)
         : ContiguousInternalMemoryDataFacadeBase(allocator),
-          ContiguousInternalMemoryAlgorithmDataFacade<algorithm::MLD>(allocator)
+          ContiguousInternalMemoryAlgorithmDataFacade<MLD>(allocator)
 
     {
     }

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -64,13 +64,13 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
         if (config.use_shared_memory)
         {
             util::Log(logDEBUG) << "Using shared memory with algorithm "
-                                << algorithm::name<AlgorithmT>();
+                                << routing_algorithms::name<AlgorithmT>();
             facade_provider = std::make_unique<WatchingProvider<AlgorithmT>>();
         }
         else
         {
             util::Log(logDEBUG) << "Using internal memory with algorithm "
-                                << algorithm::name<AlgorithmT>();
+                                << routing_algorithms::name<AlgorithmT>();
             facade_provider =
                 std::make_unique<ImmutableProvider<AlgorithmT>>(config.storage_config);
         }
@@ -143,7 +143,8 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
     const plugins::TilePlugin tile_plugin;
 };
 
-template <> bool Engine<algorithm::CH>::CheckCompability(const EngineConfig &config)
+template <>
+bool Engine<routing_algorithms::ch::Algorithm>::CheckCompability(const EngineConfig &config)
 {
     if (config.use_shared_memory)
     {
@@ -168,9 +169,10 @@ template <> bool Engine<algorithm::CH>::CheckCompability(const EngineConfig &con
     }
 }
 
-template <> bool Engine<algorithm::CoreCH>::CheckCompability(const EngineConfig &config)
+template <>
+bool Engine<routing_algorithms::corech::Algorithm>::CheckCompability(const EngineConfig &config)
 {
-    if (!Engine<algorithm::CH>::CheckCompability(config))
+    if (!Engine<routing_algorithms::ch::Algorithm>::CheckCompability(config))
     {
         return false;
     }

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -49,7 +49,7 @@ class EngineInterface
     virtual Status Tile(const api::TileParameters &parameters, std::string &result) const = 0;
 };
 
-template <typename AlgorithmT> class Engine final : public EngineInterface
+template <typename Algorithm> class Engine final : public EngineInterface
 {
   public:
     explicit Engine(const EngineConfig &config)
@@ -64,15 +64,14 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
         if (config.use_shared_memory)
         {
             util::Log(logDEBUG) << "Using shared memory with algorithm "
-                                << routing_algorithms::name<AlgorithmT>();
-            facade_provider = std::make_unique<WatchingProvider<AlgorithmT>>();
+                                << routing_algorithms::name<Algorithm>();
+            facade_provider = std::make_unique<WatchingProvider<Algorithm>>();
         }
         else
         {
             util::Log(logDEBUG) << "Using internal memory with algorithm "
-                                << routing_algorithms::name<AlgorithmT>();
-            facade_provider =
-                std::make_unique<ImmutableProvider<AlgorithmT>>(config.storage_config);
+                                << routing_algorithms::name<Algorithm>();
+            facade_provider = std::make_unique<ImmutableProvider<Algorithm>>(config.storage_config);
         }
     }
 
@@ -87,7 +86,7 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
                  util::json::Object &result) const override final
     {
         auto facade = facade_provider->Get();
-        auto algorithms = RoutingAlgorithms<AlgorithmT>{heaps, *facade};
+        auto algorithms = RoutingAlgorithms<Algorithm>{heaps, *facade};
         return route_plugin.HandleRequest(*facade, algorithms, params, result);
     }
 
@@ -95,7 +94,7 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
                  util::json::Object &result) const override final
     {
         auto facade = facade_provider->Get();
-        auto algorithms = RoutingAlgorithms<AlgorithmT>{heaps, *facade};
+        auto algorithms = RoutingAlgorithms<Algorithm>{heaps, *facade};
         return table_plugin.HandleRequest(*facade, algorithms, params, result);
     }
 
@@ -103,14 +102,14 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
                    util::json::Object &result) const override final
     {
         auto facade = facade_provider->Get();
-        auto algorithms = RoutingAlgorithms<AlgorithmT>{heaps, *facade};
+        auto algorithms = RoutingAlgorithms<Algorithm>{heaps, *facade};
         return nearest_plugin.HandleRequest(*facade, algorithms, params, result);
     }
 
     Status Trip(const api::TripParameters &params, util::json::Object &result) const override final
     {
         auto facade = facade_provider->Get();
-        auto algorithms = RoutingAlgorithms<AlgorithmT>{heaps, *facade};
+        auto algorithms = RoutingAlgorithms<Algorithm>{heaps, *facade};
         return trip_plugin.HandleRequest(*facade, algorithms, params, result);
     }
 
@@ -118,22 +117,22 @@ template <typename AlgorithmT> class Engine final : public EngineInterface
                  util::json::Object &result) const override final
     {
         auto facade = facade_provider->Get();
-        auto algorithms = RoutingAlgorithms<AlgorithmT>{heaps, *facade};
+        auto algorithms = RoutingAlgorithms<Algorithm>{heaps, *facade};
         return match_plugin.HandleRequest(*facade, algorithms, params, result);
     }
 
     Status Tile(const api::TileParameters &params, std::string &result) const override final
     {
         auto facade = facade_provider->Get();
-        auto algorithms = RoutingAlgorithms<AlgorithmT>{heaps, *facade};
+        auto algorithms = RoutingAlgorithms<Algorithm>{heaps, *facade};
         return tile_plugin.HandleRequest(*facade, algorithms, params, result);
     }
 
     static bool CheckCompability(const EngineConfig &config);
 
   private:
-    std::unique_ptr<DataFacadeProvider<AlgorithmT>> facade_provider;
-    mutable SearchEngineData heaps;
+    std::unique_ptr<DataFacadeProvider<Algorithm>> facade_provider;
+    mutable SearchEngineData<Algorithm> heaps;
 
     const plugins::ViaRoutePlugin route_plugin;
     const plugins::TablePlugin table_plugin;

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -93,32 +93,32 @@ template <typename AlgorithmT> class RoutingAlgorithms final : public RoutingAlg
 
     bool HasAlternativePathSearch() const final override
     {
-        return algorithm_trais::HasAlternativePathSearch<AlgorithmT>::value;
+        return routing_algorithms::HasAlternativePathSearch<AlgorithmT>::value;
     }
 
     bool HasShortestPathSearch() const final override
     {
-        return algorithm_trais::HasShortestPathSearch<AlgorithmT>::value;
+        return routing_algorithms::HasShortestPathSearch<AlgorithmT>::value;
     }
 
     bool HasDirectShortestPathSearch() const final override
     {
-        return algorithm_trais::HasDirectShortestPathSearch<AlgorithmT>::value;
+        return routing_algorithms::HasDirectShortestPathSearch<AlgorithmT>::value;
     }
 
     bool HasMapMatching() const final override
     {
-        return algorithm_trais::HasMapMatching<AlgorithmT>::value;
+        return routing_algorithms::HasMapMatching<AlgorithmT>::value;
     }
 
     bool HasManyToManySearch() const final override
     {
-        return algorithm_trais::HasManyToManySearch<AlgorithmT>::value;
+        return routing_algorithms::HasManyToManySearch<AlgorithmT>::value;
     }
 
     bool HasGetTileTurns() const final override
     {
-        return algorithm_trais::HasGetTileTurns<AlgorithmT>::value;
+        return routing_algorithms::HasGetTileTurns<AlgorithmT>::value;
     }
 
   private:
@@ -131,7 +131,7 @@ template <typename AlgorithmT>
 InternalRouteResult
 RoutingAlgorithms<AlgorithmT>::AlternativePathSearch(const PhantomNodes &phantom_node_pair) const
 {
-    return routing_algorithms::alternativePathSearch(heaps, facade, phantom_node_pair);
+    return routing_algorithms::ch::alternativePathSearch(heaps, facade, phantom_node_pair);
 }
 
 template <typename AlgorithmT>
@@ -156,7 +156,7 @@ std::vector<EdgeWeight> RoutingAlgorithms<AlgorithmT>::ManyToManySearch(
     const std::vector<std::size_t> &source_indices,
     const std::vector<std::size_t> &target_indices) const
 {
-    return routing_algorithms::manyToManySearch(
+    return routing_algorithms::ch::manyToManySearch(
         heaps, facade, phantom_nodes, source_indices, target_indices);
 }
 
@@ -168,13 +168,13 @@ inline routing_algorithms::SubMatchingList RoutingAlgorithms<AlgorithmT>::MapMat
     const std::vector<boost::optional<double>> &trace_gps_precision,
     const bool allow_splitting) const
 {
-    return routing_algorithms::mapMatching(heaps,
-                                           facade,
-                                           candidates_list,
-                                           trace_coordinates,
-                                           trace_timestamps,
-                                           trace_gps_precision,
-                                           allow_splitting);
+    return routing_algorithms::ch::mapMatching(heaps,
+                                               facade,
+                                               candidates_list,
+                                               trace_coordinates,
+                                               trace_timestamps,
+                                               trace_gps_precision,
+                                               allow_splitting);
 }
 
 template <typename AlgorithmT>
@@ -187,42 +187,45 @@ inline std::vector<routing_algorithms::TurnData> RoutingAlgorithms<AlgorithmT>::
 
 // MLD overrides for not implemented
 template <>
-InternalRouteResult inline RoutingAlgorithms<algorithm::MLD>::AlternativePathSearch(
-    const PhantomNodes &) const
+InternalRouteResult inline RoutingAlgorithms<
+    routing_algorithms::mld::Algorithm>::AlternativePathSearch(const PhantomNodes &) const
 {
     throw util::exception("AlternativePathSearch is not implemented");
 }
 
 template <>
 inline InternalRouteResult
-RoutingAlgorithms<algorithm::MLD>::ShortestPathSearch(const std::vector<PhantomNodes> &,
-                                                      const boost::optional<bool>) const
+RoutingAlgorithms<routing_algorithms::mld::Algorithm>::ShortestPathSearch(
+    const std::vector<PhantomNodes> &, const boost::optional<bool>) const
 {
     throw util::exception("ShortestPathSearch is not implemented");
 }
 
 template <>
 inline std::vector<EdgeWeight>
-RoutingAlgorithms<algorithm::MLD>::ManyToManySearch(const std::vector<PhantomNode> &,
-                                                    const std::vector<std::size_t> &,
-                                                    const std::vector<std::size_t> &) const
+RoutingAlgorithms<routing_algorithms::mld::Algorithm>::ManyToManySearch(
+    const std::vector<PhantomNode> &,
+    const std::vector<std::size_t> &,
+    const std::vector<std::size_t> &) const
 {
     throw util::exception("ManyToManySearch is not implemented");
 }
 
 template <>
 inline routing_algorithms::SubMatchingList
-RoutingAlgorithms<algorithm::MLD>::MapMatching(const routing_algorithms::CandidateLists &,
-                                               const std::vector<util::Coordinate> &,
-                                               const std::vector<unsigned> &,
-                                               const std::vector<boost::optional<double>> &,
-                                               const bool) const
+RoutingAlgorithms<routing_algorithms::mld::Algorithm>::MapMatching(
+    const routing_algorithms::CandidateLists &,
+    const std::vector<util::Coordinate> &,
+    const std::vector<unsigned> &,
+    const std::vector<boost::optional<double>> &,
+    const bool) const
 {
     throw util::exception("MapMatching is not implemented");
 }
 
 template <>
-inline std::vector<routing_algorithms::TurnData> RoutingAlgorithms<algorithm::MLD>::GetTileTurns(
+inline std::vector<routing_algorithms::TurnData>
+RoutingAlgorithms<routing_algorithms::mld::Algorithm>::GetTileTurns(
     const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &,
     const std::vector<std::size_t> &) const
 {

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -187,7 +187,8 @@ inline std::vector<routing_algorithms::TurnData> RoutingAlgorithms<Algorithm>::G
 
 // CoreCH overrides
 template <>
-InternalRouteResult inline RoutingAlgorithms<routing_algorithms::corech::Algorithm>::AlternativePathSearch(const PhantomNodes &) const
+InternalRouteResult inline RoutingAlgorithms<
+    routing_algorithms::corech::Algorithm>::AlternativePathSearch(const PhantomNodes &) const
 {
     throw util::exception("AlternativePathSearch is disabled due to performance reasons");
 }
@@ -208,14 +209,6 @@ InternalRouteResult inline RoutingAlgorithms<
     routing_algorithms::mld::Algorithm>::AlternativePathSearch(const PhantomNodes &) const
 {
     throw util::exception("AlternativePathSearch is not implemented");
-}
-
-template <>
-inline InternalRouteResult
-RoutingAlgorithms<routing_algorithms::mld::Algorithm>::ShortestPathSearch(
-    const std::vector<PhantomNodes> &, const boost::optional<bool>) const
-{
-    throw util::exception("ShortestPathSearch is not implemented");
 }
 
 template <>

--- a/include/engine/routing_algorithms/alternative_path.hpp
+++ b/include/engine/routing_algorithms/alternative_path.hpp
@@ -15,12 +15,13 @@ namespace engine
 {
 namespace routing_algorithms
 {
-
+namespace ch
+{
 InternalRouteResult
 alternativePathSearch(SearchEngineData &search_engine_data,
-                      const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+                      const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                       const PhantomNodes &phantom_node_pair);
-
+} // namespace ch
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm

--- a/include/engine/routing_algorithms/alternative_path.hpp
+++ b/include/engine/routing_algorithms/alternative_path.hpp
@@ -18,8 +18,8 @@ namespace routing_algorithms
 namespace ch
 {
 InternalRouteResult
-alternativePathSearch(SearchEngineData &search_engine_data,
-                      const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
+alternativePathSearch(SearchEngineData<Algorithm> &search_engine_data,
+                      const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                       const PhantomNodes &phantom_node_pair);
 } // namespace ch
 } // namespace routing_algorithms

--- a/include/engine/routing_algorithms/direct_shortest_path.hpp
+++ b/include/engine/routing_algorithms/direct_shortest_path.hpp
@@ -21,11 +21,16 @@ namespace routing_algorithms
 /// by the previous route.
 /// This variation is only an optimazation for graphs with slow queries, for example
 /// not fully contracted graphs.
-template <typename AlgorithmT>
+template <typename Algorithm>
 InternalRouteResult
-directShortestPathSearch(SearchEngineData &engine_working_data,
-                         const datafacade::ContiguousInternalMemoryDataFacade<AlgorithmT> &facade,
+directShortestPathSearch(SearchEngineData<Algorithm> &engine_working_data,
+                         const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                          const PhantomNodes &phantom_nodes);
+
+InternalRouteResult directShortestPathSearch(
+    SearchEngineData<mld::Algorithm> &engine_working_data,
+    const datafacade::ContiguousInternalMemoryDataFacade<mld::Algorithm> &facade,
+    const PhantomNodes &phantom_nodes);
 
 } // namespace routing_algorithms
 } // namespace engine

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -19,7 +19,7 @@ namespace routing_algorithms
 namespace ch
 {
 std::vector<EdgeWeight>
-manyToManySearch(SearchEngineData &engine_working_data,
+manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                  const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,
                  const std::vector<std::size_t> &source_indices,

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -13,16 +13,18 @@ namespace osrm
 {
 namespace engine
 {
-
 namespace routing_algorithms
 {
 
+namespace ch
+{
 std::vector<EdgeWeight>
 manyToManySearch(SearchEngineData &engine_working_data,
-                 const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+                 const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,
                  const std::vector<std::size_t> &source_indices,
                  const std::vector<std::size_t> &target_indices);
+} // namespace ch
 
 } // namespace routing_algorithms
 } // namespace engine

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -22,23 +22,27 @@ static const constexpr double DEFAULT_GPS_PRECISION = 5;
 
 //[1] "Hidden Markov Map Matching Through Noise and Sparseness";
 //     P. Newson and J. Krumm; 2009; ACM GIS
-SubMatchingList
-mapMatching(SearchEngineData &engine_working_data,
-            const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
-            const CandidateLists &candidates_list,
-            const std::vector<util::Coordinate> &trace_coordinates,
-            const std::vector<unsigned> &trace_timestamps,
-            const std::vector<boost::optional<double>> &trace_gps_precision,
-            const bool allow_splitting);
+namespace ch
+{
+SubMatchingList mapMatching(SearchEngineData &engine_working_data,
+                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                            const CandidateLists &candidates_list,
+                            const std::vector<util::Coordinate> &trace_coordinates,
+                            const std::vector<unsigned> &trace_timestamps,
+                            const std::vector<boost::optional<double>> &trace_gps_precision,
+                            const bool allow_splitting);
+}
 
-SubMatchingList
-mapMatching(SearchEngineData &engine_working_data,
-            const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
-            const CandidateLists &candidates_list,
-            const std::vector<util::Coordinate> &trace_coordinates,
-            const std::vector<unsigned> &trace_timestamps,
-            const std::vector<boost::optional<double>> &trace_gps_precision,
-            const bool allow_splitting);
+namespace corech
+{
+SubMatchingList mapMatching(SearchEngineData &engine_working_data,
+                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                            const CandidateLists &candidates_list,
+                            const std::vector<util::Coordinate> &trace_coordinates,
+                            const std::vector<unsigned> &trace_timestamps,
+                            const std::vector<boost::optional<double>> &trace_gps_precision,
+                            const bool allow_splitting);
+}
 }
 }
 }

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -22,27 +22,15 @@ static const constexpr double DEFAULT_GPS_PRECISION = 5;
 
 //[1] "Hidden Markov Map Matching Through Noise and Sparseness";
 //     P. Newson and J. Krumm; 2009; ACM GIS
-namespace ch
-{
-SubMatchingList mapMatching(SearchEngineData &engine_working_data,
+template<typename Algorithm>
+SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
                             const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                             const CandidateLists &candidates_list,
                             const std::vector<util::Coordinate> &trace_coordinates,
                             const std::vector<unsigned> &trace_timestamps,
                             const std::vector<boost::optional<double>> &trace_gps_precision,
                             const bool allow_splitting);
-}
 
-namespace corech
-{
-SubMatchingList mapMatching(SearchEngineData &engine_working_data,
-                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                            const CandidateLists &candidates_list,
-                            const std::vector<util::Coordinate> &trace_coordinates,
-                            const std::vector<unsigned> &trace_timestamps,
-                            const std::vector<boost::optional<double>> &trace_gps_precision,
-                            const bool allow_splitting);
-}
 }
 }
 }

--- a/include/engine/routing_algorithms/map_matching.hpp
+++ b/include/engine/routing_algorithms/map_matching.hpp
@@ -22,7 +22,7 @@ static const constexpr double DEFAULT_GPS_PRECISION = 5;
 
 //[1] "Hidden Markov Map Matching Through Noise and Sparseness";
 //     P. Newson and J. Krumm; 2009; ACM GIS
-template<typename Algorithm>
+template <typename Algorithm>
 SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
                             const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                             const CandidateLists &candidates_list,
@@ -30,7 +30,6 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
                             const std::vector<unsigned> &trace_timestamps,
                             const std::vector<boost::optional<double>> &trace_gps_precision,
                             const bool allow_splitting);
-
 }
 }
 }

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -37,6 +37,10 @@ static constexpr bool FORWARD_DIRECTION = true;
 static constexpr bool REVERSE_DIRECTION = false;
 static constexpr bool DO_NOT_FORCE_LOOPS = false;
 
+bool needsLoopForward(const PhantomNode &source_phantom, const PhantomNode &target_phantom);
+
+bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &target_phantom);
+
 template <bool DIRECTION, typename Heap>
 void insertNodesInHeap(Heap &heap, const PhantomNode &phantom_node)
 {

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -58,7 +58,8 @@ void insertNodesInHeap(Heap &heap, const PhantomNode &phantom_node)
 }
 
 template <bool DIRECTION>
-void insertNodesInHeap(SearchEngineData::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+void insertNodesInHeap(SearchEngineData<ch::Algorithm>::ManyToManyQueryHeap &heap,
+                       const PhantomNode &phantom_node)
 {
     BOOST_ASSERT(phantom_node.IsValid());
 

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -365,10 +365,11 @@ inline void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorith
                    SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                    SearchEngineData<Algorithm>::QueryHeap &,
                    SearchEngineData<Algorithm>::QueryHeap &,
-                   std::int32_t &weight,
+                   EdgeWeight &weight,
                    std::vector<NodeID> &packed_leg,
                    const bool force_loop_forward,
                    const bool force_loop_reverse,
+                   const PhantomNodes & /*phantom_nodes*/,
                    const int duration_upper_bound = INVALID_EDGE_WEIGHT)
 {
     search(facade,
@@ -380,10 +381,6 @@ inline void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorith
            force_loop_reverse,
            duration_upper_bound);
 }
-
-bool needsLoopForward(const PhantomNode &source_phantom, const PhantomNode &target_phantom);
-
-bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &target_phantom);
 
 double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                        const std::vector<NodeID> &packed_path,
@@ -437,6 +434,7 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorit
             std::vector<NodeID> &packed_leg,
             const bool force_loop_forward,
             const bool force_loop_reverse,
+            const PhantomNodes &phantom_nodes,
             int duration_upper_bound = INVALID_EDGE_WEIGHT);
 
 // Requires the heaps for be empty
@@ -451,6 +449,17 @@ getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<corech::
                    const PhantomNode &source_phantom,
                    const PhantomNode &target_phantom,
                    int duration_upper_bound = INVALID_EDGE_WEIGHT);
+
+template <typename RandomIter, typename FacadeT>
+void unpackPath(const FacadeT &facade,
+                RandomIter packed_path_begin,
+                RandomIter packed_path_end,
+                const PhantomNodes &phantom_nodes,
+                std::vector<PathData> &unpacked_path)
+{
+    return ch::unpackPath(facade, packed_path_begin, packed_path_end, phantom_nodes, unpacked_path);
+}
+
 } // namespace corech
 
 } // namespace routing_algorithms

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -23,7 +23,7 @@ namespace ch
 
 // Stalling
 template <bool DIRECTION, typename HeapT>
-bool stallAtNode(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+bool stallAtNode(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  const NodeID node,
                  const EdgeWeight weight,
                  const HeapT &query_heap)
@@ -49,7 +49,7 @@ bool stallAtNode(const datafacade::ContiguousInternalMemoryDataFacade<algorithm:
 }
 
 template <bool DIRECTION>
-void relaxOutgoingEdges(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void relaxOutgoingEdges(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                         const NodeID node,
                         const EdgeWeight weight,
                         SearchEngineData::QueryHeap &heap)
@@ -113,7 +113,7 @@ we need to add an offset to the termination criterion.
 static constexpr bool ENABLE_STALLING = true;
 static constexpr bool DISABLE_STALLING = false;
 template <bool DIRECTION, bool STALLING = ENABLE_STALLING>
-void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  SearchEngineData::QueryHeap &forward_heap,
                  SearchEngineData::QueryHeap &reverse_heap,
                  NodeID &middle_node_id,
@@ -186,9 +186,8 @@ void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<algorithm:
 }
 
 template <bool UseDuration>
-EdgeWeight
-getLoopWeight(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
-              NodeID node)
+EdgeWeight getLoopWeight(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                         NodeID node)
 {
     EdgeWeight loop_weight = UseDuration ? MAXIMAL_EDGE_DURATION : INVALID_EDGE_WEIGHT;
     for (auto edge : facade.GetAdjacentEdgeRange(node))
@@ -228,7 +227,7 @@ getLoopWeight(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH
  * original edge found.
  */
 template <typename BidirectionalIterator, typename Callback>
-void unpackPath(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void unpackPath(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                 BidirectionalIterator packed_path_begin,
                 BidirectionalIterator packed_path_end,
                 Callback &&callback)
@@ -325,7 +324,7 @@ void unpackPath(const FacadeT &facade,
  * @param to the node the CH edge finishes at
  * @param unpacked_path the sequence of original NodeIDs that make up the expanded CH edge
  */
-void unpackEdge(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void unpackEdge(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                 const NodeID from,
                 const NodeID to,
                 std::vector<NodeID> &unpacked_path);
@@ -351,7 +350,7 @@ void retrievePackedPathFromSingleHeap(const SearchEngineData::QueryHeap &search_
 // && source_phantom.GetForwardWeightPlusOffset() > target_phantom.GetForwardWeightPlusOffset())
 // requires
 // a force loop, if the heaps have been initialized with positive offsets.
-void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
             SearchEngineData::QueryHeap &forward_heap,
             SearchEngineData::QueryHeap &reverse_heap,
             std::int32_t &weight,
@@ -361,7 +360,7 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> 
             const int duration_upper_bound = INVALID_EDGE_WEIGHT);
 
 // Alias to be compatible with the overload for CoreCH that needs 4 heaps
-inline void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+inline void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                    SearchEngineData::QueryHeap &forward_heap,
                    SearchEngineData::QueryHeap &reverse_heap,
                    SearchEngineData::QueryHeap &,
@@ -382,31 +381,11 @@ inline void search(const datafacade::ContiguousInternalMemoryDataFacade<algorith
            duration_upper_bound);
 }
 
-// assumes that heaps are already setup correctly.
-// A forced loop might be necessary, if source and target are on the same segment.
-// If this is the case and the offsets of the respective direction are larger for the source
-// than the target
-// then a force loop is required (e.g. source_phantom.forward_segment_id ==
-// target_phantom.forward_segment_id
-// && source_phantom.GetForwardWeightPlusOffset() > target_phantom.GetForwardWeightPlusOffset())
-// requires
-// a force loop, if the heaps have been initialized with positive offsets.
-void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
-            SearchEngineData::QueryHeap &forward_heap,
-            SearchEngineData::QueryHeap &reverse_heap,
-            SearchEngineData::QueryHeap &forward_core_heap,
-            SearchEngineData::QueryHeap &reverse_core_heap,
-            int &weight,
-            std::vector<NodeID> &packed_leg,
-            const bool force_loop_forward,
-            const bool force_loop_reverse,
-            int duration_upper_bound = INVALID_EDGE_WEIGHT);
-
 bool needsLoopForward(const PhantomNode &source_phantom, const PhantomNode &target_phantom);
 
 bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &target_phantom);
 
-double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                        const std::vector<NodeID> &packed_path,
                        const PhantomNode &source_phantom,
                        const PhantomNode &target_phantom);
@@ -415,20 +394,7 @@ double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<algo
 // If heaps should be adjusted to be initialized outside of this function,
 // the addition of force_loop parameters might be required
 double
-getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
-                   SearchEngineData::QueryHeap &forward_core_heap,
-                   SearchEngineData::QueryHeap &reverse_core_heap,
-                   const PhantomNode &source_phantom,
-                   const PhantomNode &target_phantom,
-                   int duration_upper_bound = INVALID_EDGE_WEIGHT);
-
-// Requires the heaps for be empty
-// If heaps should be adjusted to be initialized outside of this function,
-// the addition of force_loop parameters might be required
-double
-getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                    SearchEngineData::QueryHeap &forward_heap,
                    SearchEngineData::QueryHeap &reverse_heap,
                    const PhantomNode &source_phantom,
@@ -437,7 +403,7 @@ getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorith
 
 // Alias to be compatible with the overload for CoreCH that needs 4 heaps
 inline double
-getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                    SearchEngineData::QueryHeap &forward_heap,
                    SearchEngineData::QueryHeap &reverse_heap,
                    SearchEngineData::QueryHeap &,
@@ -449,8 +415,44 @@ getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorith
     return getNetworkDistance(
         facade, forward_heap, reverse_heap, source_phantom, target_phantom, duration_upper_bound);
 }
-
 } // namespace ch
+
+namespace corech
+{
+// assumes that heaps are already setup correctly.
+// A forced loop might be necessary, if source and target are on the same segment.
+// If this is the case and the offsets of the respective direction are larger for the source
+// than the target
+// then a force loop is required (e.g. source_phantom.forward_segment_id ==
+// target_phantom.forward_segment_id
+// && source_phantom.GetForwardWeightPlusOffset() > target_phantom.GetForwardWeightPlusOffset())
+// requires
+// a force loop, if the heaps have been initialized with positive offsets.
+void search(const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
+            SearchEngineData::QueryHeap &forward_heap,
+            SearchEngineData::QueryHeap &reverse_heap,
+            SearchEngineData::QueryHeap &forward_core_heap,
+            SearchEngineData::QueryHeap &reverse_core_heap,
+            int &weight,
+            std::vector<NodeID> &packed_leg,
+            const bool force_loop_forward,
+            const bool force_loop_reverse,
+            int duration_upper_bound = INVALID_EDGE_WEIGHT);
+
+// Requires the heaps for be empty
+// If heaps should be adjusted to be initialized outside of this function,
+// the addition of force_loop parameters might be required
+double
+getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
+                   SearchEngineData::QueryHeap &forward_heap,
+                   SearchEngineData::QueryHeap &reverse_heap,
+                   SearchEngineData::QueryHeap &forward_core_heap,
+                   SearchEngineData::QueryHeap &reverse_core_heap,
+                   const PhantomNode &source_phantom,
+                   const PhantomNode &target_phantom,
+                   int duration_upper_bound = INVALID_EDGE_WEIGHT);
+} // namespace corech
+
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -52,7 +52,7 @@ template <bool DIRECTION>
 void relaxOutgoingEdges(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                         const NodeID node,
                         const EdgeWeight weight,
-                        SearchEngineData::QueryHeap &heap)
+                        SearchEngineData<Algorithm>::QueryHeap &heap)
 {
     for (const auto edge : facade.GetAdjacentEdgeRange(node))
     {
@@ -114,8 +114,8 @@ static constexpr bool ENABLE_STALLING = true;
 static constexpr bool DISABLE_STALLING = false;
 template <bool DIRECTION, bool STALLING = ENABLE_STALLING>
 void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                 SearchEngineData::QueryHeap &forward_heap,
-                 SearchEngineData::QueryHeap &reverse_heap,
+                 SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                 SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                  NodeID &middle_node_id,
                  EdgeWeight &upper_bound,
                  EdgeWeight min_edge_offset,
@@ -329,12 +329,12 @@ void unpackEdge(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> 
                 const NodeID to,
                 std::vector<NodeID> &unpacked_path);
 
-void retrievePackedPathFromHeap(const SearchEngineData::QueryHeap &forward_heap,
-                                const SearchEngineData::QueryHeap &reverse_heap,
+void retrievePackedPathFromHeap(const SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                                const SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                                 const NodeID middle_node_id,
                                 std::vector<NodeID> &packed_path);
 
-void retrievePackedPathFromSingleHeap(const SearchEngineData::QueryHeap &search_heap,
+void retrievePackedPathFromSingleHeap(const SearchEngineData<Algorithm>::QueryHeap &search_heap,
                                       const NodeID middle_node_id,
                                       std::vector<NodeID> &packed_path);
 
@@ -351,8 +351,8 @@ void retrievePackedPathFromSingleHeap(const SearchEngineData::QueryHeap &search_
 // requires
 // a force loop, if the heaps have been initialized with positive offsets.
 void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-            SearchEngineData::QueryHeap &forward_heap,
-            SearchEngineData::QueryHeap &reverse_heap,
+            SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+            SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
             std::int32_t &weight,
             std::vector<NodeID> &packed_leg,
             const bool force_loop_forward,
@@ -361,10 +361,10 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &fac
 
 // Alias to be compatible with the overload for CoreCH that needs 4 heaps
 inline void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
-                   SearchEngineData::QueryHeap &,
-                   SearchEngineData::QueryHeap &,
+                   SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &,
+                   SearchEngineData<Algorithm>::QueryHeap &,
                    std::int32_t &weight,
                    std::vector<NodeID> &packed_leg,
                    const bool force_loop_forward,
@@ -395,8 +395,8 @@ double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::
 // the addition of force_loop parameters might be required
 double
 getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                    const PhantomNode &source_phantom,
                    const PhantomNode &target_phantom,
                    int duration_upper_bound = INVALID_EDGE_WEIGHT);
@@ -404,10 +404,10 @@ getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algo
 // Alias to be compatible with the overload for CoreCH that needs 4 heaps
 inline double
 getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
-                   SearchEngineData::QueryHeap &,
-                   SearchEngineData::QueryHeap &,
+                   SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &,
+                   SearchEngineData<Algorithm>::QueryHeap &,
                    const PhantomNode &source_phantom,
                    const PhantomNode &target_phantom,
                    int duration_upper_bound = INVALID_EDGE_WEIGHT)
@@ -429,10 +429,10 @@ namespace corech
 // requires
 // a force loop, if the heaps have been initialized with positive offsets.
 void search(const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
-            SearchEngineData::QueryHeap &forward_heap,
-            SearchEngineData::QueryHeap &reverse_heap,
-            SearchEngineData::QueryHeap &forward_core_heap,
-            SearchEngineData::QueryHeap &reverse_core_heap,
+            SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+            SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
+            SearchEngineData<Algorithm>::QueryHeap &forward_core_heap,
+            SearchEngineData<Algorithm>::QueryHeap &reverse_core_heap,
             int &weight,
             std::vector<NodeID> &packed_leg,
             const bool force_loop_forward,
@@ -444,10 +444,10 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorit
 // the addition of force_loop parameters might be required
 double
 getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
-                   SearchEngineData::QueryHeap &forward_core_heap,
-                   SearchEngineData::QueryHeap &reverse_core_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &forward_core_heap,
+                   SearchEngineData<Algorithm>::QueryHeap &reverse_core_heap,
                    const PhantomNode &source_phantom,
                    const PhantomNode &target_phantom,
                    int duration_upper_bound = INVALID_EDGE_WEIGHT);

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -57,7 +57,7 @@ bool checkParentCellRestriction(CellID cell, LevelID, CellID parent) { return ce
 }
 
 template <bool DIRECTION, typename... Args>
-void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::MLD> &facade,
+void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  SearchEngineData::MultiLayerDijkstraHeap &forward_heap,
                  SearchEngineData::MultiLayerDijkstraHeap &reverse_heap,
                  NodeID &middle_node,
@@ -171,7 +171,7 @@ void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<algorithm:
 
 template <typename... Args>
 std::tuple<EdgeWeight, NodeID, NodeID, std::vector<EdgeID>>
-search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::MLD> &facade,
+search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
        SearchEngineData::MultiLayerDijkstraHeap &forward_heap,
        SearchEngineData::MultiLayerDijkstraHeap &reverse_heap,
        Args... args)

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -83,35 +83,10 @@ void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm>
         auto path_weight = weight + reverse_weight;
 
         // if loops are forced, they are so at the source
-        if ((force_loop_forward && forward_heap.GetData(node).parent == node) ||
-            (force_loop_reverse && reverse_heap.GetData(node).parent == node) ||
-            // in this case we are looking at a bi-directional way where the source
-            // and target phantom are on the same edge based node
-            path_weight < 0)
+        if (!(force_loop_forward && forward_heap.GetData(node).parent == node) &&
+            !(force_loop_reverse && reverse_heap.GetData(node).parent == node) &&
+            (path_weight >= 0) && (path_weight < path_upper_bound))
         {
-            // check whether there is a loop present at the node
-            for (const auto edge : facade.GetAdjacentEdgeRange(node))
-            {
-                const auto &data = facade.GetEdgeData(edge);
-                if (DIRECTION == FORWARD_DIRECTION ? data.forward : data.backward)
-                {
-                    const NodeID to = facade.GetTarget(edge);
-                    if (to == node)
-                    {
-                        const EdgeWeight edge_weight = data.weight;
-                        const EdgeWeight loop_weight = path_weight + edge_weight;
-                        if (loop_weight >= 0 && loop_weight < path_upper_bound)
-                        {
-                            middle_node = node;
-                            path_upper_bound = loop_weight;
-                        }
-                    }
-                }
-            }
-        }
-        else if (path_weight >= 0 && path_weight < path_upper_bound)
-        {
-
             middle_node = node;
             path_upper_bound = path_weight;
         }

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -58,8 +58,8 @@ bool checkParentCellRestriction(CellID cell, LevelID, CellID parent) { return ce
 
 template <bool DIRECTION, typename... Args>
 void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                 SearchEngineData::MultiLayerDijkstraHeap &forward_heap,
-                 SearchEngineData::MultiLayerDijkstraHeap &reverse_heap,
+                 SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                 SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                  NodeID &middle_node,
                  EdgeWeight &path_upper_bound,
                  Args... args)
@@ -172,8 +172,8 @@ void routingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm>
 template <typename... Args>
 std::tuple<EdgeWeight, NodeID, NodeID, std::vector<EdgeID>>
 search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-       SearchEngineData::MultiLayerDijkstraHeap &forward_heap,
-       SearchEngineData::MultiLayerDijkstraHeap &reverse_heap,
+       SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+       SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
        Args... args)
 {
 

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -318,7 +318,7 @@ inline void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorith
                    const PhantomNodes &phantom_nodes,
                    const int duration_upper_bound = INVALID_EDGE_WEIGHT)
 {
-    (void)duration_upper_bound;
+    (void)duration_upper_bound; // TODO: limiting search radius is not implemented for MLD
 
     NodeID source_node, target_node;
     std::vector<EdgeID> unpacked_edges;

--- a/include/engine/routing_algorithms/shortest_path.hpp
+++ b/include/engine/routing_algorithms/shortest_path.hpp
@@ -13,7 +13,7 @@ namespace engine
 namespace routing_algorithms
 {
 
-template<typename Algorithm>
+template <typename Algorithm>
 InternalRouteResult
 shortestPathSearch(SearchEngineData<Algorithm> &engine_working_data,
                    const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,

--- a/include/engine/routing_algorithms/shortest_path.hpp
+++ b/include/engine/routing_algorithms/shortest_path.hpp
@@ -15,13 +15,13 @@ namespace routing_algorithms
 
 InternalRouteResult
 shortestPathSearch(SearchEngineData &engine_working_data,
-                   const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+                   const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint);
 
 InternalRouteResult
 shortestPathSearch(SearchEngineData &engine_working_data,
-                   const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
+                   const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint);
 

--- a/include/engine/routing_algorithms/shortest_path.hpp
+++ b/include/engine/routing_algorithms/shortest_path.hpp
@@ -13,15 +13,10 @@ namespace engine
 namespace routing_algorithms
 {
 
+template<typename Algorithm>
 InternalRouteResult
-shortestPathSearch(SearchEngineData &engine_working_data,
-                   const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
-                   const std::vector<PhantomNodes> &phantom_nodes_vector,
-                   const boost::optional<bool> continue_straight_at_waypoint);
-
-InternalRouteResult
-shortestPathSearch(SearchEngineData &engine_working_data,
-                   const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
+shortestPathSearch(SearchEngineData<Algorithm> &engine_working_data,
+                   const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint);
 

--- a/include/engine/routing_algorithms/tile_turns.hpp
+++ b/include/engine/routing_algorithms/tile_turns.hpp
@@ -29,7 +29,7 @@ struct TurnData final
 using RTreeLeaf = datafacade::BaseDataFacade::RTreeLeaf;
 
 std::vector<TurnData>
-getTileTurns(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+getTileTurns(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
              const std::vector<RTreeLeaf> &edges,
              const std::vector<std::size_t> &sorted_edge_indexes);
 

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -24,14 +24,7 @@ struct ManyToManyHeapData : HeapData
     ManyToManyHeapData(NodeID p, EdgeWeight duration) : HeapData(p), duration(duration) {}
 };
 
-struct MultiLayerDijkstraHeapData : HeapData
-{
-    bool from_clique_arc;
-    MultiLayerDijkstraHeapData(NodeID p) : HeapData(p), from_clique_arc(false) {}
-    MultiLayerDijkstraHeapData(NodeID p, bool from) : HeapData(p), from_clique_arc(from) {}
-};
-
-struct SearchEngineData
+template <typename Algorithm> struct SearchEngineData
 {
     using QueryHeap = util::
         BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::UnorderedMapStorage<NodeID, int>>;
@@ -45,58 +38,45 @@ struct SearchEngineData
 
     using ManyToManyHeapPtr = boost::thread_specific_ptr<ManyToManyQueryHeap>;
 
-    using MultiLayerDijkstraHeap = util::BinaryHeap<NodeID,
-                                                    NodeID,
-                                                    EdgeWeight,
-                                                    MultiLayerDijkstraHeapData,
-                                                    util::UnorderedMapStorage<NodeID, int>>;
-
-    using MultiLayerDijkstraHeapPtr = boost::thread_specific_ptr<MultiLayerDijkstraHeap>;
-
-private:
     static SearchEngineHeapPtr forward_heap_1;
     static SearchEngineHeapPtr reverse_heap_1;
-    static MultiLayerDijkstraHeapPtr mld_forward_heap;
-    static MultiLayerDijkstraHeapPtr mld_reverse_heap;
-
-public:
     static SearchEngineHeapPtr forward_heap_2;
     static SearchEngineHeapPtr reverse_heap_2;
     static SearchEngineHeapPtr forward_heap_3;
     static SearchEngineHeapPtr reverse_heap_3;
     static ManyToManyHeapPtr many_to_many_heap;
 
-    template <typename Algorithm>
-    void InitializeOrClearFirstThreadLocalStorage(Algorithm, const unsigned number_of_nodes);
+    void InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
 
-    template <typename Algorithm> auto GetForwardHeapPtr(Algorithm) const
-    {
-        return forward_heap_1.get();
-    }
+    void InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
 
-    template <typename Algorithm> auto GetReverseHeapPtr(Algorithm) const
-    {
-        return reverse_heap_1.get();
-    }
+    void InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
 
-    void InitializeOrClearFirstThreadLocalStorage(routing_algorithms::mld::Algorithm,
-                                                  const unsigned number_of_nodes);
+    void InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
+};
 
-    auto GetForwardHeapPtr(routing_algorithms::mld::Algorithm) const
-    {
-        return mld_forward_heap.get();
-    }
+struct MultiLayerDijkstraHeapData
+{
+    NodeID parent;
+    bool from_clique_arc;
+    MultiLayerDijkstraHeapData(NodeID p) : parent(p), from_clique_arc(false) {}
+    MultiLayerDijkstraHeapData(NodeID p, bool from) : parent(p), from_clique_arc(from) {}
+};
 
-    auto GetReverseHeapPtr(routing_algorithms::mld::Algorithm) const
-    {
-        return mld_reverse_heap.get();
-    }
+template <> struct SearchEngineData<routing_algorithms::mld::Algorithm>
+{
+    using QueryHeap = util::BinaryHeap<NodeID,
+                                       NodeID,
+                                       EdgeWeight,
+                                       MultiLayerDijkstraHeapData,
+                                       util::UnorderedMapStorage<NodeID, int>>;
 
-    void InitializeOrClearSecondThreadLocalStorage(const unsigned number_of_nodes);
+    using SearchEngineHeapPtr = boost::thread_specific_ptr<QueryHeap>;
 
-    void InitializeOrClearThirdThreadLocalStorage(const unsigned number_of_nodes);
+    static SearchEngineHeapPtr forward_heap_1;
+    static SearchEngineHeapPtr reverse_heap_1;
 
-    void InitializeOrClearManyToManyThreadLocalStorage(const unsigned number_of_nodes);
+    void InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
 };
 }
 }

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -3,7 +3,7 @@
 
 #include <boost/thread/tss.hpp>
 
-#include "partition/multi_level_partition.hpp"
+#include "engine/algorithm.hpp"
 #include "util/binary_heap.hpp"
 #include "util/typedefs.hpp"
 
@@ -53,25 +53,50 @@ struct SearchEngineData
 
     using MultiLayerDijkstraHeapPtr = boost::thread_specific_ptr<MultiLayerDijkstraHeap>;
 
+private:
     static SearchEngineHeapPtr forward_heap_1;
     static SearchEngineHeapPtr reverse_heap_1;
+    static MultiLayerDijkstraHeapPtr mld_forward_heap;
+    static MultiLayerDijkstraHeapPtr mld_reverse_heap;
+
+public:
     static SearchEngineHeapPtr forward_heap_2;
     static SearchEngineHeapPtr reverse_heap_2;
     static SearchEngineHeapPtr forward_heap_3;
     static SearchEngineHeapPtr reverse_heap_3;
     static ManyToManyHeapPtr many_to_many_heap;
-    static MultiLayerDijkstraHeapPtr mld_forward_heap;
-    static MultiLayerDijkstraHeapPtr mld_reverse_heap;
 
-    void InitializeOrClearFirstThreadLocalStorage(const unsigned number_of_nodes);
+    template <typename Algorithm>
+    void InitializeOrClearFirstThreadLocalStorage(Algorithm, const unsigned number_of_nodes);
+
+    template <typename Algorithm> auto GetForwardHeapPtr(Algorithm) const
+    {
+        return forward_heap_1.get();
+    }
+
+    template <typename Algorithm> auto GetReverseHeapPtr(Algorithm) const
+    {
+        return reverse_heap_1.get();
+    }
+
+    void InitializeOrClearFirstThreadLocalStorage(routing_algorithms::mld::Algorithm,
+                                                  const unsigned number_of_nodes);
+
+    auto GetForwardHeapPtr(routing_algorithms::mld::Algorithm) const
+    {
+        return mld_forward_heap.get();
+    }
+
+    auto GetReverseHeapPtr(routing_algorithms::mld::Algorithm) const
+    {
+        return mld_reverse_heap.get();
+    }
 
     void InitializeOrClearSecondThreadLocalStorage(const unsigned number_of_nodes);
 
     void InitializeOrClearThirdThreadLocalStorage(const unsigned number_of_nodes);
 
     void InitializeOrClearManyToManyThreadLocalStorage(const unsigned number_of_nodes);
-
-    void InitializeOrClearMultiLayerDijkstraThreadLocalStorage(const unsigned number_of_nodes);
 };
 }
 }

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -75,8 +75,12 @@ template <> struct SearchEngineData<routing_algorithms::mld::Algorithm>
 
     static SearchEngineHeapPtr forward_heap_1;
     static SearchEngineHeapPtr reverse_heap_1;
+    static SearchEngineHeapPtr forward_heap_2;
+    static SearchEngineHeapPtr reverse_heap_2;
 
     void InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
+
+    void InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
 };
 }
 }

--- a/src/engine/routing_algorithms/alternative_path.cpp
+++ b/src/engine/routing_algorithms/alternative_path.cpp
@@ -164,8 +164,8 @@ void computeLengthAndSharingOfViaPath(
 {
     engine_working_data.InitializeOrClearSecondThreadLocalStorage(facade.GetNumberOfNodes());
 
-    QueryHeap &existing_forward_heap = *engine_working_data.forward_heap_1;
-    QueryHeap &existing_reverse_heap = *engine_working_data.reverse_heap_1;
+    auto &existing_forward_heap = *engine_working_data.GetForwardHeapPtr(Algorithm{});
+    auto &existing_reverse_heap = *engine_working_data.GetReverseHeapPtr(Algorithm{});
     QueryHeap &new_forward_heap = *engine_working_data.forward_heap_2;
     QueryHeap &new_reverse_heap = *engine_working_data.reverse_heap_2;
 
@@ -575,12 +575,13 @@ alternativePathSearch(SearchEngineData &engine_working_data,
     std::vector<SearchSpaceEdge> reverse_search_space;
 
     // Init queues, semi-expensive because access to TSS invokes a sys-call
-    engine_working_data.InitializeOrClearFirstThreadLocalStorage(facade.GetNumberOfNodes());
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(Algorithm{},
+                                                                 facade.GetNumberOfNodes());
     engine_working_data.InitializeOrClearSecondThreadLocalStorage(facade.GetNumberOfNodes());
     engine_working_data.InitializeOrClearThirdThreadLocalStorage(facade.GetNumberOfNodes());
 
-    QueryHeap &forward_heap1 = *(engine_working_data.forward_heap_1);
-    QueryHeap &reverse_heap1 = *(engine_working_data.reverse_heap_1);
+    auto &forward_heap1 = *engine_working_data.GetForwardHeapPtr(Algorithm{});
+    auto &reverse_heap1 = *engine_working_data.GetReverseHeapPtr(Algorithm{});
     QueryHeap &forward_heap2 = *(engine_working_data.forward_heap_2);
     QueryHeap &reverse_heap2 = *(engine_working_data.reverse_heap_2);
 

--- a/src/engine/routing_algorithms/alternative_path.cpp
+++ b/src/engine/routing_algorithms/alternative_path.cpp
@@ -19,6 +19,8 @@ namespace engine
 {
 namespace routing_algorithms
 {
+namespace ch
+{
 
 namespace
 {
@@ -48,15 +50,14 @@ struct RankedCandidateNode
 
 // todo: reorder parameters
 template <bool DIRECTION>
-void alternativeRoutingStep(
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
-    QueryHeap &heap1,
-    QueryHeap &heap2,
-    NodeID *middle_node,
-    EdgeWeight *upper_bound_to_shortest_path_weight,
-    std::vector<NodeID> &search_space_intersection,
-    std::vector<SearchSpaceEdge> &search_space,
-    const EdgeWeight min_edge_offset)
+void alternativeRoutingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                            QueryHeap &heap1,
+                            QueryHeap &heap2,
+                            NodeID *middle_node,
+                            EdgeWeight *upper_bound_to_shortest_path_weight,
+                            std::vector<NodeID> &search_space_intersection,
+                            std::vector<SearchSpaceEdge> &search_space,
+                            const EdgeWeight min_edge_offset)
 {
     QueryHeap &forward_heap = DIRECTION == FORWARD_DIRECTION ? heap1 : heap2;
     QueryHeap &reverse_heap = DIRECTION == FORWARD_DIRECTION ? heap2 : heap1;
@@ -154,7 +155,7 @@ void retrievePackedAlternatePath(const QueryHeap &forward_heap1,
 // done at this stage
 void computeLengthAndSharingOfViaPath(
     SearchEngineData &engine_working_data,
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+    const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
     const NodeID via_node,
     int *real_length_of_via_path,
     int *sharing_of_via_path,
@@ -319,7 +320,7 @@ void computeLengthAndSharingOfViaPath(
 // conduct T-Test
 bool viaNodeCandidatePassesTTest(
     SearchEngineData &engine_working_data,
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+    const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
     QueryHeap &existing_forward_heap,
     QueryHeap &existing_reverse_heap,
     QueryHeap &new_forward_heap,
@@ -563,7 +564,7 @@ bool viaNodeCandidatePassesTTest(
 
 InternalRouteResult
 alternativePathSearch(SearchEngineData &engine_working_data,
-                      const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+                      const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                       const PhantomNodes &phantom_node_pair)
 {
     InternalRouteResult raw_route_data;
@@ -846,6 +847,7 @@ alternativePathSearch(SearchEngineData &engine_working_data,
     return raw_route_data;
 }
 
+} // namespace ch
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm}

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -109,7 +109,7 @@ InternalRouteResult directShortestPathSearchImpl(
 template <>
 InternalRouteResult directShortestPathSearch(
     SearchEngineData &engine_working_data,
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
+    const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
     const PhantomNodes &phantom_nodes)
 {
     return ch::directShortestPathSearchImpl(engine_working_data, facade, phantom_nodes);
@@ -118,7 +118,7 @@ InternalRouteResult directShortestPathSearch(
 template <>
 InternalRouteResult directShortestPathSearch(
     SearchEngineData &engine_working_data,
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+    const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
     const PhantomNodes &phantom_nodes)
 {
     return ch::directShortestPathSearchImpl(engine_working_data, facade, phantom_nodes);
@@ -127,7 +127,7 @@ InternalRouteResult directShortestPathSearch(
 template <>
 InternalRouteResult directShortestPathSearch(
     SearchEngineData &engine_working_data,
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::MLD> &facade,
+    const datafacade::ContiguousInternalMemoryDataFacade<mld::Algorithm> &facade,
     const PhantomNodes &phantom_nodes)
 {
     engine_working_data.InitializeOrClearMultiLayerDijkstraThreadLocalStorage(

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -84,7 +84,8 @@ InternalRouteResult directShortestPathSearchImpl(
            weight,
            packed_leg,
            DO_NOT_FORCE_LOOPS,
-           DO_NOT_FORCE_LOOPS);
+           DO_NOT_FORCE_LOOPS,
+           phantom_nodes);
 
     std::vector<EdgeID> unpacked_edges;
     auto source_node = SPECIAL_NODEID, target_node = SPECIAL_NODEID;
@@ -139,8 +140,8 @@ InternalRouteResult directShortestPathSearch(
     EdgeWeight weight;
     NodeID source_node, target_node;
     std::vector<EdgeID> unpacked_edges;
-    std::tie(weight, source_node, target_node, unpacked_edges) =
-        mld::search(facade, forward_heap, reverse_heap, phantom_nodes);
+    std::tie(weight, source_node, target_node, unpacked_edges) = mld::search(
+        facade, forward_heap, reverse_heap, DO_NOT_FORCE_LOOPS, DO_NOT_FORCE_LOOPS, phantom_nodes);
 
     return extractRoute(facade, weight, source_node, target_node, unpacked_edges, phantom_nodes);
 }

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -55,16 +55,17 @@ namespace ch
 /// by the previous route.
 /// This variation is only an optimazation for graphs with slow queries, for example
 /// not fully contracted graphs.
-template <typename AlgorithmT>
+template <typename Algorithm>
 InternalRouteResult directShortestPathSearchImpl(
     SearchEngineData &engine_working_data,
-    const datafacade::ContiguousInternalMemoryDataFacade<AlgorithmT> &facade,
+    const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
     const PhantomNodes &phantom_nodes)
 {
-    engine_working_data.InitializeOrClearFirstThreadLocalStorage(facade.GetNumberOfNodes());
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(Algorithm{},
+                                                                 facade.GetNumberOfNodes());
     engine_working_data.InitializeOrClearSecondThreadLocalStorage(facade.GetNumberOfNodes());
-    auto &forward_heap = *(engine_working_data.forward_heap_1);
-    auto &reverse_heap = *(engine_working_data.reverse_heap_1);
+    auto &forward_heap = *engine_working_data.GetForwardHeapPtr(Algorithm{});
+    auto &reverse_heap = *engine_working_data.GetReverseHeapPtr(Algorithm{});
     auto &forward_core_heap = *(engine_working_data.forward_heap_2);
     auto &reverse_core_heap = *(engine_working_data.reverse_heap_2);
     forward_heap.Clear();
@@ -130,10 +131,10 @@ InternalRouteResult directShortestPathSearch(
     const datafacade::ContiguousInternalMemoryDataFacade<mld::Algorithm> &facade,
     const PhantomNodes &phantom_nodes)
 {
-    engine_working_data.InitializeOrClearMultiLayerDijkstraThreadLocalStorage(
-        facade.GetNumberOfNodes());
-    auto &forward_heap = *(engine_working_data.mld_forward_heap);
-    auto &reverse_heap = *(engine_working_data.mld_reverse_heap);
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(mld::Algorithm{},
+                                                                 facade.GetNumberOfNodes());
+    auto &forward_heap = *engine_working_data.GetForwardHeapPtr(mld::Algorithm{});
+    auto &reverse_heap = *engine_working_data.GetReverseHeapPtr(mld::Algorithm{});
     forward_heap.Clear();
     reverse_heap.Clear();
     insertNodesInHeaps(forward_heap, reverse_heap, phantom_nodes);

--- a/src/engine/routing_algorithms/many_to_many.cpp
+++ b/src/engine/routing_algorithms/many_to_many.cpp
@@ -15,10 +15,10 @@ namespace engine
 namespace routing_algorithms
 {
 
-using ManyToManyQueryHeap = SearchEngineData::ManyToManyQueryHeap;
-
 namespace ch
 {
+
+using ManyToManyQueryHeap = SearchEngineData<Algorithm>::ManyToManyQueryHeap;
 
 namespace
 {
@@ -151,7 +151,7 @@ void backwardRoutingStep(const datafacade::ContiguousInternalMemoryDataFacade<Al
 }
 
 std::vector<EdgeWeight>
-manyToManySearch(SearchEngineData &engine_working_data,
+manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                  const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,
                  const std::vector<std::size_t> &source_indices,

--- a/src/engine/routing_algorithms/many_to_many.cpp
+++ b/src/engine/routing_algorithms/many_to_many.cpp
@@ -17,6 +17,9 @@ namespace routing_algorithms
 
 using ManyToManyQueryHeap = SearchEngineData::ManyToManyQueryHeap;
 
+namespace ch
+{
+
 namespace
 {
 struct NodeBucket
@@ -34,7 +37,7 @@ struct NodeBucket
 using SearchSpaceWithBuckets = std::unordered_map<NodeID, std::vector<NodeBucket>>;
 
 template <bool DIRECTION>
-void relaxOutgoingEdges(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void relaxOutgoingEdges(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                         const NodeID node,
                         const EdgeWeight weight,
                         const EdgeWeight duration,
@@ -69,7 +72,7 @@ void relaxOutgoingEdges(const datafacade::ContiguousInternalMemoryDataFacade<alg
     }
 }
 
-void forwardRoutingStep(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void forwardRoutingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                         const unsigned row_idx,
                         const unsigned number_of_targets,
                         ManyToManyQueryHeap &query_heap,
@@ -126,11 +129,10 @@ void forwardRoutingStep(const datafacade::ContiguousInternalMemoryDataFacade<alg
     relaxOutgoingEdges<FORWARD_DIRECTION>(facade, node, source_weight, source_duration, query_heap);
 }
 
-void backwardRoutingStep(
-    const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
-    const unsigned column_idx,
-    ManyToManyQueryHeap &query_heap,
-    SearchSpaceWithBuckets &search_space_with_buckets)
+void backwardRoutingStep(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                         const unsigned column_idx,
+                         ManyToManyQueryHeap &query_heap,
+                         SearchSpaceWithBuckets &search_space_with_buckets)
 {
     const NodeID node = query_heap.DeleteMin();
     const EdgeWeight target_weight = query_heap.GetKey(node);
@@ -150,7 +152,7 @@ void backwardRoutingStep(
 
 std::vector<EdgeWeight>
 manyToManySearch(SearchEngineData &engine_working_data,
-                 const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+                 const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,
                  const std::vector<std::size_t> &source_indices,
                  const std::vector<std::size_t> &target_indices)
@@ -240,6 +242,7 @@ manyToManySearch(SearchEngineData &engine_working_data,
     return durations_table;
 }
 
+} // namespace ch
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -420,14 +420,15 @@ mapMatchingImpl(SearchEngineData<Algorithm> &engine_working_data,
     return sub_matchings;
 }
 
-template<>
-SubMatchingList mapMatching(SearchEngineData<ch::Algorithm> &engine_working_data,
-                            const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
-                            const CandidateLists &candidates_list,
-                            const std::vector<util::Coordinate> &trace_coordinates,
-                            const std::vector<unsigned> &trace_timestamps,
-                            const std::vector<boost::optional<double>> &trace_gps_precision,
-                            const bool use_tidying)
+template <>
+SubMatchingList
+mapMatching(SearchEngineData<ch::Algorithm> &engine_working_data,
+            const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
+            const CandidateLists &candidates_list,
+            const std::vector<util::Coordinate> &trace_coordinates,
+            const std::vector<unsigned> &trace_timestamps,
+            const std::vector<boost::optional<double>> &trace_gps_precision,
+            const bool use_tidying)
 {
     return mapMatchingImpl(engine_working_data,
                            facade,
@@ -438,14 +439,15 @@ SubMatchingList mapMatching(SearchEngineData<ch::Algorithm> &engine_working_data
                            use_tidying);
 }
 
-template<>
-SubMatchingList mapMatching(SearchEngineData<corech::Algorithm> &engine_working_data,
-                            const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
-                            const CandidateLists &candidates_list,
-                            const std::vector<util::Coordinate> &trace_coordinates,
-                            const std::vector<unsigned> &trace_timestamps,
-                            const std::vector<boost::optional<double>> &trace_gps_precision,
-                            const bool use_tidying)
+template <>
+SubMatchingList
+mapMatching(SearchEngineData<corech::Algorithm> &engine_working_data,
+            const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
+            const CandidateLists &candidates_list,
+            const std::vector<util::Coordinate> &trace_coordinates,
+            const std::vector<unsigned> &trace_timestamps,
+            const std::vector<boost::optional<double>> &trace_gps_precision,
+            const bool use_tidying)
 {
 
     return mapMatchingImpl(engine_working_data,

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -49,7 +49,7 @@ unsigned getMedianSampleTime(const std::vector<unsigned> &timestamps)
 
 template <typename Algorithm>
 SubMatchingList
-mapMatchingImpl(SearchEngineData &engine_working_data,
+mapMatchingImpl(SearchEngineData<Algorithm> &engine_working_data,
                 const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                 const CandidateLists &candidates_list,
                 const std::vector<util::Coordinate> &trace_coordinates,
@@ -142,13 +142,13 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
     }
 
     const auto nodes_number = facade.GetNumberOfNodes();
-    engine_working_data.InitializeOrClearFirstThreadLocalStorage(Algorithm{}, nodes_number);
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(nodes_number);
     engine_working_data.InitializeOrClearSecondThreadLocalStorage(nodes_number);
 
-    auto &forward_heap = *engine_working_data.GetForwardHeapPtr(Algorithm{});
-    auto &reverse_heap = *engine_working_data.GetReverseHeapPtr(Algorithm{});
-    auto &forward_core_heap = *(engine_working_data.forward_heap_2);
-    auto &reverse_core_heap = *(engine_working_data.reverse_heap_2);
+    auto &forward_heap = *engine_working_data.forward_heap_1;
+    auto &reverse_heap = *engine_working_data.reverse_heap_1;
+    auto &forward_core_heap = *engine_working_data.forward_heap_2;
+    auto &reverse_core_heap = *engine_working_data.reverse_heap_2;
 
     std::size_t breakage_begin = map_matching::INVALID_STATE;
     std::vector<std::size_t> split_points;
@@ -420,10 +420,9 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
     return sub_matchings;
 }
 
-namespace ch
-{
-SubMatchingList mapMatching(SearchEngineData &engine_working_data,
-                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+template<>
+SubMatchingList mapMatching(SearchEngineData<ch::Algorithm> &engine_working_data,
+                            const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                             const CandidateLists &candidates_list,
                             const std::vector<util::Coordinate> &trace_coordinates,
                             const std::vector<unsigned> &trace_timestamps,
@@ -438,12 +437,10 @@ SubMatchingList mapMatching(SearchEngineData &engine_working_data,
                            trace_gps_precision,
                            use_tidying);
 }
-}
 
-namespace corech
-{
-SubMatchingList mapMatching(SearchEngineData &engine_working_data,
-                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+template<>
+SubMatchingList mapMatching(SearchEngineData<corech::Algorithm> &engine_working_data,
+                            const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
                             const CandidateLists &candidates_list,
                             const std::vector<util::Coordinate> &trace_coordinates,
                             const std::vector<unsigned> &trace_timestamps,
@@ -458,7 +455,6 @@ SubMatchingList mapMatching(SearchEngineData &engine_working_data,
                            trace_timestamps,
                            trace_gps_precision,
                            use_tidying);
-}
 }
 
 } // namespace routing_algorithms

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -47,10 +47,10 @@ unsigned getMedianSampleTime(const std::vector<unsigned> &timestamps)
 }
 }
 
-template <typename AlgorithmT>
+template <typename Algorithm>
 SubMatchingList
 mapMatchingImpl(SearchEngineData &engine_working_data,
-                const datafacade::ContiguousInternalMemoryDataFacade<AlgorithmT> &facade,
+                const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                 const CandidateLists &candidates_list,
                 const std::vector<util::Coordinate> &trace_coordinates,
                 const std::vector<unsigned> &trace_timestamps,
@@ -141,11 +141,12 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
         return sub_matchings;
     }
 
-    engine_working_data.InitializeOrClearFirstThreadLocalStorage(facade.GetNumberOfNodes());
-    engine_working_data.InitializeOrClearSecondThreadLocalStorage(facade.GetNumberOfNodes());
+    const auto nodes_number = facade.GetNumberOfNodes();
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(Algorithm{}, nodes_number);
+    engine_working_data.InitializeOrClearSecondThreadLocalStorage(nodes_number);
 
-    auto &forward_heap = *(engine_working_data.forward_heap_1);
-    auto &reverse_heap = *(engine_working_data.reverse_heap_1);
+    auto &forward_heap = *engine_working_data.GetForwardHeapPtr(Algorithm{});
+    auto &reverse_heap = *engine_working_data.GetReverseHeapPtr(Algorithm{});
     auto &forward_core_heap = *(engine_working_data.forward_heap_2);
     auto &reverse_core_heap = *(engine_working_data.reverse_heap_2);
 

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -419,14 +419,15 @@ mapMatchingImpl(SearchEngineData &engine_working_data,
     return sub_matchings;
 }
 
-SubMatchingList
-mapMatching(SearchEngineData &engine_working_data,
-            const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
-            const CandidateLists &candidates_list,
-            const std::vector<util::Coordinate> &trace_coordinates,
-            const std::vector<unsigned> &trace_timestamps,
-            const std::vector<boost::optional<double>> &trace_gps_precision,
-            const bool use_tidying)
+namespace ch
+{
+SubMatchingList mapMatching(SearchEngineData &engine_working_data,
+                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                            const CandidateLists &candidates_list,
+                            const std::vector<util::Coordinate> &trace_coordinates,
+                            const std::vector<unsigned> &trace_timestamps,
+                            const std::vector<boost::optional<double>> &trace_gps_precision,
+                            const bool use_tidying)
 {
     return mapMatchingImpl(engine_working_data,
                            facade,
@@ -436,15 +437,17 @@ mapMatching(SearchEngineData &engine_working_data,
                            trace_gps_precision,
                            use_tidying);
 }
+}
 
-SubMatchingList
-mapMatching(SearchEngineData &engine_working_data,
-            const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
-            const CandidateLists &candidates_list,
-            const std::vector<util::Coordinate> &trace_coordinates,
-            const std::vector<unsigned> &trace_timestamps,
-            const std::vector<boost::optional<double>> &trace_gps_precision,
-            const bool use_tidying)
+namespace corech
+{
+SubMatchingList mapMatching(SearchEngineData &engine_working_data,
+                            const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                            const CandidateLists &candidates_list,
+                            const std::vector<util::Coordinate> &trace_coordinates,
+                            const std::vector<unsigned> &trace_timestamps,
+                            const std::vector<boost::optional<double>> &trace_gps_precision,
+                            const bool use_tidying)
 {
 
     return mapMatchingImpl(engine_working_data,
@@ -454,6 +457,7 @@ mapMatching(SearchEngineData &engine_working_data,
                            trace_timestamps,
                            trace_gps_precision,
                            use_tidying);
+}
 }
 
 } // namespace routing_algorithms

--- a/src/engine/routing_algorithms/routing_base.cpp
+++ b/src/engine/routing_algorithms/routing_base.cpp
@@ -1,0 +1,28 @@
+#include "engine/routing_algorithms/routing_base.hpp"
+
+namespace osrm
+{
+namespace engine
+{
+namespace routing_algorithms
+{
+
+bool needsLoopForward(const PhantomNode &source_phantom, const PhantomNode &target_phantom)
+{
+    return source_phantom.forward_segment_id.enabled && target_phantom.forward_segment_id.enabled &&
+           source_phantom.forward_segment_id.id == target_phantom.forward_segment_id.id &&
+           source_phantom.GetForwardWeightPlusOffset() >
+               target_phantom.GetForwardWeightPlusOffset();
+}
+
+bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &target_phantom)
+{
+    return source_phantom.reverse_segment_id.enabled && target_phantom.reverse_segment_id.enabled &&
+           source_phantom.reverse_segment_id.id == target_phantom.reverse_segment_id.id &&
+           source_phantom.GetReverseWeightPlusOffset() >
+               target_phantom.GetReverseWeightPlusOffset();
+}
+
+} // namespace routing_algorithms
+} // namespace engine
+} // namespace osrm

--- a/src/engine/routing_algorithms/routing_base_ch.cpp
+++ b/src/engine/routing_algorithms/routing_base_ch.cpp
@@ -139,22 +139,6 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &fac
     }
 }
 
-bool needsLoopForward(const PhantomNode &source_phantom, const PhantomNode &target_phantom)
-{
-    return source_phantom.forward_segment_id.enabled && target_phantom.forward_segment_id.enabled &&
-           source_phantom.forward_segment_id.id == target_phantom.forward_segment_id.id &&
-           source_phantom.GetForwardWeightPlusOffset() >
-               target_phantom.GetForwardWeightPlusOffset();
-}
-
-bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &target_phantom)
-{
-    return source_phantom.reverse_segment_id.enabled && target_phantom.reverse_segment_id.enabled &&
-           source_phantom.reverse_segment_id.id == target_phantom.reverse_segment_id.id &&
-           source_phantom.GetReverseWeightPlusOffset() >
-               target_phantom.GetReverseWeightPlusOffset();
-}
-
 double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                        const std::vector<NodeID> &packed_path,
                        const PhantomNode &source_phantom,
@@ -290,6 +274,7 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &fac
             std::vector<NodeID> &packed_leg,
             const bool force_loop_forward,
             const bool force_loop_reverse,
+            const PhantomNodes & /*phantom_nodes*/,
             EdgeWeight weight_upper_bound)
 {
     NodeID middle = SPECIAL_NODEID;
@@ -486,6 +471,7 @@ double getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<A
            packed_path,
            DO_NOT_FORCE_LOOPS,
            DO_NOT_FORCE_LOOPS,
+           {source_phantom, target_phantom},
            weight_upper_bound);
 
     double distance = std::numeric_limits<double>::max();

--- a/src/engine/routing_algorithms/routing_base_ch.cpp
+++ b/src/engine/routing_algorithms/routing_base_ch.cpp
@@ -16,7 +16,7 @@ namespace ch
  * @param to the node the CH edge finishes at
  * @param unpacked_path the sequence of original NodeIDs that make up the expanded CH edge
  */
-void unpackEdge(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void unpackEdge(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                 const NodeID from,
                 const NodeID to,
                 std::vector<NodeID> &unpacked_path)
@@ -71,7 +71,7 @@ void retrievePackedPathFromSingleHeap(const SearchEngineData::QueryHeap &search_
 // && source_phantom.GetForwardWeightPlusOffset() > target_phantom.GetForwardWeightPlusOffset())
 // requires
 // a force loop, if the heaps have been initialized with positive offsets.
-void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
             SearchEngineData::QueryHeap &forward_heap,
             SearchEngineData::QueryHeap &reverse_heap,
             EdgeWeight &weight,
@@ -139,190 +139,6 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> 
     }
 }
 
-// assumes that heaps are already setup correctly.
-// A forced loop might be necessary, if source and target are on the same segment.
-// If this is the case and the offsets of the respective direction are larger for the source
-// than the target
-// then a force loop is required (e.g. source_phantom.forward_segment_id ==
-// target_phantom.forward_segment_id
-// && source_phantom.GetForwardWeightPlusOffset() > target_phantom.GetForwardWeightPlusOffset())
-// requires
-// a force loop, if the heaps have been initialized with positive offsets.
-void search(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
-            SearchEngineData::QueryHeap &forward_heap,
-            SearchEngineData::QueryHeap &reverse_heap,
-            SearchEngineData::QueryHeap &forward_core_heap,
-            SearchEngineData::QueryHeap &reverse_core_heap,
-            EdgeWeight &weight,
-            std::vector<NodeID> &packed_leg,
-            const bool force_loop_forward,
-            const bool force_loop_reverse,
-            EdgeWeight weight_upper_bound)
-{
-    NodeID middle = SPECIAL_NODEID;
-    weight = weight_upper_bound;
-
-    using CoreEntryPoint = std::tuple<NodeID, EdgeWeight, NodeID>;
-    std::vector<CoreEntryPoint> forward_entry_points;
-    std::vector<CoreEntryPoint> reverse_entry_points;
-
-    // get offset to account for offsets on phantom nodes on compressed edges
-    const auto min_edge_offset = std::min(0, forward_heap.MinKey());
-    // we only every insert negative offsets for nodes in the forward heap
-    BOOST_ASSERT(reverse_heap.MinKey() >= 0);
-
-    // run two-Target Dijkstra routing step.
-    while (0 < (forward_heap.Size() + reverse_heap.Size()))
-    {
-        if (!forward_heap.Empty())
-        {
-            if (facade.IsCoreNode(forward_heap.Min()))
-            {
-                const NodeID node = forward_heap.DeleteMin();
-                const EdgeWeight key = forward_heap.GetKey(node);
-                forward_entry_points.emplace_back(node, key, forward_heap.GetData(node).parent);
-            }
-            else
-            {
-                routingStep<FORWARD_DIRECTION>(facade,
-                                               forward_heap,
-                                               reverse_heap,
-                                               middle,
-                                               weight,
-                                               min_edge_offset,
-                                               force_loop_forward,
-                                               force_loop_reverse);
-            }
-        }
-        if (!reverse_heap.Empty())
-        {
-            if (facade.IsCoreNode(reverse_heap.Min()))
-            {
-                const NodeID node = reverse_heap.DeleteMin();
-                const EdgeWeight key = reverse_heap.GetKey(node);
-                reverse_entry_points.emplace_back(node, key, reverse_heap.GetData(node).parent);
-            }
-            else
-            {
-                routingStep<REVERSE_DIRECTION>(facade,
-                                               reverse_heap,
-                                               forward_heap,
-                                               middle,
-                                               weight,
-                                               min_edge_offset,
-                                               force_loop_reverse,
-                                               force_loop_forward);
-            }
-        }
-    }
-
-    const auto insertInCoreHeap = [](const CoreEntryPoint &p,
-                                     SearchEngineData::QueryHeap &core_heap) {
-        NodeID id;
-        EdgeWeight weight;
-        NodeID parent;
-        // TODO this should use std::apply when we get c++17 support
-        std::tie(id, weight, parent) = p;
-        core_heap.Insert(id, weight, parent);
-    };
-
-    forward_core_heap.Clear();
-    for (const auto &p : forward_entry_points)
-    {
-        insertInCoreHeap(p, forward_core_heap);
-    }
-
-    reverse_core_heap.Clear();
-    for (const auto &p : reverse_entry_points)
-    {
-        insertInCoreHeap(p, reverse_core_heap);
-    }
-
-    // get offset to account for offsets on phantom nodes on compressed edges
-    EdgeWeight min_core_edge_offset = 0;
-    if (forward_core_heap.Size() > 0)
-    {
-        min_core_edge_offset = std::min(min_core_edge_offset, forward_core_heap.MinKey());
-    }
-    if (reverse_core_heap.Size() > 0 && reverse_core_heap.MinKey() < 0)
-    {
-        min_core_edge_offset = std::min(min_core_edge_offset, reverse_core_heap.MinKey());
-    }
-    BOOST_ASSERT(min_core_edge_offset <= 0);
-
-    // run two-target Dijkstra routing step on core with termination criterion
-    while (0 < forward_core_heap.Size() && 0 < reverse_core_heap.Size() &&
-           weight > (forward_core_heap.MinKey() + reverse_core_heap.MinKey()))
-    {
-        routingStep<FORWARD_DIRECTION, DISABLE_STALLING>(facade,
-                                                         forward_core_heap,
-                                                         reverse_core_heap,
-                                                         middle,
-                                                         weight,
-                                                         min_core_edge_offset,
-                                                         force_loop_forward,
-                                                         force_loop_reverse);
-
-        routingStep<REVERSE_DIRECTION, DISABLE_STALLING>(facade,
-                                                         reverse_core_heap,
-                                                         forward_core_heap,
-                                                         middle,
-                                                         weight,
-                                                         min_core_edge_offset,
-                                                         force_loop_reverse,
-                                                         force_loop_forward);
-    }
-
-    // No path found for both target nodes?
-    if (weight_upper_bound <= weight || SPECIAL_NODEID == middle)
-    {
-        weight = INVALID_EDGE_WEIGHT;
-        return;
-    }
-
-    // Was a paths over one of the forward/reverse nodes not found?
-    BOOST_ASSERT_MSG((SPECIAL_NODEID != middle && INVALID_EDGE_WEIGHT != weight), "no path found");
-
-    // we need to unpack sub path from core heaps
-    if (facade.IsCoreNode(middle))
-    {
-        if (weight != forward_core_heap.GetKey(middle) + reverse_core_heap.GetKey(middle))
-        {
-            // self loop
-            BOOST_ASSERT(forward_core_heap.GetData(middle).parent == middle &&
-                         reverse_core_heap.GetData(middle).parent == middle);
-            packed_leg.push_back(middle);
-            packed_leg.push_back(middle);
-        }
-        else
-        {
-            std::vector<NodeID> packed_core_leg;
-            retrievePackedPathFromHeap(
-                forward_core_heap, reverse_core_heap, middle, packed_core_leg);
-            BOOST_ASSERT(packed_core_leg.size() > 0);
-            retrievePackedPathFromSingleHeap(forward_heap, packed_core_leg.front(), packed_leg);
-            std::reverse(packed_leg.begin(), packed_leg.end());
-            packed_leg.insert(packed_leg.end(), packed_core_leg.begin(), packed_core_leg.end());
-            retrievePackedPathFromSingleHeap(reverse_heap, packed_core_leg.back(), packed_leg);
-        }
-    }
-    else
-    {
-        if (weight != forward_heap.GetKey(middle) + reverse_heap.GetKey(middle))
-        {
-            // self loop
-            BOOST_ASSERT(forward_heap.GetData(middle).parent == middle &&
-                         reverse_heap.GetData(middle).parent == middle);
-            packed_leg.push_back(middle);
-            packed_leg.push_back(middle);
-        }
-        else
-        {
-            retrievePackedPathFromHeap(forward_heap, reverse_heap, middle, packed_leg);
-        }
-    }
-}
-
 bool needsLoopForward(const PhantomNode &source_phantom, const PhantomNode &target_phantom)
 {
     return source_phantom.forward_segment_id.enabled && target_phantom.forward_segment_id.enabled &&
@@ -339,7 +155,7 @@ bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &ta
                target_phantom.GetReverseWeightPlusOffset();
 }
 
-double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                        const std::vector<NodeID> &packed_path,
                        const PhantomNode &source_phantom,
                        const PhantomNode &target_phantom)
@@ -398,54 +214,12 @@ double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<algo
 // Requires the heaps for be empty
 // If heaps should be adjusted to be initialized outside of this function,
 // the addition of force_loop parameters might be required
-double
-getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
-                   SearchEngineData::QueryHeap &forward_core_heap,
-                   SearchEngineData::QueryHeap &reverse_core_heap,
-                   const PhantomNode &source_phantom,
-                   const PhantomNode &target_phantom,
-                   EdgeWeight weight_upper_bound)
-{
-    forward_heap.Clear();
-    reverse_heap.Clear();
-    forward_core_heap.Clear();
-    reverse_core_heap.Clear();
-
-    insertNodesInHeaps(forward_heap, reverse_heap, {source_phantom, target_phantom});
-
-    EdgeWeight weight = INVALID_EDGE_WEIGHT;
-    std::vector<NodeID> packed_path;
-    search(facade,
-           forward_heap,
-           reverse_heap,
-           forward_core_heap,
-           reverse_core_heap,
-           weight,
-           packed_path,
-           DO_NOT_FORCE_LOOPS,
-           DO_NOT_FORCE_LOOPS,
-           weight_upper_bound);
-
-    double distance = std::numeric_limits<double>::max();
-    if (weight != INVALID_EDGE_WEIGHT)
-    {
-        return getPathDistance(facade, packed_path, source_phantom, target_phantom);
-    }
-    return distance;
-}
-
-// Requires the heaps for be empty
-// If heaps should be adjusted to be initialized outside of this function,
-// the addition of force_loop parameters might be required
-double
-getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
-                   SearchEngineData::QueryHeap &forward_heap,
-                   SearchEngineData::QueryHeap &reverse_heap,
-                   const PhantomNode &source_phantom,
-                   const PhantomNode &target_phantom,
-                   EdgeWeight weight_upper_bound)
+double getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                          SearchEngineData::QueryHeap &forward_heap,
+                          SearchEngineData::QueryHeap &reverse_heap,
+                          const PhantomNode &source_phantom,
+                          const PhantomNode &target_phantom,
+                          EdgeWeight weight_upper_bound)
 {
     forward_heap.Clear();
     reverse_heap.Clear();
@@ -494,8 +268,235 @@ getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<algorith
 
     return getPathDistance(facade, packed_path, source_phantom, target_phantom);
 }
-
 } // namespace ch
+
+namespace corech
+{
+// Assumes that heaps are already setup correctly.
+// A forced loop might be necessary, if source and target are on the same segment.
+// If this is the case and the offsets of the respective direction are larger for the source
+// than the target
+// then a force loop is required (e.g. source_phantom.forward_segment_id ==
+// target_phantom.forward_segment_id
+// && source_phantom.GetForwardWeightPlusOffset() > target_phantom.GetForwardWeightPlusOffset())
+// requires
+// a force loop, if the heaps have been initialized with positive offsets.
+void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+            SearchEngineData::QueryHeap &forward_heap,
+            SearchEngineData::QueryHeap &reverse_heap,
+            SearchEngineData::QueryHeap &forward_core_heap,
+            SearchEngineData::QueryHeap &reverse_core_heap,
+            EdgeWeight &weight,
+            std::vector<NodeID> &packed_leg,
+            const bool force_loop_forward,
+            const bool force_loop_reverse,
+            EdgeWeight weight_upper_bound)
+{
+    NodeID middle = SPECIAL_NODEID;
+    weight = weight_upper_bound;
+
+    using CoreEntryPoint = std::tuple<NodeID, EdgeWeight, NodeID>;
+    std::vector<CoreEntryPoint> forward_entry_points;
+    std::vector<CoreEntryPoint> reverse_entry_points;
+
+    // get offset to account for offsets on phantom nodes on compressed edges
+    const auto min_edge_offset = std::min(0, forward_heap.MinKey());
+    // we only every insert negative offsets for nodes in the forward heap
+    BOOST_ASSERT(reverse_heap.MinKey() >= 0);
+
+    // run two-Target Dijkstra routing step.
+    while (0 < (forward_heap.Size() + reverse_heap.Size()))
+    {
+        if (!forward_heap.Empty())
+        {
+            if (facade.IsCoreNode(forward_heap.Min()))
+            {
+                const NodeID node = forward_heap.DeleteMin();
+                const EdgeWeight key = forward_heap.GetKey(node);
+                forward_entry_points.emplace_back(node, key, forward_heap.GetData(node).parent);
+            }
+            else
+            {
+                ch::routingStep<FORWARD_DIRECTION>(facade,
+                                                   forward_heap,
+                                                   reverse_heap,
+                                                   middle,
+                                                   weight,
+                                                   min_edge_offset,
+                                                   force_loop_forward,
+                                                   force_loop_reverse);
+            }
+        }
+        if (!reverse_heap.Empty())
+        {
+            if (facade.IsCoreNode(reverse_heap.Min()))
+            {
+                const NodeID node = reverse_heap.DeleteMin();
+                const EdgeWeight key = reverse_heap.GetKey(node);
+                reverse_entry_points.emplace_back(node, key, reverse_heap.GetData(node).parent);
+            }
+            else
+            {
+                ch::routingStep<REVERSE_DIRECTION>(facade,
+                                                   reverse_heap,
+                                                   forward_heap,
+                                                   middle,
+                                                   weight,
+                                                   min_edge_offset,
+                                                   force_loop_reverse,
+                                                   force_loop_forward);
+            }
+        }
+    }
+
+    const auto insertInCoreHeap = [](const CoreEntryPoint &p,
+                                     SearchEngineData::QueryHeap &core_heap) {
+        NodeID id;
+        EdgeWeight weight;
+        NodeID parent;
+        // TODO this should use std::apply when we get c++17 support
+        std::tie(id, weight, parent) = p;
+        core_heap.Insert(id, weight, parent);
+    };
+
+    forward_core_heap.Clear();
+    for (const auto &p : forward_entry_points)
+    {
+        insertInCoreHeap(p, forward_core_heap);
+    }
+
+    reverse_core_heap.Clear();
+    for (const auto &p : reverse_entry_points)
+    {
+        insertInCoreHeap(p, reverse_core_heap);
+    }
+
+    // get offset to account for offsets on phantom nodes on compressed edges
+    EdgeWeight min_core_edge_offset = 0;
+    if (forward_core_heap.Size() > 0)
+    {
+        min_core_edge_offset = std::min(min_core_edge_offset, forward_core_heap.MinKey());
+    }
+    if (reverse_core_heap.Size() > 0 && reverse_core_heap.MinKey() < 0)
+    {
+        min_core_edge_offset = std::min(min_core_edge_offset, reverse_core_heap.MinKey());
+    }
+    BOOST_ASSERT(min_core_edge_offset <= 0);
+
+    // run two-target Dijkstra routing step on core with termination criterion
+    while (0 < forward_core_heap.Size() && 0 < reverse_core_heap.Size() &&
+           weight > (forward_core_heap.MinKey() + reverse_core_heap.MinKey()))
+    {
+        ch::routingStep<FORWARD_DIRECTION, ch::DISABLE_STALLING>(facade,
+                                                                 forward_core_heap,
+                                                                 reverse_core_heap,
+                                                                 middle,
+                                                                 weight,
+                                                                 min_core_edge_offset,
+                                                                 force_loop_forward,
+                                                                 force_loop_reverse);
+
+        ch::routingStep<REVERSE_DIRECTION, ch::DISABLE_STALLING>(facade,
+                                                                 reverse_core_heap,
+                                                                 forward_core_heap,
+                                                                 middle,
+                                                                 weight,
+                                                                 min_core_edge_offset,
+                                                                 force_loop_reverse,
+                                                                 force_loop_forward);
+    }
+
+    // No path found for both target nodes?
+    if (weight_upper_bound <= weight || SPECIAL_NODEID == middle)
+    {
+        weight = INVALID_EDGE_WEIGHT;
+        return;
+    }
+
+    // Was a paths over one of the forward/reverse nodes not found?
+    BOOST_ASSERT_MSG((SPECIAL_NODEID != middle && INVALID_EDGE_WEIGHT != weight), "no path found");
+
+    // we need to unpack sub path from core heaps
+    if (facade.IsCoreNode(middle))
+    {
+        if (weight != forward_core_heap.GetKey(middle) + reverse_core_heap.GetKey(middle))
+        {
+            // self loop
+            BOOST_ASSERT(forward_core_heap.GetData(middle).parent == middle &&
+                         reverse_core_heap.GetData(middle).parent == middle);
+            packed_leg.push_back(middle);
+            packed_leg.push_back(middle);
+        }
+        else
+        {
+            std::vector<NodeID> packed_core_leg;
+            ch::retrievePackedPathFromHeap(
+                forward_core_heap, reverse_core_heap, middle, packed_core_leg);
+            BOOST_ASSERT(packed_core_leg.size() > 0);
+            ch::retrievePackedPathFromSingleHeap(forward_heap, packed_core_leg.front(), packed_leg);
+            std::reverse(packed_leg.begin(), packed_leg.end());
+            packed_leg.insert(packed_leg.end(), packed_core_leg.begin(), packed_core_leg.end());
+            ch::retrievePackedPathFromSingleHeap(reverse_heap, packed_core_leg.back(), packed_leg);
+        }
+    }
+    else
+    {
+        if (weight != forward_heap.GetKey(middle) + reverse_heap.GetKey(middle))
+        {
+            // self loop
+            BOOST_ASSERT(forward_heap.GetData(middle).parent == middle &&
+                         reverse_heap.GetData(middle).parent == middle);
+            packed_leg.push_back(middle);
+            packed_leg.push_back(middle);
+        }
+        else
+        {
+            ch::retrievePackedPathFromHeap(forward_heap, reverse_heap, middle, packed_leg);
+        }
+    }
+}
+
+// Requires the heaps for be empty
+// If heaps should be adjusted to be initialized outside of this function,
+// the addition of force_loop parameters might be required
+double getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                          SearchEngineData::QueryHeap &forward_heap,
+                          SearchEngineData::QueryHeap &reverse_heap,
+                          SearchEngineData::QueryHeap &forward_core_heap,
+                          SearchEngineData::QueryHeap &reverse_core_heap,
+                          const PhantomNode &source_phantom,
+                          const PhantomNode &target_phantom,
+                          EdgeWeight weight_upper_bound)
+{
+    forward_heap.Clear();
+    reverse_heap.Clear();
+    forward_core_heap.Clear();
+    reverse_core_heap.Clear();
+
+    insertNodesInHeaps(forward_heap, reverse_heap, {source_phantom, target_phantom});
+
+    EdgeWeight weight = INVALID_EDGE_WEIGHT;
+    std::vector<NodeID> packed_path;
+    search(facade,
+           forward_heap,
+           reverse_heap,
+           forward_core_heap,
+           reverse_core_heap,
+           weight,
+           packed_path,
+           DO_NOT_FORCE_LOOPS,
+           DO_NOT_FORCE_LOOPS,
+           weight_upper_bound);
+
+    double distance = std::numeric_limits<double>::max();
+    if (weight != INVALID_EDGE_WEIGHT)
+    {
+        return ch::getPathDistance(facade, packed_path, source_phantom, target_phantom);
+    }
+    return distance;
+}
+} // namespace corech
+
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm

--- a/src/engine/routing_algorithms/routing_base_ch.cpp
+++ b/src/engine/routing_algorithms/routing_base_ch.cpp
@@ -31,8 +31,8 @@ void unpackEdge(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> 
     unpacked_path.emplace_back(to);
 }
 
-void retrievePackedPathFromHeap(const SearchEngineData::QueryHeap &forward_heap,
-                                const SearchEngineData::QueryHeap &reverse_heap,
+void retrievePackedPathFromHeap(const SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                                const SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                                 const NodeID middle_node_id,
                                 std::vector<NodeID> &packed_path)
 {
@@ -42,7 +42,7 @@ void retrievePackedPathFromHeap(const SearchEngineData::QueryHeap &forward_heap,
     retrievePackedPathFromSingleHeap(reverse_heap, middle_node_id, packed_path);
 }
 
-void retrievePackedPathFromSingleHeap(const SearchEngineData::QueryHeap &search_heap,
+void retrievePackedPathFromSingleHeap(const SearchEngineData<Algorithm>::QueryHeap &search_heap,
                                       const NodeID middle_node_id,
                                       std::vector<NodeID> &packed_path)
 {
@@ -72,8 +72,8 @@ void retrievePackedPathFromSingleHeap(const SearchEngineData::QueryHeap &search_
 // requires
 // a force loop, if the heaps have been initialized with positive offsets.
 void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-            SearchEngineData::QueryHeap &forward_heap,
-            SearchEngineData::QueryHeap &reverse_heap,
+            SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+            SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
             EdgeWeight &weight,
             std::vector<NodeID> &packed_leg,
             const bool force_loop_forward,
@@ -215,8 +215,8 @@ double getPathDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algo
 // If heaps should be adjusted to be initialized outside of this function,
 // the addition of force_loop parameters might be required
 double getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                          SearchEngineData::QueryHeap &forward_heap,
-                          SearchEngineData::QueryHeap &reverse_heap,
+                          SearchEngineData<Algorithm>::QueryHeap &forward_heap,
+                          SearchEngineData<Algorithm>::QueryHeap &reverse_heap,
                           const PhantomNode &source_phantom,
                           const PhantomNode &target_phantom,
                           EdgeWeight weight_upper_bound)
@@ -282,10 +282,10 @@ namespace corech
 // requires
 // a force loop, if the heaps have been initialized with positive offsets.
 void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-            SearchEngineData::QueryHeap &forward_heap,
-            SearchEngineData::QueryHeap &reverse_heap,
-            SearchEngineData::QueryHeap &forward_core_heap,
-            SearchEngineData::QueryHeap &reverse_core_heap,
+            SearchEngineData<ch::Algorithm>::QueryHeap &forward_heap,
+            SearchEngineData<ch::Algorithm>::QueryHeap &reverse_heap,
+            SearchEngineData<ch::Algorithm>::QueryHeap &forward_core_heap,
+            SearchEngineData<ch::Algorithm>::QueryHeap &reverse_core_heap,
             EdgeWeight &weight,
             std::vector<NodeID> &packed_leg,
             const bool force_loop_forward,
@@ -350,7 +350,7 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &fac
     }
 
     const auto insertInCoreHeap = [](const CoreEntryPoint &p,
-                                     SearchEngineData::QueryHeap &core_heap) {
+                                     SearchEngineData<ch::Algorithm>::QueryHeap &core_heap) {
         NodeID id;
         EdgeWeight weight;
         NodeID parent;
@@ -460,10 +460,10 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &fac
 // If heaps should be adjusted to be initialized outside of this function,
 // the addition of force_loop parameters might be required
 double getNetworkDistance(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                          SearchEngineData::QueryHeap &forward_heap,
-                          SearchEngineData::QueryHeap &reverse_heap,
-                          SearchEngineData::QueryHeap &forward_core_heap,
-                          SearchEngineData::QueryHeap &reverse_core_heap,
+                          SearchEngineData<ch::Algorithm>::QueryHeap &forward_heap,
+                          SearchEngineData<ch::Algorithm>::QueryHeap &reverse_heap,
+                          SearchEngineData<ch::Algorithm>::QueryHeap &forward_core_heap,
+                          SearchEngineData<ch::Algorithm>::QueryHeap &reverse_core_heap,
                           const PhantomNode &source_phantom,
                           const PhantomNode &target_phantom,
                           EdgeWeight weight_upper_bound)

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -230,13 +230,14 @@ void unpackLegs(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> 
              phantom_nodes_vector[current_leg].target_phantom.forward_segment_id.id));
     }
 }
+}
 
 template <typename Algorithm>
 InternalRouteResult
-shortestPathSearchImpl(SearchEngineData<Algorithm> &engine_working_data,
-                       const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
-                       const std::vector<PhantomNodes> &phantom_nodes_vector,
-                       const boost::optional<bool> continue_straight_at_waypoint)
+shortestPathSearch(SearchEngineData<Algorithm> &engine_working_data,
+                   const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
+                   const std::vector<PhantomNodes> &phantom_nodes_vector,
+                   const boost::optional<bool> continue_straight_at_waypoint)
 {
     InternalRouteResult raw_route_data;
     raw_route_data.segment_end_coordinates = phantom_nodes_vector;
@@ -487,40 +488,24 @@ shortestPathSearchImpl(SearchEngineData<Algorithm> &engine_working_data,
 
     return raw_route_data;
 }
-}
 
-template <>
-InternalRouteResult
+template InternalRouteResult
 shortestPathSearch(SearchEngineData<ch::Algorithm> &engine_working_data,
                    const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
-                   const boost::optional<bool> continue_straight_at_waypoint)
-{
-    return shortestPathSearchImpl(
-        engine_working_data, facade, phantom_nodes_vector, continue_straight_at_waypoint);
-}
+                   const boost::optional<bool> continue_straight_at_waypoint);
 
-template <>
-InternalRouteResult
+template InternalRouteResult
 shortestPathSearch(SearchEngineData<corech::Algorithm> &engine_working_data,
                    const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
-                   const boost::optional<bool> continue_straight_at_waypoint)
-{
-    return shortestPathSearchImpl(
-        engine_working_data, facade, phantom_nodes_vector, continue_straight_at_waypoint);
-}
+                   const boost::optional<bool> continue_straight_at_waypoint);
 
-template <>
-InternalRouteResult
+template InternalRouteResult
 shortestPathSearch(SearchEngineData<mld::Algorithm> &engine_working_data,
                    const datafacade::ContiguousInternalMemoryDataFacade<mld::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
-                   const boost::optional<bool> continue_straight_at_waypoint)
-{
-    return shortestPathSearchImpl(
-        engine_working_data, facade, phantom_nodes_vector, continue_straight_at_waypoint);
-}
+                   const boost::optional<bool> continue_straight_at_waypoint);
 
 } // namespace routing_algorithms
 } // namespace engine

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -198,7 +198,7 @@ void search(const datafacade::ContiguousInternalMemoryDataFacade<AlgorithmT> &fa
     }
 }
 
-void unpackLegs(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+void unpackLegs(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                 const std::vector<PhantomNodes> &phantom_nodes_vector,
                 const std::vector<NodeID> &total_packed_path,
                 const std::vector<std::size_t> &packed_leg_begin,
@@ -486,7 +486,7 @@ shortestPathSearchImpl(SearchEngineData &engine_working_data,
 
 InternalRouteResult
 shortestPathSearch(SearchEngineData &engine_working_data,
-                   const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+                   const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint)
 {
@@ -496,7 +496,7 @@ shortestPathSearch(SearchEngineData &engine_working_data,
 
 InternalRouteResult
 shortestPathSearch(SearchEngineData &engine_working_data,
-                   const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CoreCH> &facade,
+                   const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint)
 {

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -228,10 +228,10 @@ void unpackLegs(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorit
     }
 }
 
-template <typename AlgorithmT>
+template <typename Algorithm>
 InternalRouteResult
 shortestPathSearchImpl(SearchEngineData &engine_working_data,
-                       const datafacade::ContiguousInternalMemoryDataFacade<AlgorithmT> &facade,
+                       const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                        const std::vector<PhantomNodes> &phantom_nodes_vector,
                        const boost::optional<bool> continue_straight_at_waypoint)
 {
@@ -241,11 +241,12 @@ shortestPathSearchImpl(SearchEngineData &engine_working_data,
         !(continue_straight_at_waypoint ? *continue_straight_at_waypoint
                                         : facade.GetContinueStraightDefault());
 
-    engine_working_data.InitializeOrClearFirstThreadLocalStorage(facade.GetNumberOfNodes());
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(Algorithm{},
+                                                                 facade.GetNumberOfNodes());
     engine_working_data.InitializeOrClearSecondThreadLocalStorage(facade.GetNumberOfNodes());
 
-    QueryHeap &forward_heap = *(engine_working_data.forward_heap_1);
-    QueryHeap &reverse_heap = *(engine_working_data.reverse_heap_1);
+    auto &forward_heap = *engine_working_data.GetForwardHeapPtr(Algorithm{});
+    auto &reverse_heap = *engine_working_data.GetReverseHeapPtr(Algorithm{});
     QueryHeap &forward_core_heap = *(engine_working_data.forward_heap_2);
     QueryHeap &reverse_core_heap = *(engine_working_data.reverse_heap_2);
 

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -16,7 +16,7 @@ namespace
 {
 
 const static constexpr bool DO_NOT_FORCE_LOOP = false;
-using QueryHeap = SearchEngineData::QueryHeap;
+using QueryHeap = SearchEngineData<ch::Algorithm>::QueryHeap;
 
 // allows a uturn at the target_phantom
 // searches source forward/reverse -> target forward/reverse
@@ -230,7 +230,7 @@ void unpackLegs(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorit
 
 template <typename Algorithm>
 InternalRouteResult
-shortestPathSearchImpl(SearchEngineData &engine_working_data,
+shortestPathSearchImpl(SearchEngineData<Algorithm> &engine_working_data,
                        const datafacade::ContiguousInternalMemoryDataFacade<Algorithm> &facade,
                        const std::vector<PhantomNodes> &phantom_nodes_vector,
                        const boost::optional<bool> continue_straight_at_waypoint)
@@ -241,14 +241,13 @@ shortestPathSearchImpl(SearchEngineData &engine_working_data,
         !(continue_straight_at_waypoint ? *continue_straight_at_waypoint
                                         : facade.GetContinueStraightDefault());
 
-    engine_working_data.InitializeOrClearFirstThreadLocalStorage(Algorithm{},
-                                                                 facade.GetNumberOfNodes());
+    engine_working_data.InitializeOrClearFirstThreadLocalStorage(facade.GetNumberOfNodes());
     engine_working_data.InitializeOrClearSecondThreadLocalStorage(facade.GetNumberOfNodes());
 
-    auto &forward_heap = *engine_working_data.GetForwardHeapPtr(Algorithm{});
-    auto &reverse_heap = *engine_working_data.GetReverseHeapPtr(Algorithm{});
-    QueryHeap &forward_core_heap = *(engine_working_data.forward_heap_2);
-    QueryHeap &reverse_core_heap = *(engine_working_data.reverse_heap_2);
+    auto &forward_heap = *engine_working_data.forward_heap_1;
+    auto &reverse_heap = *engine_working_data.reverse_heap_1;
+    auto &forward_core_heap = *engine_working_data.forward_heap_2;
+    auto &reverse_core_heap = *engine_working_data.reverse_heap_2;
 
     int total_weight_to_forward = 0;
     int total_weight_to_reverse = 0;
@@ -485,8 +484,9 @@ shortestPathSearchImpl(SearchEngineData &engine_working_data,
 }
 }
 
+template<>
 InternalRouteResult
-shortestPathSearch(SearchEngineData &engine_working_data,
+shortestPathSearch(SearchEngineData<ch::Algorithm> &engine_working_data,
                    const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint)
@@ -495,8 +495,9 @@ shortestPathSearch(SearchEngineData &engine_working_data,
         engine_working_data, facade, phantom_nodes_vector, continue_straight_at_waypoint);
 }
 
+template<>
 InternalRouteResult
-shortestPathSearch(SearchEngineData &engine_working_data,
+shortestPathSearch(SearchEngineData<corech::Algorithm> &engine_working_data,
                    const datafacade::ContiguousInternalMemoryDataFacade<corech::Algorithm> &facade,
                    const std::vector<PhantomNodes> &phantom_nodes_vector,
                    const boost::optional<bool> continue_straight_at_waypoint)

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -456,20 +456,9 @@ shortestPathSearchImpl(SearchEngineData<Algorithm> &engine_working_data,
                  total_weight_to_reverse != INVALID_EDGE_WEIGHT);
 
     // We make sure the fastest route is always in packed_legs_to_forward
-    if (total_weight_to_forward > total_weight_to_reverse)
-    {
-        // insert sentinel
-        packed_leg_to_reverse_begin.push_back(total_packed_path_to_reverse.size());
-        BOOST_ASSERT(packed_leg_to_reverse_begin.size() == phantom_nodes_vector.size() + 1);
-
-        unpackLegs(facade,
-                   phantom_nodes_vector,
-                   total_packed_path_to_reverse,
-                   packed_leg_to_reverse_begin,
-                   total_weight_to_reverse,
-                   raw_route_data);
-    }
-    else
+    if (total_weight_to_forward < total_weight_to_reverse ||
+        (total_weight_to_forward == total_weight_to_reverse &&
+         total_packed_path_to_forward.size() < total_packed_path_to_reverse.size()))
     {
         // insert sentinel
         packed_leg_to_forward_begin.push_back(total_packed_path_to_forward.size());
@@ -480,6 +469,19 @@ shortestPathSearchImpl(SearchEngineData<Algorithm> &engine_working_data,
                    total_packed_path_to_forward,
                    packed_leg_to_forward_begin,
                    total_weight_to_forward,
+                   raw_route_data);
+    }
+    else
+    {
+        // insert sentinel
+        packed_leg_to_reverse_begin.push_back(total_packed_path_to_reverse.size());
+        BOOST_ASSERT(packed_leg_to_reverse_begin.size() == phantom_nodes_vector.size() + 1);
+
+        unpackLegs(facade,
+                   phantom_nodes_vector,
+                   total_packed_path_to_reverse,
+                   packed_leg_to_reverse_begin,
+                   total_weight_to_reverse,
                    raw_route_data);
     }
 

--- a/src/engine/routing_algorithms/tile_turns.cpp
+++ b/src/engine/routing_algorithms/tile_turns.cpp
@@ -8,7 +8,7 @@ namespace routing_algorithms
 {
 
 std::vector<TurnData>
-getTileTurns(const datafacade::ContiguousInternalMemoryDataFacade<algorithm::CH> &facade,
+getTileTurns(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm> &facade,
              const std::vector<RTreeLeaf> &edges,
              const std::vector<std::size_t> &sorted_edge_indexes)
 {

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -7,20 +7,16 @@ namespace osrm
 namespace engine
 {
 
-SearchEngineData::SearchEngineHeapPtr SearchEngineData::forward_heap_1;
-SearchEngineData::SearchEngineHeapPtr SearchEngineData::reverse_heap_1;
-SearchEngineData::SearchEngineHeapPtr SearchEngineData::forward_heap_2;
-SearchEngineData::SearchEngineHeapPtr SearchEngineData::reverse_heap_2;
-SearchEngineData::SearchEngineHeapPtr SearchEngineData::forward_heap_3;
-SearchEngineData::SearchEngineHeapPtr SearchEngineData::reverse_heap_3;
-SearchEngineData::ManyToManyHeapPtr SearchEngineData::many_to_many_heap;
-
-SearchEngineData::MultiLayerDijkstraHeapPtr SearchEngineData::mld_forward_heap;
-SearchEngineData::MultiLayerDijkstraHeapPtr SearchEngineData::mld_reverse_heap;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::forward_heap_1;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::reverse_heap_1;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::forward_heap_2;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::reverse_heap_2;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::forward_heap_3;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::reverse_heap_3;
+template<typename Algorithm> typename SearchEngineData<Algorithm>::ManyToManyHeapPtr SearchEngineData<Algorithm>::many_to_many_heap;
 
 template <typename Algorithm>
-void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(Algorithm,
-                                                                const unsigned number_of_nodes)
+void SearchEngineData<Algorithm>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes)
 {
     if (forward_heap_1.get())
     {
@@ -41,36 +37,9 @@ void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(Algorithm,
     }
 }
 
-template void
-SearchEngineData::InitializeOrClearFirstThreadLocalStorage(routing_algorithms::ch::Algorithm,
-                                                           const unsigned number_of_nodes);
-template void
-SearchEngineData::InitializeOrClearFirstThreadLocalStorage(routing_algorithms::corech::Algorithm,
-                                                           const unsigned number_of_nodes);
-
-void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(routing_algorithms::mld::Algorithm,
-                                                                const unsigned number_of_nodes)
-{
-    if (mld_forward_heap.get())
-    {
-        mld_forward_heap->Clear();
-    }
-    else
-    {
-        mld_forward_heap.reset(new MultiLayerDijkstraHeap(number_of_nodes));
-    }
-
-    if (mld_reverse_heap.get())
-    {
-        mld_reverse_heap->Clear();
-    }
-    else
-    {
-        mld_reverse_heap.reset(new MultiLayerDijkstraHeap(number_of_nodes));
-    }
-}
-
-void SearchEngineData::InitializeOrClearSecondThreadLocalStorage(const unsigned number_of_nodes)
+template <typename Algorithm>
+void SearchEngineData<Algorithm>::InitializeOrClearSecondThreadLocalStorage(
+    unsigned number_of_nodes)
 {
     if (forward_heap_2.get())
     {
@@ -91,7 +60,8 @@ void SearchEngineData::InitializeOrClearSecondThreadLocalStorage(const unsigned 
     }
 }
 
-void SearchEngineData::InitializeOrClearThirdThreadLocalStorage(const unsigned number_of_nodes)
+template <typename Algorithm>
+void SearchEngineData<Algorithm>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes)
 {
     if (forward_heap_3.get())
     {
@@ -112,7 +82,9 @@ void SearchEngineData::InitializeOrClearThirdThreadLocalStorage(const unsigned n
     }
 }
 
-void SearchEngineData::InitializeOrClearManyToManyThreadLocalStorage(const unsigned number_of_nodes)
+template <typename Algorithm>
+void SearchEngineData<Algorithm>::InitializeOrClearManyToManyThreadLocalStorage(
+    unsigned number_of_nodes)
 {
     if (many_to_many_heap.get())
     {
@@ -123,5 +95,77 @@ void SearchEngineData::InitializeOrClearManyToManyThreadLocalStorage(const unsig
         many_to_many_heap.reset(new ManyToManyQueryHeap(number_of_nodes));
     }
 }
+
+// CH
+using CH = routing_algorithms::ch::Algorithm;
+template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::forward_heap_1;
+template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::reverse_heap_1;
+template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::forward_heap_2;
+template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::reverse_heap_2;
+template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::forward_heap_3;
+template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::reverse_heap_3;
+template SearchEngineData<CH>::ManyToManyHeapPtr SearchEngineData<CH>::many_to_many_heap;
+
+template
+void SearchEngineData<routing_algorithms::ch::Algorithm>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
+
+template
+void SearchEngineData<CH>::InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
+
+template
+void SearchEngineData<CH>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
+
+template
+void SearchEngineData<CH>::InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
+
+// CoreCH
+using CoreCH = routing_algorithms::corech::Algorithm;
+template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::forward_heap_1;
+template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::reverse_heap_1;
+template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::forward_heap_2;
+template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::reverse_heap_2;
+template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::forward_heap_3;
+template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::reverse_heap_3;
+template SearchEngineData<CoreCH>::ManyToManyHeapPtr SearchEngineData<CoreCH>::many_to_many_heap;
+
+template
+void SearchEngineData<CoreCH>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
+
+template
+void SearchEngineData<CoreCH>::InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
+
+template
+void SearchEngineData<CoreCH>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
+
+template
+void SearchEngineData<CoreCH>::InitializeOrClearManyToManyThreadLocalStorage(
+    unsigned number_of_nodes);
+
+// MLD
+using MLD = routing_algorithms::mld::Algorithm;
+SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::forward_heap_1;
+SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::reverse_heap_1;
+
+void SearchEngineData<MLD>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes)
+{
+    if (forward_heap_1.get())
+    {
+        forward_heap_1->Clear();
+    }
+    else
+    {
+        forward_heap_1.reset(new QueryHeap(number_of_nodes));
+    }
+
+    if (reverse_heap_1.get())
+    {
+        reverse_heap_1->Clear();
+    }
+    else
+    {
+        reverse_heap_1.reset(new QueryHeap(number_of_nodes));
+    }
+}
+
 }
 }

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -7,13 +7,27 @@ namespace osrm
 namespace engine
 {
 
-template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::forward_heap_1;
-template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::reverse_heap_1;
-template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::forward_heap_2;
-template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::reverse_heap_2;
-template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::forward_heap_3;
-template<typename Algorithm> typename SearchEngineData<Algorithm>::SearchEngineHeapPtr SearchEngineData<Algorithm>::reverse_heap_3;
-template<typename Algorithm> typename SearchEngineData<Algorithm>::ManyToManyHeapPtr SearchEngineData<Algorithm>::many_to_many_heap;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::SearchEngineHeapPtr
+    SearchEngineData<Algorithm>::forward_heap_1;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::SearchEngineHeapPtr
+    SearchEngineData<Algorithm>::reverse_heap_1;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::SearchEngineHeapPtr
+    SearchEngineData<Algorithm>::forward_heap_2;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::SearchEngineHeapPtr
+    SearchEngineData<Algorithm>::reverse_heap_2;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::SearchEngineHeapPtr
+    SearchEngineData<Algorithm>::forward_heap_3;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::SearchEngineHeapPtr
+    SearchEngineData<Algorithm>::reverse_heap_3;
+template <typename Algorithm>
+typename SearchEngineData<Algorithm>::ManyToManyHeapPtr
+    SearchEngineData<Algorithm>::many_to_many_heap;
 
 template <typename Algorithm>
 void SearchEngineData<Algorithm>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes)
@@ -106,17 +120,18 @@ template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::forward
 template SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::reverse_heap_3;
 template SearchEngineData<CH>::ManyToManyHeapPtr SearchEngineData<CH>::many_to_many_heap;
 
-template
-void SearchEngineData<routing_algorithms::ch::Algorithm>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<routing_algorithms::ch::Algorithm>::InitializeOrClearFirstThreadLocalStorage(
+    unsigned number_of_nodes);
 
-template
-void SearchEngineData<CH>::InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<CH>::InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
 
-template
-void SearchEngineData<CH>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<CH>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
 
-template
-void SearchEngineData<CH>::InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<CH>::InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
 
 // CoreCH
 using CoreCH = routing_algorithms::corech::Algorithm;
@@ -128,23 +143,24 @@ template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>:
 template SearchEngineData<CoreCH>::SearchEngineHeapPtr SearchEngineData<CoreCH>::reverse_heap_3;
 template SearchEngineData<CoreCH>::ManyToManyHeapPtr SearchEngineData<CoreCH>::many_to_many_heap;
 
-template
-void SearchEngineData<CoreCH>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<CoreCH>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
 
-template
-void SearchEngineData<CoreCH>::InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<CoreCH>::InitializeOrClearSecondThreadLocalStorage(unsigned number_of_nodes);
 
-template
-void SearchEngineData<CoreCH>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
+template void
+SearchEngineData<CoreCH>::InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
 
-template
-void SearchEngineData<CoreCH>::InitializeOrClearManyToManyThreadLocalStorage(
-    unsigned number_of_nodes);
+template void
+SearchEngineData<CoreCH>::InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
 
 // MLD
 using MLD = routing_algorithms::mld::Algorithm;
 SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::forward_heap_1;
 SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::reverse_heap_1;
+SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::forward_heap_2;
+SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::reverse_heap_2;
 
 void SearchEngineData<MLD>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes)
 {
@@ -167,5 +183,25 @@ void SearchEngineData<MLD>::InitializeOrClearFirstThreadLocalStorage(unsigned nu
     }
 }
 
+void SearchEngineData<MLD>::InitializeOrClearSecondThreadLocalStorage(unsigned)
+{
+    if (forward_heap_2.get())
+    {
+        forward_heap_2->Clear();
+    }
+    else
+    {
+        forward_heap_2.reset(new QueryHeap(1));
+    }
+
+    if (reverse_heap_2.get())
+    {
+        reverse_heap_2->Clear();
+    }
+    else
+    {
+        reverse_heap_2.reset(new QueryHeap(1));
+    }
+}
 }
 }

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -18,7 +18,9 @@ SearchEngineData::ManyToManyHeapPtr SearchEngineData::many_to_many_heap;
 SearchEngineData::MultiLayerDijkstraHeapPtr SearchEngineData::mld_forward_heap;
 SearchEngineData::MultiLayerDijkstraHeapPtr SearchEngineData::mld_reverse_heap;
 
-void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(const unsigned number_of_nodes)
+template <typename Algorithm>
+void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(Algorithm,
+                                                                const unsigned number_of_nodes)
 {
     if (forward_heap_1.get())
     {
@@ -36,6 +38,35 @@ void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(const unsigned n
     else
     {
         reverse_heap_1.reset(new QueryHeap(number_of_nodes));
+    }
+}
+
+template void
+SearchEngineData::InitializeOrClearFirstThreadLocalStorage(routing_algorithms::ch::Algorithm,
+                                                           const unsigned number_of_nodes);
+template void
+SearchEngineData::InitializeOrClearFirstThreadLocalStorage(routing_algorithms::corech::Algorithm,
+                                                           const unsigned number_of_nodes);
+
+void SearchEngineData::InitializeOrClearFirstThreadLocalStorage(routing_algorithms::mld::Algorithm,
+                                                                const unsigned number_of_nodes)
+{
+    if (mld_forward_heap.get())
+    {
+        mld_forward_heap->Clear();
+    }
+    else
+    {
+        mld_forward_heap.reset(new MultiLayerDijkstraHeap(number_of_nodes));
+    }
+
+    if (mld_reverse_heap.get())
+    {
+        mld_reverse_heap->Clear();
+    }
+    else
+    {
+        mld_reverse_heap.reset(new MultiLayerDijkstraHeap(number_of_nodes));
     }
 }
 
@@ -90,28 +121,6 @@ void SearchEngineData::InitializeOrClearManyToManyThreadLocalStorage(const unsig
     else
     {
         many_to_many_heap.reset(new ManyToManyQueryHeap(number_of_nodes));
-    }
-}
-
-void SearchEngineData::InitializeOrClearMultiLayerDijkstraThreadLocalStorage(
-    const unsigned number_of_nodes)
-{
-    if (mld_forward_heap.get())
-    {
-        mld_forward_heap->Clear();
-    }
-    else
-    {
-        mld_forward_heap.reset(new MultiLayerDijkstraHeap(number_of_nodes));
-    }
-
-    if (mld_reverse_heap.get())
-    {
-        mld_reverse_heap->Clear();
-    }
-    else
-    {
-        mld_reverse_heap.reset(new MultiLayerDijkstraHeap(number_of_nodes));
     }
 }
 }

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -18,11 +18,14 @@ namespace osrm
 
 OSRM::OSRM(engine::EngineConfig &config)
 {
+    using CH = engine::routing_algorithms::ch::Algorithm;
+    using CoreCH = engine::routing_algorithms::corech::Algorithm;
+    using MLD = engine::routing_algorithms::mld::Algorithm;
+
     if (config.algorithm == EngineConfig::Algorithm::CoreCH ||
         config.algorithm == EngineConfig::Algorithm::CH)
     {
-        bool corech_compatible =
-            engine::Engine<engine::algorithm::CoreCH>::CheckCompability(config);
+        bool corech_compatible = engine::Engine<CoreCH>::CheckCompability(config);
 
         // Activate CoreCH if we can because it is faster
         if (config.algorithm == EngineConfig::Algorithm::CH && corech_compatible)
@@ -40,13 +43,13 @@ OSRM::OSRM(engine::EngineConfig &config)
     switch (config.algorithm)
     {
     case EngineConfig::Algorithm::CH:
-        engine_ = std::make_unique<engine::Engine<engine::algorithm::CH>>(config);
+        engine_ = std::make_unique<engine::Engine<CH>>(config);
         break;
     case EngineConfig::Algorithm::CoreCH:
-        engine_ = std::make_unique<engine::Engine<engine::algorithm::CoreCH>>(config);
+        engine_ = std::make_unique<engine::Engine<CoreCH>>(config);
         break;
     case EngineConfig::Algorithm::MLD:
-        engine_ = std::make_unique<engine::Engine<engine::algorithm::MLD>>(config);
+        engine_ = std::make_unique<engine::Engine<MLD>>(config);
         break;
     default:
         util::exception("Algorithm not implemented!");

--- a/unit_tests/engine/base64.cpp
+++ b/unit_tests/engine/base64.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(hint_encoding_decoding_roundtrip)
 
     const Coordinate coordinate;
     const PhantomNode phantom;
-    const osrm::test::MockDataFacade<osrm::engine::datafacade::CH> facade{};
+    const osrm::test::MockDataFacade<osrm::engine::routing_algorithms::ch::Algorithm> facade{};
 
     const Hint hint{phantom, facade.GetCheckSum()};
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(hint_encoding_decoding_roundtrip_bytewise)
 
     const Coordinate coordinate;
     const PhantomNode phantom;
-    const osrm::test::MockDataFacade<osrm::engine::datafacade::CH> facade{};
+    const osrm::test::MockDataFacade<osrm::engine::routing_algorithms::ch::Algorithm> facade{};
 
     const Hint hint{phantom, facade.GetCheckSum()};
 

--- a/unit_tests/engine/base64.cpp
+++ b/unit_tests/engine/base64.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(hint_encoding_decoding_roundtrip)
 
     const Coordinate coordinate;
     const PhantomNode phantom;
-    const osrm::test::MockDataFacade<osrm::engine::algorithm::CH> facade{};
+    const osrm::test::MockDataFacade<osrm::engine::datafacade::CH> facade{};
 
     const Hint hint{phantom, facade.GetCheckSum()};
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(hint_encoding_decoding_roundtrip_bytewise)
 
     const Coordinate coordinate;
     const PhantomNode phantom;
-    const osrm::test::MockDataFacade<osrm::engine::algorithm::CH> facade{};
+    const osrm::test::MockDataFacade<osrm::engine::datafacade::CH> facade{};
 
     const Hint hint{phantom, facade.GetCheckSum()};
 

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -238,8 +238,8 @@ class MockBaseDataFacade : public engine::datafacade::BaseDataFacade
 template <typename AlgorithmT> class MockAlgorithmDataFacade;
 
 template <>
-class MockAlgorithmDataFacade<engine::algorithm::CH>
-    : public engine::datafacade::AlgorithmDataFacade<engine::algorithm::CH>
+class MockAlgorithmDataFacade<engine::datafacade::CH>
+    : public engine::datafacade::AlgorithmDataFacade<engine::datafacade::CH>
 {
   private:
     EdgeData foo;
@@ -281,8 +281,8 @@ class MockAlgorithmDataFacade<engine::algorithm::CH>
 };
 
 template <>
-class MockAlgorithmDataFacade<engine::algorithm::CoreCH>
-    : public engine::datafacade::AlgorithmDataFacade<engine::algorithm::CoreCH>
+class MockAlgorithmDataFacade<engine::datafacade::CoreCH>
+    : public engine::datafacade::AlgorithmDataFacade<engine::datafacade::CoreCH>
 {
   private:
     EdgeData foo;
@@ -297,10 +297,10 @@ class MockDataFacade final : public MockBaseDataFacade, public MockAlgorithmData
 };
 
 template <>
-class MockDataFacade<engine::algorithm::CoreCH> final
+class MockDataFacade<engine::datafacade::CoreCH> final
     : public MockBaseDataFacade,
-      public MockAlgorithmDataFacade<engine::algorithm::CH>,
-      public MockAlgorithmDataFacade<engine::algorithm::CoreCH>
+      public MockAlgorithmDataFacade<engine::datafacade::CH>,
+      public MockAlgorithmDataFacade<engine::datafacade::CoreCH>
 {
 };
 

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -47,6 +47,7 @@ using TestStaticRTree = StaticRTree<TestData,
                                     TEST_LEAF_NODE_SIZE>;
 using MiniStaticRTree =
     StaticRTree<TestData, std::vector<Coordinate>, osrm::storage::Ownership::Container, 2, 128>;
+using TestDataFacade = MockDataFacade<osrm::engine::routing_algorithms::ch::Algorithm>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
 constexpr unsigned RANDOM_SEED = 42;
@@ -360,8 +361,8 @@ BOOST_AUTO_TEST_CASE(radius_regression_test)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_angle", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    MockDataFacade<engine::datafacade::CH> mockfacade;
-    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::datafacade::CH>> query(
+    TestDataFacade mockfacade;
+    engine::GeospatialQuery<MiniStaticRTree, TestDataFacade> query(
         rtree, fixture.coords, mockfacade);
 
     Coordinate input(FloatLongitude{5.2}, FloatLatitude{5.0});
@@ -387,8 +388,8 @@ BOOST_AUTO_TEST_CASE(bearing_tests)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_bearing", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    MockDataFacade<engine::datafacade::CH> mockfacade;
-    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::datafacade::CH>> query(
+    TestDataFacade mockfacade;
+    engine::GeospatialQuery<MiniStaticRTree, TestDataFacade> query(
         rtree, fixture.coords, mockfacade);
 
     Coordinate input(FloatLongitude{5.1}, FloatLatitude{5.0});
@@ -461,8 +462,8 @@ BOOST_AUTO_TEST_CASE(bbox_search_tests)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_bbox", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    MockDataFacade<engine::datafacade::CH> mockfacade;
-    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::datafacade::CH>> query(
+    TestDataFacade mockfacade;
+    engine::GeospatialQuery<MiniStaticRTree, TestDataFacade> query(
         rtree, fixture.coords, mockfacade);
 
     {

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -360,8 +360,8 @@ BOOST_AUTO_TEST_CASE(radius_regression_test)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_angle", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    MockDataFacade<engine::algorithm::CH> mockfacade;
-    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::algorithm::CH>> query(
+    MockDataFacade<engine::datafacade::CH> mockfacade;
+    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::datafacade::CH>> query(
         rtree, fixture.coords, mockfacade);
 
     Coordinate input(FloatLongitude{5.2}, FloatLatitude{5.0});
@@ -387,8 +387,8 @@ BOOST_AUTO_TEST_CASE(bearing_tests)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_bearing", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    MockDataFacade<engine::algorithm::CH> mockfacade;
-    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::algorithm::CH>> query(
+    MockDataFacade<engine::datafacade::CH> mockfacade;
+    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::datafacade::CH>> query(
         rtree, fixture.coords, mockfacade);
 
     Coordinate input(FloatLongitude{5.1}, FloatLatitude{5.0});
@@ -461,8 +461,8 @@ BOOST_AUTO_TEST_CASE(bbox_search_tests)
     std::string nodes_path;
     build_rtree<GraphFixture, MiniStaticRTree>("test_bbox", &fixture, leaves_path, nodes_path);
     MiniStaticRTree rtree(nodes_path, leaves_path, fixture.coords);
-    MockDataFacade<engine::algorithm::CH> mockfacade;
-    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::algorithm::CH>> query(
+    MockDataFacade<engine::datafacade::CH> mockfacade;
+    engine::GeospatialQuery<MiniStaticRTree, MockDataFacade<engine::datafacade::CH>> query(
         rtree, fixture.coords, mockfacade);
 
     {


### PR DESCRIPTION
# Issue

Implementation of the MLD shortest path plugin. It uses algorithm-aware Heaps 

There are still problems that must be fixed:
* some tests with self-loops(?) fail
* [`phantom_nodes`](https://github.com/Project-OSRM/osrm-backend/blob/784c5f05922b0573fc84f74c1b3b55e9a9915ccc/include/engine/routing_algorithms/routing_base_ch.hpp#L439) added to `search` functions parameters. It can be fixed via algorithm specific parameter packs.
* `SearchEngineData` for MLD needs ["fake" core heaps](https://github.com/Project-OSRM/osrm-backend/blob/784c5f05922b0573fc84f74c1b3b55e9a9915ccc/src/engine/search_engine_data.cpp#L162-L164). It can be solved only by moving access to core heaps into `corech` namespace. it requires refactoring of heaps usage.

## Tasklist
 - [x] all tests pass for MLD via tests
 - [x] fixed `{ch,corech,mld}::search` interface
 - [x] refactor `SearchEngineData` usage
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
The PR is the pre-condition for #3888 
