### PR TITLE
Adds lane anticipation Oak St -> Franklin St -> Fell St scenario

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -814,3 +814,32 @@ Feature: Turn Lane Guidance
             | waypoints | route        | turns                    | locations | lanes                                                                                                                                                                                                                                                                                        |
             | a,i       | road,road    | depart,arrive            | a,i       | ;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:true none:true none:false;none:true none:true right:false,     |
             | a,j       | road,7th,7th | depart,turn right,arrive | a,h,j     | ;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:true none:true none:true;left:false none:false none:false none:true;left:false none:false none:false none:true,none:false none:false right:true, |
+
+    @anticipate
+    Scenario: Oak St, Franklin St
+        Given a grid size of 10 meters
+        Given the node map
+            """
+                   g
+                   .     . f
+                 . d `
+            e `    .
+                   .
+                   .
+                   .     . c
+                 . b `
+            a `
+
+            """
+
+        And the ways
+            | nodes | name        | turn:lanes                                  | oneway | highway   |
+            | ab    | Oak St      | left\|left\|left                            | yes    | secondary |
+            | cb    | Oak St      | right                                       | yes    | tertiary  |
+            | bd    | Franklin St | left;through\|through\|through;right\|right | yes    | secondary |
+            | dg    | Franklin St |                                             | yes    | secondary |
+            | edf   | Fell St     |                                             |        | secondary |
+
+        When I route I should get
+            | waypoints | route                              | turns                               | lanes                                                                                              |
+            | a,f       | Oak St,Franklin St,Fell St,Fell St | depart,turn left,turn right,arrive  | ,left:false left:true left:true,straight;left:false straight:false straight;right:true right:true, |


### PR DESCRIPTION
@willwhite - here's lane anticipation for the scenario we talked about. The lanes are currently mis-tagged for the turn from Franklin St onto Fell St.

Have a look at the Mapillary dashcam footage below: it should be
- `left;through`
- `through`
- `through;right`
- `right`

from left to right.

With these tags in place lane anticipation will tell you to
- take the rightmost two left lanes (and not the left most left lane) for the turn Oak St -> Franklin St
- Take any of the right most two right lanes for the turn from Franklin St -> Fell St

https://www.mapillary.com/app/?lat=37.775930901480024&lng=-122.42109881428001&z=17&pKey=rSSaBbwtVo34rmqUYdo23A&focus=photo&x=0.4815946242458291&y=0.6041937843190558&zoom=0

https://www.mapillary.com/app/?lat=37.775191666666665&lng=-122.42150000000001&z=17&pKey=h4jxCSEQubsrMxbKUsXF0w&focus=photo&x=0.5157998076106902&y=0.5951778130191712&zoom=0

![map1](https://user-images.githubusercontent.com/527241/28474695-d92a36ca-6e49-11e7-9914-eff2a1aa84b7.png)

![map](https://user-images.githubusercontent.com/527241/28474696-d92f7522-6e49-11e7-9bfb-d5cfbbb53fb6.png)

