### PR TITLE
Don't scan back clique arcs in customization

### DIFF
--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -21,11 +21,12 @@ class CellCustomizer
     {
         bool from_clique;
     };
+
+  public:
     using Heap = util::
         BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::ArrayStorage<NodeID, int>>;
     using HeapPtr = tbb::enumerable_thread_specific<Heap>;
 
-  public:
     CellCustomizer(const partition::MultiLevelPartition &partition) : partition(partition) {}
 
     template <typename GraphT>

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -23,14 +23,15 @@ class CellCustomizer
     };
 
   public:
-    using Heap = util::
-        BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::ArrayStorage<NodeID, int>>;
+    using Heap =
+        util::BinaryHeap<NodeID, NodeID, EdgeWeight, HeapData, util::ArrayStorage<NodeID, int>>;
     using HeapPtr = tbb::enumerable_thread_specific<Heap>;
 
     CellCustomizer(const partition::MultiLevelPartition &partition) : partition(partition) {}
 
     template <typename GraphT>
-    void Customize(const GraphT &graph, Heap& heap, partition::CellStorage &cells, LevelID level, CellID id)
+    void Customize(
+        const GraphT &graph, Heap &heap, partition::CellStorage &cells, LevelID level, CellID id)
     {
         auto cell = cells.GetCell(level, id);
         auto destinations = cell.GetDestinationNodes();
@@ -77,7 +78,7 @@ class CellCustomizer
         {
             tbb::parallel_for(tbb::blocked_range<std::size_t>(0, partition.GetNumberOfCells(level)),
                               [&](const tbb::blocked_range<std::size_t> &range) {
-                                  auto& heap = heaps.local();
+                                  auto &heap = heaps.local();
                                   for (auto id = range.begin(), end = range.end(); id != end; ++id)
                                   {
                                       Customize(graph, heap, cells, level, id);
@@ -87,7 +88,6 @@ class CellCustomizer
     }
 
   private:
-
     template <bool first_level, typename GraphT>
     void RelaxNode(const GraphT &graph,
                    const partition::CellStorage &cells,

--- a/include/util/binary_heap.hpp
+++ b/include/util/binary_heap.hpp
@@ -19,15 +19,21 @@ namespace util
 template <typename NodeID, typename Key> class GenerationArrayStorage
 {
     using GenerationCounter = std::uint16_t;
-  public:
-    explicit GenerationArrayStorage(std::size_t size) : positions(size, 0), generation(1), generations(size, 0) {}
 
-    Key &operator[](NodeID node) {
+  public:
+    explicit GenerationArrayStorage(std::size_t size)
+        : positions(size, 0), generation(1), generations(size, 0)
+    {
+    }
+
+    Key &operator[](NodeID node)
+    {
         generation[node] = generation;
         return positions[node];
     }
 
-    Key peek_index(const NodeID node) const {
+    Key peek_index(const NodeID node) const
+    {
         if (generations[node] < generation)
         {
             return std::numeric_limits<Key>::max();
@@ -35,7 +41,8 @@ template <typename NodeID, typename Key> class GenerationArrayStorage
         return positions[node];
     }
 
-    void Clear() {
+    void Clear()
+    {
         generation++;
         // if generation overflows we end up at 0 again and need to clear the vector
         if (generation == 0)

--- a/include/util/binary_heap.hpp
+++ b/include/util/binary_heap.hpp
@@ -20,7 +20,7 @@ template <typename NodeID, typename Key> class GenerationArrayStorage
 {
     using GenerationCounter = std::uint16_t;
   public:
-    explicit GenerationArrayStorage(std::size_t size) : positions(size, 0), generation(0), generations(size, 0) {}
+    explicit GenerationArrayStorage(std::size_t size) : positions(size, 0), generation(1), generations(size, 0) {}
 
     Key &operator[](NodeID node) {
         generation[node] = generation;
@@ -37,10 +37,11 @@ template <typename NodeID, typename Key> class GenerationArrayStorage
 
     void Clear() {
         generation++;
-        if (generation == std::numeric_limits<GenerationCounter>::max())
+        // if generation overflows we end up at 0 again and need to clear the vector
+        if (generation == 0)
         {
+            generation = 1;
             std::fill(generations.begin(), generations.end(), 0);
-            std::fill(positions.begin(), positions.end(), 0);
         }
     }
 

--- a/include/util/binary_heap.hpp
+++ b/include/util/binary_heap.hpp
@@ -126,10 +126,6 @@ template <typename NodeID,
           typename IndexStorage = ArrayStorage<NodeID, NodeID>>
 class BinaryHeap
 {
-  private:
-    BinaryHeap(const BinaryHeap &right);
-    void operator=(const BinaryHeap &right);
-
   public:
     using WeightType = Weight;
     using DataType = Data;

--- a/include/util/binary_heap.hpp
+++ b/include/util/binary_heap.hpp
@@ -16,6 +16,40 @@ namespace osrm
 namespace util
 {
 
+template <typename NodeID, typename Key> class GenerationArrayStorage
+{
+    using GenerationCounter = std::uint16_t;
+  public:
+    explicit GenerationArrayStorage(std::size_t size) : positions(size, 0), generation(0), generations(size, 0) {}
+
+    Key &operator[](NodeID node) {
+        generation[node] = generation;
+        return positions[node];
+    }
+
+    Key peek_index(const NodeID node) const {
+        if (generations[node] < generation)
+        {
+            return std::numeric_limits<Key>::max();
+        }
+        return positions[node];
+    }
+
+    void Clear() {
+        generation++;
+        if (generation == std::numeric_limits<GenerationCounter>::max())
+        {
+            std::fill(generations.begin(), generations.end(), 0);
+            std::fill(positions.begin(), positions.end(), 0);
+        }
+    }
+
+  private:
+    GenerationCounter generation;
+    std::vector<GenerationCounter> generations;
+    std::vector<Key> positions;
+};
+
 template <typename NodeID, typename Key> class ArrayStorage
 {
   public:

--- a/unit_tests/customizer/cell_customization.cpp
+++ b/unit_tests/customizer/cell_customization.cpp
@@ -59,6 +59,7 @@ BOOST_AUTO_TEST_CASE(two_level_test)
 
     CellStorage storage(mlp, graph);
     CellCustomizer customizer(mlp);
+    CellCustomizer::Heap heap(graph.GetNumberOfNodes());
 
     auto cell_1_0 = storage.GetCell(1, 0);
     auto cell_1_1 = storage.GetCell(1, 1);
@@ -80,8 +81,8 @@ BOOST_AUTO_TEST_CASE(two_level_test)
     REQUIRE_SIZE_RANGE(cell_1_1.GetOutWeight(2), 2);
     REQUIRE_SIZE_RANGE(cell_1_1.GetInWeight(3), 2);
 
-    customizer.Customize(graph, storage, 1, 0);
-    customizer.Customize(graph, storage, 1, 1);
+    customizer.Customize(graph, heap, storage, 1, 0);
+    customizer.Customize(graph, heap, storage, 1, 1);
 
     // cell 0
     // check row source -> destination
@@ -203,14 +204,15 @@ BOOST_AUTO_TEST_CASE(four_levels_test)
     REQUIRE_SIZE_RANGE(cell_3_0.GetDestinationNodes(), 0);
 
     CellCustomizer customizer(mlp);
+    CellCustomizer::Heap heap(graph.GetNumberOfNodes());
 
-    customizer.Customize(graph, storage, 1, 0);
-    customizer.Customize(graph, storage, 1, 1);
-    customizer.Customize(graph, storage, 1, 2);
-    customizer.Customize(graph, storage, 1, 3);
+    customizer.Customize(graph, heap, storage, 1, 0);
+    customizer.Customize(graph, heap, storage, 1, 1);
+    customizer.Customize(graph, heap, storage, 1, 2);
+    customizer.Customize(graph, heap, storage, 1, 3);
 
-    customizer.Customize(graph, storage, 2, 0);
-    customizer.Customize(graph, storage, 2, 1);
+    customizer.Customize(graph, heap, storage, 2, 0);
+    customizer.Customize(graph, heap, storage, 2, 1);
 
     // level 1
     // cell 0


### PR DESCRIPTION
# Issue

Fix a performance problem in the customization that gives a factor ~3 speedup on Bayern.

## Tasklist
 - [x] review
 - [x] adjust for comments