### PR TITLE
Docker: Use ubuntu as base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,27 @@
-FROM alpine:3.5
+FROM ubuntu:16.04
 
-RUN mkdir /opt
 WORKDIR /opt
 
 RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
-    echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    apk update && \
-    apk upgrade && \
-    apk add git cmake wget make libc-dev gcc g++ bzip2-dev boost-dev zlib-dev expat-dev lua5.1-dev libtbb@testing libtbb-dev@testing && \
-    \
-    echo "Building libstxxl" && \
-    cd /opt && \
-    git clone --depth 1 --branch 1.4.1 https://github.com/stxxl/stxxl.git && \
-    cd stxxl && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release .. && \
-    make -j${NPROC} && \
-    make install
+    apt-get update -y && \
+    apt-get install -y \
+        build-essential \
+        git \
+        cmake \
+        pkg-config \
+        libbz2-dev \
+        libstxxl-dev \
+        libstxxl1v5 \
+        libxml2-dev \
+        libzip-dev \
+        libboost-all-dev \
+        lua5.2 \
+        liblua5.2-dev \
+        libtbb-dev \
+        libjemalloc-dev
 
 ARG DOCKER_TAG
+
 RUN mkdir /src
 COPY . /src
 WORKDIR /src
@@ -28,6 +30,7 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1 && \
     mkdir build && \
     cd build && \
     BUILD_TYPE="Release" && \
@@ -40,14 +43,13 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     make -j${NPROC} install && \
     cd ../profiles && \
     cp -r * /opt && \
