### PR TITLE
Via way traffic signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
       - Pass functions instead of strings to `WayHandlers.run()`, so it's possible to mix in your own functions.
       - Reorders arguments to `WayHandlers` functions to match `process_way()`.
       - Profiles must return a hash of profile functions. This makes it easier for profiles to include each other.
+      - BREAKING: Traffic signals will no longer be represented as turns internally. This requires re-processing of data but enables via-way turn restrictions across highway=traffic_signals
       - Guidance: add support for throughabouts
     - Bugfixes
       - Properly save/retrieve datasource annotations for road segments ([#4346](https://github.com/Project-OSRM/osrm-backend/issues/4346)

--- a/features/car/restrictions.feature
+++ b/features/car/restrictions.feature
@@ -954,11 +954,11 @@ Feature: Car - Turn restrictions
         # this case is currently not handling the via-way restrictions and we need support for looking across traffic signals.
         # It is mainly included to show limitations and to prove that we don't crash hard here
         When I route I should get
-            | from | to | route        |
-            | a    | d  | ab,bge,de,de |
-            | a    | f  | ab,bge,ef,ef |
-            | c    | d  | bc,bge,de,de |
-            | c    | f  | bc,bge,ef,ef |
+            | from | to | route              |
+            | a    | d  | ab,bge,ef,ef,de,de |
+            | a    | f  | ab,bge,ef,ef       |
+            | c    | d  | bc,bge,de,de       |
+            | c    | f  | bc,bge,de,de,ef,ef |
 
       # don't crash hard on invalid restrictions
       @restriction @invalid

--- a/features/car/traffic_light_penalties.feature
+++ b/features/car/traffic_light_penalties.feature
@@ -60,3 +60,34 @@ Feature: Car - Handle traffic lights
         When I route I should get
             | from | to | route   | geometry       |
             | a    | c  | abc,abc | _ibE_ibE?gJ?gJ |
+
+    @traffic
+    Scenario: Traffic update on the edge with a traffic signal
+        Given the node map
+            """
+            a - b - c
+            """
+
+        And the ways
+          | nodes | highway |
+          | abc   | primary |
+
+
+        And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+
+        And the contract extra arguments "--segment-speed-file {speeds_file}"
+        And the customize extra arguments "--segment-speed-file {speeds_file}"
+        And the speed file
+        """
+        1,2,65
+        2,1,65
+        """
+        And the query options
+          | annotations | datasources,nodes,speed,duration,weight |
+
+        When I route I should get
+          | from | to | route   | speed   | weights | time  | distances | a:datasources | a:nodes | a:speed | a:duration |  a:weight |
+          | a    | c  | abc,abc | 59 km/h | 24.2,0  | 24.2s | 399.9m,0m |           1:0 |  1:2:3  |   18:18 |  11.1:11.1 | 11.1:11.1 |
+          | c    | a  | abc,abc | 59 km/h | 24.2,0  | 24.2s | 399.9m,0m |           0:1 |  3:2:1  |   18:18 |  11.1:11.1 | 11.1:11.1 |

--- a/features/car/traffic_light_penalties.feature
+++ b/features/car/traffic_light_penalties.feature
@@ -37,3 +37,26 @@ Feature: Car - Handle traffic lights
             | 3    | 4  |  13.1s | no turn with traffic light    |
             | g    | j  |  18.7s | turn with no traffic light    |
             | k    | n  |  20.7s | turn with traffic light       |
+
+
+    Scenario: Tarrif Signal Geometry
+        Given the query options
+            | overview   | full      |
+            | geometries | polyline  |
+
+        Given the node map
+            """
+            a - b - c
+            """
+
+        And the ways
+            | nodes | highway |
+            | abc   | primary |
+
+        And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+
+        When I route I should get
+            | from | to | route   | geometry       |
+            | a    | c  | abc,abc | _ibE_ibE?gJ?gJ |

--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -809,14 +809,14 @@ Feature: Simple Turns
 
         When I route I should get
             | waypoints | route               | turns                    | intersections                                         |
-            | a,g       | Perle,Heide,Heide   | depart,turn right,arrive | true:90;true:90 true:180 false:270 true:345;true:18   |
-            | a,k       | Perle,Friede,Friede | depart,turn left,arrive  | true:90;true:90 true:180 false:270 true:345;true:153  |
-            | a,e       | Perle,Perle         | depart,arrive            | true:90,true:90 true:180 false:270 true:345;true:270  |
-            | e,k       | Perle,Friede,Friede | depart,turn right,arrive | true:270;false:90 true:180 true:270 true:345;true:153 |
-            | e,g       | Perle,Heide,Heide   | depart,turn left,arrive  | true:270;false:90 true:180 true:270 true:345;true:18  |
-            | h,k       | Heide,Friede        | depart,arrive            | true:16,true:90 true:180 true:270 true:345;true:153   |
-            | h,e       | Heide,Perle,Perle   | depart,turn right,arrive | true:16;true:90 true:180 true:270 true:345;true:270   |
-            | h,a       | Heide,Perle,Perle   | depart,turn left,arrive  | true:16;true:90 true:180 true:270 true:345;true:90    |
+            | a,g       | Perle,Heide,Heide   | depart,turn right,arrive | true:90;true:90 true:195 false:270 true:345;true:18   |
+            | a,k       | Perle,Friede,Friede | depart,turn left,arrive  | true:90;true:90 true:195 false:270 true:345;true:153  |
+            | a,e       | Perle,Perle         | depart,arrive            | true:90,true:90 true:195 false:270 true:345;true:270  |
+            | e,k       | Perle,Friede,Friede | depart,turn right,arrive | true:270;false:90 true:195 true:270 true:345;true:153 |
+            | e,g       | Perle,Heide,Heide   | depart,turn left,arrive  | true:270;false:90 true:195 true:270 true:345;true:18  |
+            | h,k       | Heide,Friede        | depart,arrive            | true:16,true:90 true:195 true:270 true:345;true:153   |
+            | h,e       | Heide,Perle,Perle   | depart,turn right,arrive | true:16;true:90 true:195 true:270 true:345;true:270   |
+            | h,a       | Heide,Perle,Perle   | depart,turn left,arrive  | true:16;true:90 true:195 true:270 true:345;true:90    |
 
     #http://www.openstreetmap.org/#map=19/52.53293/13.32956
     Scenario: Curved Exit from Curved Road
@@ -1006,8 +1006,8 @@ Feature: Simple Turns
             | waypoints | route               | turns                          |
             | a,e       | Heide,Heide,Heide   | depart,continue uturn,arrive   |
             | a,g       | Heide,Fenn,Fenn     | depart,turn right,arrive       |
-            | a,h       | Heide,Friede,Friede | depart,turn slight left,arrive |
-            | i,e       | Perle,Heide,Heide   | depart,turn right,arrive       |
+            | a,h       | Heide,Friede,Friede | depart,turn left,arrive        |
+            | i,e       | Perle,Heide,Heide   | depart,turn sharp right,arrive |
             | i,h       | Perle,Friede,Friede | depart,turn left,arrive        |
 
     #http://www.openstreetmap.org/#map=19/52.48630/13.36017

--- a/features/testbot/penalty.feature
+++ b/features/testbot/penalty.feature
@@ -26,6 +26,33 @@ Feature: Penalties
             | a    | c  | abc,abc | 20s +-1 | 200m +-1 |
             | d    | f  | def,def | 27s +-1 | 200m +-1 |
 
+    # Penalties not on the phantom nodes
+    Scenario: Traffic signals should incur a delay, without changing distance
+        Given the node map
+            """
+            a b c d e
+            f g h i j
+            """
+
+        And the nodes
+            | node | highway         |
+            | c    | traffic_signals |
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bcd   |
+            | de    |
+            | fg    |
+            | ghi   |
+            | ij    |
+
+        When I route I should get
+            | from | to | route     | time    | distance |
+            | a    | e  | ab,bcd,de | 47s +-1 | 400m +-1 |
+            | f    | j  | fg,ghi,ij | 40s +-1 | 400m +-1 |
+
+
     Scenario: Signal penalty should not depend on way type
         Given the node map
             """

--- a/features/testbot/penalty.feature
+++ b/features/testbot/penalty.feature
@@ -72,55 +72,35 @@ Feature: Penalties
             | from | to | route       | time    |
             | a    | e  | abcde,abcde | 61s +-1 |
 
-        @todo
-        Scenario: Signal penalty should not depend on way type
-            Given the node map
-                """
-                a b c
-                d e f
-                g h i
-                """
+    @todo
+    Scenario: Signal penalty should not depend on way type
+        Given the node map
+            """
+            a b c
+            d e f
+            g h i
+            """
 
-            And the nodes
-                | node | highway         |
-                | b    | traffic_signals |
-                | e    | traffic_signals |
-                | h    | traffic_signals |
+        And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+            | e    | traffic_signals |
+            | h    | traffic_signals |
 
-            And the ways
-                | nodes | highway   |
-                | abc   | primary   |
-                | def   | secondary |
-                | ghi   | tertiary  |
+        And the ways
+            | nodes | highway   |
+            | abc   | primary   |
+            | def   | secondary |
+            | ghi   | tertiary  |
 
-            When I route I should get
-                | from | to | route   | time    |
-                | a    | b  | abc,abc | 10s +-1 |
-                | a    | c  | abc,abc | 27s +-1 |
-                | d    | e  | def,def | 20s +-1 |
-                | d    | f  | def,def | 47s +-1 |
-                | g    | h  | ghi,ghi | 30s +-1 |
-                | g    | i  | ghi,ghi | 67s +-1 |
-
-        Scenario: Passing multiple traffic signals should incur a accumulated delay
-            Given the node map
-                """
-                a b c d e
-                """
-
-            And the nodes
-                | node | highway         |
-                | b    | traffic_signals |
-                | c    | traffic_signals |
-                | d    | traffic_signals |
-
-            And the ways
-                | nodes |
-                | abcde |
-
-            When I route I should get
-                | from | to | route       | time    |
-                | a    | e  | abcde,abcde | 61s +-1 |
+        When I route I should get
+            | from | to | route   | time    |
+            | a    | b  | abc,abc | 10s +-1 |
+            | a    | c  | abc,abc | 27s +-1 |
+            | d    | e  | def,def | 20s +-1 |
+            | d    | f  | def,def | 47s +-1 |
+            | g    | h  | ghi,ghi | 30s +-1 |
+            | g    | i  | ghi,ghi | 67s +-1 |
 
     @todo
     Scenario: Starting or ending at a traffic signal should not incur a delay

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -53,9 +53,9 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         source_node.fwd_segment_position + (reversed_source ? 1 : 0);
     const auto source_node_id =
         reversed_source ? source_node.reverse_segment_id.id : source_node.forward_segment_id.id;
-    const auto source_gemetry_id = facade.GetGeometryIndex(source_node_id).id;
+    const auto source_geometry_id = facade.GetGeometryIndex(source_node_id).id;
     const std::vector<NodeID> source_geometry =
-        facade.GetUncompressedForwardGeometry(source_gemetry_id);
+        facade.GetUncompressedForwardGeometry(source_geometry_id);
     geometry.osm_node_ids.push_back(
         facade.GetOSMNodeIDOfNode(source_geometry[source_segment_start_coordinate]));
 
@@ -102,9 +102,9 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
 
     const auto target_node_id =
         reversed_target ? target_node.reverse_segment_id.id : target_node.forward_segment_id.id;
-    const auto target_gemetry_id = facade.GetGeometryIndex(target_node_id).id;
+    const auto target_geometry_id = facade.GetGeometryIndex(target_node_id).id;
     const std::vector<DatasourceID> forward_datasources =
-        facade.GetUncompressedForwardDatasources(target_gemetry_id);
+        facade.GetUncompressedForwardDatasources(target_geometry_id);
 
     // FIXME if source and target phantoms are on the same segment then duration and weight
     // will be from one projected point till end of segment
@@ -127,7 +127,7 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     const auto target_segment_end_coordinate =
         target_node.fwd_segment_position + (reversed_target ? 0 : 1);
     const std::vector<NodeID> target_geometry =
-        facade.GetUncompressedForwardGeometry(target_gemetry_id);
+        facade.GetUncompressedForwardGeometry(target_geometry_id);
     geometry.osm_node_ids.push_back(
         facade.GetOSMNodeIDOfNode(target_geometry[target_segment_end_coordinate]));
 

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -151,6 +151,7 @@ void annotatePath(const FacadeT &facade,
         std::vector<EdgeWeight> weight_vector;
         std::vector<EdgeWeight> duration_vector;
         std::vector<DatasourceID> datasource_vector;
+
         if (geometry_index.forward)
         {
             id_vector = facade.GetUncompressedForwardGeometry(geometry_index.id);
@@ -165,6 +166,7 @@ void annotatePath(const FacadeT &facade,
             duration_vector = facade.GetUncompressedReverseDurations(geometry_index.id);
             datasource_vector = facade.GetUncompressedReverseDatasources(geometry_index.id);
         }
+
         BOOST_ASSERT(id_vector.size() > 0);
         BOOST_ASSERT(datasource_vector.size() > 0);
         BOOST_ASSERT(weight_vector.size() == id_vector.size() - 1);
@@ -307,24 +309,6 @@ void annotatePath(const FacadeT &facade,
             std::max(unpacked_path.front().weight_until_turn - source_weight, 0);
         unpacked_path.front().duration_until_turn =
             std::max(unpacked_path.front().duration_until_turn - source_duration, 0);
-    }
-
-    // there is no equivalent to a node-based node in an edge-expanded graph.
-    // two equivalent routes may start (or end) at different node-based edges
-    // as they are added with the offset how much "weight" on the edge
-    // has already been traversed. Depending on offset one needs to remove
-    // the last node.
-    if (unpacked_path.size() > 1)
-    {
-        const std::size_t last_index = unpacked_path.size() - 1;
-        const std::size_t second_to_last_index = last_index - 1;
-
-        if (unpacked_path[last_index].turn_via_node ==
-            unpacked_path[second_to_last_index].turn_via_node)
-        {
-            unpacked_path.pop_back();
-        }
-        BOOST_ASSERT(!unpacked_path.empty());
     }
 }
 

--- a/include/extractor/compressed_edge_container.hpp
+++ b/include/extractor/compressed_edge_container.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/optional.hpp>
+
 namespace osrm
 {
 namespace extractor
@@ -36,7 +38,11 @@ class CompressedEdgeContainer
                       const EdgeWeight weight1,
                       const EdgeWeight weight2,
                       const EdgeDuration duration1,
-                      const EdgeDuration duration2);
+                      const EdgeDuration duration2,
+                      // node-penalties can be added before/or after the traversal of an edge which
+                      // depends on whether we traverse the link forwards or backwards.
+                      const boost::optional<EdgeWeight> node_weight_penalty = boost::none,
+                      const boost::optional<EdgeDuration> node_duration_penalty = boost::none);
 
     void AddUncompressedEdge(const EdgeID edge_id,
                              const NodeID target_node,

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -40,7 +40,7 @@ class ExtractionContainers
     using NameOffsets = std::vector<unsigned>;
 
     std::vector<OSMNodeID> barrier_nodes;
-    std::vector<OSMNodeID> traffic_lights;
+    std::vector<OSMNodeID> traffic_signals;
     NodeIDVector used_node_id_list;
     NodeVector all_nodes_list;
     EdgeVector all_edges_list;

--- a/include/extractor/extraction_turn.hpp
+++ b/include/extractor/extraction_turn.hpp
@@ -22,6 +22,14 @@ struct ExtractionTurn
     {
     }
 
+    ExtractionTurn(const bool has_traffic_light = false)
+        : angle(0), turn_type(guidance::TurnType::NoTurn),
+          direction_modifier(guidance::DirectionModifier::Straight),
+          has_traffic_light(has_traffic_light), weight(0.), duration(0.), source_restricted(false),
+          target_restricted(false)
+    {
+    }
+
     const double angle;
     const guidance::TurnType::Enum turn_type;
     const guidance::DirectionModifier::Enum direction_modifier;

--- a/include/extractor/graph_compressor.hpp
+++ b/include/extractor/graph_compressor.hpp
@@ -1,6 +1,7 @@
 #ifndef GEOMETRY_COMPRESSOR_HPP
 #define GEOMETRY_COMPRESSOR_HPP
 
+#include "extractor/scripting_environment.hpp"
 #include "util/typedefs.hpp"
 
 #include "util/node_based_graph.hpp"
@@ -24,6 +25,7 @@ class GraphCompressor
   public:
     void Compress(const std::unordered_set<NodeID> &barrier_nodes,
                   const std::unordered_set<NodeID> &traffic_lights,
+                  ScriptingEnvironment &scripting_environment,
                   std::vector<TurnRestriction> &turn_restrictions,
                   util::NodeBasedDynamicGraph &graph,
                   CompressedEdgeContainer &geometry_compressor);

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -103,14 +103,17 @@ SegmentDuration CompressedEdgeContainer::ClipDuration(const SegmentDuration dura
 //   ----------> via_node_id -----------> target_node_id
 //     weight_1                weight_2
 //     duration_1              duration_2
-void CompressedEdgeContainer::CompressEdge(const EdgeID edge_id_1,
-                                           const EdgeID edge_id_2,
-                                           const NodeID via_node_id,
-                                           const NodeID target_node_id,
-                                           const EdgeWeight weight1,
-                                           const EdgeWeight weight2,
-                                           const EdgeDuration duration1,
-                                           const EdgeDuration duration2)
+void CompressedEdgeContainer::CompressEdge(
+    const EdgeID edge_id_1,
+    const EdgeID edge_id_2,
+    const NodeID via_node_id,
+    const NodeID target_node_id,
+    const EdgeWeight weight1,
+    const EdgeWeight weight2,
+    const EdgeDuration duration1,
+    const EdgeDuration duration2,
+    const boost::optional<EdgeWeight> node_weight_penalty,
+    const boost::optional<EdgeDuration> node_duration_penalty)
 {
     // remove super-trivial geometries
     BOOST_ASSERT(SPECIAL_EDGEID != edge_id_1);
@@ -151,9 +154,11 @@ void CompressedEdgeContainer::CompressEdge(const EdgeID edge_id_1,
     std::vector<OnewayCompressedEdge> &edge_bucket_list1 =
         m_compressed_oneway_geometries[edge_bucket_id1];
 
+    bool was_empty = edge_bucket_list1.empty();
+
     // note we don't save the start coordinate: it is implicitly given by edge 1
     // weight1 is the distance to the (currently) last coordinate in the bucket
-    if (edge_bucket_list1.empty())
+    if (was_empty)
     {
         edge_bucket_list1.emplace_back(
             OnewayCompressedEdge{via_node_id, ClipWeight(weight1), ClipDuration(duration1)});
@@ -161,6 +166,14 @@ void CompressedEdgeContainer::CompressEdge(const EdgeID edge_id_1,
 
     BOOST_ASSERT(0 < edge_bucket_list1.size());
     BOOST_ASSERT(!edge_bucket_list1.empty());
+
+    // if the via-node offers a penalty, we add the weight of the penalty as an artificial
+    // segment that references SPECIAL_NODEID
+    if (node_weight_penalty && node_duration_penalty)
+    {
+        edge_bucket_list1.emplace_back(OnewayCompressedEdge{
+            via_node_id, ClipWeight(*node_weight_penalty), ClipDuration(*node_duration_penalty)});
+    }
 
     if (HasEntryForID(edge_id_2))
     {

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -168,6 +168,11 @@ NBGToEBG EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const N
             m_compressed_edge_container.GetBucketReference(edge_id_2)[segment_count - 1 - i]
                 .node_id);
         const NodeID current_edge_target_coordinate_id = forward_geometry[i].node_id;
+
+        // don't add node-segments for penalties
+        if (current_edge_target_coordinate_id == current_edge_source_coordinate_id)
+            continue;
+
         BOOST_ASSERT(current_edge_target_coordinate_id != current_edge_source_coordinate_id);
 
         // build edges

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -616,17 +616,17 @@ void ExtractionContainers::WriteNodes(storage::io::FileWriter &file_out) const
         util::UnbufferedLog log;
         log << "Writing traffic light nodes     ... ";
         TIMER_START(write_nodes);
-        std::vector<NodeID> internal_traffic_lights;
-        for (const auto osm_id : traffic_lights)
+        std::vector<NodeID> internal_traffic_signals;
+        for (const auto osm_id : traffic_signals)
         {
             const auto node_id = mapExternalToInternalNodeID(
                 used_node_id_list.begin(), used_node_id_list.end(), osm_id);
             if (node_id != SPECIAL_NODEID)
             {
-                internal_traffic_lights.push_back(node_id);
+                internal_traffic_signals.push_back(node_id);
             }
         }
-        storage::serialization::write(file_out, internal_traffic_lights);
+        storage::serialization::write(file_out, internal_traffic_signals);
         log << "ok, after " << TIMER_SEC(write_nodes) << "s";
     }
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -454,15 +454,16 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
                                   guidance::LaneDescriptionMap &turn_lane_map)
 {
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    std::unordered_set<NodeID> traffic_signals;
 
     auto node_based_graph =
-        LoadNodeBasedGraph(barrier_nodes, traffic_lights, coordinates, osm_node_ids);
+        LoadNodeBasedGraph(barrier_nodes, traffic_signals, coordinates, osm_node_ids);
 
     CompressedEdgeContainer compressed_edge_container;
     GraphCompressor graph_compressor;
     graph_compressor.Compress(barrier_nodes,
-                              traffic_lights,
+                              traffic_signals,
+                              scripting_environment,
                               turn_restrictions,
                               *node_based_graph,
                               compressed_edge_container);
@@ -474,7 +475,7 @@ Extractor::BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
     EdgeBasedGraphFactory edge_based_graph_factory(node_based_graph,
                                                    compressed_edge_container,
                                                    barrier_nodes,
-                                                   traffic_lights,
+                                                   traffic_signals,
                                                    coordinates,
                                                    osm_node_ids,
                                                    scripting_environment.GetProfileProperties(),

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -69,7 +69,7 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
     }
     if (result_node.traffic_lights)
     {
-        external_memory.traffic_lights.push_back(id);
+        external_memory.traffic_signals.push_back(id);
     }
 }
 

--- a/src/updater/csv_source.cpp
+++ b/src/updater/csv_source.cpp
@@ -36,7 +36,19 @@ SegmentLookupTable readSegmentValues(const std::vector<std::string> &paths)
     CSVFilesParser<Segment, SpeedSource> parser(
         1, qi::ulong_long >> ',' >> qi::ulong_long, qi::uint_ >> -(',' >> qi::double_));
 
-    return parser(paths);
+    // Check consistency of keys in the result lookup table
+    auto result = parser(paths);
+    const auto found_inconsistency =
+        std::find_if(std::begin(result.lookup), std::end(result.lookup), [](const auto &entry) {
+            return entry.first.from == entry.first.to;
+        });
+    if (found_inconsistency != std::end(result.lookup))
+    {
+        throw util::exception("empty segment in CSV with node " +
+                              std::to_string(found_inconsistency->first.from) + " " + SOURCE_REF);
+    }
+
+    return std::move(result);
 }
 
 TurnLookupTable readTurnValues(const std::vector<std::string> &paths)

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -4,6 +4,8 @@
 #include "util/node_based_graph.hpp"
 #include "util/typedefs.hpp"
 
+#include "../unit_tests/mocks/mock_scripting_environment.hpp"
+
 #include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -55,6 +57,7 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     std::unordered_set<NodeID> traffic_lights;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
+    test::MockScriptingEnvironment scripting_environment;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
                                     MakeUnitEdge(1, 0),
@@ -70,7 +73,8 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[6].data));
 
     Graph graph(5, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
+    compressor.Compress(
+        barrier_nodes, traffic_lights, scripting_environment, restrictions, graph, container);
 
     BOOST_CHECK_EQUAL(graph.FindEdge(0, 1), SPECIAL_EDGEID);
     BOOST_CHECK_EQUAL(graph.FindEdge(1, 2), SPECIAL_EDGEID);
@@ -92,6 +96,7 @@ BOOST_AUTO_TEST_CASE(loop_test)
     std::unordered_set<NodeID> traffic_lights;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
+    test::MockScriptingEnvironment scripting_environment;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
                                     MakeUnitEdge(0, 5),
@@ -120,7 +125,8 @@ BOOST_AUTO_TEST_CASE(loop_test)
     BOOST_ASSERT(edges[10].data.IsCompatibleTo(edges[11].data));
 
     Graph graph(6, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
+    compressor.Compress(
+        barrier_nodes, traffic_lights, scripting_environment, restrictions, graph, container);
 
     BOOST_CHECK_EQUAL(graph.FindEdge(5, 0), SPECIAL_EDGEID);
     BOOST_CHECK_EQUAL(graph.FindEdge(0, 1), SPECIAL_EDGEID);
@@ -144,6 +150,7 @@ BOOST_AUTO_TEST_CASE(t_intersection)
     std::unordered_set<NodeID> traffic_lights;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
+    test::MockScriptingEnvironment scripting_environment;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
                                     MakeUnitEdge(1, 0),
@@ -159,7 +166,8 @@ BOOST_AUTO_TEST_CASE(t_intersection)
     BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[5].data));
 
     Graph graph(4, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
+    compressor.Compress(
+        barrier_nodes, traffic_lights, scripting_environment, restrictions, graph, container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);
@@ -177,6 +185,7 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
     std::unordered_set<NodeID> traffic_lights;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
+    test::MockScriptingEnvironment scripting_environment;
 
     std::vector<InputEdge> edges = {
         MakeUnitEdge(0, 1), MakeUnitEdge(1, 0), MakeUnitEdge(1, 2), MakeUnitEdge(2, 1)};
@@ -186,7 +195,8 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
     BOOST_ASSERT(edges[2].data.IsCompatibleTo(edges[3].data));
 
     Graph graph(5, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
+    compressor.Compress(
+        barrier_nodes, traffic_lights, scripting_environment, restrictions, graph, container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);
@@ -203,6 +213,7 @@ BOOST_AUTO_TEST_CASE(direction_changes)
     std::unordered_set<NodeID> traffic_lights;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
+    test::MockScriptingEnvironment scripting_environment;
 
     std::vector<InputEdge> edges = {
         MakeUnitEdge(0, 1), MakeUnitEdge(1, 0), MakeUnitEdge(1, 2), MakeUnitEdge(2, 1)};
@@ -210,7 +221,8 @@ BOOST_AUTO_TEST_CASE(direction_changes)
     edges[1].data.reversed = true;
 
     Graph graph(5, edges);
-    compressor.Compress(barrier_nodes, traffic_lights, restrictions, graph, container);
+    compressor.Compress(
+        barrier_nodes, traffic_lights, scripting_environment, restrictions, graph, container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);

--- a/unit_tests/mocks/mock_scripting_environment.hpp
+++ b/unit_tests/mocks/mock_scripting_environment.hpp
@@ -1,0 +1,47 @@
+#ifndef MOCK_SCRIPTING_ENVIRONMENT_HPP_
+#define MOCK_SCRIPTING_ENVIRONMENT_HPP_
+
+#include "extractor/extraction_segment.hpp"
+#include "extractor/extraction_turn.hpp"
+#include "extractor/profile_properties.hpp"
+#include "extractor/scripting_environment.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace osrm
+{
+
+namespace test
+{
+
+// a mock implementation of the scripting environment doing exactly nothing
+class MockScriptingEnvironment : public extractor::ScriptingEnvironment
+{
+
+    const extractor::ProfileProperties &GetProfileProperties() override final
+    {
+        static extractor::ProfileProperties properties;
+        return properties;
+    }
+
+    std::vector<std::string> GetNameSuffixList() override final { return {}; }
+
+    std::vector<std::string> GetRestrictions() override final { return {}; }
+    void ProcessTurn(extractor::ExtractionTurn &) override final {}
+    void ProcessSegment(extractor::ExtractionSegment &) override final {}
+
+    void ProcessElements(const osmium::memory::Buffer &,
+                         const extractor::RestrictionParser &,
+                         std::vector<std::pair<const osmium::Node &, extractor::ExtractionNode>> &,
+                         std::vector<std::pair<const osmium::Way &, extractor::ExtractionWay>> &,
+                         std::vector<extractor::InputConditionalTurnRestriction> &) override final
+    {
+    }
+};
+
+} // namespace test
+} // namespace osrm
+
+#endif // MOCK_SCRIPTING_ENVIRONMENT_HPP_


### PR DESCRIPTION
# Issue

Second step towards https://github.com/Project-OSRM/osrm-backend/issues/2681.

This PR removes the restriction that we cannot compress `traffic_signals` or anything similar that offers a node penalty.

The basic idea behind node-penalties is that we add a `turn`. So `abc` with a traffic signal at `b` becomes `ab` `bc` with a `turn` of type `NoTurn` in between and a turn penalty that matches the expected delay of the traffic signal.

This way of modelling node-penalties complicates multiple features in OSRM:
 - turn lanes
 - sliproad handling
 - via way restrictions
 - turn angle computations

and possibly even more.

This PR models node-penalties as segments within the graph. `abc` becomes `abbc` with the node-penalty applied to the segment `bb`. This way we don't create artificial turns that influence a lot of the codebase.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] clean-up
    - [x] remove debug
    ~-[]strip lookahead code from turn lanes / sliproads / turn-angles...~ -> should move to a dedicated ticket and kept out of this PR
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Requires #4255 
