### PR TITLE
explicitly use local version for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     ]
   },
   "scripts": {
-    "lint": "eslint -c ./.eslintrc features/step_definitions/ features/support/",
+    "lint": "node ./node_modules/eslint/bin/eslint.js -c ./.eslintrc features/step_definitions/ features/support/",
     "test": "npm run lint && node ./node_modules/cucumber/bin/cucumber.js features/ -p verify && node ./node_modules/cucumber/bin/cucumber.js features/ -p mld",
     "clean": "rm -rf test/cache",
     "docs": "./scripts/build_api_docs.sh",


### PR DESCRIPTION
# Issue

Explicitly use install eslint version from `node_modules/eslint/bin/eslint.js` instead of potentially conflicting global version.

Fixes builds from failing due to different eslint versions on linux/mac os environments.

## Tasklist
 - [ ] review
 - [ ] adjust for comments