### PR TITLE
Catch well-known exceptions and return defined error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
       - `osrm-partition` now ensures it is called before `osrm-contract` and removes inconsitent .hsgr files automatically.
     - Features
       - Added conditional restriction support with `parse-conditional-restrictions=true|false` to osrm-extract. This option saves conditional turn restrictions to the .restrictions file for parsing by contract later. Added `parse-conditionals-from-now=utc time stamp` and `--time-zone-file=/path/to/file`  to osrm-contract
+      - Command-line tools (osrm-extract, osrm-contract, osrm-routed, etc) now return error codes and legible error messages for common problem scenarios, rather than ugly C++ crashes
     - Files
       - .osrm.nodes file was renamed to .nbg_nodes and .ebg_nodes was added
     - Guidance

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ file(GLOB UpdaterGlob src/updater/*.cpp)
 file(GLOB StorageGlob src/storage/*.cpp)
 file(GLOB ServerGlob src/server/*.cpp src/server/**/*.cpp)
 file(GLOB EngineGlob src/engine/*.cpp src/engine/**/*.cpp)
+file(GLOB ErrorcodesGlob src/osrm/errorcodes.cpp)
 
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})

--- a/include/osrm/error_codes.hpp
+++ b/include/osrm/error_codes.hpp
@@ -1,0 +1,37 @@
+#ifndef OSRM_ERRORCODES_HPP
+#define OSRM_ERRORCODES_HPP
+
+#include <string>
+
+namespace osrm
+{
+
+/**
+ * Various error codes that can be returned by OSRM internal functions.
+ * Note: often, these translate into return codes from `int main()` functions.
+ *       Thus, do not change the order - if adding new codes, append them to the
+ *       end, so the code values do not change for users that are checking for
+ *       certain values.
+ */
+enum ErrorCode
+{
+    InvalidFingerprint = 2, // Start at 2 to avoid colliding with POSIX EXIT_FAILURE
+    IncompatibleFileVersion,
+    FileOpenError,
+    FileReadError,
+    FileWriteError,
+    FileIOError,
+    UnexpectedEndOfFile,
+    IncompatibleDataset,
+    UnknownAlgorithm
+#ifndef NDEBUG
+    // Leave this at the end.  In debug mode, we assert that the size of
+    // this enum matches the number of messages we have documented, and __ENDMARKER__
+    // is used as the "count" value.
+    ,
+    __ENDMARKER__
+#endif
+};
+}
+
+#endif // OSRM_ERRORCODES_HPP

--- a/include/osrm/exception.hpp
+++ b/include/osrm/exception.hpp
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace osrm
 {
 using util::exception;
+using util::RuntimeError;
 }
 
 #endif

--- a/include/util/exception_utils.hpp
+++ b/include/util/exception_utils.hpp
@@ -10,6 +10,6 @@
 #define OSRM_SOURCE_FILE_ PROJECT_RELATIVE_PATH_(__FILE__)
 
 // This is the macro to use
-#define SOURCE_REF std::string(" (at ") + OSRM_SOURCE_FILE_ + ":" + std::to_string(__LINE__) + ")"
+#define SOURCE_REF OSRM_SOURCE_FILE_ + ":" + std::to_string(__LINE__)
 
 #endif // SOURCE_MACROS_HPP

--- a/src/extractor/raster_source.cpp
+++ b/src/extractor/raster_source.cpp
@@ -108,7 +108,8 @@ int SourceContainer::LoadRasterSource(const std::string &path_string,
     boost::filesystem::path filepath(path_string);
     if (!boost::filesystem::exists(filepath))
     {
-        throw util::exception(path_string + " does not exist" + SOURCE_REF);
+        throw util::RuntimeError(
+            path_string, ErrorCode::FileOpenError, SOURCE_REF, "File not found");
     }
 
     RasterGrid rasterData{filepath, ncols, nrows};

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -36,7 +36,9 @@ OSRM::OSRM(engine::EngineConfig &config)
         // throw error if dataset is not usable with CoreCH
         if (config.algorithm == EngineConfig::Algorithm::CoreCH && !corech_compatible)
         {
-            throw util::exception("Dataset is not compatible with CoreCH.");
+            throw util::RuntimeError("Dataset is not compatible with CoreCH.",
+                                     ErrorCode::IncompatibleDataset,
+                                     SOURCE_REF);
         }
     }
 

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -1,6 +1,7 @@
 #include "storage/io.hpp"
 #include "osrm/contractor.hpp"
 #include "osrm/contractor_config.hpp"
