### PR TITLE
refactor the bike profile, other fixes

### DIFF
--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -170,12 +170,6 @@ Feature: Bike - Access tags on ways
             | bridleway | designated |      |         |              |
             | bridleway |            |      |         |              |
 
-    Scenario: Bike - Tram with oneway when access is implicit
-        Then routability should be
-            | highway | railway | access | oneway | forw    | backw        |
-            | (nil)   | tram    |        | yes    | cycling | pushing bike |
-            | (nil)   | tram    | psv    | yes    | cycling | pushing bike |
-
     Scenario: Bike - Access combinations
         Then routability should be
             | highway    | access     | bothw   |

--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -172,9 +172,9 @@ Feature: Bike - Access tags on ways
 
     Scenario: Bike - Tram with oneway when access is implicit
         Then routability should be
-            | highway     | railway | access | oneway | forw    | backw        |
-            | residential | tram    |        | yes    | cycling | pushing bike |
-            | service     | tram    | psv    | yes    | cycling | pushing bike |
+            | highway | railway | access | oneway | forw    | backw        |
+            | (nil)   | tram    |        | yes    | cycling | pushing bike |
+            | (nil)   | tram    | psv    | yes    | cycling | pushing bike |
 
     Scenario: Bike - Access combinations
         Then routability should be
@@ -183,3 +183,21 @@ Feature: Bike - Access tags on ways
             | steps      | permissive | cycling |
             | footway    | permissive | cycling |
             | garbagetag | permissive | cycling |
+
+    Scenario: Bike - Access and pushing bikes
+        Then routability should be
+            | highway | bicycle | foot | bothw        |
+            | primary |         |      | cycling      |
+            | primary | yes     |      | cycling      |
+            | primary | no      |      |              |
+            | primary |         | yes  | cycling      |
+            | primary |         | no   | cycling      |
+            | primary | no      | yes  |              |
+            | primary | yes     | no   | cycling      |
+            | footway |         |      | pushing bike |
+            | footway | yes     |      | cycling      |
+            | footway | no      |      |              |
+            | footway |         | yes  | pushing bike |
+            | footway |         | no   |              |
+            | footway | no      | yes  |              |
+            | footway | yes     | no   | cycling      |

--- a/features/bicycle/alley.feature
+++ b/features/bicycle/alley.feature
@@ -6,11 +6,33 @@ Feature: Bicycle - Route around alleys
         """
         profile.properties.weight_name = 'cyclability'
         """
+        
+        Given the query options
+            | annotations | weight,nodes |
+
+    Scenario: Bicycle - Rate on alleys
+
+        Given the node map
+            """
+            a---b
+            c---d
+            e---f
+            """
+
+        And the ways
+            | nodes | highway     | service  |
+            | ab    | residential |          |
+            | cd    | service     | invalid  |
+            | ef    | service     | alley    |
+
+        When I route I should get
+            | from | to | weight |
+            | a    | b  | 48     |
+            | c    | d  | 48     |
+            | e    | f  | 96     |
+
 
     Scenario: Bicycle - Avoid taking alleys
