### PR TITLE
Fix turn lanes data propagation after traffic signs

### DIFF
--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -1242,5 +1242,5 @@ Feature: Turn Lane Guidance
             | mdhk  | road2 | 2     |                              | yes    |
 
         When I route I should get
-            | waypoints | route             | turns                        | lanes | locations |
-            | a,f       | road1,road1,road1 | depart,continue uturn,arrive | ,,    | a,d,f     |
+            | waypoints | route             | turns                        | lanes                                                | locations |
+            | a,f       | road1,road1,road1 | depart,continue uturn,arrive | ,left:true straight:false straight;right:false,      | a,d,f     |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -1215,3 +1215,32 @@ Feature: Turn Lane Guidance
             | waypoints | route            | turns                   | lanes                              |
             | a,d       | road,cross,cross | depart,turn left,arrive | ,none:true none:false right:false, |
             | a,c       | road,road        | depart,arrive           | ,                                  |
+
+    @4189
+    Scenario: U-turn after a traffic light
+        Given the node map
+            """
+                j k
+                : :
+            f---g-h-i
+                : :
+            a-b-c-d-e
+                : :
+                l m
+            """
+
+        And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+
+        And the ways
+            | nodes | name  | lanes | turn:lanes                   | oneway |
+            | ab    | road1 | 3     | left\|through\|through;right | yes    |
+            | bcde  | road1 | 2     |                              | yes    |
+            | ihgf  | road1 | 2     |                              | yes    |
+            | jgcl  | road2 | 2     |                              | yes    |
+            | mdhk  | road2 | 2     |                              | yes    |
+
+        When I route I should get
+            | waypoints | route             | turns                        | lanes | locations |
+            | a,f       | road1,road1,road1 | depart,continue uturn,arrive | ,,    | a,d,f     |

--- a/src/extractor/guidance/turn_lane_handler.cpp
+++ b/src/extractor/guidance/turn_lane_handler.cpp
@@ -180,7 +180,7 @@ TurnLaneScenario TurnLaneHandler::deduceScenario(const NodeID at,
         (intersection.size() == 2 &&
          ((lane_description_id != INVALID_LANE_DESCRIPTIONID &&
            lane_description_id ==
-               node_based_graph.GetEdgeData(intersection[1].eid).lane_description_id) ||
+               node_based_graph.GetEdgeData(intersection[1].eid).lane_description_id) &&
           angularDeviation(intersection[1].angle, STRAIGHT_ANGLE) < FUZZY_ANGLE_DIFFERENCE));
 
     if (is_going_straight_and_turns_continue)


### PR DESCRIPTION
# Issue

Fix #4189 

EDIT: the origin of missing turning lanes announcement  is in missing left turn in OSM.
Also the lane data was not propagating over  traffic signs and this PR fixes it.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
