### PR TITLE
Makes suffix list aware of 45-degree directions

### DIFF
--- a/features/guidance/suffix-changes.feature
+++ b/features/guidance/suffix-changes.feature
@@ -128,3 +128,29 @@ Feature: Suppress New Names on dedicated Suffices
             | waypoints | route   | turns         |
             | a,c       | 42,42 S | depart,arrive |
 
+
+    # http://www.openstreetmap.org/edit#map=18/38.90361/-77.00814
+    Scenario: 45 Degree Granularity
+        Given a grid size of 5 meters
+        Given the node map
+            """
+            a  f
+
+            b  e
+
+            c  d
+
+            x  y
+
+            """
+
+        And the ways
+            | nodes  | highway | name                           | oneway |
+            | abcx   | primary | North Capitol Street Nortwest  | yes    |
+            | ydef   | primary | North Capitol Street Northeast | yes    |
+            | cd     | primary |                                |        |
+
+       When I route I should get
+            | waypoints | route                                                                                       | turns                    |
+            | a,f       | North Capitol Street Nortwest,North Capitol Street Northeast,North Capitol Street Northeast | depart,turn uturn,arrive |
+

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -43,7 +43,8 @@ local profile = {
 
   -- a list of suffixes to suppress in name change instructions
   suffix_list = {
-    'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'North', 'South', 'West', 'East'
+    'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW',
+    'North', 'Northeast', 'East', 'Southeast', 'South', 'Southwest', 'West', 'Northwest'
   },
 
   barrier_whitelist = Set {

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -72,7 +72,8 @@ local profile = {
 
   -- list of suffixes to suppress in name change instructions
   suffix_list = Set {
-    'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'North', 'South', 'West', 'East'
+    'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW',
+    'North', 'Northeast', 'East', 'Southeast', 'South', 'Southwest', 'West', 'Northwest'
   },
 
   avoid = Set {


### PR DESCRIPTION
Teaches the suffix list to recognize e.g. "Northeast -> Northwest" changes. Should fix:

http://map.project-osrm.org/?z=18&center=38.903614%2C-77.008139&loc=38.904927%2C-77.009128&loc=38.904981%2C-77.008967&hl=en&alt=0

(see test below)

@willwhite @danpat 