### PR TITLE
Whitelists scripts/node_install.sh for from-source compilation, resolves #4431

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@
 !profiles/*
 !profiles/lib/*
 !profiles/examples/*
+!scripts/node_install.sh


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/4431. Required for from-source fallback if no pre-built binaries were found.