### PR TITLE
Set testbot profile and adjust expectations

### DIFF
--- a/features/testbot/zero-speed-updates.feature
+++ b/features/testbot/zero-speed-updates.feature
@@ -111,8 +111,8 @@ Feature: Check zero speed updates
             """
 
         When I route I should get
-          | from | to | bearings | code    |
-          |    1 |  2 | 270 270  | NoRoute |
+          | from | to | bearings | code      |
+          |    1 |  2 | 270 270  | NoSegment |
 
 
     Scenario: Via routing on restricted oneway

--- a/src/engine/routing_algorithms/shortest_path.cpp
+++ b/src/engine/routing_algorithms/shortest_path.cpp
@@ -131,8 +131,6 @@ void search(SearchEngineData<Algorithm> &engine_working_data,
                                     source_phantom.GetReverseWeightPlusOffset(),
                                 source_phantom.reverse_segment_id.id);
         }
-        BOOST_ASSERT(forward_heap.Size() > 0);
-        BOOST_ASSERT(reverse_heap.Size() > 0);
 
         search(engine_working_data,
                facade,
@@ -166,8 +164,7 @@ void search(SearchEngineData<Algorithm> &engine_working_data,
                                     source_phantom.GetReverseWeightPlusOffset(),
                                 source_phantom.reverse_segment_id.id);
         }
-        BOOST_ASSERT(forward_heap.Size() > 0);
-        BOOST_ASSERT(reverse_heap.Size() > 0);
+
         search(engine_working_data,
                facade,
                forward_heap,


### PR DESCRIPTION
# Issue

Fixes #4062. Tests in 9358aa11287bd450468cc7067085f9e519dec9bc  implicitly use the bicycle profile.

For testbot profile:
* expectation in `Routing on restricted oneway` is modified because  segments are onway.
* some tests hit now incorrect assertion for empty heaps. This handled now in `search` functions after 9358aa11287bd450468cc7067085f9e519dec9bc

The first commit already landed in master :man_facepalming: but the second one is required.


## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
