### PR TITLE
Disable boost::interprocess condition variables on Linux

### DIFF
--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -12,7 +12,8 @@
 #include <boost/interprocess/sync/scoped_lock.hpp>
 
 #if defined(__linux__)
-#define USE_BOOST_INTERPROCESS_CONDITION 1
+// See issue #3911, boost interprocess is broken with a glibc > 2.25
+// #define USE_BOOST_INTERPROCESS_CONDITION 1
 #endif
 
 namespace osrm


### PR DESCRIPTION
# Issue

This "fixes" issue #3911 by not using the glibc based POSIX conditions variables in shared memory because they break on 2.25.

## Tasklist
 - [x] review
 - [x] adjust for comments
