### PR TITLE
Use correctly traffic light penalty for no_turn turns

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -322,7 +322,7 @@ function way_function(way, result)
   }
 
   -- perform an quick initial check and abort if the way is
-  -- obviously not routable. 
+  -- obviously not routable.
   -- highway or route tags must be in data table, bridge is optional
   if (not data.highway or data.highway == '') and
   (not data.route or data.route == '')
@@ -405,14 +405,15 @@ function turn_function (turn)
     if turn.direction_modifier == direction_modifier.u_turn then
       turn.duration = turn.duration + profile.u_turn_penalty
     end
-
-    -- for distance based routing we don't want to have penalties based on turn angle
-    if properties.weight_name == 'distance' then
-       turn.weight = 0
-    else
-       turn.weight = turn.duration
-    end
   end
+
+  -- for distance based routing we don't want to have penalties based on turn angle
+  if properties.weight_name == 'distance' then
+     turn.weight = 0
+  else
+     turn.weight = turn.duration
+  end
+
   if properties.weight_name == 'routability' then
       -- penalize turns from non-local access only segments onto local access only tags
       if not turn.source_restricted and turn.target_restricted then


### PR DESCRIPTION
# Issue

For http://map.project-osrm.org/?z=16&center=48.145590%2C11.535505&loc=48.149118%2C11.536576&loc=48.142060%2C11.534431&hl=en&alt=0 with two parallel paths, 
the current path weight does not include a  traffic light penalty
```
curl 'localhost:5000/route/v1/driving/11.536576,48.149118;11.534431,48.14206' | jq '.routes[] | [.weight, .duration|tostring] | join(" ")'
"73.2 75.2"
```
![before](https://user-images.githubusercontent.com/4421046/27789054-383eb612-5feb-11e7-8f84-b521765795eb.png)

The  shortest path is
![after](https://user-images.githubusercontent.com/4421046/27789063-4683c76c-5feb-11e7-8e16-817dc8689d4c.png)
that avoids an intersection with the traffic light https://www.openstreetmap.org/node/737218957
```
 curl -s 'localhost:5000/route/v1/driving/11.536576,48.149118;11.534431,48.14206' | jq '.routes[] | [.weight, .duration|tostring] | join(" ")'
"73.2 73.2"
```

The PR fixes car profile. Bicycle and foot profiles could also have the same issue.


## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
