### PR TITLE
Makes construction=minor ways routable again, see #4258

### DIFF
--- a/features/car/construction.feature
+++ b/features/car/construction.feature
@@ -14,3 +14,4 @@ Feature: Car - all construction tags the OpenStreetMap community could think of 
             | primary      |              |     yes  |       |
             | primary      |           no |          | x     |
             | primary      |     widening |          | x     |
+            | primary      |        minor |          | x     |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -70,6 +70,12 @@ function setup()
 
     restricted_highway_whitelist = Set { },
 
+    construction_whitelist = Set {
+      'no',
+      'widening',
+      'minor',
+    },
+
     access_tags_hierarchy = Sequence {
       'bicycle',
       'vehicle',

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -53,17 +53,17 @@ function setup()
     },
 
     access_tag_whitelist = Set {
-    	'yes',
-    	'permissive',
-     	'designated'
+      'yes',
+      'permissive',
+      'designated'
     },
 
     access_tag_blacklist = Set {
-    	'no',
-     	'private',
-     	'agricultural',
-     	'forestry',
-     	'delivery'
+      'no',
+      'private',
+      'agricultural',
+      'forestry',
+      'delivery'
     },
 
     restricted_access_tag_list = Set { },
@@ -71,24 +71,24 @@ function setup()
     restricted_highway_whitelist = Set { },
 
     access_tags_hierarchy = Sequence {
-    	'bicycle',
-    	'vehicle',
-    	'access'
+      'bicycle',
+      'vehicle',
+      'access'
     },
 
     restrictions = Set {
-    	'bicycle'
+      'bicycle'
     },
 
     cycleway_tags = Set {
-    	'track',
-    	'lane',
-    	'opposite',
-    	'opposite_lane',
-    	'opposite_track',
-    	'share_busway',
-    	'sharrow',
-    	'shared',
+      'track',
+      'lane',
+      'opposite',
+      'opposite_lane',
+      'opposite_track',
+      'share_busway',
+      'sharrow',
+      'shared',
       'shared_lane'
     },
 
@@ -206,7 +206,7 @@ local function parse_maxspeed(source)
     return n
 end
 
-function process_node (profile, node, result)
+function process_node(profile, node, result)
   -- parse access and barrier tags
   local highway = node:get_value_by_key("highway")
   local is_crossing = highway and highway == "crossing"
@@ -493,7 +493,7 @@ function handle_bicycle_tags(profile,way,result,data)
       end
   end
 end
-function process_way (profile, way, result)
+function process_way(profile, way, result)
   -- the initial filtering of ways based on presence of tags
   -- affects processing times significantly, because all ways
   -- have to be checked.

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -155,6 +155,12 @@ function setup()
       'living_street',
     },
 
+    construction_whitelist = Set {
+      'no',
+      'widening',
+      'minor',
+    },
+
     route_speeds = {
       ferry = 5,
       shuttle_train = 10

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -26,7 +26,7 @@ function setup()
       use_turn_restrictions          = true,
       traffic_light_penalty          = 2,
     },
-    
+
     default_mode              = mode.driving,
     default_speed             = 10,
     oneway_handling           = true,
@@ -140,19 +140,19 @@ function setup()
       ["drive-thru"] = 0.5
     },
 
-   restricted_highway_whitelist = Set {
-        'motorway',
-        'motorway_link',
-        'trunk',
-        'trunk_link',
-        'primary',
-        'primary_link',
-        'secondary',
-        'secondary_link',
-        'tertiary',
-        'tertiary_link',
-        'residential',
-        'living_street',
+    restricted_highway_whitelist = Set {
+      'motorway',
+      'motorway_link',
+      'trunk',
+      'trunk_link',
+      'primary',
+      'primary_link',
+      'secondary',
+      'secondary_link',
+      'tertiary',
+      'tertiary_link',
+      'residential',
+      'living_street',
     },
 
     route_speeds = {
@@ -262,7 +262,7 @@ function setup()
   }
 end
 
-function process_node (profile, node, result)
+function process_node(profile, node, result)
   -- parse access and barrier tags
   local access = find_access_tag(node, profile.access_tags_hierarchy)
   if access then
@@ -375,7 +375,7 @@ function process_way(profile, way, result)
   WayHandlers.run(profile,way,result,data,handlers)
 end
 
-function process_turn (profile, turn)
+function process_turn(profile, turn)
   -- Use a sigmoid function to return a penalty that maxes out at turn_penalty
   -- over the space of 0-180 degrees.  Values here were chosen by fitting
   -- the function to some turn penalty samples from real driving.
@@ -404,7 +404,7 @@ function process_turn (profile, turn)
   else
      turn.weight = turn.duration
   end
-  
+
   if profile.properties.weight_name == 'routability' then
       -- penalize turns from non-local access only segments onto local access only tags
       if not turn.source_restricted and turn.target_restricted then

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -57,6 +57,8 @@ function setup()
 
     restricted_highway_whitelist = Set { },
 
+    construction_whitelist = Set {},
+
     access_tags_hierarchy = Sequence {
       'foot',
       'access'

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -137,7 +137,7 @@ function setup()
   }
 end
 
-function process_node (profile, node, result)
+function process_node(profile, node, result)
   -- parse access and barrier tags
   local access = find_access_tag(node, profile.access_tags_hierarchy)
   if access then

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -521,7 +521,7 @@ function WayHandlers.blocked_ways(profile,way,result,data)
     local construction = way:get_value_by_key('construction')
 
     -- Of course there are negative tags to handle, too
-    if construction and construction ~= 'no' and construction ~= 'widening' and construction ~= 'minor' then
+    if construction and not profile.construction_whitelist[construction] then
       return false
     end
   end

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -521,7 +521,7 @@ function WayHandlers.blocked_ways(profile,way,result,data)
     local construction = way:get_value_by_key('construction')
 
     -- Of course there are negative tags to handle, too
-    if construction and construction ~= 'no' and construction ~= 'widening' then
+    if construction and construction ~= 'no' and construction ~= 'widening' and construction ~= 'minor' then
       return false
     end
   end


### PR DESCRIPTION
In #4258 we removed construction tags except for `construction=widening` and `construction=no`.

Turns out we missed `construction=minor` in the list of 3804 unique construction values.

This affects 1194 ways on the planet.