### PR TITLE
Adds type declarations for node-osrm, resolves #4286

### DIFF
--- a/example/example.ts
+++ b/example/example.ts
@@ -1,0 +1,25 @@
+import { EngineConfig, OSRM, RouteParams, RouteCallback } from 'osrm';
+
+
+const cfg: EngineConfig = { 'path': 'nonexistent',
+                            'algorithm': 'MLD' };
+
+const osrm = new OSRM(cfg);
+
+const depart = [ 13.414307, 52.521835 ];
+const arrive = [ 13.402290, 52.523728 ];
+const routeParams = { 'coordinates': [ depart, arrive ] };
+
+const routeCallback: RouteCallback = (error, result) => {
+  if (error) {
+    console.log(`Error: ${error}`);
+    return;
+  }
+
+  const waypoints = result!.waypoints;
+  const routes = result!.routes;
+
+  console.log(`Ok:\nwaypoints:\n${waypoints}\nroutes:\n${routes}`);
+};
+
+osrm.route(routeParams, routeCallback);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,122 @@
+// Type definitions for node-osrm.
+// Project: https://github.com/Project-OSRM/osrm-backend
+
+// Impl. - type definition documentation, reference and examples can be found here:
+// https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html
+//
+// Truth can only be found in include/nodejs/node_osrm_support.hpp
+
+declare namespace osrm {
+
+  /*
+   * Open Source Routing Machine (OSRM).
+   */
+  export class OSRM {
+    constructor(config: FilePath | EngineConfig);
+
+    route(params: RouteParams, callback: RouteCallback): void;
+
+    //  nearest(): void;
+    //  table(): void;
+    //  tile(): void;
+    //  match(): void;
+    //  trip(): void
+  }
+
+  /*
+   * Path to a file.
+   */
+  export type FilePath = string;
+
+  /*
+   * Routing Engine Configuration.
+   */
+  export interface EngineConfig {
+    path?: FilePath;
+    shared_memory?: boolean;
+
+    algorithm?: RoutingAlgorithm;
+
+    max_locations_trip?: number;
+    max_locations_viaroute?: number;
+    max_locations_distance_table?: number;
+    max_locations_map_matching?: number;
+    max_results_nearest?: number;
+    max_alternatives?: number;
+  }
+
+  /*
+   * Implemented Routing Algorithms.
+   *
+   * CH:     Contraction Hierarchies
+   * CoreCH: Contraction Hierarchies with a contraction threshold to speed up contraction
+   * MLD:    Multi-Level Dijkstra
+   */
+  export type RoutingAlgorithm = 'CH' | 'CoreCH' | 'MLD';
+
+
+  /*
+   * Geographic coordinate on planet Earth's surface.
+   */
+  export type Coordinate = number[];
+
+
+  /*
+   * Parameters for the Route service.
+   */
+  export interface RouteParams {
+    coordinates: Coordinate[];
+
+  }
+
+
+  /*
+   * Callback function.
+   */
+  export type Callback<T> = (error: Error, result?: T) => void;
+
+  export type RouteCallback = Callback<RouteResult>;
+
+
+  /*
+   *
+   */
+  export interface Waypoint {
+    name: string;
+    location: Coordinate;
+    distance?: number;
+    hint?: string;
+  }
+
+  /*
+   *
+   */
+  export interface Route {
+    distance: number;
+    duration: number;
+    weight: number;
+    weight_name: number;
+    //geometry?
+    legs: RouteLeg[];
+  }
+
+  /*
+   *
+   */
+  export interface RouteLeg {
+
+  }
+
+  /*
+   * Callback results.
+   */
+  export interface RouteResult {
+    waypoints: Waypoint[];
+    routes:    Route[];
+  }
+
+} // namespace osrm
+
+declare module 'osrm' {
+  export = osrm;
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-pre-gyp"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "binary": {
     "module_name": "node_osrm",
     "module_path": "./lib/binding/",


### PR DESCRIPTION
Here are some type definitions for our Node.js bindings. Includes some basic engine types, route parameter and route result types. Work in progress, pr mostly for visibility.

Here's an example for a compile time error message if you mistype and try to use the MxD algorithm:

```typescript
example.ts(4,7): error TS2322: Type '{ 'path': string; 'algorithm': "MxD"; }' is not assignable to type 'EngineConfig'.
  Types of property 'algorithm' are incompatible.
    Type '"MxD"' is not assignable to type '"CH" | "CoreCH" | "MLD" | undefined'.
```