### PR TITLE
Fix instruction for turning on through street that is not straight

### DIFF
--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -1371,3 +1371,75 @@ Feature: Simple Turns
         When I route I should get
             | waypoints | route       |
             | g,e       | abcde,abcde |
+
+    Scenario: small ticks in roads
+        Given the node map
+            """
+                          e
+                           `
+                            `
+                             `
+                              `
+                               d
+                                c
+            a - - - - - - - b``
+                                  `
+
+                                     `
+
+                                        `
+
+                                           `
+
+                                              `
+
+                                                  `
+
+                                                      `
+
+                                                          `
+
+                                                              `
+
+                                                                  `
+
+                                                                      `
+
+                                                                          `
+
+                                                                              `
+
+                                                                                  `
+
+                                                                                      `
+
+                                                                                          `
+
+                                                                                              `
+
+                                                                                                 `
+                                                                                                   `
+
+                                                                                                       `
+
+
+                                                                                                            `
+
+
+                                                                                                                `
+
+
+                                                                                                                    f
+
+            """
+
+        And the ways
+            | nodes | oneway | name |
+            | abc   | yes    | fww  |
+            | fcde  | no     | jahn |
+
+        When I route I should get
+            | waypoints | route         | turns                       |
+            | a,f       | fww,jahn,jahn | depart,turn straight,arrive |
+            | a,e       | fww,jahn,jahn | depart,turn left,arrive     |
+

--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -1372,7 +1372,9 @@ Feature: Simple Turns
             | waypoints | route       |
             | g,e       | abcde,abcde |
 
-    Scenario: small ticks in roads
+    # 4205
+    # https://www.openstreetmap.org/node/36153635#map=19/51.97548/7.61795
+    Scenario: merging onto a through street
         Given the node map
             """
                           e
@@ -1439,7 +1441,6 @@ Feature: Simple Turns
             | fcde  | no     | jahn |
 
         When I route I should get
-            | waypoints | route         | turns                       |
-            | a,f       | fww,jahn,jahn | depart,turn straight,arrive |
-            | a,e       | fww,jahn,jahn | depart,turn left,arrive     |
-
+            | waypoints | route         | turns                    |
+            | a,f       | fww,jahn,jahn | depart,turn right,arrive |
+            | a,e       | fww,jahn,jahn | depart,turn left,arrive  |


### PR DESCRIPTION
# Issue

Resolves #4205 

Turning onto a through street often feels like going straight. We currently consider all angles though, which is not what is intended. This PR changes the requirements to consider only narrow turns as going straight, improving the behaviour on merges.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments