### PR TITLE
Parallize scripting on osmium::Buffer granularity

### DIFF
--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -58,13 +58,12 @@ class ScriptingEnvironment
     virtual void ProcessTurn(ExtractionTurn &turn) = 0;
     virtual void ProcessSegment(ExtractionSegment &segment) = 0;
 
-    virtual void
-    ProcessElements(const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
-                    const RestrictionParser &restriction_parser,
-                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes,
-                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
-                    tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
-                        &resulting_restrictions) = 0;
+    virtual void ProcessElements(
+        const osmium::memory::Buffer &buffer,
+        const RestrictionParser &restriction_parser,
+        std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
+        std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
+        std::vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions) = 0;
 };
 }
 }

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -65,13 +65,12 @@ class Sol2ScriptingEnvironment final : public ScriptingEnvironment
     void ProcessTurn(ExtractionTurn &turn) override;
     void ProcessSegment(ExtractionSegment &segment) override;
 
-    void
-    ProcessElements(const std::vector<osmium::memory::Buffer::const_iterator> &osm_elements,
-                    const RestrictionParser &restriction_parser,
-                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionNode>> &resulting_nodes,
-                    tbb::concurrent_vector<std::pair<std::size_t, ExtractionWay>> &resulting_ways,
-                    tbb::concurrent_vector<boost::optional<InputRestrictionContainer>>
-                        &resulting_restrictions) override;
+    void ProcessElements(
+        const osmium::memory::Buffer &buffer,
+        const RestrictionParser &restriction_parser,
+        std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
+        std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
+        std::vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions) override;
 
   private:
     void InitContext(LuaScriptingContext &context);


### PR DESCRIPTION
Fixes #3447 and reduces parsing time by about 15%.

## Tasklist
 - [x] review
 - [x] adjust for comments