### PR TITLE
Fixes Node.js bindings always enabling alternatives when using boolean overload

### DIFF
--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -721,7 +721,7 @@ argumentsToRouteParameter(const Nan::FunctionCallbackInfo<v8::Value> &args,
         if (value->IsBoolean())
         {
             params->alternatives = value->BooleanValue();
-            params->number_of_alternatives = 1u;
+            params->number_of_alternatives = value->BooleanValue() ? 1u : 0u;
         }
         else if (value->IsNumber())
         {


### PR DESCRIPTION
When using the Node.js bindings and using the boolean overload for requesting alternatives (`alternatives: true`) we set the boolean libosrm RouteParam parameter to the user specified value and fix the number parameter to one:

https://github.com/Project-OSRM/osrm-backend/blob/5ede5577d169efee0a6bc78fb15c2de406de74bf/include/nodejs/node_osrm_support.hpp#L723-L724

In https://github.com/Project-OSRM/osrm-backend/blob/master/src/engine/plugins/viaroute.cpp#L101-L106 we try to be smart in case the user gets the boolean and the number value out of sync.

Turns out the combination of both is a bad idea.