### PR TITLE
Allow to use service exits on service roundabouts #4030

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
     - Files
       - .osrm.nodes file was renamed to .nbg_nodes and .ebg_nodes was added
 
+# 5.7.1
+    - Bugfixes
+      - #4030 Roundabout edge-case crashes post-processing
+
 # 5.7.0
   - Changes from 5.6
     - Algorithm:

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -793,3 +793,27 @@ Feature: Basic Roundabout
             | f    | e  | af,ed,ed | depart,roundabout-exit-1,arrive | 120.1m   |
             | k    | l  | kg,hl,hl | depart,roundabout-exit-1,arrive | 80.1m    |
             | l    | k  | hl,kg,kg | depart,roundabout-exit-1,arrive | 120.1m   |
+
+    Scenario: Service roundabout with service exits
+        Given the node map
+            """
+                e
+            f a d
+            g b1c
+              h
+            """
+
+        And the ways
+            | nodes | highway  | junction   |
+            | abcda | service  | roundabout |
+            | de    | service  |            |
+            | af    | service  |            |
+            | bg    | tertiary |            |
+            | bh    | service  |            |
+
+        When I route I should get
+            | from | to | route       | turns                           |
+            |    1 | e  | abcda,de,de | depart,roundabout-exit-1,arrive |
+            |    1 | f  | abcda,af,af | depart,roundabout-exit-1,arrive |
+            |    1 | g  | abcda,bg,bg | depart,roundabout-exit-1,arrive |
+            |    1 | h  | abcda,bh,bh | depart,roundabout-exit-1,arrive |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -794,7 +794,9 @@ Feature: Basic Roundabout
             | k    | l  | kg,hl,hl | depart,roundabout-exit-1,arrive | 80.1m    |
             | l    | k  | hl,kg,kg | depart,roundabout-exit-1,arrive | 120.1m   |
 
+    @4030 @4075
     Scenario: Service roundabout with service exits
+      # Counting of service exits must be adjusted in #4075
         Given the node map
             """
                 e

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -168,8 +168,8 @@ class RouteAPI : public BaseAPI
                  */
 
                 guidance::trimShortSegments(steps, leg_geometry);
-                leg.steps = guidance::collapseTurnInstructions(std::move(steps));
-                leg.steps = guidance::postProcess(std::move(leg.steps));
+                leg.steps = guidance::postProcess(std::move(steps));
+                leg.steps = guidance::collapseTurnInstructions(std::move(leg.steps));
                 leg.steps = guidance::buildIntersections(std::move(leg.steps));
                 leg.steps = guidance::suppressShortNameSegments(std::move(leg.steps));
                 leg.steps = guidance::assignRelativeLocations(std::move(leg.steps),


### PR DESCRIPTION
# Issue

The problem is described in #4030 and PR enables service exits for service roundabouts.

![screenshot from 2017-05-22 18-11-25](https://cloud.githubusercontent.com/assets/4421046/26318126/4eeafc50-3f1a-11e7-901d-e24ae9f140e4.png)


## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
