### PR TITLE
[EXPERIMENTAL] Supply additional name hint to guide coordinate snapping

### DIFF
--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -121,7 +121,7 @@ module.exports = function () {
 
             r.which = dir;
 
-            this.requestRoute((dir === 'forw' ? [a, b] : [b, a]), [], [], this.queryParams, (err, res, body) => {
+            this.requestRoute((dir === 'forw' ? [a, b] : [b, a]), [], [], [], this.queryParams, (err, res, body) => {
                 if (err) return callback(err);
 
                 r.query = this.query;

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -46,9 +46,10 @@ module.exports = function () {
         return waypoints.map(w => [w.lon, w.lat].map(ensureDecimal).join(','));
     };
 
-    this.requestRoute = (waypoints, bearings, approaches, userParams, callback) => {
+    this.requestRoute = (waypoints, bearings, approaches, namehints, userParams, callback) => {
         if (bearings.length && bearings.length !== waypoints.length) throw new Error('*** number of bearings does not equal the number of waypoints');
         if (approaches.length && approaches.length !== waypoints.length) throw new Error('*** number of approaches does not equal the number of waypoints');
+        if (namehints.length && namehints.length !== waypoints.length) throw new Error('*** number of name hints does not equal the number of waypoints');
 
         var defaults = {
                 output: 'json',
@@ -70,6 +71,10 @@ module.exports = function () {
 
         if (approaches.length) {
             params.approaches = approaches.join(';');
+        }
+
+        if (namehints.length) {
+            params.name_hints = namehints.join(';');
         }
         return this.requestPath('route', params, callback);
     };

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -220,7 +220,8 @@ module.exports = function () {
                     var params = this.overwriteParams(defaultParams, userParams),
                         waypoints = [],
                         bearings = [],
-                        approaches = [];
+                        approaches = [],
+                        namehints = [];
 
                     if (row.bearings) {
                         got.bearings = row.bearings;
@@ -230,6 +231,11 @@ module.exports = function () {
                     if (row.approaches) {
                         got.approaches = row.approaches;
                         approaches = row.approaches.split(' ').filter(b => !!b);
+                    }
+
+                    if (row.name_hints) {
+                        got.name_hints = row.name_hints;
+                        namehints = row.name_hints.split(',').filter(b => !!b);
                     }
 
                     if (row.from && row.to) {
@@ -243,7 +249,7 @@ module.exports = function () {
 
                         got.from = row.from;
                         got.to = row.to;
-                        this.requestRoute(waypoints, bearings, approaches, params, afterRequest);
+                        this.requestRoute(waypoints, bearings, approaches, namehints, params, afterRequest);
                     } else if (row.waypoints) {
                         row.waypoints.split(',').forEach((n) => {
                             var node = this.findNodeByName(n.trim());
@@ -251,7 +257,7 @@ module.exports = function () {
                             waypoints.push(node);
                         });
                         got.waypoints = row.waypoints;
-                        this.requestRoute(waypoints, bearings, approaches, params, afterRequest);
+                        this.requestRoute(waypoints, bearings, approaches, namehints, params, afterRequest);
                     } else {
                         return cb(new Error('*** no waypoints'));
                     }

--- a/features/testbot/namehint.feature
+++ b/features/testbot/namehint.feature
@@ -1,0 +1,26 @@
+@routing @testbot @routes @snapping
+Feature: Name hints when snapping
+
+    Background:
+        Given the profile "testbot"
+
+    Scenario: Snap to nearby named roads, instead of the closest
+
+        Given the node map
+            """
+            a-----------b
+
+
+              1       2
+            c-----------d
+            """
+
+        And the ways
+            | nodes | name    |
+            | ab    | test st |
+            | cd    | side st |
+
+        When I route I should get
+            | from | to | name_hints | route            |
+            | 1    | 2  | test,test  | test st,test st  |
+            | 1    | 2  | side,side  | side st,side st  |

--- a/include/engine/api/base_parameters.hpp
+++ b/include/engine/api/base_parameters.hpp
@@ -68,6 +68,7 @@ struct BaseParameters
     std::vector<boost::optional<double>> radiuses;
     std::vector<boost::optional<Bearing>> bearings;
     std::vector<boost::optional<Approach>> approaches;
+    std::vector<boost::optional<std::string>> name_hints;
     std::vector<std::string> exclude;
 
     // Adds hints to response which can be included in subsequent requests, see `hints` above.
@@ -78,10 +79,12 @@ struct BaseParameters
                    std::vector<boost::optional<double>> radiuses_ = {},
                    std::vector<boost::optional<Bearing>> bearings_ = {},
                    std::vector<boost::optional<Approach>> approaches_ = {},
+                   std::vector<boost::optional<std::string>> name_hints_ = {},
                    bool generate_hints_ = true,
                    std::vector<std::string> exclude = {})
         : coordinates(coordinates_), hints(hints_), radiuses(radiuses_), bearings(bearings_),
-          approaches(approaches_), exclude(std::move(exclude)), generate_hints(generate_hints_)
+          approaches(approaches_), name_hints(name_hints_), exclude(std::move(exclude)),
+          generate_hints(generate_hints_)
     {
     }
 
@@ -92,6 +95,7 @@ struct BaseParameters
                (bearings.empty() || bearings.size() == coordinates.size()) &&
                (radiuses.empty() || radiuses.size() == coordinates.size()) &&
                (approaches.empty() || approaches.size() == coordinates.size()) &&
+               (name_hints.empty() || name_hints.size() == coordinates.size()) &&
                std::all_of(bearings.begin(),
                            bearings.end(),
                            [](const boost::optional<Bearing> bearing_and_range) {

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -742,14 +742,15 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
             input_coordinate, max_results, max_distance, bearing, bearing_range, approach);
     }
 
-    std::pair<PhantomNode, PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const Approach approach) const override final
+    std::pair<PhantomNode, PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
+        const util::Coordinate input_coordinate,
+        const Approach approach,
+        const boost::optional<std::string> &name_hint) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
         return m_geospatial_query->NearestPhantomNodeWithAlternativeFromBigComponent(
-            input_coordinate, approach);
+            input_coordinate, approach, name_hint);
     }
 
     std::pair<PhantomNode, PhantomNode>

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -135,9 +135,11 @@ class BaseDataFacade
                         const double max_distance,
                         const Approach approach) const = 0;
 
-    virtual std::pair<PhantomNode, PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const Approach approach) const = 0;
+    virtual std::pair<PhantomNode, PhantomNode> NearestPhantomNodeWithAlternativeFromBigComponent(
+        const util::Coordinate input_coordinate,
+        const Approach approach,
+        const boost::optional<std::string> &name_hint) const = 0;
+
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -592,6 +592,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
         return std::make_pair(forward_bearing_valid, backward_bearing_valid);
     }
 
+    // Implementation from
+    // https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C.2B.2B
     int levenshtein_distance(const util::StringView &s1, const std::string &s2) const
     {
         // To change the type this function manipulates and returns, change
@@ -634,8 +636,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
 
         auto dist = std::abs(levenshtein_distance(name, *name_hint));
 
-        util::Log(logDEBUG) << "Hint = " << *name_hint << " name = " << name
-                            << " distance = " << dist;
+        util::Log(logDEBUG) << "Hint = '" << *name_hint << "' name = '" << name
+                            << "' distance = " << dist;
 
         // If the hint is a substring of the name, or the name is a substring of the hint,
         // or the edit distance is less than 3, consider it an OK match

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -268,6 +268,7 @@ class BasePlugin
         const bool use_bearings = !parameters.bearings.empty();
         const bool use_radiuses = !parameters.radiuses.empty();
         const bool use_approaches = !parameters.approaches.empty();
+        const bool use_name_hints = !parameters.name_hints.empty();
 
         BOOST_ASSERT(parameters.IsValid());
         for (const auto i : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
@@ -275,6 +276,10 @@ class BasePlugin
             Approach approach = engine::Approach::UNRESTRICTED;
             if (use_approaches && parameters.approaches[i])
                 approach = parameters.approaches[i].get();
+
+            boost::optional<std::string> name_hint;
+            if (use_name_hints && parameters.name_hints[i])
+                name_hint = parameters.name_hints[i].get();
 
             if (use_hints && parameters.hints[i] &&
                 parameters.hints[i]->IsValid(parameters.coordinates[i], facade))
@@ -318,7 +323,7 @@ class BasePlugin
                 {
                     phantom_node_pairs[i] =
                         facade.NearestPhantomNodeWithAlternativeFromBigComponent(
-                            parameters.coordinates[i], approach);
+                            parameters.coordinates[i], approach, name_hint);
                 }
             }
 

--- a/include/server/api/base_parameters_grammar.hpp
+++ b/include/server/api/base_parameters_grammar.hpp
@@ -167,11 +167,11 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                         (-approach_type %
                          ';')[ph::bind(&engine::api::BaseParameters::approaches, qi::_r1) = qi::_1];
 
+        // TODO: limit name length, allow more chars, strip spaces, remove doublespaces, etc
         name_hints_rule =
             qi::lit("name_hints=") >
-            (qi_as_string[+qi::char_(
-                 "a-zA-Z,' ")] % // TODO: be more sophisticated about accepting name strings
-             ';')[ph::bind(add_name_hint, qi::_r1, qi::_1)];
+            (-qi::as_string[+qi::char_("a-zA-Z,' ")])[ph::bind(add_name_hint, qi::_r1, qi::_1)] %
+                ';';
 
         exclude_rule = qi::lit("exclude=") >
                        (qi::as_string[+qi::char_("a-zA-Z0-9")] %

--- a/include/server/api/base_parameters_grammar.hpp
+++ b/include/server/api/base_parameters_grammar.hpp
@@ -87,6 +87,11 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
             }
         };
 
+        const auto add_name_hint = [](engine::api::BaseParameters &base_parameters,
+                                      const boost::optional<std::string> &hint_string) {
+            base_parameters.name_hints.emplace_back(hint_string);
+        };
+
         const auto add_bearing =
             [](engine::api::BaseParameters &base_parameters,
                boost::optional<boost::fusion::vector2<short, short>> bearing_range) {
@@ -162,6 +167,12 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                         (-approach_type %
                          ';')[ph::bind(&engine::api::BaseParameters::approaches, qi::_r1) = qi::_1];
 
+        name_hints_rule =
+            qi::lit("name_hints=") >
+            (qi_as_string[+qi::char_(
+                 "a-zA-Z,' ")] % // TODO: be more sophisticated about accepting name strings
+             ';')[ph::bind(add_name_hint, qi::_r1, qi::_1)];
+
         exclude_rule = qi::lit("exclude=") >
                        (qi::as_string[+qi::char_("a-zA-Z0-9")] %
                         ',')[ph::bind(&engine::api::BaseParameters::exclude, qi::_r1) = qi::_1];
@@ -171,6 +182,7 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                     | bearings_rule(qi::_r1)       //
                     | generate_hints_rule(qi::_r1) //
                     | approach_rule(qi::_r1)       //
+                    | name_hints_rule(qi::_r1)     //
                     | exclude_rule(qi::_r1);
     }
 
@@ -185,6 +197,7 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
 
     qi::rule<Iterator, Signature> generate_hints_rule;
     qi::rule<Iterator, Signature> approach_rule;
+    qi::rule<Iterator, Signature> name_hints_rule;
     qi::rule<Iterator, Signature> exclude_rule;
 
     qi::rule<Iterator, osrm::engine::Bearing()> bearing_rule;


### PR DESCRIPTION
# Issue

This PR adds a name hint to help guide coordinate snapping.  If supplied as part of the request, coordinates will only snap to roads that are "similar" (to be defined) to the supplied name hint.

The new parameter is of the form `name_hint=main st;destination st`.  I'm still toying with the actual filtering/selection logic, suggestions welcome.

## Why?
Geocoders don't always return a coordinate that's ideal for routing purposes.  It's not always closest to the intended destination road.

A good example is this address:

http://www.openstreetmap.org/node/596865687

which you can search for with Nominatim as "4850 Edgeware Road".  The data is sourced from the San Diego GIS department and published as public domain data.

Unfortunately, OSRM snaps this coordinate to the alley behind the house, which is closer to the geocoded coordinate than Edgeware Road.

## Tasklist
 - [ ] Make matches case insensitive
 - [ ] Consider stripping prefix/suffix
 - [ ] Limit r-tree search when no nearby names match to avoid runaway searches
 - [ ] Avoid re-checking segments from the same named road that don't match
 - [ ] Finalize selection logic
 - [ ] Consider API/parameter naming
 - [ ] Implement for all `Nearest*` methods
 - [ ] Make hints optional for each coordinate (i.e. blank = no name filtering)
 - [ ] Benchmark
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments