### PR TITLE
Add destination tags check in the best option for obvious turns

### DIFF
--- a/features/guidance/ramp.feature
+++ b/features/guidance/ramp.feature
@@ -276,3 +276,23 @@ Feature: Ramp Guidance
         When I route I should get
             | waypoints | route                        |
             | a,e       | boarding,boaty mc boatface,, |
+
+
+    # https://www.openstreetmap.org/way/392513452
+    Scenario: Fork with destinations
+        Given the node map
+            """
+                    ..---c
+            a.b..--------d
+            """
+
+        And the ways
+            | nodes | highway       | name | oneway | destination                      | destination:ref                       |
+            | ab    | unclassified  |      | yes    | San Jose;San Francisco           | US 101 South; US 101 North;I 380 West |
+            | bc    | unclassified  |      | yes    | Terminals                        |                                       |
+            | bd    | motorway_link |      | yes    | San Francisco;San Jose;San Bruno | US 101 South; US 101 North;I 380 West |
+
+       When I route I should get
+            | waypoints | route | turns                              |
+            | a,c       | ,     | depart,arrive                      |
+            | a,d       | ,,    | depart,on ramp slight right,arrive |

--- a/features/guidance/ramp.feature
+++ b/features/guidance/ramp.feature
@@ -293,6 +293,6 @@ Feature: Ramp Guidance
             | bd    | motorway_link |      | yes    | San Francisco;San Jose;San Bruno | US 101 South; US 101 North;I 380 West |
 
        When I route I should get
-            | waypoints | route | turns                              |
-            | a,c       | ,     | depart,arrive                      |
-            | a,d       | ,,    | depart,on ramp slight right,arrive |
+            | waypoints | route | turns                           |
+            | a,c       | ,,    | depart,continue straight,arrive |
+            | a,d       | ,,    | depart,on ramp straight,arrive  |

--- a/include/util/guidance/destinations_similarity.hpp
+++ b/include/util/guidance/destinations_similarity.hpp
@@ -1,0 +1,56 @@
+#ifndef OSRM_UTIL_GUIDANCE_DESTINATIONS_SIMILARITY_HPP
+#define OSRM_UTIL_GUIDANCE_DESTINATIONS_SIMILARITY_HPP
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/function_output_iterator.hpp>
+
+#include <iostream>
+
+namespace osrm
+{
+namespace util
+{
+namespace guidance
+{
+
+template <typename T> auto getDestinationTokens(const T &destination)
+{
+    std::vector<std::string> splited;
+    boost::split(splited, destination, boost::is_any_of(",:"));
+
+    std::set<std::string> tokens;
+    std::transform(
+        splited.begin(), splited.end(), std::inserter(tokens, tokens.end()), [](auto token) {
+            boost::trim(token);
+            boost::to_lower(token);
+            return token;
+        });
+    return tokens;
+}
+
+template <typename T> double getSetsSimilarity(const T &lhs, const T &rhs)
+{
+    if (lhs.size() + rhs.size() == 0)
+        return 1.;
+
+    std::size_t count = 0;
+    auto counter = [&count](const std::string &) { ++count; };
+    std::set_intersection(lhs.begin(),
+                          lhs.end(),
+                          rhs.begin(),
+                          rhs.end(),
+                          boost::make_function_output_iterator(std::ref(counter)));
+
+    return static_cast<double>(count) / (lhs.size() + rhs.size() - count);
+}
+
+} // namespace guidance
+} // namespace util
+} // namespace osrm
+
+#endif /* OSRM_UTIL_GUIDANCE_DESTINATIONS_SIMILARITY_HPP */

