### PR TITLE
Canonicalizes exits string list handling in the profiles

### DIFF
--- a/features/guidance/exit-numbers-names.feature
+++ b/features/guidance/exit-numbers-names.feature
@@ -41,8 +41,8 @@ Feature: Exit Numbers and Names
             | ef     | motorway_link | ExitRamp |              |
 
        When I route I should get
-            | waypoints | route                      | turns                               | exits   |
-            | a,f       | MainRoad,ExitRamp,ExitRamp | depart,off ramp slight right,arrive | ,10;12, |
+            | waypoints | route                      | turns                               | exits    |
+            | a,f       | MainRoad,ExitRamp,ExitRamp | depart,off ramp slight right,arrive | ,10; 12, |
 
 
     Scenario: Exit number on the ways after the motorway junction, multiple exits

--- a/profiles/lib/handlers.lua
+++ b/profiles/lib/handlers.lua
@@ -48,7 +48,7 @@ function Handlers.handle_names(way,result,data,profile)
   end
 
   if exits then
-    result.exits = exits
+    result.exits = canonicalizeStringList(exits, ";")
   end
 end
 


### PR DESCRIPTION
Looking over https://github.com/Project-OSRM/osrm-backend/issues/4270 I found some inconsistencies in canonicalizing our string lists. We do the same for ref and should be consistent here.

- [x] Review
- [x] Resolved feedback comments