### PR TITLE
Fixed getting entry bearing for maneuver.

### DIFF
--- a/src/engine/guidance/collapse_scenario_detection.cpp
+++ b/src/engine/guidance/collapse_scenario_detection.cpp
@@ -17,7 +17,7 @@ namespace
 {
 
 // check bearings for u-turns.
-// since bearings are wrapped around at 0 (we only support 0,360), we need to do some minor math to
+// since bearings are wrapped around at 0 (we only support 0,360), we need to do some minor math to
 // check if bearings `a` and `b` go in opposite directions. In general we accept some minor
 // deviations for u-turns.
 bool bearingsAreReversed(const double bearing_in, const double bearing_out)
@@ -123,7 +123,7 @@ bool isStaggeredIntersection(const RouteStepIterator step_prior_to_intersection,
 
     const auto angle = [](const RouteStep &step) {
         const auto &intersection = step.intersections.front();
-        const auto entry_bearing = intersection.bearings[intersection.in];
+        const auto entry_bearing = util::bearing::reverse(intersection.bearings[intersection.in]);
         const auto exit_bearing = intersection.bearings[intersection.out];
         return util::bearing::angleBetween(entry_bearing, exit_bearing);
     };


### PR DESCRIPTION
To get entry bearing for maneuver, we need to reverse 'in' bearing for intersection, how it's made in other functions.