### PR TITLE
Reintroduce location for NodeRef in luabinding

### DIFF
--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -396,8 +396,12 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                "target_restricted",
                                                &ExtractionTurn::target_restricted);
 
-    // Keep in mind .location is undefined since we're not using libosmium's location cache
-    context.state.new_usertype<osmium::NodeRef>("NodeRef", "id", &osmium::NodeRef::ref);
+    // Keep in mind .location is available only if .pbf is preprocessed to set the location with the
+    // ref using osmium command "osmium add-locations-to-ways"
+    context.state.new_usertype<osmium::NodeRef>(
+        "NodeRef", "id", &osmium::NodeRef::ref, "location", [](const osmium::NodeRef &nref) {
+            return nref.location();
+        });
 
     context.state.new_usertype<InternalExtractorEdge>("EdgeSource",
                                                       "source_coordinate",


### PR DESCRIPTION
Hello,

This PR reintroduce the location  NodeRef in luabinding.
We can feed NodeRef with `osmium-tool` and access to them with `--with-osm-metadata` option on `osrm-extract` command.
In lua script we can test if the location is valid with #3453.

This is a bug/forgets, could you add this PR to the next release ?

Best regards,
Maxime