### PR TITLE
Bundles nan, node-cmake and node-pre-gyp for bootstrapping node-osrm, resolves #4216

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "xmlbuilder": "^4.2.1"
   },
   "bundleDependencies": [
+    "nan",
+    "node-cmake",
     "node-pre-gyp"
   ],
   "main": "lib/index.js",


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/4216.

Building `node-osrm` from source requires nan, node-cmake and
node-pre-gyp npm packages already \*. In order to bootstrap we
bundle these dev packages in the bundle we publish to npm.

\* See `src/nodejs/CMakeLists.txt`

Check `npm pack` - we now expect to see a `node_modules` directory
with nan, node-cmake, and node-pre-gyp already there.