-        Given the query options
-            | annotations | nodes |
-
         Given the node map
             """
             a-----b-----c
@@ -28,6 +50,8 @@ Feature: Bicycle - Route around alleys
 
         When I route I should get
             | from | to | a:nodes    | weight | #                                |
+            | a    | d  | 1:4        | 56.3   |                                  |
+            | b    | e  | 2:5        | 104.4  |                                  |
             | a    | f  | 1:2:3:6    | 200.4  | Avoids d,e,f                     |
             | a    | e  | 1:2:5      | 176.4  | Take the alley b,e if neccessary |
             | d    | f  | 4:1:2:3:6  | 252.6  | Avoids the alley d,e,f           |

--- a/features/bicycle/area.feature
+++ b/features/bicycle/area.feature
@@ -99,14 +99,41 @@ Feature: Bike - Squares and other areas
             | abcda | (nil)   | platform |
 
         When I route I should get
-            | from | to | route       |
-            | x    | y  | xa,abcda,by |
-            | y    | x  | by,abcda,xa |
-            | a    | b  | abcda,abcda |
-            | a    | d  | abcda,abcda |
-            | b    | c  | abcda,abcda |
-            | c    | b  | abcda,abcda |
-            | c    | d  | abcda,abcda |
-            | d    | c  | abcda,abcda |
-            | d    | a  | abcda,abcda |
-            | a    | d  | abcda,abcda |
+            | from | to | route          |
+            | x    | y  | xa,abcda,by,by |
+            | y    | x  | by,abcda,xa,xa |
+            | a    | b  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |
+            | b    | c  | abcda,abcda    |
+            | c    | b  | abcda,abcda    |
+            | c    | d  | abcda,abcda    |
+            | d    | c  | abcda,abcda    |
+            | d    | a  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |
+
+    @train @platform
+    Scenario: Bike - public transport platforms
+        Given the node map
+            """
+            x a b y
+              d c
+            """
+
+        And the ways
+            | nodes | highway | public_transport |
+            | xa    | primary |                  |
+            | by    | primary |                  |
+            | abcda | (nil)   | platform         |
+
+        When I route I should get
+            | from | to | route          |
+            | x    | y  | xa,abcda,by,by |
+            | y    | x  | by,abcda,xa,xa |
+            | a    | b  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |
+            | b    | c  | abcda,abcda    |
+            | c    | b  | abcda,abcda    |
+            | c    | d  | abcda,abcda    |
+            | d    | c  | abcda,abcda    |
+            | d    | a  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |

--- a/features/bicycle/cycleway.feature
+++ b/features/bicycle/cycleway.feature
@@ -85,13 +85,21 @@ Feature: Bike - Cycle tracks/lanes
             | highway     | cycleway | oneway | forw    | backw        |
             | motorway    | track    | yes    | cycling |              |
             | residential | track    | yes    | cycling | pushing bike |
-            | cycleway    | track    | yes    | cycling | pushing bike |
+            | cycleway    | track    | yes    | cycling |              |
             | footway     | track    | yes    | cycling | pushing bike |
 
     Scenario: Bike - Cycleway on oneways, speeds
         Then routability should be
             | highway     | cycleway | oneway | forw    | backw      |
             | motorway    | track    | yes    | 15 km/h |            |
-            | residential | track    | yes    | 15 km/h | 6 km/h +-1 |
-            | cycleway    | track    | yes    | 15 km/h | 6 km/h +-1 |
-            | footway     | track    | yes    | 15 km/h | 6 km/h +-1 |
+            | residential | track    | yes    | 15 km/h | 5 km/h +-1 |
+            | cycleway    | track    | yes    | 15 km/h |            |
+            | footway     | track    | yes    | 15 km/h | 5 km/h +-1 |
+
+    Scenario: Bike - Directional sideways and oneway
+        Then routability should be
+            | highway     | oneway | cycleway:right | cycleway:left | forw         | backw        |
+            | primary     | yes    | track          |               | cycling      | pushing bike |
+            | primary     | yes    |                | track         | cycling      | cycling      |
+            | primary     | -1     | track          |               | cycling      | cycling      |
+            | primary     | -1     |                | track         | pushing bike | cycling      |

--- a/features/bicycle/cycleway.feature
+++ b/features/bicycle/cycleway.feature
@@ -7,78 +7,77 @@ Feature: Bike - Cycle tracks/lanes
 
     Scenario: Bike - Cycle tracks/lanes should enable biking
         Then routability should be
-            | highway     | cycleway     | forw | backw |
-            | motorway    |              |      |       |
-            | motorway    | track        | x    |       |
-            | motorway    | lane         | x    |       |
-            | motorway    | shared       | x    |       |
-            | motorway    | share_busway | x    |       |
-            | motorway    | sharrow      | x    |       |
-            | some_tag    | track        | x    | x     |
-            | some_tag    | lane         | x    | x     |
-            | some_tag    | shared       | x    | x     |
-            | some_tag    | share_busway | x    | x     |
-            | some_tag    | sharrow      | x    | x     |
-            | residential | track        | x    | x     |
-            | residential | lane         | x    | x     |
-            | residential | shared       | x    | x     |
-            | residential | share_busway | x    | x     |
-            | residential | sharrow      | x    | x     |
+            | highway     | cycleway     | forw       | backw       |
+            | motorway    | track        | cycling    |             |
+            | motorway    | lane         | cycling    |             |
+            | motorway    | shared       | cycling    |             |
+            | motorway    | share_busway | cycling    |             |
+            | motorway    | sharrow      | cycling    |             |
+            | some_tag    | track        | cycling    | cycling     |
+            | some_tag    | lane         | cycling    | cycling     |
+            | some_tag    | shared       | cycling    | cycling     |
+            | some_tag    | share_busway | cycling    | cycling     |
+            | some_tag    | sharrow      | cycling    | cycling     |
+            | residential | track        | cycling    | cycling     |
+            | residential | lane         | cycling    | cycling     |
+            | residential | shared       | cycling    | cycling     |
+            | residential | share_busway | cycling    | cycling     |
+            | residential | sharrow      | cycling    | cycling     |
 
     Scenario: Bike - Left/right side cycleways on implied bidirectionals
         Then routability should be
-            | highway | cycleway | cycleway:left | cycleway:right | forw | backw |
-            | primary |          |               |                | x    | x     |
-            | primary | track    |               |                | x    | x     |
-            | primary | opposite |               |                | x    | x     |
-            | primary |          | track         |                | x    | x     |
-            | primary |          | opposite      |                | x    | x     |
-            | primary |          |               | track          | x    | x     |
-            | primary |          |               | opposite       | x    | x     |
-            | primary |          | track         | track          | x    | x     |
-            | primary |          | opposite      | opposite       | x    | x     |
-            | primary |          | track         | opposite       | x    | x     |
-            | primary |          | opposite      | track          | x    | x     |
+            | highway | cycleway | cycleway:left | cycleway:right | forw       | backw       |
+            | primary |          |               |                | cycling    | cycling     |
+            | primary | track    |               |                | cycling    | cycling     |
+            | primary | opposite |               |                | cycling    | cycling     |
+            | primary |          | track         |                | cycling    | cycling     |
+            | primary |          | opposite      |                | cycling    | cycling     |
+            | primary |          |               | track          | cycling    | cycling     |
+            | primary |          |               | opposite       | cycling    | cycling     |
+            | primary |          | track         | track          | cycling    | cycling     |
+            | primary |          | opposite      | opposite       | cycling    | cycling     |
+            | primary |          | track         | opposite       | cycling    | cycling     |
+            | primary |          | opposite      | track          | cycling    | cycling     |
 
     Scenario: Bike - Left/right side cycleways on implied oneways
         Then routability should be
-            | highway  | cycleway | cycleway:left | cycleway:right | forw | backw |
-            | primary  |          |               |                | x    | x     |
-            | motorway |          |               |                |      |       |
-            | motorway | track    |               |                | x    |       |
-            | motorway | opposite |               |                |      | x     |
-            | motorway |          | track         |                |      | x     |
-            | motorway |          | opposite      |                |      | x     |
-            | motorway |          |               | track          | x    |       |
-            | motorway |          |               | opposite       | x    |       |
-            | motorway |          | track         | track          | x    | x     |
-            | motorway |          | opposite      | opposite       | x    | x     |
-            | motorway |          | track         | opposite       | x    | x     |
-            | motorway |          | opposite      | track          | x    | x     |
+            | highway  | cycleway | cycleway:left | cycleway:right | forw    | backw   |
+            | primary  |          |               |                | cycling | cycling |
+            | motorway |          |               |                |         |         |
+            | motorway | track    |               |                | cycling |         |
+            | motorway | opposite |               |                |         | cycling |
+            | motorway |          | track         |                |         | cycling |
+            | motorway |          | opposite      |                |         | cycling |
+            | motorway |          |               | track          | cycling |         |
+            | motorway |          |               | opposite       | cycling |         |
+            | motorway |          | track         | track          | cycling | cycling |
+            | motorway |          | opposite      | opposite       | cycling | cycling |
+            | motorway |          | track         | opposite       | cycling | cycling |
+            | motorway |          | opposite      | track          | cycling | cycling |
 
     Scenario: Bike - Invalid cycleway tags
         Then routability should be
-            | highway  | cycleway   | bothw |
-            | primary  |            | x     |
-            | primary  | yes        | x     |
-            | primary  | no         | x     |
-            | primary  | some_track | x     |
-            | motorway |            |       |
-            | motorway | yes        |       |
-            | motorway | no         |       |
-            | motorway | some_track |       |
+            | highway  | cycleway   | bothw   |
+            | primary  |            | cycling |
+            | primary  | yes        | cycling |
+            | primary  | no         | cycling |
+            | primary  | some_track | cycling |
+            | motorway |            |         |
+            | motorway | yes        |         |
+            | motorway | no         |         |
+            | motorway | some_track |         |
 
     Scenario: Bike - Access tags should overwrite cycleway access
         Then routability should be
-            | highway     | cycleway | access | forw | backw |
-            | motorway    | track    | no     |      |       |
-            | residential | track    | no     |      |       |
-            | footway     | track    | no     |      |       |
-            | cycleway    | track    | no     |      |       |
-            | motorway    | lane     | yes    | x    |       |
-            | residential | lane     | yes    | x    | x     |
-            | footway     | lane     | yes    | x    | x     |
-            | cycleway    | lane     | yes    | x    | x     |
+            | highway     | cycleway | access | forw    | backw   |  
+            | motorway    | track    | no     |         |         |  
+            | residential | track    | no     |         |         |  
+            | footway     | track    | no     |         |         |  
+            | cycleway    | track    | no     |         |         |  
+            | motorway    | lane     | yes    | cycling |         |  
+            | residential | lane     | yes    | cycling | cycling |  
+            | footway     | lane     | yes    | cycling | cycling |  
+            | cycleway    | lane     | yes    | cycling | cycling |  
 
     Scenario: Bike - Cycleway on oneways, modes
         Then routability should be

--- a/features/bicycle/ferry.feature
+++ b/features/bicycle/ferry.feature
@@ -24,6 +24,44 @@ Feature: Bike - Handle ferry routes
             | c    | e  | cde,cde         |
             | c    | g  | cde,efg,efg     |
 
+    Scenario: Bike - Ferry route, access denied
+        Given the node map
+            """
+            a b c
+                d
+                e f g
+            """
+
+        And the ways
+            | nodes | highway | route | bicycle |
+            | abc   | primary |       |         |
+            | cde   |         | ferry | no      |
+            | efg   | primary |       |         |
+
+        When I route I should get
+            | from | to | route |
+            | a    | g  |       |  
+            | c    | e  |       |
+            | c    | g  |       |
+
+    @todo
+    Scenario: Bike - Ferry route should be unattractive, even when fast
+        Given the node map
+            """
+            c---------------d
+            |               |
+            b-----a ~ f-----e
+            """
+
+        And the ways
+            | nodes  | highway | route | bicycle | duration |
+            | abcdef | primary |       |         |          |
+            | af     |         | ferry | yes     | 00:01    |
+
+        When I route I should get
+            | from | to | route         | time |
+            | a    | f  | abcdef,abcdef | 432s |
+
     Scenario: Bike - Ferry duration, single node
         Given the node map
             """
