### PR TITLE
Make empty CSV entries non-fatal

### DIFF
--- a/src/updater/csv_source.cpp
+++ b/src/updater/csv_source.cpp
@@ -44,8 +44,8 @@ SegmentLookupTable readSegmentValues(const std::vector<std::string> &paths)
         });
     if (found_inconsistency != std::end(result.lookup))
     {
-        throw util::exception("empty segment in CSV with node " +
-                              std::to_string(found_inconsistency->first.from) + " " + SOURCE_REF);
+        util::Log(logWARNING) << "Empty segment in CSV with node " +
+                                     std::to_string(found_inconsistency->first.from);
     }
 
     return result;

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -221,6 +221,12 @@ updateSegmentData(const UpdaterConfig &config,
             {
                 auto u = osm_node_ids[nodes_range[segment_offset]];
                 auto v = osm_node_ids[nodes_range[segment_offset + 1]];
+
+                // Self-loops are artifical segments (e.g. traffic light nodes), do not
+                // waste time updating them with traffic data
+                if (u == v)
+                    continue;
+
                 if (auto value = segment_speed_lookup({u, v}))
                 {
                     auto segment_length = segment_lengths[segment_offset];
@@ -254,6 +260,12 @@ updateSegmentData(const UpdaterConfig &config,
             {
                 auto u = osm_node_ids[nodes_range[segment_offset]];
                 auto v = osm_node_ids[nodes_range[segment_offset + 1]];
+
+                // Self-loops are artifical segments (e.g. traffic light nodes), do not
+                // waste time updating them with traffic data
+                if (u == v)
+                    continue;
+
                 if (auto value = segment_speed_lookup({v, u}))
                 {
                     auto segment_length = segment_lengths[segment_offset];


### PR DESCRIPTION
# Issue

With https://github.com/Project-OSRM/osrm-backend/commit/4757c96d9a91cc7fb3ad61bcb2ef9a2a9283017d, we added a check to abort if a self-loop is found in traffic data updates (`nodeA,nodeA,speed`).

However, this doesn't need to be fatal - we can warn-and-ignore instead, which makes things a little bit more robust in a large-scale environment where all kinds of weird data can crop up.

This change removes the exception throwing, and protects the artificial edges from traffic updates, which avoids any problems that might have caused, and possibly speeds things up fractionally because we don't need to search for artificial edges in the loaded traffic data.

## Tasklist
 - [ ] review
 - [ ] adjust for comments