### PR TITLE
Fix boost::optional construction error

### DIFF
--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -249,7 +249,7 @@ IntersectionView IntersectionGenerator::TransformIntersectionShapeIntoView(
             return pair.second->is_only;
         });
         if (itr != restrictions.second)
-            return {itr->second->AsNodeRestriction().to};
+            return itr->second->AsNodeRestriction().to;
         else
             return boost::none;
     };


### PR DESCRIPTION
# Issue

Small fix for 
```
/osrm-backend/src/extractor/guidance/intersection_generator.cpp:252:56: error: converting to ‘boost::optional<unsigned int>’ from initializer list would use explicit constructor ‘boost::optional<T>::optional(Expr&&, typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr> >::type*) [with Expr = unsigned int&; T = unsigned int; typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr> >::type = void]’
             return {itr->second->AsNodeRestriction().to};
```

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
