### PR TITLE
Respect initial bearings order

### DIFF
--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -1368,5 +1368,5 @@ Feature: Simple Turns
 
        When I route I should get
             | waypoints | route        | turns                           |
-            | a,d       | ab,bcd,bcd   | depart,fork slight left,arrive  |
-            | a,g       | ab,befg,befg | depart,fork slight right,arrive |
+            | a,d       | ab,bcd,bcd   | depart,fork slight right,arrive |
+            | a,g       | ab,befg,befg | depart,fork slight left,arrive  |

--- a/features/guidance/turn.feature
+++ b/features/guidance/turn.feature
@@ -1349,3 +1349,24 @@ Feature: Simple Turns
        When I route I should get
             | waypoints | route    | turns                   |
             | a,d       | ab,dc,dc | depart,turn left,arrive |
+
+
+    # https://www.openstreetmap.org/node/1332083066
+    Scenario: Turns ordering must respect initial bearings
+        Given the node map
+            """
+            a . be .
+                  \ c.
+                 d/    .f . g
+            """
+
+        And the ways
+            | nodes | highway | oneway |
+            | ab    | primary | yes    |
+            | bcd   | primary | yes    |
+            | befg  | primary | yes    |
+
+       When I route I should get
+            | waypoints | route        | turns                           |
+            | a,d       | ab,bcd,bcd   | depart,fork slight left,arrive  |
+            | a,g       | ab,befg,befg | depart,fork slight right,arrive |

--- a/include/extractor/guidance/coordinate_extractor.hpp
+++ b/include/extractor/guidance/coordinate_extractor.hpp
@@ -153,6 +153,14 @@ class CoordinateExtractor
                       const double length,
                       const double rate) const;
 
+    // find the coordinate at a specific distance in the vector
+    util::Coordinate
+    ExtractCoordinateAtLength(const double distance,
+                              const std::vector<util::Coordinate> &coordinates) const;
+    util::Coordinate ExtractCoordinateAtLength(const double distance,
+                                               const std::vector<util::Coordinate> &coordinates,
+                                               const std::vector<double> &length_cache) const;
+
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;
     const extractor::CompressedEdgeContainer &compressed_geometries;
@@ -241,14 +249,6 @@ class CoordinateExtractor
                         const double segment_length,
                         const std::vector<double> &segment_distances,
                         const std::uint8_t considered_lanes) const;
-
-    // find the coordinate at a specific location in the vector
-    util::Coordinate ExtractCoordinateAtLength(const double distance,
-                                               const std::vector<util::Coordinate> &coordinates,
-                                               const std::vector<double> &length_cache) const;
-    util::Coordinate
-    ExtractCoordinateAtLength(const double distance,
-                              const std::vector<util::Coordinate> &coordinates) const;
 };
 
 } // namespace guidance

--- a/src/extractor/guidance/intersection_generator.cpp
+++ b/src/extractor/guidance/intersection_generator.cpp
@@ -192,10 +192,11 @@ IntersectionGenerator::ComputeIntersectionShape(const NodeID node_at_center_of_i
                  next != intersection.end();
                  ++curr, ++next)
             {
-                if (!bearings_order(*curr, *next))
-                { // If the true bearing is out of the initial order then adjust to keep the order.
-                    // The adjustment angle is at most 0.5 degree or a half-angle
-                    // between the current bearing and the base bearing to prevent overlaps.
+                if (bearings_order(*next, *curr))
+                { // If the true bearing is out of the initial order (next before current) then
+                    // adjust the next bearing to keep the order. The adjustment angle is at most
+                    // 0.5° or a half-angle between the current bearing and the base bearing.
+                    // to prevent overlapping over base bearing + 360°.
                     const auto angle_adjustment = std::min(
                         .5, util::restrictAngleToValidRange(base_bearing - curr->bearing) / 2.);
                     next->bearing =


### PR DESCRIPTION
# Issue

PR fixes #4331.

For the sample intersection

| way | initial bearing | extracted bearing |
|---|---|---|
| [394198761](https://www.openstreetmap.org/way/394198761) | 325.895 | 322.542 |
| [118426709](https://www.openstreetmap.org/way/118426709) | 162.921 | 163.646 |
| [6323556](https://www.openstreetmap.org/way/6323556) | 151.491 | 170.53  |

PR adds ordering by initial bearings and adjustment of bearings to keep the original order.
For the above example, bearings ordered in the initial order are `322.542, 170.53, 163.646` and after the adjustment are `322.542,170.53,171.03`.

The adjustment angle is at most 0.5 degree or a half-angle between the road bearing and the base bearing.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

