### PR TITLE
[profile][car] Remove the non common use barrier=checkpoint #4405

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -46,7 +46,6 @@ function setup()
     barrier_whitelist = Set {
       'cattle_grid',
       'border_control',
-      'checkpoint',
       'toll_booth',
       'sally_port',
       'gate',


### PR DESCRIPTION
Remove the non common use barrier=checkpoint as the right tag is military=checkpoint and does not need to be whitelisted.