### PR TITLE
add support for visualising turn penalties in MLD Debug tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
       - .osrm.nodes file was renamed to .nbg_nodes and .ebg_nodes was added
     - Guidance
       - #4075 Changed counting of exits on service roundabouts
+    - Debug Tiles
+      - added support for visualising turn penalties to the MLD plugin
     - Bugfixes
       - Fixed a copy/paste issue assigning wrong directions in similar turns (left over right)
       - #4074: fixed a bug that would announce entering highway ramps as u-turns

--- a/include/engine/algorithm.hpp
+++ b/include/engine/algorithm.hpp
@@ -102,6 +102,9 @@ template <> struct HasShortestPathSearch<mld::Algorithm> final : std::true_type
 template <> struct HasMapMatching<mld::Algorithm> final : std::true_type
 {
 };
+template <> struct HasGetTileTurns<mld::Algorithm> final : std::true_type
+{
+};
 }
 }
 }

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -221,15 +221,6 @@ RoutingAlgorithms<routing_algorithms::mld::Algorithm>::ManyToManySearch(
 {
     throw util::exception("ManyToManySearch is not implemented");
 }
-
-template <>
-inline std::vector<routing_algorithms::TurnData>
-RoutingAlgorithms<routing_algorithms::mld::Algorithm>::GetTileTurns(
-    const std::vector<datafacade::BaseDataFacade::RTreeLeaf> &,
-    const std::vector<std::size_t> &) const
-{
-    throw util::exception("GetTileTurns is not implemented");
-}
 }
 }
 

--- a/include/engine/routing_algorithms/tile_turns.hpp
+++ b/include/engine/routing_algorithms/tile_turns.hpp
@@ -33,6 +33,11 @@ getTileTurns(const datafacade::ContiguousInternalMemoryDataFacade<ch::Algorithm>
              const std::vector<RTreeLeaf> &edges,
              const std::vector<std::size_t> &sorted_edge_indexes);
 
+std::vector<TurnData>
+getTileTurns(const datafacade::ContiguousInternalMemoryDataFacade<mld::Algorithm> &facade,
+             const std::vector<RTreeLeaf> &edges,
+             const std::vector<std::size_t> &sorted_edge_indexes);
+
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -20,11 +20,9 @@
 
 BOOST_AUTO_TEST_SUITE(tile)
 
-BOOST_AUTO_TEST_CASE(test_tile)
+template <typename algorithm> void test_tile(algorithm &osrm)
 {
     using namespace osrm;
-
-    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm");
 
     // This tile should contain most of monaco
     TileParameters params{17059, 11948, 15};
@@ -211,11 +209,32 @@ BOOST_AUTO_TEST_CASE(test_tile)
     BOOST_CHECK(number_of_turns_found > 700);
 }
 
-BOOST_AUTO_TEST_CASE(test_tile_turns)
+BOOST_AUTO_TEST_CASE(test_tile_ch)
+{
+    using namespace osrm;
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm", osrm::EngineConfig::Algorithm::CH);
+    test_tile(osrm);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_corech)
+{
+    using namespace osrm;
+    auto osrm =
+        getOSRM(OSRM_TEST_DATA_DIR "/corech/monaco.osrm", osrm::EngineConfig::Algorithm::CoreCH);
+    test_tile(osrm);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_mld)
+{
+    using namespace osrm;
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/mld/monaco.osrm", osrm::EngineConfig::Algorithm::MLD);
+    test_tile(osrm);
+}
+
+template <typename algorithm> void test_tile_turns(algorithm &osrm)
 {
     using namespace osrm;
 
-    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm");
     // Small tile where we can test all the values
     TileParameters params{272953, 191177, 19};
 
@@ -359,11 +378,34 @@ BOOST_AUTO_TEST_CASE(test_tile_turns)
     CHECK_EQUAL_RANGE(actual_turn_bearings, expected_turn_bearings);
 }
 
-BOOST_AUTO_TEST_CASE(test_tile_speeds)
+BOOST_AUTO_TEST_CASE(test_tile_turns_ch)
 {
     using namespace osrm;
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm", osrm::EngineConfig::Algorithm::CH);
 
-    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm");
+    test_tile_turns(osrm);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_turns_corech)
+{
+    using namespace osrm;
+    auto osrm =
+        getOSRM(OSRM_TEST_DATA_DIR "/corech/monaco.osrm", osrm::EngineConfig::Algorithm::CoreCH);
+
+    test_tile_turns(osrm);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_turns_mld)
+{
+    using namespace osrm;
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/mld/monaco.osrm", osrm::EngineConfig::Algorithm::MLD);
+
+    test_tile_turns(osrm);
+}
+
+template <typename algorithm> void test_tile_speeds(algorithm &osrm)
+{
+    using namespace osrm;
 
     // Small tile so we can test all the values
     // TileParameters params{272953, 191177, 19};
@@ -520,6 +562,31 @@ BOOST_AUTO_TEST_CASE(test_tile_speeds)
                                                      "Rue Professeur Calmette",
                                                      "Rue Professeur Calmette"};
     BOOST_CHECK(actual_names == expected_names);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_speeds_ch)
+{
+    using namespace osrm;
+
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/ch/monaco.osrm", osrm::EngineConfig::Algorithm::CH);
+    test_tile_speeds(osrm);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_speeds_corech)
+{
+    using namespace osrm;
+
+    auto osrm =
+        getOSRM(OSRM_TEST_DATA_DIR "/corech/monaco.osrm", osrm::EngineConfig::Algorithm::CoreCH);
+    test_tile_speeds(osrm);
+}
+
+BOOST_AUTO_TEST_CASE(test_tile_speeds_mld)
+{
+    using namespace osrm;
+
+    auto osrm = getOSRM(OSRM_TEST_DATA_DIR "/mld/monaco.osrm", osrm::EngineConfig::Algorithm::MLD);
+    test_tile_speeds(osrm);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/4153.

Adds support to the debug tiles generated with the MLD plugin. Opposed to the CH plugin, finding the edges that contain turn information is a bit simpler (we do not need to consider shortcuts but can call FindEdge directly on the base layer of MLD).

The PR refactors parts of the CH process to generate tiles to allow re-usage in the MLD plugin.
We simply need to be able to swap out how the edges are located.

## Tasklist
 - [x] refactor so that main function calls do not duplicate code
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

/cc @danpat 

Tiles generated with CH:

![screen shot 2017-06-14 at 16 52 00 2](https://user-images.githubusercontent.com/12932279/27139510-8225ff14-5123-11e7-8a51-dd5ed94e653e.png)

Tiles generated with MLD:

![screen shot 2017-06-14 at 16 58 33 2](https://user-images.githubusercontent.com/12932279/27139544-94b6311c-5123-11e7-92b3-2cd8184bc5bb.png)