@@ -44,6 +82,13 @@ Feature: Bike - Handle ferry routes
             | be    |         | ferry | yes     | 0:10     |
             | bg    |         | ferry | yes     | 1:00     |
             | bi    |         | ferry | yes     | 10:00    |
+
+        When I route I should get
+            | from | to | route | time    |
+            | b    | c  | bc,bc | 60s     |
+            | b    | e  | be,be | 603.1s  |
+            | b    | g  | bg,bg | 3606.2s |
+            | b    | i  | bi,bi | 36008s  |
 
     Scenario: Bike - Ferry duration, multiple nodes
         Given the node map

--- a/features/bicycle/ferry.feature
+++ b/features/bicycle/ferry.feature
@@ -65,30 +65,25 @@ Feature: Bike - Handle ferry routes
     Scenario: Bike - Ferry duration, single node
         Given the node map
             """
-            a b c d
-                e f
-                g h
-                i j
+            b c
+              e
+              g
+              i
             """
 
         And the ways
             | nodes | highway | route | bicycle | duration |
-            | ab    | primary |       |         |          |
-            | cd    | primary |       |         |          |
-            | ef    | primary |       |         |          |
-            | gh    | primary |       |         |          |
-            | ij    | primary |       |         |          |
             | bc    |         | ferry | yes     | 0:01     |
             | be    |         | ferry | yes     | 0:10     |
             | bg    |         | ferry | yes     | 1:00     |
             | bi    |         | ferry | yes     | 10:00    |
 
         When I route I should get
-            | from | to | route | time    |
-            | b    | c  | bc,bc | 60s     |
-            | b    | e  | be,be | 603.1s  |
-            | b    | g  | bg,bg | 3606.2s |
-            | b    | i  | bi,bi | 36008s  |
+            | from | to | route | time     |
+            | b    | c  | bc,bc | 67.1s    |
+            | b    | e  | be,be | 613.8s   |
+            | b    | g  | bg,bg | 3600s    |
+            | b    | i  | bi,bi | 36030.6s |
 
     Scenario: Bike - Ferry duration, multiple nodes
         Given the node map

--- a/features/bicycle/pushing.feature
+++ b/features/bicycle/pushing.feature
@@ -61,28 +61,28 @@ Feature: Bike - Accessability of different way types
             | runway   |      |              |              |
             | runway   | yes  | pushing bike | pushing bike |
 
-    @todo
     Scenario: Bike - Pushing bikes on ways with foot=yes in one direction
         Then routability should be
-            | highway  | foot:forward | foot:backward | forw         | backw        |
-            | motorway |              |               |              |              |
-            | motorway | yes          |               | pushing bike |              |
-            | motorway |              | yes           |              | pushing bike |
+            | highway | foot:forward | foot:backward | forw         | backw        |
+            | primary |              |               | cycling      | cycling      |
+            | runway  |              |               |              |              |
+            | runway  | yes          |               | pushing bike |              |
+            | runway  |              | yes           |              | pushing bike |
 
     @construction
     Scenario: Bike - Don't allow routing on ways still under construction
         Then routability should be
-            | highway      | foot | bicycle | bothw |
-            | primary      |      |         | x     |
-            | construction |      |         |       |
-            | construction | yes  |         |       |
-            | construction |      | yes     |       |
+            | highway      | foot | bicycle | bothw   |
+            | primary      |      |         | cycling |
+            | construction |      |         |         |
+            | construction | yes  |         |         |
+            | construction |      | yes     |         |
 
     @roundabout
     Scenario: Bike - Don't push bikes against oneway flow on roundabouts
         Then routability should be
-            | junction   | forw | backw |
-            | roundabout | x    |       |
+            | junction   | forw    | backw |
+            | roundabout | cycling |       |
 
     Scenario: Bike - Instructions when pushing bike on oneways
         Given the node map
@@ -125,3 +125,18 @@ Feature: Bike - Accessability of different way types
             | d    | a  | cd,bc,ab,ab | cycling,pushing bike,cycling,cycling |
             | c    | a  | bc,ab,ab    | pushing bike,cycling,cycling         |
             | d    | b  | cd,bc,bc    | cycling,pushing bike,pushing bike    |
+
+    Scenario: Bike - Pushing bikes on man_made=*
+        Then routability should be
+            | highway | man_made | forw         | backw        |
+            | (nil)   | pier     | pushing bike | pushing bike |
+
+    Scenario: Bike - Pushing bikes on railway=*
+        Then routability should be
+            | highway | railway  | forw         | backw        |
+            | (nil)   | platform | pushing bike | pushing bike |
+
+    Scenario: Bike - Pushing bikes on public_transport=*
+        Then routability should be
+            | highway | public_transport | forw         | backw        |
+            | (nil)   | platform         | pushing bike | pushing bike |

--- a/features/bicycle/safety.feature
+++ b/features/bicycle/safety.feature
@@ -19,7 +19,7 @@ Feature: Bicycle - Adds penalties to unsafe roads
             | tertiary_link  |          | 15 km/h    | 15 km/h    |       3.3 |        3.3 |
             | residential    |          | 15 km/h    | 15 km/h    |       4.2 |        4.2 |
             | cycleway       |          | 15 km/h    | 15 km/h    |       4.2 |        4.2 |
-            | footway        |          | 6 km/h +-1 | 6 km/h +-1 |       1.7 |        1.7 |
+            | footway        |          | 6 km/h +-1 | 6 km/h +-1 |       1.4 |        1.4 |
 
     Scenario: Bike - Apply no penalties to ways with cycleways
         Then routability should be
@@ -59,7 +59,7 @@ Feature: Bicycle - Adds penalties to unsafe roads
             | tertiary_link  | track          |               | 15 km/h     | 15 km/h     |       4.2 |        3.3 |
             | residential    | track          |               | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
             | cycleway       | track          |               | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
-            | footway        | track          |               | 15 km/h     | 6 km/h +-1  |       4.2 |        1.7 |
+            | footway        | track          |               | 15 km/h     | 6 km/h +-1  |       4.2 |        1.4 |
             | motorway       |                | track         |             | 15 km/h     |           |        4.2 |
             | primary        |                | track         | 15 km/h     | 15 km/h     |       2.9 |        4.2 |
             | secondary      |                | track         | 15 km/h     | 15 km/h     |       3.1 |        4.2 |
@@ -69,7 +69,7 @@ Feature: Bicycle - Adds penalties to unsafe roads
             | tertiary_link  |                | track         | 15 km/h     | 15 km/h     |       3.3 |        4.2 |
             | residential    |                | track         | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
             | cycleway       |                | track         | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
-            | footway        |                | track         | 6 km/h +-1  | 15 km/h     |       1.7 |        4.2 |
+            | footway        |                | track         | 6 km/h +-1  | 15 km/h     |       1.4 |        4.2 |
             | motorway       | lane           |               | 15 km/h     |             |       4.2 |            |
             | primary        | lane           |               | 15 km/h     | 15 km/h     |       4.2 |        2.9 |
             | secondary      | lane           |               | 15 km/h     | 15 km/h     |       4.2 |        3.1 |
@@ -79,7 +79,7 @@ Feature: Bicycle - Adds penalties to unsafe roads
             | tertiary_link  | lane           |               | 15 km/h     | 15 km/h     |       4.2 |        3.3 |
             | residential    | lane           |               | 15 km/h +-1 | 15 km/h +-1 |       4.2 |        4.2 |
             | cycleway       | lane           |               | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
-            | footway        | lane           |               | 15 km/h     | 6 km/h +-1  |       4.2 |        1.7 |
+            | footway        | lane           |               | 15 km/h     | 6 km/h +-1  |       4.2 |        1.4 |
             | motorway       |                | lane          |             | 15 km/h     |           |        4.2 |
             | primary        |                | lane          | 15 km/h     | 15 km/h     |       2.9 |        4.2 |
             | secondary      |                | lane          | 15 km/h +-1 | 15 km/h +-1 |       3.1 |        4.2 |
@@ -89,7 +89,7 @@ Feature: Bicycle - Adds penalties to unsafe roads
             | tertiary_link  |                | lane          | 15 km/h     | 15 km/h     |       3.3 |        4.2 |
             | residential    |                | lane          | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
             | cycleway       |                | lane          | 15 km/h     | 15 km/h     |       4.2 |        4.2 |
-            | footway        |                | lane          | 6 km/h +-1  | 15 km/h     |       1.7 |        4.2 |
+            | footway        |                | lane          | 6 km/h +-1  | 15 km/h     |       1.4 |        4.2 |
             | motorway       | shared_lane    |               | 15 km/h     |             |       4.2 |            |
             | primary        | shared_lane    |               | 15 km/h     | 15 km/h     |       4.2 |        2.9 |
             | motorway       |                | shared_lane   |             | 15 km/h     |           |        4.2 |

--- a/features/bicycle/surface.feature
+++ b/features/bicycle/surface.feature
@@ -54,6 +54,6 @@ Feature: Bike - Surfaces
       When I route I should get
         | from | to | route | modes                     | speed   |
         | a    | b  | ab,ab | cycling,cycling           | 15 km/h |
-        | b    | a  | ab,ab | pushing bike,pushing bike | 6 km/h  |
-        | c    | d  | cd,cd | pushing bike,pushing bike | 6 km/h  |
-        | d    | c  | cd,cd | pushing bike,pushing bike | 6 km/h  |
+        | b    | a  | ab,ab | pushing bike,pushing bike | 5 km/h  |
+        | c    | d  | cd,cd | pushing bike,pushing bike | 5 km/h  |
+        | d    | c  | cd,cd | pushing bike,pushing bike | 5 km/h  |

--- a/features/bicycle/train.feature
+++ b/features/bicycle/train.feature
@@ -31,7 +31,7 @@ Feature: Bike - Handle ferry routes
             | 2    | 3  | cd,de,ef,ef | cycling,train,cycling,cycling |
             | 3    | 4  |             |                               |
 
-    Scenario: Bike - Bringing bikes on trains, invalid railway tag is accepted if access specified
+    Scenario: Bike - Ingore invalid railway tag is accepted if access specified
         Given the node map
             """
             a 1 b   c 2 d   e 3 f   g 4 h
@@ -48,10 +48,10 @@ Feature: Bike - Handle ferry routes
             | fg    |         | invalid_tag | no      |
 
         When I route I should get
-            | from | to | route    |                     |
-            | 1    | 2  |          |                     |
-            | 2    | 3  | cd,de,ef | train, train, train | 
-            | 3    | 4  |          |                     |
+            | from | to | route    |
+            | 1    | 2  |          |
+            | 2    | 3  | cd,de,ef | 
+            | 3    | 4  |          |
 
     @construction
     Scenario: Bike - Don't route on railways under construction

--- a/features/bicycle/train.feature
+++ b/features/bicycle/train.feature
@@ -26,10 +26,10 @@ Feature: Bike - Handle ferry routes
             | fg    |         | train   | no      |
 
         When I route I should get
-            | from | to | route       |
-            | 1    | 2  |             |
-            | 2    | 3  | cd,de,ef,ef |
-            | 3    | 4  |             |
+            | from | to | route       | modes                         |
+            | 1    | 2  |             |                               |
+            | 2    | 3  | cd,de,ef,ef | cycling,train,cycling,cycling |
+            | 3    | 4  |             |                               |
 
     Scenario: Bike - Bringing bikes on trains, invalid railway tag is accepted if access specified
         Given the node map
@@ -48,10 +48,10 @@ Feature: Bike - Handle ferry routes
             | fg    |         | invalid_tag | no      |
 
         When I route I should get
-            | from | to | route |
-            | 1    | 2  |       |
-            | 2    | 3  | cd,de,ef|
-            | 3    | 4  |       |
+            | from | to | route    |                     |
+            | 1    | 2  |          |                     |
+            | 2    | 3  | cd,de,ef | train, train, train | 
+            | 3    | 4  |          |                     |
 
     @construction
     Scenario: Bike - Don't route on railways under construction

--- a/features/bicycle/train.feature
+++ b/features/bicycle/train.feature
@@ -21,9 +21,9 @@ Feature: Bike - Handle ferry routes
             | cd    | primary |         |         |
             | ef    | primary |         |         |
             | gh    | primary |         |         |
-            | bc    |         | train   |         |
-            | de    |         | train   | yes     |
-            | fg    |         | train   | no      |
+            | bc    | (nil)   | train   |         |
+            | de    | (nil)   | train   | yes     |
+            | fg    | (nil)   | train   | no      |
 
         When I route I should get
             | from | to | route       | modes                         |
@@ -31,7 +31,7 @@ Feature: Bike - Handle ferry routes
             | 2    | 3  | cd,de,ef,ef | cycling,train,cycling,cycling |
             | 3    | 4  |             |                               |
 
-    Scenario: Bike - Ingore invalid railway tag is accepted if access specified
+    Scenario: Bike - Ignore invalid railway tag is accepted if access specified
         Given the node map
             """
             a 1 b   c 2 d   e 3 f   g 4 h

--- a/features/bicycle/way.feature
+++ b/features/bicycle/way.feature
@@ -9,31 +9,31 @@ Feature: Bike - Accessability of different way types
     # Pier is not allowed, since it's tagged using man_made=pier.
 
         Then routability should be
-            | highway        | bothw |
-            | (nil)          |       |
-            | motorway       |       |
-            | motorway_link  |       |
-            | trunk          |       |
-            | trunk_link     |       |
-            | primary        | x     |
-            | primary_link   | x     |
-            | secondary      | x     |
-            | secondary_link | x     |
-            | tertiary       | x     |
-            | tertiary_link  | x     |
-            | residential    | x     |
-            | service        | x     |
-            | unclassified   | x     |
-            | living_street  | x     |
-            | road           | x     |
-            | track          | x     |
-            | path           | x     |
-            | footway        | x     |
-            | pedestrian     | x     |
-            | steps          | x     |
-            | cycleway       | x     |
-            | bridleway      |       |
-            | pier           |       |
+            | highway        | bothw        |
+            | (nil)          |              |
+            | motorway       |              |
+            | motorway_link  |              |
+            | trunk          |              |
+            | trunk_link     |              |
+            | primary        | cycling      |
+            | primary_link   | cycling      |
+            | secondary      | cycling      |
+            | secondary_link | cycling      |
+            | tertiary       | cycling      |
+            | tertiary_link  | cycling      |
+            | residential    | cycling      |
+            | service        | cycling      |
+            | unclassified   | cycling      |
+            | living_street  | cycling      |
+            | road           | cycling      |
+            | track          | cycling      |
+            | path           | cycling      |
+            | footway        | pushing bike |
+            | pedestrian     | pushing bike |
+            | steps          | pushing bike |
+            | cycleway       | cycling      |
+            | bridleway      |              |
+            | pier           | pushing bike |
 
     Scenario: Bike - Routability of man_made structures
         Then routability should be

