### PR TITLE
fix continue_straight interaction with bearing specification

### DIFF
--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -352,3 +352,64 @@ Feature: Via points
             | waypoints | bearings   | route    | turns                    |
             | 1,a       | 90,2 270,2 | ab,ab,ab | depart,turn uturn,arrive |
             | 1,b       | 270,2 90,2 | ab,ab,ab | depart,turn uturn,arrive |
+
+    Scenario: Continue Straight in presence of Bearings
+        Given the node map
+            """
+            h - a 1 b -- g
+                |   |
+                |   |- 2 c - f
+                |        3
+                e ------ d - i
+                         |
+                         j
+            """
+
+        And the query options
+            | continue_straight | false |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | no     |
+            | bc    | no     |
+            | cdea  | no     |
+            | ah    | yes    |
+            | bg    | yes    |
+            | cf    | yes    |
+            | di    | yes    |
+            | dj    | yes    |
+
+        When I route I should get
+            | waypoints | bearings               | route                           |
+            | 1,2,3     | 270,90 180,180 180,180 | ab,cdea,cdea,bc,bc,bc,cdea,cdea |
+
+    Scenario: Continue Straight in presence of Bearings
+        Given the node map
+            """
+            h - a 1 b -- g
+                |   |
+                |   |- 2 c - f
+                |        3
+                e ------ d - i
+                         |
+                         j
+            """
+
+        And the query options
+            | continue_straight | true |
+
+        And the ways
+            | nodes | oneway |
+            | ab    | no     |
+            | bc    | no     |
+            | cdea  | no     |
+            | ah    | yes    |
+            | bg    | yes    |
+            | cf    | yes    |
+            | di    | yes    |
+            | dj    | yes    |
+
+        When I route I should get
+            | waypoints | bearings               | route                                   |
+            | 1,2,3     | 270,90 180,180 180,180 | ab,cdea,cdea,bc,bc,bc,ab,cdea,cdea,cdea |
+

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -77,27 +77,10 @@ ViaRoutePlugin::HandleRequest(const datafacade::ContiguousInternalMemoryDataFaca
 
     auto snapped_phantoms = SnapPhantomNodes(phantom_node_pairs);
 
-    const bool continue_straight_at_waypoint = route_parameters.continue_straight
-                                                   ? *route_parameters.continue_straight
-                                                   : facade.GetContinueStraightDefault();
-
     std::vector<PhantomNodes> start_end_nodes;
-    auto build_phantom_pairs = [&start_end_nodes, continue_straight_at_waypoint](
-        const PhantomNode &first_node, const PhantomNode &second_node) {
+    auto build_phantom_pairs = [&start_end_nodes](const PhantomNode &first_node,
+                                                  const PhantomNode &second_node) {
         start_end_nodes.push_back(PhantomNodes{first_node, second_node});
-        auto &last_inserted = start_end_nodes.back();
-        // enable forward direction if possible
-        if (last_inserted.source_phantom.forward_segment_id.id != SPECIAL_SEGMENTID)
-        {
-            last_inserted.source_phantom.forward_segment_id.enabled |=
-                !continue_straight_at_waypoint;
-        }
-        // enable reverse direction if possible
-        if (last_inserted.source_phantom.reverse_segment_id.id != SPECIAL_SEGMENTID)
-        {
-            last_inserted.source_phantom.reverse_segment_id.enabled |=
-                !continue_straight_at_waypoint;
-        }
     };
     util::for_each_pair(snapped_phantoms, build_phantom_pairs);
 


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/4011

It seems that we incorrectly disabled segments via the continue_straight parameter.
Continue_straight is a via-only parameter and can only be evaluated during the query.
From my understanding, we should not disable start/end locations in the viaplugin.

The added tests show the fixed behaviour when using bearings with continue_straight.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

