### PR TITLE
Use foot profile in bike profile

### DIFF
--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -7,126 +7,216 @@ Feature: Bike - Access tags on ways
 
     Scenario: Bike - Access tag hierarchy on ways
         Then routability should be
-            | highway | access | vehicle | bicycle | bothw   |
-            | primary |        |         |         | cycling |
-            | primary | yes    |         |         | cycling |
-            | primary | no     |         |         |         |
-            | primary |        | yes     |         | cycling |
-            | primary |        | no      |         |         |
-            | primary | no     | yes     |         | cycling |
-            | primary | yes    | no      |         |         |
-            | primary |        |         | yes     | cycling |
-            | primary |        |         | no      |         |
-            | primary | no     |         | yes     | cycling |
-            | primary | yes    |         | no      |         |
-            | primary |        | no      | yes     | cycling |
-            | primary |        | yes     | no      |         |
+            | access | vehicle | bicycle  | bothw        |
+            |        |         |          | cycling      |
+            |        |         | yes      | cycling      |
+            |        |         | no       |              |
+            |        |         | dismount | pushing bike |
+            |        | yes     |          | cycling      |
+            |        | yes     | yes      | cycling      |
+            |        | yes     | no       |              |
+            |        | yes     | dismount | pushing bike |
+            |        | no      |          | pushing bike |
+            |        | no      | yes      | cycling      |
+            |        | no      | no       |              |
+            |        | no      | dismount | pushing bike |
+            | yes    |         |          | cycling      |
+            | yes    |         | yes      | cycling      |
+            | yes    |         | no       |              |
+            | yes    |         | dismount | pushing bike |
+            | yes    | yes     |          | cycling      |
+            | yes    | yes     | yes      | cycling      |
+            | yes    | yes     | no       |              |
+            | yes    | yes     | dismount | pushing bike |
+            | yes    | no      |          | pushing bike |
+            | yes    | no      | yes      | cycling      |
+            | yes    | no      | no       |              |
+            | yes    | no      | dismount | pushing bike |
+            | no     |         |          |              |
+            | no     |         | yes      | cycling      |
+            | no     |         | no       |              |
+            | no     |         | dismount |              |
+            | no     | yes     |          | cycling      |
+            | no     | yes     | yes      | cycling      |
+            | no     | yes     | no       |              |
+            | no     | yes     | dismount |              |
+            | no     | no      |          |              |
+            | no     | no      | yes      | cycling      |
+            | no     | no      | no       |              |
+            | no     | no      | dismount |              |
 
-    @todo
+    Scenario: Bike - Access tag for both bicycle and foot
+        Then routability should be
+            | access | foot | bicycle  | bothw        |
+            |        |      |          | cycling      |
+            |        |      | yes      | cycling      |
+            |        |      | no       |              |
+            |        |      | dismount | pushing bike |
+            |        | yes  |          | cycling      |
+            |        | yes  | yes      | cycling      |
+            |        | yes  | no       |              |
+            |        | yes  | dismount | pushing bike |
+            |        | no   |          | cycling      |
+            |        | no   | yes      | cycling      |
+            |        | no   | no       |              |
+            |        | no   | dismount |              |
+            | yes    |      |          | cycling      |
+            | yes    |      | yes      | cycling      |
+            | yes    |      | no       |              |
+            | yes    |      | dismount | pushing bike |
+            | yes    | yes  |          | cycling      |
+            | yes    | yes  | yes      | cycling      |
+            | yes    | yes  | no       |              |
+            | yes    | yes  | dismount | pushing bike |
+            | yes    | no   |          | cycling      |
+            | yes    | no   | yes      | cycling      |
+            | yes    | no   | no       |              |
+            | yes    | no   | dismount |              |
+            | no     |      |          |              |
+            | no     |      | yes      | cycling      |
+            | no     |      | no       |              |
+            | no     |      | dismount |              |
+            | no     | yes  |          | pushing bike |
+            | no     | yes  | yes      | cycling      |
+            | no     | yes  | no       |              |
+            | no     | yes  | dismount | pushing bike |
+            | no     | no   |          |              |
+            | no     | no   | yes      | cycling      |
+            | no     | no   | no       |              |
+            | no     | no   | dismount |              |
+
     Scenario: Bike - Access tag in forward direction
         Then routability should be
