### PR TITLE
Add define WIN32_LEAN_AND_MEAN for Visual C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   # using Visual Studio C++
   set(BOOST_COMPONENTS ${BOOST_COMPONENTS} zlib)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # avoid compiler error C1128 from scripting_environment_lua.cpp
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32_LEAN_AND_MEAN") # avoid compiler error C2011 from dual #include of winsock.h and winsock2.h
   add_dependency_defines(-DBOOST_LIB_DIAGNOSTIC)
   add_dependency_defines(-D_CRT_SECURE_NO_WARNINGS)
   add_dependency_defines(-DNOMINMAX) # avoid min and max macros that can break compilation


### PR DESCRIPTION
Helps to avoid compiler C2011 errors due to WinSock types redefinition from dual #include of winsock.h and winsock2.h

------

This helps to cope with WinSock being include by third-party libraries or client code itself.

There have been [several issues reported about compilation errors due to WinSock](https://github.com/Project-OSRM/osrm-backend/search?q=WinSock&type=Issues), so perhaps this fix could have solved those too. 

Sample of compile errors with minimal extract of includes tree showing the problem (`winsock.h` and `winsock2.h` inclusion):

Compiling `src/extractor/extractor.cpp` file with MSVC:

```
...
1>Note: including file: F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\osmium/io/any_input.hpp
1>Note: including file:  F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\osmium/io/any_compression.hpp
1>Note: including file:   F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\osmium/io/bzip2_compression.hpp
1>Note: including file:    F:\V9.x64\Libraries\External\Source\bzip2\bzip2\bzlib.h
1>Note: including file:     C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\windows.h
...
1>Note: including file:      C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\winsock.h
...
1>Note: including file:  F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\osmium/io/pbf_input.hpp
1>Note: including file:   F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\osmium/io/detail/pbf_input_format.hpp
1>Note: including file:    C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.10.25017\include\cassert
1>Note: including file:     C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\ucrt\assert.h
1>Note: including file:    F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\protozero/pbf_message.hpp
1>Note: including file:     F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\protozero/pbf_reader.hpp
1>Note: including file:      F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\protozero/config.hpp
1>Note: including file:       C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.10.25017\include\cassert
1>Note: including file:        C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\ucrt\assert.h
1>Note: including file:      F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\protozero/iterators.hpp
1>Note: including file:      F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\protozero/types.hpp
1>Note: including file:    F:\V9.x64\Libraries\External\Source\libosmium\libosmium\include\osmium/io/detail/pbf.hpp
1>Note: including file:     C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\winsock2.h
...
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\shared\ws2def.h(103): warning C4005: 'AF_IPX': macro redefinition
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\winsock.h(457): note: see previous definition of 'AF_IPX'
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\shared\ws2def.h(136): warning C4005: 'AF_MAX': macro redefinition
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\winsock.h(476): note: see previous definition of 'AF_MAX'
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\shared\ws2def.h(185): warning C4005: 'SO_DONTLINGER': macro redefinition
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\winsock.h(399): note: see previous definition of 'SO_DONTLINGER'
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\shared\ws2def.h(235): error C2011: 'sockaddr': 'struct' type redefinition
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um\winsock.h(1007): note: see declaration of 'sockaddr'
```
...
```