### PR TITLE
Enable OSX binary publishing for both NodeJS 4 and NodeJS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,15 @@ matrix:
       osx_image: xcode8.2
       compiler: "mason-osx-release"
       # we use the xcode provides clang and don't install our own
-      env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON
+      env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="4"
+      after_success:
+        - ./scripts/travis/publish.sh
+
+    - os: osx
+      osx_image: xcode8.2
+      compiler: "mason-osx-release"
+      # we use the xcode provides clang and don't install our own
+      env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="6"
       after_success:
         - ./scripts/travis/publish.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ git:
 sudo: required
 dist: trusty
 
-node_js:
-    - "4"
-    - "6"
-
 notifications:
   email: false
 


### PR DESCRIPTION
# Issue

This adds a Travis configuration to build on OSX with NodeJS 6.  Previously, we were only building there with NodeJS 4, and only publishing the NodeJS 4 module.  Users on OSX with NodeJS 6 were unable to do `npm install osrm` and use the pre-built binaries.

https://github.com/Project-OSRM/osrm-backend/issues/4432

## Tasklist
 - [x] review
 - [ ] adjust for comments
