### PR TITLE
Avoid boost::numeric_cast on trusted coordinates

### DIFF
--- a/include/server/api/base_parameters_grammar.hpp
+++ b/include/server/api/base_parameters_grammar.hpp
@@ -111,15 +111,15 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                                                 qi::_1,
                                                 qi::_2)];
 
-        location_rule =
-            (double_ > qi::lit(',') >
-             double_)[qi::_val = ph::bind(
-                          [](double lon, double lat) {
-                              return util::Coordinate(util::toFixed(util::FloatLongitude{lon}),
-                                                      util::toFixed(util::FloatLatitude{lat}));
-                          },
-                          qi::_1,
-                          qi::_2)];
+        location_rule = (double_ > qi::lit(',') >
+                         double_)[qi::_val = ph::bind(
+                                      [](double lon, double lat) {
+                                          return util::Coordinate(
+                                              util::toFixed(util::UnsafeFloatLongitude{lon}),
+                                              util::toFixed(util::UnsafeFloatLatitude{lat}));
+                                      },
+                                      qi::_1,
+                                      qi::_2)];
 
         polyline_rule = qi::as_string[qi::lit("polyline(") > +polyline_chars > ')']
                                      [qi::_val = ph::bind(

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -54,8 +54,8 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
                                      const ExtractionNode &result_node)
 {
     external_memory.all_nodes_list.push_back(
-        {util::toFixed(util::FloatLongitude{input_node.location().lon()}),
-         util::toFixed(util::FloatLatitude{input_node.location().lat()}),
+        {util::toFixed(util::UnsafeFloatLongitude{input_node.location().lon()}),
+         util::toFixed(util::UnsafeFloatLatitude{input_node.location().lat()}),
          OSMNodeID{static_cast<std::uint64_t>(input_node.id())},
          result_node.barrier,
          result_node.traffic_lights});

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -125,14 +125,17 @@ BOOST_AUTO_TEST_CASE(compute_angle)
     end = Coordinate{FloatLongitude{1 + std::numeric_limits<double>::epsilon()}, FloatLatitude{0}};
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
+}
 
-    // Invalid values
-    BOOST_CHECK_THROW(
-        coordinate_calculation::computeAngle(
-            Coordinate(FloatLongitude{0}, FloatLatitude{0}),
-            Coordinate(FloatLongitude{1}, FloatLatitude{0}),
-            Coordinate(FloatLongitude{std::numeric_limits<double>::max()}, FloatLatitude{0})),
-        boost::numeric::positive_overflow);
+BOOST_AUTO_TEST_CASE(invalid_values)
+{
+    // Invalid values for unsafe types
+    BOOST_CHECK_THROW(coordinate_calculation::computeAngle(
+                          Coordinate(UnsafeFloatLongitude{0}, UnsafeFloatLatitude{0}),
+                          Coordinate(UnsafeFloatLongitude{1}, UnsafeFloatLatitude{0}),
+                          Coordinate(UnsafeFloatLongitude{std::numeric_limits<double>::max()},
+                                     UnsafeFloatLatitude{0})),
+                      boost::numeric::positive_overflow);
 }
 
 // Regression test for bug captured in #1347


### PR DESCRIPTION
# Issue

During profiling for https://github.com/Project-OSRM/osrm-backend/pull/4056, I found that `toFixed()` was surprisingly high on the list of things that take up CPU time during route calculation.

This change creates a new longitude/latitude type that's flagged (via naming) as "unsafe" - instances of these unsafe types are passed to different versions of the `toFixed()` function which continue to perform `boost::numeric_cast` checks.  Not-`Unsafe*` variables are routed to simpler versions of `toFixed()` that don't perform overflow checking.

Data supplied by external sources: (1) user supplied coordinates in queries, and (2) longitude/latitude values read from `.osm` files during pre-processing are created as `Unsafe(Longitude|Latitude)` types, which causes them to receive an extra `boost::numeric_cast` check.

Data that comes from internally, already vetted sources (such as `GetCoordinateOfNode()` on the `datafacade`) is routed to the simpler `toFixed()` function which doesn't perform a `boost::numeric_cast`.

Our `rtree-bench` does a lot of lookups of already safe coordinates.  Here's the performance before this change:

```
./src/benchmarks/rtree-bench moldova-latest.osrm.ramIndex moldova-latest.osrm.fileIndex moldova-latest.osrm.nodes
Running raw RTree queries (1 result) with 10000 coordinates: Took 0.551909 seconds (551.91ms)  ->  0.055191 ms/query (551.91ms)
Running raw RTree queries (10 results) with 10000 coordinates: Took 0.595937 seconds (595.938ms)  ->  0.0595938 ms/query (595.938ms)
```

and after:

```
./src/benchmarks/rtree-bench moldova-latest.osrm.ramIndex moldova-latest.osrm.fileIndex moldova-latest.osrm.nodes
Running raw RTree queries (1 result) with 10000 coordinates: Took 0.45309 seconds (453.09ms)  ->  0.045309 ms/query (453.09ms)
Running raw RTree queries (10 results) with 10000 coordinates: Took 0.506266 seconds (506.266ms)  ->  0.0506266 ms/query (506.266ms)
```

## Tasklist
 - [X] Quantify performance gain (coordinate lookups are 19% faster)
 - [x] review
 - [x] adjust for comments