### PR TITLE
Split travis jobs for less timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,22 @@ matrix:
 
     # Debug Builds
     - os: linux
-      compiler: "format-taginfo"
+      compiler: "format-taginfo-docs"
+      env: NODE=6
       sudo: false
       before_install:
       install:
+        - source $NVM_DIR/nvm.sh
+        - nvm install $NODE
+        - nvm use $NODE
+        - npm --version
+        - npm install --ignore-scripts
+        - npm link --ignore-scripts
       script:
-        - ${MASON} install clang-format 3.8.1 && PATH=$(${MASON} prefix clang-format 3.8.1)/bin:${PATH} ./scripts/format.sh
+        - ${MASON} install clang-format 3.8.1
+        - PATH=$(${MASON} prefix clang-format 3.8.1)/bin:${PATH} ./scripts/format.sh && ./scripts/error_on_dirty.sh
         - ./scripts/check_taginfo.py taginfo.json profiles/car.lua
+        - npm run docs && ./scripts/error_on_dirty.sh
       after_success:
 
     - os: linux
@@ -332,8 +341,6 @@ install:
   - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
   - make --jobs=${JOBS}
   - popd
-  # building docs only works with npm3+ not with yarn or npm2
-  #- yarn run docs
 
 script:
   - if [[ $TARGET_ARCH == armhf ]] ; then echo "Skip tests for $TARGET_ARCH" && exit 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,14 +48,32 @@ matrix:
 
     # Debug Builds
     - os: linux
-      compiler: "gcc-6-debug-cov-asan"
+      compiler: "format-taginfo"
+      sudo: false
+      before_install:
+      install:
+      script:
+        - ${MASON} install clang-format 3.8.1 && PATH=$(${MASON} prefix clang-format 3.8.1)/bin:${PATH} ./scripts/format.sh
+        - ./scripts/check_taginfo.py taginfo.json profiles/car.lua
+      after_success:
+
+    - os: linux
+      compiler: "gcc-6-debug-cov"
       addons: &gcc6
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
-      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_COVERAGE=ON ENABLE_SANITIZER=ON
+      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' ENABLE_COVERAGE=ON
       after_success:
         - bash <(curl -s https://codecov.io/bash)
+
+    - os: linux
+      compiler: "gcc-6-debug-asan"
+      addons: &gcc6
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
+      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_SANITIZER=ON
 
     - os: linux
       compiler: "clang-4.0-debug"
@@ -247,10 +265,6 @@ before_install:
       fi
     fi
   - |
-    if [ -n "${RUN_CLANG_FORMAT}" ]; then
-      ${MASON} install clang-format 3.8.1 && PATH=$(${MASON} prefix clang-format 3.8.1)/bin:${PATH} ./scripts/format.sh
-    fi
-  - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       sudo mdutil -i off /
     fi
@@ -289,10 +303,6 @@ before_install:
   - mkdir ${OSRM_BUILD_DIR}
 
 install:
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      ./scripts/check_taginfo.py taginfo.json profiles/car.lua
-    fi
   - pushd ${OSRM_BUILD_DIR}
   - |
     cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \

--- a/scripts/error_on_dirty.sh
+++ b/scripts/error_on_dirty.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+MSG="The following files have been modified:"
+dirty=$(git ls-files --modified)
+
+if [[ $dirty ]]; then
+    echo $MSG
+    echo $dirty
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -36,14 +36,3 @@ fi
 
 find src include unit_tests example -type f -name '*.hpp' -o -name '*.cpp' \
   | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}
-
-
-dirty=$(git ls-files --modified)
-
-if [[ $dirty ]]; then
-    echo "The following files do not adhere to the .clang-format style file:"
-    echo $dirty
-    exit 1
-else
-    exit 0
-fi


### PR DESCRIPTION
# Issue

Tries to address https://github.com/Project-OSRM/osrm-backend/issues/3976 by splitting the coverage and sanitizer builds. Also moves the script tests (formating, taginfo, docs) to an own job.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
