### PR TITLE
Revert "Publicly expose binaries to Node.js bindings, resolves #4377"

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,14 +65,5 @@
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}/{configuration}/",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
-  },
-  "bin": {
-    "osrm-extract": "./lib/binding/osrm-extract",
-    "osrm-contract": "./lib/binding/osrm-contract",
-    "osrm-partition": "./lib/binding/osrm-partition",
-    "osrm-customize": "./lib/binding/osrm-customize",
-    "osrm-routed": "./lib/binding/osrm-routed",
-    "osrm-components": "./lib/binding/osrm-components",
-    "osrm-datastore": "./lib/binding/osrm-datastore"
   }
 }


### PR DESCRIPTION
# Issue

Per https://github.com/Project-OSRM/osrm-backend/issues/4377#issuecomment-322555522, I'm rolling back 4686272f87cff27755fe004721702f0751b88cbb, which unfortunately broke installation of the node module (fortunately, only release candidates so far).

I've re-opened #4377 with a possible future option for implementing this, but for now I'm reverting this change to unblock the 5.11 release process.