### PR TITLE
Refactor osrm-extract and osrm-contract to use osrm lib interface

### DIFF
--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -1,7 +1,6 @@
-#include "contractor/contractor.hpp"
-#include "contractor/contractor_config.hpp"
-#include "extractor/profile_properties.hpp"
 #include "storage/io.hpp"
+#include "osrm/contractor.hpp"
+#include "osrm/contractor_config.hpp"
 #include "util/log.hpp"
 #include "util/version.hpp"
 
@@ -170,12 +169,12 @@ int main(int argc, char *argv[]) try
 
     tbb::task_scheduler_init init(contractor_config.requested_num_threads);
 
-    auto exitcode = contractor::Contractor(contractor_config).Run();
+    osrm::contract(contractor_config);
 
     util::DumpSTXXLStats();
     util::DumpMemoryStats();
 
-    return exitcode;
+    return EXIT_SUCCESS;
 }
 catch (const std::bad_alloc &e)
 {

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -1,6 +1,5 @@
-#include "extractor/extractor.hpp"
-#include "extractor/extractor_config.hpp"
-#include "extractor/scripting_environment_lua.hpp"
+#include "osrm/extractor.hpp"
+#include "osrm/extractor_config.hpp"
 #include "util/log.hpp"
 #include "util/version.hpp"
 
@@ -156,15 +155,12 @@ int main(int argc, char *argv[]) try
         return EXIT_FAILURE;
     }
 
-    // setup scripting environment
-    extractor::Sol2ScriptingEnvironment scripting_environment(
-        extractor_config.profile_path.string().c_str());
-    auto exitcode = extractor::Extractor(extractor_config).run(scripting_environment);
+    osrm::extract(extractor_config);
 
     util::DumpSTXXLStats();
     util::DumpMemoryStats();
 
-    return exitcode;
+    return EXIT_SUCCESS;
 }
 catch (const std::bad_alloc &e)
 {


### PR DESCRIPTION
Simplifies implementation of the tools slightly.
Ensures `osrm::extract` and `osrm::contract` keep working.

Follows up PR #3787 (see https://github.com/Project-OSRM/osrm-backend/pull/3787#issuecomment-285090810)
