### PR TITLE
Fix collapsing turns after crossing roundabout

### DIFF
--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -843,6 +843,6 @@ Feature: Basic Roundabout
 
 
         When I route I should get
-            | from | to | route                           | turns                                                                           | distance |
-            | e    | k  | ebds,ebds,ds,ufghl,gi,jhik,jhik | depart,rotary-exit-1,rotary-exit-1,rstur-exit-2,invalid right,turn right,arrive | 189.1m   |
-            | 1    | k  | ebds,ds,ufghl,gi,jhik,jhik      | depart,rotary-exit-1,rstur-exit-2,invalid right,turn right,arrive               | 159.1m   |
+            | from | to | route                        | turns                                                             | distance |
+            | e    | k  | ebds,ebds,ds,ufghl,jhik,jhik | depart,rotary-exit-1,rotary-exit-1,rstur-exit-2,turn right,arrive | 189.1m   |
+            | 1    | k  | ebds,ds,ufghl,jhik,jhik      | depart,rotary-exit-1,rstur-exit-2,turn right,arrive               | 159.1m   |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -816,3 +816,33 @@ Feature: Basic Roundabout
             |    1 | f  | abcda,df,df | depart,roundabout-exit-2,arrive |
             |    1 | g  | abcda,ag,ag | depart,roundabout-exit-3,arrive |
             |    1 | h  | abcda,bh,bh | depart,roundabout-exit-4,arrive |
+
+    Scenario: Collapsing a sliproad step after roundabouts
+        Given the node map
+            """
+                  a         r          j
+                ╱   ╲     ╱   ╲        │
+            e——b——1——d———s     u——f——g—h——l
+                ╲   ╱     ╲   ╱       `i
+                  c         t          │
+                  │         │          │
+                  m         v          k
+            """
+
+        And the ways
+            | nodes | highway  | junction   | oneway | #         |
+            | abcda | tertiary | roundabout |        | circle    |
+            | ebds  | tertiary |            |        | road      |
+            | cm    | tertiary |            |        |           |
+            | ds    | tertiary |            |        | road      |
+            | rstur | tertiary | roundabout |        | circle2   |
+            | ufghl | tertiary |            |        | road      |
+            | tv    | tertiary |            |        |           |
+            | gi    | tertiary |            | yes    | sliproad  |
+            | jhik  | tertiary |            |        | crossroad |
+
+
+        When I route I should get
+            | from | to | route                           | turns                                                                           | distance |
+            | e    | k  | ebds,ebds,ds,ufghl,gi,jhik,jhik | depart,rotary-exit-1,rotary-exit-1,rstur-exit-2,invalid right,turn right,arrive | 189.1m   |
+            | 1    | k  | ebds,ds,ufghl,gi,jhik,jhik      | depart,rotary-exit-1,rstur-exit-2,invalid right,turn right,arrive               | 159.1m   |

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -165,6 +165,10 @@ class RouteAPI : public BaseAPI
                  * to find a via point.
                  * The same exit will be emitted, though, if we should start routing at S, making
                  * the overall response consistent.
+                 *
+                 * ⚠ CAUTION: order of post-processing steps is important
+                 *    - postProcess must be called before collapseTurnInstructions that expects
+                 *      post-processed roundabouts without Exit instructions
                  */
 
                 guidance::trimShortSegments(steps, leg_geometry);

--- a/src/engine/guidance/collapse_turns.cpp
+++ b/src/engine/guidance/collapse_turns.cpp
@@ -315,6 +315,12 @@ RouteSteps collapseTurnInstructions(RouteSteps steps)
         if (entersRoundabout(current_step->maneuver.instruction) ||
             staysOnRoundabout(current_step->maneuver.instruction))
         {
+            // If postProcess is called before then all corresponding leavesRoundabout steps are
+            // removed and the current roundabout step can be ignored by directly proceeding to
+            // the next step.
+            // If postProcess is not called before then all steps till the next leavesRoundabout
+            // step must be skipped to prevent incorrect roundabouts post-processing.
+
             // are we done for good?
             if (current_step + 1 == steps.end())
                 break;

--- a/src/engine/guidance/collapse_turns.cpp
+++ b/src/engine/guidance/collapse_turns.cpp
@@ -315,22 +315,6 @@ RouteSteps collapseTurnInstructions(RouteSteps steps)
         if (entersRoundabout(current_step->maneuver.instruction) ||
             staysOnRoundabout(current_step->maneuver.instruction))
         {
-            // Skip over all instructions within the roundabout or check for
-            // special case from setUpRoundabout of a single Enter{Rotary,..} instruction
-            auto next_exit_or_enter =
-                std::find_if(current_step + 1, std::prev(steps.end()), [](const auto &step) {
-                    return leavesRoundabout(step.maneuver.instruction) ||
-                           entersRoundabout(step.maneuver.instruction);
-                });
-
-            bool is_touching_or_crossing_roundabout =
-                !leavesRoundabout(next_exit_or_enter->maneuver.instruction) &&
-                current_step->maneuver.exit == 1;
-
-            // If the instruction touches or crosses the roundabout then the current instruction
-            // is also an exit one otherwise move the current step to the corresponding exit
-            current_step = is_touching_or_crossing_roundabout ? current_step : next_exit_or_enter;
-
             // are we done for good?
             if (current_step + 1 == steps.end())
                 break;


### PR DESCRIPTION
# Issue

Fixes `collapseTurnInstructions` that ignores all instructions between an open roundabout and end of `steps`. The check is pretty conservative:

* finds a step that either `leavesRoundabout`, `entersRoundabout` or the last one
* if the found step is `leavesRoundabout` then previous behavior is conserved
* if the found step is not `leavesRoundabout` and `maneuver.exit == 1` then it is assumed that the exit step  is the current one

**Implicit assumption:** it is not possible to enter twice into the same roundabout, otherwise instructions that touch or cross roundabouts are indistinguishable.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
Related issue #4100
Related discussion  #4107