### PR TITLE
Add osm nodes to `nearest` response

### DIFF
--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -42,10 +42,12 @@ class NearestAPI final : public BaseAPI
                            auto waypoint = MakeWaypoint(phantom_node);
                            waypoint.values["distance"] = phantom_with_distance.distance;
 
+                           
+
                            util::json::Array nodes;
 
-                           std::uint64_t from_node = static_cast<std::uint64_t>(SPECIAL_OSM_NODEID);
-                           std::uint64_t to_node = static_cast<std::uint64_t>(SPECIAL_OSM_NODEID);
+                           std::uint64_t from_node = 0;
+                           std::uint64_t to_node = 0;
 
                            std::vector<NodeID> forward_geometry;
                            if (phantom_node.forward_segment_id.enabled )

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -42,15 +42,13 @@ class NearestAPI final : public BaseAPI
                            auto waypoint = MakeWaypoint(phantom_node);
                            waypoint.values["distance"] = phantom_with_distance.distance;
 
-                           
-
                            util::json::Array nodes;
 
                            std::uint64_t from_node = 0;
                            std::uint64_t to_node = 0;
 
                            std::vector<NodeID> forward_geometry;
-                           if (phantom_node.forward_segment_id.enabled )
+                           if (phantom_node.forward_segment_id.enabled)
                            {
                                auto segment_id = phantom_node.forward_segment_id.id;
                                const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
@@ -72,7 +70,8 @@ class NearestAPI final : public BaseAPI
                                    geometry[phantom_node.fwd_segment_position + 1]);
                                from_node = static_cast<std::uint64_t>(osm_node_id);
                            }
-                           else if (phantom_node.forward_segment_id.enabled && phantom_node.fwd_segment_position > 0)
+                           else if (phantom_node.forward_segment_id.enabled &&
+                                    phantom_node.fwd_segment_position > 0)
                            {
                                // In the case of one way, rely on forward segment only
                                auto osm_node_id = facade.GetOSMNodeIDOfNode(

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -38,8 +38,49 @@ class NearestAPI final : public BaseAPI
                        phantom_nodes.front().end(),
                        waypoints.values.begin(),
                        [this](const PhantomNodeWithDistance &phantom_with_distance) {
-                           auto waypoint = MakeWaypoint(phantom_with_distance.phantom_node);
+                           auto &phantom_node = phantom_with_distance.phantom_node;
+                           auto waypoint = MakeWaypoint(phantom_node);
                            waypoint.values["distance"] = phantom_with_distance.distance;
+
+                           util::json::Array nodes;
+
+                           std::uint64_t from_node = static_cast<std::uint64_t>(SPECIAL_OSM_NODEID);
+                           std::uint64_t to_node = static_cast<std::uint64_t>(SPECIAL_OSM_NODEID);
+
+                           std::vector<NodeID> forward_geometry;
+                           if (phantom_node.forward_segment_id.enabled )
+                           {
+                               auto segment_id = phantom_node.forward_segment_id.id;
+                               const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
+                               forward_geometry =
+                                   facade.GetUncompressedForwardGeometry(geometry_id);
+
+                               auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                                   forward_geometry[phantom_node.fwd_segment_position]);
+                               to_node = static_cast<std::uint64_t>(osm_node_id);
+                           }
+
+                           if (phantom_node.reverse_segment_id.enabled)
+                           {
+                               auto segment_id = phantom_node.reverse_segment_id.id;
+                               const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
+                               std::vector<NodeID> geometry =
+                                   facade.GetUncompressedForwardGeometry(geometry_id);
+                               auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                                   geometry[phantom_node.fwd_segment_position + 1]);
+                               from_node = static_cast<std::uint64_t>(osm_node_id);
+                           }
+                           else if (phantom_node.forward_segment_id.enabled && phantom_node.fwd_segment_position > 0)
+                           {
+                               // In the case of one way, rely on forward segment only
+                               auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                                   forward_geometry[phantom_node.fwd_segment_position - 1]);
+                               from_node = static_cast<std::uint64_t>(osm_node_id);
+                           }
+                           nodes.values.push_back(from_node);
+                           nodes.values.push_back(to_node);
+                           waypoint.values["nodes"] = std::move(nodes);
+
                            return waypoint;
                        });
 

--- a/unit_tests/library/nearest.cpp
+++ b/unit_tests/library/nearest.cpp
@@ -108,10 +108,8 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_for_location_in_small_component)
 
         const auto &nodes = waypoint_object.values.at("nodes").get<json::Array>().values;
         BOOST_CHECK(nodes.size() == 2);
-        BOOST_CHECK(nodes[0].get<util::json::Number>().value !=
-                    0);
-        BOOST_CHECK(nodes[1].get<util::json::Number>().value !=
-                    0);
+        BOOST_CHECK(nodes[0].get<util::json::Number>().value != 0);
+        BOOST_CHECK(nodes[1].get<util::json::Number>().value != 0);
     }
 }
 

--- a/unit_tests/library/nearest.cpp
+++ b/unit_tests/library/nearest.cpp
@@ -109,9 +109,9 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_for_location_in_small_component)
         const auto &nodes = waypoint_object.values.at("nodes").get<json::Array>().values;
         BOOST_CHECK(nodes.size() == 2);
         BOOST_CHECK(nodes[0].get<util::json::Number>().value !=
-                    static_cast<std::uint64_t>(SPECIAL_OSM_NODEID));
+                    0);
         BOOST_CHECK(nodes[1].get<util::json::Number>().value !=
-                    static_cast<std::uint64_t>(SPECIAL_OSM_NODEID));
+                    0);
     }
 }
 

--- a/unit_tests/library/nearest.cpp
+++ b/unit_tests/library/nearest.cpp
@@ -105,6 +105,13 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_for_location_in_small_component)
         // Nearest service should snap to road network without considering components.
         const auto distance = waypoint_object.values.at("distance").get<json::Number>().value;
         BOOST_CHECK_LT(distance, 20);
+
+        const auto &nodes = waypoint_object.values.at("nodes").get<json::Array>().values;
+        BOOST_CHECK(nodes.size() == 2);
+        BOOST_CHECK(nodes[0].get<util::json::Number>().value !=
+                    static_cast<std::uint64_t>(SPECIAL_OSM_NODEID));
+        BOOST_CHECK(nodes[1].get<util::json::Number>().value !=
+                    static_cast<std::uint64_t>(SPECIAL_OSM_NODEID));
     }
 }
 


### PR DESCRIPTION
# Issue

The goal is to provide OSM node ids in `nearest` response as requested by #2548.

## TODO list
 - [x] update http docs
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
 Related to PR #2581
