### PR TITLE
Incompatible dataset abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - Bugfixes
       - Fixed a copy/paste issue assigning wrong directions in similar turns (left over right)
       - #4074: fixed a bug that would announce entering highway ramps as u-turns
+      - #4122: osrm-routed/libosrm should throw exception when a dataset incompatible with the requested algorithm is loaded
 
 # 5.7.1
     - Bugfixes

--- a/features/options/routed/invalid.feature
+++ b/features/options/routed/invalid.feature
@@ -14,5 +14,5 @@ Feature: osrm-routed command line options: invalid options
     Scenario: osrm-routed - Missing file
         When I try to run "osrm-routed over-the-rainbow.osrm"
         Then stderr should contain "over-the-rainbow.osrm"
-        And stderr should contain "not found"
+        And stderr should contain "Required files are missing"
         And it should exit with an error

--- a/src/storage/storage_config.cpp
+++ b/src/storage/storage_config.cpp
@@ -14,9 +14,9 @@ bool CheckFileList(const std::vector<boost::filesystem::path> &files)
     bool success = true;
     for (auto &path : files)
     {
-        if (!boost::filesystem::is_regular_file(path))
+        if (!boost::filesystem::exists(path))
         {
-            util::Log(logWARNING) << "Missing/Broken File: " << path.string();
+            util::Log(logERROR) << "Missing File: " << path.string();
             success = false;
         }
     }
@@ -61,14 +61,6 @@ bool StorageConfig::IsValid() const
     {
         return false;
     }
-
-    // TODO: add algorithm checks
-
-    // CH files
-    CheckFileList({hsgr_data_path, core_data_path});
-
-    // MLD files
-    CheckFileList({mld_partition_path, mld_storage_path, mld_graph_path});
 
     return true;
 }

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -223,32 +223,16 @@ int main(int argc, const char *argv[]) try
     {
         config.storage_config = storage::StorageConfig(base_path);
     }
+    if (!config.use_shared_memory && !config.storage_config.IsValid())
+    {
+        util::Log(logERROR) << "Required files are missing, cannot continue";
+        return EXIT_FAILURE;
+    }
     if (!config.IsValid())
     {
         if (base_path.empty() != config.use_shared_memory)
         {
             util::Log(logWARNING) << "Path settings and shared memory conflicts.";
-        }
-        else
-        {
-            auto required_files = {config.storage_config.ram_index_path,
-                                   config.storage_config.file_index_path,
-                                   config.storage_config.hsgr_data_path,
-                                   config.storage_config.node_based_nodes_data_path,
-                                   config.storage_config.edge_based_nodes_data_path,
-                                   config.storage_config.edges_data_path,
-                                   config.storage_config.core_data_path,
-                                   config.storage_config.geometries_path,
-                                   config.storage_config.datasource_indexes_path,
-                                   config.storage_config.names_data_path,
-                                   config.storage_config.properties_path};
-            for (auto file : required_files)
-            {
-                if (!boost::filesystem::is_regular_file(file))
-                {
-                    util::Log(logWARNING) << file << " is not found";
-                }
-            }
         }
         return EXIT_FAILURE;
     }

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -23,9 +23,12 @@ test('constructor: does not accept more than one parameter', function(assert) {
 });
 
 test('constructor: throws if necessary files do not exist', function(assert) {
-    assert.plan(1);
-    assert.throws(function() { new OSRM("missing.osrm"); },
-        /Problem opening file: missing.osrm.names/);
+    assert.plan(2);
+    assert.throws(function() { new OSRM('missing.osrm'); },
+        /Required files are missing, cannot continue/);
+
+    assert.throws(function() { new OSRM({path: 'missing.osrm', algorithm: 'MLD'}); },
+        /Required files are missing, cannot continue/);
 });
 
 test('constructor: takes a shared memory argument', function(assert) {
@@ -80,6 +83,19 @@ test('constructor: loads CoreCH if given as algorithm', function(assert) {
     assert.plan(1);
     var osrm = new OSRM({algorithm: 'CoreCH', path: monaco_corech_path});
     assert.ok(osrm);
+});
+
+test('constructor: autoswitches to CoreCH for a CH dataset if capable', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({algorithm: 'CH', path: monaco_corech_path});
+    assert.ok(osrm);
+});
+
+test('constructor: throws if data doesn\'t match algorithm', function(assert) {
+    assert.plan(3);
+    assert.throws(function() { new OSRM({algorithm: 'CoreCH', path: monaco_mld_path}); });
+    assert.throws(function() { new OSRM({algorithm: 'CoreCH', path: monaco_path}); });
+    assert.throws(function() { new OSRM({algorithm: 'MLD', path: monaco_path}); });
 });
 
 require('./route.js');

--- a/unit_tests/library/algorithm.cpp
+++ b/unit_tests/library/algorithm.cpp
@@ -1,0 +1,34 @@
+#include <boost/test/test_case_template.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "fixture.hpp"
+
+#include "osrm/exception.hpp"
+
+BOOST_AUTO_TEST_SUITE(table)
+
+BOOST_AUTO_TEST_CASE(test_incompatible_with_mld)
+{
+    // Can't use the MLD algorithm with CH data
+    BOOST_CHECK_THROW(
+        getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm", osrm::EngineConfig::Algorithm::MLD),
+        osrm::exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_incompatible_with_corech)
+{
+    // Note - CH-only data can't be used with the CoreCH algorithm
+    BOOST_CHECK_THROW(
+        getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm", osrm::EngineConfig::Algorithm::CoreCH),
+        osrm::exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_incompatible_with_ch)
+{
+    // Can't use the CH algorithm with MLD data
+    BOOST_CHECK_THROW(
+        getOSRM(OSRM_TEST_DATA_DIR "/mld/monaco.osrm", osrm::EngineConfig::Algorithm::CH),
+        osrm::exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/library/fixture.hpp
+++ b/unit_tests/library/fixture.hpp
@@ -9,11 +9,14 @@
 // I couldn't get Boost.UnitTest to provide a test suite level fixture with custom
 // arguments per test suite (osrm base path from argv), so this has to suffice.
 
-inline osrm::OSRM getOSRM(const std::string &base_path)
+inline osrm::OSRM
+getOSRM(const std::string &base_path,
+        osrm::EngineConfig::Algorithm algorithm = osrm::EngineConfig::Algorithm::CH)
 {
     osrm::EngineConfig config;
     config.storage_config = {base_path};
     config.use_shared_memory = false;
+    config.algorithm = algorithm;
 
     return osrm::OSRM{config};
 }

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -7,6 +7,7 @@
 
 #include "osrm/coordinate.hpp"
 #include "osrm/engine_config.hpp"
+#include "osrm/exception.hpp"
 #include "osrm/json_container.hpp"
 #include "osrm/json_container.hpp"
 #include "osrm/osrm.hpp"


### PR DESCRIPTION
# Issue

This PR addresses https://github.com/Project-OSRM/osrm-backend/issues/4122 by causing the `OSRM::OSRM()` constructor to throw an exception if the dataset that is being loaded is not compatible with the algorithm chosen.  Prior to this change, the failure wasn't seen until the first query attempted to access the loaded dataset.  It is generally preferable to be [fail-fast](https://en.wikipedia.org/wiki/Fail-fast).

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments