### PR TITLE
Route by supporting physical limitation of height and weight

### DIFF
--- a/features/car/physical_limitation.feature
+++ b/features/car/physical_limitation.feature
@@ -1,0 +1,45 @@
+@routing @car
+Feature: Car - Handle physical limitation
+
+    Background:
+        Given the profile "car"
+
+    Scenario: Car - Use a narrow way
+        Then routability should be
+            | highway | width  | narrow | bothw |
+            | primary |        |        | x     |
+            | primary | narrow |        | x     |
+            | primary |        | yes    | x     |
+            | primary | 1.8    |        |       |
+            | primary | 1.9    |        |       |
+            | primary | 2.0    |        | x     |
+            | primary | 2.1    |        | x     |
+            | primary | 1m     |        |       |
+            | primary | 1 m    |        |       |
+            | primary | 3 m    |        | x     |
+            | primary | 6'     |        |       |
+            | primary | 6'0"   |        |       |
+            | primary | 6'2"   |        |       |
+            | primary | 6'3"   |        | x     |
+            | primary | 7'     |        | x     |
+            | primary | 7'0"   |        | x     |
+
+    Scenario: Car - Limited by width
+        Then routability should be
+            | highway | maxwidth:physical | maxwidth | width | est_width | bothw |
+            | primary | 1                 |          |       |           |       |
+            | primary | 3                 |          |       |           | x     |
+            | primary |                   | 1        |       |           |       |
+            | primary |                   | 3        |       |           | x     |
+            | primary |                   |          | 1     |           |       |
+            | primary |                   |          | 3     |           | x     |
+            | primary |                   |          |       | 1         |       |
+            | primary |                   |          |       | 3         | x     |
+
+    Scenario: Car - Limited by height
+        Then routability should be
+            | highway | maxheight:physical | maxheight | bothw |
+            | primary | 1                  |           |       |
+            | primary | 3                  |           | x     |
+            | primary |                    | 1         |       |
+            | primary |                    | 3         | x     |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -37,6 +37,10 @@ function setup()
     turn_bias                 = 1.075,
     cardinal_directions       = false,
 
+    -- Size of the vehicle, to be limited by physical restriction of the way
+    vehicle_height = 2.5, -- in metters, 2.5m is the height of van
+    vehicle_width = 1.9, -- in metters, ways with narrow tag are considered narrower than 2.2m
+
     -- a list of suffixes to suppress in name change instructions. The suffixes also include common substrings of each other
     suffix_list = {
       'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'North', 'South', 'West', 'East', 'Nor', 'Sou', 'We', 'Ea'
@@ -357,6 +361,8 @@ function process_way(profile, way, result, relations)
     -- toll=yes and oneway=reversible
     WayHandlers.blocked_ways,
     WayHandlers.avoid_ways,
+    WayHandlers.handle_height,
+    WayHandlers.handle_width,
 
     -- determine access status by checking our hierarchy of
     -- access tags, e.g: motorcar, motor_vehicle, vehicle

--- a/profiles/lib/measure.lua
+++ b/profiles/lib/measure.lua
@@ -6,65 +6,37 @@ Measure = {}
 local inch_to_meters = 0.0254
 local feet_to_inches = 12
 
+--- Parse string as a height in meters.
 --- according to http://wiki.openstreetmap.org/wiki/Key:maxheight
-local meters_parse_patterns = Sequence {
-  "%d+",
-  "%d+.%d+",
-  "%d+.%d+ m",
-  "%d+,%d+ m", -- wrong
-  "%d+.%d+m",  -- wrong
-  "%d+,%d+m",  -- wrong
-}
+function Measure.parse_value_meters(value)
+  local n = tonumber(value:gsub(",", "."):match("%d+%.?%d*"))
+  if n then
+    inches = value:match("'.*")
+    if inches then -- Imperial unit to metric
+      -- try to parse feets/inch
+      n = n * feet_to_inches
+      local m = tonumber(inches:match("%d+"))
+      if m then
+        n = n + m
+      end
+      n = n * inch_to_meters
+    end
+    return n
+  end
 
-local feet_parse_patterns = Sequence {
-  "%d+\'%d+\'",
-}
+  print("Can't parse value: ", value)
+end
 
 --- according to http://wiki.openstreetmap.org/wiki/Map_Features/Units#Explicit_specifications
 local tonns_parse_patterns = Sequence {
   "%d+",
   "%d+.%d+",
-  "%d+.%d+ t"
+  "%d+.%d+ ?t"
 }
 
 local kg_parse_patterns = Sequence {
-  "%d+ kg"
+  "%d+ ?kg"
 }
-
-function Measure.convert_feet_to_inches(feet)
-  return feet * feet_to_inches
-end
-
-function Measure.convert_inches_to_meters(inches)
-  return inches * inch_to_meters
-end
-
---- Parse string as a height in meters.
-function Measure.parse_value_meters(value)
-  -- try to parse meters
-  for i, templ in ipairs(meters_parse_patterns) do
-    m = string.match(value, templ)
-    if m then
-      return tonumber(m)
-    end
-  end
-
-  -- try to parse feets/inch
-  for i, templ in ipairs(feet_parse_patterns) do
-    m = string.match(value, templ)
-    if m then
-      feet, inch = m
-      feet = tonumber(feet)
-      inch = tonumber(inch)
-
-      inch = inch + feet * feet_to_inches
-      return Measure.convert_inches_to_meters(inch)
-    end
-  end
-
-  print("Can't parse value: ", value)
-  return
-end
 
 --- Parse weight value in kilograms
 function Measure.parse_value_kilograms(value)
@@ -91,28 +63,22 @@ end
 
 --- Get maxheight of specified way in meters. If there are no
 --- max height, then return nil
-function Measure.get_max_height(way)
-  raw_value = way:get_value_by_key('maxheight')
+function Measure.get_max_height(raw_value)
   if raw_value then
     return Measure.parse_value_meters(raw_value)
   end
-
-  -- TODO: parse another tags
 end
 
 --- Get maxwidth of specified way in meters.
-function Measure.get_max_width(way)
-  raw_value = way:get_value_by_key('maxwidth')
+function Measure.get_max_width(raw_value)
   if raw_value then
     return Measure.parse_value_meters(raw_value)
   end
 end
 
 --- Get maxweight of specified way in kilogramms
-function Measure.get_max_weight(way)
-  raw_value = way:get_value_by_key('maxweight')
+function Measure.get_max_weight(raw_value)
   if raw_value then
-    -- print(way:id(), raw_value)
     return Measure.parse_value_kilograms(raw_value)
   end
 end

--- a/profiles/lib/measure.lua
+++ b/profiles/lib/measure.lua
@@ -20,6 +20,17 @@ local feet_parse_patterns = Sequence {
   "%d+\'%d+\'",
 }
 
+--- according to http://wiki.openstreetmap.org/wiki/Map_Features/Units#Explicit_specifications
+local tonns_parse_patterns = Sequence {
+  "%d+",
+  "%d+.%d+",
+  "%d+.%d+ t"
+}
+
+local kg_parse_patterns = Sequence {
+  "%d+ kg"
+}
+
 function Measure.convert_feet_to_inches(feet)
   return feet * feet_to_inches
 end
@@ -51,6 +62,30 @@ function Measure.parse_value_meters(value)
     end
   end
 
+  print("Can't parse value: ", value)
+  return
+end
+
+--- Parse weight value in kilograms
+function Measure.parse_value_kilograms(value)
+  -- try to parse kilograms
+  for i, templ in ipairs(kg_parse_patterns) do
+    m = string.match(value, templ)
+    if m then
+      return tonumber(m)
+    end
+  end
+
+  -- try to parse tonns
+  for i, templ in ipairs(tonns_parse_patterns) do
+    m = string.match(value, templ)
+    if m then
+      return tonumber(m) * 1000
+    end
+  end
+
+  --
+  print("Can't parse value: ", value)
   return
 end
 
@@ -69,8 +104,16 @@ end
 function Measure.get_max_width(way)
   raw_value = way:get_value_by_key('maxwidth')
   if raw_value then
-    print(way:id(), raw_value)
     return Measure.parse_value_meters(raw_value)
+  end
+end
+
+--- Get maxweight of specified way in kilogramms
+function Measure.get_max_weight(way)
+  raw_value = way:get_value_by_key('maxweight')
+  if raw_value then
+    -- print(way:id(), raw_value)
+    return Measure.parse_value_kilograms(raw_value)
   end
 end
 

--- a/profiles/lib/measure.lua
+++ b/profiles/lib/measure.lua
@@ -1,0 +1,78 @@
+local Sequence = require('lib/sequence')
+
+Measure = {}
+
+-- measurements conversion constants
+local inch_to_meters = 0.0254
+local feet_to_inches = 12
+
+--- according to http://wiki.openstreetmap.org/wiki/Key:maxheight
+local meters_parse_patterns = Sequence {
+  "%d+",
+  "%d+.%d+",
+  "%d+.%d+ m",
+  "%d+,%d+ m", -- wrong
+  "%d+.%d+m",  -- wrong
+  "%d+,%d+m",  -- wrong
+}
+
+local feet_parse_patterns = Sequence {
+  "%d+\'%d+\'",
+}
+
+function Measure.convert_feet_to_inches(feet)
+  return feet * feet_to_inches
+end
+
+function Measure.convert_inches_to_meters(inches)
+  return inches * inch_to_meters
+end
+
+--- Parse string as a height in meters.
+function Measure.parse_value_meters(value)
+  -- try to parse meters
+  for i, templ in ipairs(meters_parse_patterns) do
+    m = string.match(value, templ)
+    if m then
+      return tonumber(m)
+    end
+  end
+
+  -- try to parse feets/inch
+  for i, templ in ipairs(feet_parse_patterns) do
+    m = string.match(value, templ)
+    if m then
+      feet, inch = m
+      feet = tonumber(feet)
+      inch = tonumber(inch)
+
+      inch = inch + feet * feet_to_inches
+      return Measure.convert_inches_to_meters(inch)
+    end
+  end
+
+  return
+end
+
+--- Get maxheight of specified way in meters. If there are no
+--- max height, then return nil
+function Measure.get_max_height(way)
+  raw_value = way:get_value_by_key('maxheight')
+  if raw_value then
+    return Measure.parse_value_meters(raw_value)
+  end
+
+  -- TODO: parse another tags
+end
+
+--- Get maxwidth of specified way in meters.
+function Measure.get_max_width(way)
+  raw_value = way:get_value_by_key('maxwidth')
+  if raw_value then
+    print(way:id(), raw_value)
+    return Measure.parse_value_meters(raw_value)
+  end
+end
+
+
+return Measure;


### PR DESCRIPTION
In short: test for maxwidth and maxheight.

Define a vehicle size using height and width.
Then validate the sizes to set mode.inaccessible if the vehicle can't fit on the way.

This PR only check for maxwidth and maxheight and not for maxweight and maxlength. Because the first two are physical limitations, the last are more legal issues.

This PR is extracted from a soft constrained truck profile I'm building. I treat maxweight and maxlength as soft legal limitation by adjusting weight.
If you don't want this in the core I can submit it to the contrib repo.