### PR TITLE
Parallelize ManyToMany plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
       - New function to support relations: `process_relation`. Read more in profiles documentation.
     - Infrastructure:
       - Lua 5.1 support is removed due to lack of support in sol2 https://github.com/ThePhD/sol2/issues/302
+    - Node.js Bindings:
+      - Exposes `use_threads_number=Number` parameter of `EngineConfig` to limit a number of threads in a TBB internal pool
 
 # 5.12.0
     - Guidance

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -24,6 +24,8 @@
 #include "util/fingerprint.hpp"
 #include "util/json_container.hpp"
 
+#include <tbb/task_scheduler_init.h>
+
 #include <memory>
 #include <string>
 
@@ -53,7 +55,8 @@ template <typename Algorithm> class Engine final : public EngineInterface
 {
   public:
     explicit Engine(const EngineConfig &config)
-        : route_plugin(config.max_locations_viaroute, config.max_alternatives), //
+        : task_scheduler(config.use_threads_number),
+          route_plugin(config.max_locations_viaroute, config.max_alternatives), //
           table_plugin(config.max_locations_distance_table),                    //
           nearest_plugin(config.max_results_nearest),                           //
           trip_plugin(config.max_locations_trip),                               //
@@ -125,6 +128,7 @@ template <typename Algorithm> class Engine final : public EngineInterface
     }
     std::unique_ptr<DataFacadeProvider<Algorithm>> facade_provider;
     mutable SearchEngineData<Algorithm> heaps;
+    tbb::task_scheduler_init task_scheduler;
 
     const plugins::ViaRoutePlugin route_plugin;
     const plugins::TablePlugin table_plugin;

--- a/include/engine/engine_config.hpp
+++ b/include/engine/engine_config.hpp
@@ -90,6 +90,8 @@ struct EngineConfig final
     int max_alternatives = 3; // set an arbitrary upper bound; can be adjusted by user
     bool use_shared_memory = true;
     Algorithm algorithm = Algorithm::CH;
+    int use_threads_number = 1;
+    std::string verbosity;
 };
 }
 }

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -20,8 +20,8 @@ template <typename Algorithm>
 std::vector<EdgeWeight> manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                                          const DataFacade<Algorithm> &facade,
                                          const std::vector<PhantomNode> &phantom_nodes,
-                                         const std::vector<std::size_t> &source_indices,
-                                         const std::vector<std::size_t> &target_indices);
+                                         std::vector<std::size_t> source_indices,
+                                         std::vector<std::size_t> target_indices);
 
 } // namespace routing_algorithms
 } // namespace engine

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -186,6 +186,7 @@ inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo
         params->Get(Nan::New("max_locations_map_matching").ToLocalChecked());
     auto max_results_nearest = params->Get(Nan::New("max_results_nearest").ToLocalChecked());
     auto max_alternatives = params->Get(Nan::New("max_alternatives").ToLocalChecked());
+    auto use_threads_number = params->Get(Nan::New("use_threads_number").ToLocalChecked());
 
     if (!max_locations_trip->IsUndefined() && !max_locations_trip->IsNumber())
     {
@@ -217,6 +218,11 @@ inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo
         Nan::ThrowError("max_alternatives must be an integral number");
         return engine_config_ptr();
     }
+    if (!use_threads_number->IsUndefined() && !use_threads_number->IsNumber())
+    {
+        Nan::ThrowError("use_threads_number must be an integral number");
+        return engine_config_ptr();
+    }
 
     if (max_locations_trip->IsNumber())
         engine_config->max_locations_trip = static_cast<int>(max_locations_trip->NumberValue());
@@ -233,6 +239,8 @@ inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo
         engine_config->max_results_nearest = static_cast<int>(max_results_nearest->NumberValue());
     if (max_alternatives->IsNumber())
         engine_config->max_alternatives = static_cast<int>(max_alternatives->NumberValue());
+    if (use_threads_number->IsNumber())
+        engine_config->use_threads_number = static_cast<int>(use_threads_number->NumberValue());
 
     return engine_config;
 }

--- a/src/engine/engine_config.cpp
+++ b/src/engine/engine_config.cpp
@@ -20,7 +20,7 @@ bool EngineConfig::IsValid() const
                               unlimited_or_more_than(max_locations_trip, 2) &&
                               unlimited_or_more_than(max_locations_viaroute, 2) &&
                               unlimited_or_more_than(max_results_nearest, 0) &&
-                              max_alternatives >= 0;
+                              max_alternatives >= 0 && use_threads_number >= 1;
 
     return ((use_shared_memory && all_path_are_empty) || storage_config.IsValid()) && limits_valid;
 }

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -87,6 +87,8 @@ inline unsigned generateServerProgramOptions(const int argc,
     using boost::program_options::value;
     using boost::filesystem::path;
 
+    const auto hardware_threads = std::max<int>(1, std::thread::hardware_concurrency());
+
     // declare a group of options that will be allowed only on command line
     boost::program_options::options_description generic_options("Options");
     generic_options.add_options() //
@@ -106,7 +108,7 @@ inline unsigned generateServerProgramOptions(const int argc,
          value<int>(&ip_port)->default_value(5000),
          "TCP/IP port") //
         ("threads,t",
-         value<int>(&config.use_threads_number)->default_value(8),
+         value<int>(&config.use_threads_number)->default_value(hardware_threads),
          "Number of threads to use") //
         ("shared-memory,s",
          value<bool>(&config.use_shared_memory)->implicit_value(true)->default_value(false),
@@ -194,6 +196,9 @@ inline unsigned generateServerProgramOptions(const int argc,
     {
         util::Log(logWARNING) << "Shared memory settings conflict with path settings.";
     }
+
+    // Adjust number of threads to hardware concurrency
+    config.use_threads_number = std::min(hardware_threads, config.use_threads_number);
 
     std::cout << visible_options;
     return INIT_OK_DO_NOT_START_ENGINE;


### PR DESCRIPTION
# Issue

Backward and forward searches in manyToMany plugin are independent and can be easily parallelized.
Here is timing results in milliseconds with 4 cores (2 real + 2 HT) for 25x25 random table requests for DE-sized extract:

![par_ser](https://user-images.githubusercontent.com/4421046/29838718-41349ad2-8cfc-11e7-8c0f-a297ef81197c.png)



## Tasklist
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
