### PR TITLE
Prevent linkage errors when load/write extracted graph from external app

### DIFF
--- a/include/partition/edge_based_graph_reader.hpp
+++ b/include/partition/edge_based_graph_reader.hpp
@@ -26,7 +26,7 @@ namespace partition
 {
 
 // Bidirectional (s,t) to (s,t) and (t,s)
-std::vector<extractor::EdgeBasedEdge>
+inline std::vector<extractor::EdgeBasedEdge>
 splitBidirectionalEdges(const std::vector<extractor::EdgeBasedEdge> &edges)
 {
     std::vector<extractor::EdgeBasedEdge> directed;
@@ -136,7 +136,8 @@ std::vector<OutputEdgeT> prepareEdgesForUsageInGraph(std::vector<extractor::Edge
     return output_edges;
 }
 
-std::vector<extractor::EdgeBasedEdge> graphToEdges(const DynamicEdgeBasedGraph &edge_based_graph)
+inline std::vector<extractor::EdgeBasedEdge>
+graphToEdges(const DynamicEdgeBasedGraph &edge_based_graph)
 {
     auto range = tbb::blocked_range<NodeID>(0, edge_based_graph.GetNumberOfNodes());
     auto max_turn_id =


### PR DESCRIPTION
# Issue

There were linkage errors, when use graph load/unload code from external application.
```cpp
std::shared_ptr<DynamicEdgeBasedGraph> LoadEdgeBasedGraph(boost::filesystem::path const & path)
  {
      EdgeID max_node_id;
      std::vector<osrm::extractor::EdgeBasedEdge> edges;
      osrm::extractor::files::readEdgeBasedGraph(path, max_node_id, edges);

      auto directed = osrm::partition::splitBidirectionalEdges(edges);
      auto tidied = osrm::partition::prepareEdgesForUsageInGraph<osrm::partition::DynamicEdgeBasedGraphEdge>(std::move(directed));

      return std::shared_ptr<DynamicEdgeBasedGraph>(new DynamicEdgeBasedGraph(max_node_id + 1, std::move(tidied)));
}
```

## Tasklist
 - [x] review
 - [x] adjust for comments
