### PR TITLE
Parallelize creation of edge-expanded edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
       - Added conditional restriction support with `parse-conditional-restrictions=true|false` to osrm-extract. This option saves conditional turn restrictions to the .restrictions file for parsing by contract later. Added `parse-conditionals-from-now=utc time stamp` and `--time-zone-file=/path/to/file`  to osrm-contract
       - Command-line tools (osrm-extract, osrm-contract, osrm-routed, etc) now return error codes and legible error messages for common problem scenarios, rather than ugly C++ crashes
       - Speed up pre-processing by only running the Lua `node_function` for nodes that have tags.  Cuts OSM file parsing time in half.
+      - osrm-extract now performs generation of edge-expanded-edges using all available CPUs, which should make osrm-extract significantly faster on multi-CPU machines
     - Files
       - .osrm.nodes file was renamed to .nbg_nodes and .ebg_nodes was added
     - Guidance

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -18,6 +18,7 @@
 #include "extractor/query_node.hpp"
 #include "extractor/restriction_map.hpp"
 
+#include "util/concurrent_id_map.hpp"
 #include "util/deallocating_vector.hpp"
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
@@ -40,6 +41,9 @@
 #include <vector>
 
 #include <boost/filesystem/fstream.hpp>
+
+#include <tbb/concurrent_unordered_map.h>
+#include <tbb/concurrent_vector.h>
 
 namespace osrm
 {
@@ -167,9 +171,9 @@ class EdgeBasedGraphFactory
     std::size_t skipped_uturns_counter;
     std::size_t skipped_barrier_turns_counter;
 
-    std::unordered_map<util::guidance::BearingClass, BearingClassID> bearing_class_hash;
+    util::ConcurrentIDMap<util::guidance::BearingClass, BearingClassID> bearing_class_hash;
     std::vector<BearingClassID> bearing_class_by_node_based_node;
-    std::unordered_map<util::guidance::EntryClass, EntryClassID> entry_class_hash;
+    util::ConcurrentIDMap<util::guidance::EntryClass, EntryClassID> entry_class_hash;
 };
 } // namespace extractor
 } // namespace osrm

--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -65,12 +65,16 @@ const constexpr char *scenario_names[] = {"Simple",
 
 class TurnLaneHandler
 {
+    using UpgradableMutex = boost::interprocess::interprocess_upgradable_mutex;
+    using ScopedReaderLock = boost::interprocess::sharable_lock<UpgradableMutex>;
+    using ScopedWriterLock = boost::interprocess::scoped_lock<UpgradableMutex>;
+
   public:
     typedef std::vector<TurnLaneData> LaneDataVector;
 
     TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
-                    std::vector<std::uint32_t> &turn_lane_offsets,
-                    std::vector<TurnLaneType::Mask> &turn_lane_masks,
+                    const std::vector<std::uint32_t> &turn_lane_offsets,
+                    const std::vector<TurnLaneType::Mask> &turn_lane_masks,
                     LaneDescriptionMap &lane_description_map,
                     const TurnAnalysis &turn_analysis,
                     util::guidance::LaneDataIdMap &id_map);
@@ -86,8 +90,8 @@ class TurnLaneHandler
     // we need to be able to look at previous intersections to, in some cases, find the correct turn
     // lanes for a turn
     const util::NodeBasedDynamicGraph &node_based_graph;
-    std::vector<std::uint32_t> &turn_lane_offsets;
-    std::vector<TurnLaneType::Mask> &turn_lane_masks;
+    const std::vector<std::uint32_t> &turn_lane_offsets;
+    const std::vector<TurnLaneType::Mask> &turn_lane_masks;
     LaneDescriptionMap &lane_description_map;
     const TurnAnalysis &turn_analysis;
     util::guidance::LaneDataIdMap &id_map;

--- a/include/extractor/guidance/turn_lane_types.hpp
+++ b/include/extractor/guidance/turn_lane_types.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/functional/hash.hpp>
 
+#include "util/concurrent_id_map.hpp"
 #include "util/json_container.hpp"
 #include "util/typedefs.hpp"
 
@@ -93,9 +94,9 @@ struct TurnLaneDescription_hash
     }
 };
 