--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -7,57 +7,57 @@ Feature: Car - Restricted access
 
     Scenario: Car - Access tag hierarchy on ways
         Then routability should be
-            | access | vehicle | motor_vehicle | motorcar | bothw |
-            |        |         |               |          | x     |
-            | yes    |         |               |          | x     |
-            | no     |         |               |          |       |
-            |        | yes     |               |          | x     |
-            |        | no      |               |          |       |
-            | no     | yes     |               |          | x     |
-            | yes    | no      |               |          |       |
-            |        |         | yes           |          | x     |
-            |        |         | no            |          |       |
-            | no     |         | yes           |          | x     |
-            | yes    |         | no            |          |       |
-            |        | no      | yes           |          | x     |
-            |        | yes     | no            |          |       |
-            |        |         |               | yes      | x     |
-            |        |         |               | no       |       |
-            | no     |         |               | yes      | x     |
-            | yes    |         |               | no       |       |
-            |        | no      |               | yes      | x     |
-            |        | yes     |               | no       |       |
-            |        |         | no            | yes      | x     |
-            |        |         | yes           | no       |       |
+            | access | vehicle | motor_vehicle | motorcar | bothw   |  
+            |        |         |               |          | driving |  
+            | yes    |         |               |          | driving |  
+            | no     |         |               |          |         |  
+            |        | yes     |               |          | driving |  
+            |        | no      |               |          |         |  
+            | no     | yes     |               |          | driving |  
+            | yes    | no      |               |          |         |  
+            |        |         | yes           |          | driving |  
+            |        |         | no            |          |         |  
+            | no     |         | yes           |          | driving |  
+            | yes    |         | no            |          |         |  
+            |        | no      | yes           |          | driving |  
+            |        | yes     | no            |          |         |  
+            |        |         |               | yes      | driving |  
+            |        |         |               | no       |         |  
+            | no     |         |               | yes      | driving |  
+            | yes    |         |               | no       |         |  
+            |        | no      |               | yes      | driving |  
+            |        | yes     |               | no       |         |  
+            |        |         | no            | yes      | driving |  
+            |        |         | yes           | no       |         |  
 
     Scenario: Car - Access tag hierarchy and forward/backward
         Then routability should be
-            | access | access:forward | access:backward | motorcar | motorcar:forward | motorcar:backward | forw | backw |
-            |        |                |                 |          |                  |                   | x    | x     |
-            | yes    |                |                 |          |                  |                   | x    | x     |
-            | yes    | no             |                 |          |                  |                   |      | x     |
-            | yes    | yes            |                 | no       |                  |                   |      |       |
-            | yes    | yes            |                 | yes      | no               |                   |      | x     |
-            | yes    |                |                 |          |                  |                   | x    | x     |
-            | yes    |                | no              |          |                  |                   | x    |       |
-            | yes    |                | yes             | no       |                  |                   |      |       |
-            | yes    |                | yes             | yes      |                  | no                | x    |       |
-            | no     |                |                 |          |                  |                   |      |       |
-            | no     | yes            |                 |          |                  |                   | x    |       |
-            | no     | no             |                 | yes      |                  |                   | x    | x     |
-            | no     | no             |                 | no       | yes              |                   | x    |       |
-            | no     |                |                 |          |                  |                   |      |       |
-            | no     |                | yes             |          |                  |                   |      | x     |
-            | no     |                | no              | yes      |                  |                   | x    | x     |
-            | no     |                | no              | no       |                  | yes               |      | x     |
-            |        | no             |                 |          | no               |                   |      | x     |
-            |        |                | no              |          |                  | no                | x    |       |
-            |        | no             |                 |          |                  | no                |      |       |
-            |        |                | no              | no       |                  |                   |      |       |
-            |        | no             |                 |          | yes              |                   | x    | x     |
-            |        |                | no              |          |                  | yes               | x    | x     |
-            |        | yes            |                 |          | no               |                   |      | x     |
-            |        |                | yes             |          |                  | no                | x    |       |
+            | access | access:forward | access:backward | motorcar | motorcar:forward | motorcar:backward | forw    | backw   |  
+            |        |                |                 |          |                  |                   | driving | driving |  
+            | yes    |                |                 |          |                  |                   | driving | driving |  
+            | yes    | no             |                 |          |                  |                   |         | driving |  
+            | yes    | yes            |                 | no       |                  |                   |         |         |  
+            | yes    | yes            |                 | yes      | no               |                   |         | driving |  
+            | yes    |                |                 |          |                  |                   | driving | driving |  
+            | yes    |                | no              |          |                  |                   | driving |         |  
+            | yes    |                | yes             | no       |                  |                   |         |         |  
+            | yes    |                | yes             | yes      |                  | no                | driving |         |  
+            | no     |                |                 |          |                  |                   |         |         |  
+            | no     | yes            |                 |          |                  |                   | driving |         |  
+            | no     | no             |                 | yes      |                  |                   | driving | driving |  
+            | no     | no             |                 | no       | yes              |                   | driving |         |  
+            | no     |                |                 |          |                  |                   |         |         |  
+            | no     |                | yes             |          |                  |                   |         | driving |  
+            | no     |                | no              | yes      |                  |                   | driving | driving |  
+            | no     |                | no              | no       |                  | yes               |         | driving |  
+            |        | no             |                 |          | no               |                   |         | driving |  
+            |        |                | no              |          |                  | no                | driving |         |  
+            |        | no             |                 |          |                  | no                |         |         |  
+            |        |                | no              | no       |                  |                   |         |         |  
+            |        | no             |                 |          | yes              |                   | driving | driving |  
+            |        |                | no              |          |                  | yes               | driving | driving |  
+            |        | yes            |                 |          | no               |                   |         | driving |  
+            |        |                | yes             |          |                  | no                | driving |         |  
 
     Scenario: Car - Access tag hierarchy on nodes
         Then routability should be
@@ -193,9 +193,10 @@ Feature: Car - Restricted access
     @hov
     Scenario: Car - I-66 use HOV-only roads with heavy penalty
         Then routability should be
-            | highway  | hov         | hov:lanes                          | lanes | access     | oneway | forw | backw | forw_rate  |
-            | motorway | designated  | designated\|designated\|designated | 3     | hov        | yes    | x    |       | 25         |
-            | motorway | lane        |                                    | 3     | designated | yes    | x    |       | 25         |
+            | highway  | hov         | hov:lanes                          | lanes | access     | forw | backw | forw_rate  |
+            | primary  |             |                                    |       |            | x    | x     | 25         |
+            | motorway | designated  | designated\|designated\|designated | 3     | hov        | x    |       | 25         |
+            | motorway | lane        |                                    | 3     | designated | x    |       | 25         |
 
     @hov
     Scenario: Car - a way with all lanes HOV-designated is highly penalized by default (similar to hov=designated)

--- a/features/car/classes.feature
+++ b/features/car/classes.feature
@@ -11,10 +11,10 @@ Feature: Car - Mode flag
             """
 
         And the ways
-            | nodes | highway | route |
-            | ab    | primary |       |
-            | bc    |         | ferry |
-            | cd    | primary |       |
+            | nodes | highway | route | motorcar |
+            | ab    | primary |       |          |
+            | bc    |         | ferry |  yes     |
+            | cd    | primary |       |          |
 
         When I route I should get
             | from | to | route       | turns                                              | classes                  |

--- a/features/car/ferry.feature
+++ b/features/car/ferry.feature
@@ -7,105 +7,89 @@ Feature: Car - Handle ferry routes
     Scenario: Car - Use a ferry route
         Given the node map
             """