--- a/unit_tests/util/destinations_similarity.cpp
+++ b/unit_tests/util/destinations_similarity.cpp
@@ -1,0 +1,37 @@
+#include "util/guidance/destinations_similarity.hpp"
+
+#include <boost/test/test_case_template.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <iterator>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(destination_similarity_test)
+
+using namespace osrm;
+using namespace osrm::util;
+using namespace osrm::util::guidance;
+
+BOOST_AUTO_TEST_CASE(similarity_test)
+{
+    struct Data
+    {
+        std::string lhs, rhs;
+        double result;
+    } const data[] = {{"", "", 1.},
+                      {"A", "A", 1.},
+                      {"A", "B", 0.},
+                      {"A", "A, B", 0.5},
+                      {"US 101 South,  US 101 North, I 380 West: San Jose, San Francisco",
+                       "US 101, US 101 North, I 380 West",
+                       1. / 3}};
+
+    for (std::size_t i = 0; i < sizeof(data) / sizeof(data[0]); ++i)
+    {
+        const auto &lhs = getDestinationTokens(data[i].lhs);
+        const auto &rhs = getDestinationTokens(data[i].rhs);
+        BOOST_CHECK_EQUAL(getSetsSimilarity(lhs, rhs), data[i].result);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

PR fixes some cases in finding of obvious turns https://github.com/Project-OSRM/osrm-backend/issues/3365#issuecomment-319931253 using destination tags. 

The comparing function for the best option now includes a similarity check of `in_way` destinations and destinations of candidates. The check modifies results of `findObviousTurn` at 170 places in CA and DE.

Some examples of new behavior will be:
- [`Continue towards Terminals` and `Take the ramp towards US 101 South`](http://map.project-osrm.org/?z=18&center=37.614852%2C-122.392641&loc=37.614950%2C-122.392368&loc=37.614724%2C-122.392899&hl=en&alt=0)

- [`Keep left at the fork towards San Francisco Airport Domestic Arrivals`](http://map.project-osrm.org/?z=18&center=37.613305%2C-122.393575&loc=37.612328%2C-122.394669&loc=37.613203%2C-122.395350&hl=en&alt=0)

- [`Keep left at the fork towards Avalon Drive` and `Keep right at the fork towards Westborough Boulevard`](http://map.project-osrm.org/?z=18&center=37.638096%2C-122.439070&loc=37.638568%2C-122.440513&loc=37.639834%2C-122.441205&hl=en&alt=0)

- [`Keep left at the fork towards I 280 North: San Francisco` and `Keep right at the fork towards Sneath Lane`](http://map.project-osrm.org/?z=18&center=37.629572%2C-122.431448&loc=37.628397%2C-122.431469&loc=37.629770%2C-122.433057&hl=en&alt=0)

- [`Keep left at the fork towards San Bruno Avenue` and `	Keep right at the fork towards Sneath Lane`](http://map.project-osrm.org/?z=17&center=37.629600%2C-122.431512&loc=37.631499%2C-122.436801&loc=37.629596%2C-122.434913&hl=en&alt=0)

- [`Keep left at the fork` and `Keep right at the fork towards Sneath Lane`](http://map.project-osrm.org/?z=18&center=37.629538%2C-122.435557&loc=37.629472%2C-122.435031&loc=37.629770%2C-122.436072&hl=en&alt=0)

- [`Keep right at the fork towards A 9: München` and `Keep left at the fork towards A 9: Stuttgart`](http://map.project-osrm.org/?z=18&center=48.206416%2C11.619394&loc=48.206643%2C11.619673&loc=48.206071%2C11.620885&hl=en&alt=0)

- [`Keep left at the fork onto Abfahrt 19 Kreuz Bochum/Witten` and `Keep right at the fork towards A 44: Bochum`](http://map.project-osrm.org/?z=18&center=51.463896%2C7.287181&loc=51.464405%2C7.288029&loc=51.463493%2C7.288131&hl=en&alt=0)

- [`Keep left at the fork towards Grazer Damm` and `Keep right at the fork towards A 103: Steglitz`](http://map.project-osrm.org/?z=18&center=52.474166%2C13.348571&loc=52.474730%2C13.348668&loc=52.473606%2C13.348410&hl=en&alt=0)

- [`Keep right at the fork towards A 113: Dresden` and `Keep left at the fork towards A 100: Grenzallee`](http://map.project-osrm.org/?z=18&center=52.463450%2C13.449840&loc=52.463331%2C13.449465&loc=52.463527%2C13.450232&hl=en&alt=0)

- [`Keep left at the fork` and `Keep right at the fork towards James M Wood Boulevard`](http://map.project-osrm.org/?z=18&center=34.047368%2C-118.267007&loc=34.047055%2C-118.267538&loc=34.048010%2C-118.265950&hl=en&alt=0)

At some places, like http://map.project-osrm.org/?z=18&center=52.477123%2C13.353994&loc=52.477363%2C13.354306&loc=52.476752%2C13.353860&hl=en&alt=0, 
changed results do not change guidance instructions.


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
