### PR TITLE
Process relevant nodes only

### DIFF
--- a/features/options/profiles/version2.feature
+++ b/features/options/profiles/version2.feature
@@ -85,3 +85,159 @@ Feature: Profile API version 2
            | a    | b  | ac,cb,cb | 19.2s |
            | a    | d  | ac,cd,cd | 19.2s |
            | a    | e  | ac,ce    | 20s   |
+
+    Scenario: Process only nodes with relevant tags
+        Given the profile file
+            """
+            functions = require('lib/profile_v2')
+
+            function setup()
+              return {
+                node_tags_requiring_processing = {
+                  'barrier'
+                }
+              }
+            end
+
+            function process_node(profile, node, result)
+              print ('process_node ' .. node:id())
+            end
+
+            function process_way(profile, way, result)
+              result.name = way:get_value_by_key('name')
+              result.weight = 10
+              result.forward_mode = mode.driving
+              result.backward_mode = mode.driving
+              result.forward_speed = 36
+              result.backward_speed = 36
+            end
+
+            return {
+              setup = setup,
+              process_node = process_node,
+              process_way = process_way
+            }
+            """
+        And the node map
+            """
+            abc
+            """
+        And the ways
+            | nodes   |
+            | abc     |
+        And the nodes
+            | node  | barrier | color |
+            | a     | bollard |       |
+            | b     |         | pink  |
+            | c     |         |       |
+
+        And the data has been saved to disk
+
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
+        Then it should exit successfully
+        And stdout should contain "process_node 1"
+        And stdout should not contain "process_node 2"
+        And stdout should not contain "process_node 3"
+
+    Scenario: Process all nodes if profile.node_tags_requiring_processing is empty
+        Given the profile file
+            """
+            functions = require('lib/profile_v2')
+
+            function setup()
+              return {
+                node_tags_requiring_processing = {
+                }
+              }
+            end
+
+            function process_node(profile, node, result)
+              print ('process_node ' .. node:id())
+            end
+
+            function process_way(profile, way, result)
+              result.name = way:get_value_by_key('name')
+              result.weight = 10
+              result.forward_mode = mode.driving
+              result.backward_mode = mode.driving
+              result.forward_speed = 36
+              result.backward_speed = 36
+            end
+
+            return {
+              setup = setup,
+              process_node = process_node,
+              process_way = process_way
+            }
+            """
+        And the node map
+            """
+            abc
+            """
+        And the ways
+            | nodes   |
+            | abc     |
+        And the nodes
+            | node  | barrier | color |
+            | a     | bollard |       |
+            | b     |         | pink  |
+            | c     |         |       |
+
+        And the data has been saved to disk
+
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
+        Then it should exit successfully
+        And stdout should contain "process_node 1"
+        And stdout should contain "process_node 2"
+        And stdout should contain "process_node 3"
+
+
+    Scenario: Process all nodes if profile.node_tags_requiring_processing is missing
+        Given the profile file
+            """
+            functions = require('lib/profile_v2')
+
+            function setup()
+              return {
+              }
+            end
+
+            function process_node(profile, node, result)
+              print ('process_node ' .. node:id())
+            end
+
+            function process_way(profile, way, result)
+              result.name = way:get_value_by_key('name')
+              result.weight = 10
+              result.forward_mode = mode.driving
+              result.backward_mode = mode.driving
+              result.forward_speed = 36
+              result.backward_speed = 36
+            end
+
+            return {
+              setup = setup,
+              process_node = process_node,
+              process_way = process_way
+            }
+            """
+        And the node map
+            """
+            abc
+            """
+        And the ways
+            | nodes   |
+            | abc     |
+        And the nodes
+            | node  | barrier | color |
+            | a     | bollard |       |
+            | b     |         | pink  |
+            | c     |         |       |
+
+        And the data has been saved to disk
+
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
+        Then it should exit successfully
+        And stdout should contain "process_node 1"
+        And stdout should contain "process_node 2"
+        And stdout should contain "process_node 3"

--- a/features/options/profiles/version2.feature
+++ b/features/options/profiles/version2.feature
@@ -89,7 +89,13 @@ Feature: Profile API version 2
     Scenario: Process only nodes with relevant tags
         Given the profile file
             """
-            functions = require('lib/profile_v2')
+            api_version = 2
+
+            Set = require('lib/set')
+            Sequence = require('lib/sequence')
+            Handlers = require("lib/way_handlers")
+            find_access_tag = require("lib/access").find_access_tag
+            limit = require("lib/maxspeed").limit
 
             function setup()
               return {
@@ -142,7 +148,13 @@ Feature: Profile API version 2
     Scenario: Process all nodes if profile.node_tags_requiring_processing is empty
         Given the profile file
             """
-            functions = require('lib/profile_v2')
+            api_version = 2
+
+            Set = require('lib/set')
+            Sequence = require('lib/sequence')
+            Handlers = require("lib/way_handlers")
+            find_access_tag = require("lib/access").find_access_tag
+            limit = require("lib/maxspeed").limit
 
             function setup()
               return {
@@ -195,7 +207,13 @@ Feature: Profile API version 2
     Scenario: Process all nodes if profile.node_tags_requiring_processing is missing
         Given the profile file
             """
-            functions = require('lib/profile_v2')
+            api_version = 2
+
+            Set = require('lib/set')
+            Sequence = require('lib/sequence')
+            Handlers = require("lib/way_handlers")
+            find_access_tag = require("lib/access").find_access_tag
+            limit = require("lib/maxspeed").limit
 
             function setup()
               return {

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -38,6 +38,7 @@ struct LuaScriptingContext final
 
     int api_version;
     sol::table profile_table;
+    std::vector<std::string> node_tags_requiring_processing;
 };
 
 /**

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -194,6 +194,15 @@ function setup()
     avoid = Set {
       'impassable',
       'construction'
+    },
+
+    node_tags_requiring_processing = {
+      'barrier',
+      'highway',
+      'crossing',
+      'bicycle',
+      'vehicle',
+      'access'
     }
   }
 end

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -264,6 +264,15 @@ function setup()
       ["nl:rural"] = 80,
       ["nl:trunk"] = 100,
       ["none"] = 140
+    },
+
+    node_tags_requiring_processing = {
+      'barrier',
+      'highway',
+      'motorcar',
+      'motor_vehicle',
+      'vehicle',
+      'access'
     }
   }
 end

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -135,6 +135,14 @@ function setup()
     },
 
     smoothness_speeds = {
+    },
+
+    node_tags_requiring_processing = {
+      'barrier',
+      'highway',
+      'crossing',
+      'foot',
+      'access'
     }
   }
 end

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -495,6 +495,16 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         context.has_way_function = context.way_function.valid();
         context.has_segment_function = context.segment_function.valid();
 
+        // fetch list of tags requiring node processing
+        sol::table node_tags_table = context.profile_table["node_tags_requiring_processing"];
+        if (node_tags_table.valid())
+        {
+            for (auto &&pair : node_tags_table)
+            {
+                context.node_tags_requiring_processing.push_back(pair.second.as<std::string>());
+            };
+        }
+
         // read properties from 'profile.properties' table
         sol::table properties = context.profile_table["properties"];
         if (properties.valid())
@@ -812,8 +822,28 @@ void LuaScriptingContext::ProcessNode(const osmium::Node &node, ExtractionNode &
     switch (api_version)
     {
     case 2:
-        node_function(profile_table, node, result);
+    {
+        bool process = false;
+
+        if (node_tags_requiring_processing.empty())
+            process = true;
+        else
+        {
+            for (auto &&tag : node_tags_requiring_processing)
+            {
+                auto v = node.get_value_by_key(tag.c_str());
+                if (v && *v)
+                {
+                    process = true;
+                    break;
+                }
+            }
+        }
+
+        if (process)
+            node_function(profile_table, node, result);
         break;
+    }
     case 1:
     case 0:
         node_function(node, result);


### PR DESCRIPTION
# Issue

During extraction, processing of nodes takes a lot of time, because there are so many. With this PR, the LUA node function is only called if at least one of a list of relevant tags is present. The list is set by the LUA profile.

The list of relevant tags is typically small. For car it's:
```lua
    node_tags_requiring_processing = {
      'barrier',
      'highway',
      'motorcar',
      'motor_vehicle',
      'vehicle',
      'access'
    }
```


Testing on data for Denmark with the car profile, it cuts the parsing step from about 24s to 16s, or around 30%. The total time of running osrm-extract is reduced from about 135s to 117s, or around 15%.

This PR is based on the profiles v2 branch, and should therefore NOT be merged into the current master.