+    cd /opt && \
     \
     echo "Cleaning up" && \
     strip /usr/local/bin/* && \
-    rm /usr/local/lib/libstxxl* && \
-    cd /opt && \
-    apk del boost-dev && \
-    apk del g++ cmake libc-dev expat-dev zlib-dev bzip2-dev lua5.1-dev git make gcc && \
-    apk add boost-filesystem boost-program_options boost-regex boost-iostreams boost-thread libgomp lua5.1 expat && \
-    rm -rf /src /opt/stxxl /usr/local/bin/stxxl_tool /usr/local/lib/libosrm*
+    rm -rf /src && \
+    apt-get autoremove -y
+
+WORKDIR /opt
 
 EXPOSE 5000


### PR DESCRIPTION
# Issue

After reading https://github.com/Project-OSRM/osrm-backend/issues/3906 and doing internal tests (in which Alpine Linux was slower by several factors for processing the planet) I was curious how big the impact was.

I ran tests locally, that show Ubuntu to be faster, but not that much faster. Still, this might be a worthwhile optimization, with the trade-off of the docker image growing in size significantly.

Further results are below under `details`.

## Tasklist

- [ ] Run docker image on planet (need to figure out how to actually do that from a branch)
- [ ] Slim down image size (@daniel-j-h do you know which apt packages can be removed again?)

<details> 

- Run on osrm v5.7.3
- Images downloaded locally, only running
- On local Macbook, without other bigger processes running

What? | Alpine | Ubuntu
----|---|---
Processing for Berlin | 1:24 | 1:06
Processing for Italy | 33:05 | 27:04
Image size | 72 MB | 919 MB

```
### UBUNTU

$rm -rf ./*.osrm* && time docker run -t -v $(pwd):/data osrm/osrm-backend:local-ubuntu-jemalloc bash -c "export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1 && osrm-extract -p /opt/car.lua /data/italy-latest.osm.pbf && osrm-contract /data/italy-latest.osrm"
[info] Using script /opt/car.lua
[info] Input file: italy-latest.osm.pbf
[info] Profile: car.lua
[info] Threads: 4
[info] Parsing in progress..
[STXXL-MSG] STXXL v1.4.1 (prerelease/Debug)
[STXXL-ERRMSG] Warning: no config file found.
[STXXL-ERRMSG] Using default disk configuration.
[STXXL-MSG] Disk '/var/tmp/stxxl' is allocated, space: 1000 MiB, I/O implementation: syscall autogrow delete_on_exit queue=0 devid=0
[info] input file generated by osmium/1.5.1
[info] timestamp: 2017-06-07T20:43:32Z
[info] Found 3 turn restriction tags:
[info]   motorcar
[info]   motor_vehicle
[info]   vehicle
[info] Parsing finished after 312.626 seconds
[info] Raw input contains 155283375 nodes, 16806178 ways, and 247909 relations
[info] Sorting used nodes        ... ok, after 2.40028s
[info] Erasing duplicate nodes   ... ok, after 3.32795s
[info] Sorting all nodes         ... ok, after 57.1011s
[info] Building node id map      ... ok, after 41.3302s
[info] setting number of nodes   ... ok
[info] Confirming/Writing used nodes     ... ok, after 35.0345s
[info] Processed 20192129 nodes
[info] Sorting edges by start    ... ok, after 11.5673s
[info] Setting start coords      ... ok, after 48.5977s
[info] Sorting edges by target   ... ok, after 10.3956s
[info] Computing edge weights    ... ok, after 49.6987s
[info] Sorting edges by renumbered start ... ok, after 10.9147s
[info] Writing used edges       ... ok, after 8.1136sProcessed 21100490 edges
[info] Sorting used ways         ... ok, after 0.40491s
[info] Sorting 62391 restriction. by from... ok, after 0.022076s
[info] Fixing restriction starts ... ok, after 0.198453s
[info] Sorting restrictions. by to  ... ok, after 0.020923s
[info] Fixing restriction ends   ... ok, after 0.201534s
[info] usable restrictions: 60475
[info] writing street name index ... ok, after 0.345831s
[info] extraction finished after 603.18s
[info] Generating edge-expanded graph representation
[info]  - 60475 restrictions.
[info] Importing number_of_nodes new = 20192129 nodes
[info]  - 6460 bollard nodes, 16986 traffic lights
[info]  and 21100490 edges
[info] Graph loaded ok and has 21100490 edges
[info] . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Node compression ratio: 0.159707
[info] Edge compression ratio: 0.195728
[info] Generating edge expanded nodes ...
[info] . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Generated 21096465 nodes in edge-expanded graph
[info] Generating edge-expanded edges
[info] . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Created 129 entry classes and 28838 Bearing Classes
[info] Writing Turn Lane Data to File...
[info] done.
[info] Generated 21096465 edge based nodes
[info] Node-based graph contains 7312168 edges
[info] Edge-expanded graph ...
[info]   contains 13421715 edges
[info]   skips 0 turns, defined by 60339 restrictions
[info]   skips 0 U turns
[info]   skips 0 turns over barriers
[info] Handled: 1558 of 10284 lanes: 15.1497 %.
[info] Timing statistics for edge-expanded graph:
[info] Renumbering edges: 0.166249s
[info] Generating nodes: 10.3627s
[info] Generating edges: 215.76s
[info] Writing turn lane masks...
[info] done (0.001917)
[info] Writing Intersection Classification Data
[info] ok, after 1.36352s for 20192129 Indices into 28838 bearing classes and 129 entry classes and 105830 bearing values.
[info] Saving edge-based node weights to file.
[info] Done writing. (0.198328)
[info] Computing strictly connected components ...
[info] large component [4088]=7233968
[info] SCC run took: 0.617761s
[info] Building r-tree ...
[info] constructing r-tree of 21096465 edge elements build on-top of 20192129 coordinates
[info] finished r-tree construction in 53.1805 seconds
[info] Writing node map ...
[info] Writing edge-based-graph edges       ...
[info] ok, after 14.9377s
[info] Processed 13421715 edges
[info] Expansion: 68945 nodes/sec and 24967 edges/sec
[info] To prepare the data for routing, run: ./osrm-contract /data/italy-latest.osrm
[info] STXXL: peak bytes used: 9105833984
[info] STXXL: total disk allocated: 9105833984
[info] RAM: peak bytes used: 5490515968
[STXXL-ERRMSG] Removing disk file: /var/tmp/stxxl
[info] Input file: italy-latest.osrm
[info] Threads: 4
[info] Reading node weights.
[info] Done reading node weights.
[info] Loading edge-expanded graph representation
[STXXL-MSG] STXXL v1.4.1 (prerelease/Debug)
[STXXL-ERRMSG] Warning: no config file found.
[STXXL-ERRMSG] Using default disk configuration.
[STXXL-MSG] Disk '/var/tmp/stxxl' is allocated, space: 1000 MiB, I/O implementation: syscall autogrow delete_on_exit queue=0 devid=0
[info] merged 28112 edges out of 26843430
[info] contractor finished initalization
[info] initializing elimination PQ ...ok
[info] preprocessing 7312168 nodes ...
[info] . 10% . 20% . 30% . 40% . 50% . 60% . [flush 4825016 nodes]  70% . 80% . 90% . 100%[info] [core] 1 nodes 16497325 edges.

[info] Getting edges of minimized graph . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Contraction took 637.271 sec
[info] Preprocessing : 649.372 seconds
[info] finished preprocessing
[info] STXXL: peak bytes used: 331350016
[info] STXXL: total disk allocated: 1048576000
[info] RAM: peak bytes used: 1618997248
[STXXL-ERRMSG] Removing disk file: /var/tmp/stxxl
docker run -t -v $(pwd):/data osrm/osrm-backend:local-ubuntu-jemalloc bash -c  0.02s user 0.04s system 0% cpu 27:04.19 total

### ALPINE

$ rm -rf ./*.osrm* && time docker run -t -v $(pwd):/data osrm/osrm-backend:v5.7.3 sh -c "osrm-extract -p /opt/car.lua /data/italy-latest.osm.pbf && osrm-contract /data/italy-latest.osrm"
[info] Using script /opt/car.lua
[info] Input file: italy-latest.osm.pbf
[info] Profile: car.lua
[info] Threads: 4
[info] Parsing in progress..
[STXXL-MSG] STXXL v1.4.1 (prerelease/Release) (git e7d36edd8152c73b115bd36cbcf566626d995434)
[STXXL-ERRMSG] Warning: no config file found.
[STXXL-ERRMSG] Using default disk configuration.
[STXXL-MSG] Disk '/var/tmp/stxxl' is allocated, space: 1000 MiB, I/O implementation: syscall autogrow delete_on_exit queue=0 devid=0
[info] input file generated by osmium/1.5.1
[info] timestamp: 2017-06-07T20:43:32Z
[info] Found 3 turn restriction tags:
[info]   motorcar
[info]   motor_vehicle
[info]   vehicle
[info] Parsing finished after 354.572 seconds
[info] Raw input contains 155283375 nodes, 16806178 ways, and 247909 relations
[info] Sorting used nodes        ... ok, after 1.64295s
[info] Erasing duplicate nodes   ... ok, after 2.83656s
[info] Sorting all nodes         ... ok, after 47.0658s
[info] Building node id map      ... ok, after 34.387s
[info] setting number of nodes   ... ok
[info] Confirming/Writing used nodes     ... ok, after 136.015s
[info] Processed 20192129 nodes
[info] Sorting edges by start    ... ok, after 8.357s
[info] Setting start coords      ... ok, after 36.8363s
[info] Sorting edges by target   ... ok, after 9.28333s
[info] Computing edge weights    ... ok, after 41.3018s
[info] Sorting edges by renumbered start ... ok, after 10.8615s
[info] Writing used edges       ... ok, after 6.00462sProcessed 21100491 edges
[info] Sorting used ways         ... ok, after 1.36676s
[info] Sorting 62391 restriction. by from... ok, after 0.059301s
[info] Fixing restriction starts ... ok, after 0.237444s
[info] Sorting restrictions. by to  ... ok, after 0.052838s
[info] Fixing restriction ends   ... ok, after 0.232799s
[info] usable restrictions: 60475
[info] writing street name index ... ok, after 1.35843s
[info] extraction finished after 700.961s
[info] Generating edge-expanded graph representation
[info]  - 60475 restrictions.
[info] Importing number_of_nodes new = 20192129 nodes
[info]  - 6460 bollard nodes, 16986 traffic lights
[info]  and 21100491 edges
[info] Graph loaded ok and has 21100491 edges
[info] . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Node compression ratio: 0.159707
[info] Edge compression ratio: 0.195728
[info] Generating edge expanded nodes ...
[info] . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Generated 21096465 nodes in edge-expanded graph
[info] Generating edge-expanded edges
[info] . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Created 129 entry classes and 28838 Bearing Classes
[info] Writing Turn Lane Data to File...
[info] done.
[info] Generated 21096465 edge based nodes
[info] Node-based graph contains 7312168 edges
[info] Edge-expanded graph ...
[info]   contains 13421715 edges
[info]   skips 0 turns, defined by 60339 restrictions
[info]   skips 0 U turns
[info]   skips 0 turns over barriers
[info] Handled: 1558 of 10283 lanes: 15.1512 %.
[info] Timing statistics for edge-expanded graph:
[info] Renumbering edges: 0.162782s
[info] Generating nodes: 12.2696s
[info] Generating edges: 388.414s
[info] Writing turn lane masks...
[info] done (0.002519)
[info] Writing Intersection Classification Data
[info] ok, after 1.07414s for 20192129 Indices into 28838 bearing classes and 129 entry classes and 105831 bearing values.
[info] Saving edge-based node weights to file.
[info] Done writing. (0.259842)
[info] Computing strictly connected components ...
[info] large component [4088]=7233968
[info] SCC run took: 0.622083s
[info] Building r-tree ...
[info] constructing r-tree of 21096465 edge elements build on-top of 20192129 coordinates
[info] finished r-tree construction in 51.6161 seconds
[info] Writing node map ...
[info] Writing edge-based-graph edges       ...
[info] ok, after 63.9802s
[info] Processed 13421715 edges
[info] Expansion: 38379 nodes/sec and 13898 edges/sec
[info] To prepare the data for routing, run: ./osrm-contract /data/italy-latest.osrm
[info] STXXL: peak bytes used: 9105833984
[info] STXXL: total disk allocated: 9105833984
[info] RAM: peak bytes used: 5788823552
[STXXL-ERRMSG] Removing disk file: /var/tmp/stxxl
[info] Input file: italy-latest.osrm
[info] Threads: 4
[info] Reading node weights.
[info] Done reading node weights.
[info] Loading edge-expanded graph representation
[STXXL-MSG] STXXL v1.4.1 (prerelease/Release) (git e7d36edd8152c73b115bd36cbcf566626d995434)
[STXXL-ERRMSG] Warning: no config file found.
[STXXL-ERRMSG] Using default disk configuration.
[STXXL-MSG] Disk '/var/tmp/stxxl' is allocated, space: 1000 MiB, I/O implementation: syscall autogrow delete_on_exit queue=0 devid=0
[info] merged 28112 edges out of 26843430
[info] contractor finished initalization
[info] initializing elimination PQ ...ok
[info] preprocessing 7312168 nodes ...
[info] . 10% . 20% . 30% . 40% . 50% . 60% . [flush 4825033 nodes]  70% . 80% . 90% . 100%[info] [core] 1 nodes 16493834 edges.

[info] Getting edges of minimized graph . 10% . 20% . 30% . 40% . 50% . 60% . 70% . 80% . 90% . 100%
[info] Contraction took 622.018 sec
[info] Preprocessing : 633.15 seconds
[info] finished preprocessing
[info] STXXL: peak bytes used: 331350016
[info] STXXL: total disk allocated: 1048576000
[info] RAM: peak bytes used: 1617301504
[STXXL-ERRMSG] Removing disk file: /var/tmp/stxxl
docker run -t -v $(pwd):/data osrm/osrm-backend:v5.7.3 sh -c   0.05s user 0.05s system 0% cpu 33:05.82 total
```