### PR TITLE
Set OSRM_BUILD_DIR based on CMake build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if(BUILD_AS_SUBPROJECT)
   message(STATUS "Building libosrm as subproject.")
 endif()
 
+# set OSRM_BUILD_DIR location (might be used in various scripts)
+if (NOT WIN32 AND NOT DEFINED ENV{OSRM_BUILD_DIR})
+  set(ENV{OSRM_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 option(ENABLE_MASON "Use mason for dependencies" OFF)
 option(ENABLE_CCACHE "Speed up incremental rebuilds via ccache" ON)
 option(BUILD_TOOLS "Build OSRM tools" OFF)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -96,7 +96,7 @@ set(TEST_DATA_DIR "${CMAKE_SOURCE_DIR}/test/data")
 add_dependencies(library-tests osrm-extract osrm-contract osrm-partition)
 # We can't run this Makefile on windows
 if (NOT WIN32)
-  add_custom_command(TARGET library-tests POST_BUILD COMMAND make -C ${TEST_DATA_DIR})
+  add_custom_command(TARGET library-tests POST_BUILD COMMAND make -C ${TEST_DATA_DIR} OSRM_BUILD_DIR=$ENV{OSRM_BUILD_DIR})
 endif()
 
 target_compile_definitions(extractor-tests PRIVATE COMPILE_DEFINITIONS OSRM_FIXTURES_DIR="${CMAKE_SOURCE_DIR}/unit_tests/fixtures")


### PR DESCRIPTION
For typical local workflow, CMake can auto-configure most of the environment, for _convenience_.

Helps to avoid
```
make[4]: *** No rule to make target `../../build/osrm-extract', needed by `monaco.osrm'. Stop.
```

## Tasklist
 - [x] review
