### PR TITLE
respect difference between continue/turn on changing end-of-road

### DIFF
--- a/features/guidance/anticipate-lanes.feature
+++ b/features/guidance/anticipate-lanes.feature
@@ -52,9 +52,9 @@ Feature: Turn Lane Guidance
             | dy    |                       |                     | YSt  |
 
        When I route I should get
-            | waypoints | route               | turns                                   | lanes                                                         |
-            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,turn right,arrive | ,straight:false right:false right:true,left:false right:true, |
-            | e,a       | MySt,MySt,MySt,MySt | depart,continue left,turn left,arrive   | ,left:true left:false straight:false,left:true right:false,   |
+            | waypoints | route               | turns                                       | lanes                                                         |
+            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,continue right,arrive | ,straight:false right:false right:true,left:false right:true, |
+            | e,a       | MySt,MySt,MySt,MySt | depart,continue left,continue left,arrive   | ,left:true left:false straight:false,left:true right:false,   |
 
     @anticipate
     Scenario: Anticipate Lane Change for quick same direction turns, changing between streets
@@ -780,8 +780,8 @@ Feature: Turn Lane Guidance
             | dy    |                                | YSt  |
 
        When I route I should get
-            | waypoints | route               | turns                                   | lanes                                                                        |
-            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,turn right,arrive | ,straight:false straight:false right:false right:true,left:false right:true, |
+            | waypoints | route               | turns                                       | lanes                                                                        |
+            | a,e       | MySt,MySt,MySt,MySt | depart,continue right,continue right,arrive | ,straight:false straight:false right:false right:true,left:false right:true, |
 
     @anticipate
     Scenario: Don't Overdo It

--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -628,9 +628,9 @@ Feature: Collapse
             | cf    | secondary | bottom |
 
         When I route I should get
-            | waypoints | turns                                   | route               | locations |
-            | a,d       | depart,continue right,turn right,arrive | road,road,road,road | a,b,c,d   |
-            | d,a       | depart,continue left,turn left,arrive   | road,road,road,road | d,c,b,a   |
+            | waypoints | turns                                       | route               | locations |
+            | a,d       | depart,continue right,continue right,arrive | road,road,road,road | a,b,c,d   |
+            | d,a       | depart,continue left,continue left,arrive   | road,road,road,road | d,c,b,a   |
 
     Scenario: Forking before a turn
         Given the node map

--- a/features/guidance/continue.feature
+++ b/features/guidance/continue.feature
@@ -136,3 +136,24 @@ Feature: Continue Instructions
           | a,d       | abcdefb,abcdefb,abcdefb | depart,continue right,arrive |
           # continuing right here, since the turn to the left is more expensive
           | a,e       | abcdefb,abcdefb,abcdefb | depart,continue right,arrive |
+
+    Scenario: End-Of-Road Continue
+        Given the node map
+            """
+            a - b - c
+                |
+                d - e
+                |
+                f
+            """
+
+        And the ways
+            | nodes | highway | name |
+            | abc   | primary | road |
+            | bdf   | primary | road |
+            | ed    | primary | turn |
+
+
+        When I route I should get
+            | waypoints | route               | turns                                  |
+            | e,a       | turn,road,road,road | depart,turn right,continue left,arrive |

--- a/features/guidance/turn-lanes.feature
+++ b/features/guidance/turn-lanes.feature
@@ -835,9 +835,9 @@ Feature: Turn Lane Guidance
             | cf    | secondary | bottom |                    |
 
         When I route I should get
-            | waypoints | turns                                   | route               | lanes                        |
-            | a,d       | depart,continue right,turn right,arrive | road,road,road,road | ,straight:false right:true,, |
-            | d,a       | depart,continue left,turn left,arrive   | road,road,road,road | ,left:true straight:false,,  |
+            | waypoints | turns                                       | route               | lanes                        |
+            | a,d       | depart,continue right,continue right,arrive | road,road,road,road | ,straight:false right:true,, |
+            | d,a       | depart,continue left,continue left,arrive   | road,road,road,road | ,left:true straight:false,,  |
 
     @simple
     Scenario: Merge Lanes Onto Freeway

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -629,7 +629,21 @@ std::vector<RouteStep> buildIntersections(std::vector<RouteStep> steps)
                 BOOST_ASSERT(step_index > 0);
                 const auto &previous_step = steps[last_valid_instruction];
                 if (previous_step.intersections.size() < MIN_END_OF_ROAD_INTERSECTIONS)
-                    step.maneuver.instruction.type = TurnType::Turn;
+                {
+                    bool same_name =
+                        !(step.name.empty() && step.ref.empty()) &&
+                        !util::guidance::requiresNameAnnounced(previous_step.name,
+                                                               previous_step.ref,
+                                                               previous_step.pronunciation,
+                                                               previous_step.exits,
+                                                               step.name,
+                                                               step.ref,
+                                                               step.pronunciation,
+                                                               step.exits);
+
+                    step.maneuver.instruction.type =
+                        same_name ? TurnType::Continue : TurnType::Turn;
+                }
             }
 
             // Remember the last non silent instruction


### PR DESCRIPTION
# Issue

Resolves https://github.com/Project-OSRM/osrm-backend/issues/4391

It turns out that we turn end-of-road in turns, whenever there are not enough roads in between. Sometimes we require a `continue`, though, to be consistent.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments