### PR TITLE
OMT packing for rtree.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -702,6 +702,11 @@ if(BUILD_TOOLS)
 
   install(TARGETS osrm-io-benchmark DESTINATION bin)
 
+  add_executable(osrm-rtree-dump src/tools/rtree-dump.cpp $<TARGET_OBJECTS:UTIL>)
+  target_link_libraries(osrm-rtree-dump ${BOOST_BASE_LIBRARIES})
+
+  install(TARGETS osrm-rtree-dump DESTINATION bin)
+
   if(SHAPEFILE_FOUND AND (Boost_VERSION VERSION_GREATER 106000 OR ENABLE_MASON))
     add_executable(osrm-extract-conditionals src/tools/extract-conditionals.cpp $<TARGET_OBJECTS:UTIL>)
     target_include_directories(osrm-extract-conditionals PRIVATE ${LIBSHAPEFILE_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,7 +703,7 @@ if(BUILD_TOOLS)
   install(TARGETS osrm-io-benchmark DESTINATION bin)
 
   add_executable(osrm-rtree-dump src/tools/rtree-dump.cpp $<TARGET_OBJECTS:UTIL>)
-  target_link_libraries(osrm-rtree-dump ${BOOST_BASE_LIBRARIES})
+  target_link_libraries(osrm-rtree-dump ${BOOST_BASE_LIBRARIES} ${MAYBE_SHAPEFILE})
 
   install(TARGETS osrm-rtree-dump DESTINATION bin)
 

--- a/features/bicycle/ferry.feature
+++ b/features/bicycle/ferry.feature
@@ -53,8 +53,8 @@ Feature: Bike - Handle ferry routes
     Scenario: Bike - Ferry duration, multiple nodes
         Given the node map
             """
-            x         y
-              a b c d
+                       
+            x a b c d y
             """
 
         And the ways

--- a/features/car/bridge.feature
+++ b/features/car/bridge.feature
@@ -33,9 +33,9 @@ Feature: Car - Handle driving
     Scenario: Car - Control test without durations, osrm uses movable bridge speed to calculate duration
         Given the node map
             """
-            a b c
+            a b1c
                 d
-                e f g
+                e2f g
             """
 
         And the ways
@@ -48,8 +48,8 @@ Feature: Car - Handle driving
             | from | to | route           | modes                           | speed   | time     |
             | a    | g  | abc,cde,efg,efg | driving,driving,driving,driving | 13 km/h | 340s +-1 |
             | b    | f  | abc,cde,efg,efg | driving,driving,driving,driving | 9 km/h  | 318s +-1 |
-            | c    | e  | cde,cde         | driving,driving                 | 5 km/h  | 295s +-1 |
-            | e    | c  | cde,cde         | driving,driving                 | 5 km/h  | 295s +-1 |
+            | 1    | 2  | abc,cde,efg     | driving,driving,driving         | 7 km/h  | 306s +-1 |
+            | 2    | 1  | efg,cde,abc     | driving,driving,driving         | 7 km/h  | 306s +-1 |
 
     Scenario: Car - Properly handle durations
         Given the node map

--- a/features/car/destination.feature
+++ b/features/car/destination.feature
@@ -8,7 +8,7 @@ Feature: Car - Destination only, no passing through
         Given the node map
             """
             a       e
-              b c d
+              b2c1d
 
             x       y
             """
@@ -24,18 +24,18 @@ Feature: Car - Destination only, no passing through
             | from | to | route      |
             | a    | b  | ab,ab      |
             | a    | c  | ab,bcd     |
-            | a    | d  | ab,bcd,bcd |
+            | a    | 1  | ab,bcd,bcd |
             | a    | e  | axye,axye  |
             | e    | d  | de,de      |
             | e    | c  | de,bcd     |
-            | e    | b  | de,bcd,bcd |
+            | e    | 2  | de,bcd,bcd |
             | e    | a  | axye,axye  |
 
     Scenario: Car - Destination only street
         Given the node map
             """
             a       e
-              b c d
+              b2c1d
 
             x       y
             """
@@ -52,11 +52,11 @@ Feature: Car - Destination only, no passing through
             | from | to | route       |
             | a    | b  | ab,ab       |
             | a    | c  | ab,bc       |
-            | a    | d  | ab,cd       |
+            | a    | 1  | ab,cd       |
             | a    | e  | axye,axye   |
             | e    | d  | de,de       |
             | e    | c  | de,cd       |
-            | e    | b  | de,bc       |
+            | e    | 2  | de,bc       |
             | e    | a  | axye,axye   |
 
     Scenario: Car - Routing inside a destination only area
@@ -117,7 +117,7 @@ Feature: Car - Destination only, no passing through
                    +    \
                    +    |
                    d    |
-                    \___e
+                    1___e
             """
 
         And the ways
@@ -129,5 +129,5 @@ Feature: Car - Destination only, no passing through
         When I route I should get
             | from | to | route         |
             | e    | a  | acbe,acbe     |
-            | d    | a  | de,acbe,acbe  |
+            | 1    | a  | de,acbe,acbe  |
             | c    | d  | cd,cd         |

--- a/features/car/weight.feature
+++ b/features/car/weight.feature
@@ -30,7 +30,7 @@ Feature: Car - weights
             a
             |
             b
-            |\
+            |\ 1
             | e
             |/
             c
@@ -60,7 +60,7 @@ Feature: Car - weights
         When I route I should get
             | from | to | route       | speed   | weight |
             | a    | d  | ab,bc,cd,cd | 65 km/h | 44.4   |
-            | a    | e  | ab,be,be    | 14 km/h | 112    |
+            | a    | 1  | ab,be,be    | 16 km/h | 81.6   |
 
     Scenario: Distance weights
         Given the profile file "car" extended with

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -970,7 +970,7 @@ Feature: Simple Turns
             j k a   b   x
                   e   c
                     d
-
+                  1
                   h
             """
 
@@ -990,7 +990,7 @@ Feature: Simple Turns
 
         When I route I should get
             | waypoints | turns                                        | route                                                         |
-            | a,h       | depart,off ramp right,turn sharp left,arrive | Blue Star Memorial Hwy,bcde,Centreville Road,Centreville Road |
+            | a,1       | depart,off ramp right,turn sharp left,arrive | Blue Star Memorial Hwy,bcde,Centreville Road,Centreville Road |
 
     @todo
     # https://www.openstreetmap.org/#map=20/52.51609/13.41080

--- a/features/testbot/basic.feature
+++ b/features/testbot/basic.feature
@@ -260,7 +260,9 @@ Feature: Basic Routing
         Given the node map
             """
                   d
+                  2
             a b c
+                  1
                   e
             """
 
@@ -274,7 +276,7 @@ Feature: Basic Routing
         When I route I should get
             | from | to | route    |
             | d    | c  | de,ce,ce |
-            | e    | d  | de,de    |
+            | 1    | 2  | de,de    |
 
     Scenario: Ambiguous edge weights - Use minimal edge weight
         Given the node map

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -228,7 +228,7 @@ Feature: Basic Map Matching
 
         Given the node map
             """
-            a b c d e   g h
+          1 a2b4c d e3  g h
                 i
             """
 
@@ -246,15 +246,15 @@ Feature: Basic Map Matching
         And the customize extra arguments "--segment-speed-file {speeds_file}"
 
         When I match I should get
-            | trace | matchings | a:duration      |
-            | abeh  | abeh      | 1:0,1:1:1,0:2:1 |
-            | abci  | abci      | 1:0,1,0:1       |
+            | trace | a:duration              |
+            | a23h  | 0.5,0.5:1:1:1:0.4,1.6:1 |
+            | a24i  | 0.5,0.5:0.4,0.6:1.4     |
 
         # The following is the same as the above, but separated for readability (line length)
         When I match I should get
-            | trace | matchings | a:nodes               |
-            | abeh  | abeh      | 1:2:3,2:3:4:5,4:5:6:7 |
-            | abci  | abci      | 1:2:3,2:3,2:3:8       |
+            | trace | a:nodes               |
+            | a23h  | 1:2,1:2:3:4:5:6,5:6:7 |
+            | a24i  | 1:2,1:2:3,2:3:8       |
 
     Scenario: Testbot - Regression test for #3037
         Given the query options

--- a/features/testbot/oneway.feature
+++ b/features/testbot/oneway.feature
@@ -10,8 +10,11 @@ Feature: Testbot - oneways
         """
                 v
         x   d c
+           1 
+           2
           e     b
           f     a
+           3
             g h   y
           z
         """
@@ -36,7 +39,7 @@ Feature: Testbot - oneways
             | a    | b  | ab,ab                   |
             | b    | c  | bc,bc                   |
             | c    | d  | cd,cd                   |
-            | d    | e  | de,de                   |
+            | 1    | 2  | de,de                   |
             | e    | f  | ef,ef                   |
             | f    | g  | fg,fg                   |
             | g    | h  | gh,gh                   |
@@ -45,7 +48,7 @@ Feature: Testbot - oneways
             | c    | b  | cd,de,ef,fg,gh,ha,ab,ab |
             | d    | c  | de,ef,fg,gh,ha,ab,bc,bc |
             | e    | d  | ef,fg,gh,ha,ab,bc,cd,cd |
-            | f    | e  | fg,gh,ha,ab,bc,cd,de,de |
+            | 3    | 2  | fg,gh,ha,ab,bc,cd,de,de |
             | g    | f  | gh,ha,ab,bc,cd,de,ef,ef |
             | h    | g  | ha,ab,bc,cd,de,ef,fg,fg |
             | a    | h  | ab,bc,cd,de,ef,fg,gh,gh |

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -8,9 +8,9 @@ Feature: Traffic - speeds
                 /  |
               f    5
            //  \   4
-          //     \ |g
+          /7     \ 6g
          d--- e --1b
-          \        |
+          \        8
             \      |
               \    |
                 \  |
@@ -146,13 +146,13 @@ Feature: Traffic - speeds
 
         When I route I should get
           | from | to | route    | speed   | weights     | a:datasources |
-          | a    | b  | fb,fb    | 36 km/h | 38.3,0      | 0:0           |
+          | a    | 6  | fb,fb    | 36 km/h | 30.7,0      | 0             |
           | a    | c  | fb,bc,bc | 30 km/h | 38.3,66.7,0 | 0:1           |
           | b    | c  | bc,bc    | 27 km/h | 66.7,0      | 1             |
-          | a    | d  | fb,df,df | 36 km/h | 0.7,39,0    | 0:0           |
+          | a    | 7  | fb,df,df | 36 km/h | 0.7,25,0    | 0:0           |
           | d    | c  | dc,dc    | 36 km/h | 70.7,0      | 0:1           |
-          | g    | b  | fb,fb    | 36 km/h | 10.8,0      | 0:0           |
-          | a    | g  | fb,fb    | 36 km/h | 27.5,0      | 0             |
+          | g    | 8  | fb,bc    | 29 km/h | 17.7,0      | 0:1           |
+          | a    | g  | fb,fb    | 36 km/h | 33.9,0      | 0             |
 
 
     Scenario: Verify that negative values cause an error, they're not valid at all

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -62,8 +62,8 @@ Feature: Traffic - speeds
           | b    | c  | bc,bc          | 27 km/h | 66.7,0            | 1             |
           | a    | d  | ad,ad          | 27 km/h | 94.3,0            | 1             |
           | d    | c  | dc,dc          | 36 km/h | 70.7,0            | 0:1           |
-          | g    | b  | fb,fb          | 37 km/h | 4.4,0             | 0:0           |
-          | a    | g  | ad,de,eb,fb,fb | 30 km/h | 94.3,25,25,4.4,0  | 1:0:0:0       |
+          | 6    | b  | fb,fb          | 36 km/h | 7.6,0             | 0:0           |
+          | a    | 8  | ad,de,eb,bc,bc | 30 km/h | 94.3,25,25,13.3,0 | 1:0:0:1       |
 
 
     Scenario: Weighting based on speed file weights, ETA based on file durations

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -2,15 +2,31 @@
 Feature: Traffic - speeds
 
     Background: Use specific speeds
-        Given the node locations
-          | node |   lat |   lon |
-          | a    |   0.1 |   0.1 |
-          | b    |  0.05 |   0.1 |
-          | c    |   0.0 |   0.1 |
-          | d    |  0.05 |  0.03 |
-          | e    |  0.05 | 0.066 |
-          | f    | 0.075 | 0.066 |
-          | g    | 0.075 |   0.1 |
+        Given the node map
+        """
+                  2a
+                /  |
+              f    5
+           //  \   4
+          //     \g|
+         d--- e --1b
+          \        |
+            \      |
+              \    |
+                \  |
+                  3c
+        """
+
+        And the nodes
+            | node | id |
+            | a    | 1  |
+            | b    | 2  |
+            | c    | 3  |
+            | d    | 4  |
+            | e    | 5  |
+            | f    | 6  |
+            | g    | 7  |
+
         And the ways
           | nodes | highway |
           | ab    | primary |
@@ -40,14 +56,14 @@ Feature: Traffic - speeds
           | annotations | datasources |
 
         When I route I should get
-          | from | to | route       | speed   | weights              | a:datasources |
-          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0:0       |
-          | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       | 1:0           |
-          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1:0           |
-          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1:0           |
-          | d    | c  | dc,dc       | 36 km/h | 956.8,0              | 0             |
-          | g    | b  | fb,fb       | 36 km/h | 164.7,0              | 0             |
-          | a    | g  | ad,df,fb,fb | 30 km/h | 1275.7,487.5,304.7,0 | 1:0:0         |
+          | from | to | route          | speed   | weights           | a:datasources |
+          | 2    | 1  | ad,de,eb,eb    | 30 km/h | 89.6,25,20,0      | 1:0:0         |
+          | a    | c  | ad,dc,dc       | 31 km/h | 94.3,70.7,0       | 1:0:1         |
+          | b    | c  | bc,bc          | 27 km/h | 66.7,0            | 1             |
+          | a    | d  | ad,ad          | 27 km/h | 94.3,0            | 1             |
+          | d    | c  | dc,dc          | 36 km/h | 70.7,0            | 0:1           |
+          | g    | b  | fb,fb          | 36 km/h | 10.8,0            | 0:0           |
+          | a    | g  | ad,de,eb,fb,fb | 31 km/h | 94.3,25,25,10.8,0 | 1:0:0:0       |
 
 
     Scenario: Weighting based on speed file weights, ETA based on file durations
@@ -67,13 +83,13 @@ Feature: Traffic - speeds
 
         When I route I should get
           | from | to | route       | speed   | weights              | a:datasources |
-          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0:0       |
-          | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       | 1:0           |
-          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1:0           |
-          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1:0           |
-          | d    | c  | dc,dc       | 36 km/h | 956.8,0              | 0             |
-          | g    | b  | ab,ab       | 1 km/h  | 10010.4,0            | 1:0           |
-          | a    | g  | ab,ab       | 1 km/h  | 10010.3,0            | 1             |
+          | 2    | 1  | ad,de,eb,eb | 30 km/h | 89.6,25,20,0         | 1:0:0         |
+          | 2    | 3  | ad,dc,dc    | 31 km/h | 89.6,67.2,0          | 1:0           |
+          | b    | c  | bc,bc       | 27 km/h | 66.7,0               | 1             |
+          | a    | d  | ad,ad       | 27 km/h | 94.3,0               | 1             |
+          | d    | c  | dc,dc       | 36 km/h | 70.7,0               | 0:1           |
+          | 4    | 5  | ab,ab       | 1 km/h  | 360,0                | 1             |
+          | 5    | 4  | ab,ab       | 1 km/h  | 360,0                | 1             |
 
 
     Scenario: Weighting based on speed file weights, ETA based on file durations
@@ -88,8 +104,8 @@ Feature: Traffic - speeds
         And the customize extra arguments "--segment-speed-file {speeds_file}"
         And the speed file
         """
-        1,2,1,0.27777777
-        2,1,1,0.27777777
+        1,2,1,0.499962
+        2,1,1,0.499962
         2,3,27,7.5
         3,2,27
         1,4,1
@@ -99,15 +115,15 @@ Feature: Traffic - speeds
           | annotations | datasources |
 
         When I route I should get
-          | from | to | route       | speed   | weights                     | a:datasources |
-          | a    | b  | ab,ab       | 1 km/h  | 20020.735,0                 | 1:0           |
-          | a    | c  | ab,bc,bc    | 2 km/h  | 20020.735,741.509,0         | 1:1:0         |
-          | b    | c  | bc,bc       | 27 km/h | 741.509,0                   | 1:0           |
-          | a    | d  | ab,eb,de,de | 2 km/h  | 20020.735,378.169,400.415,0 | 1:0:0         |
-          | d    | c  | dc,dc       | 36 km/h | 956.805,0                   | 0             |
-          | g    | b  | ab,ab       | 1 km/h  | 10010.365,0                 | 1:0           |
-          | a    | g  | ab,ab       | 1 km/h  | 10010.37,0                  | 1             |
-          | g    | a  | ab,ab       | 1 km/h  | 10010.37,0                  | 1:1           |
+          | from | to | route       | speed   | weights          | a:datasources |
+          | a    | b  | ab,ab       | 1 km/h  | 1000,0           | 1             |
+          | a    | c  | ab,bc,bc    | 2 km/h  | 1000,66.676,0    | 1:1           |
+          | b    | c  | bc,bc       | 27 km/h | 66.676,0         | 1             |
+          | a    | d  | ab,eb,de,de | 2 km/h  | 1000,25,24.989,0 | 1:0:0:1       |
+          | d    | c  | dc,dc       | 36 km/h | 70.708,0         | 0:1           |
+          | 4    | b  | ab,ab       | 1 km/h  | 400,0            | 1             |
+          | 5    | 4  | ab,ab       | 1 km/h  | 200,0            | 1             |
+          | 4    | 5  | ab,ab       | 1 km/h  | 200,0            | 1             |
 
 
     Scenario: Speeds that isolate a single node (a)
@@ -129,14 +145,14 @@ Feature: Traffic - speeds
           | annotations | true |
 
         When I route I should get
-          | from | to | route    | speed   | weights       | a:datasources |
-          | a    | b  | fb,fb    | 36 km/h | 329.4,0       | 0             |
-          | a    | c  | fb,bc,bc | 30 km/h | 329.4,741.5,0 | 0:1:0         |
-          | b    | c  | bc,bc    | 27 km/h | 741.5,0       | 1:0           |
-          | a    | d  | fb,df,df | 36 km/h | 140,487.5,0   | 0:0:0         |
-          | d    | c  | dc,dc    | 36 km/h | 956.8,0       | 0             |
-          | g    | b  | fb,fb    | 36 km/h | 164.7,0       | 0             |
-          | a    | g  | fb,fb    | 36 km/h | 164.7,0       | 0             |
+          | from | to | route    | speed   | weights     | a:datasources |
+          | a    | b  | fb,fb    | 36 km/h | 38.3,0      | 0:0           |
+          | a    | c  | fb,bc,bc | 30 km/h | 38.3,66.7,0 | 0:1           |
+          | b    | c  | bc,bc    | 27 km/h | 66.7,0      | 1             |
+          | a    | d  | fb,df,df | 36 km/h | 0.7,39,0    | 0:0           |
+          | d    | c  | dc,dc    | 36 km/h | 70.7,0      | 0:1           |
+          | g    | b  | fb,fb    | 36 km/h | 10.8,0      | 0:0           |
+          | a    | g  | fb,fb    | 36 km/h | 27.5,0      | 0             |
 
 
     Scenario: Verify that negative values cause an error, they're not valid at all

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -8,7 +8,7 @@ Feature: Traffic - speeds
                 /  |
               f    5
            //  \   4
-          //     \g|
+          //     \ |g
          d--- e --1b
           \        |
             \      |
@@ -62,8 +62,8 @@ Feature: Traffic - speeds
           | b    | c  | bc,bc          | 27 km/h | 66.7,0            | 1             |
           | a    | d  | ad,ad          | 27 km/h | 94.3,0            | 1             |
           | d    | c  | dc,dc          | 36 km/h | 70.7,0            | 0:1           |
-          | g    | b  | fb,fb          | 36 km/h | 10.8,0            | 0:0           |
-          | a    | g  | ad,de,eb,fb,fb | 31 km/h | 94.3,25,25,10.8,0 | 1:0:0:0       |
+          | g    | b  | fb,fb          | 37 km/h | 4.4,0             | 0:0           |
+          | a    | g  | ad,de,eb,fb,fb | 30 km/h | 94.3,25,25,4.4,0  | 1:0:0:0       |
 
 
     Scenario: Weighting based on speed file weights, ETA based on file durations

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -62,7 +62,7 @@ Feature: Traffic - speeds
           | b    | c  | bc,bc          | 27 km/h | 66.7,0            | 1             |
           | a    | d  | ad,ad          | 27 km/h | 94.3,0            | 1             |
           | d    | c  | dc,dc          | 36 km/h | 70.7,0            | 0:1           |
-          | 6    | b  | fb,fb          | 36 km/h | 7.6,0             | 0:0           |
+          | 6    | 8  | fb,bc          | 30 km/h | 20.9,0            | 0:1           |
           | a    | 8  | ad,de,eb,bc,bc | 30 km/h | 94.3,25,25,13.3,0 | 1:0:0:1       |
 
 

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -214,6 +214,9 @@ Feature: Weight tests
         end
         function turn_function (turn)
           print (turn.angle)
+          if turn.angle == 0 then
+            return
+          end
           turn.weight = 2 + turn.angle / 100
           turn.duration = turn.angle
         end
@@ -221,6 +224,8 @@ Feature: Weight tests
 
         Given the node map
             """
+                    f
+                    ⋮
             a---b---c---d
                     ⋮
                     e
@@ -228,13 +233,16 @@ Feature: Weight tests
 
         And the ways
             | nodes |
-            | abcd  |
+            | abc   |
+            | cd    |
             | ce    |
+            | cf    |
 
         When I route I should get
             | waypoints | route | distance | weights      | times          |
-            | a,c       | ,     | 40m +-.1 | 5.119,0      | 289.9s,0s      |
+            | a,d       | ,     | 60m +-.1 | 5.329,0      | 300s,0s      |
             | a,e       | ,,    | 60m +-.1 | 5.119,1.11,0 | 289.9s,100s,0s |
+            | a,f       | ,,    | 60m +-.1 | 3.319,1.11,0 | 110s,100s,0s   |
             | e,a       | ,,    | 60m +-.1 | 2.21,2.22,0  | 10.1s,200s,0s  |
             | e,d       | ,,    | 40m +-.1 | 4.009,1.11,0 | 189.9s,100s,0s |
             | d,e       | ,,    | 40m +-.1 | 2.21,1.11,0  | 10.1s,100s,0s  |

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -28,7 +28,7 @@ bool stallAtNode(const datafacade::ContiguousInternalMemoryDataFacade<Algorithm>
                  const EdgeWeight weight,
                  const HeapT &query_heap)
 {
-    for (auto edge : facade.GetAdjacentEdgeRange(node))
+    for (const auto &edge : facade.GetAdjacentEdgeRange(node))
     {
         const auto &data = facade.GetEdgeData(edge);
         if (DIRECTION == REVERSE_DIRECTION ? data.forward : data.backward)

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -62,6 +62,14 @@ struct RectangleInt2D
         BOOST_ASSERT(max_lat != FixedLatitude{std::numeric_limits<std::int32_t>::min()});
     }
 
+    void Extend(const FixedLongitude lon_, const FixedLatitude lat_)
+    {
+        min_lon = std::min(min_lon, lon_);
+        max_lon = std::max(max_lon, lon_);
+        min_lat = std::min(min_lat, lat_);
+        max_lat = std::max(max_lat, lat_);
+    }
+
     Coordinate Centroid() const
     {
         Coordinate centroid;

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -385,10 +385,12 @@ class StaticRTree
 
                 // Now, for each column we generated, sort those by latitude, so the data
                 // is ready for the subsequent tile-by-tile processing in the next loop.
-                tbb::parallel_do(tiles, [&](const std::pair<EdgeIndex, EdgeIndex> tile) {
-                    tbb::parallel_sort(
-                        edges.begin() + tile.first, edges.begin() + tile.second, latitude_compare);
-                });
+                tbb::parallel_do(
+                    tiles.begin(), tiles.end(), [&](const std::pair<EdgeIndex, EdgeIndex> tile) {
+                        tbb::parallel_sort(edges.begin() + tile.first,
+                                           edges.begin() + tile.second,
+                                           latitude_compare);
+                    });
             }
 
             // Because we used a queue above, the m_search_tree vector is sorted in

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -6,7 +6,6 @@
 #include "util/coordinate_calculation.hpp"
 #include "util/deallocating_vector.hpp"
 #include "util/exception.hpp"
-#include "util/hilbert_value.hpp"
 #include "util/integer_range.hpp"
 #include "util/rectangle.hpp"
 #include "util/typedefs.hpp"
@@ -23,11 +22,13 @@
 #include <boost/format.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
 
+#include <tbb/parallel_do.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_sort.h>
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <limits>
 #include <memory>
 #include <queue>
@@ -54,8 +55,7 @@ namespace util
 // are computed, this means the internal distance metric doesn not represent meters!
 template <class EdgeDataT,
           storage::Ownership Ownership = storage::Ownership::Container,
-          std::uint32_t BRANCHING_FACTOR = 128,
-          std::uint32_t LEAF_PAGE_SIZE = 4096>
+          std::uint32_t BRANCHING_FACTOR = 63>
 class StaticRTree
 {
     template <typename T> using Vector = ViewOrVector<T, Ownership>;
@@ -64,11 +64,6 @@ class StaticRTree
     using Rectangle = RectangleInt2D;
     using EdgeData = EdgeDataT;
     using CoordinateList = Vector<util::Coordinate>;
-
-    static_assert(LEAF_PAGE_SIZE >= sizeof(uint32_t) + sizeof(EdgeDataT), "page size is too small");
-    static_assert(((LEAF_PAGE_SIZE - 1) & LEAF_PAGE_SIZE) == 0, "page size is not a power of 2");
-    static constexpr std::uint32_t LEAF_NODE_SIZE =
-        (LEAF_PAGE_SIZE - sizeof(uint32_t) - sizeof(Rectangle)) / sizeof(EdgeDataT);
 
     struct CandidateSegment
     {
@@ -84,43 +79,24 @@ class StaticRTree
         std::uint32_t is_leaf : 1;
     };
 
+    /**
+     * TODO: Because the OMT tree packing is balanced and full, we
+     *       can probably calculate the child count, leaf status
+     *       and child index offset at query time, saving 8 bytes
+     *       here.  I'm leaving this note here as a reminder for
+     *       future work.
+     */
     struct TreeNode
     {
-        TreeNode() : child_count(0) {}
-        std::uint32_t child_count;
-        Rectangle minimum_bounding_rectangle;
-        TreeIndex children[BRANCHING_FACTOR];
+        TreeNode() : child_count(0), is_leaf(false) {}
+        std::uint32_t child_count : 31; // How many children this node has
+        bool is_leaf : 1; // false means children are TreeNodes, true indicates children are edges
+        std::uint32_t first_child_index; // offset of either the TreeNode in m_search_tree or the
+                                         // edge data in m_edges, depending on is_leaf
+        Rectangle minimum_bounding_rectangle; // the bounding box of this node
     };
-
-    struct ALIGNED(LEAF_PAGE_SIZE) LeafNode
-    {
-        LeafNode() : object_count(0), objects() {}
-        std::uint32_t object_count;
-        Rectangle minimum_bounding_rectangle;
-        std::array<EdgeDataT, LEAF_NODE_SIZE> objects;
-    };
-    static_assert(sizeof(LeafNode) == LEAF_PAGE_SIZE, "LeafNode size does not fit the page size");
 
   private:
-    struct WrappedInputElement
-    {
-        explicit WrappedInputElement(const uint64_t _hilbert_value,
-                                     const std::uint32_t _array_index)
-            : m_hilbert_value(_hilbert_value), m_array_index(_array_index)
-        {
-        }
-
-        WrappedInputElement() : m_hilbert_value(0), m_array_index(UINT_MAX) {}
-
-        uint64_t m_hilbert_value;
-        std::uint32_t m_array_index;
-
-        inline bool operator<(const WrappedInputElement &other) const
-        {
-            return m_hilbert_value < other.m_hilbert_value;
-        }
-    };
-
     struct QueryCandidate
     {
         QueryCandidate(std::uint64_t squared_min_dist, TreeIndex tree_index)
@@ -158,189 +134,295 @@ class StaticRTree
     Vector<TreeNode> m_search_tree;
     const Vector<Coordinate> &m_coordinate_list;
 
-    boost::iostreams::mapped_file_source m_leaves_region;
+    boost::iostreams::mapped_file_source m_edges_region;
     // read-only view of leaves
-    util::vector_view<const LeafNode> m_leaves;
+    util::vector_view<const EdgeDataT> m_edges;
 
   public:
     StaticRTree(const StaticRTree &) = delete;
     StaticRTree &operator=(const StaticRTree &) = delete;
 
-    // Construct a packed Hilbert-R-Tree with Kamel-Faloutsos algorithm [1]
-    explicit StaticRTree(const std::vector<EdgeDataT> &input_data_vector,
+    /**
+     * Constructs an R-Tree using a modified OMT (Lee-Lee) approach.  Based on the rbush
+     * library by Vladimir Agafonkin (https://github.com/mourner/rbush).
+     *
+     * The main characteristic of OMT packing is:
+     *   The elements (EdgeDataT) are broken up into N groups, such that those
+     *   groups can be evenly divided into a tree with degree BRANCHING_FACTOR.
+     * The resulting tree has N branches from the root, then all subtrees use
+     * BRANCHING_FACTOR branches.
+     * This gives us even distribution of the data, and equal tree depth at all
+     * leaf nodes.  It can be thought of as breaking up the data into "tiles"
+     *
+     * During construction, nodes are recursively sorted into first vertical columns,
+     * then horizontal groups.  This produces efficient packing with minimal overlap.
+     *
+     * TODO: the packing is based on the centroid of each EdgeDataT - we could probably
+     * do a little bit better if we considered the bounding box of the EdgeDataT instead.
+     *
+     * Tree structure
+     * level
+     *   0                   A
+     *               ---------------------
+     *             /       |       |       \   <- First level has N children
+     *   1         B       C       D       E      (here N=4)
+     *           /   \   /   \   /   \   /   \
+     *   2       F   G   H   I   J   K   L   M  <- other levels have M chidren
+     *          / \ / \ / \ / \ / \ / \ / \ / \    (here, M=2)
+     *   3      N O P Q R S T U V W X Y Z 1 2 3
+     *
+     * TreeNodes get packed into a vector in BFS order like this:
+     *  ABCDEFGHIJKLMNOPQRSTUVWXYZ123
+     *
+     * EdgeDataT is similarly packed - the children of the bottom nodes (N to 3)
+     * are packed in order.
+     *
+     * @param edges the vector of EdgeDataT objects you want to insert into the tree.
+     * @param tree_node_filename the file to write the TreeNode data to (the .ramIndex file).
+     *                           This data will be later loaded into RAM.
+     * @param leaf_node_filename the file to write the sorted EdgeDataT data to
+     *                           (the .fileIndex file).  This data remains on disk and is read
+     *                           on-demand at query time (via mmap()).
+     * @param coordinate_list the actual coordinate data (EdgeDataT's u and v properties are
+                              expected to be indexes into this vector)
+     */
+    explicit StaticRTree(std::vector<EdgeDataT> &&edges,
                          const std::string &tree_node_filename,
                          const std::string &leaf_node_filename,
                          const Vector<Coordinate> &coordinate_list)
         : m_coordinate_list(coordinate_list)
     {
-        const uint64_t element_count = input_data_vector.size();
-        std::vector<WrappedInputElement> input_wrapper_vector(element_count);
-
-        // generate auxiliary vector of hilbert-values
-        tbb::parallel_for(
-            tbb::blocked_range<uint64_t>(0, element_count),
-            [&input_data_vector, &input_wrapper_vector, this](
-                const tbb::blocked_range<uint64_t> &range) {
-                for (uint64_t element_counter = range.begin(), end = range.end();
-                     element_counter != end;
-                     ++element_counter)
-                {
-                    WrappedInputElement &current_wrapper = input_wrapper_vector[element_counter];
-                    current_wrapper.m_array_index = element_counter;
-
-                    EdgeDataT const &current_element = input_data_vector[element_counter];
-
-                    // Get Hilbert-Value for centroid in mercartor projection
-                    BOOST_ASSERT(current_element.u < m_coordinate_list.size());
-                    BOOST_ASSERT(current_element.v < m_coordinate_list.size());
-
-                    Coordinate current_centroid = coordinate_calculation::centroid(
-                        m_coordinate_list[current_element.u], m_coordinate_list[current_element.v]);
-                    current_centroid.lat = FixedLatitude{static_cast<std::int32_t>(
-                        COORDINATE_PRECISION *
-                        web_mercator::latToY(toFloating(current_centroid.lat)))};
-
-                    current_wrapper.m_hilbert_value = GetHilbertCode(current_centroid);
-                }
-            });
-
-        // open leaf file
-        boost::filesystem::ofstream leaf_node_file(leaf_node_filename, std::ios::binary);
-
-        // sort the hilbert-value representatives
-        tbb::parallel_sort(input_wrapper_vector.begin(), input_wrapper_vector.end());
-        std::vector<TreeNode> tree_nodes_in_level;
-
-        // pack M elements into leaf node, write to leaf file and add child index to the parent node
-        uint64_t wrapped_element_index = 0;
-        for (std::uint32_t node_index = 0; wrapped_element_index < element_count; ++node_index)
+        /**
+         * This structure describes the tile of EdgeDataT that we're working on for
+         * the current loop.
+         */
+        struct Tile
         {
-            TreeNode current_node;
-            for (std::uint32_t leaf_index = 0;
-                 leaf_index < BRANCHING_FACTOR && wrapped_element_index < element_count;
-                 ++leaf_index)
+            Tile(std::size_t parent_, std::size_t left_, std::size_t right_, std::size_t height_)
+                : parent_treenode_index{parent_}, left_edge_index{left_}, right_edge_index{right_},
+                  current_tree_height{height_}
             {
-                LeafNode current_leaf;
-                Rectangle &rectangle = current_leaf.minimum_bounding_rectangle;
-                for (std::uint32_t object_index = 0;
-                     object_index < LEAF_NODE_SIZE && wrapped_element_index < element_count;
-                     ++object_index, ++wrapped_element_index)
-                {
-                    const std::uint32_t input_object_index =
-                        input_wrapper_vector[wrapped_element_index].m_array_index;
-                    const EdgeDataT &object = input_data_vector[input_object_index];
-
-                    current_leaf.object_count += 1;
-                    current_leaf.objects[object_index] = object;
-
-                    Coordinate projected_u{
-                        web_mercator::fromWGS84(Coordinate{m_coordinate_list[object.u]})};
-                    Coordinate projected_v{
-                        web_mercator::fromWGS84(Coordinate{m_coordinate_list[object.v]})};
-
-                    BOOST_ASSERT(std::abs(toFloating(projected_u.lon).operator double()) <= 180.);
-                    BOOST_ASSERT(std::abs(toFloating(projected_u.lat).operator double()) <= 180.);
-                    BOOST_ASSERT(std::abs(toFloating(projected_v.lon).operator double()) <= 180.);
-                    BOOST_ASSERT(std::abs(toFloating(projected_v.lat).operator double()) <= 180.);
-
-                    rectangle.min_lon =
-                        std::min(rectangle.min_lon, std::min(projected_u.lon, projected_v.lon));
-                    rectangle.max_lon =
-                        std::max(rectangle.max_lon, std::max(projected_u.lon, projected_v.lon));
-
-                    rectangle.min_lat =
-                        std::min(rectangle.min_lat, std::min(projected_u.lat, projected_v.lat));
-                    rectangle.max_lat =
-                        std::max(rectangle.max_lat, std::max(projected_u.lat, projected_v.lat));
-
-                    BOOST_ASSERT(rectangle.IsValid());
-                }
-
-                // append the leaf node to the current tree node
-                current_node.child_count += 1;
-                current_node.children[leaf_index] =
-                    TreeIndex{node_index * BRANCHING_FACTOR + leaf_index, true};
-                current_node.minimum_bounding_rectangle.MergeBoundingBoxes(
-                    current_leaf.minimum_bounding_rectangle);
-
-                // write leaf_node to leaf node file
-                leaf_node_file.write((char *)&current_leaf, sizeof(current_leaf));
             }
+            std::size_t parent_treenode_index;
+            std::size_t left_edge_index;
+            std::size_t right_edge_index;
+            std::size_t current_tree_height;
+        };
 
-            tree_nodes_in_level.emplace_back(current_node);
-        }
-        leaf_node_file.flush();
-        leaf_node_file.close();
+        // We create this tree using a queue, adding nodes to create to the end.
+        // This means we end up with BFS sorted TreeNode and EdgeDataT lists.
+        // See TODO notes on TreeNode for a future possible optimization where
+        // we calculate list offsets dynamically, rather than by storing indexes
+        // in TreeNodes.
+        std::queue<Tile> queue;
+        queue.emplace(0, 0, edges.size() - 1, 0);
 
-        std::uint32_t processing_level = 0;
-        while (1 < tree_nodes_in_level.size())
+        // TODO: we do a lot of sorting - it would make sense to only calculate centroids once
+        //       or consider sorting by the east-most longitude
+        auto longitude_compare = [this](const EdgeDataT &a, const EdgeDataT &b) {
+            auto a_centroid =
+                coordinate_calculation::centroid(m_coordinate_list[a.u], m_coordinate_list[a.v]);
+            auto b_centroid =
+                coordinate_calculation::centroid(m_coordinate_list[b.u], m_coordinate_list[b.v]);
+            return a_centroid.lon < b_centroid.lon;
+        };
+
+        // TODO: same as other sort - we're probably doing this a lot more than necessary
+        auto latitude_compare = [this](const EdgeDataT &a, const EdgeDataT &b) {
+            auto a_centroid =
+                coordinate_calculation::centroid(m_coordinate_list[a.u], m_coordinate_list[a.v]);
+            auto b_centroid =
+                coordinate_calculation::centroid(m_coordinate_list[b.u], m_coordinate_list[b.v]);
+            return a_centroid.lat < b_centroid.lat;
+        };
+
         {
-            std::vector<TreeNode> tree_nodes_in_next_level;
-            std::uint32_t processed_tree_nodes_in_level = 0;
-            while (processed_tree_nodes_in_level < tree_nodes_in_level.size())
+            // Prepare the leaf_node_file for writing
+            storage::io::FileWriter leaf_node_file(leaf_node_filename,
+                                                   storage::io::FileWriter::HasNoFingerprint);
+
+            // position of the last leaf node written to diskcountindex
+            std::size_t saved_edges_count = 0;
+
+            // Create the tree in breadth-first order
+            while (!queue.empty())
             {
-                TreeNode parent_node;
-                // pack BRANCHING_FACTOR elements into tree_nodes each
-                for (std::uint32_t current_child_node_index = 0;
-                     current_child_node_index < BRANCHING_FACTOR;
-                     ++current_child_node_index)
-                {
-                    if (processed_tree_nodes_in_level < tree_nodes_in_level.size())
-                    {
-                        TreeNode &current_child_node =
-                            tree_nodes_in_level[processed_tree_nodes_in_level];
-                        // add tree node to parent entry
-                        parent_node.children[current_child_node_index] =
-                            TreeIndex{m_search_tree.size(), false};
-                        m_search_tree.emplace_back(current_child_node);
-                        // merge MBRs
-                        parent_node.minimum_bounding_rectangle.MergeBoundingBoxes(
-                            current_child_node.minimum_bounding_rectangle);
-                        // increase counters
-                        ++parent_node.child_count;
-                        ++processed_tree_nodes_in_level;
-                    }
-                }
-                tree_nodes_in_next_level.emplace_back(parent_node);
-            }
-            tree_nodes_in_level.swap(tree_nodes_in_next_level);
-            ++processing_level;
-        }
-        BOOST_ASSERT_MSG(tree_nodes_in_level.size() == 1, "tree broken, more than one root node");
-        // last remaining entry is the root node, store it
-        m_search_tree.emplace_back(tree_nodes_in_level[0]);
+                auto current_tile = queue.front();
+                queue.pop();
 
-        // reverse and renumber tree to have root at index 0
-        std::reverse(m_search_tree.begin(), m_search_tree.end());
+                // This is the number of EdgeDataT elements below the current tree node
+                const auto number_of_edges =
+                    current_tile.right_edge_index - current_tile.left_edge_index + 1;
 
-        std::uint32_t search_tree_size = m_search_tree.size();
-        tbb::parallel_for(
-            tbb::blocked_range<std::uint32_t>(0, search_tree_size),
-            [this, &search_tree_size](const tbb::blocked_range<std::uint32_t> &range) {
-                for (std::uint32_t i = range.begin(), end = range.end(); i != end; ++i)
+                // The default number of children (not const because it's different for the root
+                // node and leaf nodes)
+                auto number_of_tiles = BRANCHING_FACTOR;
+
+                // We've hit the bottom of the tree and we're building a leaf node
+                if (number_of_edges <= number_of_tiles)
                 {
-                    TreeNode &current_tree_node = this->m_search_tree[i];
-                    for (std::uint32_t j = 0; j < current_tree_node.child_count; ++j)
+                    TreeNode leaf_node;
+                    leaf_node.is_leaf = true;
+                    leaf_node.child_count = number_of_edges;
+
+                    // Calculate the bounding-box for this leaf node based on the
+                    // endpoints of the EdgeDataT values contained within
+                    std::for_each(edges.begin() + current_tile.left_edge_index,
+                                  edges.begin() + current_tile.right_edge_index,
+                                  [this, &leaf_node](const EdgeDataT &edge) {
+                                      Coordinate projected_u{web_mercator::fromWGS84(
+                                          Coordinate{m_coordinate_list[edge.u]})};
+                                      Coordinate projected_v{web_mercator::fromWGS84(
+                                          Coordinate{m_coordinate_list[edge.v]})};
+                                      leaf_node.minimum_bounding_rectangle.Extend(projected_u.lon,
+                                                                                  projected_u.lat);
+                                      leaf_node.minimum_bounding_rectangle.Extend(projected_v.lon,
+                                                                                  projected_v.lat);
+                                  });
+
+                    // We're appending to the edges data, so the current size is where our new data
+                    // will be inserted.
+                    leaf_node.first_child_index = saved_edges_count;
+                    m_search_tree.push_back(leaf_node);
+
+                    // If this node isn't also the root node, we need to update the parent child
+                    // count and bounding box
+                    if (current_tile.current_tree_height != 0)
                     {
-                        if (!current_tree_node.children[j].is_leaf)
+                        // If this is the first child of the parent, we need to save the pointer
+                        // to the current position in the m_search_tree array, as this is where
+                        // the children for this parent begin
+                        if (m_search_tree[current_tile.parent_treenode_index].child_count == 0)
                         {
-                            const std::uint32_t old_id = current_tree_node.children[j].index;
-                            const std::uint32_t new_id = search_tree_size - old_id - 1;
-                            current_tree_node.children[j].index = new_id;
+                            m_search_tree[current_tile.parent_treenode_index].first_child_index =
+                                m_search_tree.size() - 1;
                         }
+                        ++m_search_tree[current_tile.parent_treenode_index].child_count;
+                    }
+                    // The root node can have > BRANCHING_FACTOR entries, but everone else
+                    // should have max BRANCHING_FACTOR.
+                    BOOST_ASSERT(current_tile.parent_treenode_index == 0 ||
+                                 m_search_tree[current_tile.parent_treenode_index].child_count <=
+                                     BRANCHING_FACTOR);
+
+                    saved_edges_count += number_of_edges;
+                    leaf_node_file.WriteFrom(edges.data() + current_tile.left_edge_index,
+                                             number_of_edges);
+                    continue;
+                }
+
+                // Add a new empty node to the back.  Note that the attributes on this newly
+                // added node will be updated when we're processing it's children, we only insert
+                // it as a placeholder at this time.
+                m_search_tree.push_back(TreeNode());
+
+                // Special case for the root node (height = 0),
+                if (current_tile.current_tree_height == 0)
+                {
+                    // Calculate the final tree height
+                    current_tile.current_tree_height =
+                        std::ceil(std::log(number_of_edges) / std::log(number_of_tiles));
+                    // Figure out the number of children needed at the root node
+                    number_of_tiles =
+                        std::ceil(number_of_edges /
+                                  std::pow(number_of_tiles, current_tile.current_tree_height - 1));
+                }
+                else
+                {
+                    // This is a regular tree node
+                    BOOST_ASSERT(m_search_tree[current_tile.parent_treenode_index].child_count <
+                                 BRANCHING_FACTOR);
+                    // Check to see if the parent node knows about the newly inserted item yet,
+                    // if not, save the index of the current node as the first child offset
+                    if (m_search_tree[current_tile.parent_treenode_index].child_count == 0)
+                    {
+                        m_search_tree[current_tile.parent_treenode_index].first_child_index =
+                            m_search_tree.size() - 1;
+                    }
+                    // Increment the parent node's child count to include the node we're
+                    // working on
+                    ++m_search_tree[current_tile.parent_treenode_index].child_count;
+                }
+
+                // Calculate the number of entries in each tile for this iteration
+                const std::size_t edges_per_tile =
+                    std::ceil(static_cast<double>(number_of_edges) / number_of_tiles);
+                std::size_t edges_per_column =
+                    edges_per_tile * std::ceil(std::sqrt(number_of_tiles));
+
+                // We need to save the indexes of each tile calculate so that we can
+                // sort the items within
+                typedef std::size_t EdgeIndex;
+                std::vector<std::pair<EdgeIndex, EdgeIndex>> tiles;
+
+                // Break the current tile up into columns
+                for (auto column_start = current_tile.left_edge_index;
+                     column_start <= current_tile.right_edge_index;
+                     column_start += edges_per_column)
+                {
+                    auto column_end = std::min(column_start + edges_per_column - 1,
+                                               current_tile.right_edge_index);
+                    // Store the column start/end for sorting below
+                    tiles.emplace_back(column_start, column_end);
+
+                    // Now, break this column up into rows (edges_per_tile entries)
+                    for (auto row_start = column_start; row_start <= column_end;
+                         row_start += edges_per_tile)
+                    {
+                        auto row_end = std::min(row_start + edges_per_tile - 1, column_end);
+                        // Queue up this range of edges for processing in a later loop
+                        queue.emplace(m_search_tree.size() - 1,
+                                      row_start,
+                                      row_end,
+                                      current_tile.current_tree_height - 1);
                     }
                 }
+
+                // Sort the current containing tile by longitude
+                tbb::parallel_sort(edges.begin() + current_tile.left_edge_index,
+                                   edges.begin() + current_tile.right_edge_index,
+                                   longitude_compare);
+
+                // Now, for each column we generated, sort those by latitude, so the data
+                // is ready for the subsequent tile-by-tile processing in the next loop.
+                tbb::parallel_do(tiles, [&](const std::pair<EdgeIndex, EdgeIndex> tile) {
+                    tbb::parallel_sort(
+                        edges.begin() + tile.first, edges.begin() + tile.second, latitude_compare);
+                });
+            }
+
+            // Because we used a queue above, the m_search_tree vector is sorted in
+            // the same order as a breadth-first-search of the tree.  We can iterate
+            // over this in reverse and propogate node recangle sizes up the tree
+            // The leaf nodes already have their bounding box set, so we just need to
+            // propogate those up the tree
+            std::for_each(m_search_tree.rbegin(), m_search_tree.rend(), [this](TreeNode &node) {
+                if (node.child_count == 0 || node.is_leaf)
+                {
+                    return;
+                }
+                std::for_each(m_search_tree.begin() + node.first_child_index,
+                              m_search_tree.begin() + node.first_child_index + node.child_count,
+                              [&node](const TreeNode &child) {
+                                  node.minimum_bounding_rectangle.MergeBoundingBoxes(
+                                      child.minimum_bounding_rectangle);
+                              });
             });
 
-        // open tree file
-        storage::io::FileWriter tree_node_file(tree_node_filename,
-                                               storage::io::FileWriter::GenerateFingerprint);
+            // Note: leaf_node_file auto-closes at the end of the block
+        }
 
-        std::uint64_t size_of_tree = m_search_tree.size();
-        BOOST_ASSERT_MSG(0 < size_of_tree, "tree empty");
+        // Now, write out the tree nodes
+        {
+            storage::io::FileWriter tree_node_file(tree_node_filename,
+                                                   storage::io::FileWriter::GenerateFingerprint);
 
-        tree_node_file.WriteOne(size_of_tree);
-        tree_node_file.WriteFrom(&m_search_tree[0], size_of_tree);
+            std::uint64_t size_of_tree = m_search_tree.size();
+            BOOST_ASSERT_MSG(0 < size_of_tree, "tree empty");
+
+            tree_node_file.WriteOne(size_of_tree);
+            tree_node_file.WriteFrom(m_search_tree.data(), size_of_tree);
+        }
 
         MapLeafNodesFile(leaf_node_filename);
     }
@@ -375,11 +457,11 @@ class StaticRTree
         // open leaf node file and return a pointer to the mapped leaves data
         try
         {
-            m_leaves_region.open(leaf_file);
-            std::size_t num_leaves = m_leaves_region.size() / sizeof(LeafNode);
-            auto data_ptr = m_leaves_region.data();
-            BOOST_ASSERT(reinterpret_cast<uintptr_t>(data_ptr) % alignof(LeafNode) == 0);
-            m_leaves.reset(reinterpret_cast<const LeafNode *>(data_ptr), num_leaves);
+            m_edges_region.open(leaf_file);
+            std::size_t num_edges = m_edges_region.size() / sizeof(EdgeDataT);
+            auto data_ptr = m_edges_region.data();
+            BOOST_ASSERT(reinterpret_cast<uintptr_t>(data_ptr) % alignof(EdgeDataT) == 0);
+            m_edges.reset(reinterpret_cast<const EdgeDataT *>(data_ptr), num_edges);
         }
         catch (const std::exception &exc)
         {
@@ -402,58 +484,59 @@ class StaticRTree
                 web_mercator::latToY(toFloating(FixedLatitude(search_rectangle.max_lat)))})};
         std::vector<EdgeDataT> results;
 
-        std::queue<TreeIndex> traversal_queue;
-        traversal_queue.push(TreeIndex{});
+        std::queue<std::uint32_t> traversal_queue;
+        traversal_queue.push(0);
 
         while (!traversal_queue.empty())
         {
             auto const current_tree_index = traversal_queue.front();
             traversal_queue.pop();
+            const TreeNode &current_tree_node = m_search_tree[current_tree_index];
 
-            if (current_tree_index.is_leaf)
+            if (current_tree_node.is_leaf)
             {
-                const LeafNode &current_leaf_node = m_leaves[current_tree_index.index];
 
-                for (const auto i : irange(0u, current_leaf_node.object_count))
-                {
-                    const auto &current_edge = current_leaf_node.objects[i];
+                // TODO: we could potentially speed this up by having the current edge boxes
+                // available in the leafnode directly
+                std::for_each(m_edges.begin() + current_tree_node.first_child_index,
+                              m_edges.begin() + current_tree_node.first_child_index +
+                                  current_tree_node.child_count,
+                              [&](const EdgeDataT &current_edge) {
 
-                    // we don't need to project the coordinates here,
-                    // because we use the unprojected rectangle to test against
-                    const Rectangle bbox{std::min(m_coordinate_list[current_edge.u].lon,
-                                                  m_coordinate_list[current_edge.v].lon),
-                                         std::max(m_coordinate_list[current_edge.u].lon,
-                                                  m_coordinate_list[current_edge.v].lon),
-                                         std::min(m_coordinate_list[current_edge.u].lat,
-                                                  m_coordinate_list[current_edge.v].lat),
-                                         std::max(m_coordinate_list[current_edge.u].lat,
-                                                  m_coordinate_list[current_edge.v].lat)};
+                                  // we don't need to project the coordinates here,
+                                  // because we use the unprojected rectangle to test
+                                  // against
+                                  const Rectangle bbox{
+                                      std::min(m_coordinate_list[current_edge.u].lon,
+                                               m_coordinate_list[current_edge.v].lon),
+                                      std::max(m_coordinate_list[current_edge.u].lon,
+                                               m_coordinate_list[current_edge.v].lon),
+                                      std::min(m_coordinate_list[current_edge.u].lat,
+                                               m_coordinate_list[current_edge.v].lat),
+                                      std::max(m_coordinate_list[current_edge.u].lat,
+                                               m_coordinate_list[current_edge.v].lat)};
 
-                    // use the _unprojected_ input rectangle here
-                    if (bbox.Intersects(search_rectangle))
-                    {
-                        results.push_back(current_edge);
-                    }
-                }
+                                  // use the _unprojected_ input rectangle here
+                                  if (bbox.Intersects(search_rectangle))
+                                  {
+                                      results.push_back(current_edge);
+                                  }
+                              });
             }
             else
             {
-                const TreeNode &current_tree_node = m_search_tree[current_tree_index.index];
-
-                // If it's a tree node, look at all children and add them
-                // to the search queue if their bounding boxes intersect
-                for (std::uint32_t i = 0; i < current_tree_node.child_count; ++i)
-                {
-                    const TreeIndex child_id = current_tree_node.children[i];
-                    const auto &child_rectangle =
-                        child_id.is_leaf ? m_leaves[child_id.index].minimum_bounding_rectangle
-                                         : m_search_tree[child_id.index].minimum_bounding_rectangle;
-
-                    if (child_rectangle.Intersects(projected_rectangle))
-                    {
-                        traversal_queue.push(child_id);
-                    }
-                }
+                std::accumulate(
+                    m_search_tree.begin() + current_tree_node.first_child_index,
+                    m_search_tree.begin() + current_tree_node.first_child_index +
+                        current_tree_node.child_count,
+                    current_tree_node.first_child_index,
+                    [&](const std::uint32_t child_index, const TreeNode &child_node) {
+                        if (child_node.minimum_bounding_rectangle.Intersects(projected_rectangle))
+                        {
+                            traversal_queue.push(child_index);
+                        }
+                        return child_index + 1;
+                    });
             }
         }
         return results;
@@ -482,7 +565,7 @@ class StaticRTree
 
         // initialize queue with root element
         std::priority_queue<QueryCandidate> traversal_queue;
-        traversal_queue.push(QueryCandidate{0, TreeIndex{}});
+        traversal_queue.push(QueryCandidate{0, TreeIndex{0, m_search_tree[0].is_leaf}});
 
         while (!traversal_queue.empty())
         {
@@ -507,27 +590,36 @@ class StaticRTree
             }
             else
             { // current candidate is an actual road segment
-                auto edge_data =
-                    m_leaves[current_tree_index.index].objects[current_query_node.segment_index];
+                auto edge_data = m_edges[current_query_node.segment_index];
                 const auto &current_candidate =
                     CandidateSegment{current_query_node.fixed_projected_coordinate, edge_data};
 
-                // to allow returns of no-results if too restrictive filtering, this needs to be
-                // done here even though performance would indicate that we want to stop after
+                /*
+                                std::clog << "Selecting item at " <<
+                   current_query_node.squared_min_dist
+                                          << std::endl;
+                                          */
+                // to allow returns of no-results if too restrictive filtering, this needs
+                // to be
+                // done here even though performance would indicate that we want to stop
+                // after
                 // adding the first candidate
                 if (terminate(results.size(), current_candidate))
                 {
+                    // std::clog << "Terminating" << std::endl;
                     break;
                 }
 
                 auto use_segment = filter(current_candidate);
                 if (!use_segment.first && !use_segment.second)
                 {
+                    // std::clog << "Can't use" << std::endl;
                     continue;
                 }
                 edge_data.forward_segment_id.enabled &= use_segment.first;
                 edge_data.reverse_segment_id.enabled &= use_segment.second;
 
+                // std::clog << "Pushing result" << std::endl;
                 // store phantom node in result vector
                 results.push_back(std::move(edge_data));
             }
@@ -543,51 +635,69 @@ class StaticRTree
                          const FloatCoordinate &projected_input_coordinate,
                          QueueT &traversal_queue) const
     {
-        const LeafNode &current_leaf_node = m_leaves[leaf_id.index];
+        const auto &current_leaf_node = m_search_tree[leaf_id.index];
+        BOOST_ASSERT(current_leaf_node.is_leaf);
 
-        // current object represents a block on disk
-        for (const auto i : irange(0u, current_leaf_node.object_count))
-        {
-            const auto &current_edge = current_leaf_node.objects[i];
-            const auto projected_u = web_mercator::fromWGS84(m_coordinate_list[current_edge.u]);
-            const auto projected_v = web_mercator::fromWGS84(m_coordinate_list[current_edge.v]);
+        // Using ::accumulate here instead of ::for_each so that we can get access to the
+        // current
+        // index being processed (current_edge_index).  This is basically the same
+        std::accumulate(
+            m_edges.begin() + current_leaf_node.first_child_index,
+            m_edges.begin() + current_leaf_node.first_child_index + current_leaf_node.child_count,
+            current_leaf_node.first_child_index,
+            [&](std::uint32_t current_edge_index, const EdgeDataT &current_edge) {
+                const auto projected_u = web_mercator::fromWGS84(m_coordinate_list[current_edge.u]);
+                const auto projected_v = web_mercator::fromWGS84(m_coordinate_list[current_edge.v]);
+                FloatCoordinate projected_nearest;
+                std::tie(std::ignore, projected_nearest) =
+                    coordinate_calculation::projectPointOnSegment(
+                        projected_u, projected_v, projected_input_coordinate);
 
-            FloatCoordinate projected_nearest;
-            std::tie(std::ignore, projected_nearest) =
-                coordinate_calculation::projectPointOnSegment(
-                    projected_u, projected_v, projected_input_coordinate);
+                const auto squared_distance = coordinate_calculation::squaredEuclideanDistance(
+                    projected_input_coordinate_fixed, projected_nearest);
+                BOOST_ASSERT(0. <= squared_distance);
+                traversal_queue.push(
+                    QueryCandidate{squared_distance,
+                                   leaf_id,            // Index to the leaf node
+                                   current_edge_index, // position of the edge in the big data dump
+                                   Coordinate{projected_nearest}});
 
-            const auto squared_distance = coordinate_calculation::squaredEuclideanDistance(
-                projected_input_coordinate_fixed, projected_nearest);
-            // distance must be non-negative
-            BOOST_ASSERT(0. <= squared_distance);
-            traversal_queue.push(
-                QueryCandidate{squared_distance, leaf_id, i, Coordinate{projected_nearest}});
-        }
+                return current_edge_index + 1;
+
+            });
     }
 
     template <class QueueT>
-    void ExploreTreeNode(const TreeIndex &parent_id,
+    void ExploreTreeNode(const TreeIndex &tree_node_index,
                          const Coordinate &fixed_projected_input_coordinate,
                          QueueT &traversal_queue) const
     {
-        const TreeNode &parent = m_search_tree[parent_id.index];
-        for (std::uint32_t i = 0; i < parent.child_count; ++i)
-        {
-            const TreeIndex child_id = parent.children[i];
-            const auto &child_rectangle =
-                child_id.is_leaf ? m_leaves[child_id.index].minimum_bounding_rectangle
-                                 : m_search_tree[child_id.index].minimum_bounding_rectangle;
-            const auto squared_lower_bound_to_element =
-                child_rectangle.GetMinSquaredDist(fixed_projected_input_coordinate);
-            traversal_queue.push(QueryCandidate{squared_lower_bound_to_element, child_id});
-        }
+        const auto &tree_node = m_search_tree[tree_node_index.index];
+        BOOST_ASSERT(tree_node.is_leaf == tree_node_index.is_leaf);
+        BOOST_ASSERT(!tree_node.is_leaf);
+
+        std::accumulate(m_search_tree.begin() + tree_node.first_child_index,
+                        m_search_tree.begin() + tree_node.first_child_index + tree_node.child_count,
+                        tree_node.first_child_index,
+                        [&](const std::uint32_t child_index, const TreeNode &child) {
+
+                            const auto squared_lower_bound_to_element =
+                                child.minimum_bounding_rectangle.GetMinSquaredDist(
+                                    fixed_projected_input_coordinate);
+
+                            traversal_queue.push(
+                                QueryCandidate{squared_lower_bound_to_element,
+                                               TreeIndex{child_index, child.is_leaf}});
+
+                            return child_index + 1;
+                        });
     }
 };
 
 //[1] "On Packing R-Trees"; I. Kamel, C. Faloutsos; 1993; DOI: 10.1145/170088.170403
 //[2] "Nearest Neighbor Queries", N. Roussopulos et al; 1995; DOI: 10.1145/223784.223794
-//[3] "Distance Browsing in Spatial Databases"; G. Hjaltason, H. Samet; 1999; ACM Trans. DB Sys
+//[3] "Distance Browsing in Spatial Databases"; G. Hjaltason, H. Samet; 1999; ACM Trans. DB
+// Sys
 // Vol.24 No.2, pp.265-318
 }
 }

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -1,6 +1,8 @@
 file(GLOB RTreeBenchmarkSources static_rtree.cpp)
 file(GLOB MatchBenchmarkSources match.cpp)
 file(GLOB AliasBenchmarkSources alias.cpp)
+file(GLOB RouteBenchmarkSources route.cpp)
+file(GLOB TableBenchmarkSources table.cpp)
 
 add_executable(rtree-bench
 	EXCLUDE_FROM_ALL
@@ -40,8 +42,32 @@ target_link_libraries(alias-bench
 	${TBB_LIBRARIES}
 	${MAYBE_SHAPEFILE})
 
+add_executable(route-bench
+	EXCLUDE_FROM_ALL
+	${RouteBenchmarkSources}
+	$<TARGET_OBJECTS:UTIL>)
+
+target_link_libraries(route-bench
+	osrm
+	${BOOST_BASE_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
+	${TBB_LIBRARIES})
+
+add_executable(table-bench
+	EXCLUDE_FROM_ALL
+	${TableBenchmarkSources}
+	$<TARGET_OBJECTS:UTIL>)
+
+target_link_libraries(table-bench
+	osrm
+	${BOOST_BASE_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
+	${TBB_LIBRARIES})
+
 add_custom_target(benchmarks
 	DEPENDS
 	rtree-bench
 	match-bench
-    alias-bench)
+    alias-bench
+	route-bench
+	table-bench)

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -51,7 +51,8 @@ target_link_libraries(route-bench
 	osrm
 	${BOOST_BASE_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
-	${TBB_LIBRARIES})
+	${TBB_LIBRARIES}
+	${MAYBE_SHAPEFILE})
 
 add_executable(table-bench
 	EXCLUDE_FROM_ALL
@@ -62,12 +63,13 @@ target_link_libraries(table-bench
 	osrm
 	${BOOST_BASE_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
-	${TBB_LIBRARIES})
+	${TBB_LIBRARIES}
+	${MAYBE_SHAPEFILE})
 
 add_custom_target(benchmarks
 	DEPENDS
 	rtree-bench
 	match-bench
-    alias-bench
+        alias-bench
 	route-bench
 	table-bench)

--- a/src/benchmarks/table.cpp
+++ b/src/benchmarks/table.cpp
@@ -1,0 +1,114 @@
+#include "extractor/edge_based_node.hpp"
+#include "extractor/external_memory_node.hpp"
+#include "extractor/query_node.hpp"
+#include "storage/io.hpp"
+#include "engine/geospatial_query.hpp"
+#include "osrm/engine_config.hpp"
+#include "osrm/json_container.hpp"
+#include "osrm/osrm.hpp"
+#include "osrm/status.hpp"
+#include "osrm/table_parameters.hpp"
+#include "util/coordinate.hpp"
+#include "util/serialization.hpp"
+#include "util/static_rtree.hpp"
+#include "util/timing_util.hpp"
+
+#include <iostream>
+#include <random>
+
+#include <boost/filesystem/fstream.hpp>
+using namespace osrm;
+
+// Choosen by a fair W20 dice roll (this value is completely arbitrary)
+constexpr unsigned RANDOM_SEED = 13;
+
+std::vector<util::Coordinate> loadCoordinates(const boost::filesystem::path &nodes_file)
+{
+    storage::io::FileReader nodes_path_file_reader(nodes_file,
+                                                   storage::io::FileReader::VerifyFingerprint);
+
+    std::vector<util::Coordinate> coords;
+    storage::serialization::read(nodes_path_file_reader, coords);
+    util::Log() << "Node file contains " << coords.size() << " nodes";
+    return coords;
+}
+
+template <typename QueryT>
+void benchmarkQuery(const std::vector<std::vector<util::Coordinate>> &queries,
+                    const std::string &name,
+                    QueryT query)
+{
+    std::cout << "Running " << name << " with " << queries.size() << " queries: " << std::flush;
+
+    TIMER_START(query);
+    for (const auto &q : queries)
+    {
+        auto result = query(q);
+        (void)result;
+    }
+    TIMER_STOP(query);
+
+    std::cout << "Took " << TIMER_SEC(query) << " seconds "
+              << "(" << TIMER_MSEC(query) << "ms"
+              << ")  ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
+              << "(" << TIMER_MSEC(query) << "ms"
+              << ")" << std::endl;
+}
+
+void benchmark(OSRM &osrm,
+               const std::vector<util::Coordinate> &coords,
+               const unsigned num_queries,
+               const unsigned table_size)
+{
+    std::mt19937 mt_rand(RANDOM_SEED);
+    std::uniform_int_distribution<> coord_udist(0, coords.size());
+    std::vector<std::vector<util::Coordinate>> queries;
+    for (unsigned i = 0; i < num_queries; i++)
+    {
+        std::vector<util::Coordinate> query;
+        for (unsigned j = 0; j < table_size; j++)
+        {
+            query.push_back(coords[coord_udist(mt_rand)]);
+        }
+        queries.push_back(query);
+    }
+
+    benchmarkQuery(queries,
+                   "Table " + std::to_string(table_size) + "x" + std::to_string(table_size),
+                   [&osrm](const std::vector<util::Coordinate> &q) {
+                       TableParameters params;
+
+                       params.coordinates = q;
+                       json::Object result;
+                       const auto rc = osrm.Table(params, result);
+                       return rc;
+                   });
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2)
+    {
+        std::cout << "./route-bench file.osrm" << std::endl;
+        return EXIT_FAILURE;
+    }
+    osrm::util::LogPolicy::GetInstance().Unmute();
+
+    const char *file_path = argv[1];
+
+    using namespace osrm;
+
+    // Configure based on a .osrm base path, and no datasets in shared mem from osrm-datastore
+    EngineConfig config;
+    config.storage_config = {file_path};
+    config.use_shared_memory = false;
+
+    // Routing machine with several services (such as Route, Table, Nearest, Trip, Match)
+    OSRM osrm{config};
+
+    auto coords = loadCoordinates(std::string(file_path) + ".nodes");
+
+    benchmark(osrm, coords, 100, 300);
+
+    return 0;
+}

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -564,7 +564,7 @@ void Extractor::BuildRTree(std::vector<EdgeBasedNode> node_based_edge_list,
     node_based_edge_list.resize(new_size);
 
     TIMER_START(construction);
-    util::StaticRTree<EdgeBasedNode> rtree(node_based_edge_list,
+    util::StaticRTree<EdgeBasedNode> rtree(std::move(node_based_edge_list),
                                            config.rtree_nodes_output_path,
                                            config.rtree_leafs_output_path,
                                            coordinates);

--- a/src/tools/rtree-dump.cpp
+++ b/src/tools/rtree-dump.cpp
@@ -1,0 +1,94 @@
+#include "util/static_rtree.hpp"
+#include "util/web_mercator.hpp"
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+    using namespace osrm;
+    using EdgeDataT = int;
+    using RTree = util::StaticRTree<EdgeDataT>;
+
+    if (argc < 2)
+    {
+        std::cout << "Usage: " << argv[0] << " filename.osrm" << std::endl;
+        return EXIT_SUCCESS;
+    }
+
+    std::string node_file = argv[1];
+    // using dummy <int> here, we don't need any templated types
+    std::vector<RTree::TreeNode> m_search_tree;
+
+    storage::io::FileReader tree_node_file(node_file + ".ramIndex",
+                                           storage::io::FileReader::VerifyFingerprint);
+
+    const auto tree_size = tree_node_file.ReadElementCount64();
+
+    m_search_tree.resize(tree_size);
+    tree_node_file.ReadInto(&m_search_tree[0], tree_size);
+
+    struct nodeinfo
+    {
+        decltype(RTree::TreeNode::first_child_index) index;
+        int depth;
+    };
+    // queue for breadth-first traversal
+    std::queue<nodeinfo> queue;
+
+    queue.push({0, 0});
+    auto first = true;
+
+    std::cout << "{\"type\":\"FeatureCollection\",\"features\":[";
+
+    std::string strokes[] = {"red", "blue", "green", "orange", "yellow"};
+
+    while (!queue.empty())
+    {
+        auto info = queue.front();
+        queue.pop();
+
+        auto node = m_search_tree[info.index];
+        auto depth = info.depth;
+
+        auto min_coord = util::web_mercator::toWGS84(
+            {util::toFloating(node.minimum_bounding_rectangle.min_lon),
+             util::toFloating(node.minimum_bounding_rectangle.min_lat)});
+        auto max_coord = util::web_mercator::toWGS84(
+            {util::toFloating(node.minimum_bounding_rectangle.max_lon),
+             util::toFloating(node.minimum_bounding_rectangle.max_lat)});
+
+        // Write out geojson showing the boundaries
+        if (first)
+        {
+            first = false;
+        }
+        else
+        {
+            std::cout << "," << std::endl;
+        }
+
+        std::cout << "{\"type\":\"Feature\",\"properties\":{\"depth\":" << depth << ","
+                  << "\"stroke\": \"" << strokes[depth] << "\","
+                  << "\"fill-opacity\":0,"
+                  << "\"stroke-opacity\":1,"
+                  << "\"stroke-width\":2"
+                  << "},\"geometry\":{";
+        std::cout << " \"type\":\"Polygon\",\"coordinates\":[[";
+        std::cout << "[" << min_coord.lon << "," << min_coord.lat << "],";
+        std::cout << "[" << min_coord.lon << "," << max_coord.lat << "],";
+        std::cout << "[" << max_coord.lon << "," << max_coord.lat << "],";
+        std::cout << "[" << max_coord.lon << "," << min_coord.lat << "],";
+        std::cout << "[" << min_coord.lon << "," << min_coord.lat << "]";
+        std::cout << "]]}}";
+        if (!node.is_leaf)
+        {
+            for (auto i = node.first_child_index; i < node.first_child_index + node.child_count;
+                 i++)
+            {
+                queue.push({i, depth + 1});
+            }
+        }
+    }
+    std::cout << "]}" << std::endl;
+}

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -37,14 +37,12 @@ using namespace osrm::util;
 using namespace osrm::test;
 
 constexpr uint32_t TEST_BRANCHING_FACTOR = 8;
-constexpr uint32_t TEST_LEAF_NODE_SIZE = 64;
+constexpr uint32_t TEST_LEAF_PAGE_SIZE = 64;
 
 using TestData = extractor::EdgeBasedNode;
-using TestStaticRTree = StaticRTree<TestData,
-                                    osrm::storage::Ownership::Container,
-                                    TEST_BRANCHING_FACTOR,
-                                    TEST_LEAF_NODE_SIZE>;
-using MiniStaticRTree = StaticRTree<TestData, osrm::storage::Ownership::Container, 2, 128>;
+using TestStaticRTree =
+    StaticRTree<TestData, osrm::storage::Ownership::Container, TEST_BRANCHING_FACTOR>;
+using MiniStaticRTree = StaticRTree<TestData, osrm::storage::Ownership::Container, 4>;
 using TestDataFacade = MockDataFacade<osrm::engine::routing_algorithms::ch::Algorithm>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
@@ -180,17 +178,17 @@ struct GraphFixture
     std::vector<TestData> edges;
 };
 
-typedef RandomGraphFixture<TEST_LEAF_NODE_SIZE * 3, TEST_LEAF_NODE_SIZE / 2>
+typedef RandomGraphFixture<TEST_LEAF_PAGE_SIZE * 3, TEST_LEAF_PAGE_SIZE / 2>
     TestRandomGraphFixture_LeafHalfFull;
-typedef RandomGraphFixture<TEST_LEAF_NODE_SIZE * 5, TEST_LEAF_NODE_SIZE>
+typedef RandomGraphFixture<TEST_LEAF_PAGE_SIZE * 5, TEST_LEAF_PAGE_SIZE>
     TestRandomGraphFixture_LeafFull;
-typedef RandomGraphFixture<TEST_LEAF_NODE_SIZE * 10, TEST_LEAF_NODE_SIZE * 2>
+typedef RandomGraphFixture<TEST_LEAF_PAGE_SIZE * 10, TEST_LEAF_PAGE_SIZE * 2>
     TestRandomGraphFixture_TwoLeaves;
-typedef RandomGraphFixture<TEST_LEAF_NODE_SIZE * TEST_BRANCHING_FACTOR * 3,
-                           TEST_LEAF_NODE_SIZE * TEST_BRANCHING_FACTOR>
+typedef RandomGraphFixture<TEST_LEAF_PAGE_SIZE * TEST_BRANCHING_FACTOR * 3,
+                           TEST_LEAF_PAGE_SIZE * TEST_BRANCHING_FACTOR>
     TestRandomGraphFixture_Branch;
-typedef RandomGraphFixture<TEST_LEAF_NODE_SIZE * TEST_BRANCHING_FACTOR * 3,
-                           TEST_LEAF_NODE_SIZE * TEST_BRANCHING_FACTOR * 2>
+typedef RandomGraphFixture<TEST_LEAF_PAGE_SIZE * TEST_BRANCHING_FACTOR * 3,
+                           TEST_LEAF_PAGE_SIZE * TEST_BRANCHING_FACTOR * 2>
     TestRandomGraphFixture_MultipleLevels;
 typedef RandomGraphFixture<10, 30> TestRandomGraphFixture_10_30;
 
@@ -273,7 +271,7 @@ void construction_test(const std::string &prefix, FixtureT *fixture)
 
 BOOST_FIXTURE_TEST_CASE(construct_tiny, TestRandomGraphFixture_10_30)
 {
-    using TinyTestTree = StaticRTree<TestData, osrm::storage::Ownership::Container, 2, 64>;
+    using TinyTestTree = StaticRTree<TestData, osrm::storage::Ownership::Container, 2>;
     construction_test<TinyTestTree>("test_tiny", this);
 }
 

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -253,7 +253,7 @@ void build_rtree(const std::string &prefix,
     nodes_path = prefix + ".ramIndex";
     leaves_path = prefix + ".fileIndex";
 
-    RTreeT r(fixture->edges, nodes_path, leaves_path, fixture->coords);
+    RTreeT r(std::move(fixture->edges), nodes_path, leaves_path, fixture->coords);
 }
 
 template <typename RTreeT = TestStaticRTree, typename FixtureT>


### PR DESCRIPTION
# Issue

This PR is to address https://github.com/Project-OSRM/osrm-backend/issues/3378.  Our current RTree uses a Hilbert sort to group leaf nodes.  For road network data, this gives us a less-than-optimal packing with quite a lot of overlap for leaf nodes.  We can speed up coordinate snapping by using a better packing method.

This PR implements the [Overlap Minimizing Top-down bulk-loading](http://ftp.informatik.rwth-aachen.de/Publications/CEUR-WS/Vol-74/files/FORUM_18.pdf) in our rtree, which produces an RTree with far less overlap than the current Hilbert Sort approach.

As a bonus, OMT makes it easy to back the TreeNode data into a breadth-first-search linear order, which means we don't need fixed-sized child arrays in the TreeNode struct, range pointers are sufficient.  This greatly reduces the size of the `.ramIndex` files.

## Tasklist
 - [ ] compare to Boost's packing approach, which is an [altered STR method](https://github.com/boostorg/geometry/blob/develop/include/boost/geometry/index/detail/rtree/pack_create.hpp#L110)
 - [ ] benchmarking
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments