### PR TITLE
Make gitsha available in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,8 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     \
     echo "Building OSRM ${DOCKER_TAG}" && \
     cd /src && \
+    git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
+    echo "Building OSRM gitsha ${cat /opt/OSRM_GITSHA}" && \
     mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_LTO=On .. && \


### PR DESCRIPTION
# Issue

It would be great to retain the gitsha so that when you get a `latest` image from dockerhub you know exactly which code as used.

While working on this I also changed when `COPY . /src` is executed, which makes local development with docker easier, since OS packages remain cached.

## Tasklist

- [ ] Make sure this docker file actually works locally
 - [ ] 👀 @danpat 
 - [ ] merge

/cc @daniel-j-h 