### PR TITLE
Include 'rate' property (reciprocal of weight) on debug tile edges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
       - #4075 Changed counting of exits on service roundabouts
     - Debug Tiles
       - added support for visualising turn penalties to the MLD plugin
+      - added support for showing the rate (reciprocal of weight) on each edge when used
     - Bugfixes
       - Fixed a copy/paste issue assigning wrong directions in similar turns (left over right)
       - #4074: fixed a bug that would announce entering highway ramps as u-turns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     - Debug Tiles
       - added support for visualising turn penalties to the MLD plugin
       - added support for showing the rate (reciprocal of weight) on each edge when used
+      - added support for turn weights in addition to turn durations in debug tiles
     - Bugfixes
       - Fixed a copy/paste issue assigning wrong directions in similar turns (left over right)
       - #4074: fixed a bug that would announce entering highway ramps as u-turns

--- a/docs/http.md
+++ b/docs/http.md
@@ -419,8 +419,10 @@ Vector tiles contain two layers:
 | `speed`      | `integer` | the speed on that road segment, in km/h  |
 | `is_small`   | `boolean` | whether this segment belongs to a small (< 1000 node) [strongly connected component](https://en.wikipedia.org/wiki/Strongly_connected_component) |
 | `datasource` | `string`  | the source for the speed value (normally `lua profile` unless you're using the [traffic update feature](https://github.com/Project-OSRM/osrm-backend/wiki/Traffic), in which case it contains the stem of the filename that supplied the speed value for this segment |
-| `duration`   | `float`   | how long this segment takes to traverse, in seconds |
+| `duration`   | `float`   | how long this segment takes to traverse, in seconds.  This value is to calculate the total route ETA. |
+| `weight  `   | `integer` | how long this segment takes to traverse, in units (may differ from `duration` when artificial biasing is applied in the Lua profiles).  ACTUAL ROUTING USES THIS VALUE. |
 | `name`       | `string`  | the name of the road this segment belongs to |
+| `rate`       | `float`   | the value of `length/weight` - analagous to `speed`, but using the `weight` value rather than `duration`, rounded to the nearest integer |
 
 `turns` layer:
 
@@ -429,6 +431,7 @@ Vector tiles contain two layers:
 | `bearing_in` | `integer` | the absolute bearing that approaches the intersection.  -180 to +180, 0 = North, 90 = East |
 | `turn_angle` | `integer` | the angle of the turn, relative to the `bearing_in`.  -180 to +180, 0 = straight ahead, 90 = 90-degrees to the right |
 | `cost`       | `float`   | the time we think it takes to make that turn, in seconds.  May be negative, depending on how the data model is constructed (some turns get a "bonus"). |
+| `weight`     | `float`   | the weight we think it takes to make that turn.  May be negative, depending on how the data model is constructed (some turns get a "bonus"). ACTUAL ROUTING USES THIS VALUE |
 
 
 ## Result objects

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -53,7 +53,7 @@ template <typename algorithm> void test_tile(algorithm &osrm)
         auto property_iter_pair = feature_message.get_packed_uint32();
         auto value_begin = property_iter_pair.begin();
         auto value_end = property_iter_pair.end();
-        BOOST_CHECK_EQUAL(std::distance(value_begin, value_end), 12);
+        BOOST_CHECK_EQUAL(std::distance(value_begin, value_end), 14);
         auto iter = value_begin;
         BOOST_CHECK_EQUAL(*iter++, 0); // speed key
         BOOST_CHECK_LT(*iter++, 128);  // speed value
@@ -70,6 +70,9 @@ template <typename algorithm> void test_tile(algorithm &osrm)
         BOOST_CHECK_GT(*iter++, 130);  // duration value
         // name
         BOOST_CHECK_EQUAL(*iter++, 5);
+        BOOST_CHECK_GT(*iter++, 130);
+        // rate
+        BOOST_CHECK_EQUAL(*iter++, 6);
         BOOST_CHECK_GT(*iter++, 130);
         BOOST_CHECK(iter == value_end);
         // geometry
@@ -138,7 +141,7 @@ template <typename algorithm> void test_tile(algorithm &osrm)
         }
     }
 
-    BOOST_CHECK_EQUAL(number_of_speed_keys, 6);
+    BOOST_CHECK_EQUAL(number_of_speed_keys, 7);
     BOOST_CHECK_GT(number_of_speed_values, 128); // speed value resolution
 
     tile_message.next();
@@ -425,8 +428,10 @@ template <typename algorithm> void test_tile_speeds(algorithm &osrm)
     std::vector<int> found_speed_indexes;
     std::vector<int> found_component_indexes;
     std::vector<int> found_datasource_indexes;
+    std::vector<int> found_weight_indexes;
     std::vector<int> found_duration_indexes;
     std::vector<int> found_name_indexes;
+    std::vector<int> found_rate_indexes;
 
     const auto check_feature = [&](protozero::pbf_reader feature_message) {
         feature_message.next(); // advance parser to first entry
@@ -443,7 +448,7 @@ template <typename algorithm> void test_tile_speeds(algorithm &osrm)
         auto property_iter_pair = feature_message.get_packed_uint32();
         auto value_begin = property_iter_pair.begin();
         auto value_end = property_iter_pair.end();
-        BOOST_CHECK_EQUAL(std::distance(value_begin, value_end), 12);
+        BOOST_CHECK_EQUAL(std::distance(value_begin, value_end), 14);
         auto iter = value_begin;
         BOOST_CHECK_EQUAL(*iter++, 0); // speed key
         found_speed_indexes.push_back(*iter++);
@@ -453,12 +458,14 @@ template <typename algorithm> void test_tile_speeds(algorithm &osrm)
         BOOST_CHECK_EQUAL(*iter++, 2); // data source key
         found_datasource_indexes.push_back(*iter++);
         BOOST_CHECK_EQUAL(*iter++, 3); // weight key
-        found_duration_indexes.push_back(*iter++);
+        found_weight_indexes.push_back(*iter++);
         BOOST_CHECK_EQUAL(*iter++, 4); // duration key
         found_duration_indexes.push_back(*iter++);
         // name
         BOOST_CHECK_EQUAL(*iter++, 5);
         found_name_indexes.push_back(*iter++);
+        BOOST_CHECK_EQUAL(*iter++, 6);
+        found_rate_indexes.push_back(*iter++);
         BOOST_CHECK(iter == value_end);
         // geometry
         feature_message.next();


### PR DESCRIPTION
# Issue

This PR is to address https://github.com/Project-OSRM/osrm-backend/issues/4018 where we're not exposing the reciprocal of the `weight` property (analogous to `speed` if doing time-based routing).

This PR exposes a new property called `rate` for each edge.  Similar to `speed`, it's encoded to 1 decimal place of precision, and the value is in `meters per unit(weight)`, where `weight` is the internal unit-less cost of edge traversal.

**ALSO**, this PR exposes the turn weight property for the turn layer.  Given that actual routing occurs using weights, it'd be helpful to expose the `weight` value for turns in addition to the `cost` (duration) (which is only used for ETA calculation).

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments