### PR TITLE
Add workaround for Visual C++ issue with std::array in debug

### DIFF
--- a/include/extractor/profile_properties.hpp
+++ b/include/extractor/profile_properties.hpp
@@ -83,7 +83,8 @@ struct ProfileProperties
     std::string GetClassName(std::size_t index) const
     {
         BOOST_ASSERT(index <= MAX_CLASS_INDEX);
-        return std::string(class_names[index]);
+        const auto &name_it = std::begin(class_names) + index;
+        return std::string(*name_it);
     }
 
     double GetWeightMultiplier() const { return std::pow(10., weight_precision); }


### PR DESCRIPTION
If Visual C++ `_ITERATOR_DEBUG_LEVEL > 0`  (eg. while building Debug configuration), then accessing `std::array<char[N], M>` elements via reference to const causes compilation error:

```
...\msvc\14.10.25017\include\array(181): error C2440: 'return': cannot convert from 'const char *' to 'const char (&)[256]'
```

Alternative workaround is to remove `const` qualifier from the `GetClassName` method.

------

TBH, I haven't checked in details why the iterator debug facilities are being **annoying**.
I have reported it as an issue 
https://developercommunity.visualstudio.com/content/problem/90761/iterator-debug-level-causes-problems-with-stdarray.html