-            | highway | access:forward | vehicle:forward | bicycle:forward | forw    | backw |
-            | primary |                |                 |                 | cycling |       |
-            | primary | yes            |                 |                 | cycling |       |
-            | primary | no             |                 |                 |         |       |
-            | primary |                | yes             |                 | cycling |       |
-            | primary |                | no              |                 |         |       |
-            | primary | no             | yes             |                 | cycling |       |
-            | primary | yes            | no              |                 |         |       |
-            | primary |                |                 | yes             | cycling |       |
-            | primary |                |                 | no              |         |       |
-            | primary | no             |                 | yes             | cycling |       |
-            | primary | yes            |                 | no              |         |       |
-            | primary |                | no              | yes             | cycling |       |
-            | primary |                | yes             | no              |         |       |
-            | runway  |                |                 |                 | cycling |       |
-            | runway  | yes            |                 |                 | cycling |       |
-            | runway  | no             |                 |                 |         |       |
-            | runway  |                | yes             |                 | cycling |       |
-            | runway  |                | no              |                 |         |       |
-            | runway  | no             | yes             |                 | cycling |       |
-            | runway  | yes            | no              |                 |         |       |
-            | runway  |                |                 | yes             | cycling |       |
-            | runway  |                |                 | no              |         |       |
-            | runway  | no             |                 | yes             | cycling |       |
-            | runway  | yes            |                 | no              |         |       |
-            | runway  |                | no              | yes             | cycling |       |
-            | runway  |                | yes             | no              |         |       |
+            | access:forward | vehicle:forward | bicycle:forward | forw         | backw   |
+            |                |                 |                 | cycling      | cycling |
+            | no             |                 |                 |              | cycling |
+            | yes            | no              |                 | pushing bike | cycling |
+            |                | yes             | no              | pushing bike | cycling |
+            | yes            |                 |                 | cycling      | cycling |
+            | no             | yes             |                 | cycling      | cycling |
+            |                | no              | yes             | cycling      | cycling |
 
-    @todo
     Scenario: Bike - Access tag in backward direction
         Then routability should be
-            | highway | access:forward | vehicle:forward | bicycle:forward | forw | backw   |
-            | primary |                |                 |                 |      | cycling |
-            | primary | yes            |                 |                 |      | cycling |
-            | primary | no             |                 |                 |      |         |
-            | primary |                | yes             |                 |      | cycling |
-            | primary |                | no              |                 |      |         |
-            | primary | no             | yes             |                 |      | cycling |
-            | primary | yes            | no              |                 |      |         |
-            | primary |                |                 | yes             |      | cycling |
-            | primary |                |                 | no              |      |         |
-            | primary | no             |                 | yes             |      | cycling |
-            | primary | yes            |                 | no              |      |         |
-            | primary |                | no              | yes             |      | cycling |
-            | primary |                | yes             | no              |      |         |
-            | runway  |                |                 |                 |      | cycling |
-            | runway  | yes            |                 |                 |      | cycling |
-            | runway  | no             |                 |                 |      |         |
-            | runway  |                | yes             |                 |      | cycling |
-            | runway  |                | no              |                 |      |         |
-            | runway  | no             | yes             |                 |      | cycling |
-            | runway  | yes            | no              |                 |      |         |
-            | runway  |                |                 | yes             |      | cycling |
-            | runway  |                |                 | no              |      |         |
-            | runway  | no             |                 | yes             |      | cycling |
-            | runway  | yes            |                 | no              |      |         |
-            | runway  |                | no              | yes             |      | cycling |
-            | runway  |                | yes             | no              |      |         |
+            | access:backward | vehicle:backward | bicycle:backward | forw    | backw        |
+            |                 |                  |                  | cycling | cycling      |
+            | no              |                  |                  | cycling |              |
+            | yes             | no               |                  | cycling | pushing bike |
+            |                 | yes              | no               | cycling | pushing bike |
+            | yes             |                  |                  | cycling | cycling      |
+            | no              | yes              |                  | cycling | cycling      |
+            |                 | no               | yes              | cycling | cycling      |
+
 
     Scenario: Bike - Overwriting implied acccess on ways
         Then routability should be
-            | highway  | access | vehicle | bicycle | bothw   |
-            | cycleway |        |         |         | cycling |
-            | runway   |        |         |         |         |
-            | cycleway | no     |         |         |         |
-            | cycleway |        | no      |         |         |
-            | cycleway |        |         | no      |         |
-            | runway   | yes    |         |         | cycling |
-            | runway   |        | yes     |         | cycling |
-            | runway   |        |         | yes     | cycling |
+            | highway  | access | vehicle | bicycle | foot | bothw        |
+            | cycleway |        |         |         |      | cycling      |
+            | runway   |        |         |         |      |              |
+            | cycleway | no     |         |         |      |              |
+            | cycleway |        | no      |         |      |              |
+            | cycleway |        |         | no      |      |              |
+            | cycleway |        |         |         | no   | cycling      |
+            | runway   | yes    |         |         |      | cycling      |
+            | runway   |        | yes     |         |      | cycling      |
+            | runway   |        |         | yes     |      | cycling      |
+            | runway   |        |         |         | yes  | pushing bike |
 
-    Scenario: Bike - Access tags on ways
+    Scenario: Bike - Access tags on ways where you can bike
         Then routability should be
-            | access       | vehicle      | bicycle      | bothw   |
-            |              |              |              | cycling |
-            | yes          |              |              | cycling |
-            | permissive   |              |              | cycling |
-            | designated   |              |              | cycling |
-            | some_tag     |              |              | cycling |
-            | no           |              |              |         |
-            | private      |              |              |         |
-            | agricultural |              |              |         |
-            | forestry     |              |              |         |
-            | delivery     |              |              |         |
-            |              | yes          |              | cycling |
-            |              | permissive   |              | cycling |
-            |              | designated   |              | cycling |
-            |              | some_tag     |              | cycling |
-            |              | no           |              |         |
-            |              | private      |              |         |
-            |              | agricultural |              |         |
-            |              | forestry     |              |         |
-            |              | delivery     |              |         |
-            |              |              | yes          | cycling |
-            |              |              | permissive   | cycling |
-            |              |              | designated   | cycling |
-            |              |              | some_tag     | cycling |
-            |              |              | no           |         |
-            |              |              | private      |         |
-            |              |              | agricultural |         |
-            |              |              | forestry     |         |
-            |              |              | delivery     |         |
+            | highway | access       | bicycle      | foot         | bothw        |
+            |         |              |              |              | cycling      |
+            | primary | yes          |              |              | cycling      |
+            | primary | permissive   |              |              | cycling      |
+            | primary | designated   |              |              | cycling      |
+            | primary | some_tag     |              |              | cycling      |
+            | primary | no           |              |              |              |
+            | primary | private      |              |              |              |
+            | primary | agricultural |              |              |              |
+            | primary | forestry     |              |              |              |
+            | primary | delivery     |              |              |              |
+            | primary |              | yes          |              | cycling      |
+            | primary |              | permissive   |              | cycling      |
+            | primary |              | designated   |              | cycling      |
+            | primary |              | some_tag     |              | cycling      |
+            | primary |              | no           |              |              |
+            | primary |              | private      |              |              |
+            | primary |              | agricultural |              |              |
+            | primary |              | forestry     |              |              |
+            | primary |              | delivery     |              |              |
+            | primary |              |              | yes          | cycling      |
+            | primary |              |              | permissive   | cycling      |
+            | primary |              |              | designated   | cycling      |
+            | primary |              |              | some_tag     | cycling      |
+            | primary |              |              | no           | cycling      |
+            | primary |              |              | private      | cycling      |
+            | primary |              |              | agricultural | cycling      |
+            | primary |              |              | forestry     | cycling      |
+            | primary |              |              | delivery     | cycling      |
+ 
+    Scenario: Bike - Access tags on ways where you can push bike
+        Then routability should be
+            | highway | access       | bicycle      | foot         | bothw        |
+            |         |              |              |              | cycling      |
+            | footway | yes          |              |              | cycling      |
+            | footway | permissive   |              |              | cycling      |
+            | footway | designated   |              |              | cycling      |
+            | footway | some_tag     |              |              | cycling      |
+            | footway | no           |              |              |              |
+            | footway | private      |              |              |              |
+            | footway | agricultural |              |              |              |
+            | footway | forestry     |              |              |              |
+            | footway | delivery     |              |              |              |
+            | footway |              | yes          |              | cycling      |
+            | footway |              | permissive   |              | cycling      |
+            | footway |              | designated   |              | cycling      |
+            | footway |              | some_tag     |              | cycling      |
+            | footway |              | no           |              |              |
+            | footway |              | private      |              |              |
+            | footway |              | agricultural |              |              |
+            | footway |              | forestry     |              |              |
+            | footway |              | delivery     |              |              |
+            | footway |              |              | yes          | pushing bike |
+            | footway |              |              | permissive   | pushing bike |
+            | footway |              |              | designated   | pushing bike |
+            | footway |              |              | some_tag     | pushing bike |
+            | footway |              |              | no           |              |
+            | footway |              |              | private      |              |
+            | footway |              |              | agricultural |              |
+            | footway |              |              | forestry     |              |
+            | footway |              |              | delivery     |              |
+
+    Scenario: Bike - Access tags on ways where you can neither bike or push bike
+        Then routability should be
+            | highway | access       | bicycle      | foot         | bothw        |
+            |         |              |              |              | cycling      |
+            | runway  | yes          |              |              | cycling      |
+            | runway  | permissive   |              |              | cycling      |
+            | runway  | designated   |              |              | cycling      |
+            | runway  | some_tag     |              |              | cycling      |
+            | runway  | no           |              |              |              |
+            | runway  | private      |              |              |              |
+            | runway  | agricultural |              |              |              |
+            | runway  | forestry     |              |              |              |
+            | runway  | delivery     |              |              |              |
+            | runway  |              | yes          |              | cycling      |
+            | runway  |              | permissive   |              | cycling      |
+            | runway  |              | designated   |              | cycling      |
+            | runway  |              | some_tag     |              | cycling      |
+            | runway  |              | no           |              |              |
+            | runway  |              | private      |              |              |
+            | runway  |              | agricultural |              |              |
+            | runway  |              | forestry     |              |              |
+            | runway  |              | delivery     |              |              |
+            | runway  |              |              | yes          | pushing bike |
+            | runway  |              |              | permissive   | pushing bike |
+            | runway  |              |              | designated   | pushing bike |
+            | runway  |              |              | some_tag     | pushing bike |
+            | runway  |              |              | no           |              |
+            | runway  |              |              | private      |              |
+            | runway  |              |              | agricultural |              |
+            | runway  |              |              | forestry     |              |
+            | runway  |              |              | delivery     |              |
 
     Scenario: Bike - Access tags on both node and way
         Then routability should be
@@ -143,14 +233,14 @@ Feature: Bike - Access tags on ways
 
     Scenario: Bike - Access combinations
         Then routability should be
-            | highway     | access     | vehicle    | bicycle    | forw    | backw   |
-            | runway      | private    |            | yes        | cycling | cycling |
-            | footway     |            | no         | permissive | cycling | cycling |
-            | motorway    |            |            | yes        | cycling |         |
-            | track       | forestry   |            | permissive | cycling | cycling |
-            | cycleway    | yes        | designated | no         |         |         |
-            | primary     |            | yes        | private    |         |         |
-            | residential | permissive |            | no         |         |         |
+            | highway     | access     | vehicle    | bicycle    | forw         | backw        |
+            | runway      | private    |            | yes        | cycling      | cycling      |
+            | footway     |            | no         | permissive | cycling      | cycling      |
+            | motorway    |            |            | yes        | cycling      |              |
+            | track       | forestry   |            | permissive | cycling      | cycling      |
+            | cycleway    | yes        | designated | no         |              |              |
+            | primary     |            | yes        | private    |              |              |
+            | residential | permissive |            | no         |              |              |
 
     Scenario: Bike - Ignore access tags for other modes
         Then routability should be
@@ -170,16 +260,35 @@ Feature: Bike - Access tags on ways
             | bridleway | designated |      |         |              |
             | bridleway |            |      |         |              |
 
-    Scenario: Bike - Tram with oneway when access is implicit
-        Then routability should be
-            | highway     | railway | access | oneway | forw    | backw        |
-            | residential | tram    |        | yes    | cycling | pushing bike |
-            | service     | tram    | psv    | yes    | cycling | pushing bike |
-
-    Scenario: Bike - Access combinations
+    Scenario: Bike - Access permissive combinations
         Then routability should be
             | highway    | access     | bothw   |
             | primary    | permissive | cycling |
             | steps      | permissive | cycling |
             | footway    | permissive | cycling |
             | garbagetag | permissive | cycling |
+
+
+    Scenario: Bike - bicycle=no should prevent pushing bike
+        Then routability should be
+            | highway | oneway | bicycle | forw         | backw        |
+            | footway |        |         | pushing bike | pushing bike |
+            | footway |        | no      |              |              |
+            | primary | yes    |         | cycling      | pushing bike |
+            | primary | yes    | no      |              |              |
+
+    Scenario: Bike - access=no should prevent pushing bike
+        Then routability should be
+            | highway | oneway | access | forw         | backw        |
+            | footway |        |        | pushing bike | pushing bike |
+            | footway |        | no     |              |              |
+            | primary | yes    |        | cycling      | pushing bike |
+            | primary | yes    | no     |              |              |
+
+    Scenario: Bike - vehicle=no should not prevent pushing bike
+        Then routability should be
+            | highway | oneway | vehicle | forw         | backw        |
+            | footway |        |         | pushing bike | pushing bike |
+            | footway |        | no      | pushing bike | pushing bike |
+            | primary | yes    |         | cycling      | pushing bike |
+            | primary | yes    | no      | pushing bike | pushing bike |

--- a/features/bicycle/area.feature
+++ b/features/bicycle/area.feature
@@ -99,14 +99,14 @@ Feature: Bike - Squares and other areas
             | abcda | (nil)   | platform |
 
         When I route I should get
-            | from | to | route       |
-            | x    | y  | xa,abcda,by |
-            | y    | x  | by,abcda,xa |
-            | a    | b  | abcda,abcda |
-            | a    | d  | abcda,abcda |
-            | b    | c  | abcda,abcda |
-            | c    | b  | abcda,abcda |
-            | c    | d  | abcda,abcda |
-            | d    | c  | abcda,abcda |
-            | d    | a  | abcda,abcda |
-            | a    | d  | abcda,abcda |
+            | from | to | route          |
+            | x    | y  | xa,abcda,by,by |
+            | y    | x  | by,abcda,xa,xa |
+            | a    | b  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |
+            | b    | c  | abcda,abcda    |
+            | c    | b  | abcda,abcda    |
+            | c    | d  | abcda,abcda    |
+            | d    | c  | abcda,abcda    |
+            | d    | a  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |

--- a/features/bicycle/cycleway.feature
+++ b/features/bicycle/cycleway.feature
@@ -70,28 +70,36 @@ Feature: Bike - Cycle tracks/lanes
 
     Scenario: Bike - Access tags should overwrite cycleway access
         Then routability should be
-            | highway     | cycleway | access | forw | backw |
-            | motorway    | track    | no     |      |       |
-            | residential | track    | no     |      |       |
-            | footway     | track    | no     |      |       |
-            | cycleway    | track    | no     |      |       |
-            | motorway    | lane     | yes    | x    |       |
-            | residential | lane     | yes    | x    | x     |
-            | footway     | lane     | yes    | x    | x     |
-            | cycleway    | lane     | yes    | x    | x     |
+            | highway     | cycleway | access | forw    | backw   |
+            | motorway    | track    | no     |         |         |
+            | residential | track    | no     |         |         |
+            | footway     | track    | no     |         |         |
+            | cycleway    | track    | no     |         |         |
+            | motorway    | track    | yes    | cycling |         |
+            | residential | track    | yes    | cycling | cycling |
+            | footway     | track    | yes    | cycling | cycling |
+            | cycleway    | track    | yes    | cycling | cycling |
 
     Scenario: Bike - Cycleway on oneways, modes
         Then routability should be
