### PR TITLE
Expose Map Matching `gaps` and `tidy` parameters in Node.js bindings

### DIFF
--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -194,6 +194,8 @@ if they can not be matched successfully.
     -   `options.overview` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Add overview geometry either `full`, `simplified` according to highest zoom level it could be display on, or not at all (`false`). (optional, default `simplified`)
     -   `options.timestamps` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** Timestamp of the input location (integers, UNIX-like timestamp).
     -   `options.radiuses` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Standard deviation of GPS precision used for map matching. If applicable use GPS accuracy. Can be `null` for default value `5` meters or `double >= 0`.
+    -   `options.gaps` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Allows the input track splitting based on huge timestamp gaps between points. Either `split` or `ignore`. (optional, default `split`)
+    -   `options.tidy` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Allows the input track modification to obtain better matching quality for noisy tracks. (optional, default `false`)
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** 
 
 **Examples**

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -1070,6 +1070,51 @@ argumentsToMatchParameter(const Nan::FunctionCallbackInfo<v8::Value> &args,
         }
     }
 
+    if (obj->Has(Nan::New("gaps").ToLocalChecked()))
+    {
+        v8::Local<v8::Value> gaps = obj->Get(Nan::New("gaps").ToLocalChecked());
+        if (gaps.IsEmpty())
+            return match_parameters_ptr();
+
+        if (!gaps->IsString())
+        {
+            Nan::ThrowError("Gaps must be a string: [split, ignore]");
+            return match_parameters_ptr();
+        }
+
+        const Nan::Utf8String gaps_utf8str(gaps);
+        std::string gaps_str{*gaps_utf8str, *gaps_utf8str + gaps_utf8str.length()};
+
+        if (gaps_str == "split")
+        {
+            params->gaps = osrm::MatchParameters::GapsType::Split;
+        }
+        else if (gaps_str == "ignore")
+        {
+            params->gaps = osrm::MatchParameters::GapsType::Ignore;
+        }
+        else
+        {
+            Nan::ThrowError("'gaps' param must be one of [split, ignore]");
+            return match_parameters_ptr();
+        }
+    }
+
+    if (obj->Has(Nan::New("tidy").ToLocalChecked()))
+    {
+        v8::Local<v8::Value> tidy = obj->Get(Nan::New("tidy").ToLocalChecked());
+        if (tidy.IsEmpty())
+            return match_parameters_ptr();
+
+        if (!tidy->IsBoolean())
+        {
+            Nan::ThrowError("tidy must be of type Boolean");
+            return match_parameters_ptr();
+        }
+
+        params->tidy = tidy->BooleanValue();
+    }
+
     bool parsedSuccessfully = parseCommonParameters(obj, params);
     if (!parsedSuccessfully)
     {

--- a/test/nodejs/match.js
+++ b/test/nodejs/match.js
@@ -133,7 +133,9 @@ test('match: match in Monaco with all options', function(assert) {
         steps: true,
         annotations: true,
         overview: 'false',
-        geometries: 'geojson'
+        geometries: 'geojson',
+        gaps: 'split',
+        tidy: false
     };
     osrm.match(options, function(err, response) {
         assert.ifError(err);
@@ -195,4 +197,29 @@ test('match: throws on invalid timestamps param', function(assert) {
     options.timestamps = [1424684612, 1424684616];
     assert.throws(function() { osrm.match(options, function(err, response) {}) },
         /Timestamp array must have the same size as the coordinates array/);
+});
+
+test('match: throws on invalid gaps param', function(assert) {
+    assert.plan(2);
+    var osrm = new OSRM(data_path);
+    var options = {
+        coordinates: three_test_coordinates,
+        gaps: ['invalid gaps param']
+    };
+    assert.throws(function() { osrm.match(options, function(err, response) {}) },
+        /Gaps must be a string: \[split, ignore\]/);
+    options.gaps = 'invalid gaps param';
+    assert.throws(function() { osrm.match(options, function(err, response) {}) },
+        /'gaps' param must be one of \[split, ignore\]/);
+});
+
+test('match: throws on invalid tidy param', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var options = {
+        coordinates: three_test_coordinates,
+        tidy: 'invalid tidy param'
+    };
+    assert.throws(function() { osrm.match(options, function(err, response) {}) },
+        /tidy must be of type Boolean/);
 });


### PR DESCRIPTION
Expose Map Matching `gaps` and `tidy` parameters in Node.js bindings according to #4021

 - [x]  parse flags and set options in node_osrm_support.hpp
 - [x]   write docs in docs/nodejs/api.md