### PR TITLE
Discards construction and proposed ways, resolves #4230

### DIFF
--- a/features/car/construction.feature
+++ b/features/car/construction.feature
@@ -1,0 +1,16 @@
+@routing @car @construction
+Feature: Car - all construction tags the OpenStreetMap community could think of and then some
+
+    Background:
+        Given the profile "car"
+
+    Scenario: Various ways to tag construction and proposed roads
+        Then routability should be
+            | highway      | construction | proposed | bothw |
+            | primary      |              |          | x     |
+            | construction |              |          |       |
+            | proposed     |              |          |       |
+            | primary      |          yes |          |       |
+            | primary      |              |     yes  |       |
+            | primary      |           no |          | x     |
+            | primary      |     widening |          | x     |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -189,7 +189,8 @@ local profile = {
 
   avoid = Set {
     'impassable',
-    'construction'
+    'construction',
+    'proposed'
   }
 }
 

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -110,7 +110,9 @@ local profile = {
     'reversible',
     'impassable',
     'hov_lanes',
-    'steps'
+    'steps',
+    'construction',
+    'proposed'
   },
 
   speeds = Sequence {

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -76,7 +76,9 @@ local profile = {
   },
 
   avoid = Set {
-    'impassable'
+    'impassable',
+    'construction',
+    'proposed'
   },
 
   speeds = Sequence {

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -513,6 +513,25 @@ function Handlers.handle_blocked_ways(way,result,data,profile)
     return false
   end
 
+  -- In addition to the highway=construction tag above handle the construction=* tag
+  -- http://wiki.openstreetmap.org/wiki/Key:construction
+  -- https://taginfo.openstreetmap.org/keys/construction#values
+  if profile.avoid.construction then
+    local construction = way:get_value_by_key('construction')
+
+    -- Of course there are negative tags to handle, too
+    if construction and construction ~= 'no' and construction ~= 'widening' then
+      return false
+    end
+  end
+
+  -- Not only are there multiple construction tags there is also a proposed=* tag.
+  -- http://wiki.openstreetmap.org/wiki/Key:proposed
+  -- https://taginfo.openstreetmap.org/keys/proposed#values
+  if profile.avoid.proposed and way:get_value_by_key('proposed') then
+    return false
+  end
+
   -- Reversible oneways change direction with low frequency (think twice a day):
   -- do not route over these at all at the moment because of time dependence.
   -- Note: alternating (high frequency) oneways are handled below with penalty.

--- a/taginfo.json
+++ b/taginfo.json
@@ -367,6 +367,16 @@
             "description": "A Roundabout where the traffic on the roundabout not always has right of way."
         },
         {
+            "key": "proposed",
+            "object_types": [ "way" ],
+            "description": "Proposed ways. Discarded for routing"
+        },
+        {
+            "key": "construction",
+            "object_types": [ "way" ],
+            "description": "Ways under construction. Discarded for routing except construction=no, construction=widening"
+        },
+        {
             "key": "type",
             "value": "restriction",
             "object_types": [ "relation" ]


### PR DESCRIPTION
For #4230: discards `highway=construction`, `highway=proposed`, `construction=`, `proposed=`.

http://wiki.openstreetmap.org/wiki/Key:construction
http://wiki.openstreetmap.org/wiki/Key:proposed
http://wiki.openstreetmap.org/wiki/Key:highway

I see no reason we ever want to route over these tags. Please correct me if I'm wrong or if there are any edge cases I haven't thought of. Better to be safe than sorry here.

cc @emiltin @1ec5 