-typedef std::unordered_map<guidance::TurnLaneDescription,
-                           LaneDescriptionID,
-                           guidance::TurnLaneDescription_hash>
+typedef util::ConcurrentIDMap<guidance::TurnLaneDescription,
+                              LaneDescriptionID,
+                              guidance::TurnLaneDescription_hash>
     LaneDescriptionMap;
 
 } // guidance

--- a/include/extractor/turn_data_container.hpp
+++ b/include/extractor/turn_data_container.hpp
@@ -31,6 +31,15 @@ void write(storage::io::FileWriter &writer,
            const detail::TurnDataContainerImpl<Ownership> &turn_data);
 }
 
+struct TurnData
+{
+    extractor::guidance::TurnInstruction turn_instruction;
+    LaneDataID lane_data_id;
+    EntryClassID entry_class_id;
+    util::guidance::TurnBearing pre_turn_bearing;
+    util::guidance::TurnBearing post_turn_bearing;
+};
+
 namespace detail
 {
 template <storage::Ownership Ownership> class TurnDataContainerImpl
@@ -75,17 +84,20 @@ template <storage::Ownership Ownership> class TurnDataContainerImpl
 
     // Used by EdgeBasedGraphFactory to fill data structure
     template <typename = std::enable_if<Ownership == storage::Ownership::Container>>
-    void push_back(extractor::guidance::TurnInstruction turn_instruction,
-                   LaneDataID lane_data_id,
-                   EntryClassID entry_class_id,
-                   util::guidance::TurnBearing pre_turn_bearing,
-                   util::guidance::TurnBearing post_turn_bearing)
+    void push_back(const TurnData &data)
     {
-        turn_instructions.push_back(turn_instruction);
-        lane_data_ids.push_back(lane_data_id);
-        entry_class_ids.push_back(entry_class_id);
-        pre_turn_bearings.push_back(pre_turn_bearing);
-        post_turn_bearings.push_back(post_turn_bearing);
+        turn_instructions.push_back(data.turn_instruction);
+        lane_data_ids.push_back(data.lane_data_id);
+        entry_class_ids.push_back(data.entry_class_id);
+        pre_turn_bearings.push_back(data.pre_turn_bearing);
+        post_turn_bearings.push_back(data.post_turn_bearing);
+    }
+
+    template <typename = std::enable_if<Ownership == storage::Ownership::Container>>
+    void append(const std::vector<TurnData> &others)
+    {
+        std::for_each(
+            others.begin(), others.end(), [this](const TurnData &other) { push_back(other); });
     }
 
     friend void serialization::read<Ownership>(storage::io::FileReader &reader,

--- a/include/util/concurrent_id_map.hpp
+++ b/include/util/concurrent_id_map.hpp
@@ -1,0 +1,57 @@
+#ifndef CONCURRENT_ID_MAP_HPP
+#define CONCURRENT_ID_MAP_HPP
+
+#include <boost/interprocess/sync/interprocess_upgradable_mutex.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+#include <boost/interprocess/sync/sharable_lock.hpp>
+
+#include <unordered_map>
+
+namespace osrm
+{
+namespace util
+{
+
+/**
+ * This is a special purpose map for caching incrementing IDs
+ */
+template <typename KeyType, typename ValueType, typename HashType = std::hash<KeyType>>
+struct ConcurrentIDMap
+{
+    static_assert(std::is_unsigned<ValueType>::value, "Only unsigned integer types are supported.");
+
+    using UpgradableMutex = boost::interprocess::interprocess_upgradable_mutex;
+    using ScopedReaderLock = boost::interprocess::sharable_lock<UpgradableMutex>;
+    using ScopedWriterLock = boost::interprocess::scoped_lock<UpgradableMutex>;
+
+    std::unordered_map<KeyType, ValueType, HashType> data;
+    mutable UpgradableMutex mutex;
+
+    const ValueType ConcurrentFindOrAdd(const KeyType &key)
+    {
+        {
+            ScopedReaderLock sentry{mutex};
+            const auto result = data.find(key);
+            if (result != data.end())
+            {
+                return result->second;
+            }
+        }
+        {
+            ScopedWriterLock sentry{mutex};
+            const auto result = data.find(key);
+            if (result != data.end())
+            {
+                return result->second;
+            }
+            const auto id = static_cast<ValueType>(data.size());
+            data[key] = id;
+            return id;
+        }
+    }
+};
+
+} // util
+} // osrm
+
+#endif // CONCURRENT_ID_MAP_HPP

--- a/include/util/guidance/turn_lanes.hpp
+++ b/include/util/guidance/turn_lanes.hpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "util/concurrent_id_map.hpp"
 #include "util/typedefs.hpp"
 
 #include <boost/functional/hash.hpp>
@@ -97,7 +98,7 @@ class LaneTupleIdPair
     }
 };
 
