### PR TITLE
Ignore build directories starting with _build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 
 # build related files #
 #######################
+/_build*
 /build/
 /example/build/
 /test/data/monaco*


### PR DESCRIPTION
Convenient to manage multiple builds with basic naming convention (eg. `_build.gcc7`, `_build.vs2017`).
