### PR TITLE
Exposes EngineConfig system-wide limits in Node.js bindings, resolves #4226

### DIFF
--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -176,6 +176,64 @@ inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo
         return engine_config_ptr();
     }
 
+    // Set EngineConfig system-wide limits on construction, if requested
+
+    auto max_locations_trip = params->Get(Nan::New("max_locations_trip").ToLocalChecked());
+    auto max_locations_viaroute = params->Get(Nan::New("max_locations_viaroute").ToLocalChecked());
+    auto max_locations_distance_table =
+        params->Get(Nan::New("max_locations_distance_table").ToLocalChecked());
+    auto max_locations_map_matching =
+        params->Get(Nan::New("max_locations_map_matching").ToLocalChecked());
+    auto max_results_nearest = params->Get(Nan::New("max_results_nearest").ToLocalChecked());
+    auto max_alternatives = params->Get(Nan::New("max_alternatives").ToLocalChecked());
+
+    if (!max_locations_trip->IsUndefined() && !max_locations_trip->IsNumber())
+    {
+        Nan::ThrowError("max_locations_trip must be an integral number");
+        return engine_config_ptr();
+    }
+    if (!max_locations_viaroute->IsUndefined() && !max_locations_viaroute->IsNumber())
+    {
+        Nan::ThrowError("max_locations_viaroute must be an integral number");
+        return engine_config_ptr();
+    }
+    if (!max_locations_distance_table->IsUndefined() && !max_locations_distance_table->IsNumber())
+    {
+        Nan::ThrowError("max_locations_distance_table must be an integral number");
+        return engine_config_ptr();
+    }
+    if (!max_locations_map_matching->IsUndefined() && !max_locations_map_matching->IsNumber())
+    {
+        Nan::ThrowError("max_locations_map_matching must be an integral number");
+        return engine_config_ptr();
+    }
+    if (!max_results_nearest->IsUndefined() && !max_results_nearest->IsNumber())
+    {
+        Nan::ThrowError("max_results_nearest must be an integral number");
+        return engine_config_ptr();
+    }
+    if (!max_alternatives->IsUndefined() && !max_alternatives->IsNumber())
+    {
+        Nan::ThrowError("max_alternatives must be an integral number");
+        return engine_config_ptr();
+    }
+
+    if (max_locations_trip->IsNumber())
+        engine_config->max_locations_trip = static_cast<int>(max_locations_trip->NumberValue());
+    if (max_locations_viaroute->IsNumber())
+        engine_config->max_locations_viaroute =
+            static_cast<int>(max_locations_viaroute->NumberValue());
+    if (max_locations_distance_table->IsNumber())
+        engine_config->max_locations_distance_table =
+            static_cast<int>(max_locations_distance_table->NumberValue());
+    if (max_locations_map_matching->IsNumber())
+        engine_config->max_locations_map_matching =
+            static_cast<int>(max_locations_map_matching->NumberValue());
+    if (max_results_nearest->IsNumber())
+        engine_config->max_results_nearest = static_cast<int>(max_results_nearest->NumberValue());
+    if (max_alternatives->IsNumber())
+        engine_config->max_alternatives = static_cast<int>(max_alternatives->NumberValue());
+
     return engine_config;
 }
 

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -98,6 +98,37 @@ test('constructor: throws if data doesn\'t match algorithm', function(assert) {
     assert.throws(function() { new OSRM({algorithm: 'MLD', path: monaco_path}); });
 });
 
+test('constructor: parses custom limits', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({
+        path: monaco_mld_path,
+        algorithm: 'MLD',
+        max_locations_trip: 1,
+        max_locations_viaroute: 1,
+        max_locations_distance_table: 1,
+        max_locations_map_matching: 1,
+        max_results_nearest: 1,
+        max_alternatives: 1,
+    });
+    assert.ok(osrm);
+});
+
+test('constructor: throws on invalid custom limits', function(assert) {
+    assert.plan(1);
+    assert.throws(function() {
+        var osrm = new OSRM({
+            path: monaco_mld_path,
+            algorithm: 'MLD',
+            max_locations_trip: 'unlimited',
+            max_locations_viaroute: true,
+            max_locations_distance_table: false,
+            max_locations_map_matching: 'a lot',
+            max_results_nearest: null,
+            max_alternatives: '10'
+        })
+    });
+});
+
 require('./route.js');
 require('./trip.js');
 require('./match.js');

--- a/test/nodejs/route.js
+++ b/test/nodejs/route.js
@@ -549,3 +549,30 @@ test('route: throws on bad approaches', function(assert) {
     }, function(err, route) {}) },
         /Approach must be a string: \[curb, unrestricted\] or null/);
 });
+
+test('route: routes Monaco with custom limits on MLD', function(assert) {
+    assert.plan(2);
+    var osrm = new OSRM({
+        path: monaco_mld_path,
+        algorithm: 'MLD',
+        max_alternatives: 10,
+    });
+    osrm.route({coordinates: two_test_coordinates, alternatives: 10}, function(err, route) {
+        assert.ifError(err);
+        assert.ok(Array.isArray(route.routes));
+    });
+});
+
+test('route:  in Monaco with custom limits on MLD', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({
+        path: monaco_mld_path,
+        algorithm: 'MLD',
+        max_alternatives: 10,
+    });
+    osrm.route({coordinates: two_test_coordinates, alternatives: 11}, function(err, route) {
+        console.log(err)
+        assert.equal(err.message, 'TooBig');
+    });
+});
+


### PR DESCRIPTION
For #4226. Exposes `EngineConfig` limits.

Sidenote: at some point we should re-write our Node.js bindings and auto-generate the v8 parsing code ..
