### PR TITLE
Document default values of global properties set in profile

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,12 +31,12 @@ Attribute                     | Type     | Notes
 ------------------------------|----------|----------------------------------------------------------------------------
 weight_name                   | String   | Name used in output for the routing weight property (default 'duration')
 weight_precision              | Unsigned | Decimal precision of edge weights (default 1)
-left_hand_driving             | Boolean  | Are vehicles assumed to drive on the left? (used in guidance)
-use_turn_restrictions         | Boolean  | Are turn instructions followed?
-continue_straight_at_waypoint | Boolean  | Must the route continue straight on at a via point, or are U-turns allowed?
+left_hand_driving             | Boolean  | Are vehicles assumed to drive on the left? (used in guidance, default false)
+use_turn_restrictions         | Boolean  | Are turn instructions followed? (default false)
+continue_straight_at_waypoint | Boolean  | Must the route continue straight on at a via point, or are U-turns allowed? (default true)
 max_speed_for_map_matching    | Float    | Maximum vehicle speed to be assumed in matching (in m/s)
 max_turn_weight               | Float    | Maximum turn penalty weight
-force_split_edges             | Boolean  | True value forces a split of forward and backward edges of extracted ways and guarantees that segment_function will be called for all segments
+force_split_edges             | Boolean  | True value forces a split of forward and backward edges of extracted ways and guarantees that segment_function will be called for all segments (default false)
 
 ## way_function
 


### PR DESCRIPTION
Should spare users time spent on digging through the source code.

BTW, It would be good to mark attributes with mandatory/optional, what you think?

p.s. Sorry for missing `[ci skip]` in commit message.