### PR TITLE
Fix for overlapping ways in invalidateExitAgainstDirection

### DIFF
--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -768,3 +768,28 @@ Feature: Basic Roundabout
            | g,f       | 45 90    | gch,edf,edf | depart,roundabout-exit-2,arrive |
            | g,h       | 45 135   | gch,gch,gch | depart,roundabout-exit-1,arrive |
            | e,e       | 90 270   | edf,edf,edf | depart,roundabout-exit-3,arrive |
+
+    Scenario: CCW and CW roundabouts with overlaps
+        Given the node map
+            """
+            a   d          g   h
+
+            b   c          j   i
+            f   e          k   l
+            """
+
+        And the ways
+            | nodes | highway  | junction   |
+            | abcda | tertiary | roundabout |
+            | ed    | tertiary |            |
+            | af    | tertiary |            |
+            | ghijg | tertiary | roundabout |
+            | kg    | tertiary |            |
+            | hl    | tertiary |            |
+
+        When I route I should get
+            | from | to | route    | turns                           | distance |
+            | e    | f  | ed,af,af | depart,roundabout-exit-1,arrive | 80.1m    |
+            | f    | e  | af,ed,ed | depart,roundabout-exit-1,arrive | 120.1m   |
+            | k    | l  | kg,hl,hl | depart,roundabout-exit-1,arrive | 80.1m    |
+            | l    | k  | hl,kg,kg | depart,roundabout-exit-1,arrive | 120.1m   |

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -279,7 +279,8 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
     };
 
     // due to merging of roads, the u-turn might actually not be part of the intersection anymore
-    const auto uturn_bearing = [&]() {
+    // uturn is a pair of {edge id, bearing}
+    const auto uturn = [&]() {
         const auto merge_entry = std::find_if(
             performed_merges.begin(), performed_merges.end(), [&uturn_edge_itr](const auto entry) {
                 return entry.merged_eid == uturn_edge_itr->eid;
@@ -292,7 +293,8 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
                 normalized_intersection.end(),
                 [&](const IntersectionShapeData &road) { return road.eid == merged_into_id; });
             BOOST_ASSERT(merged_u_turn != normalized_intersection.end());
-            return util::bearing::reverse(merged_u_turn->bearing);
+            return std::make_pair(merged_u_turn->eid,
+                                  util::bearing::reverse(merged_u_turn->bearing));
         }
         else
         {
@@ -302,7 +304,9 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
                              connect_to_previous_node);
             BOOST_ASSERT(uturn_edge_at_normalized_intersection_itr !=
                          normalized_intersection.end());
-            return util::bearing::reverse(uturn_edge_at_normalized_intersection_itr->bearing);
+            return std::make_pair(
+                uturn_edge_at_normalized_intersection_itr->eid,
+                util::bearing::reverse(uturn_edge_at_normalized_intersection_itr->bearing));
         }
     }();
 
@@ -315,7 +319,7 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
                        return IntersectionViewData(
                            road,
                            is_allowed_turn(road),
-                           util::bearing::angleBetween(uturn_bearing, road.bearing));
+                           util::bearing::angleBetween(uturn.second, road.bearing));
                    });
 
     const auto uturn_edge_at_intersection_view_itr =
@@ -370,9 +374,22 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
               std::end(intersection_view),
               std::mem_fn(&IntersectionViewData::CompareByAngle));
 
-    OSRM_ASSERT(intersection_view[0].angle >= 0. &&
-                    intersection_view[0].angle < std::numeric_limits<double>::epsilon(),
+    // Move entering_via_edge to intersection front and place all roads prior entering_via_edge
+    // at the end of the intersection view with 360° angle
+    auto entering_via_it = std::find_if(intersection_view.begin(),
+                                        intersection_view.end(),
+                                        [&uturn](auto &road) { return road.eid == uturn.first; });
+
+    OSRM_ASSERT(entering_via_it != intersection_view.end() && entering_via_it->angle >= 0. &&
+                    entering_via_it->angle < std::numeric_limits<double>::epsilon(),
                 coordinates[node_at_intersection]);
+
+    if (entering_via_it != intersection_view.begin() && entering_via_it != intersection_view.end())
+    {
+        std::for_each(
+            intersection_view.begin(), entering_via_it, [](auto &road) { road.angle = 360.; });
+        std::rotate(intersection_view.begin(), entering_via_it, intersection_view.end());
+    }
 
     return intersection_view;
 }

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -1,6 +1,7 @@
 #include "extractor/guidance/roundabout_handler.hpp"
 #include "extractor/guidance/constants.hpp"
 
+#include "util/assert.hpp"
 #include "util/bearing.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/guidance/name_announcements.hpp"
@@ -157,6 +158,8 @@ void RoundaboutHandler::invalidateExitAgainstDirection(const NodeID from_nid,
             }
         }
     }
+
+    OSRM_ASSERT(invalidate_from <= invalidate_to, coordinates[from_nid]);
 
     // Exiting roundabouts at an entry point is technically a data-modelling issue.
     // This workaround handles cases in which an exit precedes and entry. The resulting


### PR DESCRIPTION
# Issue

PR fixes invalidateExitAgainstDirection in case of overlapping ways, issue #4024 

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x]  fix the issue
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
