### PR TITLE
Fix incorrect exit turn invalidation

### DIFF
--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -222,6 +222,43 @@ Feature: Basic Roundabout
            | j,f       | jkl,def,def | depart,roundabout-exit-2,arrive |
            | j,c       | jkl,abc,abc | depart,roundabout-exit-3,arrive |
 
+     Scenario: Mixed Entry and Exit - clockwise order
+        Given the node map
+           """
+             c   a
+           j   b   f
+             k   e
+           l   h   d
+             g   i
+           """
+
+        And the ways
+           | nodes | junction   | oneway |
+           | abc   |            | yes    |
+           | def   |            | yes    |
+           | ghi   |            | yes    |
+           | jkl   |            | yes    |
+           | behkb | roundabout | yes    |
+
+        When I route I should get
+           | waypoints | route       | turns                           |
+           | a,c       | abc,abc,abc | depart,roundabout-exit-4,arrive |
+           | a,l       | abc,jkl,jkl | depart,roundabout-exit-3,arrive |
+           | a,i       | abc,ghi,ghi | depart,roundabout-exit-2,arrive |
+           | a,f       | abc,def,def | depart,roundabout-exit-1,arrive |
+           | d,f       | def,def,def | depart,roundabout-exit-4,arrive |
+           | d,c       | def,abc,abc | depart,roundabout-exit-3,arrive |
+           | d,l       | def,jkl,jkl | depart,roundabout-exit-2,arrive |
+           | d,i       | def,ghi,ghi | depart,roundabout-exit-1,arrive |
+           | g,i       | ghi,ghi,ghi | depart,roundabout-exit-4,arrive |
+           | g,f       | ghi,def,def | depart,roundabout-exit-3,arrive |
+           | g,c       | ghi,abc,abc | depart,roundabout-exit-2,arrive |
+           | g,l       | ghi,jkl,jkl | depart,roundabout-exit-1,arrive |
+           | j,l       | jkl,jkl,jkl | depart,roundabout-exit-4,arrive |
+           | j,i       | jkl,ghi,ghi | depart,roundabout-exit-3,arrive |
+           | j,f       | jkl,def,def | depart,roundabout-exit-2,arrive |
+           | j,c       | jkl,abc,abc | depart,roundabout-exit-1,arrive |
+
     Scenario: Mixed Entry and Exit - segregated roads, different names
         Given the node map
            """
@@ -707,3 +744,27 @@ Feature: Basic Roundabout
         When I route I should get
             | waypoints | route          | turns                                                                           |
             | a,h       | ab,ef,ef,fh,fh | depart,roundabout-exit-4,notification slight right,notification straight,arrive |
+
+
+     Scenario: Drive through roundabout
+        Given the node map
+           """
+              a
+            b e d  f
+              c
+            g   h
+           """
+
+        And the ways
+           | nodes | junction   | oneway |
+           | abcda | roundabout | yes    |
+           | edf   |            |        |
+           | gch   |            | yes    |
+
+        When I route I should get
+           | waypoints | bearings | route       | turns                           |
+           | e,f       | 90 90    | edf,edf,edf | depart,roundabout-exit-1,arrive |
+           | e,h       | 90 135   | edf,gch,gch | depart,roundabout-exit-2,arrive |
+           | g,f       | 45 90    | gch,edf,edf | depart,roundabout-exit-2,arrive |
+           | g,h       | 45 135   | gch,gch,gch | depart,roundabout-exit-1,arrive |
+           | e,e       | 90 270   | edf,edf,edf | depart,roundabout-exit-3,arrive |

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -111,20 +111,26 @@ void RoundaboutHandler::invalidateExitAgainstDirection(const NodeID from_nid,
     if (in_edge_data.roundabout || in_edge_data.circular)
         return;
 
-    std::cout << "invalidateExitAgainstDirection\n";
-
     // Find range in which exits that must be invalidated (shaded areas):
-    // exit..end   exit..end  begin..exit for ↺ roundabouts
-    // ⭦           ⭦  ⭩         ⭦
-    //  ⭡⭧          ⭡⭩ ▒       ▒⭨⭡
-    //  ⭡⭦          ⭡⭨▒▒       ▒▒⭡⭨
-    // ⭧▒▒⭦        ⭧▒▒▒▒      ▒▒⭧
+    //   exit..end   exit..end  begin..exit for ↺ roundabouts
+    // *************************************
+    // * <--.   ^    <--.   /     <--.     *
+    // *     | /         | /░         |    *
+    // *     |/          |v░░      -->|    *
+    // *     |^          |\ ░      ░░░|\   *
+    // *     |░\         |░\░      ░░░| \  *
+    // *  --'░░░\     --'░░░v      --'   v *
+    // *************************************
     //
     // begin..exit  begin..exit  exit..end for ↻ roundabouts
-    // ⭨▒▒▒         ⭨▒▒ ⭩        ▒▒⭨
-    //  ⭣⭧▒          ⭣⭩           ▒▒⭣⭧
-    //  ⭣⭦▒          ⭣⭨           ▒⭧⭣
-    // ⭩  ⭦         ⭩              ⭩
+    // *************************************
+    // *  --.░░░^     --.░░░/      --.   ^ *
+    // *     |░/░        |░/       ░░░| /  *
+    // *     |/░░        |v        ░░░|/   *
+    // *     |^░░        |\        -->|    *
+    // *     | \░        | \          |    *
+    // * <--'   \    <--'   v     <--'     *
+    // *************************************
     bool roundabout_entry_first = false;
     auto invalidate_from = intersection.end(), invalidate_to = intersection.end();
     for (auto road = intersection.begin(); road != intersection.end(); ++road)


### PR DESCRIPTION
# Issue

Fixes #3977 by checking an additional case if a roundabout entry is before a roundabout exit in counter-clockwise order. The check works for both CCW and CW roundabouts.

Fixed guidance instructions in #3977 
![fixed_exit](https://cloud.githubusercontent.com/assets/4421046/25481703/b0a32ac4-2b4e-11e7-9afd-87eb30a2d518.png)
and  https://github.com/Project-OSRM/osrm-backend/blob/d441b0975834686f92c9544e89fd7a93ff4c30e9/features/guidance/roundabout.feature#L766-L771 may be related to #3979

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
