### PR TITLE
Use CSV mmaped files

### DIFF
--- a/features/car/traffic_turn_penalties.feature
+++ b/features/car/traffic_turn_penalties.feature
@@ -48,7 +48,6 @@ Feature: Traffic - turn penalties
             | mn    | primary |
             | mp    | primary |
         And the profile "car"
-        And the extract extra arguments "--generate-edge-lookup"
 
     Scenario: Weighting not based on turn penalty file
         When I route I should get

--- a/features/car/weight.feature
+++ b/features/car/weight.feature
@@ -51,7 +51,6 @@ Feature: Car - weights
             | cd    | primary | yes    |
             | be    | service | yes    |
             | ec    | service | yes    |
-        And the extract extra arguments "--generate-edge-lookup"
         And the contract extra arguments "--segment-speed-file {speeds_file}"
         And the customize extra arguments "--segment-speed-file {speeds_file}"
         And the speed file

--- a/features/options/contract/edge-weight-updates-over-factor.feature
+++ b/features/options/contract/edge-weight-updates-over-factor.feature
@@ -20,7 +20,7 @@ Feature: osrm-contract command line option: edge-weight-updates-over-factor
         And the data has been saved to disk
 
     Scenario: Logging weight with updates over factor of 2, long segment
-        When I run "osrm-extract --profile {profile_file} {osm_file} --generate-edge-lookup"
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
         When I run "osrm-contract --edge-weight-updates-over-factor 2 --segment-speed-file {speeds_file} {processed_file}"
         Then stderr should not contain "Speed values were used to update 2 segment(s)"
         And stderr should contain "Segment: 1,2"