+#include "osrm/exception.hpp"
 #include "util/log.hpp"
 #include "util/timezones.hpp"
 #include "util/version.hpp"
@@ -187,9 +188,18 @@ int main(int argc, char *argv[]) try
 
     return EXIT_SUCCESS;
 }
+catch (const osrm::RuntimeError &e)
+{
+    util::DumpSTXXLStats();
+    util::DumpMemoryStats();
+    util::Log(logERROR) << e.what();
+    return e.GetCode();
+}
 catch (const std::bad_alloc &e)
 {
-    util::Log(logERROR) << "[exception] " << e.what();
+    util::DumpSTXXLStats();
+    util::DumpMemoryStats();
+    util::Log(logERROR) << e.what();
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;
 }

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -1,5 +1,6 @@
 #include "customizer/customizer.hpp"
 
+#include "osrm/exception.hpp"
 #include "util/log.hpp"
 #include "util/meminfo.hpp"
 #include "util/version.hpp"
@@ -167,8 +168,15 @@ int main(int argc, char *argv[]) try
 
     return exitcode;
 }
+catch (const osrm::RuntimeError &e)
+{
+    util::DumpMemoryStats();
+    util::Log(logERROR) << e.what();
+    return e.GetCode();
+}
 catch (const std::bad_alloc &e)
 {
+    util::DumpMemoryStats();
     util::Log(logERROR) << "[exception] " << e.what();
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -1,3 +1,4 @@
+#include "osrm/exception.hpp"
 #include "osrm/extractor.hpp"
 #include "osrm/extractor_config.hpp"
 #include "util/log.hpp"
@@ -168,8 +169,24 @@ int main(int argc, char *argv[]) try
 
     return EXIT_SUCCESS;
 }
+catch (const osrm::RuntimeError &e)
+{
+    util::DumpSTXXLStats();
+    util::DumpMemoryStats();
+    util::Log(logERROR) << e.what();
+    return e.GetCode();
+}
+catch (const std::system_error &e)
+{
+    util::DumpSTXXLStats();
+    util::DumpMemoryStats();
+    util::Log(logERROR) << e.what();
+    return e.code().value();
+}
 catch (const std::bad_alloc &e)
 {
+    util::DumpSTXXLStats();
+    util::DumpMemoryStats();
     util::Log(logERROR) << "[exception] " << e.what();
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -1,6 +1,7 @@
 #include "partition/partition_config.hpp"
 #include "partition/partitioner.hpp"
 
+#include "osrm/exception.hpp"
 #include "util/log.hpp"
 #include "util/meminfo.hpp"
 #include "util/timing_util.hpp"
@@ -238,8 +239,16 @@ int main(int argc, char *argv[]) try
 
     return exitcode;
 }
+catch (const osrm::RuntimeError &e)
+{
+    util::DumpMemoryStats();
+    util::Log(logERROR) << e.what();
+    return EXIT_FAILURE;
+    return e.GetCode();
+}
 catch (const std::bad_alloc &e)
 {
+    util::DumpMemoryStats();
     util::Log(logERROR) << "[exception] " << e.what();
     util::Log(logERROR) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -1,9 +1,11 @@
 #include "server/server.hpp"
-#include "util/exception.hpp"
+#include "util/exception_utils.hpp"
 #include "util/log.hpp"
+#include "util/meminfo.hpp"
 #include "util/version.hpp"
 
 #include "osrm/engine_config.hpp"
+#include "osrm/exception.hpp"
 #include "osrm/osrm.hpp"
 #include "osrm/storage_config.hpp"
 
@@ -57,7 +59,7 @@ EngineConfig::Algorithm stringToAlgorithm(const std::string &algorithm)
         return EngineConfig::Algorithm::CoreCH;
     if (algorithm == "MLD")
         return EngineConfig::Algorithm::MLD;
-    throw util::exception("Invalid algorithm name: " + algorithm);
+    throw util::RuntimeError(algorithm, ErrorCode::UnknownAlgorithm, SOURCE_REF);
 }
 
 // generate boost::program_options object for the routing part
