### PR TITLE
Log warning for intersections with more then 32 streets

### DIFF
--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -85,12 +85,6 @@ class Extractor
                        std::vector<util::Coordinate> &coordinates,
                        extractor::PackedOSMIDs &osm_node_ids);
 
-    void WriteIntersectionClassificationData(
-        const std::string &output_file_name,
-        const std::vector<std::uint32_t> &node_based_intersection_classes,
-        const std::vector<util::guidance::BearingClass> &bearing_classes,
-        const std::vector<util::guidance::EntryClass> &entry_classes) const;
-
     // Writes compressed node based graph and its embedding into a file for osrm-partition to use.
     static void WriteCompressedNodeBasedGraph(const std::string &path,
                                               const util::NodeBasedDynamicGraph &graph,

--- a/include/extractor/guidance/turn_classification.hpp
+++ b/include/extractor/guidance/turn_classification.hpp
@@ -3,6 +3,7 @@
 
 #include "extractor/guidance/intersection.hpp"
 
+#include "util/coordinate.hpp"
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
 
@@ -16,7 +17,7 @@ namespace guidance
 {
 
 std::pair<util::guidance::EntryClass, util::guidance::BearingClass>
-classifyIntersection(Intersection intersection);
+classifyIntersection(Intersection intersection, const osrm::util::Coordinate &location);
 
 } // namespace guidance
 } // namespace extractor

--- a/include/util/guidance/entry_class.hpp
+++ b/include/util/guidance/entry_class.hpp
@@ -43,7 +43,8 @@ class EntryClass
 
     // we are hiding the access to the flags behind a protection wall, to make sure the bit logic
     // isn't tempered with. zero based indexing
-    void activate(std::uint32_t index);
+    // return true if was activated and false if activation failed
+    bool activate(std::uint32_t index);
 
     // check whether a certain turn allows entry
     bool allowsEntry(std::uint32_t index) const;

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -499,7 +499,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                         // the entry class depends on the turn, so we have to classify the
                         // interesction for
                         // every edge
-                        const auto turn_classification = classifyIntersection(intersection);
+                        const auto turn_classification = classifyIntersection(
+                            intersection, m_coordinates[node_at_center_of_intersection]);
 
                         const auto entry_class_id =
                             entry_class_hash.ConcurrentFindOrAdd(turn_classification.first);

--- a/src/extractor/guidance/turn_classification.cpp
+++ b/src/extractor/guidance/turn_classification.cpp
@@ -12,7 +12,7 @@ namespace guidance
 {
 
 std::pair<util::guidance::EntryClass, util::guidance::BearingClass>
-classifyIntersection(Intersection intersection)
+classifyIntersection(Intersection intersection, const osrm::util::Coordinate &location)
 {
     if (intersection.empty())
         return {};
@@ -56,7 +56,12 @@ classifyIntersection(Intersection intersection)
         for (const auto &road : intersection)
         {
             if (road.entry_allowed)
-                entry_class.activate(number);
+            {
+                if (!entry_class.activate(number))
+                    util::Log(logWARNING) << "Road " << number << " was not activated at "
+                                          << location;
+            }
+
             auto discrete_bearing_class =
                 util::guidance::BearingClass::getDiscreteBearing(std::round(road.bearing));
             bearing_class.add(std::round(discrete_bearing_class *
@@ -69,7 +74,11 @@ classifyIntersection(Intersection intersection)
         for (const auto &road : intersection)
         {
             if (road.entry_allowed)
-                entry_class.activate(number);
+            {
+                if (!entry_class.activate(number))
+                    util::Log(logWARNING) << "Road " << number << " was not activated at "
+                                          << location;
+            }
             bearing_class.add(std::round(road.bearing));
             ++number;
         }

--- a/src/util/guidance/entry_class.cpp
+++ b/src/util/guidance/entry_class.cpp
@@ -2,6 +2,8 @@
 
 #include <boost/assert.hpp>
 
+#include <climits>
+
 namespace osrm
 {
 namespace util
@@ -9,16 +11,19 @@ namespace util
 namespace guidance
 {
 
-void EntryClass::activate(std::uint32_t index)
+bool EntryClass::activate(std::uint32_t index)
 {
-    BOOST_ASSERT(index < 8 * sizeof(FlagBaseType));
-    enabled_entries_flags |= (1 << index);
+    if (index >= CHAR_BIT * sizeof(FlagBaseType))
+        return false;
+
+    enabled_entries_flags |= (FlagBaseType{1} << index);
+    return true;
 }
 
 bool EntryClass::allowsEntry(std::uint32_t index) const
 {
-    BOOST_ASSERT(index < 8 * sizeof(FlagBaseType));
-    return 0 != (enabled_entries_flags & (1 << index));
+    BOOST_ASSERT(index < CHAR_BIT * sizeof(FlagBaseType));
+    return 0 != (enabled_entries_flags & (FlagBaseType{1} << index));
 }
 
 bool EntryClass::operator==(const EntryClass &other) const


### PR DESCRIPTION
# Issue

The PR doubles size of `EntryClass` to prevent assertions 
```
[assert][140167020267392] /mnt/persist/api-osrm-routed-no-stxxl/2017-07-10-140458/osrm/src/util/guidance/entry_class.cpp:14
in: void osrm::util::guidance::EntryClass::activate(uint32_t): index < 8 * sizeof(FlagBaseType)
```
for nodes like http://www.openstreetmap.org/node/27547986#map=18/47.90601/106.92157

## Tasklist
 - [x] review
 - [x] adjust for comments