@@ -44,6 +44,6 @@ Feature: osrm-contract command line option: edge-weight-updates-over-factor
         """
         And the data has been saved to disk
 
-        When I run "osrm-extract --profile {profile_file} {osm_file} --generate-edge-lookup"
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
         When I run "osrm-contract --edge-weight-updates-over-factor 2 --segment-speed-file {speeds_file} {processed_file}"
         Then stderr should contain "Speed values were used to update 2 segments for 'steps' profile"

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -4,7 +4,6 @@ Feature: Basic Map Matching
     Background:
         Given the profile "testbot"
         Given a grid size of 10 meters
-        Given the extract extra arguments "--generate-edge-lookup"
         Given the query options
             | geometries | geojson |
 

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -22,7 +22,6 @@ Feature: Traffic - speeds
           | df    | primary |
           | fb    | primary |
         And the profile "testbot"
-        And the extract extra arguments "--generate-edge-lookup"
 
 
     Scenario: Weighting based on speed file

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -153,3 +153,11 @@ Feature: Traffic - speeds
         When I try to run "osrm-contract --segment-speed-file {speeds_file} {processed_file}"
         And stderr should contain "malformed"
         And it should exit with an error
+
+    Scenario: Check with an empty speed file
+        Given the speed file
+        """
+        """
+        And the data has been extracted
+        When I try to run "osrm-contract --segment-speed-file {speeds_file} {processed_file}"
+        And it should exit successfully

--- a/features/testbot/traffic_turn_penalties.feature
+++ b/features/testbot/traffic_turn_penalties.feature
@@ -31,7 +31,6 @@ Feature: Traffic - turn penalties applied to turn onto which a phantom node snap
             | dg    | primary |
         And the profile "testbot"
         # Since testbot doesn't have turn penalties, a penalty from file of 0 should produce a neutral effect
-        And the extract extra arguments "--generate-edge-lookup"
 
     Scenario: Weighting based on turn penalty file, with an extreme negative value -- clamps and does not fail
         Given the turn penalty file

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -4,7 +4,6 @@ Feature: Weight tests
     Background:
         Given the profile "testbot"
         Given a grid size of 10 meters
-        Given the extract extra arguments "--generate-edge-lookup"
         Given the query options
             | geometries | geojson |
 

--- a/include/updater/csv_file_parser.hpp
+++ b/include/updater/csv_file_parser.hpp
@@ -23,11 +23,6 @@ namespace osrm
 namespace updater
 {
 
-namespace
-{
-namespace qi = boost::spirit::qi;
-}
-
 // Functor to parse a list of CSV files using "key,value,comment" grammar.
 // Key and Value structures must be a model of Random Access Sequence.
 // Also the Value structure must have source member that will be filled
@@ -35,8 +30,8 @@ namespace qi = boost::spirit::qi;
 template <typename Key, typename Value> struct CSVFilesParser
 {
     using Iterator = boost::iostreams::mapped_file_source::iterator;
-    using KeyRule = qi::rule<Iterator, Key()>;
-    using ValueRule = qi::rule<Iterator, Value()>;
+    using KeyRule = boost::spirit::qi::rule<Iterator, Key()>;
+    using ValueRule = boost::spirit::qi::rule<Iterator, Value()>;
 
     CSVFilesParser(std::size_t start_index, const KeyRule &key_rule, const ValueRule &value_rule)
         : start_index(start_index), key_rule(key_rule), value_rule(value_rule)
@@ -94,6 +89,8 @@ template <typename Key, typename Value> struct CSVFilesParser
     // Parse a single CSV file and return result as a vector<Key, Value>
     auto ParseCSVFile(const std::string &filename, std::size_t file_id) const
     {
+        namespace qi = boost::spirit::qi;
+
         std::vector<std::pair<Key, Value>> result;
         try
         {
@@ -105,7 +102,7 @@ template <typename Key, typename Value> struct CSVFilesParser
 
             BOOST_ASSERT(file_id <= std::numeric_limits<std::uint8_t>::max());
             ValueRule value_source =
-                value_rule[qi::_val = qi::_1, boost::phoenix::bind(&Value::source, qi::_val) = file_id];
+                value_rule[qi::_val = qi::_1, bind(&Value::source, qi::_val) = file_id];
             qi::rule<Iterator, std::pair<Key, Value>()> csv_line =
                 (key_rule >> ',' >> value_source) >> -(',' >> *(qi::char_ - qi::eol));
             const auto ok = qi::parse(first, last, -(csv_line % qi::eol) >> *qi::eol, result);
@@ -117,8 +114,8 @@ template <typename Key, typename Value> struct CSVFilesParser
                     --begin_of_line;
                 auto line_number = std::count(mmap.begin(), first, '\n') + 1;
                 const auto message = boost::format("CSV file %1% malformed on line %2%:\n %3%\n") %
-                    filename % std::to_string(line_number) %
-                    std::string(begin_of_line + 1, std::find(first, last, '\n'));
+                                     filename % std::to_string(line_number) %
+                                     std::string(begin_of_line + 1, std::find(first, last, '\n'));
                 throw util::exception(message.str() + SOURCE_REF);
             }
 
@@ -126,10 +123,10 @@ template <typename Key, typename Value> struct CSVFilesParser
 
             return std::move(result);
         }
-        catch (const boost::exception& e)
+        catch (const boost::exception &e)
         {
-            const auto message = boost::format("exception in loading %1%:\n %2%") %
-                filename % boost::diagnostic_information(e);
+            const auto message = boost::format("exception in loading %1%:\n %2%") % filename %
+                                 boost::diagnostic_information(e);
             throw util::exception(message.str() + SOURCE_REF);
         }
     }


### PR DESCRIPTION
# Issue

Benchmarking of #3974 for ~3GB CSV files shows that ~3 minutes loading time was spent in the stream `std::ifstream` with iterators wrapped into `boost::spirit::line_pos_iterator` that are used used by qi as `boost::spirit::multi_pass` iterators. This PR changes `std::ifstream` to `boost::iostreams::mapped_file_source` and reduces loading time for benchmark to ~35-40 seconds with ~10 seconds used for parsing.

/cc @danpat 

## Tasklist
 - [x] review
 - [x] adjust for comments