-            | highway     | cycleway | oneway | forw         | backw        |
-            | motorway    | track    | yes    | cycling      |              |
-            | residential | track    | yes    | cycling      | pushing bike |
-            | cycleway    | track    | yes    | cycling      | pushing bike |
-            | footway     | track    | yes    | pushing bike | pushing bike |
+            | highway     | cycleway | oneway | forw    | backw        |  
+            | motorway    | track    | yes    | cycling |              |  
+            | residential | track    | yes    | cycling | pushing bike |  
+            | cycleway    | track    | yes    | cycling |              |  
+            | footway     | track    | yes    | cycling | pushing bike |  
 
     Scenario: Bike - Cycleway on oneways, speeds
         Then routability should be
-            | highway     | cycleway | oneway | forw       | backw      |
-            | motorway    | track    | yes    | 15 km/h    |            |
-            | residential | track    | yes    | 15 km/h    | 6 km/h     |
-            | cycleway    | track    | yes    | 15 km/h    | 6 km/h     |
-            | footway     | track    | yes    | 6 km/h +-1 | 6 km/h +-1 |
+            | highway     | cycleway | oneway | forw         | backw      |  
+            | motorway    | track    | yes    | 15 km/h +- 2 |            |  
+            | residential | track    | yes    | 15 km/h +-2  | 5 km/h +-2 |  
+            | cycleway    | track    | yes    | 15 km/h +-2  |            |  
+            | footway     | track    | yes    | 15 km/h +-2  | 5 km/h +-2 |  
+
+    Scenario: Bike - Directional sideways and oneway
+        Then routability should be
+            | highway     | oneway | cycleway:right | cycleway:left | forw         | backw        |
+            | primary     | yes    | track          |               | cycling      | pushing bike |
+            | primary     | yes    |                | track         | cycling      | cycling      |
+            | primary     | -1     | track          |               | cycling      | cycling      |
+            | primary     | -1     |                | track         | pushing bike | cycling      |

