### PR TITLE
don't collapse u-turns into combined turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
       - Fixed a copy/paste issue assigning wrong directions in similar turns (left over right)
       - #4074: fixed a bug that would announce entering highway ramps as u-turns
       - #4122: osrm-routed/libosrm should throw exception when a dataset incompatible with the requested algorithm is loaded
+      - Avoid collapsing u-turns into combined turn instructions
 
 # 5.7.1
     - Bugfixes

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -1072,5 +1072,5 @@ Feature: Collapse
             | bd    | service   |
 
         When I route I should get
-            | waypoints | bearings | route        | turns                                      | locations |
-            | 1,2       | 90 270   | ab,bd,ab,ab  | depart,turn right,end of road right,arrive | _,b,b,_   |
+            | waypoints | bearings | route          | turns                                             | locations |
+            | 1,2       | 90 270   | ab,bd,bd,ab,ab | depart,turn left,continue uturn,turn right,arrive | _,b,d,b,_ |

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -399,7 +399,7 @@ Feature: Collapse
             | waypoints | route | turns         |
             | a,d       | ,     | depart,arrive |
 
-    # This scenario could be considered to require a `turn left`. The danger to create random/unwanted instructions 
+    # This scenario could be considered to require a `turn left`. The danger to create random/unwanted instructions
     # from a setting like this are just to big, though. Therefore I opted to use `depart,arrive` only
     Scenario: Crossing Bridge into Segregated Turn
         Given the node map
@@ -1055,3 +1055,22 @@ Feature: Collapse
        When I route I should get
          | waypoints | route                                            | turns                   | locations |
          | a,i       | President Avenue,Princes Highway,Princes Highway | depart,turn left,arrive | a,b,i     |
+
+
+    Scenario: Don't combine uturns
+        Given the node map
+            """
+              2   d
+            a - - b - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - c
+              1
+			"""
+
+        And the ways
+            | nodes | highway   |
+            | ab    | tertiary  |
+            | bc    | tertiary  |
+            | bd    | service   |
+
+        When I route I should get
+            | waypoints | bearings | route        | turns                                      | locations |
+            | 1,2       | 90 270   | ab,bd,ab,ab  | depart,turn right,end of road right,arrive | _,b,b,_   |

--- a/src/engine/guidance/collapse_scenario_detection.cpp
+++ b/src/engine/guidance/collapse_scenario_detection.cpp
@@ -61,6 +61,22 @@ bool isShortAndUndisturbed(const RouteStep &step)
     return is_short && noIntermediaryIntersections(step);
 }
 
+// On dual carriageways, we might want to use u-turns in combination with new-name instructions.
+// Otherwise a u-turn should never be part of a collapsing instructions.
+bool noBadUTurnCombination(const RouteStepIterator first, const RouteStepIterator second)
+{
+    auto has_uturn = hasModifier(*first, DirectionModifier::UTurn) ||
+                     hasModifier(*second, DirectionModifier::UTurn);
+
+    auto const from_name_change_into_uturn =
+        hasTurnType(*first, TurnType::NewName) && hasModifier(*second, DirectionModifier::UTurn);
+
+    auto const uturn_into_name_change =
+        hasTurnType(*second, TurnType::NewName) && hasModifier(*first, DirectionModifier::UTurn);
+
+    return !has_uturn || from_name_change_into_uturn || uturn_into_name_change;
+}
+
 } // namespace
 
 bool basicCollapsePreconditions(const RouteStepIterator first, const RouteStepIterator second)
@@ -70,7 +86,10 @@ bool basicCollapsePreconditions(const RouteStepIterator first, const RouteStepIt
 
     const auto waypoint_type = hasWaypointType(*first) || hasWaypointType(*second);
 
-    return !has_roundabout_type && !waypoint_type && haveSameMode(*first, *second);
+    const auto contains_bad_uturn = !noBadUTurnCombination(first, second);
+
+    return !has_roundabout_type && !waypoint_type && haveSameMode(*first, *second) &&
+           !contains_bad_uturn;
 }
 
 bool basicCollapsePreconditions(const RouteStepIterator first,
@@ -81,8 +100,11 @@ bool basicCollapsePreconditions(const RouteStepIterator first,
                                      hasRoundaboutType(second->maneuver.instruction) ||
                                      hasRoundaboutType(third->maneuver.instruction);
 
+    const auto contains_bad_uturn =
+        !noBadUTurnCombination(first, second) && !noBadUTurnCombination(second, third);
+
     // require modes to match up
-    return !has_roundabout_type && haveSameMode(*first, *second, *third);
+    return !has_roundabout_type && haveSameMode(*first, *second, *third) && !contains_bad_uturn;
 }
 
 bool isStaggeredIntersection(const RouteStepIterator step_prior_to_intersection,


### PR DESCRIPTION
# Issue

Prevents issues that arise from combining u-turns into other turns. U-Turns are always a dedicated maneuver and shouldn't be collapsed.

## Tasklist

- [x] add regression / cucumber cases (see docs/testing.md) (current test does not fail yet)
- [x] review
- [x] adjust for comments
