### PR TITLE
Fixes  obvious turn detection no longer taking entry allowed into account

### DIFF
--- a/features/guidance/advanced-lanes.feature
+++ b/features/guidance/advanced-lanes.feature
@@ -35,10 +35,10 @@ Feature: Turn Lane Guidance
             | restriction | bc       | cd     | c        | no_right_turn |
 
        When I route I should get
-            | waypoints | route                | turns                           | lanes                                  |
-            | a,e       | in,cross,cross       | depart,turn left,arrive         | ,left:true straight:false right:false, |
-            | a,g       | in,straight,straight | depart,new name straight,arrive | ,left:false straight:true right:false, |
-            | a,f       | in,cross,cross       | depart,turn right,arrive        | ,left:false straight:false right:true, |
+            | waypoints | route                | turns                           | lanes                      |
+            | a,e       | in,cross,cross       | depart,turn left,arrive         | ,left:true straight:false, |
+            | a,g       | in,straight,straight | depart,new name straight,arrive | ,left:false straight:true, |
+            | a,f       | in,cross,cross       | depart,continue right,arrive    | ,,                         |
 
     @sliproads
     Scenario: Separate Turn Lanes

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -359,7 +359,7 @@ Feature: Collapse
             | a,g       | first,second,second | depart,turn left,arrive        | a,b,g     |
             | d,g       | first,second,second | depart,turn right,arrive       | d,e,g     |
             | g,f       | second,first,first  | depart,turn right,arrive       | g,e,f     |
-            | g,c       | second,first,first  | depart,end of road left,arrive | g,b,c     |
+            | g,c       | second,first,first  | depart,turn left,arrive        | g,e,c     |
 
     Scenario: Do not collapse turning roads
         Given the node map
@@ -690,9 +690,9 @@ Feature: Collapse
             | restriction | bc       | dc     | c        | no_right_turn |
 
         When I route I should get
-            | waypoints | route            | turns                   | locations |
-            | a,g       | road,cross,cross | depart,turn left,arrive | a,b,g     |
-            | a,e       | road,road        | depart,arrive           | a,e       |
+            | waypoints | route                 | turns                                        | locations |
+            | a,g       | road,road,cross,cross | depart,continue slight left,turn left,arrive | a,b,c,g   |
+            | a,e       | road,road             | depart,arrive                                | a,e       |
 
     Scenario: On-Off on Highway
         Given the node map
@@ -996,8 +996,8 @@ Feature: Collapse
             a . . b .'
                       ` d.
                         f e
-			"""
-			#Check collapse.detail for a similar case (shorter) that does not classify these turns as a sliproad anymore
+            """
+            #Check collapse.detail for a similar case (shorter) that does not classify these turns as a sliproad anymore
 
         And the ways
             | nodes | name  | oneway | highway   |
@@ -1016,9 +1016,9 @@ Feature: Collapse
 
         When I route I should get
             | waypoints | route                 | turns                                      | locations |
-			|       a,g | road,cross,cross	    | depart,fork left,arrive 			         | a,b,g 	 |
-     		|       a,e | road,road,road 		| depart,fork slight right,arrive 			 | a,b,e 	 |
-     		|       a,f | road,road,cross,cross | depart,fork slight right,turn right,arrive | a,b,d,f 	 |
+            |       a,g | road,road,cross,cross | depart,fork slight left,turn left,arrive   | a,b,c,g   |
+            |       a,e | road,road,road        | depart,fork slight right,arrive            | a,b,e     |
+            |       a,f | road,road,cross,cross | depart,fork slight right,turn right,arrive | a,b,d,f   |
 
 
     # http://www.openstreetmap.org/way/92415447 #3933

--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -201,14 +201,14 @@ Feature: Simple Turns
             | ef      | residential  | road | 2     | yes    |
 
        When I route I should get
-            | waypoints | route          | turns                        | locations |
-            | a,c       | road,road      | depart,arrive                | a,c       |
-            | c,a       | road,road      | depart,arrive                | c,a       |
-            | g,a       | turn,road,road | depart,turn left,arrive      | g,b,a     |
-            | g,c       | turn,road,road | depart,turn right,arrive     | g,b,c     |
-            | g,f       | turn,road,road | depart,turn left,arrive      | g,e,f     |
-            | c,f       | road,road,road | depart,continue right,arrive | c,b,f     |
-            | a,f       | road,road,road | depart,continue uturn,arrive | a,b,f     |
+            | waypoints | route          | turns                          | locations |
+            | a,c       | road,road      | depart,arrive                  | a,c       |
+            | c,a       | road,road      | depart,arrive                  | c,a       |
+            | g,a       | turn,road,road | depart,turn left,arrive        | g,b,a     |
+            | g,c       | turn,road,road | depart,turn right,arrive       | g,b,c     |
+            | g,f       | turn,road,road | depart,end of road left,arrive | g,e,f     |
+            | c,f       | road,road,road | depart,turn right,arrive       | c,b,f     |
+            | a,f       | road,road,road | depart,continue uturn,arrive   | a,b,f     |
 
     # http://www.openstreetmap.org/#map=19/52.48753/13.52838
     Scenario: Traffic Circle
@@ -1312,8 +1312,8 @@ Feature: Simple Turns
 
         # we don't care for turn instructions, this is a coordinate extraction bug check
         When I route I should get
-            | waypoints | route      | intersections                                |
-            | a,g       | ab,bcdefgh | true:90,true:45 false:180 false:270;true:180 |
+            | waypoints | route              | intersections                                |
+            | a,g       | ab,bcdefgh,bcdefgh | true:90;true:45 false:180 false:270;true:180 |
 
     #https://github.com/Project-OSRM/osrm-backend/pull/3469#issuecomment-270806580
     Scenario: Oszillating Lower Priority Road

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -1319,3 +1319,33 @@ Feature: Simple Turns
         When I route I should get
             | waypoints | route           | ref             | turns                                         |
             | a,h       | Road,,,         | C 42,,C 42,C 42 | depart,on ramp right,merge slight left,arrive |
+
+    Scenario: End of road, T-intersection, no obvious turn, only one road allowed
+        Given the node map
+            """
+                           d
+                          .
+            a . b  .  .  c
+                    '   .
+                      'e
+                      .
+                      f
+            """
+
+        And the ways
+            | nodes  | highway      | oneway | ref       |
+            | ab     | primary      |        | B 191     |
+            | bc     | primary      |        | B 191     |
+            | be     | primary_link | yes    |           |
+            | dc     | primary      |        | B 4;B 191 |
+            | ce     | primary      |        | B 4       |
+            | ef     | primary      |        | B 4       |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction     |
+            | restriction | bc       | ce     | c        | no_right_turn   |
+            | restriction | be       | ef     | e        | only_right_turn |
+
+       When I route I should get
+            | waypoints | route    | turns                   |
+            | a,d       | ab,dc,dc | depart,turn left,arrive |

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -410,14 +410,11 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
             const auto &best_option_data =
                 node_based_graph.GetEdgeData(intersection[best_option].eid);
             const auto adjusted_distinction_ratio = [&]() {
-                // not allowed competitors are easily distinct
-                if (!intersection[index].entry_allowed)
-                    return 0.7 * DISTINCTION_RATIO;
-                // a bit less obvious are road classes
-                else if (in_way_data.road_classification == best_option_data.road_classification &&
-                         best_option_data.road_classification.GetPriority() <
-                             node_based_graph.GetEdgeData(intersection[index].eid)
-                                 .road_classification.GetPriority())
+                // obviousness by road classes
+                if (in_way_data.road_classification == best_option_data.road_classification &&
+                    best_option_data.road_classification.GetPriority() <
+                        node_based_graph.GetEdgeData(intersection[index].eid)
+                            .road_classification.GetPriority())
                     return 0.8 * DISTINCTION_RATIO;
                 // if road classes are the same, we use the full ratio
                 else


### PR DESCRIPTION
For #3987.

This adds a failing test case for obvious turn at the end of the road.

Note how the skewed angles are required, the test works with:

```
                         d
                         .
            a . b  .  .  c
                    '    .
                      '  e
                         .
                         f
```

Obvious turn detection for end of road scenarios in [TurnHandler](https://github.com/Project-OSRM/osrm-backend/blob/0e39aa9488bff97cffda1d12fb18cdeb537e0c03/src/extractor/guidance/turn_handler.cpp#L226-L228) most likely needs a fix for this.

cc @karenzshea @oxidase 