### PR TITLE
do not change fork directions when combining turns

### DIFF
--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -97,5 +97,7 @@ Feature: Simple Turns
             | ei    | left  | yes    |
 
         When I route I should get
-            | waypoints | route        | turns                    |
-            | g,a       | in,road,road | depart,fork right,arrive |
+            | waypoints | route          | turns                           |
+            | g,a       | in,road,road   | depart,fork slight right,arrive |
+            | g,h       | in,right,right | depart,fork straight,arrive     |
+            | g,i       | in,left,left   | depart,fork slight left,arrive  |


### PR DESCRIPTION
# Issue

Forks can end up showing `fork-straight` when using a combined turn angle. Instead of changing the fork angle to be more or less to the `right|left`, we should keep unmodified directions for forks when combining turns.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md) (updated)
 - [x] review
 - [x] adjust for comments