### PR TITLE
Uses correct coefficients for local optimality and stretch test in ch alternatives

### DIFF
--- a/features/testbot/alternative_loop.feature
+++ b/features/testbot/alternative_loop.feature
@@ -55,8 +55,8 @@ Feature: Alternative route
 
         When I route I should get
             | from | to | route    | alternative       |
-            | b    | c  | bc,bc    |                   |
-            #| c    | b  | bc,bc    |                   | # alternative path depends on phantom snapping order
+            | b    | c  | bc,bc    | ab,ae,ef,fd,cd,cd |
+            #| c    | b  | bc,bc    | cd,fd,ef,ae,ab,ab | # alternative path depends on phantom snapping order
             | 1    | c  | ab,bc,bc | ab,ae,ef,fd,cd,cd |
             #| c    | 1  | bc,ab    | cd,fd,ef,ae,ab    | # alternative path depends on phantom snapping order
             | 2 | c | bc,bc          |                   |

--- a/features/testbot/alternative_loop.feature
+++ b/features/testbot/alternative_loop.feature
@@ -30,3 +30,38 @@ Feature: Alternative route
             | 3    | 4  | bd,dc,ca,ab,bd,bd |             |
             | 5    | 6  | dc,ca,ab,bd,dc,dc |             |
             | 7    | 8  | ca,ab,bd,dc,ca,ca |             |
+
+    @4111
+    Scenario: Alternative Loop Paths with single node path
+        Given the node map
+            """
+            a1b2c3d
+
+
+            e     f
+            """
+
+        And the ways
+            | nodes | maxspeed |
+            | ab    |      30  |
+            | bc    |       3  |
+            | cd    |      30  |
+            | ae    |      30  |
+            | ef    |      30  |
+            | fd    |      30  |
+
+        And the query options
+            | alternatives | true |
+
+        When I route I should get
+            | from | to | route    | alternative       |
+            | b    | c  | bc,bc    |                   |
+            #| c    | b  | bc,bc    |                   | # alternative path depends on phantom snapping order
+            | 1    | c  | ab,bc,bc | ab,ae,ef,fd,cd,cd |
+            #| c    | 1  | bc,ab    | cd,fd,ef,ae,ab    | # alternative path depends on phantom snapping order
+            | 2 | c | bc,bc          |                   |
+            | c | 2 | bc,bc          |                   |
+            | 1 | 3 | ab,ae,ef,fd,cd | ab,bc,cd          |
+            #| 3 | 1 | cd,fd,ef,ae,ab | cd,bc,ab          | # alternative path depends on phantom snapping order
+            | b | 3 | bc,cd          | ab,ae,ef,fd,cd    |
+            #| 3 | b | cd,bc,bc       | cd,fd,ef,ae,ab,ab | # alternative path depends on phantom snapping order

--- a/src/engine/routing_algorithms/alternative_path.cpp
+++ b/src/engine/routing_algorithms/alternative_path.cpp
@@ -24,7 +24,7 @@ namespace ch
 
 namespace
 {
-const double constexpr VIAPATH_ALPHA = 0.10;
+const double constexpr VIAPATH_ALPHA = 0.25;   // alternative is local optimum on 25% sub-paths
 const double constexpr VIAPATH_EPSILON = 0.15; // alternative at most 15% longer
 const double constexpr VIAPATH_GAMMA = 0.75;   // alternative shares at most 75% with the shortest.
 
@@ -398,8 +398,7 @@ bool viaNodeCandidatePassesTTest(
     {
         return false;
     }
-    const EdgeWeight T_threshold =
-        static_cast<EdgeWeight>(VIAPATH_EPSILON * weight_of_shortest_path);
+    const EdgeWeight T_threshold = static_cast<EdgeWeight>(VIAPATH_ALPHA * weight_of_shortest_path);
     EdgeWeight unpacked_until_weight = 0;
 
     std::stack<SearchSpaceEdge> unpack_stack;
@@ -732,7 +731,7 @@ alternativePathSearch(SearchEngineData<Algorithm> &engine_working_data,
             (approximated_sharing <= upper_bound_to_shortest_path_weight * VIAPATH_GAMMA);
         const bool stretch_passes =
             (approximated_weight - approximated_sharing) <
-            ((1. + VIAPATH_ALPHA) * (upper_bound_to_shortest_path_weight - approximated_sharing));
+            ((1. + VIAPATH_EPSILON) * (upper_bound_to_shortest_path_weight - approximated_sharing));
 
         if (weight_passes && sharing_passes && stretch_passes)
         {


### PR DESCRIPTION
The alpha constant is for the local optimality T-Test threshold.

Before we used epsilon for the T-Test threshold, but the epsilon
constant is meant to be used for the stretch test(s) only.

This changeset fixes the local optimality T-Test and uses the
epsilon constant for the two stretch tests:
- We test the stretch for the total route against epsilon and
- We test the detour against the epsilon now, too

We can discuss if the second stretch test should actually use
epsilon, too, or a adapted value of it - but definitely not alpha.

---

👴 🚗 ⚡️ <details>This is a Back To The Future reference - I hope you got it</details>

Seems like the t-test come in through [this](https://github.com/Project-OSRM/osrm-backend/commit/5ebc4b392f44f14b3deb025acef06ed050ce23b2) commit in 2012 and it introduced the epsilon constant.
The constant was then later on re-used for the stretch test.