### PR TITLE
Don't merge curved roads

### DIFF
--- a/features/guidance/merge-segregated-roads.feature
+++ b/features/guidance/merge-segregated-roads.feature
@@ -523,3 +523,42 @@ Feature: Merge Segregated Roads
             | a,d       | horiz,horiz      | true:90,false:0 true:60 true:90 true:180 false:270,false:0 true:90 false:180 false:270 true:300;true:270									    |
             | j,h       | vert,horiz,horiz | true:0;true:0 true:90 false:180 false:270 true:300,false:60 false:120 false:240 true:300,false:0 false:90 false:120 true:180 true:270;true:90  |
             | j,l       | vert,vert        | true:0,true:0 true:90 false:180 false:270 true:300,true:0 false:90 false:180 true:240 false:270;true:180									    |
+
+
+    Scenario: Square Area - Don't merge almost circular roads
+        Given a grid size of 2 meters
+        Given the node map
+            """
+                                 i
+                                /
+                               /
+                              /
+                       b---- g .
+                            /     p .
+                  a        /          \           f
+                   \      /             o        /
+                     \   /               \     /
+                       c                  n   /
+                     /  \                  \/
+                    /    k                  e
+                   /     \               /
+                  h       l            /
+                            \        /
+                              m  . d
+                                 /
+                                j
+            """
+
+        And the ways
+            | nodes       | name           | oneway |
+            | ac          | Halenseestraße | yes    |
+            | gb          | Halenseestraße | yes    |
+            | cklmdenopgc | Rathenauplatz  | yes    |
+            | ig          | Kurfürstendamm | yes    |
+            | ef          | Kurfürstendamm | yes    |
+            | ch          | Hubertusallee  | yes    |
+            | jd          | Hubertusallee  | yes    |
+
+        When I route I should get
+            | waypoints | route                                                    | turns                                            |
+            | i,h       | Kurfürstendamm,Rathenauplatz,Hubertusallee,Hubertusallee | depart,turn slight left,turn slight right,arrive |

--- a/features/guidance/merge-segregated-roads.feature
+++ b/features/guidance/merge-segregated-roads.feature
@@ -560,5 +560,5 @@ Feature: Merge Segregated Roads
             | jd          | Hubertusallee  | yes    |
 
         When I route I should get
-            | waypoints | route                                                    | turns                                            |
-            | i,h       | Kurfürstendamm,Rathenauplatz,Hubertusallee,Hubertusallee | depart,turn slight left,turn slight right,arrive |
+            | waypoints | route                                      | turns                       |
+            | i,h       | Kurfürstendamm,Hubertusallee,Hubertusallee | depart,turn straight,arrive |

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -378,6 +378,8 @@ bool areParallel(const iterator_type lhs_begin,
     return std::abs(slope_rhs) < 0.20; // twenty percent incline at the most
 }
 
+double computeArea(const std::vector<Coordinate> &polygon);
+
 } // ns coordinate_calculation
 } // ns util
 } // ns osrm

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -408,4 +408,29 @@ BOOST_AUTO_TEST_CASE(regression_test_3516)
     BOOST_CHECK_EQUAL(nearest_location, v);
 }
 
+BOOST_AUTO_TEST_CASE(computeArea)
+{
+    using osrm::util::coordinate_calculation::computeArea;
+
+    //
+    auto rhombus = std::vector<Coordinate>{{FloatLongitude{.00}, FloatLatitude{.00}},
+                                           {FloatLongitude{.01}, FloatLatitude{.01}},
+                                           {FloatLongitude{.02}, FloatLatitude{.00}},
+                                           {FloatLongitude{.01}, FloatLatitude{-.01}},
+                                           {FloatLongitude{.00}, FloatLatitude{.00}}};
+
+    BOOST_CHECK_CLOSE(2 * 1112.263 * 1112.263, computeArea(rhombus), 1e-3);
+
+    // edge cases
+    auto self_intersection = std::vector<Coordinate>{{FloatLongitude{.00}, FloatLatitude{.00}},
+                                                     {FloatLongitude{.00}, FloatLatitude{.02}},
+                                                     {FloatLongitude{.01}, FloatLatitude{.01}},
+                                                     {FloatLongitude{.02}, FloatLatitude{.00}},
+                                                     {FloatLongitude{.02}, FloatLatitude{.02}},
+                                                     {FloatLongitude{.01}, FloatLatitude{.01}},
+                                                     {FloatLongitude{.00}, FloatLatitude{.00}}};
+    BOOST_CHECK(computeArea(self_intersection) < 1e-3);
+    BOOST_CHECK_CLOSE(0, computeArea({}), 1e-3);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

The PR resurrects #2741 to avoid merging roads that are better fitted to a circle than line.
This prevents merging of round intersections, here are locations in CA and DE extracts:
https://api.mapbox.com/styles/v1/oxidase/cj6w8nt4v8vpp2ro262yx9csb.html?title=true&access_token=pk.eyJ1Ijoib3hpZGFzZSIsImEiOiJjaXcxNWMxYmswMDRlMnlxOWtlem0yamU3In0.PjtHAtgQDzxhZ1BE484Sqw#1.73/53.3/-17.8

The idea is to use Taubin algebraic fit and check quadratic error with respect to a line fitting and if circle fitted is better and radius is less than circumference divided by 3 (rounded pi) than roads will not be merged.

## Tasklist
 - [ ] ADD OWN TASKS HERE
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
