### PR TITLE
Time information for maximum distance in matching

### DIFF
--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -358,8 +358,8 @@ Feature: Basic Map Matching
             | trace  | matchings | alternatives         |
             | abcdef | abcde     | 0,0,0,0,1,1          |
 
-    Scenario: Testbot - Speed greater than speed threshhold
-        Given a grid size of 10 meters
+    Scenario: Testbot - Speed greater than speed threshold
+        Given a grid size of 100 meters
         Given the query options
             | geometries | geojson  |
 
@@ -379,8 +379,8 @@ Feature: Basic Map Matching
             | trace | timestamps | matchings |
             | abcd  | 0 1 2 3    | ab,cd     |
 
-    Scenario: Testbot - Speed less than speed threshhold
-        Given a grid size of 10 meters
+    Scenario: Testbot - Speed less than speed threshold
+        Given a grid size of 100 meters
         Given the query options
             | geometries | geojson  |
 
@@ -396,6 +396,28 @@ Feature: Basic Map Matching
         When I match I should get
             | trace | timestamps | matchings |
             | abcd  | 0 1 2 3    | abcd      |
+
+    Scenario: Testbot - Huge gap in the coordinates
+        Given a grid size of 100 meters
+        Given the query options
+            | geometries | geojson  |
+            | gaps | ignore |
+
+        Given the node map
+            """
+            a b c d ---- x
+                         |
+                         |
+                         y ---- z ---- efjk
+            """
+
+        And the ways
+            | nodes   | oneway |
+            | abcdxyzefjk  | no     |
+
+        When I match I should get
+            | trace     | timestamps           | matchings  |
+            | abcdefjk  | 0 1 2 3 50 51 52 53  | abcdefjk   |
 
     # Regression test 1 for issue 3176
     Scenario: Testbot - multiple segments: properly expose OSM IDs

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -145,7 +145,8 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
     for (auto t = initial_timestamp + 1; t < candidates_list.size(); ++t)
     {
 
-        const auto step_time = trace_timestamps[t] - trace_timestamps[prev_unbroken_timestamps.back()];
+        const auto step_time =
+            trace_timestamps[t] - trace_timestamps[prev_unbroken_timestamps.back()];
         const auto max_distance_delta = [&] {
             if (use_timestamps)
             {

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -145,8 +145,17 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
     for (auto t = initial_timestamp + 1; t < candidates_list.size(); ++t)
     {
 
-        const auto step_time =
-            trace_timestamps[t] - trace_timestamps[prev_unbroken_timestamps.back()];
+        const auto step_time = [&] {
+            if (use_timestamps)
+            {
+                return trace_timestamps[t] - trace_timestamps[prev_unbroken_timestamps.back()];
+            }
+            else
+            {
+                return 1u;
+            }
+        }();
+
         const auto max_distance_delta = [&] {
             if (use_timestamps)
             {


### PR DESCRIPTION
# Issue
#4163 
Allowed maximum distance were calculated only by median time sample of the whole track. So distance can be impossible if the source track has gaps in its sequence. I suggest to calculate this distance for each coordinate pair separately.
