### PR TITLE
Fixed breaking publishing due to node-cmake upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "main": "lib/index.js",
   "binary": {
-    "module_name": "node-osrm",
+    "module_name": "node_osrm",
     "module_path": "./lib/binding/",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}/{configuration}/",


### PR DESCRIPTION
# Issue

The package.json still contained the wrong module name breaking node-pre-gyp publishing.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