-            a b c
-                d
-                e f g
+            a b---c d
             """
 
         And the ways
-            | nodes | highway | route | bicycle |
-            | abc   | primary |       |         |
-            | cde   |         | ferry | yes     |
-            | efg   | primary |       |         |
+            | nodes | highway | route | motorcar |
+            | ab    | primary |       |          |
+            | bc    |         | ferry | yes      |
+            | cd    | primary |       |          |
 
         When I route I should get
-            | from | to | route           | modes                         |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving |
-            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving |
-            | e    | c  | cde,cde         | ferry,ferry                   |
-            | e    | b  | cde,abc,abc     | ferry,driving,driving         |
-            | e    | a  | cde,abc,abc     | ferry,driving,driving         |
-            | c    | e  | cde,cde         | ferry,ferry                   |
-            | c    | f  | cde,efg,efg     | ferry,driving,driving         |
-            | c    | g  | cde,efg,efg     | ferry,driving,driving         |
+            | from | to | route       | modes                         |
+            | a    | c  | ab,bc,bc    | driving,ferry,ferry           |
+            | a    | d  | ab,bc,cd,cd | driving,ferry,driving,driving |
+            | b    | c  | bc,bc       | ferry,ferry                   |
+            | b    | d  | bc,cd,cd    | ferry,driving,driving         |
 
 
-    Scenario: Car - Use default speeds to calculate duration if no duration given
+    Scenario: Car - Ferry with no duration, use default speed
         Given the node map
             """
-            a b c
-                d
-                e f g
+            a b---c d
             """
 
         And the ways
-            | nodes | highway | route |
-            | abc   | primary |       |
-            | cde   |         | ferry |
-            | efg   | primary |       |
+            | nodes | highway | route | motorcar |
+            | ab    | primary |       |          |
+            | bc    |         | ferry | yes      |
+            | cd    | primary |       |          |
 
         When I route I should get
-            | from | to | route           | modes                         | speed   | time    |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 12 km/h | 173.4s  |
-            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 9 km/h  | 162.4s  |
-            | c    | e  | cde,cde         | ferry,ferry                   | 5 km/h  | 151.4s  |
-            | e    | c  | cde,cde         | ferry,ferry                   | 5 km/h  | 151.4s  |
+            | from | to | route | modes       | speed  | time |
+            | b    | c  | bc,bc | ferry,ferry | 5 km/h | 144s |
+            | c    | b  | bc,bc | ferry,ferry | 5 km/h | 144s |
 
-    Scenario: Car - Properly handle simple durations
+    Scenario: Car - Ferry with simple durations
         Given the node map
             """
-            a b c
-                d
-                e f g
+            a b---c d
             """
 
         And the ways
-            | nodes | highway | route | duration |
-            | abc   | primary |       |          |
-            | cde   |         | ferry | 00:01:00 |
-            | efg   | primary |       |          |
+            | nodes | highway | route | motorcar | duration |
+            | ab    | primary |       |          |          |
+            | bc    |         | ferry | yes      | 00:01:00 |
+            | cd    | primary |       |          |          |
 
         When I route I should get
-            | from | to | route           | modes                         | speed   | time  |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 24 km/h | 89.4s |
-            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h | 78.4s |
-            | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
-            | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
+            | from | to | route | modes       | speed   | time |
+            | b    | c  | bc,bc | ferry,ferry | 12 km/h | 60s  |
+            | c    | b  | bc,bc | ferry,ferry | 12 km/h | 60s  |
 
-    Scenario: Car - Properly handle ISO 8601 durations
+    Scenario: Car - Ferry with ISO 8601 durations
         Given the node map
             """
-            a b c
-                d
-                e f g
+            a b---c d
             """
 
         And the ways
-            | nodes | highway | route | duration |
-            | abc   | primary |       |          |
-            | cde   |         | ferry | PT1M     |
-            | efg   | primary |       |          |
+            | nodes | highway | route | motorcar | duration |
+            | ab    | primary |       |          |          |
+            | bc    |         | ferry | yes      | PT1M     |
+            | cd    | primary |       |          |          |
 
         When I route I should get
-            | from | to | route           | modes                         | speed   | time  |
-            | a    | g  | abc,cde,efg,efg | driving,ferry,driving,driving | 24 km/h | 89.4s |
-            | b    | f  | abc,cde,efg,efg | driving,ferry,driving,driving | 18 km/h | 78.4s |
-            | c    | e  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
-            | e    | c  | cde,cde         | ferry,ferry                   | 11 km/h | 67.4s |
+            | from | to | route | modes       | speed   | time |
+            | b    | c  | bc,bc | ferry,ferry | 12 km/h | 60s  |
+            | c    | b  | bc,bc | ferry,ferry | 12 km/h | 60s  |
 
 	@snapping
     Scenario: Car - Snapping when using a ferry
         Given the node map
             """
-            a b   c d   e f
+            a
+            b-1-2-e 
+                  f
             """
 
         And the ways
-            | nodes | highway | route | duration |
-            | ab    | primary |       |          |
-            | bcde  |         | ferry | 0:10     |
-            | ef    | primary |       |          |
+            | nodes | highway | route | motorcar | duration |
+            | ab    | primary |       |          |          |
+            | be  |           | ferry | yes      | 0:30:00  |
+            | ef    | primary |       |          |          |
 
         When I route I should get
-            | from | to | route     | modes       | time  |
-            | c    | d  | bcde,bcde | ferry,ferry | 600s  |
+            | from | to | route | modes       | time  |
+            | 1    | 2  | be,be | ferry,ferry | 600s  |

--- a/features/car/oneway.feature
+++ b/features/car/oneway.feature
@@ -8,11 +8,13 @@ Feature: Car - Oneway streets
     Scenario: Car - Simple oneway
         Then routability should be
             | highway | oneway | forw | backw |
+            | primary |        | x    | x     |
             | primary | yes    | x    |       |
 
     Scenario: Car - Simple reverse oneway
         Then routability should be
             | highway | oneway | forw | backw |
+            | primary |        | x    | x     |
             | primary | -1     |      | x     |
 
     Scenario: Car - Mode specific oneway
@@ -40,6 +42,9 @@ Feature: Car - Oneway streets
             | motorway        | roundabout | x    |       |                       |
             | motorway_link   | roundabout | x    |       |                       |
             | primary         | roundabout | x    |       |                       |
+            | motorway        | circular   | x    |       |                       |
+            | motorway_link   | circular   | x    |       |                       |
+            | primary         | circular   | x    |       |                       |
 
     Scenario: Car - Overrule implied oneway
         Then routability should be

--- a/features/car/shuttle_train.feature
+++ b/features/car/shuttle_train.feature
@@ -4,30 +4,40 @@ Feature: Car - Handle ferryshuttle train routes
     Background:
         Given the profile "car"
 
-    Scenario: Car - Use a ferry route
+    Scenario: Car - Use a shuttle train without duration
         Given the node map
             """
