### PR TITLE
Some algorithm datafacade interface refactoring

### DIFF
--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -73,6 +73,7 @@ template <> class AlgorithmDataFacade<MLD>
 {
   public:
     using EdgeData = extractor::EdgeBasedEdge::EdgeData;
+    using NodeFnT = std::function<void(NodeID, EdgeWeight, EdgeDuration)>;
 
     // search graph access
     virtual unsigned GetNumberOfNodes() const = 0;
@@ -91,9 +92,14 @@ template <> class AlgorithmDataFacade<MLD>
 
     virtual EdgeRange GetAdjacentEdgeRange(const NodeID node) const = 0;
 
-    virtual const partition::MultiLevelPartitionView &GetMultiLevelPartition() const = 0;
+    virtual LevelID GetQueryLevel(NodeID source, NodeID target, NodeID node) const = 0;
+    virtual LevelID GetHighestDifferentLevel(NodeID first, NodeID second) const = 0;
 
-    virtual const partition::CellStorageView &GetCellStorage() const = 0;
+    virtual void ForEachSourceNodes(LevelID level, NodeID node, NodeFnT const &fn) const = 0;
+    virtual void ForEachDestinationNodes(LevelID level, NodeID node, NodeFnT const &fn) const = 0;
+
+    virtual CellID GetPartitionCell(LevelID level, NodeID node) const = 0;
+    virtual uint8_t GetNumberOfLevels() const = 0;
 
     virtual EdgeRange GetBorderEdgeRange(const LevelID level, const NodeID node) const = 0;
 


### PR DESCRIPTION
Now it doesn't depend on cell and partiition data storage implementation

# Issue

Currently interface of algorithm datafacade depends on implementation of CellStorage and PartitionView. It doesn't allow to implement another way to store this data for MLD. This pull requests implement data structure independent interface for MLD algorithm datafacade.

## Tasklist
 - [x] ADD OWN TASKS HERE
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
