### PR TITLE
Misc warning fixes

### DIFF
--- a/cmake/NodeJS.cmake
+++ b/cmake/NodeJS.cmake
@@ -595,7 +595,7 @@ function(add_nodejs_module NAME)
         PUBLIC ${NODEJS_DEFINITIONS}
     )
     # This properly defines includes for the module
-    target_include_directories(${NAME} PUBLIC ${NODEJS_INCLUDE_DIRS})
+    target_include_directories(${NAME} SYSTEM PUBLIC ${NODEJS_INCLUDE_DIRS})
 
     # Add link flags to the module
     target_link_libraries(${NAME} ${NODEJS_LIBRARIES})

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -761,7 +761,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         return edge_based_node_data.GetGeometryID(id);
     }
 
-    ComponentID GetComponentID(const NodeID id) const
+    ComponentID GetComponentID(const NodeID id) const override final
     {
         return edge_based_node_data.GetComponentID(id);
     }

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -53,7 +53,7 @@ struct PhantomNode
           forward_duration(MAXIMAL_EDGE_DURATION), reverse_duration(MAXIMAL_EDGE_DURATION),
           forward_duration_offset(0), reverse_duration_offset(0), fwd_segment_position(0),
           is_valid_forward_source{false}, is_valid_forward_target{false},
-          is_valid_reverse_source{false}, is_valid_reverse_target{false}, unused{0}
+          is_valid_reverse_source{false}, is_valid_reverse_target{false}
     {
     }
 
@@ -148,7 +148,7 @@ struct PhantomNode
           is_valid_forward_source{is_valid_forward_source},
           is_valid_forward_target{is_valid_forward_target},
           is_valid_reverse_source{is_valid_reverse_source},
-          is_valid_reverse_target{is_valid_reverse_target}, unused{0}
+          is_valid_reverse_target{is_valid_reverse_target}
     {
     }
 
@@ -173,7 +173,7 @@ struct PhantomNode
     unsigned short is_valid_forward_target : 1;
     unsigned short is_valid_reverse_source : 1;
     unsigned short is_valid_reverse_target : 1;
-    unsigned short unused : 12;
+    unsigned short : 12; // Unused padding out to 16 bits (2 bytes)
 };
 
 static_assert(sizeof(PhantomNode) == 64, "PhantomNode has more padding then expected");

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -75,7 +75,7 @@ inline void ParseResult(const osrm::Status &result_status, osrm::json::Object &r
     }
 }
 
-inline void ParseResult(const osrm::Status &result_status, const std::string & /*unused*/) {}
+inline void ParseResult(const osrm::Status & /*result_status*/, const std::string & /*unused*/) {}
 
 inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo<v8::Value> &args)
 {


### PR DESCRIPTION
# Issue

These commits fix various compiler warnings that have crept in (under `clang`).

  - v8 includes should be included with `-isystem` to avoid warnings from code that is not ours
  - unused variables don't need to be named
  - one function that overrode a virtual didn't have `override` at the implementation
  - unused struct padding doesn't need to be named or initialized

## Tasklist
 - [x] review
 - [x] adjust for comments