### PR TITLE
Lua scripting speedups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Features
       - Added conditional restriction support with `parse-conditional-restrictions=true|false` to osrm-extract. This option saves conditional turn restrictions to the .restrictions file for parsing by contract later. Added `parse-conditionals-from-now=utc time stamp` and `--time-zone-file=/path/to/file`  to osrm-contract
       - Command-line tools (osrm-extract, osrm-contract, osrm-routed, etc) now return error codes and legible error messages for common problem scenarios, rather than ugly C++ crashes
+      - Speed up pre-processing by only running the Lua `node_function` for nodes that have tags.  Cuts OSM file parsing time in half.
     - Files
       - .osrm.nodes file was renamed to .nbg_nodes and .ebg_nodes was added
     - Guidance

--- a/include/extractor/profile_properties.hpp
+++ b/include/extractor/profile_properties.hpp
@@ -22,7 +22,7 @@ struct ProfileProperties
         : traffic_signal_penalty(0), u_turn_penalty(0),
           max_speed_for_map_matching(DEFAULT_MAX_SPEED), continue_straight_at_waypoint(true),
           use_turn_restrictions(false), left_hand_driving(false), fallback_to_duration(true),
-          weight_name{"duration"}
+          weight_name{"duration"}, call_tagless_node_function(true)
     {
         BOOST_ASSERT(weight_name[MAX_WEIGHT_NAME_LENGTH] == '\0');
     }
@@ -88,6 +88,8 @@ struct ProfileProperties
     char weight_name[MAX_WEIGHT_NAME_LENGTH + 1];
     unsigned weight_precision = 1;
     bool force_split_edges = false;
+
+    bool call_tagless_node_function = true;
 };
 }
 }

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -31,6 +31,11 @@ struct LuaScriptingContext final
     bool has_way_function;
     bool has_segment_function;
 
+    sol::function turn_function;
+    sol::function way_function;
+    sol::function node_function;
+    sol::function segment_function;
+
     int api_version;
 };
 

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -15,6 +15,11 @@ properties.continue_straight_at_waypoint = false
 properties.weight_name                   = 'duration'
 --properties.weight_name                   = 'cyclability'
 
+-- Set to true if you need to call the node_function for every node.
+-- Generally can be left as false to avoid unnecessary Lua calls
+-- (which slow down pre-processing).
+properties.call_tagless_node_function      = false
+
 
 local default_speed = 15
 local walking_speed = 6

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -20,6 +20,12 @@ properties.weight_name                     = 'routability'
 -- For shortest distance without penalties for accessibility
 --properties.weight_name                     = 'distance'
 
+-- Set to true if you need to call the node_function for every node.
+-- Generally can be left as false to avoid unnecessary Lua calls
+-- (which slow down pre-processing).
+properties.call_tagless_node_function      = false
+
+
 local profile = {
   default_mode      = mode.driving,
   default_speed     = 10,

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -14,6 +14,11 @@ properties.continue_straight_at_waypoint = false
 properties.weight_name                   = 'duration'
 --properties.weight_name                   = 'routability'
 
+-- Set to true if you need to call the node_function for every node.
+-- Generally can be left as false to avoid unnecessary Lua calls
+-- (which slow down pre-processing).
+properties.call_tagless_node_function      = false
+
 local walking_speed = 5
 
 local profile = {

--- a/profiles/rasterbot.lua
+++ b/profiles/rasterbot.lua
@@ -3,6 +3,11 @@ api_version = 1
 
 properties.force_split_edges = true
 
+-- Set to true if you need to call the node_function for every node.
+-- Generally can be left as false to avoid unnecessary Lua calls
+-- (which slow down pre-processing).
+properties.call_tagless_node_function      = false
+
 -- Minimalist node_ and way_functions in order to test source_ and segment_functions
 
 function node_function (node, result)

--- a/profiles/rasterbotinterp.lua
+++ b/profiles/rasterbotinterp.lua
@@ -1,6 +1,11 @@
 api_version = 1
 -- Rasterbot profile
 
+-- Set to true if you need to call the node_function for every node.
+-- Generally can be left as false to avoid unnecessary Lua calls
+-- (which slow down pre-processing).
+properties.call_tagless_node_function      = false
+
 -- Minimalist node_ and way_functions in order to test source_ and segment_functions
 
 function node_function (node, result)

--- a/profiles/testbot.lua
+++ b/profiles/testbot.lua
@@ -22,6 +22,11 @@ properties.use_turn_restrictions         = true
 properties.max_speed_for_map_matching    = 30/3.6 --km -> m/s
 properties.weight_name                   = 'duration'
 
+-- Set to true if you need to call the node_function for every node.
+-- Generally can be left as false to avoid unnecessary Lua calls
+-- (which slow down pre-processing).
+properties.call_tagless_node_function      = false
+
 local uturn_penalty                      = 20
 local traffic_light_penalty              = 7     -- seconds
 

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -249,7 +249,9 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "max_turn_weight",
         sol::property(&ProfileProperties::GetMaxTurnWeight),
         "force_split_edges",
-        &ProfileProperties::force_split_edges);
+        &ProfileProperties::force_split_edges,
+        "call_tagless_node_function",
+        &ProfileProperties::call_tagless_node_function);
 
     context.state.new_usertype<std::vector<std::string>>(
         "vector",
@@ -510,7 +512,9 @@ void Sol2ScriptingEnvironment::ProcessElements(
                 {
                 case osmium::item_type::node:
                     result_node.clear();
-                    if (local_context.has_node_function)
+                    if (local_context.has_node_function &&
+                        (!static_cast<const osmium::Node &>(*entity).tags().empty() ||
+                         local_context.properties.call_tagless_node_function))
                     {
                         local_context.ProcessNode(static_cast<const osmium::Node &>(*entity),
                                                   result_node);


### PR DESCRIPTION
# Issue

After a bit of conversation with @joto, it looks like there are some easy speedups we can make with our Lua handling code to make `osrm-exract` run a lot faster.

  1) Don't make copies of `sol::function` objects for every call - this is simply unnecessary, and using thread-local cached copies gives us a 12-13% speedup very easily.

  2) Make calling the node_function optional.  If the profile property `call_tagless_node_function` is set to `false`, then the `node_function` won't get called if there are no tags on a node (you only need to call this in situations where you're doing coordinate lookups for nodes for some reason.  The default profiles don't do this).  Because there are more nodes than anything else, and most of them have no tags, this creates a speedup of 269 sec -> 135 seconds testing `us-west-latest.osm.pbf`.
  This change should be backwards compatible.  For those with old scripts that don't include the new `call_tagless_node_function` profile property, it will default to the old behaviour of calling the `node_function` for every node.  Users can add this property to their existing scripts to gain access to the speedup.

## Tasklist
 - [ ] review
 - [ ] adjust for comments