### PR TITLE
added check for sharp angles between ramps

### DIFF
--- a/include/extractor/guidance/validation_handler.hpp
+++ b/include/extractor/guidance/validation_handler.hpp
@@ -46,7 +46,7 @@ class ValidationHandler final : public IntersectionHandler
                             const EdgeID via_eid,
                             Intersection intersection) const override final
     {
-        // checkForSharpTurnsOntoRamps(nid, via_eid, intersection);
+        checkForSharpTurnsOntoRamps(nid, via_eid, intersection);
         checkForSharpTurnsBetweenRamps(nid, via_eid, intersection);
 
         return intersection;


### PR DESCRIPTION
# Issue

[Provide an IntersectionValidationHandler](https://github.com/Project-OSRM/osrm-backend/issues/4146)

## Tasklist
 - [x] Write the check + cucumber test for a small testing subject. Don't commit the cuke test
 - [x] Run on the original part of the world where we saw this problem: http://map.project-osrm.org/?z=18&center=52.309541%2C9.871645&loc=52.309089%2C9.872187&loc=52.310581%2C9.870207&hl=en&alt=0.  (Download the OSM pbf of this, use JOSM to remove the fixed turn restriction that Moritz added, and run the extractor on this pbf. <-- We actually found another sharp turn between ramps across from the reported one!)
 - [x] Run on whole of Germany to fine-tune the check (whether we should whittle down by different road classification priorities)
 - [x] Review
 - [x] Adjust for comments
 - [x] Merge

Optionally:
 - [x] Make a pretty map and OSM diary about it!

## Requirements / Relations
[Implements Intersection Validation Handler, resolves #4146](https://github.com/Project-OSRM/osrm-backend/pull/4160)

cc/ @MoKob @daniel-j-h 