### PR TITLE
Fix roundabouts with footway exits

### DIFF
--- a/features/guidance/roundabout-turn-bike.feature
+++ b/features/guidance/roundabout-turn-bike.feature
@@ -61,7 +61,7 @@ Feature: Basic Roundabout
            | waypoints | route          | turns                                                              |
            | a,d       | ab,cd,cd       | depart,roundabout turn left exit-1,arrive                          |
            | a,f       | ab,ef,ef,ef    | depart,roundabout turn left exit-1,notification right,arrive       |
-           | a,h       | ab,bgecb,gh,gh | depart,invalid right,notification right,arrive                     |
+           | a,h       | ab,bgecb,gh,gh | depart,roundabout turn right exit-1,notification right,arrive      |
            | d,f       | cd,ef,ef,ef    | depart,roundabout turn sharp left exit-2,notification right,arrive |
            | d,h       | cd,gh,gh,gh    | depart,roundabout turn left exit-2,notification right,arrive       |
            | d,a       | cd,ab,ab       | depart,roundabout turn right exit-1,arrive                         |
@@ -70,4 +70,4 @@ Feature: Basic Roundabout
            | f,d       | ef,cd,cd       | depart,roundabout turn right exit-1,arrive                         |
            | h,a       | gh,ab,ab       | depart,roundabout turn left exit-2,arrive                          |
            | h,d       | gh,cd,cd       | depart,roundabout turn straight exit-1,arrive                      |
-           | h,f       | gh,bgecb,ef,ef | depart,invalid right,notification right,arrive                     |
+           | h,f       | gh,bgecb,ef,ef | depart,roundabout turn right exit-1,notification right,arrive      |

--- a/features/guidance/roundabout-turn-bike.feature
+++ b/features/guidance/roundabout-turn-bike.feature
@@ -37,3 +37,37 @@ Feature: Basic Roundabout
            | h,a       | gh,ab,ab | depart,roundabout turn left exit-3,arrive     |
            | h,d       | gh,cd,cd | depart,roundabout turn straight exit-2,arrive |
            | h,f       | gh,ef,ef | depart,roundabout turn right exit-1,arrive    |
+
+    # https://www.openstreetmap.org/way/223225602
+    Scenario: Enter and Exit with changing mode
+        Given the node map
+            """
+                a
+                b
+            h g   c d
+                e
+                f
+            """
+
+       And the ways
+            | nodes | junction   | highway     |
+            | ab    |            | residential |
+            | cd    |            | residential |
+            | ef    |            | footway     |
+            | gh    |            | footway     |
+            | bgecb | roundabout | residential |
+
+       When I route I should get
+           | waypoints | route          | turns                                                              |
+           | a,d       | ab,cd,cd       | depart,roundabout turn left exit-1,arrive                          |
+           | a,f       | ab,ef,ef,ef    | depart,roundabout turn left exit-1,notification right,arrive       |
+           | a,h       | ab,bgecb,gh,gh | depart,invalid right,notification right,arrive                     |
+           | d,f       | cd,ef,ef,ef    | depart,roundabout turn sharp left exit-2,notification right,arrive |
+           | d,h       | cd,gh,gh,gh    | depart,roundabout turn left exit-2,notification right,arrive       |
+           | d,a       | cd,ab,ab       | depart,roundabout turn right exit-1,arrive                         |
+           | f,h       | ef,gh,gh,gh    | depart,roundabout turn sharp left exit-3,notification right,arrive |
+           | f,a       | ef,ab,ab       | depart,roundabout turn straight exit-2,arrive                      |
+           | f,d       | ef,cd,cd       | depart,roundabout turn right exit-1,arrive                         |
+           | h,a       | gh,ab,ab       | depart,roundabout turn left exit-2,arrive                          |
+           | h,d       | gh,cd,cd       | depart,roundabout turn straight exit-1,arrive                      |
+           | h,f       | gh,bgecb,ef,ef | depart,invalid right,notification right,arrive                     |

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -171,9 +171,11 @@ void closeOffRoundabout(const bool on_roundabout,
         if (!guidance::haveSameMode(exit_step, prev_step))
         {
             BOOST_ASSERT(leavesRoundabout(exit_step.maneuver.instruction));
-            prev_step.maneuver.instruction = exit_step.maneuver.instruction;
             if (!entersRoundabout(prev_step.maneuver.instruction))
-                prev_step.maneuver.exit = exit_step.maneuver.exit;
+            {
+                prev_step.maneuver.instruction = exit_step.maneuver.instruction;
+            }
+            prev_step.maneuver.exit = exit_step.maneuver.exit;
             exit_step.maneuver.instruction.type = TurnType::Notification;
             step_index--;
         }
@@ -198,9 +200,12 @@ void closeOffRoundabout(const bool on_roundabout,
         {
             auto &propagation_step = steps[propagation_index];
             auto &next_step = steps[propagation_index + 1];
-            propagation_step.ElongateBy(next_step);
-            propagation_step.maneuver.exit = next_step.maneuver.exit;
-            next_step.Invalidate();
+            if (guidance::haveSameMode(propagation_step, next_step))
+            {
+                propagation_step.ElongateBy(next_step);
+                propagation_step.maneuver.exit = next_step.maneuver.exit;
+                next_step.Invalidate();
+            }
 
             if (entersRoundabout(propagation_step.maneuver.instruction))
             {


### PR DESCRIPTION
# Issue

Assertion in #4129 occurs due to overwriting `EnterRoundabout` instruction at https://github.com/Project-OSRM/osrm-backend/blob/62b6c47a3112e47896b763b94fc0bd243c3b88e0/src/engine/guidance/post_processing.cpp#L171-L179 , so [`enterRoundabout`](https://github.com/Project-OSRM/osrm-backend/blob/62b6c47a3112e47896b763b94fc0bd243c3b88e0/src/engine/guidance/post_processing.cpp#L205) could correspond to another roundabout

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] fix the issue
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
