### PR TITLE
Enable turning off logging output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_CCACHE "Speed up incremental rebuilds via ccache" ON)
 option(BUILD_TOOLS "Build OSRM tools" OFF)
 option(BUILD_PACKAGE "Build OSRM package" OFF)
 option(ENABLE_ASSERTIONS "Use assertions in release mode" OFF)
+option(ENABLE_LOGGING "Output log messages" ON)
 option(ENABLE_COVERAGE "Build with coverage instrumentalisation" OFF)
 option(ENABLE_SANITIZER "Use memory sanitizer for Debug build" OFF)
 option(ENABLE_STXXL "Use STXXL library" ON)
@@ -716,6 +717,12 @@ if (ENABLE_ASSERTIONS)
   message(STATUS "Enabling assertions")
   add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
 endif()
+
+if (NOT ENABLE_LOGGING)
+  message(STATUS "Disabling logging")
+  add_definitions(-DOSRM_LOGGING_DISABLED)
+endif()
+
 
 # Add RPATH info to executables so that when they are run after being installed
 # (i.e., from /usr/local/bin/) the linker can find library dependencies. For

--- a/include/util/log.hpp
+++ b/include/util/log.hpp
@@ -52,6 +52,13 @@ class Log
     LogLevel level;
     std::ostringstream buffer;
     std::ostream &stream;
+
+    struct null_streambuf : public std::streambuf
+    {
+        virtual std::streamsize xsputn (const char*, std::streamsize n) { return n; }
+        virtual int overflow (int) { return 1; }
+    } null_buffer;
+    std::streambuf* saved_buffer;
 };
 
 /**


### PR DESCRIPTION
# Issue

#4298

This PR addresses the issue allowing to control logging output:

* Adds CMake option: `ENABLE_LOGGING` (default ON; if OFF, then `osrm::util::LogPolicy` forces to mute logs).
* Adds null/no-op stream buffer pluggable into output stream used with/passed to instance of `osrm::util::Log`.

at runtime (limited, eg.  `Extractor::run` unmutes logger) or compile time (overcomes the previous limitation mentioned, forces muted logger).


## Tasklist
 - [ ] review
