### PR TITLE
make end of road non obvious

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # UNRELEASED
+  - Changes from 5.11:
+    - Guidance
+      - now announcing turning onto oneways at the end of a road (e.g. onto dual carriageways)
 
 # 5.11.0
   - Changes from 5.10:

--- a/features/guidance/end-of-road.feature
+++ b/features/guidance/end-of-road.feature
@@ -24,6 +24,25 @@ Feature: End Of Road Instructions
             | a,c       | aeb,cbd,cbd | depart,end of road left,arrive  |
             | a,d       | aeb,cbd,cbd | depart,end of road right,arrive |
 
+    # http://map.project-osrm.org/?z=18&center=38.906632%2C-77.008265&loc=38.906463%2C-77.007621&loc=38.906822%2C-77.008860&hl=en&alt=0
+    Scenario: End of Road, unnamed oneway
+        Given the node map
+            """
+                c
+            a e b
+              f d
+            """
+
+        And the ways
+            | nodes  | highway | name | oneway |
+            | aeb    | primary | road | yes    |
+            | cbd    | primary |      | yes    |
+            | ef     | primary | turn | yes    |
+
+       When I route I should get
+            | waypoints | route | turns         |
+            | a,d       | road, | depart,arrive |
+
     @3605
     Scenario: End of Road with oneway through street
         Given the node map

--- a/features/guidance/end-of-road.feature
+++ b/features/guidance/end-of-road.feature
@@ -40,8 +40,8 @@ Feature: End Of Road Instructions
             | ef     | primary | turn | yes    |
 
        When I route I should get
-            | waypoints | route | turns         |
-            | a,d       | road, | depart,arrive |
+            | waypoints | route  | turns                           |
+            | a,d       | road,, | depart,end of road right,arrive |
 
     @3605
     Scenario: End of Road with oneway through street

--- a/features/testbot/bearing_param.feature
+++ b/features/testbot/bearing_param.feature
@@ -108,12 +108,12 @@ Feature: Bearing parameter
             | ha    | yes    | ring |
 
         When I route I should get
-            | from | to | bearings | route        | bearing               |
-            | 0    | q  | 0 90     | ia,ring,ring | 0->0,0->90,90->0      |
-            | 0    | a  | 45 90    | jb,ring,ring | 0->45,45->180,90->0   |
-            | 0    | q  | 90 90    | kc,ring,ring | 0->90,90->180,90->0   |
-            | 0    | a  | 135 90   | ld,ring,ring | 0->135,135->270,90->0 |
-            | 0    | a  | 180 90   | me,ring,ring | 0->180,180->270,90->0 |
-            | 0    | a  | 225 90   | nf,ring,ring | 0->225,225->0,90->0   |
-            | 0    | a  | 270 90   | og,ring,ring | 0->270,270->0,90->0   |
-            | 0    | a  | 315 90   | ph,ring,ring | 0->315,315->90,90->0  |
+            | from | to | bearings | route                  | bearing                             |
+            | 0    | q  | 0 90     | ia,ring,ring,ring,ring | 0->0,0->90,180->270,270->0,90->0    |
+            | 0    | a  | 45 90    | jb,ring,ring,ring,ring | 0->45,45->180,180->270,270->0,90->0 |
+            | 0    | q  | 90 90    | kc,ring,ring,ring      | 0->90,90->180,270->0,90->0          |
+            | 0    | a  | 135 90   | ld,ring,ring,ring      | 0->135,135->270,270->0,90->0        |
+            | 0    | a  | 180 90   | me,ring,ring,ring      | 0->180,180->270,270->0,90->0        |
+            | 0    | a  | 225 90   | nf,ring,ring           | 0->225,225->0,90->0                 |
+            | 0    | a  | 270 90   | og,ring,ring           | 0->270,270->0,90->0                 |
+            | 0    | a  | 315 90   | ph,ring,ring           | 0->315,315->90,90->0                |


### PR DESCRIPTION
# Issue

When reaching a oneway street at the end of the road, we currently do not emit a turn instruction. Even though there is no choice, it can make the user feel uncertain whether he is doing the right thing. E.g. if a road is modelled as dual carriage-way and has no obvious separation, turning right instead of left might be the clearer choice, an announcement of this turn will avoid confusion.

This PR introduces exactly this behaviour, announcing turns onto oneway through streets at the end of the road.

It affects quite a few intersections, as can be seen on [this map](https://www.mapbox.com/studio/styles/mokob/cj1yu7w72001f2srwyfyviz9p/edit/) -- contains values for Germany and California.

I've looked at many of the turns and from what I can tell, the selection shows a promising set.
All of these locations show a turn where we previously wouldn't have announced anything and now would announce `turn/continue right`.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
