### PR TITLE
Fix docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     cd /src && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
-    echo "Building OSRM gitsha ${cat /opt/OSRM_GITSHA}" && \
+    echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
     mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_LTO=On .. && \


### PR DESCRIPTION
# Issue

This is embarrassing. I did not check https://github.com/Project-OSRM/osrm-backend/pull/3986 correctly and the Dockerfile did not actually build. Fixed this now (and tested locally). 

We've had failing Docker Cloud builds since https://github.com/Project-OSRM/osrm-backend/pull/3986 merged, but since Docker Cloud does not support feedback back to Github, we did not actually see that. I hope that having the gitsha in the docker image will help detecting such failures earlier. 

Will merge right away.

/cc @TheMarex