### PR TITLE
Fix precision loss in angleBetween function

### DIFF
--- a/include/util/assert.hpp
+++ b/include/util/assert.hpp
@@ -34,9 +34,9 @@
 #define OSRM_ASSERT_MSG(cond, coordinate, msg)                                                     \
     do                                                                                             \
     {                                                                                              \
-        (void)cond;                                                                                \
-        (void)coordinate;                                                                          \
-        (void)msg;                                                                                 \
+        (void)(cond);                                                                              \
+        (void)(coordinate);                                                                        \
+        (void)(msg);                                                                               \
     } while (0)
 #define OSRM_ASSERT(cond, coordinate) OSRM_ASSERT_MSG(cond, coordinate, "")
 

--- a/include/util/bearing.hpp
+++ b/include/util/bearing.hpp
@@ -120,15 +120,7 @@ inline double reverse(const double bearing)
 // entry_bearing of 0.
 inline double angleBetween(const double entry_bearing, const double exit_bearing)
 {
-    // transform bearing from cw into ccw order
-    const double offset = 360 - entry_bearing;
-    const double rotated_exit = [](double bearing, const double offset) {
-        bearing += offset;
-        return bearing > 360 ? bearing - 360 : bearing;
-    }(exit_bearing, offset);
-
-    const auto angle = 540 - rotated_exit;
-    return angle >= 360 ? angle - 360 : angle;
+    return std::fmod(entry_bearing - exit_bearing + 540., 360.);
 }
 
 } // namespace bearing

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -8,6 +8,7 @@
 
 #include "storage/io.hpp"
 
+#include "util/assert.hpp"
 #include "util/bearing.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
@@ -442,7 +443,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                 auto intersection = turn_analysis.AssignTurnTypes(
                     node_along_road_entering, incoming_edge, intersection_with_flags_and_angles);
 
-                BOOST_ASSERT(intersection.valid());
+                OSRM_ASSERT(intersection.valid(), m_coordinates[node_at_center_of_intersection]);
 
                 intersection = turn_lane_handler.assignTurnLanes(
                     node_along_road_entering, incoming_edge, std::move(intersection));

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -3,6 +3,7 @@
 #include "extractor/geojson_debug_policies.hpp"
 #include "util/geojson_debug_logger.hpp"
 
+#include "util/assert.hpp"
 #include "util/bearing.hpp"
 #include "util/coordinate_calculation.hpp"
 #include "util/log.hpp"
@@ -369,8 +370,9 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
               std::end(intersection_view),
               std::mem_fn(&IntersectionViewData::CompareByAngle));
 
-    BOOST_ASSERT(intersection_view[0].angle >= 0. &&
-                 intersection_view[0].angle < std::numeric_limits<double>::epsilon());
+    OSRM_ASSERT(intersection_view[0].angle >= 0. &&
+                    intersection_view[0].angle < std::numeric_limits<double>::epsilon(),
+                coordinates[node_at_intersection]);
 
     return intersection_view;
 }

--- a/unit_tests/util/bearing.cpp
+++ b/unit_tests/util/bearing.cpp
@@ -47,4 +47,10 @@ BOOST_AUTO_TEST_CASE(bearing_range_test)
     BOOST_CHECK_EQUAL(true, bearing::CheckInBounds(1, 1, 0));
 }
 
+BOOST_AUTO_TEST_CASE(bearing_angle_test)
+{
+    BOOST_CHECK_EQUAL(bearing::angleBetween(257.78421507794314, 77.784215077943117), 0.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(77.784215077943117, 257.78421507794314), 0.);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/bearing.cpp
+++ b/unit_tests/util/bearing.cpp
@@ -51,6 +51,29 @@ BOOST_AUTO_TEST_CASE(bearing_angle_test)
 {
     BOOST_CHECK_EQUAL(bearing::angleBetween(257.78421507794314, 77.784215077943117), 0.);
     BOOST_CHECK_EQUAL(bearing::angleBetween(77.784215077943117, 257.78421507794314), 0.);
+
+    // Check quadrants
+    BOOST_CHECK_EQUAL(bearing::angleBetween(45., 45.), 180.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(45., 315.), 270.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(45., 225.), 0.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(45., 135.), 90.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(45., 90.), 135.);
+
+    // Check edge cases
+    BOOST_CHECK_EQUAL(bearing::angleBetween(0., 360.), 180.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(360., 0.), 180.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(0., 0.), 180.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(360., 360.), 180.);
+
+    BOOST_CHECK_EQUAL(bearing::angleBetween(0., 180.), 0.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(360., 180.), 0.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(180., 0.), 0.);
+    BOOST_CHECK_EQUAL(bearing::angleBetween(180., 360.), 0.);
+
+    BOOST_CHECK_EQUAL(bearing::angleBetween(90., 270.01), 359.99);
+
+    // 5 digits loss due to cancellation in  90+180-269.99
+    BOOST_CHECK_CLOSE(bearing::angleBetween(90., 269.99), 0.01, 1e-10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

In 32 bit mode  `angleBetween(257.78421507794314, 77.784215077943117)` returns 2.8421709430404007e-14 that causes an assertion #4038 
`angleBetween(77.784215077943117, 257.78421507794314)` returns 0 as expected.

In 64-bit mode both calls return 0

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
