### PR TITLE
Emit continue instruction on motorway when lanes split

### DIFF
--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -297,5 +297,5 @@ Feature: Motorway Guidance
 
         When I route I should get
             | waypoints | route | turns                               |
-            | a,c       | ,     | depart,arrive                       |
+            | a,c       | ,,    | depart,continue straight,arrive     |
             | a,f       | ,,    | depart,off ramp slight right,arrive |

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -281,3 +281,21 @@ Feature: Motorway Guidance
             | waypoints | route | turns         |
             | a,d       | ,     | depart,arrive |
             | b,d       | ,     | depart,arrive |
+
+     Scenario: Multi Lane highway splitting
+        Given the node map
+            """
+            a - - - - b - - - - - c
+                          e - - - f
+            """
+
+        And the ways
+            | nodes | name | ref    | highway       | oneway | lanes |
+            | ab    |      | US 101 | motorway      | yes    | 5     |
+            | bc    |      | US 101 | motorway      | yes    | 3     |
+            | bef   |      |        | motorway_link | yes    | 2     |
+
+        When I route I should get
+            | waypoints | route | turns                               |
+            | a,c       | ,     | depart,arrive                       |
+            | a,f       | ,,    | depart,off ramp slight right,arrive |

--- a/include/util/geojson_debug_policies.hpp
+++ b/include/util/geojson_debug_policies.hpp
@@ -18,13 +18,13 @@ namespace util
 
 struct NodeIdVectorToLineString
 {
-    NodeIdVectorToLineString(const std::vector<extractor::QueryNode> &node_coordinates);
+    NodeIdVectorToLineString(const std::vector<util::Coordinate> &node_coordinates);
 
     // converts a vector of node ids into a linestring geojson feature
     util::json::Object operator()(const std::vector<NodeID> &node_ids,
                                   const boost::optional<json::Object> &properties = {}) const;
 
-    const std::vector<extractor::QueryNode> &node_coordinates;
+    const std::vector<util::Coordinate> &node_coordinates;
 };
 
 struct CoordinateVectorToLineString
@@ -36,13 +36,13 @@ struct CoordinateVectorToLineString
 
 struct NodeIdVectorToMultiPoint
 {
-    NodeIdVectorToMultiPoint(const std::vector<extractor::QueryNode> &node_coordinates);
+    NodeIdVectorToMultiPoint(const std::vector<util::Coordinate> &node_coordinates);
 
     // converts a vector of node ids into a linestring geojson feature
     util::json::Object operator()(const std::vector<NodeID> &node_ids,
                                   const boost::optional<json::Object> &properties = {}) const;
 
-    const std::vector<extractor::QueryNode> &node_coordinates;
+    const std::vector<util::Coordinate> &node_coordinates;
 };
 
 struct CoordinateVectorToMultiPoint

--- a/include/util/geojson_debug_policy_toolkit.hpp
+++ b/include/util/geojson_debug_policy_toolkit.hpp
@@ -69,12 +69,12 @@ struct CoordinateToJsonArray
 
 struct NodeIdToCoordinate
 {
-    NodeIdToCoordinate(const std::vector<extractor::QueryNode> &node_coordinates)
+    NodeIdToCoordinate(const std::vector<util::Coordinate> &node_coordinates)
         : node_coordinates(node_coordinates)
     {
     }
 
-    const std::vector<extractor::QueryNode> &node_coordinates;
+    const std::vector<util::Coordinate> &node_coordinates;
 
     util::json::Array operator()(const NodeID nid)
     {

--- a/src/util/geojson_debug_policies.cpp
+++ b/src/util/geojson_debug_policies.cpp
@@ -11,7 +11,7 @@ namespace util
 
 //----------------------------------------------------------------
 NodeIdVectorToLineString::NodeIdVectorToLineString(
-    const std::vector<extractor::QueryNode> &node_coordinates)
+    const std::vector<util::Coordinate> &node_coordinates)
     : node_coordinates(node_coordinates)
 {
 }
@@ -32,7 +32,7 @@ operator()(const std::vector<NodeID> &node_ids,
 
 //----------------------------------------------------------------
 NodeIdVectorToMultiPoint::NodeIdVectorToMultiPoint(
-    const std::vector<extractor::QueryNode> &node_coordinates)
+    const std::vector<util::Coordinate> &node_coordinates)
     : node_coordinates(node_coordinates)
 {
 }


### PR DESCRIPTION
# Issue

resolves https://github.com/Project-OSRM/osrm-backend/issues/4340

## Impact

A list of locations triggering this changed instruction:

[Germany](http://bl.ocks.org/d/fcff660c16780abccc91f1116befd36b)

[California](http://bl.ocks.org/d/129027f0048e79a426cd9160778fe4e6)

## Tasklist
 - [ ] evaluate above maps to check whether announced turns are or aren't desirable
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
