### PR TITLE
Allow destination routing onto service roads.

### DIFF
--- a/features/car/destination.feature
+++ b/features/car/destination.feature
@@ -131,3 +131,22 @@ Feature: Car - Destination only, no passing through
             | e    | a  | acbe,acbe     |
             | d    | a  | de,acbe,acbe  |
             | c    | d  | cd,cd         |
+
+    Scenario: Car - Routing onto service roads
+        Given the node map
+            """
+               a---b---c---d----e
+                    \     /
+                     f---g
+            """
+
+        And the ways
+            | nodes | access      | highway   | oneway |
+            | abcde |             | motorway  | yes    |
+            | bfgd  | destination | service   | yes    |
+
+        When I route I should get
+            | from | to | route            |
+            | a    | e  | abcde,abcde      |
+            | a    | g  | abcde,bfgd,bfgd  |
+            | f    | e  | bfgd,abcde,abcde |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -154,6 +154,7 @@ local profile = {
       'tertiary_link',
       'residential',
       'living_street',
+      'service'
   },
 
   route_speeds = {


### PR DESCRIPTION
# Issue

Currently, if a way is tagged as `highway=service` and `access=destination`, it causes a weird cucumber test failure in the form of:

```
*** running /Users/danpat/mapbox/osrm-backend/build/osrm-routed --shared-memory=1 -p 5000 -a CH
[info] starting up engines, v5.8.0
[info] Loading from shared memory
[info] Threads: 8
[info] IP address: 0.0.0.0
[info] IP port: 5000
[info] http 1.1 compression handled by zlib version 1.2.8
[info] Listening on: 0.0.0.0:5000
libc++abi.dylib: terminating with uncaught exception of type osrm::util::exception: Dataset is not compatible with CH
```

What seems to be missing is the `service` tag in `profiles/car.lua` `restricted_highway_whitelist`.  This PR implements a test case that causes the crash above, and a fix to the `car.lua` profile that makes it go away, and appears to give correct routing results.

Note that setting the road in the test to `highway=residential` does not trigger the problem, so it seems directly related to `restricted_highway_whitelist`.

I'm still not sure why we're getting "Dataset is not compatible with CH" though, so flagging this PR as WIP.

## Tasklist
 - [ ] figure out why we're getting incompatible dataset error instead of something else
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments