### PR TITLE
handle startpoint in bicycle profile, add startpoint tests for bike, car and foot

### DIFF
--- a/features/bicycle/ferry.feature
+++ b/features/bicycle/ferry.feature
@@ -53,8 +53,7 @@ Feature: Bike - Handle ferry routes
     Scenario: Bike - Ferry duration, multiple nodes
         Given the node map
             """
-            x         y
-              a b c d
+            x a b c d y
             """
 
         And the ways
@@ -64,6 +63,6 @@ Feature: Bike - Handle ferry routes
             | abcd  |         | ferry | yes     | 1:00     |
 
         When I route I should get
-            | from | to | route     | time      |
-            | a    | d  | abcd,abcd | 3600s +-5 |
-            | d    | a  | abcd,abcd | 3600s +-5 |
+            | from | to | route     | time  |
+            | a    | d  | abcd,abcd | 3600s |
+            | d    | a  | abcd,abcd | 3600s |

--- a/features/bicycle/ferry.feature
+++ b/features/bicycle/ferry.feature
@@ -64,6 +64,6 @@ Feature: Bike - Handle ferry routes
             | abcd  |         | ferry | yes     | 1:00     |
 
         When I route I should get
-            | from | to | route     | time  |
-            | a    | d  | abcd,abcd | 3600s |
-            | d    | a  | abcd,abcd | 3600s |
+            | from | to | route     | time      |
+            | a    | d  | abcd,abcd | 3600s +-5 |
+            | d    | a  | abcd,abcd | 3600s +-5 |

--- a/features/bicycle/startpoint.feature
+++ b/features/bicycle/startpoint.feature
@@ -1,0 +1,53 @@
+@routing @bicycle @startpoint
+Feature: Bike - Allowed start/end modes
+
+    Background:
+        Given the profile "bicycle"
+
+    Scenario: Bike - Don't start/stop on ferries
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway | route | bicycle |
+            | ab    | primary |       |         |
+            | bc    |         | ferry | yes     |
+
+        When I route I should get
+            | from | to | route | modes           |
+            | 1    | 2  | ab,ab | cycling,cycling |
+            | 2    | 1  | ab,ab | cycling,cycling |
+
+    Scenario: Bike - Don't start/stop on trains
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway | railway | bicycle |
+            | ab    | primary |         |         |
+            | bc    |         | train   | yes     |
+
+        When I route I should get
+            | from | to | route | modes           |
+            | 1    | 2  | ab,ab | cycling,cycling |
+            | 2    | 1  | ab,ab | cycling,cycling |
+
+    Scenario: Bike - OK to start pushing bike
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway |
+            | ab    | primary |
+            | bc    | steps   |
+
+        When I route I should get
+            | from | to | route    | modes                             |
+            | 1    | 2  | ab,bc,bc | cycling,pushing bike,pushing bike |
+            | 2    | 1  | bc,ab,ab | pushing bike,cycling,cycling      |

--- a/features/bicycle/train.feature
+++ b/features/bicycle/train.feature
@@ -1,39 +1,71 @@
 @routing @bicycle @train
 Feature: Bike - Handle ferry routes
 # Bringing bikes on trains and subways
+# We cannot currently use a 'routability' type test, since the bike
+# profile does not allow starting/stopping on trains, and
+# it's not possible to modify the bicycle profile table because it's
+# defined as local.
 
     Background:
         Given the profile "bicycle"
 
     Scenario: Bike - Bringing bikes on trains
