### PR TITLE
Handles distinction of no-route vs invalid-route in mld alternatives

### DIFF
--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -120,9 +120,12 @@ Status ViaRoutePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithm
         routes = algorithms.ShortestPathSearch(start_end_nodes, route_parameters.continue_straight);
     }
 
+    // The post condition for all path searches is we have at least one route in our result.
+    // This route might be invalid by means of INVALID_EDGE_WEIGHT as shortest path weight.
+    BOOST_ASSERT(!routes.routes.empty());
+
     // we can only know this after the fact, different SCC ids still
     // allow for connection in one direction.
-    BOOST_ASSERT(!routes.routes.empty());
 
     if (routes.routes[0].is_valid())
     {

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -792,8 +792,15 @@ InternalManyRoutesResult alternativePathSearch(SearchEngineData<Algorithm> &sear
                                    shortest_path_via_it->node != SPECIAL_NODEID &&
                                    shortest_path_via_it->weight != INVALID_EDGE_WEIGHT;
 
+    // Care needs to be taken to meet the call sites post condition.
+    // We must return at least one route, even if it's an invalid one.
     if (!has_shortest_path)
-        return InternalManyRoutesResult{};
+    {
+        InternalRouteResult invalid;
+        invalid.shortest_path_weight = INVALID_EDGE_WEIGHT;
+        invalid.segment_end_coordinates = {phantom_node_pair};
+        return invalid;
+    }
 
     NodeID shortest_path_via = shortest_path_via_it->node;
     EdgeWeight shortest_path_weight = shortest_path_via_it->weight;


### PR DESCRIPTION
The viaroute plugin always expects a route to be there potentially
with invalid edge weight to represent no-route-found. By switching
to the many-route-result for the mld alternatives algorithm we might
return an empty many-route-result invalidating the post-condition.

At some point we should think about making the interface less prone
to errors here. Reproduce e.g. with

    wget http://download.geofabrik.de/europe/netherlands-latest.osm.pbf
    osmium extract --bbox 6.24298095703125,53.016435582533816,6.88568115234375,53.363665164191865 netherlands-latest.osm.pbf -o groningen.osm.pbf

    ./osrm-extract -p ../profiles/car.lua groningen.osm.pbf
    ./osrm-partition groningen.osrm
    ./osrm-customize groningen.osrm
    ./osrm-routed --algorithm mld groningen.osrm

    curl -s 'localhost:5000/route/v1/driving/6.565710,53.219939;6.566032,53.219994?alternatives=true'

Before: assertion / crash, after: no-route status code

cc @TheMarex @oxidase 