### PR TITLE
Don't include turn durations when calculating the speed of a segment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
       - Reorders arguments to `WayHandlers` functions to match `process_way()`.
       - Profiles must return a hash of profile functions. This makes it easier for profiles to include each other.
 
+# 5.9.2
+    - API:
+      - `annotations=durations,weights,speeds` values no longer include turn penalty values ([#4330](https://github.com/Project-OSRM/osrm-backend/issues/4330))
+
 # 5.9.1
     - Infrastructure
       - STXXL is not required by default

--- a/docs/http.md
+++ b/docs/http.md
@@ -539,10 +539,10 @@ Annotation of the whole route leg with fine-grained information about each segme
 **Properties**
 
 - `distance`: The distance, in metres, between each pair of coordinates
-- `duration`: The duration between each pair of coordinates, in seconds
+- `duration`: The duration between each pair of coordinates, in seconds.  Does not include the duration of any turns.
 - `datasources`: The index of the datasource for the speed between each pair of coordinates. `0` is the default profile, other values are supplied via `--segment-speed-file` to `osrm-contract`
 - `nodes`: The OSM node ID for each coordinate along the route, excluding the first/last user-supplied coordinates
-- `weight`: The weights between each pair of coordinates
+- `weight`: The weights between each pair of coordinates.  Does not include any turn costs.
 - `speed`: Convenience field, calculation of `distance / duration` rounded to one decimal place
 
 #### Example

--- a/features/testbot/annotations.feature
+++ b/features/testbot/annotations.feature
@@ -1,0 +1,30 @@
+@routing @speed @annotations @turn_penalty
+Feature: Annotations
+
+    Background:
+        Given the profile "turnbot"
+        Given a grid size of 100 meters
+
+    Scenario: Ensure that turn penalties aren't included in annotations
+        Given the node map
+            """
+              h i
+            j k l m
+            """
+
+        And the query options
+          | annotations | duration,speed,weight |
+
+        And the ways
+            | nodes | highway     |
+            | hk    | residential |
+            | il    | residential |
+            | jk    | residential |
+            | lk    | residential |
+            | lm    | residential |
+
+        When I route I should get
+            | from | to | route    | a:speed     | a:weight |
+            | h    | j  | hk,jk,jk | 6.7:6.7     | 15:15    |
+            | i    | m  | il,lm,lm | 6.7:6.7     | 15:15    |
+            | j    | m  | jk,lm    | 6.7:6.7:6.7 | 15:15:15 |

--- a/include/engine/guidance/leg_geometry.hpp
+++ b/include/engine/guidance/leg_geometry.hpp
@@ -38,8 +38,12 @@ struct LegGeometry
     struct Annotation
     {
         double distance; // distance in meters
-        double duration; // duration in seconds
-        double weight;   // weight value
+
+        // Total duration of a segment, in seconds, NOT including
+        // the turn penalty if the segment preceeds a turn
+        double duration;
+        double weight; // weight value, NOT including the turn weight
+
         DatasourceID datasource;
     };
     std::vector<Annotation> annotations;

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -24,9 +24,17 @@ struct PathData
     // name of the street that leads to the turn
     unsigned name_id;
     // weight that is traveled on the segment until the turn is reached
+    // including the turn weight, if one exists
     EdgeWeight weight_until_turn;
-    // duration that is traveled on the segment until the turn is reached
+    // If this segment immediately preceeds a turn, then duration_of_turn
+    // will contain the weight of the turn.  Otherwise it will be 0.
+    EdgeWeight weight_of_turn;
+    // duration that is traveled on the segment until the turn is reached,
+    // including a turn if the segment preceeds one.
     EdgeWeight duration_until_turn;
+    // If this segment immediately preceeds a turn, then duration_of_turn
+    // will contain the duration of the turn.  Otherwise it will be 0.
+    EdgeWeight duration_of_turn;
     // instruction to execute at the turn
     extractor::guidance::TurnInstruction turn_instruction;
     // turn lane data

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -186,7 +186,9 @@ void annotatePath(const FacadeT &facade,
             unpacked_path.push_back(PathData{id_vector[segment_idx + 1],
                                              name_index,
                                              weight_vector[segment_idx],
+                                             0,
                                              duration_vector[segment_idx],
+                                             0,
                                              extractor::guidance::TurnInstruction::NO_TURN(),
                                              {{0, INVALID_LANEID}, INVALID_LANE_DESCRIPTIONID},
                                              travel_mode,
@@ -200,10 +202,15 @@ void annotatePath(const FacadeT &facade,
         if (facade.HasLaneData(turn_id))
             unpacked_path.back().lane_data = facade.GetLaneData(turn_id);
 
+        const auto turn_duration = facade.GetDurationPenaltyForEdgeID(turn_id);
+        const auto turn_weight = facade.GetWeightPenaltyForEdgeID(turn_id);
+
         unpacked_path.back().entry_class = facade.GetEntryClass(turn_id);
         unpacked_path.back().turn_instruction = turn_instruction;
-        unpacked_path.back().duration_until_turn += facade.GetDurationPenaltyForEdgeID(turn_id);
-        unpacked_path.back().weight_until_turn += facade.GetWeightPenaltyForEdgeID(turn_id);
+        unpacked_path.back().duration_until_turn += turn_duration;
+        unpacked_path.back().duration_of_turn = turn_duration;
+        unpacked_path.back().weight_until_turn += turn_weight;
+        unpacked_path.back().weight_of_turn = turn_weight;
         unpacked_path.back().pre_turn_bearing = facade.PreTurnBearing(turn_id);
         unpacked_path.back().post_turn_bearing = facade.PostTurnBearing(turn_id);
     }
@@ -262,7 +269,9 @@ void annotatePath(const FacadeT &facade,
             PathData{id_vector[start_index < end_index ? segment_idx + 1 : segment_idx - 1],
                      facade.GetNameIndex(target_node_id),
                      weight_vector[segment_idx],
+                     0,
                      duration_vector[segment_idx],
+                     0,
                      extractor::guidance::TurnInstruction::NO_TURN(),
                      {{0, INVALID_LANEID}, INVALID_LANE_DESCRIPTIONID},
                      facade.GetTravelMode(target_node_id),


### PR DESCRIPTION
# Issue

This is a proposed fix for https://github.com/Project-OSRM/osrm-backend/issues/4330 where we're not returning the same values with `annotations=speed` that we load via the traffic data mechanism, because we're including turn durations in segment durations for the last segment in any leg.

This change subtracts the turn duration from the duration annotation, and corrects both the `duration` and the `speed` annotation values to align with any traffic data loaded.  Turn duration data is now not included in any duration-based annotations (it is still included in the `weight` annotation, per [this line](https://github.com/Project-OSRM/osrm-backend/blob/6c0ab24100bb0917875eedba1f3c3a64ae158799/include/engine/routing_algorithms/routing_base.hpp#L206).

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments