### PR TITLE
Via way restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
       - Profiles must return a hash of profile functions. This makes it easier for profiles to include each other.
       - Guidance: add support for throughabouts
     - Bugfixes
-      - Properly save/retrieve datasource annotations for road segments ([#4346](https://github.com/Project-OSRM/osrm-backend/issues/4346))
+      - Properly save/retrieve datasource annotations for road segments ([#4346](https://github.com/Project-OSRM/osrm-backend/issues/4346)
+    - Algorithm)
+      - BREAKING: the file format requires re-processing due to the changes on via-ways
+      - Added support for via-way restrictions
 
 # 5.9.2
     - API:

--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -537,7 +537,7 @@ Feature: Car - Turn restrictions
             | from | to | route               |
             | a    | h  | abc,cde,efc,cgh,cgh |
 
-    @restriction
+    @restriction-way
     Scenario: Car - prohibit turn
         Given the node map
             """
@@ -563,9 +563,11 @@ Feature: Car - Turn restrictions
             | restriction | ab       | be      | de     | no_right_turn |
 
         When I route I should get
-            | from | to | route       |
-            | a    | d  | ab,be,de,de |
-            | a    | f  | ab,be,ef,ef |
+            | from | to | route             | turns                                                               | locations   |
+            | a    | d  | ab,be,ef,ef,de,de | depart,turn right,turn left,continue uturn,new name straight,arrive | a,b,e,f,e,d |
+            | a    | f  | ab,be,ef,ef       | depart,turn right,turn left,arrive                                  | a,b,e,f     |
+            | c    | d  | bc,be,de,de       | depart,turn left,turn right,arrive                                  | c,b,e,d     |
+            | c    | f  | bc,be,ef,ef       | depart,turn left,turn left,arrive                                   | c,b,e,f     |
 
     @restriction @overlap
     Scenario: Car - prohibit turn
@@ -597,11 +599,11 @@ Feature: Car - Turn restrictions
             | restriction | bc       | be      | ef     | no_left_turn  |
 
         When I route I should get
-            | from | to | route       |
-            | a    | d  | ab,be,de,de |
-            | a    | f  | ab,be,ef,ef |
-            | c    | d  | bc,be,de,de |
-            | c    | f  | bc,be,ef,ef |
+            | from | to | route             |
+            | a    | d  | ab,be,ef,ef,de,de |
+            | a    | f  | ab,be,ef,ef       |
+            | c    | d  | bc,be,de,de       |
+            | c    | f  | bc,be,de,de,ef,ef |
 
     @restriction-way @overlap
     Scenario: Two times same way
@@ -618,9 +620,25 @@ Feature: Car - Turn restrictions
                 |   |
                 |   |
                 |   |
-            a - b - c - f
-                |   | \ |
-                i - d - e
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+            a - b - c - - - - - - - - - - - - - - - - - - - f
+                |   | \                                     /
+                i - d - e - - - - - - - - - - - - - - - - -
             """
 
         And the ways
@@ -641,7 +659,7 @@ Feature: Car - Turn restrictions
 
        When I route I should get
             | from | to | route                |
-            | a    | i  | ab,bc,cd,fedib,fedib |
+            | a    | i  | ab,bc,cf,fedib,fedib |
 
 
     @restriction-way @overlap
@@ -682,8 +700,8 @@ Feature: Car - Turn restrictions
 
         When I route I should get
             | from | to | route                  |
-            | a    | j  | left,third,right,right |
-            | f    | e  | right,first,left,left  |
+            | a    | j  | left,first,right,right |
+            | f    | e  | right,third,left,left  |
 
     @restriction
     Scenario: Car - allow only turn
@@ -711,9 +729,11 @@ Feature: Car - Turn restrictions
             | restriction | ab       | be      | ef     | only_left_on |
 
         When I route I should get
-            | from | to | route       |
-            | a    | d  | ab,be,de,de |
-
+            | from | to | route       | turns | locations |
+            | a    | d  | ab,be,ef,ef,de,de | depart,turn right,turn left,continue uturn,new name straight,arrive | a,b,e,f,e,d |
+            | a    | f  | ab,be,ef,ef       | depart,turn right,turn left,arrive                                  | a,b,e,f     |
+            | c    | d  | bc,be,de,de       | depart,turn left,turn right,arrive                                  | c,b,e,d     |
+            | c    | f  | bc,be,ef,ef       | depart,turn left,turn left,arrive                                   | c,b,e,f     |
 
     @restriction
     Scenario: Car - allow only turn
@@ -810,14 +830,15 @@ Feature: Car - Turn restrictions
             | restriction | gf       | fb,bc   | cd     | only_u_turn    |
 
         When I route I should get
-            | from | to | route             |
-            | a    | d  | abcd,abcd         |
-            | a    | e  | abcd,ce,ce        |
-            | a    | f  | abcd,hfb,hfb      |
-            | g    | e  | gf,hfb,abcd,ce,ce |
-            | g    | d  | gf,hfb,abcd,abcd  |
-            | h    | e  | hfb,abcd,ce,ce    |
-            | h    | d  | hfb,abcd,abcd     |
+            | from | to | route                | turns                                            | locations |
+            | a    | d  | abcd,ce,ce,abcd,abcd | depart,turn left,continue uturn,turn left,arrive | a,c,e,c,d |
+            | a    | e  | abcd,ce,ce           | depart,turn left,arrive                          | a,c,e     |
+            | a    | f  | abcd,hfb,hfb         | depart,turn right,arrive                         | a,b,f     |
+            | g    | e  | gf,hfb,abcd,ce,ce    | depart,turn right,turn right,turn left,arrive    | g,f,b,c,e |
+            | g    | d  | gf,hfb,abcd,abcd     | depart,turn right,turn right,arrive              | g,f,b,d   |
+            | h    | e  | hfb,abcd,ce,ce       | depart,end of road right,turn left,arrive        | h,b,c,e   |
+            | h    | d  | hfb,abcd,abcd        | depart,end of road right,arrive                  | h,b,d     |
+
 
     @restriction
     Scenario: Car - prohibit turn, traffic lights
@@ -855,7 +876,8 @@ Feature: Car - Turn restrictions
 
 
         When I route I should get
-            | from | to | route       |
-            | h    | j  | ab,be,de,de |
-            | h    | f  | ab,be,ef,ef |
-
+            | from | to | route             | turns                                                               | locations   |
+            | a    | d  | ab,be,ef,ef,de,de | depart,turn right,turn left,continue uturn,new name straight,arrive | a,b,e,f,e,d |
+            | a    | f  | ab,be,ef,ef       | depart,turn right,turn left,arrive                                  | a,b,e,f     |
+            | c    | d  | bc,be,de,de       | depart,turn left,turn right,arrive                                  | c,b,e,d     |
+            | c    | f  | bc,be,ef,ef       | depart,turn left,turn left,arrive                                   | c,b,e,f     |

--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -506,3 +506,356 @@ Feature: Car - Turn restrictions
             | s    | n  | sj,nj,nj |
             | s    | e  | sj,ej,ej |
 
+    @restriction @compression
+    Scenario: Restriction On Compressed Geometry
+        Given the node map
+            """
+                        i
+                        |
+                    f - e
+                    |   |
+            a - b - c - d
+                    |
+                    g
+                    |
+                    h
+            """
+
+        And the ways
+            | nodes |
+            | abc   |
+            | cde   |
+            | efc   |
+            | cgh   |
+            | ei    |
+
+        And the relations
+            | type        | way:from | node:via | way:to | restriction   |
+            | restriction | abc      | c        | cgh    | no_right_turn |
+
+        When I route I should get
+            | from | to | route               |
+            | a    | h  | abc,cde,efc,cgh,cgh |
+
+    @restriction
+    Scenario: Car - prohibit turn
+        Given the node map
+            """
+            c
+            |
+            |   f
+            |   |
+            b---e
+            |   |
+            a   d
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | be    |
+            | de    |
+            | ef    |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction   |
+            | restriction | ab       | be      | de     | no_right_turn |
+
+        When I route I should get
+            | from | to | route       |
+            | a    | d  | ab,be,de,de |
+            | a    | f  | ab,be,ef,ef |
+
+    @restriction @overlap
+    Scenario: Car - prohibit turn
+        Given the node map
+            """
+            c
+            |
+            |   f
+            |   |
+            b---e
+            |   |
+            |   d
+            |
+            a
+
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | be    |
+            | de    |
+            | ef    |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction   |
+            | restriction | ab       | be      | de     | no_right_turn |
+            | restriction | bc       | be      | ef     | no_left_turn  |
+
+        When I route I should get
+            | from | to | route       |
+            | a    | d  | ab,be,de,de |
+            | a    | f  | ab,be,ef,ef |
+            | c    | d  | bc,be,de,de |
+            | c    | f  | bc,be,ef,ef |
+
+    @restriction-way @overlap
+    Scenario: Two times same way
+        Given the node map
+            """
+                h   g
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+                |   |
+            a - b - c - f
+                |   | \ |
+                i - d - e
+            """
+
+        And the ways
+            | nodes | oneway |
+            | ab    | no     |
+            | bc    | no     |
+            | cd    | yes    |
+            | ce    | yes    |
+            | cf    | yes    |
+            | cg    | yes    |
+            | bh    | no     |
+            | fedib | yes    |
+
+       And the relations
+            | type        | way:from | way:via | way:to | restriction   |
+            | restriction | ab       | bc      | ce     | no_right_turn |
+            | restriction | ab       | bc      | cd     | no_right_turn |
+
+       When I route I should get
+            | from | to | route                |
+            | a    | i  | ab,bc,cd,fedib,fedib |
+
+
+    @restriction-way @overlap
+    Scenario: Car - prohibit turn
+        Given the node map
+            """
+            a   j
+            |   |
+            b---i
+            |   |
+            c---h
+            |   |
+            d---g
+            |   |
+            e   f
+            """
+
+        And the ways
+            | nodes | name   | oneway |
+            | ab    | left   | yes    |
+            | bc    | left   | yes    |
+            | cd    | left   | yes    |
+            | de    | left   | yes    |
+            | fg    | right  | yes    |
+            | gh    | right  | yes    |
+            | hi    | right  | yes    |
+            | ij    | right  | yes    |
+            | dg    | first  | no     |
+            | ch    | second | no     |
+            | bi    | third  | no     |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction   |
+            | restriction | ab       | bi      | ij     | no_u_turn     |
+            | restriction | bc       | ch      | hi     | no_u_turn     |
+            | restriction | fg       | dg      | de     | no_u_turn     |
+            | restriction | gh       | ch      | cd     | no_u_turn     |
+
+        When I route I should get
+            | from | to | route                  |
+            | a    | j  | left,third,right,right |
+            | f    | e  | right,first,left,left  |
+
+    @restriction
+    Scenario: Car - allow only turn
+        Given the node map
+            """
+            c
+            |
+            |   f
+            |   |
+            b---e
+            |   |
+            a   d
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | be    |
+            | de    |
+            | ef    |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction  |
+            | restriction | ab       | be      | ef     | only_left_on |
+
+        When I route I should get
+            | from | to | route       |
+            | a    | d  | ab,be,de,de |
+
+
+    @restriction
+    Scenario: Car - allow only turn
+        Given the node map
+            """
+            c
+            |
+            |   f
+            |   |
+            b---e
+            |   |
+            a   d
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | be    |
+            | de    |
+            | ef    |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction   |
+            | restriction | ab       | be      | ed     | only_right_on |
+
+        When I route I should get
+            | from | to | route       |
+            | a    | d  | ab,be,de,de |
+
+    @restriction
+    Scenario: Multi Way restriction
+        Given the node map
+            """
+                  k   j
+                  |   |
+            h - - g - f - - e
+                  |   |
+                  |   |
+            a - - b - c - - d
+                  |   |
+                  l   i
+            """
+
+        And the ways
+            | nodes | name  | oneway |
+            | ab    | horiz | yes    |
+            | bc    | horiz | yes    |
+            | cd    | horiz | yes    |
+            | ef    | horiz | yes    |
+            | fg    | horiz | yes    |
+            | gh    | horiz | yes    |
+            | ic    | vert  | yes    |
+            | cf    | vert  | yes    |
+            | fj    | vert  | yes    |
+            | kg    | vert  | yes    |
+            | gb    | vert  | yes    |
+            | bl    | vert  | yes    |
+
+        And the relations
+            | type        | way:from | way:via  | way:to | restriction |
+            | restriction | ab       | bc,cf,fg | gh     | no_u_turn   |
+
+        When I route I should get
+            | from | to | route                  |
+            | a    | h  | horiz,vert,horiz,horiz |
+
+    @restriction
+    Scenario: Multi-Way overlapping single-way
+        Given the node map
+            """
+                    e
+                    |
+            a - b - c - d
+                |
+                f - g
+                |
+                h
+            """
+
+        And the ways
+            | nodes | name |
+            | ab    | abcd |
+            | bc    | abcd |
+            | cd    | abcd |
+            | hf    | hfb  |
+            | fb    | hfb  |
+            | gf    | gf   |
+            | ce    | ce   |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction    |
+            | restriction | ab       | bc      | ce     | only_left_turn |
+            | restriction | gf       | fb,bc   | cd     | only_u_turn    |
+
+        When I route I should get
+            | from | to | route             |
+            | a    | d  | abcd,abcd         |
+            | a    | e  | abcd,ce,ce        |
+            | a    | f  | abcd,hfb,hfb      |
+            | g    | e  | gf,hfb,abcd,ce,ce |
+            | g    | d  | gf,hfb,abcd,abcd  |
+            | h    | e  | hfb,abcd,ce,ce    |
+            | h    | d  | hfb,abcd,abcd     |
+
+    @restriction
+    Scenario: Car - prohibit turn, traffic lights
+        Given the node map
+            """
+            c
+            |
+            |   f
+            |   |
+            b---e
+            |   |
+            a   d
+            |   |
+            g   i
+            |   |
+            h   j
+            """
+
+        And the ways
+            | nodes | name |
+            | hgab  | ab   |
+            | bc    | bc   |
+            | be    | be   |
+            | jide  | de   |
+            | ef    | ef   |
+
+        And the relations
+            | type        | way:from | way:via | way:to | restriction   |
+            | restriction | hgab     | be      | jide   | no_right_turn |
+
+        And the nodes
+            | node | highway         |
+            | g    | traffic_signals |
+            | i    | traffic_signals |
+
+
+        When I route I should get
+            | from | to | route       |
+            | h    | j  | ab,be,de,de |
+            | h    | f  | ab,be,ef,ef |
+

--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -639,6 +639,8 @@ Feature: Car - Turn restrictions
                 |   | \                                     /
                 i - d - e - - - - - - - - - - - - - - - - -
             """
+        # The long distances here are required to make other turns undesriable in comparison to the restricted turns.
+        # Otherwise they might just be picked without the actual turns being restricted
 
         And the ways
             | nodes | oneway |

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -92,7 +92,7 @@ class EdgeBasedGraphFactory
              const std::string &turn_duration_penalties_filename,
              const std::string &turn_penalties_index_filename,
              const std::string &cnbg_ebg_mapping_path,
-             const RestrictionMap &restriction_map,
+             const RestrictionMap &node_restriction_map,
              const WayRestrictionMap &way_restriction_map);
 
     // The following get access functions destroy the content in the factory
@@ -137,9 +137,11 @@ class EdgeBasedGraphFactory
     EdgeBasedNodeDataContainer m_edge_based_node_container;
     util::DeallocatingVector<EdgeBasedEdge> m_edge_based_edge_list;
 
-    // the number of edge-based nodes is mostly made up out of the edges in the node-based graph.
+    // The number of edge-based nodes is mostly made up out of the edges in the node-based graph.
     // Any edge in the node-based graph represents a node in the edge-based graph. In addition, we
     // add a set of artificial edge-based nodes into the mix to model via-way turn restrictions.
+    // See https://github.com/Project-OSRM/osrm-backend/issues/2681#issuecomment-313080353 for
+    // reference
     std::uint64_t m_number_of_edge_based_nodes;
 
     const std::vector<util::Coordinate> &m_coordinates;
@@ -157,15 +159,21 @@ class EdgeBasedGraphFactory
 
     unsigned RenumberEdges();
 
+    // During the generation of the edge-expanded nodes, we need to also generate duplicates that
+    // represent state during via-way restrictions (see
+    // https://github.com/Project-OSRM/osrm-backend/issues/2681#issuecomment-313080353). Access to
+    // the information on what to duplicate and how is provided via the way_restriction_map
     std::vector<NBGToEBG> GenerateEdgeExpandedNodes(const WayRestrictionMap &way_restriction_map);
 
+    // Edge-expanded edges are generate for all valid turns. The validity can be checked via the
+    // restriction maps
     void GenerateEdgeExpandedEdges(ScriptingEnvironment &scripting_environment,
                                    const std::string &original_edge_data_filename,
                                    const std::string &turn_lane_data_filename,
                                    const std::string &turn_weight_penalties_filename,
                                    const std::string &turn_duration_penalties_filename,
                                    const std::string &turn_penalties_index_filename,
-                                   const RestrictionMap &restriction_map,
+                                   const RestrictionMap &node_restriction_map,
                                    const WayRestrictionMap &way_restriction_map);
 
     NBGToEBG InsertEdgeBasedNode(const NodeID u, const NodeID v);

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -2,7 +2,6 @@
 #define EXTRACTION_CONTAINERS_HPP
 
 #include "extractor/first_and_last_segment_of_way.hpp"
-#include "extractor/guidance/turn_lane_types.hpp"
 #include "extractor/internal_extractor_edge.hpp"
 #include "extractor/query_node.hpp"
 #include "extractor/restriction.hpp"
@@ -28,7 +27,7 @@ class ExtractionContainers
     void PrepareEdges(ScriptingEnvironment &scripting_environment);
 
     void WriteNodes(storage::io::FileWriter &file_out) const;
-    void WriteRestrictions(const std::string &restrictions_file_name);
+    void WriteConditionalRestrictions(const std::string &restrictions_file_name);
     void WriteEdges(storage::io::FileWriter &file_out) const;
     void WriteCharData(const std::string &file_name);
 
@@ -36,7 +35,6 @@ class ExtractionContainers
     using NodeIDVector = std::vector<OSMNodeID>;
     using NodeVector = std::vector<QueryNode>;
     using EdgeVector = std::vector<InternalExtractorEdge>;
-    using RestrictionsVector = std::vector<InputRestrictionContainer>;
     using WayIDStartEndVector = std::vector<FirstAndLastSegmentOfWay>;
     using NameCharData = std::vector<unsigned char>;
     using NameOffsets = std::vector<unsigned>;
@@ -49,9 +47,15 @@ class ExtractionContainers
     NameCharData name_char_data;
     NameOffsets name_offsets;
     // an adjacency array containing all turn lane masks
-    RestrictionsVector restrictions_list;
     WayIDStartEndVector way_start_end_id_list;
+
     unsigned max_internal_node_id;
+
+    // list of restrictions before we transform them into the output types
+    std::vector<InputConditionalTurnRestriction> restrictions_list;
+
+    // turn restrictions split into conditional and unconditional turn restrictions
+    std::vector<ConditionalTurnRestriction> conditional_turn_restrictions;
     std::vector<TurnRestriction> unconditional_turn_restrictions;
 
     ExtractionContainers();

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -51,7 +51,10 @@ class ExtractionContainers
 
     unsigned max_internal_node_id;
 
-    // list of restrictions before we transform them into the output types
+    // list of restrictions before we transform them into the output types. Input containers
+    // reference OSMNodeIDs. We can only transform them to the correct internal IDs after we've read
+    // everything. Without a multi-parse approach, we have to remember the output restrictions
+    // before converting them to the internal formats
     std::vector<InputConditionalTurnRestriction> restrictions_list;
 
     // turn restrictions split into conditional and unconditional turn restrictions

--- a/include/extractor/extractor_callbacks.hpp
+++ b/include/extractor/extractor_callbacks.hpp
@@ -42,10 +42,10 @@ namespace extractor
 {
 
 class ExtractionContainers;
-struct InputRestrictionContainer;
 struct ExtractionNode;
 struct ExtractionWay;
 struct ProfileProperties;
+struct InputConditionalTurnRestriction;
 
 /**
  * This class is used by the extractor with the results of the
@@ -83,7 +83,7 @@ class ExtractorCallbacks
     void ProcessNode(const osmium::Node &current_node, const ExtractionNode &result_node);
 
     // warning: caller needs to take care of synchronization!
-    void ProcessRestriction(const boost::optional<InputRestrictionContainer> &restriction);
+    void ProcessRestriction(const InputConditionalTurnRestriction &restriction);
 
     // warning: caller needs to take care of synchronization!
     void ProcessWay(const osmium::Way &current_way, const ExtractionWay &result_way);

--- a/include/extractor/graph_compressor.hpp
+++ b/include/extractor/graph_compressor.hpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <unordered_set>
+#include <vector>
 
 namespace osrm
 {
@@ -14,7 +15,7 @@ namespace extractor
 {
 
 class CompressedEdgeContainer;
-class RestrictionMap;
+struct TurnRestriction;
 
 class GraphCompressor
 {
@@ -23,7 +24,7 @@ class GraphCompressor
   public:
     void Compress(const std::unordered_set<NodeID> &barrier_nodes,
                   const std::unordered_set<NodeID> &traffic_lights,
-                  RestrictionMap &restriction_map,
+                  std::vector<TurnRestriction> &turn_restrictions,
                   util::NodeBasedDynamicGraph &graph,
                   CompressedEdgeContainer &geometry_compressor);
 

--- a/include/extractor/node_data_container.hpp
+++ b/include/extractor/node_data_container.hpp
@@ -104,6 +104,16 @@ template <storage::Ownership Ownership> class EdgeBasedNodeDataContainerImpl
         util::inplacePermutation(classes.begin(), classes.end(), permutation);
     }
 
+    // all containers have the exact same size
+    std::size_t Size() const
+    {
+        BOOST_ASSERT(geometry_ids.size() == name_ids.size());
+        BOOST_ASSERT(geometry_ids.size() == component_ids.size());
+        BOOST_ASSERT(geometry_ids.size() == travel_modes.size());
+        BOOST_ASSERT(geometry_ids.size() == classes.size());
+        return geometry_ids.size();
+    }
+
   private:
     Vector<GeometryID> geometry_ids;
     Vector<NameID> name_ids;

--- a/include/extractor/restriction.hpp
+++ b/include/extractor/restriction.hpp
@@ -5,6 +5,7 @@
 #include "util/opening_hours.hpp"
 #include "util/typedefs.hpp"
 
+#include <boost/variant.hpp>
 #include <limits>
 
 namespace osrm
@@ -12,104 +13,254 @@ namespace osrm
 namespace extractor
 {
 
+// OSM offers two types of restrictions, via node and via-way restrictions. We parse both into the
+// same input container
+//
+// A restriction turning at a single node. This is the most common type of restriction:
+//
+// a - b - c
+//     |
+//     d
+//
+// ab via b to bd
+struct InputNodeRestriction
+{
+    OSMEdgeID_weak from;
+    OSMNodeID_weak via;
+    OSMEdgeID_weak to;
+};
+
+// A restriction that uses a single via-way in between
+//
+// f - e - d
+//     |
+// a - b - c
+//
+// ab via be to ef -- no u turn
+struct InputWayRestriction
+{
+    OSMEdgeID_weak from;
+    OSMEdgeID_weak via;
+    OSMEdgeID_weak to;
+};
+
+// Outside view of the variant, these are equal to the `which()` results
+enum RestrictionType
+{
+    NODE_RESTRICTION = 0,
+    WAY_RESTRICTION = 1,
+    NUM_RESTRICTION_TYPES = 2
+};
+
+namespace restriction_details
+{
+
+// currently these bits only hold an `is_only` value.
+struct Bits
+{ // mostly unused, initialised to false by default
+    Bits() : is_only(false) {}
+
+    bool is_only;
+    // when adding more bits, consider using bitfields just as in
+    // bool unused : 7;
+};
+
+} // namespace restriction
+
+struct InputTurnRestriction
+{
+    // keep in the same order as the turn restrictions below
+    boost::variant<InputNodeRestriction, InputWayRestriction> node_or_way;
+    restriction_details::Bits flags;
+
+    OSMEdgeID_weak From() const
+    {
+        return node_or_way.which() == RestrictionType::NODE_RESTRICTION
+                   ? boost::get<InputNodeRestriction>(node_or_way).from
+                   : boost::get<InputWayRestriction>(node_or_way).from;
+    }
+
+    OSMEdgeID_weak To() const
+    {
+        return node_or_way.which() == RestrictionType::NODE_RESTRICTION
+                   ? boost::get<InputNodeRestriction>(node_or_way).to
+                   : boost::get<InputWayRestriction>(node_or_way).to;
+    }
+
+    RestrictionType Type() const
+    {
+        BOOST_ASSERT(node_or_way.which() < RestrictionType::NUM_RESTRICTION_TYPES);
+        return static_cast<RestrictionType>(node_or_way.which());
+    }
+
+    InputWayRestriction &AsWayRestriction()
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
+        return boost::get<InputWayRestriction>(node_or_way);
+    }
+
+    const InputWayRestriction &AsWayRestriction() const
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
+        return boost::get<InputWayRestriction>(node_or_way);
+    }
+
+    InputNodeRestriction &AsNodeRestriction()
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
+        return boost::get<InputNodeRestriction>(node_or_way);
+    }
+
+    const InputNodeRestriction &AsNodeRestriction() const
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
+        return boost::get<InputNodeRestriction>(node_or_way);
+    }
+};
+struct InputConditionalTurnRestriction : InputTurnRestriction
+{
+    std::vector<util::OpeningHours> condition;
+};
+
+// OSRM manages restrictions based on node IDs which refer to the last node along the edge. Note
+// that this has the side-effect of not allowing parallel edges!
+struct NodeRestriction
+{
+    NodeID from;
+    NodeID via;
+    NodeID to;
+
+    // check if all parts of the restriction reference an actual node
+    bool Valid() const
+    {
+        return from != SPECIAL_NODEID && to != SPECIAL_NODEID && via != SPECIAL_NODEID;
+    };
+
+    std::string ToString() const
+    {
+        return "From " + std::to_string(from) + " via " + std::to_string(via) + " to " +
+               std::to_string(to);
+    }
+};
+
+// A way restriction in the context of OSRM requires translation into NodeIDs. This is due to the
+// compression happening in the graph creation process which would make it difficult to track
+// way-ids over a series of operations. Having access to the nodes directly allows look-up of the
+// edges in the processed structures
+struct WayRestriction
+{
+    // a way restriction in OSRM is essentially a dual node turn restriction;
+    //
+    // |     |
+    // c -x- b
+    // |     |
+    // d     a
+    //
+    // from ab via bxc to cd: no_uturn
+    //
+    // Technically, we would need only a,b,c,d to describe the full turn in terms of nodes. When
+    // parsing the relation, though, we do not know about the final representation in the node-based
+    // graph for the restriction. In case of a traffic light, for example, we might end up with bxc
+    // not being compressed to bc. For that reason, we need to maintain two node restrictions in
+    // case a way restrction is not fully collapsed
+    NodeRestriction in_restriction;
+    NodeRestriction out_restriction;
+};
+
+// Wrapper for turn restrictions that gives more information on its type / handles the switch
+// between node/way/multi-way restrictions
 struct TurnRestriction
 {
-    union WayOrNode {
-        OSMNodeID_weak node;
-        OSMEdgeID_weak way;
-    };
-    WayOrNode via;
-    WayOrNode from;
-    WayOrNode to;
+    // keep in the same order as the turn restrictions above
+    boost::variant<NodeRestriction, WayRestriction> node_or_way;
+    restriction_details::Bits flags;
 
-    std::vector<util::OpeningHours> condition;
-
-    struct Bits
-    { // mostly unused
-        Bits()
-            : is_only(false), uses_via_way(false), unused2(false), unused3(false), unused4(false),
-              unused5(false), unused6(false), unused7(false)
-        {
-        }
-
-        bool is_only : 1;
-        bool uses_via_way : 1;
-        bool unused2 : 1;
-        bool unused3 : 1;
-        bool unused4 : 1;
-        bool unused5 : 1;
-        bool unused6 : 1;
-        bool unused7 : 1;
-    } flags;
-
-    explicit TurnRestriction(NodeID node)
+    // construction for NodeRestrictions
+    explicit TurnRestriction(NodeRestriction node_restriction, bool is_only = false)
+        : node_or_way(node_restriction)
     {
-        via.node = node;
-        from.node = SPECIAL_NODEID;
-        to.node = SPECIAL_NODEID;
-    }
-
-    explicit TurnRestriction(const bool is_only = false)
-    {
-        via.node = SPECIAL_NODEID;
-        from.node = SPECIAL_NODEID;
-        to.node = SPECIAL_NODEID;
         flags.is_only = is_only;
     }
+
+    // construction for WayRestrictions
+    explicit TurnRestriction(WayRestriction way_restriction, bool is_only = false)
+        : node_or_way(way_restriction)
+    {
+        flags.is_only = is_only;
+    }
+
+    explicit TurnRestriction()
+    {
+        node_or_way = NodeRestriction{SPECIAL_EDGEID, SPECIAL_NODEID, SPECIAL_EDGEID};
+    }
+
+    WayRestriction &AsWayRestriction()
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
+        return boost::get<WayRestriction>(node_or_way);
+    }
+
+    const WayRestriction &AsWayRestriction() const
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
+        return boost::get<WayRestriction>(node_or_way);
+    }
+
+    NodeRestriction &AsNodeRestriction()
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
+        return boost::get<NodeRestriction>(node_or_way);
+    }
+
+    const NodeRestriction &AsNodeRestriction() const
+    {
+        BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
+        return boost::get<NodeRestriction>(node_or_way);
+    }
+
+    RestrictionType Type() const
+    {
+        BOOST_ASSERT(node_or_way.which() < RestrictionType::NUM_RESTRICTION_TYPES);
+        return static_cast<RestrictionType>(node_or_way.which());
+    }
+
+    // check if all elements of the edge are considered valid
+    bool Valid() const
+    {
+        if (node_or_way.which() == RestrictionType::WAY_RESTRICTION)
+        {
+            auto const &restriction = AsWayRestriction();
+            return restriction.in_restriction.Valid() && restriction.out_restriction.Valid();
+        }
+        else
+        {
+            auto const &restriction = AsNodeRestriction();
+            return restriction.Valid();
+        }
+    }
+
+    std::string ToString() const
+    {
+        std::string representation;
+        if (node_or_way.which() == RestrictionType::WAY_RESTRICTION)
+        {
+            auto const &way = AsWayRestriction();
+            representation =
+                "In: " + way.in_restriction.ToString() + " Out: " + way.out_restriction.ToString();
+        }
+        else
+        {
+            auto const &node = AsNodeRestriction();
+            representation = node.ToString();
+        }
+        representation += " is_only: " + std::to_string(flags.is_only);
+        return representation;
+    }
 };
 
-/**
- * This is just a wrapper around TurnRestriction used in the extractor.
- *
- * Could be merged with TurnRestriction. For now the type-destiction makes sense
- * as the format in which the restriction is presented in the extractor and in the
- * preprocessing is different. (see restriction_parser.cpp)
- */
-struct InputRestrictionContainer
+struct ConditionalTurnRestriction : TurnRestriction
 {
-    TurnRestriction restriction;
-
-    InputRestrictionContainer(EdgeID fromWay, EdgeID toWay, EdgeID vw)
-    {
-        restriction.from.way = fromWay;
-        restriction.to.way = toWay;
-        restriction.via.way = vw;
-    }
-    explicit InputRestrictionContainer(bool is_only = false)
-    {
-        restriction.from.way = SPECIAL_EDGEID;
-        restriction.to.way = SPECIAL_EDGEID;
-        restriction.via.node = SPECIAL_NODEID;
-        restriction.flags.is_only = is_only;
-    }
-
-    static InputRestrictionContainer min_value() { return InputRestrictionContainer(0, 0, 0); }
-    static InputRestrictionContainer max_value()
-    {
-        return InputRestrictionContainer(SPECIAL_EDGEID, SPECIAL_EDGEID, SPECIAL_EDGEID);
-    }
-};
-
-struct CmpRestrictionContainerByFrom
-{
-    using value_type = InputRestrictionContainer;
-    bool operator()(const InputRestrictionContainer &a, const InputRestrictionContainer &b) const
-    {
-        return a.restriction.from.way < b.restriction.from.way;
-    }
-    value_type max_value() const { return InputRestrictionContainer::max_value(); }
-    value_type min_value() const { return InputRestrictionContainer::min_value(); }
-};
-
-struct CmpRestrictionContainerByTo
-{
-    using value_type = InputRestrictionContainer;
-    bool operator()(const InputRestrictionContainer &a, const InputRestrictionContainer &b) const
-    {
-        return a.restriction.to.way < b.restriction.to.way;
-    }
-    value_type max_value() const { return InputRestrictionContainer::max_value(); }
-    value_type min_value() const { return InputRestrictionContainer::min_value(); }
+    std::vector<util::OpeningHours> condition;
 };
 }
 }

--- a/include/extractor/restriction.hpp
+++ b/include/extractor/restriction.hpp
@@ -5,7 +5,7 @@
 #include "util/opening_hours.hpp"
 #include "util/typedefs.hpp"
 
-#include <boost/variant.hpp>
+#include "mapbox/variant.hpp"
 #include <limits>
 
 namespace osrm
@@ -55,21 +55,21 @@ enum RestrictionType
 struct InputTurnRestriction
 {
     // keep in the same order as the turn restrictions below
-    boost::variant<InputNodeRestriction, InputWayRestriction> node_or_way;
+    mapbox::util::variant<InputNodeRestriction, InputWayRestriction> node_or_way;
     bool is_only;
 
     OSMWayID From() const
     {
         return node_or_way.which() == RestrictionType::NODE_RESTRICTION
-                   ? boost::get<InputNodeRestriction>(node_or_way).from
-                   : boost::get<InputWayRestriction>(node_or_way).from;
+                   ? mapbox::util::get<InputNodeRestriction>(node_or_way).from
+                   : mapbox::util::get<InputWayRestriction>(node_or_way).from;
     }
 
     OSMWayID To() const
     {
         return node_or_way.which() == RestrictionType::NODE_RESTRICTION
-                   ? boost::get<InputNodeRestriction>(node_or_way).to
-                   : boost::get<InputWayRestriction>(node_or_way).to;
+                   ? mapbox::util::get<InputNodeRestriction>(node_or_way).to
+                   : mapbox::util::get<InputWayRestriction>(node_or_way).to;
     }
 
     RestrictionType Type() const
@@ -81,25 +81,25 @@ struct InputTurnRestriction
     InputWayRestriction &AsWayRestriction()
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
-        return boost::get<InputWayRestriction>(node_or_way);
+        return mapbox::util::get<InputWayRestriction>(node_or_way);
     }
 
     const InputWayRestriction &AsWayRestriction() const
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
-        return boost::get<InputWayRestriction>(node_or_way);
+        return mapbox::util::get<InputWayRestriction>(node_or_way);
     }
 
     InputNodeRestriction &AsNodeRestriction()
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
-        return boost::get<InputNodeRestriction>(node_or_way);
+        return mapbox::util::get<InputNodeRestriction>(node_or_way);
     }
 
     const InputNodeRestriction &AsNodeRestriction() const
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
-        return boost::get<InputNodeRestriction>(node_or_way);
+        return mapbox::util::get<InputNodeRestriction>(node_or_way);
     }
 };
 struct InputConditionalTurnRestriction : InputTurnRestriction
@@ -120,12 +120,6 @@ struct NodeRestriction
     {
         return from != SPECIAL_NODEID && to != SPECIAL_NODEID && via != SPECIAL_NODEID;
     };
-
-    std::string ToString() const
-    {
-        return "From " + std::to_string(from) + " via " + std::to_string(via) + " to " +
-               std::to_string(to);
-    }
 
     bool operator==(const NodeRestriction &other) const
     {
@@ -168,7 +162,7 @@ struct WayRestriction
 struct TurnRestriction
 {
     // keep in the same order as the turn restrictions above
-    boost::variant<NodeRestriction, WayRestriction> node_or_way;
+    mapbox::util::variant<NodeRestriction, WayRestriction> node_or_way;
     bool is_only;
 
     // construction for NodeRestrictions
@@ -191,25 +185,25 @@ struct TurnRestriction
     WayRestriction &AsWayRestriction()
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
-        return boost::get<WayRestriction>(node_or_way);
+        return mapbox::util::get<WayRestriction>(node_or_way);
     }
 
     const WayRestriction &AsWayRestriction() const
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::WAY_RESTRICTION);
-        return boost::get<WayRestriction>(node_or_way);
+        return mapbox::util::get<WayRestriction>(node_or_way);
     }
 
     NodeRestriction &AsNodeRestriction()
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
-        return boost::get<NodeRestriction>(node_or_way);
+        return mapbox::util::get<NodeRestriction>(node_or_way);
     }
 
     const NodeRestriction &AsNodeRestriction() const
     {
         BOOST_ASSERT(node_or_way.which() == RestrictionType::NODE_RESTRICTION);
-        return boost::get<NodeRestriction>(node_or_way);
+        return mapbox::util::get<NodeRestriction>(node_or_way);
     }
 
     RestrictionType Type() const
@@ -249,24 +243,6 @@ struct TurnRestriction
         {
             return AsNodeRestriction() == other.AsNodeRestriction();
         }
-    }
-
-    std::string ToString() const
-    {
-        std::string representation;
-        if (node_or_way.which() == RestrictionType::WAY_RESTRICTION)
-        {
-            auto const &way = AsWayRestriction();
-            representation =
-                "In: " + way.in_restriction.ToString() + " Out: " + way.out_restriction.ToString();
-        }
-        else
-        {
-            auto const &node = AsNodeRestriction();
-            representation = node.ToString();
-        }
-        representation += " is_only: " + std::to_string(is_only);
-        return representation;
     }
 };
 

--- a/include/extractor/restriction_compressor.hpp
+++ b/include/extractor/restriction_compressor.hpp
@@ -1,0 +1,46 @@
+#ifndef OSRM_EXTRACTOR_RESTRICTION_COMPRESSOR_HPP_
+#define OSRM_EXTRACTOR_RESTRICTION_COMPRESSOR_HPP_
+
+#include "util/typedefs.hpp"
+
+#include <boost/unordered_map.hpp>
+#include <vector>
+
+namespace osrm
+{
+namespace extractor
+{
+
+struct NodeRestriction;
+struct TurnRestriction;
+
+// OSRM stores restrictions in the form node -> node -> node instead of way -> node -> way (or
+// way->way->way) as it is done in OSM. These restrictions need to match the state of graph
+// compression which we perform in the graph compressor that removes certain degree two nodes from
+// the graph (all but the ones with penalties/barriers, as of the state of writing).
+// Since this graph compression ins performed after creating the restrictions in the extraction
+// phase, we need to update the involved nodes whenever one of the nodes is compressed.
+//
+//
+// !!!! Will bind to the restrictions vector and modify it in-place !!!!
+class RestrictionCompressor
+{
+  public:
+    RestrictionCompressor(std::vector<TurnRestriction> &restrictions);
+
+    // account for the compression of `from-via-to` into `from-to`
+    void Compress(const NodeID from, const NodeID via, const NodeID to);
+
+  private:
+    // a turn restriction is given as `from head via node to tail`. Edges ending at `head` being
+    // contracted move the head pointer to their respective head. Edges starting at tail move the
+    // tail values to their respective tails. Way turn restrictions are represented by two
+    // node-restrictions, so we can focus on them alone
+    boost::unordered_multimap<NodeID, NodeRestriction *> heads;
+    boost::unordered_multimap<NodeID, NodeRestriction *> tails;
+};
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_RESTRICTION_COMPRESSOR_HPP_

--- a/include/extractor/restriction_compressor.hpp
+++ b/include/extractor/restriction_compressor.hpp
@@ -32,12 +32,12 @@ class RestrictionCompressor
     void Compress(const NodeID from, const NodeID via, const NodeID to);
 
   private:
-    // a turn restriction is given as `from head via node to tail`. Edges ending at `head` being
+    // a turn restriction is given as `from star via node to end`. Edges ending at `head` being
     // contracted move the head pointer to their respective head. Edges starting at tail move the
     // tail values to their respective tails. Way turn restrictions are represented by two
     // node-restrictions, so we can focus on them alone
-    boost::unordered_multimap<NodeID, NodeRestriction *> heads;
-    boost::unordered_multimap<NodeID, NodeRestriction *> tails;
+    boost::unordered_multimap<NodeID, NodeRestriction *> starts;
+    boost::unordered_multimap<NodeID, NodeRestriction *> ends;
 };
 
 } // namespace extractor

--- a/include/extractor/restriction_filter.hpp
+++ b/include/extractor/restriction_filter.hpp
@@ -1,0 +1,23 @@
+#ifndef OSRM_EXTRACTOR_RESTRICTION_FILTER_HPP_
+#define OSRM_EXTRACTOR_RESTRICTION_FILTER_HPP_
+
+#include "extractor/restriction.hpp"
+#include "util/node_based_graph.hpp"
+
+#include <vector>
+
+namespace osrm
+{
+namespace extractor
+{
+
+// To avoid handling invalid restrictions / creating unnecessary duplicate nodes for via-ways, we do
+// a pre-flight check for restrictions and remove all invalid restrictions from the data. Use as
+// `restrictions = removeInvalidRestrictions(std::move(restrictions))`
+std::vector<TurnRestriction> removeInvalidRestrictions(std::vector<TurnRestriction>,
+                                                       const util::NodeBasedDynamicGraph &);
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_RESTRICTION_FILTER_HPP_

--- a/include/extractor/restriction_map.hpp
+++ b/include/extractor/restriction_map.hpp
@@ -69,7 +69,6 @@ namespace osrm
 {
 namespace extractor
 {
-
 /**
     \brief Efficent look up if an edge is the start + via node of a TurnRestriction
     EdgeBasedEdgeFactory decides by it if edges are inserted or geometry is compressed
@@ -80,60 +79,7 @@ class RestrictionMap
     RestrictionMap() : m_count(0) {}
     RestrictionMap(const std::vector<TurnRestriction> &restriction_list);
 
-    // Replace end v with w in each turn restriction containing u as via node
-    template <class GraphT>
-    void FixupArrivingTurnRestriction(const NodeID node_u,
-                                      const NodeID node_v,
-                                      const NodeID node_w,
-                                      const GraphT &graph)
-    {
-        BOOST_ASSERT(node_u != SPECIAL_NODEID);
-        BOOST_ASSERT(node_v != SPECIAL_NODEID);
-        BOOST_ASSERT(node_w != SPECIAL_NODEID);
-
-        if (!IsViaNode(node_u))
-        {
-            return;
-        }
-
-        // find all potential start edges. It is more efficient to get a (small) list
-        // of potential start edges than iterating over all buckets
-        std::vector<NodeID> predecessors;
-        for (const EdgeID current_edge_id : graph.GetAdjacentEdgeRange(node_u))
-        {
-            const NodeID target = graph.GetTarget(current_edge_id);
-            if (node_v != target)
-            {
-                predecessors.push_back(target);
-            }
-        }
-
-        for (const NodeID node_x : predecessors)
-        {
-            const auto restriction_iterator = m_restriction_map.find({node_x, node_u});
-            if (restriction_iterator == m_restriction_map.end())
-            {
-                continue;
-            }
-
-            const unsigned index = restriction_iterator->second;
-            auto &bucket = m_restriction_bucket_list.at(index);
-
-            for (RestrictionTarget &restriction_target : bucket)
-            {
-                if (node_v == restriction_target.target_node)
-                {
-                    restriction_target.target_node = node_w;
-                }
-            }
-        }
-    }
-
     bool IsViaNode(const NodeID node) const;
-
-    // Replaces start edge (v, w) with (u, w). Only start node changes.
-    void
-    FixupStartingTurnRestriction(const NodeID node_u, const NodeID node_v, const NodeID node_w);
 
     // Check if edge (u, v) is the start of any turn restriction.
     // If so returns id of first target node.

--- a/include/extractor/restriction_map.hpp
+++ b/include/extractor/restriction_map.hpp
@@ -69,6 +69,7 @@ namespace osrm
 {
 namespace extractor
 {
+
 /**
     \brief Efficent look up if an edge is the start + via node of a TurnRestriction
     EdgeBasedEdgeFactory decides by it if edges are inserted or geometry is compressed

--- a/include/extractor/restriction_parser.hpp
+++ b/include/extractor/restriction_parser.hpp
@@ -3,8 +3,7 @@
 
 #include "extractor/restriction.hpp"
 
-#include <boost/optional/optional.hpp>
-
+#include <boost/optional.hpp>
 #include <string>
 #include <vector>
 
@@ -38,13 +37,15 @@ class ScriptingEnvironment;
  * ...----(a)-----(via)------(b)----...
  * So it can be represented by the tripe (a, via, b).
  */
+
 class RestrictionParser
 {
   public:
     RestrictionParser(bool use_turn_restrictions,
                       bool parse_conditionals,
                       std::vector<std::string> &restrictions);
-    std::vector<InputRestrictionContainer> TryParse(const osmium::Relation &relation) const;
+    boost::optional<InputConditionalTurnRestriction>
+    TryParse(const osmium::Relation &relation) const;
 
   private:
     bool ShouldIgnoreRestriction(const std::string &except_tag_string) const;

--- a/include/extractor/restriction_parser.hpp
+++ b/include/extractor/restriction_parser.hpp
@@ -3,7 +3,8 @@
 
 #include "extractor/restriction.hpp"
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional.hpp>
+
 #include <string>
 #include <vector>
 
@@ -37,7 +38,6 @@ class ScriptingEnvironment;
  * ...----(a)-----(via)------(b)----...
  * So it can be represented by the tripe (a, via, b).
  */
-
 class RestrictionParser
 {
   public:

--- a/include/extractor/scripting_environment.hpp
+++ b/include/extractor/scripting_environment.hpp
@@ -57,12 +57,12 @@ class ScriptingEnvironment
     virtual void ProcessTurn(ExtractionTurn &turn) = 0;
     virtual void ProcessSegment(ExtractionSegment &segment) = 0;
 
-    virtual void ProcessElements(
-        const osmium::memory::Buffer &buffer,
-        const RestrictionParser &restriction_parser,
-        std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
-        std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
-        std::vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions) = 0;
+    virtual void
+    ProcessElements(const osmium::memory::Buffer &buffer,
+                    const RestrictionParser &restriction_parser,
+                    std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
+                    std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
+                    std::vector<InputConditionalTurnRestriction> &resulting_restrictions) = 0;
 };
 }
 }

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -67,12 +67,12 @@ class Sol2ScriptingEnvironment final : public ScriptingEnvironment
     void ProcessTurn(ExtractionTurn &turn) override;
     void ProcessSegment(ExtractionSegment &segment) override;
 
-    void ProcessElements(
-        const osmium::memory::Buffer &buffer,
-        const RestrictionParser &restriction_parser,
-        std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
-        std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
-        std::vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions) override;
+    void
+    ProcessElements(const osmium::memory::Buffer &buffer,
+                    const RestrictionParser &restriction_parser,
+                    std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
+                    std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
+                    std::vector<InputConditionalTurnRestriction> &resulting_restrictions) override;
 
   private:
     void InitContext(LuaScriptingContext &context);

--- a/include/extractor/serialization.hpp
+++ b/include/extractor/serialization.hpp
@@ -186,18 +186,18 @@ inline void write(storage::io::FileWriter &writer, const TurnRestriction &restri
     writer.WriteOne(restriction.is_only);
     if (restriction.Type() == RestrictionType::WAY_RESTRICTION)
     {
-        write(writer, boost::get<WayRestriction>(restriction.node_or_way));
+        write(writer, mapbox::util::get<WayRestriction>(restriction.node_or_way));
     }
     else
     {
         BOOST_ASSERT(restriction.Type() == RestrictionType::NODE_RESTRICTION);
-        write(writer, boost::get<NodeRestriction>(restriction.node_or_way));
+        write(writer, mapbox::util::get<NodeRestriction>(restriction.node_or_way));
     }
 }
 
 inline void write(storage::io::FileWriter &writer, const ConditionalTurnRestriction &restriction)
 {
-    write(writer, static_cast<TurnRestriction>(restriction));
+    write(writer, static_cast<const TurnRestriction &>(restriction));
     writer.WriteElementCount64(restriction.condition.size());
     for (const auto &c : restriction.condition)
     {
@@ -210,9 +210,7 @@ inline void write(storage::io::FileWriter &writer, const ConditionalTurnRestrict
 
 inline void read(storage::io::FileReader &reader, ConditionalTurnRestriction &restriction)
 {
-    TurnRestriction base;
-    read(reader, base);
-    reinterpret_cast<TurnRestriction &>(restriction) = std::move(base);
+    read(reader, static_cast<TurnRestriction &>(restriction));
     const auto num_conditions = reader.ReadElementCount64();
     restriction.condition.resize(num_conditions);
     for (uint64_t i = 0; i < num_conditions; i++)

--- a/include/extractor/serialization.hpp
+++ b/include/extractor/serialization.hpp
@@ -165,7 +165,7 @@ inline void write(storage::io::FileWriter &writer, const WayRestriction &restric
 
 inline void read(storage::io::FileReader &reader, TurnRestriction &restriction)
 {
-    reader.ReadInto(restriction.flags);
+    reader.ReadInto(restriction.is_only);
     if (restriction.Type() == RestrictionType::WAY_RESTRICTION)
     {
         WayRestriction way_restriction;
@@ -183,7 +183,7 @@ inline void read(storage::io::FileReader &reader, TurnRestriction &restriction)
 
 inline void write(storage::io::FileWriter &writer, const TurnRestriction &restriction)
 {
-    writer.WriteOne(restriction.flags);
+    writer.WriteOne(restriction.is_only);
     if (restriction.Type() == RestrictionType::WAY_RESTRICTION)
     {
         write(writer, boost::get<WayRestriction>(restriction.node_or_way));
@@ -213,7 +213,7 @@ inline void read(storage::io::FileReader &reader, ConditionalTurnRestriction &re
     TurnRestriction base;
     read(reader, base);
     reinterpret_cast<TurnRestriction &>(restriction) = std::move(base);
-    auto num_conditions = reader.ReadElementCount64();
+    const auto num_conditions = reader.ReadElementCount64();
     restriction.condition.resize(num_conditions);
     for (uint64_t i = 0; i < num_conditions; i++)
     {
@@ -230,19 +230,18 @@ inline void read(storage::io::FileReader &reader, std::vector<TurnRestriction> &
     auto num_indices = reader.ReadElementCount64();
     restrictions.reserve(num_indices);
     TurnRestriction restriction;
-    while (num_indices > 0)
+    while (num_indices-- > 0)
     {
         read(reader, restriction);
         restrictions.push_back(std::move(restriction));
-        num_indices--;
     }
 }
 
 inline void write(storage::io::FileWriter &writer, const std::vector<TurnRestriction> &restrictions)
 {
-    std::uint64_t num_indices = restrictions.size();
+    const auto num_indices = restrictions.size();
     writer.WriteElementCount64(num_indices);
-    auto const write_restriction = [&writer](const auto &restriction) {
+    const auto write_restriction = [&writer](const auto &restriction) {
         write(writer, restriction);
     };
     std::for_each(restrictions.begin(), restrictions.end(), write_restriction);
@@ -255,20 +254,19 @@ inline void read(storage::io::FileReader &reader,
     auto num_indices = reader.ReadElementCount64();
     restrictions.reserve(num_indices);
     ConditionalTurnRestriction restriction;
-    while (num_indices > 0)
+    while (num_indices-- > 0)
     {
         read(reader, restriction);
         restrictions.push_back(std::move(restriction));
-        num_indices--;
     }
 }
 
 inline void write(storage::io::FileWriter &writer,
                   const std::vector<ConditionalTurnRestriction> &restrictions)
 {
-    std::uint64_t num_indices = restrictions.size();
+    const auto num_indices = restrictions.size();
     writer.WriteElementCount64(num_indices);
-    auto const write_restriction = [&writer](const auto &restriction) {
+    const auto write_restriction = [&writer](const auto &restriction) {
         write(writer, restriction);
     };
     std::for_each(restrictions.begin(), restrictions.end(), write_restriction);

--- a/include/extractor/way_restriction_map.hpp
+++ b/include/extractor/way_restriction_map.hpp
@@ -1,0 +1,89 @@
+#ifndef OSRM_EXTRACTOR_WAY_RESTRICTION_MAP_HPP_
+#define OSRM_EXTRACTOR_WAY_RESTRICTION_MAP_HPP_
+
+#include <utility>
+#include <vector>
+
+// to access the turn restrictions
+#include <boost/unordered_map.hpp>
+
+#include "extractor/restriction.hpp"
+#include "util/integer_range.hpp"
+#include "util/typedefs.hpp"
+
+// Given the compressed representation of via-way turn restrictions, we provide a fast access into
+// the restrictions to indicate which turns may be restricted due to a way in between
+namespace osrm
+{
+namespace extractor
+{
+
+class WayRestrictionMap
+{
+  public:
+    struct ViaWay
+    {
+        std::size_t id;
+        NodeID from;
+        NodeID to;
+    };
+    WayRestrictionMap(const std::vector<TurnRestriction> &turn_restrictions);
+
+    // check if an edge between two nodes is a restricted turn. The check needs to be performed
+    bool IsViaWay(const NodeID from, const NodeID to) const;
+
+    // number of duplicated nodes
+    std::size_t NumberOfDuplicatedNodes() const;
+
+    // returns a representative for the duplicated way, consisting of the representative ID (first
+    // ID of the nodes restrictions) and the from/to vertices of the via-way
+    // This is used to construct edge based nodes that act as intermediate nodes.
+    std::vector<ViaWay> DuplicatedNodeRepresentatives() const;
+
+    // Access all duplicated NodeIDs for a set of nodes indicating a via way
+    util::range<std::size_t> DuplicatedNodeIDs(const NodeID from, const NodeID to) const;
+
+    // check whether a turn onto a given node is restricted, when coming from a duplicated node
+    bool IsRestricted(std::size_t duplicated_node, const NodeID to) const;
+
+    TurnRestriction const &GetRestriction(std::size_t) const;
+
+    // changes edge_based_node to the correct duplicated_node_id in case node_based_from,
+    // node_based_via, node_based_to can be identified with a restriction group
+    NodeID RemapIfRestricted(const NodeID edge_based_node,
+                             const NodeID node_based_from,
+                             const NodeID node_based_via,
+                             const NodeID node_based_to,
+                             const NodeID number_of_edge_based_nodes) const;
+
+  private:
+    std::size_t AsDuplicatedNodeID(const std::size_t restriction_id) const;
+
+    // access all restrictions that have the same starting way and via way. Any duplicated node
+    // represents the same in-way + via-way combination. This vector contains data about all
+    // restrictions and their assigned duplicated nodes. It indicates the minimum restriciton ID
+    // that is represented by the next node. The ID of a node is defined as the position of the
+    // lower bound of the restrictions ID within this array
+    //
+    // a - b
+    //     |
+    // y - c - x
+    //
+    // restriction nodes | restriction id
+    // a - b - c - x : 5
+    // a - b - c - y : 6
+    //
+    //                    EBN: 0 . | 2 | 3 | 4 ...
+    // duplicated node groups: ... | 5 | 7 | ...
+    std::vector<std::size_t> duplicated_node_groups;
+
+    boost::unordered_multimap<std::pair<NodeID, NodeID>, std::size_t> restriction_starts;
+    boost::unordered_multimap<std::pair<NodeID, NodeID>, std::size_t> restriction_ends;
+
+    std::vector<TurnRestriction> restriction_data;
+};
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_WAY_RESTRICTION_MAP_HPP_

--- a/include/extractor/way_restriction_map.hpp
+++ b/include/extractor/way_restriction_map.hpp
@@ -23,30 +23,30 @@ class WayRestrictionMap
   public:
     struct ViaWay
     {
-        std::size_t id;
         NodeID from;
         NodeID to;
     };
     WayRestrictionMap(const std::vector<TurnRestriction> &turn_restrictions);
 
-    // check if an edge between two nodes is a restricted turn. The check needs to be performed
+    // Check if an edge between two nodes is a restricted turn. The check needs to be performed to
+    // find duplicated nodes during the creation of edge-based-edges
     bool IsViaWay(const NodeID from, const NodeID to) const;
 
-    // number of duplicated nodes
+    // Every via-way results in a duplicated node that is required in the edge-based-graph. This
+    // count is essentially the same as the number of valid via-way restrictions (except for
+    // non-only restrictions that share the same in/via combination)
     std::size_t NumberOfDuplicatedNodes() const;
 
-    // returns a representative for the duplicated way, consisting of the representative ID (first
+    // Returns a representative for each duplicated node, consisting of the representative ID (first
     // ID of the nodes restrictions) and the from/to vertices of the via-way
     // This is used to construct edge based nodes that act as intermediate nodes.
     std::vector<ViaWay> DuplicatedNodeRepresentatives() const;
 
     // Access all duplicated NodeIDs for a set of nodes indicating a via way
-    util::range<std::size_t> DuplicatedNodeIDs(const NodeID from, const NodeID to) const;
+    util::range<DuplicatedNodeID> DuplicatedNodeIDs(const NodeID from, const NodeID to) const;
 
     // check whether a turn onto a given node is restricted, when coming from a duplicated node
-    bool IsRestricted(std::size_t duplicated_node, const NodeID to) const;
-
-    TurnRestriction const &GetRestriction(std::size_t) const;
+    bool IsRestricted(DuplicatedNodeID duplicated_node, const NodeID to) const;
 
     // changes edge_based_node to the correct duplicated_node_id in case node_based_from,
     // node_based_via, node_based_to can be identified with a restriction group
@@ -57,7 +57,7 @@ class WayRestrictionMap
                              const NodeID number_of_edge_based_nodes) const;
 
   private:
-    std::size_t AsDuplicatedNodeID(const std::size_t restriction_id) const;
+    DuplicatedNodeID AsDuplicatedNodeID(const RestrictionID restriction_id) const;
 
     // access all restrictions that have the same starting way and via way. Any duplicated node
     // represents the same in-way + via-way combination. This vector contains data about all
@@ -75,10 +75,10 @@ class WayRestrictionMap
     //
     //                    EBN: 0 . | 2 | 3 | 4 ...
     // duplicated node groups: ... | 5 | 7 | ...
-    std::vector<std::size_t> duplicated_node_groups;
+    std::vector<DuplicatedNodeID> duplicated_node_groups;
 
-    boost::unordered_multimap<std::pair<NodeID, NodeID>, std::size_t> restriction_starts;
-    boost::unordered_multimap<std::pair<NodeID, NodeID>, std::size_t> restriction_ends;
+    boost::unordered_multimap<std::pair<NodeID, NodeID>, RestrictionID> restriction_starts;
+    boost::unordered_multimap<std::pair<NodeID, NodeID>, RestrictionID> restriction_ends;
 
     std::vector<TurnRestriction> restriction_data;
 };

--- a/include/util/serialization.hpp
+++ b/include/util/serialization.hpp
@@ -66,7 +66,7 @@ template <typename EdgeDataT>
 inline void read(storage::io::FileReader &reader, DynamicGraph<EdgeDataT> &graph)
 {
     storage::serialization::read(reader, graph.node_array);
-    auto num_edges = reader.ReadElementCount64();
+    const auto num_edges = reader.ReadElementCount64();
     graph.edge_list.resize(num_edges);
     for (auto index : irange<std::size_t>(0, num_edges))
     {

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -52,12 +52,12 @@ using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
 static_assert(std::is_pod<OSMWayID>(), "OSMWayID is not a valid alias");
 
 static const OSMNodeID SPECIAL_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
-static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::max()};
+static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint64_t>::max()};
 
 static const OSMNodeID MAX_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
 static const OSMNodeID MIN_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::min()};
-static const OSMWayID MAX_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::max()};
-static const OSMWayID MIN_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint32_t>::min()};
+static const OSMWayID MAX_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint64_t>::max()};
+static const OSMWayID MIN_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint64_t>::min()};
 
 using OSMNodeID_weak = std::uint64_t;
 using OSMEdgeID_weak = std::uint64_t;

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -51,16 +51,17 @@ static_assert(std::is_pod<OSMNodeID>(), "OSMNodeID is not a valid alias");
 using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
 static_assert(std::is_pod<OSMWayID>(), "OSMWayID is not a valid alias");
 
-static const OSMNodeID SPECIAL_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
-static const OSMWayID SPECIAL_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint64_t>::max()};
+static const OSMNodeID SPECIAL_OSM_NODEID =
+    OSMNodeID{std::numeric_limits<OSMNodeID::value_type>::max()};
+static const OSMWayID SPECIAL_OSM_WAYID =
+    OSMWayID{std::numeric_limits<OSMWayID::value_type>::max()};
 
-static const OSMNodeID MAX_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::max()};
-static const OSMNodeID MIN_OSM_NODEID = OSMNodeID{std::numeric_limits<std::uint64_t>::min()};
-static const OSMWayID MAX_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint64_t>::max()};
-static const OSMWayID MIN_OSM_WAYID = OSMWayID{std::numeric_limits<std::uint64_t>::min()};
-
-using OSMNodeID_weak = std::uint64_t;
-using OSMEdgeID_weak = std::uint64_t;
+static const OSMNodeID MAX_OSM_NODEID =
+    OSMNodeID{std::numeric_limits<OSMNodeID::value_type>::max()};
+static const OSMNodeID MIN_OSM_NODEID =
+    OSMNodeID{std::numeric_limits<OSMNodeID::value_type>::min()};
+static const OSMWayID MAX_OSM_WAYID = OSMWayID{std::numeric_limits<OSMWayID::value_type>::max()};
+static const OSMWayID MIN_OSM_WAYID = OSMWayID{std::numeric_limits<OSMWayID::value_type>::min()};
 
 using NodeID = std::uint32_t;
 using EdgeID = std::uint32_t;

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -45,11 +45,17 @@ struct osm_node_id
 struct osm_way_id
 {
 };
+struct duplicated_node
+{
+};
 }
 using OSMNodeID = osrm::Alias<std::uint64_t, tag::osm_node_id>;
 static_assert(std::is_pod<OSMNodeID>(), "OSMNodeID is not a valid alias");
 using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
 static_assert(std::is_pod<OSMWayID>(), "OSMWayID is not a valid alias");
+
+using DuplicatedNodeID = std::uint64_t;
+using RestrictionID = std::uint64_t;
 
 static const OSMNodeID SPECIAL_OSM_NODEID =
     OSMNodeID{std::numeric_limits<OSMNodeID::value_type>::max()};

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -7,6 +7,7 @@
 #include "extractor/extractor_callbacks.hpp"
 #include "extractor/files.hpp"
 #include "extractor/raster_source.hpp"
+#include "extractor/restriction_filter.hpp"
 #include "extractor/restriction_parser.hpp"
 #include "extractor/scripting_environment.hpp"
 
@@ -464,6 +465,8 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                               turn_restrictions,
                               *node_based_graph,
                               compressed_edge_container);
+
+    turn_restrictions = removeInvalidRestrictions(std::move(turn_restrictions), *node_based_graph);
 
     util::NameTable name_table(config.GetPath(".osrm.names").string());
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -24,6 +24,7 @@
 
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/restriction_map.hpp"
+#include "extractor/way_restriction_map.hpp"
 #include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
 
@@ -140,7 +141,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
                                              turn_lane_map);
 
     auto number_of_node_based_nodes = graph_size.first;
-    auto max_edge_id = graph_size.second;
+    auto max_edge_id = graph_size.second - 1;
 
     TIMER_STOP(expansion);
 
@@ -470,26 +471,36 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
 
     util::NameTable name_table(config.GetPath(".osrm.names").string());
 
-    auto restriction_map = std::make_shared<RestrictionMap>(turn_restrictions);
-    EdgeBasedGraphFactory edge_based_graph_factory(
-        node_based_graph,
-        compressed_edge_container,
-        barrier_nodes,
-        traffic_lights,
-        std::const_pointer_cast<RestrictionMap const>(restriction_map),
-        coordinates,
-        osm_node_ids,
-        scripting_environment.GetProfileProperties(),
-        name_table,
-        turn_lane_map);
+    EdgeBasedGraphFactory edge_based_graph_factory(node_based_graph,
+                                                   compressed_edge_container,
+                                                   barrier_nodes,
+                                                   traffic_lights,
+                                                   coordinates,
+                                                   osm_node_ids,
+                                                   scripting_environment.GetProfileProperties(),
+                                                   name_table,
+                                                   turn_lane_map);
 
-    edge_based_graph_factory.Run(scripting_environment,
-                                 config.GetPath(".osrm.edges").string(),
-                                 config.GetPath(".osrm.tld").string(),
-                                 config.GetPath(".osrm.turn_weight_penalties").string(),
-                                 config.GetPath(".osrm.turn_duration_penalties").string(),
-                                 config.GetPath(".osrm.turn_penalties_index").string(),
-                                 config.GetPath(".osrm.cnbg_to_ebg").string());
+    const auto create_edge_based_edges = [&]() {
+        // scoped to relase intermediate datastructures right after the call
+        RestrictionMap via_node_restriction_map(turn_restrictions);
+        WayRestrictionMap via_way_restriction_map(turn_restrictions);
+        turn_restrictions.clear();
+        turn_restrictions.shrink_to_fit();
+
+        edge_based_graph_factory.Run(scripting_environment,
+                                     config.GetPath(".osrm.edges").string(),
+                                     config.GetPath(".osrm.tld").string(),
+                                     config.GetPath(".osrm.turn_weight_penalties").string(),
+                                     config.GetPath(".osrm.turn_duration_penalties").string(),
+                                     config.GetPath(".osrm.turn_penalties_index").string(),
+                                     config.GetPath(".osrm.cnbg_to_ebg").string(),
+                                     via_node_restriction_map,
+                                     via_way_restriction_map);
+        return edge_based_graph_factory.GetNumberOfEdgeBasedNodes();
+    };
+
+    const auto number_of_edge_based_nodes = create_edge_based_edges();
 
     compressed_edge_container.PrintStatistics();
 
@@ -531,7 +542,6 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
     edge_based_graph_factory.GetEdgeBasedNodeSegments(edge_based_node_segments);
     edge_based_graph_factory.GetStartPointMarkers(node_is_startpoint);
     edge_based_graph_factory.GetEdgeBasedNodeWeights(edge_based_node_weights);
-    auto max_edge_id = edge_based_graph_factory.GetHighestEdgeID();
 
     const std::size_t number_of_node_based_nodes = node_based_graph->GetNumberOfNodes();
 
@@ -545,7 +555,7 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
     TIMER_STOP(write_intersections);
     util::Log() << "ok, after " << TIMER_SEC(write_intersections) << "s";
 
-    return std::make_pair(number_of_node_based_nodes, max_edge_id);
+    return std::make_pair(number_of_node_based_nodes, number_of_edge_based_nodes);
 }
 
 /**

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -259,7 +259,7 @@ Extractor::ParseOSMData(ScriptingEnvironment &scripting_environment,
         SharedBuffer buffer;
         std::vector<std::pair<const osmium::Node &, ExtractionNode>> resulting_nodes;
         std::vector<std::pair<const osmium::Way &, ExtractionWay>> resulting_ways;
-        std::vector<boost::optional<InputRestrictionContainer>> resulting_restrictions;
+        std::vector<InputConditionalTurnRestriction> resulting_restrictions;
     };
 
     tbb::filter_t<void, SharedBuffer> buffer_reader(
@@ -454,7 +454,6 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
 
-    auto restriction_map = std::make_shared<RestrictionMap>(turn_restrictions);
     auto node_based_graph =
         LoadNodeBasedGraph(barrier_nodes, traffic_lights, coordinates, osm_node_ids);
 
@@ -462,12 +461,13 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
     GraphCompressor graph_compressor;
     graph_compressor.Compress(barrier_nodes,
                               traffic_lights,
-                              *restriction_map,
+                              turn_restrictions,
                               *node_based_graph,
                               compressed_edge_container);
 
     util::NameTable name_table(config.GetPath(".osrm.names").string());
 
+    auto restriction_map = std::make_shared<RestrictionMap>(turn_restrictions);
     EdgeBasedGraphFactory edge_based_graph_factory(
         node_based_graph,
         compressed_edge_container,

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -73,19 +73,12 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
     }
 }
 
-void ExtractorCallbacks::ProcessRestriction(
-    const boost::optional<InputRestrictionContainer> &restriction)
+void ExtractorCallbacks::ProcessRestriction(const InputConditionalTurnRestriction &restriction)
 {
-    if (restriction)
-    {
-        external_memory.restrictions_list.push_back(restriction.get());
-        // util::Log() << "from: " << restriction.get().restriction.from.node <<
-        //                           ",via: " << restriction.get().restriction.via.node <<
-        //                           ", to: " << restriction.get().restriction.to.node <<
-        //                           ", only: " << (restriction.get().restriction.flags.is_only ?
-        //                           "y" : "n");
-    }
+    external_memory.restrictions_list.push_back(restriction);
+    // util::Log() << restriction.toString();
 }
+
 /**
  * Takes the geometry contained in the ```input_way``` and the tags computed
  * by the lua profile inside ```parsed_way``` and computes all edge segments.

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -405,13 +405,8 @@ IntersectionGenerator::GetOnlyAllowedTurnIfExistent(const NodeID coming_from_nod
     const auto only_restriction_to_node =
         restriction_map.CheckForEmanatingIsOnlyTurn(coming_from_node, node_at_intersection);
     if (only_restriction_to_node != SPECIAL_NODEID)
-    {
-        // if the mentioned node does not exist anymore, we don't return it. This checks for broken
-        // turn restrictions
-        for (const auto onto_edge : node_based_graph.GetAdjacentEdgeRange(node_at_intersection))
-            if (only_restriction_to_node == node_based_graph.GetTarget(onto_edge))
-                return only_restriction_to_node;
-    }
+        return only_restriction_to_node;
+
     // Ignore broken only restrictions.
     return boost::none;
 }

--- a/src/extractor/restriction_compressor.cpp
+++ b/src/extractor/restriction_compressor.cpp
@@ -1,0 +1,104 @@
+#include "extractor/restriction_compressor.hpp"
+#include "extractor/restriction.hpp"
+
+#include <algorithm>
+#include <boost/assert.hpp>
+#include <utility>
+
+namespace osrm
+{
+namespace extractor
+{
+
+RestrictionCompressor::RestrictionCompressor(std::vector<TurnRestriction> &restrictions)
+{
+    // add a node restriction ptr to the heads/tails maps, needs to be a reference!
+    auto index = [&](auto &element) {
+        heads.insert(std::make_pair(element.from, &element));
+        tails.insert(std::make_pair(element.to, &element));
+    };
+    // !needs to be reference, so we can get the correct address
+    const auto index_heads_and_tails = [&](auto &restriction) {
+        if (restriction.Type() == RestrictionType::WAY_RESTRICTION)
+        {
+            auto &way_restriction = restriction.AsWayRestriction();
+            index(way_restriction.in_restriction);
+            index(way_restriction.out_restriction);
+        }
+        else
+        {
+            BOOST_ASSERT(restriction.Type() == RestrictionType::NODE_RESTRICTION);
+            auto &node_restriction = restriction.AsNodeRestriction();
+            index(node_restriction);
+        }
+    };
+
+    // add all restrictions as their respective head-tail pointers
+    std::for_each(restrictions.begin(), restrictions.end(), index_heads_and_tails);
+}
+
+void RestrictionCompressor::Compress(const NodeID from, const NodeID via, const NodeID to)
+{
+    const auto get_value = [](const auto pair) { return pair.second; };
+
+    // extract all head ptrs and move them from via to from.
+    auto all_heads_range = heads.equal_range(via);
+    std::vector<NodeRestriction *> head_ptrs;
+    std::transform(
+        all_heads_range.first, all_heads_range.second, std::back_inserter(head_ptrs), get_value);
+
+    const auto update_head = [&](auto ptr) {
+        // ____ | from - p.from | via - p.via | to - p.to | ____
+        BOOST_ASSERT(ptr->from == via);
+        if (ptr->via == to)
+        {
+            ptr->from = from;
+        }
+        // ____ | to - p.from | via - p.via | from - p.to | ____
+        else
+        {
+            BOOST_ASSERT(ptr->via == from);
+            ptr->from = to;
+        }
+    };
+
+    std::for_each(head_ptrs.begin(), head_ptrs.end(), update_head);
+
+    const auto reinsert_head = [&](auto ptr) { heads.insert(std::make_pair(ptr->from, ptr)); };
+
+    // update the ptrs in our mapping
+    heads.erase(via);
+    std::for_each(head_ptrs.begin(), head_ptrs.end(), reinsert_head);
+
+    // extract all tail ptrs and move them from via to to
+    auto all_tails_range = tails.equal_range(via);
+    std::vector<NodeRestriction *> tail_ptrs;
+    std::transform(
+        all_tails_range.first, all_tails_range.second, std::back_inserter(tail_ptrs), get_value);
+
+    const auto update_tail = [&](auto ptr) {
+        BOOST_ASSERT(ptr->to == via);
+        // p.from | ____ - p.via | from - p.to | via - ____ | to
+        if (ptr->via == from)
+        {
+            ptr->to = to;
+        }
+        // p.from | ____ - p.via | to - p.to | via - ____ | from
+        else
+        {
+            BOOST_ASSERT(ptr->via == to);
+            ptr->to = from;
+        }
+    };
+
+    const auto reinsert_tail = [&](auto ptr) { tails.insert(std::make_pair(ptr->to, ptr)); };
+
+    std::for_each(tail_ptrs.begin(), tail_ptrs.end(), update_tail);
+
+    // update tail ptrs in mapping
+    tails.erase(via);
+    std::for_each(tail_ptrs.begin(), tail_ptrs.end(), reinsert_tail);
+}
+
+} // namespace extractor
+} // namespace osrm

--- a/src/extractor/restriction_filter.cpp
+++ b/src/extractor/restriction_filter.cpp
@@ -1,0 +1,88 @@
+#include "extractor/restriction_filter.hpp"
+#include "util/node_based_graph.hpp"
+#include "util/typedefs.hpp"
+
+#include <algorithm>
+#include <boost/assert.hpp>
+
+namespace osrm
+{
+namespace extractor
+{
+
+std::vector<TurnRestriction>
+removeInvalidRestrictions(std::vector<TurnRestriction> restrictions,
+                          const util::NodeBasedDynamicGraph &node_based_graph)
+{
+    // definition of what we presume to be a valid via-node restriction
+    const auto is_valid_node = [&node_based_graph](const auto &node_restriction) {
+        // a valid restriction needs to be connected to both its from and to locations
+        bool found_from = false, found_to = false;
+        for (auto eid : node_based_graph.GetAdjacentEdgeRange(node_restriction.via))
+        {
+            const auto target = node_based_graph.GetTarget(eid);
+            if (target == node_restriction.from)
+                found_from = true;
+            if (target == node_restriction.to)
+                found_to = true;
+        }
+
+        if (!found_from || !found_to)
+            return false;
+
+        return true;
+    };
+
+    // definition of what we presume to be a valid via-way restriction
+    const auto is_valid_way = [&node_based_graph, is_valid_node](const auto &way_restriction) {
+        const auto eid = node_based_graph.FindEdge(way_restriction.in_restriction.via,
+                                                   way_restriction.out_restriction.via);
+
+        // ability filter, we currently cannot handle restrictions that do not match up in geometry:
+        // restrictions cannot be interrupted by traffic signals or other similar entities that
+        // cause node penalties
+        if ((way_restriction.in_restriction.via != way_restriction.out_restriction.from) ||
+            (way_restriction.out_restriction.via != way_restriction.in_restriction.to))
+            return false;
+
+        // the edge needs to exit (we cannot handle intermediate stuff, so far)
+        if (eid == SPECIAL_EDGEID)
+            return false;
+
+        const auto &data = node_based_graph.GetEdgeData(eid);
+
+        // edge needs to be traversable for a valid restrction
+        if (data.reversed)
+            return false;
+
+        // is the in restriction referencing the correct nodes
+        if (!is_valid_node(way_restriction.in_restriction))
+            return false;
+
+        // is the out restriction referencing the correct nodes
+        if (!is_valid_node(way_restriction.out_restriction))
+            return false;
+
+        return true;
+    };
+
+    const auto is_invalid = [is_valid_way, is_valid_node](const auto &restriction) {
+        if (restriction.Type() == RestrictionType::NODE_RESTRICTION)
+        {
+            return !is_valid_node(restriction.AsNodeRestriction());
+        }
+        else
+        {
+            BOOST_ASSERT(restriction.Type() == RestrictionType::WAY_RESTRICTION);
+            return !is_valid_way(restriction.AsWayRestriction());
+        }
+    };
+
+    restrictions.erase(std::remove_if(restrictions.begin(), restrictions.end(), is_invalid),
+                       restrictions.end());
+
+    return restrictions;
+}
+
+} // namespace extractor
+} // namespace osrm

--- a/src/extractor/restriction_filter.cpp
+++ b/src/extractor/restriction_filter.cpp
@@ -78,8 +78,9 @@ removeInvalidRestrictions(std::vector<TurnRestriction> restrictions,
         }
     };
 
-    restrictions.erase(std::remove_if(restrictions.begin(), restrictions.end(), is_invalid),
-                       restrictions.end());
+    const auto end_valid_restrictions =
+        std::remove_if(restrictions.begin(), restrictions.end(), is_invalid);
+    restrictions.erase(end_valid_restrictions, restrictions.end());
 
     return restrictions;
 }

--- a/src/extractor/restriction_map.cpp
+++ b/src/extractor/restriction_map.cpp
@@ -1,5 +1,7 @@
 #include "extractor/restriction_map.hpp"
 
+#include <boost/assert.hpp>
+
 namespace osrm
 {
 namespace extractor
@@ -11,17 +13,23 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
     // a pair of starting edge and a list of all end nodes
     for (auto &restriction : restriction_list)
     {
+        // only handle node restrictions here
+        if (restriction.Type() == RestrictionType::WAY_RESTRICTION)
+            continue;
+
+        const auto &node_restriction = restriction.AsNodeRestriction();
+        BOOST_ASSERT(node_restriction.Valid());
         // This downcasting is OK because when this is called, the node IDs have been
         // renumbered into internal values, which should be well under 2^32
         // This will be a problem if we have more than 2^32 actual restrictions
-        BOOST_ASSERT(restriction.from.node < std::numeric_limits<NodeID>::max());
-        BOOST_ASSERT(restriction.via.node < std::numeric_limits<NodeID>::max());
-        m_restriction_start_nodes.insert(restriction.from.node);
-        m_no_turn_via_node_set.insert(restriction.via.node);
+        BOOST_ASSERT(node_restriction.from < std::numeric_limits<NodeID>::max());
+        BOOST_ASSERT(node_restriction.via < std::numeric_limits<NodeID>::max());
+        m_restriction_start_nodes.insert(node_restriction.from);
+        m_no_turn_via_node_set.insert(node_restriction.via);
 
         // This explicit downcasting is also OK for the same reason.
-        RestrictionSource restriction_source = {static_cast<NodeID>(restriction.from.node),
-                                                static_cast<NodeID>(restriction.via.node)};
+        RestrictionSource restriction_source = {static_cast<NodeID>(node_restriction.from),
+                                                static_cast<NodeID>(node_restriction.via)};
 
         std::size_t index;
         auto restriction_iter = m_restriction_map.find(restriction_source);
@@ -47,8 +55,7 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
             }
         }
         ++m_count;
-        BOOST_ASSERT(restriction.to.node < std::numeric_limits<NodeID>::max());
-        m_restriction_bucket_list.at(index).emplace_back(restriction.to.node,
+        m_restriction_bucket_list.at(index).emplace_back(node_restriction.to,
                                                          restriction.flags.is_only);
     }
 }

--- a/src/extractor/restriction_map.cpp
+++ b/src/extractor/restriction_map.cpp
@@ -47,7 +47,7 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
             {
                 continue;
             }
-            else if (restriction.flags.is_only)
+            else if (restriction.is_only)
             {
                 // We are going to insert an is_only_*-restriction. There can be only one.
                 m_count -= m_restriction_bucket_list.at(index).size();
@@ -55,41 +55,13 @@ RestrictionMap::RestrictionMap(const std::vector<TurnRestriction> &restriction_l
             }
         }
         ++m_count;
-        m_restriction_bucket_list.at(index).emplace_back(node_restriction.to,
-                                                         restriction.flags.is_only);
+        m_restriction_bucket_list.at(index).emplace_back(node_restriction.to, restriction.is_only);
     }
 }
 
 bool RestrictionMap::IsViaNode(const NodeID node) const
 {
     return m_no_turn_via_node_set.find(node) != m_no_turn_via_node_set.end();
-}
-
-// Replaces start edge (v, w) with (u, w). Only start node changes.
-void RestrictionMap::FixupStartingTurnRestriction(const NodeID node_u,
-                                                  const NodeID node_v,
-                                                  const NodeID node_w)
-{
-    BOOST_ASSERT(node_u != SPECIAL_NODEID);
-    BOOST_ASSERT(node_v != SPECIAL_NODEID);
-    BOOST_ASSERT(node_w != SPECIAL_NODEID);
-
-    if (!IsSourceNode(node_v))
-    {
-        return;
-    }
-
-    const auto restriction_iterator = m_restriction_map.find({node_v, node_w});
-    if (restriction_iterator != m_restriction_map.end())
-    {
-        const unsigned index = restriction_iterator->second;
-        // remove old restriction start (v,w)
-        m_restriction_map.erase(restriction_iterator);
-        m_restriction_start_nodes.emplace(node_u);
-        // insert new restriction start (u,w) (pointing to index)
-        RestrictionSource new_source = {node_u, node_w};
-        m_restriction_map.emplace(new_source, index);
-    }
 }
 
 // Check if edge (u, v) is the start of any turn restriction.

--- a/src/extractor/restriction_parser.cpp
+++ b/src/extractor/restriction_parser.cpp
@@ -125,7 +125,7 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
     // we pretend every restriction is a conditional restriction. If we do not find any restriction,
     // we can trim away the vector after parsing
     InputConditionalTurnRestriction restriction_container;
-    restriction_container.flags.is_only = is_only_restriction;
+    restriction_container.is_only = is_only_restriction;
 
     boost::optional<std::uint64_t> from = boost::none, via = boost::none, to = boost::none;
     bool is_node_restriction;
@@ -212,11 +212,13 @@ RestrictionParser::TryParse(const osmium::Relation &relation) const
     {
         if (is_node_restriction)
         {
-            restriction_container.node_or_way = InputNodeRestriction{*from, *via, *to};
+            // template struct requires bracket for ID initialisation :(
+            restriction_container.node_or_way = InputNodeRestriction{{*from}, {*via}, {*to}};
         }
         else
         {
-            restriction_container.node_or_way = InputWayRestriction{*from, *via, *to};
+            // template struct requires bracket for ID initialisation :(
+            restriction_container.node_or_way = InputWayRestriction{{*from}, {*via}, {*to}};
         }
         return restriction_container;
     }

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -613,11 +613,10 @@ void Sol2ScriptingEnvironment::ProcessElements(
     const RestrictionParser &restriction_parser,
     std::vector<std::pair<const osmium::Node &, ExtractionNode>> &resulting_nodes,
     std::vector<std::pair<const osmium::Way &, ExtractionWay>> &resulting_ways,
-    std::vector<boost::optional<InputRestrictionContainer>> &resulting_restrictions)
+    std::vector<InputConditionalTurnRestriction> &resulting_restrictions)
 {
     ExtractionNode result_node;
     ExtractionWay result_way;
-    std::vector<InputRestrictionContainer> result_res;
     auto &local_context = this->GetSol2Context();
 
     for (auto entity = buffer.cbegin(), end = buffer.cend(); entity != end; ++entity)
@@ -645,14 +644,15 @@ void Sol2ScriptingEnvironment::ProcessElements(
                 static_cast<const osmium::Way &>(*entity), std::move(result_way)));
             break;
         case osmium::item_type::relation:
-            result_res.clear();
-            result_res =
+        {
+            auto result_res =
                 restriction_parser.TryParse(static_cast<const osmium::Relation &>(*entity));
-            for (const InputRestrictionContainer &r : result_res)
+            if (result_res)
             {
-                resulting_restrictions.push_back(r);
+                resulting_restrictions.push_back(*result_res);
             }
-            break;
+        }
+        break;
         default:
             break;
         }

--- a/src/extractor/way_restriction_map.cpp
+++ b/src/extractor/way_restriction_map.cpp
@@ -1,0 +1,199 @@
+#include "extractor/way_restriction_map.hpp"
+
+#include <iterator>
+#include <tuple>
+#include <utility>
+
+namespace osrm
+{
+namespace extractor
+{
+
+namespace
+{
+struct FindViaWay
+{
+    bool operator()(const std::tuple<NodeID, NodeID> value,
+                    const TurnRestriction &restriction) const
+    {
+        const auto &way = restriction.AsWayRestriction();
+        return value < std::tie(way.in_restriction.via, way.out_restriction.via);
+    }
+    bool operator()(const TurnRestriction &restriction,
+                    const std::tuple<NodeID, NodeID> value) const
+    {
+        const auto &way = restriction.AsWayRestriction();
+        return std::tie(way.in_restriction.via, way.out_restriction.via) < value;
+    }
+};
+
+} // namespace
+
+WayRestrictionMap::WayRestrictionMap(const std::vector<TurnRestriction> &turn_restrictions)
+{
+    // get all way restrictions
+    const auto extract_restrictions = [this](const auto &turn_restriction) {
+        if (turn_restriction.Type() == RestrictionType::WAY_RESTRICTION)
+        {
+            const auto &way = turn_restriction.AsWayRestriction();
+
+            // so far we can only handle restrictions that are not interrupted
+            if (way.in_restriction.via == way.out_restriction.from &&
+                way.in_restriction.to == way.out_restriction.via)
+                restriction_data.push_back(turn_restriction);
+        }
+    };
+    std::for_each(turn_restrictions.begin(), turn_restrictions.end(), extract_restrictions);
+
+    const auto as_duplicated_node =
+        [](auto const &restriction) -> std::tuple<NodeID, NodeID, NodeID> {
+        auto &way = restriction.AsWayRestriction();
+        // group restrictions by the via-way. On same via-ways group by from
+        return std::make_tuple(
+            way.in_restriction.via, way.out_restriction.via, way.in_restriction.from);
+    };
+
+    const auto by_duplicated_node = [&](auto const &lhs, auto const &rhs) {
+        return as_duplicated_node(lhs) < as_duplicated_node(rhs);
+    };
+
+    std::sort(restriction_data.begin(), restriction_data.end(), by_duplicated_node);
+
+    std::size_t index = 0, duplication_id = 0;
+    // map all way restrictions into access containers
+    const auto prepare_way_restriction = [this, &index, &duplication_id, as_duplicated_node](
+        const auto &restriction) {
+        const auto &way = restriction.AsWayRestriction();
+        restriction_starts.insert(
+            std::make_pair(std::make_pair(way.in_restriction.from, way.in_restriction.via), index));
+        ++index;
+    };
+    std::for_each(restriction_data.begin(), restriction_data.end(), prepare_way_restriction);
+
+    std::size_t offset = 1;
+    // the first group starts at 0
+    if (!restriction_data.empty())
+        duplicated_node_groups.push_back(0);
+
+    auto const add_offset_on_new_groups = [&](auto const &lhs, auto const &rhs) {
+        BOOST_ASSERT(rhs == restriction_data[offset]);
+        // add a new lower bound for rhs
+        if (as_duplicated_node(lhs) != as_duplicated_node(rhs))
+            duplicated_node_groups.push_back(offset);
+        ++offset;
+        return false; // continue until the end
+    };
+    std::adjacent_find(restriction_data.begin(), restriction_data.end(), add_offset_on_new_groups);
+    duplicated_node_groups.push_back(restriction_data.size());
+}
+
+std::size_t WayRestrictionMap::NumberOfDuplicatedNodes() const
+{
+    return duplicated_node_groups.size() - 1;
+}
+
+bool WayRestrictionMap::IsViaWay(const NodeID from, const NodeID to) const
+{
+    // safe-guards
+    if (restriction_data.empty())
+        return false;
+
+    const auto itr = std::lower_bound(
+        restriction_data.begin(), restriction_data.end(), std::make_tuple(from, to), FindViaWay());
+
+    // no fitting restriction
+    if (itr == restriction_data.end())
+        return false;
+
+    const auto &way = itr->AsWayRestriction();
+
+    return way.out_restriction.from == from && way.out_restriction.via == to;
+}
+
+std::size_t WayRestrictionMap::AsDuplicatedNodeID(const std::size_t restriction_id) const
+{
+    return std::distance(duplicated_node_groups.begin(),
+                         std::upper_bound(duplicated_node_groups.begin(),
+                                          duplicated_node_groups.end(),
+                                          restriction_id)) -
+           1;
+}
+
+util::range<std::size_t> WayRestrictionMap::DuplicatedNodeIDs(const NodeID from,
+                                                              const NodeID to) const
+{
+    const auto duplicated_node_range_itr = std::equal_range(
+        restriction_data.begin(), restriction_data.end(), std::make_tuple(from, to), FindViaWay());
+
+    const auto as_restriction_id = [this](const auto itr) {
+        return std::distance(restriction_data.begin(), itr);
+    };
+
+    return util::irange<std::size_t>(
+        AsDuplicatedNodeID(as_restriction_id(duplicated_node_range_itr.first)),
+        AsDuplicatedNodeID(as_restriction_id(duplicated_node_range_itr.second)));
+}
+
+bool WayRestrictionMap::IsRestricted(std::size_t duplicated_node, const NodeID to) const
+{
+    // loop over all restrictions associated with the node. Mark as restricted based on
+    // is_only/restricted targets
+    for (std::size_t restriction_index = duplicated_node_groups[duplicated_node];
+         restriction_index != duplicated_node_groups[duplicated_node + 1];
+         ++restriction_index)
+    {
+        const auto &restriction = restriction_data[restriction_index];
+        const auto &way = restriction.AsWayRestriction();
+
+        if (restriction.is_only)
+            return way.out_restriction.to != to;
+        else if (to == way.out_restriction.to)
+            return true;
+    }
+    return false;
+}
+
+TurnRestriction const &WayRestrictionMap::GetRestriction(const std::size_t id) const
+{
+    return restriction_data[id];
+}
+
+std::vector<WayRestrictionMap::ViaWay> WayRestrictionMap::DuplicatedNodeRepresentatives() const
+{
+    std::vector<ViaWay> result;
+    result.reserve(NumberOfDuplicatedNodes());
+    std::transform(duplicated_node_groups.begin(),
+                   duplicated_node_groups.end() - 1,
+                   std::back_inserter(result),
+                   [&](auto const representative_id) -> ViaWay {
+                       auto &way = restriction_data[representative_id].AsWayRestriction();
+                       return {representative_id, way.in_restriction.via, way.out_restriction.via};
+                   });
+    return result;
+}
+
+NodeID WayRestrictionMap::RemapIfRestricted(const NodeID edge_based_node,
+                                            const NodeID node_based_from,
+                                            const NodeID node_based_via,
+                                            const NodeID node_based_to,
+                                            const NodeID number_of_edge_based_nodes) const
+{
+    auto range = restriction_starts.equal_range(std::make_pair(node_based_from, node_based_via));
+
+    // returns true if the ID saved in an iterator belongs to a turn restriction that references
+    // node_based_to as destination of the `in_restriction`
+    const auto restriction_targets_to = [node_based_to, this](const auto &pair) {
+        return restriction_data[pair.second].AsWayRestriction().in_restriction.to == node_based_to;
+    };
+    const auto itr = std::find_if(range.first, range.second, restriction_targets_to);
+
+    // in case we found a matching restriction, we can remap the edge_based_node
+    if (itr != range.second)
+        return number_of_edge_based_nodes - NumberOfDuplicatedNodes() +
+               AsDuplicatedNodeID(itr->second);
+    else
+        return edge_based_node;
+}
+
+} // namespace extractor
+} // namespace osrm

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -511,7 +511,7 @@ updateConditionalTurns(const UpdaterConfig &config,
 
         // only add restrictions to the lookups if the restriction is valid now
 
-        if (node_or_way.flags.is_only)
+        if (node_or_way.is_only)
         {
             is_only_lookup.lookup.push_back({std::make_tuple(c.from, c.via), c.to});
         }

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -1,6 +1,6 @@
 #include "extractor/graph_compressor.hpp"
 #include "extractor/compressed_edge_container.hpp"
-#include "extractor/restriction_map.hpp"
+#include "extractor/restriction.hpp"
 #include "util/node_based_graph.hpp"
 #include "util/typedefs.hpp"
 
@@ -8,6 +8,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <iostream>
+#include <unordered_set>
+#include <vector>
 
 BOOST_AUTO_TEST_SUITE(graph_compressor)
 
@@ -51,7 +53,7 @@ BOOST_AUTO_TEST_CASE(long_road_test)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
-    RestrictionMap map;
+    std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
@@ -68,7 +70,7 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[6].data));
 
     Graph graph(5, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, map, graph, container);
+    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
 
     BOOST_CHECK_EQUAL(graph.FindEdge(0, 1), SPECIAL_EDGEID);
     BOOST_CHECK_EQUAL(graph.FindEdge(1, 2), SPECIAL_EDGEID);
@@ -88,7 +90,7 @@ BOOST_AUTO_TEST_CASE(loop_test)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
-    RestrictionMap map;
+    std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
@@ -118,7 +120,7 @@ BOOST_AUTO_TEST_CASE(loop_test)
     BOOST_ASSERT(edges[10].data.IsCompatibleTo(edges[11].data));
 
     Graph graph(6, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, map, graph, container);
+    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
 
     BOOST_CHECK_EQUAL(graph.FindEdge(5, 0), SPECIAL_EDGEID);
     BOOST_CHECK_EQUAL(graph.FindEdge(0, 1), SPECIAL_EDGEID);
@@ -140,7 +142,7 @@ BOOST_AUTO_TEST_CASE(t_intersection)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
-    RestrictionMap map;
+    std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
@@ -157,7 +159,7 @@ BOOST_AUTO_TEST_CASE(t_intersection)
     BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[5].data));
 
     Graph graph(4, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, map, graph, container);
+    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);
@@ -173,7 +175,7 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
-    RestrictionMap map;
+    std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
 
     std::vector<InputEdge> edges = {
@@ -184,7 +186,7 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
     BOOST_ASSERT(edges[2].data.IsCompatibleTo(edges[3].data));
 
     Graph graph(5, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, map, graph, container);
+    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);
@@ -199,7 +201,7 @@ BOOST_AUTO_TEST_CASE(direction_changes)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
-    RestrictionMap map;
+    std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
 
     std::vector<InputEdge> edges = {
@@ -208,7 +210,7 @@ BOOST_AUTO_TEST_CASE(direction_changes)
     edges[1].data.reversed = true;
 
     Graph graph(5, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, map, graph, container);
+    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);


### PR DESCRIPTION
# Issue

 - refactors turn restrictions to follow strict types/structures.
 - adds support for via-way turn restrictions
 - first step towards #2681

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] add changelog entry indicating breaking changes to data-files
 - [x] review
 - [x] adjust for comments

## Performance:

Extraction of Germany:

```
	Command being timed: "./build/osrm-extract /data/europe/germany/germany-latest.osm.pbf"
	User time (seconds): 1820.21
	System time (seconds): 120.63
	Percent of CPU this job got: 289%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 11:09.29
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 29249273856
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 558
	Minor (reclaiming a frame) page faults: 7944112
	Voluntary context switches: 1733
	Involuntary context switches: 6452780
```

Contraction:
```
	Command being timed: "./build/osrm-contract /data/europe/germany/germany-latest.osrm"
	User time (seconds): 5743.62
	System time (seconds): 61.59
	Percent of CPU this job got: 350%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 27:37.11
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 12026462208
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 237
	Minor (reclaiming a frame) page faults: 2390626
	Voluntary context switches: 2106
	Involuntary context switches: 3609162
```

Partition
```
[info] RAM: peak bytes used: 2839437312
	Command being timed: "./build/osrm-partition /data/europe/germany/germany-latest.osrm"
	User time (seconds): 2416.88
	System time (seconds): 48.81
	Percent of CPU this job got: 312%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 13:09.87
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 11357749248
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 133
	Minor (reclaiming a frame) page faults: 3211197
	Voluntary context switches: 33
	Involuntary context switches: 2509986
```

Customize

```
	Command being timed: "./build/osrm-customize /data/europe/germany/germany-latest.osrm"
	User time (seconds): 92.72
	System time (seconds): 4.02
	Percent of CPU this job got: 267%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:36.15
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 11178278912
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 153
	Minor (reclaiming a frame) page faults: 1078677
	Voluntary context switches: 18
	Involuntary context switches: 68336
```

## Master

Extraction
```
	Command being timed: "./build/osrm-extract /data/europe/germany/germany-latest.osm.pbf"
	User time (seconds): 1803.88
	System time (seconds): 127.52
	Percent of CPU this job got: 285%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 11:16.82
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 29302489088
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 525
	Minor (reclaiming a frame) page faults: 9716627
	Voluntary context switches: 2248
	Involuntary context switches: 4430620
```

Contraction
```
	Command being timed: "./build/osrm-contract /data/europe/germany/germany-latest.osrm"
	User time (seconds): 5772.61
	System time (seconds): 68.48
	Percent of CPU this job got: 353%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 27:31.05
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 12026134528
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 232
	Minor (reclaiming a frame) page faults: 2396365
	Voluntary context switches: 3366
	Involuntary context switches: 4783880
```

Partition
```
	Command being timed: "./build/osrm-partition /data/europe/germany/germany-latest.osrm"
	User time (seconds): 2257.08
	System time (seconds): 46.40
	Percent of CPU this job got: 332%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 11:32.09
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 11366449152
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 133
	Minor (reclaiming a frame) page faults: 3355731
	Voluntary context switches: 33
	Involuntary context switches: 1645742
```

Customize

```
	Command being timed: "./build/osrm-customize /data/europe/germany/germany-latest.osrm"
	User time (seconds): 98.63
	System time (seconds): 5.48
	Percent of CPU this job got: 242%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:42.99
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 11177803776
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 155
	Minor (reclaiming a frame) page faults: 1078662
	Voluntary context switches: 15
	Involuntary context switches: 172589
```