--- a/features/bicycle/ferry.feature
+++ b/features/bicycle/ferry.feature
@@ -58,10 +58,10 @@ Feature: Bike - Handle ferry routes
             """
 
         And the ways
-            | nodes | highway | route | bicycle | duration |
-            | xa    | primary |       |         |          |
-            | yd    | primary |       |         |          |
-            | abcd  |         | ferry | yes     | 1:00     |
+            | nodes | highway | route | duration |
+            | xa    | primary |       |          |
+            | yd    | primary |       |          |
+            | abcd  | (nil)   | ferry | 1:00     |
 
         When I route I should get
             | from | to | route     | time  |

--- a/features/bicycle/pushing.feature
+++ b/features/bicycle/pushing.feature
@@ -72,17 +72,17 @@ Feature: Bike - Accessability of different way types
     @construction
     Scenario: Bike - Don't allow routing on ways still under construction
         Then routability should be
-            | highway      | foot | bicycle | bothw |
-            | primary      |      |         | x     |
-            | construction |      |         |       |
-            | construction | yes  |         |       |
-            | construction |      | yes     |       |
+            | highway      | foot | bicycle | bothw   |
+            | primary      |      |         | cycling |
+            | construction |      |         |         |
+            | construction | yes  |         |         |
+            | construction |      | yes     |         |
 
     @roundabout
     Scenario: Bike - Don't push bikes against oneway flow on roundabouts
         Then routability should be
-            | junction   | forw | backw |
-            | roundabout | x    |       |
+            | junction   | forw    | backw |
+            | roundabout | cycling |       |
 
     Scenario: Bike - Instructions when pushing bike on oneways
         Given the node map
@@ -125,3 +125,28 @@ Feature: Bike - Accessability of different way types
             | d    | a  | cd,bc,ab,ab | cycling,pushing bike,cycling,cycling |
             | c    | a  | bc,ab,ab    | pushing bike,cycling,cycling         |
             | d    | b  | cd,bc,bc    | cycling,pushing bike,pushing bike    |
+
+    Scenario: Bike - Pushing bikes on leisure=*
+        Then routability should be
+            | highway | leisure | forw         | backw        |  
+            | (nil)   | track   | pushing bike | pushing bike |
+
+    Scenario: Bike - Pushing bikes on man_made=*
+        Then routability should be
+            | highway | man_made | forw         | backw        |  
+            | (nil)   | pier     | pushing bike | pushing bike |  
+
+    Scenario: Bike - Pushing bikes on railway=*
+        Then routability should be
+            | highway | railway  | forw         | backw        |  
+            | (nil)   | platform | pushing bike | pushing bike |  
+
+    Scenario: Bike - Pushing bikes on public_transport=*
+        Then routability should be
+            | highway | public_transport | forw         | backw        |  
+            | (nil)   | platform         | pushing bike | pushing bike |  
+
+    Scenario: Bike - Pushing bikes on amenity=*
+        Then routability should be
+            | highway | amenity | forw    | backw   |  
+            | (nil)   | parking | cycling | cycling |  

--- a/features/bicycle/surface.feature
+++ b/features/bicycle/surface.feature
@@ -54,6 +54,6 @@ Feature: Bike - Surfaces
       When I route I should get
         | from | to | route | modes                     | speed   |
         | a    | b  | ab,ab | cycling,cycling           | 15 km/h |
-        | b    | a  | ab,ab | pushing bike,pushing bike | 6 km/h  |
-        | c    | d  | cd,cd | pushing bike,pushing bike | 6 km/h  |
-        | d    | c  | cd,cd | pushing bike,pushing bike | 6 km/h  |
+        | b    | a  | ab,ab | pushing bike,pushing bike | 5 km/h  |
+        | c    | d  | cd,cd | pushing bike,pushing bike | 5 km/h  |
+        | d    | c  | cd,cd | pushing bike,pushing bike | 5 km/h  |

--- a/features/bicycle/way.feature
+++ b/features/bicycle/way.feature
@@ -9,31 +9,31 @@ Feature: Bike - Accessability of different way types
     # Pier is not allowed, since it's tagged using man_made=pier.
 
         Then routability should be
-            | highway        | bothw |
-            | (nil)          |       |
-            | motorway       |       |
-            | motorway_link  |       |
-            | trunk          |       |
-            | trunk_link     |       |
-            | primary        | x     |
-            | primary_link   | x     |
-            | secondary      | x     |
-            | secondary_link | x     |
-            | tertiary       | x     |
-            | tertiary_link  | x     |
-            | residential    | x     |
-            | service        | x     |
-            | unclassified   | x     |
-            | living_street  | x     |
-            | road           | x     |
-            | track          | x     |
-            | path           | x     |
-            | footway        | x     |
-            | pedestrian     | x     |
-            | steps          | x     |
-            | cycleway       | x     |
-            | bridleway      |       |
-            | pier           |       |
+            | highway        | bothw        |
+            | (nil)          |              |
+            | motorway       |              |
+            | motorway_link  |              |
+            | trunk          |              |
+            | trunk_link     |              |
+            | primary        | cycling      |
+            | primary_link   | cycling      |
+            | secondary      | cycling      |
+            | secondary_link | cycling      |
+            | tertiary       | cycling      |
+            | tertiary_link  | cycling      |
+            | residential    | cycling      |
+            | service        | cycling      |
+            | unclassified   | cycling      |
+            | living_street  | cycling      |
+            | road           | cycling      |
+            | track          | cycling      |
+            | path           | cycling      |
+            | cycleway       | cycling      |
+            | footway        | pushing bike |
+            | pedestrian     | pushing bike |
+            | steps          | pushing bike |
+            | pier           | pushing bike |
+            | bridleway      |              |
 
     Scenario: Bike - Routability of man_made structures
         Then routability should be

--- a/features/foot/way.feature
+++ b/features/foot/way.feature
@@ -4,7 +4,7 @@ Feature: Foot - Accessability of different way types
     Background:
         Given the profile "foot"
 
-    Scenario: Foot - Basic access
+    Scenario: Foot - highway
         Then routability should be
             | highway        | forw |
             | motorway       |      |
@@ -31,8 +31,32 @@ Feature: Foot - Accessability of different way types
             | cycleway       |      |
             | bridleway      |      |
 
-    Scenario: Foot - Basic access
+    Scenario: Foot - leisure=*
         Then routability should be
-            | highway | leisure  | forw |
-            | (nil)   | track    |   x  |
+            | highway | leisure | forw    |  
+            | (nil)   |         |         |  
+            | (nil)   | track   | walking |  
 
+    Scenario: Foot - man_made=*
+        Then routability should be
+            | highway | man_made  | forw    |  
+            | (nil)   |           |         |  
+            | (nil)   | pier      | walking |  
+
+    Scenario: Foot - railway=*
+        Then routability should be
+            | highway | railway  | forw    |  
+            | (nil)   |          |         |  
+            | (nil)   | platform | walking |  
+
+    Scenario: Foot - public_transport=*
+        Then routability should be
+            | highway | public_transport  | forw    |  
+            | (nil)   |                   |         |  
+            | (nil)   | platform          | walking |  
+
+    Scenario: Foot - amenity=*
+        Then routability should be
+            | highway | amenity | forw    |  
+            | (nil)   |         |         |  
+            | (nil)   | parking | walking |  

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -6,11 +6,11 @@ module.exports = function () {
     this.Then(/^routability should be$/, (table, callback) => {
         this.buildWaysFromTable(table, () => {
             var directions = ['forw','backw','bothw'],
-                testedHeaders = ['forw','backw','bothw','forw_rate','backw_rate','bothw_rate'],
+                testedHeaders = ['forw','backw','bothw','forw_rate','backw_rate','bothw_rate','forw_mode','backw_mode'],
                 headers = new Set(Object.keys(table.hashes()[0]));
 
             if (!testedHeaders.some(k => !!headers.has(k))) {
-                throw new Error('*** routability table must contain either "forw", "backw", "bothw", "forw_rate" or "backw_mode" column');
+                throw new Error('*** routability table must contain either "forw", "backw", "bothw", "forw_rate" or "backw_rate" column');
             }
 
             this.reprocessAndLoadData((e) => {

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -106,12 +106,14 @@ local profile = {
   },
 
   avoid = Set {
+    'building',
     'area',
     -- 'toll',    -- uncomment this to avoid tolls
     'reversible',
     'impassable',
     'hov_lanes',
-    'steps'
+    'steps',
+    'construction'
   },
 
   speeds = Sequence {
@@ -157,14 +159,32 @@ local profile = {
       'living_street',
   },
 
-  route_speeds = {
-    ferry = 5,
-    shuttle_train = 10
+  routes = {
+    ferry = {
+      keys = { 'route' },
+      speeds = {
+        ferry = 5
+      }
+    },
+    
+    train = {
+      require_whitelisting = true,
+      keys = { 'route', 'railway' },
+      speeds = {
+        train = 10,
+        railway = 10,
+        shuttle_train = 10,
+      }
+    },
+    
+    default = {
+      keys = { 'bridge' },
+      speeds = {
+        movable = 5
+      }
+    }
   },
 
-  bridge_speeds = {
-    movable = 5
-  },
 
   -- surface/trackype/smoothness
   -- values were estimated from looking at the photos at the relevant wiki pages
@@ -225,6 +245,9 @@ local profile = {
     very_horrible   =  5,
     impassable      =  0
   },
+
+
+  maxspeed_increase = true,
 
   -- http://wiki.openstreetmap.org/wiki/Speed_limits
   maxspeed_table_default = {
@@ -334,52 +357,51 @@ function way_function(way, result)
   handlers = Sequence {
     -- set the default mode for this profile. if can be changed later
     -- in case it turns we're e.g. on a ferry
-    'handle_default_mode',
+    Handlers.handle_default_mode,
 
     -- check various tags that could indicate that the way is not
     -- routable. this includes things like status=impassable,
     -- toll=yes and oneway=reversible
-    'handle_blocked_ways',
+    Handlers.handle_blocked_ways,
 
     -- determine access status by checking our hierarchy of
     -- access tags, e.g: motorcar, motor_vehicle, vehicle
-    'handle_access',
+    Handlers.handle_access,
 
     -- check whether forward/backward directions are routable
-    'handle_oneway',
+    Handlers.handle_oneway,
 
     -- check whether forward/backward directions are routable
-    'handle_destinations',
+    Handlers.handle_destinations,
 
     -- check whether we're using a special transport mode
-    'handle_ferries',
-    'handle_movables',
+    Handlers.handle_routes,
 
     -- handle service road restrictions
-    'handle_service',
+    Handlers.handle_service,
 
     -- handle hov
-    'handle_hov',
+    Handlers.handle_hov,
 
     -- compute speed taking into account way type, maxspeed tags, etc.
-    'handle_speed',
-    'handle_surface',
-    'handle_maxspeed',
-    'handle_penalties',
+    Handlers.handle_speed,
+    Handlers.handle_surface,
+    Handlers.handle_maxspeed,
+    Handlers.handle_penalties,
 
     -- handle turn lanes and road classification, used for guidance
-    'handle_turn_lanes',
-    'handle_classification',
+    Handlers.handle_turn_lanes,
+    Handlers.handle_classification,
 
     -- handle various other flags
-    'handle_roundabouts',
-    'handle_startpoint',
+    Handlers.handle_roundabouts,
+    Handlers.handle_startpoint,
 
     -- set name, ref and pronunciation
-    'handle_names',
+    Handlers.handle_names,
 
     -- set weight properties of the way
-    'handle_weights'
+    Handlers.handle_weights
   }
 
   Handlers.run(handlers,way,result,data,profile)

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -7,6 +7,7 @@ local Set = require('lib/set')
 local Sequence = require('lib/sequence')
 local Handlers = require("lib/handlers")
 local next = next       -- bind to local for speed
+local pprint = require('lib/pprint')
 
 properties.max_speed_for_map_matching    = 40/3.6 -- kmph -> m/s
 properties.use_turn_restrictions         = false
@@ -71,7 +72,9 @@ local profile = {
   },
 
   avoid = Set {
-    'impassable'
+    'building',
+    'impassable',
+    'construction'
   },
 
   speeds = Sequence {
@@ -99,6 +102,10 @@ local profile = {
       platform        = walking_speed
     },
 
+    public_transport = {
+      platform        = walking_speed
+    },
+
     amenity = {
       parking         = walking_speed,
       parking_entrance= walking_speed
@@ -113,11 +120,32 @@ local profile = {
     }
   },
 
-  route_speeds = {
-    ferry = 5
-  },
-
-  bridge_speeds = {
+  routes = {
+    ferry = {
+      keys = { 'route' },
+      speeds = {
+        ferry = 5
+      }
+    },
+    
+    train = {
+      keys = { 'route', 'railway' },
+      speeds = {
+        train = 10,
+        railway = 10,
+        subway = 10,
+        light_rail = 10,
+        monorail = 10,
+        tram = 10
+      }
+    },
+    
+    default = {
+      keys = { 'route' },
+      speeds = {
+        movable = 5
+      }
+    }
   },
 
   surface_speeds = {
@@ -179,6 +207,7 @@ function way_function(way, result)
   -- data table for storing intermediate values during processing
   local data = {
     -- prefetch tags
+    building = way:get_value_by_key('building'),
     highway = way:get_value_by_key('highway'),
     bridge = way:get_value_by_key('bridge'),
     route = way:get_value_by_key('route'),
@@ -195,46 +224,44 @@ function way_function(way, result)
   -- of the prefetched tags to be present, ie. the data table
   -- cannot be empty
   if next(data) == nil then     -- is the data table empty?
-    return
+    return false
   end
-
   local handlers = Sequence {
     -- set the default mode for this profile. if can be changed later
     -- in case it turns we're e.g. on a ferry
-    'handle_default_mode',
+    Handlers.handle_default_mode,
 
     -- check various tags that could indicate that the way is not
     -- routable. this includes things like status=impassable,
     -- toll=yes and oneway=reversible
-    'handle_blocked_ways',
+    Handlers.handle_blocked_ways,
 
     -- determine access status by checking our hierarchy of
     -- access tags, e.g: motorcar, motor_vehicle, vehicle
-    'handle_access',
+    Handlers.handle_access,
 
     -- check whether forward/backward directons are routable
-    'handle_oneway',
+    Handlers.handle_oneway,
 
     -- check whether forward/backward directons are routable
-    'handle_destinations',
+    Handlers.handle_destinations,
 
     -- check whether we're using a special transport mode
-    'handle_ferries',
-    'handle_movables',
+    Handlers.handle_routes,
 
     -- compute speed taking into account way type, maxspeed tags, etc.
-    'handle_speed',
-    'handle_surface',
+    Handlers.handle_speed,
+    Handlers.handle_surface,
 
     -- handle turn lanes and road classification, used for guidance
-    'handle_classification',
+    Handlers.handle_classification,
 
     -- handle various other flags
-    'handle_roundabouts',
-    'handle_startpoint',
+    Handlers.handle_roundabouts,
+    Handlers.handle_startpoint,
 
     -- set name, ref and pronunciation
-    'handle_names'
+    Handlers.handle_names
   }
 
   Handlers.run(handlers,way,result,data,profile)
@@ -257,3 +284,6 @@ function turn_function (turn)
       end
   end
 end
+
+profile.way_function = way_function
+return profile

--- a/profiles/lib/profile_debugger.lua
+++ b/profiles/lib/profile_debugger.lua
@@ -90,7 +90,7 @@ function Debug.report_tag_fetches()
 end
 
 function Debug.load_profile(profile)
-  require(profile)
+  return require(profile)
 end
 
 function Debug.reset_tag_fetch_counts()
@@ -101,6 +101,10 @@ function Debug.reset_tag_fetch_counts()
 end
 
 function Debug.register_tag_fetch(k)
+  if not k then
+    return nil
+  end
+  
   if Debug.tags.total then
     Debug.tags.total = Debug.tags.total + 1
   else
@@ -126,7 +130,11 @@ function Debug.way_function(way,result)
   -- intercept tag function normally provided via C++
   function way:get_value_by_key(k)
     Debug.register_tag_fetch(k)
-    return self[k]
+    if self[k] == '' then
+      return nil
+    else
+      return self[k]
+    end
   end
   
   -- reset tag counts

--- a/profiles/lib/tags.lua
+++ b/profiles/lib/tags.lua
@@ -38,24 +38,44 @@ end
 
 function Tags.get_forward_backward_by_set(way,data,keys)
   local forward, backward
+  local forward_key, backward_key
+  local k
+  
   for i,key in ipairs(keys) do
     if not forward then
-      forward = way:get_value_by_key(key .. ':forward')
+      k = key .. ':forward'
+      forward = way:get_value_by_key(k)
+      if forward then
+        forward_key = k
+      end
+      
     end
     if not backward then
-      backward = way:get_value_by_key(key .. ':backward')
+      k = key .. ':backward'
+      backward = way:get_value_by_key(k)
+      if backward then
+        backward_key = k
+      end
     end
     if not forward or not backward then
       local common = way:get_value_by_key(key)
-      forward = forward or common
-      backward = backward or common
+      if common then
+        if not forward then
+          forward = common
+          forward_key = key
+        end
+        if not backward then
+          backward = common
+          backward_key = key
+        end
+      end
     end
     if forward and backward then
       break
     end
   end
 
-  return forward, backward
+  return forward, backward, forward_key, backward_key
 end
 
 -- look through a sequence of keys combined with a prefix


### PR DESCRIPTION
Continues the refactoring of the bike profile, to a point where the way_function is now simply a list of handlers to call.

The main change is that all pushing of bikes is is now handled by calling out to the foot profile. This greatly simplifies the bike profile and makes the handling more complete, since the foot profile handles many more edge cases than the rudimentary foot handling that was present in the bike profile.

First the normal bike handling is performed. If one or both directions is not routable my bike, the foot profile is called. Finally the result is merged, ie. if you can't bike in a particular direction, the foot result in that direction is copied to the result.

Also has some additional improvements, like providing functions directly to the Handlers.run(), making it possible to interleave your own custom functions.

The configs in the profile for speeds is improve and now handles multiple tags together.

Added a number of tests, particularly related to pushing of bikes.

There are a few tests failing, related to ferry times for cars changing slightly. Not sure why.

I'm interested in feedback on the approach of using the foot profile in the bike profile.