### PR TITLE
handle throughabouts -- do not announce going through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
       - Pass functions instead of strings to `WayHandlers.run()`, so it's possible to mix in your own functions.
       - Reorders arguments to `WayHandlers` functions to match `process_way()`.
       - Profiles must return a hash of profile functions. This makes it easier for profiles to include each other.
+      - Guidance: add support for throughabouts
 
 # 5.9.1
     - Infrastructure

--- a/features/guidance/roundabout-turn.feature
+++ b/features/guidance/roundabout-turn.feature
@@ -567,5 +567,5 @@ Feature: Basic Roundabout
             | ab    | residential   | in      |            |        |
 
         When I route I should get
-            | waypoints | turns                                                    | route                      |
-            | a,f       | depart,turn right,roundabout turn straight exit-1,arrive | in,through,through,through |
+            | waypoints | turns                    | route              |
+            | a,f       | depart,turn right,arrive | in,through,through |

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -763,7 +763,7 @@ Feature: Basic Roundabout
 
         When I route I should get
            | waypoints | bearings | route       | turns                           |
-           | e,f       | 90 90    | edf,edf,edf | depart,roundabout-exit-1,arrive |
+           | e,f       | 90 90    | edf,edf     | depart,arrive                   |
            | e,h       | 90 135   | edf,gch,gch | depart,roundabout-exit-2,arrive |
            | g,f       | 45 90    | gch,edf,edf | depart,roundabout-exit-2,arrive |
            | g,h       | 45 135   | gch,gch,gch | depart,roundabout-exit-1,arrive |
@@ -843,6 +843,6 @@ Feature: Basic Roundabout
 
 
         When I route I should get
-            | from | to | route                        | turns                                                             | distance |
-            | e    | k  | ebds,ebds,ds,ufghl,jhik,jhik | depart,rotary-exit-1,rotary-exit-1,rstur-exit-2,turn right,arrive | 189.1m   |
-            | 1    | k  | ebds,ds,ufghl,jhik,jhik      | depart,rotary-exit-1,rstur-exit-2,turn right,arrive               | 159.1m   |
+            | from | to | route                | turns                                 | distance |
+            | e    | k  | ebds,ufghl,jhik,jhik | depart,rstur-exit-2,turn right,arrive | 189.1m   |
+            | 1    | k  | ebds,ufghl,jhik,jhik | depart,rstur-exit-2,turn right,arrive | 159.1m   |


### PR DESCRIPTION
# Issue

This PR resolves #3142 and resolves #4107. For a quick fix, this PR is walking the road of the most silent instructions possible. So for going through a throughabout, we will not see any instruction in the usual case.
This might result in confusion for strange maneuvers, but I would consider most of these to ne separate issues.

Compare screenshots for examples:
![screen shot 2017-07-25 at 16 55 41 2](https://user-images.githubusercontent.com/12932279/28579814-032894aa-715e-11e7-99cc-e41a0e290387.png)
[osm-link](https://www.openstreetmap.org/#map=19/38.91721/-76.97792)

![screen shot 2017-07-25 at 17 08 27 2](https://user-images.githubusercontent.com/12932279/28579828-0fab17a2-715e-11e7-81fc-f6fee3b5642e.png)
going through the roundabout doesn't announce a maneuver. This might be overdoing the `silent` part. Should we go for a separate instruction here as in `Use the throughlane`

![screen shot 2017-07-25 at 17 10 01 2](https://user-images.githubusercontent.com/12932279/28579834-11b1418e-715e-11e7-9940-937da3099f70.png)
Exits like these make counting exits really confusing. They could use some improvement.

![screen shot 2017-07-25 at 17 11 06 2](https://user-images.githubusercontent.com/12932279/28579838-1440e404-715e-11e7-91cd-62a8cfc96d08.png)

Usually I would expect a normal `exit` to ne on the outside of the roundabout. It would be nice to clarify this through lane here.

/cc @1ec5  

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [x] ticket further improvements
 - [ ] add changelog entry
