### PR TITLE
Use correct node-loading code in rtree benchmark.

### DIFF
--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -5,6 +5,7 @@
 #include "storage/io.hpp"
 #include "engine/geospatial_query.hpp"
 #include "util/coordinate.hpp"
+#include "util/serialization.hpp"
 #include "util/timing_util.hpp"
 
 #include <iostream>
@@ -34,14 +35,8 @@ std::vector<util::Coordinate> loadCoordinates(const boost::filesystem::path &nod
     storage::io::FileReader nodes_path_file_reader(nodes_file,
                                                    storage::io::FileReader::VerifyFingerprint);
 
-    extractor::QueryNode current_node;
-    auto coordinate_count = nodes_path_file_reader.ReadElementCount64();
-    std::vector<util::Coordinate> coords(coordinate_count);
-    for (unsigned i = 0; i < coordinate_count; ++i)
-    {
-        nodes_path_file_reader.ReadInto(&current_node, 1);
-        coords[i] = util::Coordinate(current_node.lon, current_node.lat);
-    }
+    std::vector<util::Coordinate> coords;
+    storage::serialization::read(nodes_path_file_reader, coords);
     return coords;
 }
 


### PR DESCRIPTION
Our `rtree-bench` benchmark doesn't run, because the file format of the `.nodes` file changed, and this code was never updated.

This change fixes that and makes the benchmark work again.