@@ -331,8 +333,14 @@ int main(int argc, const char *argv[]) try
     routing_server.reset();
     util::Log() << "shutdown completed";
 }
+catch (const osrm::RuntimeError &e)
+{
+    util::Log(logERROR) << e.what();
+    return e.GetCode();
+}
 catch (const std::bad_alloc &e)
 {
+    util::DumpMemoryStats();
     util::Log(logWARNING) << "[exception] " << e.what();
     util::Log(logWARNING) << "Please provide more memory or consider using a larger swapfile";
     return EXIT_FAILURE;

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -1,8 +1,9 @@
 #include "storage/shared_memory.hpp"
 #include "storage/shared_monitor.hpp"
 #include "storage/storage.hpp"
-#include "util/exception.hpp"
+#include "osrm/exception.hpp"
 #include "util/log.hpp"
+#include "util/meminfo.hpp"
 #include "util/typedefs.hpp"
 #include "util/version.hpp"
 
@@ -172,8 +173,14 @@ int main(const int argc, const char *argv[]) try
 
     return storage.Run(max_wait);
 }
+catch (const osrm::RuntimeError &e)
+{
+    util::Log(logERROR) << e.what();
+    return e.GetCode();
+}
 catch (const std::bad_alloc &e)
 {
+    util::DumpMemoryStats();
     util::Log(logERROR) << "[exception] " << e.what();
     util::Log(logERROR) << "Please provide more memory or disable locking the virtual "
                            "address space (note: this makes OSRM swap, i.e. slow)";

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -17,5 +17,6 @@ namespace util
 {
 
 void exception::anchor() const {}
+void RuntimeError::anchor() const {}
 }
 }

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -25,7 +25,7 @@ test('constructor: does not accept more than one parameter', function(assert) {
 test('constructor: throws if necessary files do not exist', function(assert) {
     assert.plan(1);
     assert.throws(function() { new OSRM("missing.osrm"); },
-        /Error opening missing.osrm.names/);
+        /Problem opening file: missing.osrm.names/);
 });
 
 test('constructor: takes a shared memory argument', function(assert) {

--- a/unit_tests/util/io.cpp
+++ b/unit_tests/util/io.cpp
@@ -49,11 +49,12 @@ BOOST_AUTO_TEST_CASE(io_nonexistent_file)
                                              osrm::storage::io::FileReader::VerifyFingerprint);
         BOOST_REQUIRE_MESSAGE(false, "Should not get here");
     }
-    catch (const osrm::util::exception &e)
+    catch (const osrm::util::RuntimeError &e)
     {
-        const std::string expected("Error opening non_existent_test_io.tmp");
+        const std::string expected("Problem opening file: " + IO_NONEXISTENT_FILE);
         const std::string got(e.what());
         BOOST_REQUIRE(std::equal(expected.begin(), expected.end(), got.begin()));
+        BOOST_REQUIRE(e.GetCode() == osrm::ErrorCode::FileOpenError);
     }
 }
 
@@ -83,12 +84,12 @@ BOOST_AUTO_TEST_CASE(file_too_small)
         osrm::storage::serialization::read(infile, buffer);
         BOOST_REQUIRE_MESSAGE(false, "Should not get here");
     }
