### PR TITLE
Lets loader resolve symbols at startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,7 @@ if("${LINKER_VERSION}" MATCHES "GNU gold" OR "${LINKER_VERSION}" MATCHES "GNU ld
     set(LINKER_FLAGS "${LINKER_FLAGS} -Wl,--gc-sections")
   endif()
   # Default linker optimization flags
-  set(LINKER_FLAGS "${LINKER_FLAGS} -Wl,-O1 -Wl,--hash-style=gnu -Wl,--sort-common")
+  set(LINKER_FLAGS "${LINKER_FLAGS} -Wl,-O1 -Wl,--hash-style=gnu -Wl,--sort-common -Wl,-z,now")
 
 else()
   message(STATUS "Using unknown linker, not setting linker optimizations")


### PR DESCRIPTION
At the moment the loader will lazily resolve symbols at runtime when the
first function call happens. This can lead to situations where the libs
are not compatible but we are still able to run - until unresolveable
symbols are encountered.

This changeset tells the loader to resolve all symbols at startup,
failing hard immediately if symbols are unresolveable.

> now
>
> When generating an executable or shared library, mark it to tell the
> dynamic linker to resolve all symbols when the program is started,
> or when the shared library is linked to using dlopen, instead of
> deferring function call resolution to the point when the function is
> first called.

https://linux.die.net/man/1/ld

See https://github.com/Project-OSRM/osrm-backend/issues/3978