### PR TITLE
Make docker image with assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ In case Docker complains about not being able to connect to the Docker daemon ma
 
 After adding yourself to the `docker` group make sure to log out and back in again with your terminal.
 
+We support the following images on Docker Cloud:
+
+Name | Description
+-----|------
+`latest` | `master` compiled with release flag
+`latest-assertions` | `master` compiled with with release flag, assertions enabled and debug symbols
+`latest-debug` | `master` compiled with debug flag
+`<tag>` | specific tag compiled with release flag
+`<tag>-debug` | specific tag compiled with debug flag
 
 ### Building from Source
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,9 @@
 FROM alpine:3.5
 
-ARG DOCKER_TAG
-
-RUN mkdir /src
-COPY . /src
-
 RUN mkdir /opt
 WORKDIR /opt
+
 RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
-    case ${DOCKER_TAG} in *"-debug"*) BUILD_TYPE="Debug";; *) BUILD_TYPE="Release";; esac && \
-    \
     echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk update && \
     apk upgrade && \
@@ -23,15 +17,26 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j${NPROC} && \
-    make install && \
-    \
+    make install
+
+ARG DOCKER_TAG
+RUN mkdir /src
+COPY . /src
+WORKDIR /src
+
+RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     echo "Building OSRM ${DOCKER_TAG}" && \
-    cd /src && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
     mkdir build && \
     cd build && \
-    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_LTO=On .. && \
+    BUILD_TYPE="Release" && \
+    ENABLE_ASSERTIONS="Off" && \
+    BUILD_TOOLS="Off" && \
+    case ${DOCKER_TAG} in *"-debug"*) BUILD_TYPE="Debug";; esac && \
+    case ${DOCKER_TAG} in *"-assertions"*) BUILD_TYPE="RelWithDebInfo" && ENABLE_ASSERTIONS="On" && BUILD_TOOLS="On";; esac && \
+    echo "Building ${BUILD_TYPE} with ENABLE_ASSERTIONS=${ENABLE_ASSERTIONS} BUILD_TOOLS=${BUILD_TOOLS}" && \
+    cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS} -DBUILD_TOOLS=${BUILD_TOOLS} -DENABLE_LTO=On && \
     make -j${NPROC} install && \
     cd ../profiles && \
     cp -r * /opt && \


### PR DESCRIPTION
# Issue

We should build another class of docker images, that includes debug symbols and assertions. This will allow us to debug problems happening on large-scale datasets.

Sadly locally osrm doesn't build for me in assertion mode. Need to dig into that. Error message in details below.

## Tasklist
 - [x] Make sure docker images build locally in `release`, `debug` and `assertions` mode
 - [x] Add `latest-assertions` build rule to Docker Cloud
 - [ ] Merge

<details>

```
Scanning dependencies of target EXTRACTOR
[ 24%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/compressed_edge_container.cpp.o
[ 25%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/edge_based_graph_factory.cpp.o
[ 25%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/extraction_containers.cpp.o
c++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report,
with preprocessed source if appropriate.
See <http://gcc.gnu.org/bugs.html> for instructions.
make[2]: *** [CMakeFiles/SERVER.dir/build.make:159: CMakeFiles/SERVER.dir/src/server/api/parameters_parser.cpp.o] Error 4
make[1]: *** [CMakeFiles/Makefile2:176: CMakeFiles/SERVER.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 27%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/extractor.cpp.o
[ 27%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/extractor_callbacks.cpp.o
[ 29%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/graph_compressor.cpp.o
[ 29%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/raster_source.cpp.o
[ 30%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/restriction_map.cpp.o
[ 30%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/restriction_parser.cpp.o
[ 32%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/scripting_environment_lua.cpp.o
[ 32%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/suffix_table.cpp.o
[ 33%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/coordinate_extractor.cpp.o
[ 33%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/intersection.cpp.o
[ 35%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/intersection_generator.cpp.o
[ 35%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/intersection_handler.cpp.o
[ 37%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/intersection_normalizer.cpp.o
[ 37%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/mergable_road_detector.cpp.o
[ 38%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/motorway_handler.cpp.o
[ 38%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/node_based_graph_walker.cpp.o
[ 40%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/roundabout_handler.cpp.o
[ 40%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/sliproad_handler.cpp.o
[ 41%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/suppress_mode_handler.cpp.o
[ 41%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_analysis.cpp.o
[ 43%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_classification.cpp.o
[ 43%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_discovery.cpp.o
[ 45%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_handler.cpp.o
[ 45%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_lane_augmentation.cpp.o
[ 46%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_lane_data.cpp.o
[ 46%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_lane_handler.cpp.o
[ 48%] Building CXX object CMakeFiles/EXTRACTOR.dir/src/extractor/guidance/turn_lane_matcher.cpp.o
[ 48%] Built target EXTRACTOR
make: *** [Makefile:128: all] Error 2
```