-            a b c
-                d
-                e f g h
+            a b
+              :
+              c d
             """
 
         And the ways
-            | nodes | highway | route         | bicycle |
-            | abc   | primary |               |         |
-            | cde   |         | shuttle_train | yes     |
-            | ef    | primary |               |         |
-            | fg    |         | ferry_man     |         |
-            | gh    | primary |               | no      |
+            | nodes | highway | route         | motorcar |
+            | ab    | primary |               |          |
+            | bc    |         | shuttle_train | yes      |
+            | cd    | primary |               |          |
 
         When I route I should get
-            | from | to | route         |
-            | a    | f  | abc,cde,ef,ef |
-            | b    | f  | abc,cde,ef,ef |
-            | e    | c  | cde,cde       |
-            | e    | b  | cde,abc,abc   |
-            | e    | a  | cde,abc,abc   |
-            | c    | e  | cde,cde       |
-            | c    | f  | cde,ef,ef     |
-            | f    | g  |               |
-            | g    | h  | gh,gh         |
+            | from | to | route       | modes                         |
+            | a    | d  | ab,bc,cd,cd | driving,train,driving,driving |
+            | d    | a  | cd,bc,ab,ab | driving,train,driving,driving |
+
+    Scenario: Car - Use a shuttle train with duration
+        Given the node map
+            """
+            a b
+              :
+              c d
+            """
+
+        And the ways
+            | nodes | highway | route         | motorcar | duration |
+            | ab    | primary |               |          |          |
+            | bc    |         | shuttle_train | yes      | 00:00:15 |
+            | cd    | primary |               |          |          |
+
+        When I route I should get
+            | from | to | route       | modes                         |
+            | a    | d  | ab,bc,cd,cd | driving,train,driving,driving |
+            | d    | a  | cd,bc,ab,ab | driving,train,driving,driving |

--- a/features/foot/area.feature
+++ b/features/foot/area.feature
@@ -110,3 +110,30 @@ Feature: Foot - Squares and other areas
             | d    | c  | abcda,abcda    |
             | d    | a  | abcda,abcda    |
             | a    | d  | abcda,abcda    |
+
+    @train @platform
+    Scenario: Foot - public transport platforms
+        Given the node map
+            """
+            x a b y
+              d c
+            """
+
+        And the ways
+            | nodes | highway | public_transport |
+            | xa    | primary |                  |
+            | by    | primary |                  |
+            | abcda | (nil)   | platform         |
+
+        When I route I should get
+            | from | to | route          |
+            | x    | y  | xa,abcda,by,by |
+            | y    | x  | by,abcda,xa,xa |
+            | a    | b  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |
+            | b    | c  | abcda,abcda    |
+            | c    | b  | abcda,abcda    |
+            | c    | d  | abcda,abcda    |
+            | d    | c  | abcda,abcda    |
+            | d    | a  | abcda,abcda    |
+            | a    | d  | abcda,abcda    |

--- a/features/foot/oneway.feature
+++ b/features/foot/oneway.feature
@@ -43,6 +43,8 @@ Feature: Foot - Oneway streets
     Scenario: Foot - Walking should respect oneway:foot
         Then routability should be
             | oneway:foot | oneway | junction   | forw | backw |
+            |             |        |            | x    | x     |
+            |             | yes    |            | x    | x     |
             | yes         |        |            | x    |       |
             | yes         | yes    |            | x    |       |
             | yes         | no     |            | x    |       |

--- a/features/foot/way.feature
+++ b/features/foot/way.feature
@@ -4,35 +4,29 @@ Feature: Foot - Accessability of different way types
     Background:
         Given the profile "foot"
 
-    Scenario: Foot - Basic access
+    Scenario: Foot - Routing on highway=*
         Then routability should be
-            | highway        | forw |
-            | motorway       |      |
-            | motorway_link  |      |
-            | trunk          |      |
-            | trunk_link     |      |
-            | primary        | x    |
-            | primary_link   | x    |
-            | secondary      | x    |
-            | secondary_link | x    |
-            | tertiary       | x    |
-            | tertiary_link  | x    |
-            | residential    | x    |
-            | service        | x    |
-            | unclassified   | x    |
-            | living_street  | x    |
-            | road           | x    |
-            | track          | x    |
-            | path           | x    |
-            | footway        | x    |
-            | pedestrian     | x    |
-            | steps          | x    |
-            | pier           | x    |
-            | cycleway       |      |
-            | bridleway      |      |
-
-    Scenario: Foot - Basic access
-        Then routability should be
-            | highway | leisure  | forw |
-            | (nil)   | track    |   x  |
-
+            | highway        | bothw   |
+            | motorway       |         |
+            | motorway_link  |         |
+            | trunk          |         |
+            | trunk_link     |         |
+            | primary        | walking |
+            | primary_link   | walking |
+            | secondary      | walking |
+            | secondary_link | walking |
+            | tertiary       | walking |
+            | tertiary_link  | walking |
+            | residential    | walking |
+            | service        | walking |
+            | unclassified   | walking |
+            | living_street  | walking |
+            | road           | walking |
+            | track          | walking |
+            | path           | walking |
+            | footway        | walking |
+            | pedestrian     | walking |
+            | steps          | walking |
+            | pier           | walking |
+            | cycleway       |         |
+            | bridleway      |         |

--- a/features/foot/way.feature
+++ b/features/foot/way.feature
@@ -30,3 +30,9 @@ Feature: Foot - Accessability of different way types
             | pier           | walking |
             | cycleway       |         |
             | bridleway      |         |
+
+
+    Scenario: Foot - Basic access
+        Then routability should be
+            | highway | leisure  | forw |
+            | (nil)   | track    |   x  | 

--- a/features/guidance/bicycle-sliproads.feature
+++ b/features/guidance/bicycle-sliproads.feature
@@ -24,9 +24,9 @@ Feature: Bike - Mode flag
         And the ways
             | nodes | highway   | name   | oneway:bicycle |
             | abcd  | cycleway  | street |                |
-            | eb    | path      |        | yes            |
+            | be    | path      |        | yes            |
             | icef  | tertiary  | road   |                |
-            | geh   | secondary | street |                |
+            | geh   | secondary | cross  |                |
 
         When I route I should get
             | waypoints | route             | turns                               |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -153,26 +153,28 @@ function setup()
 
     routes = {
       railway = {
-        mode = mode.train,
         access_required = true,
-        speed = {
-          train = 10,
-          railway = 10,
-          subway = 10,
-          light_rail = 10,
-          monorail = 10,
-          tram = 10
+        mode = mode.train,
+        speed = 10,
+        types = {
+          train = {},
+          railway = {},
+          subway = {},
+          light_rail = {},
+          monorail = {},
+          tram = {}
         }
       },
       route = {
-        mode = mode.ferry,
-        access_required = true,   
-        speed = {
-          ferry = 5
+        types = {
+          ferry = {
+            access_required = true,
+            speed = 5
+            mode = mode.ferry,
+          }
         }
       }
-    },
-
+    }
 
     bridge_speeds = {
       movable = 5

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -6,7 +6,6 @@ Set = require('lib/set')
 Sequence = require('lib/sequence')
 Handlers = require("lib/way_handlers")
 find_access_tag = require("lib/access").find_access_tag
-limit = require("lib/maxspeed").limit
 pprint = require('lib/pprint')
 
 Bicycle = {}
@@ -233,20 +232,6 @@ function setup()
   profile.foot_profile.implied_oneways = profile.implied_oneways
 
   return profile
-end
-
-local function parse_maxspeed(source)
-    if not source then
-        return 0
-    end
-    local n = tonumber(source:match("%d*"))
-    if not n then
-        n = 0
-    end
-    if string.match(source, "mph") or string.match(source, "mp/h") then
-        n = (n*1609)/1000
-    end
-    return n
 end
 
 function process_node(profile, node, result)

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -38,6 +38,11 @@ function setup()
     -- Should be inverted for left-driving countries.
     turn_bias   = use_left_hand_driving and 1/1.075 or 1.075,
 
+    implied_oneways = {
+      highway = { 'motorway' },
+      junction = { 'roundabout', 'circular' }
+    },
+
     -- a list of suffixes to suppress in name change instructions
     suffix_list = {
       'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'North', 'South', 'West', 'East'

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -33,6 +33,7 @@ function setup()
     side_road_multiplier      = 0.8,
     turn_penalty              = 7.5,
     speed_reduction           = 0.8,
+    increase_speed_to_max     = true,
 
     -- Note: this biases right-side driving.
     -- Should be inverted for left-driving countries.

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -102,6 +102,10 @@ function setup()
         platform        = walking_speed
       },
 
+      public_transport = {
+        platform        = walking_speed
+      },
+
       amenity = {
         parking         = walking_speed,
         parking_entrance= walking_speed

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -74,7 +74,8 @@ function setup()
     },
 
     avoid = Set {
-      'impassable'
+      'impassable',
+      'construction'
     },
 
     speeds = Sequence {
@@ -120,8 +121,24 @@ function setup()
       }
     },
 
-    route_speeds = {
-      ferry = 5
+    routes = {
+      railway = {
+        access_required = true,
+        speed = {
+          train = 10,
+          railway = 10,
+          subway = 10,
+          light_rail = 10,
+          monorail = 10,
+          tram = 10
+        }
+      },
+      route = {
+        access_required = true,   
+        speed = {
+          ferry = 5
+        }
+      }
     },
 
     bridge_speeds = {
@@ -226,7 +243,7 @@ function process_way(profile, way, result)
     WayHandlers.destinations,
 
     -- check whether we're using a special transport mode
-    WayHandlers.ferries,
+    WayHandlers.routes,
     WayHandlers.movables,
 
     -- compute speed taking into account way type, maxspeed tags, etc.

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -122,21 +122,27 @@ function setup()
     },
 
     routes = {
-      railway = {
-        access_required = true,
-        speed = {
-          train = 10,
-          railway = 10,
-          subway = 10,
-          light_rail = 10,
-          monorail = 10,
-          tram = 10
-        }
-      },
-      route = {
-        access_required = true,   
-        speed = {
-          ferry = 5
+      access_required = false,
+      speed = 10,
+      keys = {
+        railway = {
+          mode = mode.train,
+          values = Set {
+            'train',
+            'railway',
+            'subway',
+            'light_rail',
+            'monorail',
+            'tram'
+          }
+        },
+        route = {
+          values = {
+            ferry = {
+              speed = 5,
+              mode = mode.ferry,
+            }
+          }
         }
       }
     },
@@ -236,6 +242,9 @@ function process_way(profile, way, result)
     -- access tags, e.g: motorcar, motor_vehicle, vehicle
     WayHandlers.access,
 
+    -- compute speed taking into account way type, maxspeed tags, etc.
+    WayHandlers.speed,
+
     -- check whether forward/backward directons are routable
     WayHandlers.oneway,
 
@@ -246,8 +255,7 @@ function process_way(profile, way, result)
     WayHandlers.routes,
     WayHandlers.movables,
 
-    -- compute speed taking into account way type, maxspeed tags, etc.
-    WayHandlers.speed,
+    -- handle surfaces
     WayHandlers.surface,
 
     -- handle turn lanes and road classification, used for guidance

--- a/profiles/lib/profile_debugger.lua
+++ b/profiles/lib/profile_debugger.lua
@@ -117,6 +117,8 @@ function Debug.process_way(way,result)
   
   -- setup result table
   result.road_classification = {}
+  result.forward_mode = 0
+  result.backward_mode = 0
   result.forward_speed = -1
   result.backward_speed = -1
   result.duration = 0

--- a/profiles/lib/profile_debugger.lua
+++ b/profiles/lib/profile_debugger.lua
@@ -121,6 +121,9 @@ function Debug.process_way(way,result)
   result.backward_mode = 0
   result.forward_speed = -1
   result.backward_speed = -1
+  result.forward_rate = -1
+  result.backward_rate = -1
+  result.weight = -1
   result.duration = 0
   result.forward_classes = {}
   result.backward_classes = {}

--- a/profiles/lib/tags.lua
+++ b/profiles/lib/tags.lua
@@ -121,4 +121,39 @@ function Tags.get_constant_by_key_value(way,lookup)
   end
 end
 
+-- check if key-value pairs are set in a way and return
+-- true if it is. e.g. for this input:
+--
+-- local speeds = Set {
+--  highway = Set {
+--    'residential',
+--    'primary'
+--  },
+--  amenity = Set {
+--    'parking'
+--  }
+-- }
+--
+-- we would check whether the following key-value combinations
+-- are set, and return true is so:
+--
+-- highway = residential
+-- highway = primary
+-- amenity = parking
+
+function Tags.has_key_value_combination(way,lookup)
+  if not lookup then
+    return false
+  end
+  for key,set in pairs(lookup) do
+    local got = way:get_value_by_key(key)
+    for i,want in ipairs(set) do
+      if got == want then
+        print(key,got)
+        return true
+      end
+    end
+  end
+end
+
 return Tags

--- a/profiles/lib/tags.lua
+++ b/profiles/lib/tags.lua
@@ -149,7 +149,6 @@ function Tags.has_key_value_combination(way,lookup)
     local got = way:get_value_by_key(key)
     for i,want in ipairs(set) do
       if got == want then
-        print(key,got)
         return true
       end
     end

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -18,7 +18,9 @@ function WayHandlers.new_result()
     backward_speed = -1,
     forward_mode = 0,
     backward_mode = 0,
-    duration = 0
+    duration = 0,
+    forward_classes = {},
+    backward_classes = {}
   }
 end
 
@@ -494,7 +496,6 @@ function WayHandlers.oneway(profile,way,result,data)
     result.backward_mode = mode.inaccessible
   elseif oneway ~= "no" and Tags.has_key_value_combination(way, profile.implied_oneways) then
     -- implied oneway
-    print('implied')
     data.is_forward_oneway = true
     result.backward_mode = mode.inaccessible
   end

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -159,8 +159,8 @@ end
 
 -- handling routes with durations, including ferries and railway
 function WayHandlers.routes(profile,way,result,data)
-  for key,route_type in pairs(profile.routes) do
-    local speed = route_type.speed[data[key]]
+  for key,key_settings in pairs(profile.routes) do
+    local speed = key_settings.speed[data[key]]
     if speed and speed > 0 then
       local duration  = way:get_value_by_key("duration")
       if duration and durationIsValid(duration) then
@@ -209,7 +209,6 @@ function WayHandlers.railways(profile,way,result,data)
      result.backward_mode = mode.train
      result.forward_speed = speed
      result.backward_speed = speed
-     print('rail!')
      return true
     end
   end


### PR DESCRIPTION
# Issue
the bike profile still has som long functions with old code that's hard to read. this PR is an efford to clean it up.

## Tasklist
 - [x] use foot profile to determine where you can push bikes
 - [x] add tests to check improved push handling
 - [x] add missing suffix list in bike profile
 - [ ] use existing WayHandlers when possible
 - [ ] factor remaining code out into manageable functions 
 - [ ] review
 - [ ] adjust for comments

Since this refactor touched the WayHandlers and thus other profiles, it includes a few other improvements as well:

- control what tag combinations imply oneway by setting profile.implied_oneways
- tag helper to support the above
- add missing test that circular is oneway in the car profile
- add missing support for public_transport=platform in foot profile
- add helper functions in WayHandlers for initializing and merging way result tables (used when using the foot profile in the bike profile)

the test in features/guidance/bicycle-sliproads.feature b/features/guidance/bicycle-sliproads.feature was failing, i believe this was due to an incorrect oneway direction of the slipway eb, so i changed this. is this correct?


- 