-    catch (const osrm::util::exception &e)
+    catch (const osrm::util::RuntimeError &e)
     {
-        const std::string expected(
-            "Error reading from file_too_small_test_io.tmp: Unexpected end of file");
+        const std::string expected("Unexpected end of file: " + IO_TOO_SMALL_FILE);
         const std::string got(e.what());
         BOOST_REQUIRE(std::equal(expected.begin(), expected.end(), got.begin()));
+        BOOST_REQUIRE(e.GetCode() == osrm::ErrorCode::UnexpectedEndOfFile);
     }
 }
 
@@ -111,11 +112,13 @@ BOOST_AUTO_TEST_CASE(io_corrupt_fingerprint)
                                              osrm::storage::io::FileReader::VerifyFingerprint);
         BOOST_REQUIRE_MESSAGE(false, "Should not get here");
     }
-    catch (const osrm::util::exception &e)
+    catch (const osrm::util::RuntimeError &e)
     {
-        const std::string expected("Fingerprint mismatch in corrupt_fingerprint_file_test_io.tmp");
+        const std::string expected("Fingerprint did not match the expected value: " +
+                                   IO_CORRUPT_FINGERPRINT_FILE);
         const std::string got(e.what());
         BOOST_REQUIRE(std::equal(expected.begin(), expected.end(), got.begin()));
+        BOOST_REQUIRE(e.GetCode() == osrm::ErrorCode::InvalidFingerprint);
     }
 }
 
@@ -146,11 +149,13 @@ BOOST_AUTO_TEST_CASE(io_incompatible_fingerprint)
                                              osrm::storage::io::FileReader::VerifyFingerprint);
         BOOST_REQUIRE_MESSAGE(false, "Should not get here");
     }
-    catch (const osrm::util::exception &e)
+    catch (const osrm::util::RuntimeError &e)
     {
-        const std::string expected("Fingerprint mismatch in " + IO_INCOMPATIBLE_FINGERPRINT_FILE);
+        const std::string expected("Fingerprint did not match the expected value: " +
+                                   IO_INCOMPATIBLE_FINGERPRINT_FILE);
         const std::string got(e.what());
         BOOST_REQUIRE(std::equal(expected.begin(), expected.end(), got.begin()));
+        BOOST_REQUIRE(e.GetCode() == osrm::ErrorCode::InvalidFingerprint);
     }
 }
 


### PR DESCRIPTION
# Issue

This PR is to address https://github.com/Project-OSRM/osrm-backend/issues/3968.  Currently, if any of the OSRM tools (`osrm-extract`, `osrm-contract`, etc) come across an error, we throw `osrm::util::exception`.  These don't get caught, so they trigger the default C++ [terminate handler](http://en.cppreference.com/w/cpp/error/terminate).  The default handler calls `abort()` on the current process.  In turn, this kills the process by sending it `SIGABRT`.

While this all sort of works, it's pretty messy, and doesn't leave glue code much room to figure out what went wrong, and possibly fix it.

This PR modifies the exception heirarchy, and creates a class of catchable-but-non-recoverable exceptions.  The tools have been modified to have more graceful handling of these new exceptions.

The practical outcome of this is that:

  - file permission errors
  - missing file problems
  - corrupt data problems
  - incorrect file problems
  - truncated file problems

will now print a clean error message and exit with a non-zero error code.  Users of `libosrm` will get a `osrm::RuntimeError` that can be caught for cleaner logging purposes, instead of the catch-all `osrm::exception` (although `osrm::RuntimeError` is a subclass of `osrm::exception`, so users already catching `osrm::exception` will not need any modification).

The new `osrm::RuntimeError` contains a more detailed error message, and a code value (similar to `std::runtime_error`).  The tools can use the code value as the `main()` return code, allowing management scripts to perform custom error recovery depending on the error value.

`osrm::exception` remains for "other" exceptions, where we don't want neat-and-tidy handling in various `src/tools/*.cpp` classes, and throwing `osrm::exception` will continue to trigger the C++ terminate handler.

## Tasklist
 - [ ] review
 - [ ] adjust for comments