### PR TITLE
Implements `unlimited` as dont-care for radiuses option in Node.js bindings

### DIFF
--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -442,6 +442,11 @@ inline bool argumentsToParameter(const Nan::FunctionCallbackInfo<v8::Value> &arg
             {
                 params->radiuses.emplace_back();
             }
+            else if (radius->IsString() &&
+                     *v8::String::Utf8Value(radius) == std::string("unlimited"))
+            {
+                params->radiuses.emplace_back();
+            }
             else if (radius->IsNumber() && radius->NumberValue() >= 0)
             {
                 params->radiuses.push_back(static_cast<double>(radius->NumberValue()));

--- a/src/nodejs/CMakeLists.txt
+++ b/src/nodejs/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.1)
 
 message(STATUS "Building node_osrm")
 
+if (NOT EXISTS "${PROJECT_SOURCE_DIR}/node_modules")
+  message(FATAL_ERROR "NodeJs bindings require NAN, get it via: npm install --ignore-scripts")
+endif()
+
 set(BINDING_DIR "${PROJECT_SOURCE_DIR}/lib/binding")
 
 include(NodeJS)

--- a/test/nodejs/route.js
+++ b/test/nodejs/route.js
@@ -456,7 +456,7 @@ test('route: throws on bad hints', function(assert) {
 });
 
 test('route: routes Monaco with valid radius values', function(assert) {
-    assert.plan(3);
+    assert.plan(4);
     var osrm = new OSRM(monaco_path);
     var options = {
         coordinates: two_test_coordinates,
@@ -470,6 +470,10 @@ test('route: routes Monaco with valid radius values', function(assert) {
         assert.ifError(err);
     });
     options.radiuses = [100, null];
+    osrm.route(options, function(err, route) {
+        assert.ifError(err);
+    });
+    options.radiuses = [100, 'unlimited'];
     osrm.route(options, function(err, route) {
         assert.ifError(err);
     });


### PR DESCRIPTION
For #3998. Brings Node.js bindings closer to what we advertise in the v5 API ..


Second commit checking for `node_modules` since without `npm install --ignore-scripts` error messages when compiling the Node.js bindings are atrocious.