-        Then routability should be
-            | highway | railway    | bicycle | bothw   |
-            | primary |            |         | cycling |
-            | (nil)   | train      |         |         |
-            | (nil)   | train      | no      |         |
-            | (nil)   | train      | yes     | train   |
-            | (nil)   | railway    |         |         |
-            | (nil)   | railway    | no      |         |
-            | (nil)   | railway    | yes     | train   |
-            | (nil)   | subway     |         |         |
-            | (nil)   | subway     | no      |         |
-            | (nil)   | subway     | yes     | train   |
-            | (nil)   | tram       |         |         |
-            | (nil)   | tram       | no      |         |
-            | (nil)   | tram       | yes     | train   |
-            | (nil)   | light_rail |         |         |
-            | (nil)   | light_rail | no      |         |
-            | (nil)   | light_rail | yes     | train   |
-            | (nil)   | monorail   |         |         |
-            | (nil)   | monorail   | no      |         |
-            | (nil)   | monorail   | yes     | train   |
-            | (nil)   | some_tag   |         |         |
-            | (nil)   | some_tag   | no      |         |
-            | (nil)   | some_tag   | yes     | cycling |
+        Given the node map
+            """
+            a 1 b   c 2 d   e 3 f   g 4 h
+            """
+
+        And the ways
+            | nodes | highway | railway | bicycle |
+            | ab    | primary |         |         |
+            | cd    | primary |         |         |
+            | ef    | primary |         |         |
+            | gh    | primary |         |         |
+            | bc    |         | train   |         |
+            | de    |         | train   | yes     |
+            | fg    |         | train   | no      |
+
+        When I route I should get
+            | from | to | route       |
+            | 1    | 2  |             |
+            | 2    | 3  | cd,de,ef,ef |
+            | 3    | 4  |             |
+
+    Scenario: Bike - Bringing bikes on trains, invalid railway tag is accepted if access specified
+        Given the node map
+            """
+            a 1 b   c 2 d   e 3 f   g 4 h
+            """
+
+        And the ways
+            | nodes | highway | railway     | bicycle |
+            | ab    | primary |             |         |
+            | cd    | primary |             |         |
+            | ef    | primary |             |         |
+            | gh    | primary |             |         |
+            | bc    |         | invalid_tag |         |
+            | de    |         | invalid_tag | yes     |
+            | fg    |         | invalid_tag | no      |
+
+        When I route I should get
+            | from | to | route |
+            | 1    | 2  |       |
+            | 2    | 3  | cd,de,ef|
+            | 3    | 4  |       |
 
     @construction
     Scenario: Bike - Don't route on railways under construction
-        Then routability should be
-            | highway | railway      | bicycle | bothw   |
-            | primary |              |         | cycling |
-            | (nil)   | construction | yes     |         |
+        Given the node map
+            """
+            a 1 b   c 2 d
+            """
+
+        And the ways
+            | nodes | highway | railway      | bicycle |
+            | ab    | primary |              |         |
+            | cd    | primary |              |         |
+            | bc    |         | construction | yes     |
+
+        When I route I should get
+            | from | to | route |
+            | 1    | 2  |       |

--- a/features/car/startpoint.feature
+++ b/features/car/startpoint.feature
@@ -1,0 +1,37 @@
+@routing @car @startpoint
+Feature: Car - Allowed start/end modes
+
+    Background:
+        Given the profile "car"
+
+    Scenario: Car - Don't start/stop on ferries
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway | route | bicycle |
+            | ab    | primary |       |         |
+            | bc    |         | ferry | yes     |
+
+        When I route I should get
+            | from | to | route | modes           |
+            | 1    | 2  | ab,ab | driving,driving |
+            | 2    | 1  | ab,ab | driving,driving |
+
+    Scenario: Car - Don't start/stop on trains
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway | railway | bicycle |
+            | ab    | primary |         |         |
+            | bc    |         | train   | yes     |
+
+        When I route I should get
+            | from | to | route | modes           |
+            | 1    | 2  | ab,ab | driving,driving |
+            | 2    | 1  | ab,ab | driving,driving |

--- a/features/foot/startpoint.feature
+++ b/features/foot/startpoint.feature
@@ -1,0 +1,37 @@
+@routing @foot @startpoint
+Feature: Foot - Allowed start/end modes
+
+    Background:
+        Given the profile "foot"
+
+    Scenario: Foot - Don't start/stop on ferries
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway | route | bicycle |
+            | ab    | primary |       |         |
+            | bc    |         | ferry | yes     |
+
+        When I route I should get
+            | from | to | route | modes           |
+            | 1    | 2  | ab,ab | walking,walking |
+            | 2    | 1  | ab,ab | walking,walking |
+
+    Scenario: Foot - Don't start/stop on trains
+        Given the node map
+            """
+            a 1 b 2 c
+            """
+
+        And the ways
+            | nodes | highway | railway | bicycle |
+            | ab    | primary |         |         |
+            | bc    |         | train   | yes     |
+
+        When I route I should get
+            | from | to | route | modes           |
+            | 1    | 2  | ab,ab | walking,walking |
+            | 2    | 1  | ab,ab | walking,walking |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -543,7 +543,9 @@ function way_function (way, result)
 
     -- handle various other flags
     'handle_roundabouts',
-    --'handle_startpoint',
+    
+    -- handle allowed start/end modes
+    'handle_startpoint',
 
     -- set name, ref and pronunciation
     'handle_names'


### PR DESCRIPTION
# Issue

The bicycle profile is currently not handling startpoints. This means routes can start and stop in the middle of ferries and trains. This PR fixes this by adding the 'handle_startpoint' handler.

Also adds cuke tests for bike, car and foot.

## Tasklist
 - [x] review
 - [x] adjust for comments