### PR TITLE
Trigger lane anticipation based on distance, see discussion in #4260

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -3,7 +3,7 @@ Feature: Turn Lane Guidance
 
     Background:
         Given the profile "car"
-        Given a grid size of 20 meters
+        Given a grid size of 100 meters
 
     @anticipate
     Scenario: Anticipate Lane Change for subsequent multi-lane intersections
@@ -371,9 +371,9 @@ Feature: Turn Lane Guidance
        Scenario: Anticipate Lanes for through with turn before / after
            Given the node map
                """
-               c       g       l
-               b – d – e – h - i
-               a       f       j
+               c   g   l
+               b d e h i
+               a   f   j
                """
 
            And the ways
@@ -625,38 +625,9 @@ Feature: Turn Lane Guidance
             x – b   d – y
                 |   |
                 |   |
-                |   |
-                |   |
-                |   |
-                |   |
-                |   |
-                |   |
-                |   |
-                |   |
                  | |
                  | |
-                 | |
-                 | |
-                 | |
-                 | |
-                 | |
-                 | |
-                 | |
-                 | |
-                 | |
-                 | |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
-                  |
+                 \ /
                   c
             """
 
@@ -792,13 +763,6 @@ Feature: Turn Lane Guidance
                 |
                 |
                 |
-                |
-                |
-                |
-                |
-                |
-                |
-                |
                 c
                 |
             e – d – y
@@ -823,11 +787,9 @@ Feature: Turn Lane Guidance
     Scenario: Don't Overdo It
         Given the node map
             """
-                                  q                     r                     s                     t                     u                     v
-                                  |                     |                     |                     |                     |                     |
-            a - - - - - - - - - - b - - - - - - - - - - c - - - - - - - - - - d - - - - - - - - - - e - - - - - - - - - - f - - - - - - - - - - g - h - i
-                                  |                     |                     |                     |                     |                     |   |
-                                  p                     o                     n                     m                     l                     k   j
+                  q     r     s     t     u   v
+            a - - b - - c - - d - - e - - f - g - h - i
+                  p     o     n     m     l   k   j
             """
 
         And the ways

--- a/include/engine/guidance/lane_processing.hpp
+++ b/include/engine/guidance/lane_processing.hpp
@@ -20,7 +20,7 @@ namespace guidance
 // as separate maneuvers.
 OSRM_ATTR_WARN_UNUSED
 std::vector<RouteStep> anticipateLaneChange(std::vector<RouteStep> steps,
-                                            const double min_duration_needed_for_lane_change = 10);
+                                            const double min_distance_needed_for_lane_change = 200);
 
 } // namespace guidance
 } // namespace engine


### PR DESCRIPTION
See discussion in https://github.com/Project-OSRM/osrm-backend/pull/4268: the concern was raised that our traffic speeds change and we don't want to be speed-dependent here. Triggering lane anticipation based on distance is not perfect either, but there's not much we can do without congestion / flow along the route.

The changeset here assums the user needs 200 meters for a single lane change; in case there are more lanes to the left or to the right we scale up the threshold linearly (think: crossing two lanes: 400 m, three lanes 600 m and so on).

Note: tests adapted to distance and then shrinked some scenarios down in cell sizes to make them realistic again.

@MoKob this targets your `deprecate/use-lane` - please merge into it.

cc @willwhite 
