### PR TITLE
Add response code  to result values

### DIFF
--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -16,9 +16,12 @@ module.exports = function () {
 
                     var headers = new Set(table.raw()[0]);
 
+                    got.code = 'unknown';
                     if (res.body.length) {
                         json = JSON.parse(res.body);
+                        got.code = json.code;
                     }
+
 
                     if (headers.has('status')) {
                         got.status = json.status.toString();
@@ -33,7 +36,7 @@ module.exports = function () {
                         got['#'] = row['#'];
                     }
 
-                    var subMatchings = [],
+                    var subMatchings = [''],
                         turns = '',
                         route = '',
                         duration = '',

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -39,6 +39,8 @@ module.exports = function () {
 
                         let json = JSON.parse(body);
 
+                        got.code = json.code;
+
                         let hasRoute = json.code === 'Ok';
 
                         if (hasRoute) {


### PR DESCRIPTION
# Issue

PR adds `json.code` to result values that can be checked as 
```
        When I route I should get
          | from | to | bearings | code    |
          |    1 |  2 | 270 270  | NoRoute |
```

Fixes  #3993

/cc @daniel-j-h 

## Tasklist
 - [x] review
 - [x] adjust for comments
