### PR TITLE
Fix gcc5 internal compilation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -301,7 +301,7 @@ before_install:
   - mkdir -p ${CMAKE_DIR}
   - travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${CMAKE_DIR} || travis_terminate 1
   - export PATH=${CMAKE_DIR}/bin:${PATH}
-  - ${MASON} install tbb 2017_20161128 && export LD_LIBRARY_PATH=$(${MASON} prefix tbb 2017_20161128)/lib/:${LD_LIBRARY_PATH}
+  - ${MASON} install tbb 2017_U7 && export LD_LIBRARY_PATH=$(${MASON} prefix tbb 2017_U7)/lib/:${LD_LIBRARY_PATH}
   - ${MASON} install ccache ${CCACHE_VERSION} && export PATH=$(${MASON} prefix ccache ${CCACHE_VERSION})/bin:${PATH}
   - |
     if [[ ! -z ${CLANG_VERSION} ]]; then

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -749,40 +749,36 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                                 // next to the normal restrictions tracked in `entry_allowed`, via
                                 // ways might introduce additional restrictions. These are handled
                                 // here when turning off a via-way
-                                const auto add_unrestricted_turns =
-                                    [&](const auto duplicated_node_id) {
-                                        const auto from_id =
-                                            m_number_of_edge_based_nodes -
-                                            way_restriction_map.NumberOfDuplicatedNodes() +
-                                            duplicated_node_id;
+                                for (auto duplicated_node_id : duplicated_nodes)
+                                {
+                                    const auto from_id =
+                                        m_number_of_edge_based_nodes -
+                                        way_restriction_map.NumberOfDuplicatedNodes() +
+                                        duplicated_node_id;
 
-                                        auto const node_at_end_of_turn =
-                                            m_node_based_graph->GetTarget(turn.eid);
+                                    auto const node_at_end_of_turn =
+                                        m_node_based_graph->GetTarget(turn.eid);
 
-                                        const auto is_restricted = way_restriction_map.IsRestricted(
-                                            duplicated_node_id, node_at_end_of_turn);
+                                    const auto is_restricted = way_restriction_map.IsRestricted(
+                                        duplicated_node_id, node_at_end_of_turn);
 
-                                        if (is_restricted)
-                                            return;
+                                    if (is_restricted)
+                                        continue;
 
-                                        // add into delayed data
-                                        auto edge_with_data = generate_edge(
-                                            NodeID(from_id),
-                                            m_node_based_graph->GetEdgeData(turn.eid).edge_id,
-                                            node_along_road_entering,
-                                            incoming_edge,
-                                            node_at_center_of_intersection,
-                                            turn.eid,
-                                            intersection,
-                                            turn,
-                                            entry_class_id);
+                                    // add into delayed data
+                                    auto edge_with_data = generate_edge(
+                                        NodeID(from_id),
+                                        m_node_based_graph->GetEdgeData(turn.eid).edge_id,
+                                        node_along_road_entering,
+                                        incoming_edge,
+                                        node_at_center_of_intersection,
+                                        turn.eid,
+                                        intersection,
+                                        turn,
+                                        entry_class_id);
 
-                                        buffer->delayed_data.push_back(std::move(edge_with_data));
-                                    };
-
-                                std::for_each(duplicated_nodes.begin(),
-                                              duplicated_nodes.end(),
-                                              add_unrestricted_turns);
+                                    buffer->delayed_data.push_back(std::move(edge_with_data));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# Issue

8d0202d24 introduces a generic lambda that probably hits https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69977

PR restructures the code to avoid usage of the lambda without changes in code logic.
Without the change we have to drop gcc5 support and require at least 6 or 4.9 gcc version.

/cc @MoKob 

## Tasklist
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
