### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+#* text=auto # Does it cause problems on OSX?
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cpp text
+*.hpp text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
Add the good default options as [recommended by GitHub](https://help.github.com/articles/dealing-with-line-endings/).
Helps to work around issues when using hybrid environments like the Bash On Windows (see #4228).
