### PR TITLE
Fix incorrect weight fallback for distance-based weights

### DIFF
--- a/features/car/weight.feature
+++ b/features/car/weight.feature
@@ -62,3 +62,28 @@ Feature: Car - weights
             | from | to | route       | speed   | weight |
             | a    | d  | ab,bc,cd,cd | 65 km/h | 44.4   |
             | a    | e  | ab,be,be    | 14 km/h | 112    |
+
+    Scenario: Distance weights
+        Given the profile file "car" extended with
+        """
+        api_version = 1
+        properties.weight_name = 'distance'
+        """
+
+        Given the node map
+            """
+            a---b---c
+                |
+                d
+            """
+
+        And the ways
+            | nodes |
+            | abc   |
+            | bd    |
+
+        When I route I should get
+            | waypoints | bearings | route     | distance | weights   | times          |
+            | a,b       | 90 90    | abc,abc   | 200m     | 200,0     | 11.1s,0s       |
+            | b,c       | 90 90    | abc,abc   | 200m     | 200,0     | 11.1s,0s       |
+            | a,d       | 90 180   | abc,bd,bd | 399.9m   | 200,200,0 | 13.2s,11.1s,0s |

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -441,7 +441,7 @@ end
 
 function Handlers.handle_weights(way,result,data,profile)
   if properties.weight_name == 'distance' then
-    result.weight = 0
+    result.weight = -1
      -- set weight rates to 1 for the distance weight, edge weights are distance / rate
     if (result.forward_mode ~= mode.inaccessible and result.forward_speed > 0) then
        result.forward_rate = 1


### PR DESCRIPTION
# Issue

Handler for distance weights falls back to 0 weight and 0 weight is pulled up to 0.1 in the edges processing, so distance-based routes use a "hop-based" metric. 
PR fixes behavior for https://github.com/Project-OSRM/osrm-backend/issues/505#issuecomment-294942028

Response weights are not exactly equal to distance but up some accuracy due to fixed-point weight values

|query | weight | distance|
|---|---|---|
|13.30845259029391,52.6363212194368;13.554978371883418,52.33757604865378|42734.9|42734.4|
|13.627480519531487,52.57262005644903;13.585600877684058,52.60952547773862|15714.2|15714.5|
|13.302916320218214,52.46299142575834;13.680322642831127,52.63627932403841|29666.6|29666.1|
|13.384519682216485,52.46097767252537;13.124936969677371,52.358482722348356|23212.2|23212.2|
|13.310324967495443,52.649412750885325;13.670657808089867,52.63738823933316|23843.5|23844.2|
|13.326059660831802,52.344328272140125;13.445213838673821,52.67016138021326|35081.1|35079.5|
|13.248724220015616,52.66647015348795;13.548235296977111,52.39044216041803|40738.5|40738.1|
|13.168306983145486,52.674862913525104;13.175110136012004,52.65162412125197|15682.1|15681.9|
|13.254067982457745,52.4881184626198;13.759262975380672,52.45986342177202|39335.8|39335|
|13.275270248746873,52.66559093606319;13.50159938417757,52.450426580447605|31331.7|31331.7|


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations

