### PR TITLE
Fixes Table not checking for valid phantom nodes

### DIFF
--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -67,7 +67,17 @@ Status TablePlugin::HandleRequest(const datafacade::ContiguousInternalMemoryData
         return Error("TooBig", "Too many table coordinates", result);
     }
 
-    auto snapped_phantoms = SnapPhantomNodes(GetPhantomNodes(facade, params));
+    auto phantom_nodes = GetPhantomNodes(facade, params);
+
+    if (phantom_nodes.size() != params.coordinates.size())
+    {
+        return Error("NoSegment",
+                     std::string("Could not find a matching segment for coordinate ") +
+                         std::to_string(phantom_nodes.size()),
+                     result);
+    }
+
+    auto snapped_phantoms = SnapPhantomNodes(phantom_nodes);
     auto result_table =
         algorithms.ManyToManySearch(snapped_phantoms, params.sources, params.destinations);
 

--- a/unit_tests/library/table.cpp
+++ b/unit_tests/library/table.cpp
@@ -151,4 +151,27 @@ BOOST_AUTO_TEST_CASE(test_table_three_coordinates_matrix)
     }
 }
 
+// See https://github.com/Project-OSRM/osrm-backend/pull/3992
+BOOST_AUTO_TEST_CASE(test_table_no_segment_for_some_coordinates)
+{
+    using namespace osrm;
+
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm");
+
+    TableParameters params;
+    params.coordinates.push_back(get_dummy_location());
+    params.coordinates.push_back(get_dummy_location());
+    // resembles query option: `&radiuses=0;`
+    params.radiuses.push_back(boost::make_optional(0.));
+    params.radiuses.push_back(boost::none);
+
+    json::Object result;
+
+    const auto rc = osrm.Table(params, result);
+
+    BOOST_CHECK(rc == Status::Error);
+    const auto code = result.values.at("code").get<json::String>().value;
+    BOOST_CHECK_EQUAL(code, "NoSegment");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
We failed to check if we could actually find phantom nodes for all
coordinates in the table plugin, leading to corrupt internal state.

```
curl 'http://localhost:5000/table/v1/car/7.4151,43.7305;7.4222,43.7368?radiuses=0;'
```

```
[assert][140505627227904] /tmp/osrm-backend/include/engine/routing_algorithms/routing_base.hpp:68
in: void osrm::engine::routing_algorithms::insertNodesInHeap(osrm::engine::SearchEngineData<osrm::engine::routing_algorithms::ch::Algorithm>::ManyToManyQueryHeap&, const osrm::engine::PhantomNode&) [with bool DIRECTION = false; osrm::engine::SearchEngineData<osrm::engine::routing_algorithms::ch::Algorithm>::ManyToManyQueryHeap = osrm::util::BinaryHeap<unsigned int, unsigned int, int, osrm::engine::ManyToManyHeapData, osrm::util::UnorderedMapStorage<unsigned int, int> >]: phantom_node.IsValid()
terminate called without an active exception
```