-using LaneDataIdMap = std::unordered_map<LaneTupleIdPair, LaneDataID, boost::hash<LaneTupleIdPair>>;
+using LaneDataIdMap = ConcurrentIDMap<LaneTupleIdPair, LaneDataID, boost::hash<LaneTupleIdPair>>;
 
 } // namespace guidance
 } // namespace util

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -77,8 +77,9 @@ transformTurnLaneMapIntoArrays(const guidance::LaneDescriptionMap &turn_lane_map
     //
     // turn lane offsets points into the locations of the turn_lane_masks array. We use a standard
     // adjacency array like structure to store the turn lane masks.
-    std::vector<std::uint32_t> turn_lane_offsets(turn_lane_map.size() + 2); // empty ID + sentinel
-    for (auto entry = turn_lane_map.begin(); entry != turn_lane_map.end(); ++entry)
+    std::vector<std::uint32_t> turn_lane_offsets(turn_lane_map.data.size() +
+                                                 2); // empty ID + sentinel
+    for (auto entry = turn_lane_map.data.begin(); entry != turn_lane_map.data.end(); ++entry)
         turn_lane_offsets[entry->second + 1] = entry->first.size();
 
     // inplace prefix sum
@@ -86,7 +87,7 @@ transformTurnLaneMapIntoArrays(const guidance::LaneDescriptionMap &turn_lane_map
 
     // allocate the current masks
     std::vector<guidance::TurnLaneType::Mask> turn_lane_masks(turn_lane_offsets.back());
-    for (auto entry = turn_lane_map.begin(); entry != turn_lane_map.end(); ++entry)
+    for (auto entry = turn_lane_map.data.begin(); entry != turn_lane_map.data.end(); ++entry)
         std::copy(entry->first.begin(),
                   entry->first.end(),
                   turn_lane_masks.begin() + turn_lane_offsets[entry->second]);
@@ -331,7 +332,7 @@ std::vector<TurnRestriction> Extractor::ParseOSMData(ScriptingEnvironment &scrip
                 << " ways, and " << number_of_relations << " relations";
 
     // take control over the turn lane map
-    turn_lane_map = extractor_callbacks->moveOutLaneDescriptionMap();
+    turn_lane_map.data = extractor_callbacks->moveOutLaneDescriptionMap().data;
 
     extractor_callbacks.reset();
 

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -41,7 +41,7 @@ ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containe
 {
     // we reserved 0, 1, 2, 3 for the empty case
     string_map[MapKey("", "", "", "")] = 0;
-    lane_description_map[TurnLaneDescription()] = 0;
+    lane_description_map.data[TurnLaneDescription()] = 0;
 }
 
 /**
@@ -251,18 +251,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
             return INVALID_LANE_DESCRIPTIONID;
         TurnLaneDescription lane_description = laneStringToDescription(std::move(lane_string));
 
-        const auto lane_description_itr = lane_description_map.find(lane_description);
-        if (lane_description_itr == lane_description_map.end())
-        {
-            const LaneDescriptionID new_id =
-                boost::numeric_cast<LaneDescriptionID>(lane_description_map.size());
-            lane_description_map[lane_description] = new_id;
-            return new_id;
-        }
-        else
-        {
-            return lane_description_itr->second;
-        }
+        return lane_description_map.ConcurrentFindOrAdd(lane_description);
     };
 
     // Deduplicates street names, refs, destinations, pronunciation based on the string_map.

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -34,8 +34,8 @@ std::size_t getNumberOfTurns(const Intersection &intersection)
 } // namespace
 
 TurnLaneHandler::TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
-                                 std::vector<std::uint32_t> &turn_lane_offsets,
-                                 std::vector<TurnLaneType::Mask> &turn_lane_masks,
+                                 const std::vector<std::uint32_t> &turn_lane_offsets,
+                                 const std::vector<TurnLaneType::Mask> &turn_lane_masks,
                                  LaneDescriptionMap &lane_description_map,
                                  const TurnAnalysis &turn_analysis,
                                  util::guidance::LaneDataIdMap &id_map)
@@ -781,19 +781,8 @@ Intersection TurnLaneHandler::handleSliproadTurn(Intersection intersection,
         }
     }
 
-    const auto combined_id = [&]() {
-        auto itr = lane_description_map.find(combined_description);
-        if (lane_description_map.find(combined_description) == lane_description_map.end())
-        {
-            const auto new_id = boost::numeric_cast<LaneDescriptionID>(lane_description_map.size());
-            lane_description_map[combined_description] = new_id;
-            return new_id;
-        }
-        else
-        {
-            return itr->second;
-        }
-    }();
+    const auto combined_id = lane_description_map.ConcurrentFindOrAdd(combined_description);
+
     return simpleMatchTuplesToTurns(std::move(intersection), lane_data, combined_id);
 }
 

--- a/src/extractor/guidance/turn_lane_matcher.cpp
+++ b/src/extractor/guidance/turn_lane_matcher.cpp
@@ -209,16 +209,7 @@ Intersection triviallyMatchLanesToTurns(Intersection intersection,
         util::guidance::LaneTupleIdPair key{{LaneID(data.to - data.from + 1), data.from},
                                             lane_string_id};
 
-        auto lane_data_id = boost::numeric_cast<LaneDataID>(lane_data_to_id.size());
-        const auto it = lane_data_to_id.find(key);
-
-        if (it == lane_data_to_id.end())
-            lane_data_to_id.insert({key, lane_data_id});
-        else
-            lane_data_id = it->second;
-
-        // set lane id instead after the switch:
-        road.lane_data_id = lane_data_id;
+        road.lane_data_id = lane_data_to_id.ConcurrentFindOrAdd(key);
     };
 
     if (!lane_data.empty() && lane_data.front().tag == TurnLaneType::uturn)


### PR DESCRIPTION
# Issue

This PR is to address https://github.com/Project-OSRM/osrm-backend/issues/3883.

Currently, creation of the edge-expanded graph is single-threaded.  This PR changes that so that we analyze and generate all turns using all available CPU resources.

The crux of this change is:

  - it uses `tbb::blocked_range` to break the nodes in the node-based-graph into groups
  - within each group, we perform the same logic as before, saving results to thread-local buffers
  - at the end of each block, there's a global lock where we copy results serially into the primary buffers
  - as a final step after all blocks are complete, `turn_id` values are assigned to members of `m_edge_based_edge_list[].data.turn_id`

The global lock introduces a contention point that's currently unavoidable - ordering of the various data structures must remain consistent, so items have to be appended to the main lists at the same time.  However, most of the work is in the turn analysis, and that can operate on independent worker threads.

Because of the size of the `lookup::TurnIndexBlock`, it's not practical to buffer that data in RAM during edge generation, it needs to be written to disk as processing proceeds.  This precludes the use of `tbb::enumerable_thread_specific`, as we can't guarantee that it will iterate in the same order that we write the `TurnIndexBlock` data to disk during the processing run.

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments