### PR TITLE
Fix sliproad scenario with 4 roads in a target intersection

### DIFF
--- a/features/guidance/dedicated-turn-roads.feature
+++ b/features/guidance/dedicated-turn-roads.feature
@@ -944,3 +944,30 @@ Feature: Slipways and Dedicated Turn Lanes
         When I route I should get
             | waypoints | route     | turns                                                 | locations |
             | a,k       | road,,,   | depart,turn right,roundabout turn right exit-1,arrive | a,b,h,k   |
+
+    @sliproads
+    Scenario: Sliproad with 4 roads at target
+        Given the node map
+            """
+                    d
+                    .
+            s . a . b  . c . t
+                 `  .   '
+                  ` .  '
+                   '.'
+                    e
+                    .
+                    f
+            """
+
+        And the ways
+            | nodes | highway      | name  | oneway |
+            | sabct | primary      | sabct |        |
+            | dbef  | primary      | dbef  |        |
+            | ae    | primary_link | ae    | yes    |
+            | ec    | primary_link | ec    | yes    |
+
+       When I route I should get
+            | waypoints | route              | turns                                      | locations |
+            | s,f       | sabct,ae,dbef,dbef | depart,turn right,turn slight right,arrive | s,a,e,f   |
+            | f,t       | dbef,sabct,sabct   | depart,turn right,arrive                   | f,e,t     |

--- a/features/guidance/dedicated-turn-roads.feature
+++ b/features/guidance/dedicated-turn-roads.feature
@@ -968,6 +968,6 @@ Feature: Slipways and Dedicated Turn Lanes
             | ec    | primary_link | ec    | yes    |
 
        When I route I should get
-            | waypoints | route              | turns                                      | locations |
-            | s,f       | sabct,ae,dbef,dbef | depart,turn right,turn slight right,arrive | s,a,e,f   |
-            | f,t       | dbef,sabct,sabct   | depart,turn right,arrive                   | f,e,t     |
+            | waypoints | route            | turns                    | locations |
+            | s,f       | sabct,dbef,dbef  | depart,turn right,arrive | s,a,f     |
+            | f,t       | dbef,sabct,sabct | depart,turn right,arrive | f,e,t     |


### PR DESCRIPTION
# Issue
The pull requests fixes scenario 1 of #4348

EDIT: @MoKob i did not add traffic light nodes traversing, it implies dependency on #4327 

![screenshot from 2017-08-01 17-23-51](https://user-images.githubusercontent.com/4421046/28847318-10c4c0dc-770f-11e7-878b-a908aeccc7af.png)


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

