### PR TITLE
Fix a single weekday grammar callback

### DIFF
--- a/include/util/opening_hours.hpp
+++ b/include/util/opening_hours.hpp
@@ -12,6 +12,7 @@ namespace util
 {
 
 // Helper classes for "opening hours" format http://wiki.openstreetmap.org/wiki/Key:opening_hours
+// Grammar https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification
 // Supported simplified features in CheckOpeningHours:
 // - Year/Month/Day ranges
 // - Weekday ranges

--- a/src/util/opening_hours.cpp
+++ b/src/util/opening_hours.cpp
@@ -218,9 +218,9 @@ struct opening_hours_grammar : qi::grammar<Iterator, Skipper, std::vector<Openin
         weekday_sequence = (weekday_range % ',')[ph::bind(&OpeningHours::weekdays, _r1) = _1];
 
         weekday_range
-            = wday[_a = _1, _b = _1]
-            >> -(('-' >> wday[_b = _1])
-                 | ('[' >> (nth_entry % ',') >> ']' >> -day_offset))
+            = (wday[_a = _1, _b = _1]
+               >> -(('-' >> wday[_b = _1])
+                    | ('[' >> (nth_entry % ',') >> ']' >> -day_offset)))
             [_val = ph::construct<OpeningHours::WeekdayRange>(_a, _b)]
             ;
 


### PR DESCRIPTION
# Issue

The PR adds a constructor callback for a single weekday condition like `Su 00:00-24:00`

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
