### PR TITLE
Use thread-safe lock-free assignment in PackedVector::set_value

### DIFF
--- a/features/options/contract/edge-weight-updates-over-factor.feature
+++ b/features/options/contract/edge-weight-updates-over-factor.feature
@@ -1,5 +1,4 @@
-# Broken see issue #4065
-@contract @options @edge-weight-updates-over-factor @todo
+@contract @options @edge-weight-updates-over-factor
 Feature: osrm-contract command line option: edge-weight-updates-over-factor
 
     Background: Log edge weight updates over given factor
@@ -22,6 +21,7 @@ Feature: osrm-contract command line option: edge-weight-updates-over-factor
 
     Scenario: Logging weight with updates over factor of 2, long segment
         When I run "osrm-extract --profile {profile_file} {osm_file}"
+        And the data has been partitioned
         When I run "osrm-contract --edge-weight-updates-over-factor 2 --segment-speed-file {speeds_file} {processed_file}"
         Then stderr should not contain "Speed values were used to update 2 segment(s)"
         And stderr should contain "Segment: 1,2"


### PR DESCRIPTION
# Issue

PR fixes #4110 and #4065 that is caused by data races in `PackedVector::set_value` 
Lock-free `compare_exchange_weak` is implemented in <boost/atomic/detail/operations.hpp> as it is not possible to use `atomic_compare_exchange_weak` from <stdatomic.h> within C++

EDIT: the current approach requires to add Boost.Atomics as a new dependency, so  other approaches that do not introduce a global vector lock are welcome

## Tasklist
 - [x] review
 - [x] adjust for comments

