### PR TITLE
Fixes util.format calls in Cucumber support code

### DIFF
--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -67,7 +67,7 @@ module.exports = function () {
                 if (this.nameNodeHash[name]) throw new Error(util.format('*** duplicate node %s', name));
                 this.addOSMNode(name, lonLat[0], lonLat[1], null);
             } else if (name.match(/[0-9]/) ) {
-                if (this.locationHash[name]) throw new Error(util.format('*** duplicate node %s'), name);
+                if (this.locationHash[name]) throw new Error(util.format('*** duplicate node %s', name));
                 this.addLocation(name, lonLat[0], lonLat[1], null);
             }
             cb();
@@ -89,7 +89,7 @@ module.exports = function () {
 
         let addNodeLocations = (row, cb) => {
             let name = row.node;
-            if (this.findNodeByName(name)) throw new Error(util.format('*** duplicate node %s'), name);
+            if (this.findNodeByName(name)) throw new Error(util.format('*** duplicate node %s', name));
 
             if (name.match(/[a-z]/)) {
                 let id = row.id && parseInt(row.id);
@@ -194,19 +194,19 @@ module.exports = function () {
                     isColonSeparated = key.match(/^(.*):(.*)/);
                 if (isNode) {
                     row[key].split(',').map(function(v) { return v.trim(); }).forEach((nodeName) => {
-                        if (nodeName.length !== 1) throw new Error(util.format('*** invalid relation node member "%s"'), nodeName);
+                        if (nodeName.length !== 1) throw new Error(util.format('*** invalid relation node member "%s"', nodeName));
                         let node = this.findNodeByName(nodeName);
-                        if (!node) throw new Error(util.format('*** unknown relation node member "%s"'), nodeName);
+                        if (!node) throw new Error(util.format('*** unknown relation node member "%s"', nodeName));
                         relation.addMember('node', node.id, isNode[1]);
                     });
                 } else if (isWay) {
                     row[key].split(',').map(function(v) { return v.trim(); }).forEach((wayName) => {
                         let way = this.findWayByName(wayName);
-                        if (!way) throw new Error(util.format('*** unknown relation way member "%s"'), wayName);
+                        if (!way) throw new Error(util.format('*** unknown relation way member "%s"', wayName));
                         relation.addMember('way', way.id, isWay[1]);
                     });
                 } else if (isColonSeparated && isColonSeparated[1] !== 'restriction') {
-                    throw new Error(util.format('*** unknown relation member type "%s:%s", must be either "node" or "way"'), isColonSeparated[1], isColonSeparated[2]);
+                    throw new Error(util.format('*** unknown relation member type "%s:%s", must be either "node" or "way"', isColonSeparated[1], isColonSeparated[2]));
                 } else {
                     relation.addTag(key, row[key]);
                 }

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -225,7 +225,7 @@ module.exports = function () {
                         for (var i=0; i<row.trace.length; i++) {
                             var n = row.trace[i],
                                 node = this.findNodeByName(n);
-                            if (!node) throw new Error(util.format('*** unknown waypoint node "%s"'), n);
+                            if (!node) throw new Error(util.format('*** unknown waypoint node "%s"', n));
                             trace.push(node);
                         }
                         if (row.timestamps) {

--- a/features/step_definitions/nearest.js
+++ b/features/step_definitions/nearest.js
@@ -6,10 +6,10 @@ module.exports = function () {
             if (e) return callback(e);
             var testRow = (row, ri, cb) => {
                 var inNode = this.findNodeByName(row.in);
-                if (!inNode) throw new Error(util.format('*** unknown in-node "%s"'), row.in);
+                if (!inNode) throw new Error(util.format('*** unknown in-node "%s"', row.in));
 
                 var outNode = this.findNodeByName(row.out);
-                if (!outNode) throw new Error(util.format('*** unknown out-node "%s"'), row.out);
+                if (!outNode) throw new Error(util.format('*** unknown out-node "%s"', row.out));
 
                 this.requestNearest(inNode, this.queryParams, (err, response) => {
                     if (err) return cb(err);

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -217,11 +217,11 @@ module.exports = function () {
 
                     if (row.from && row.to) {
                         var fromNode = this.findNodeByName(row.from);
-                        if (!fromNode) return cb(new Error(util.format('*** unknown from-node "%s"'), row.from));
+                        if (!fromNode) return cb(new Error(util.format('*** unknown from-node "%s"', row.from)));
                         waypoints.push(fromNode);
 
                         var toNode = this.findNodeByName(row.to);
-                        if (!toNode) return cb(new Error(util.format('*** unknown to-node "%s"'), row.to));
+                        if (!toNode) return cb(new Error(util.format('*** unknown to-node "%s"', row.to)));
                         waypoints.push(toNode);
 
                         got.from = row.from;


### PR DESCRIPTION
```
fn(util.format("%s"), 'foo')

=>

fn(util.format("%s", 'foo'))
```