### PR TITLE
Remove superfluous hyphen from short form of --version in tests

### DIFF
--- a/features/options/contract/version.feature
+++ b/features/options/contract/version.feature
@@ -8,7 +8,7 @@ Feature: osrm-contract command line options: version
         Given the profile "testbot"
 
     Scenario: osrm-contract - Version, short
-        When I run "osrm-contract --v"
+        When I run "osrm-contract -v"
         Then stderr should be empty
         And stdout should contain 1 line
         And stdout should contain /(v\d{1,2}\.\d{1,2}\.\d{1,2}|\w*-\d+-\w+)/

--- a/features/options/customize/version.feature
+++ b/features/options/customize/version.feature
@@ -5,7 +5,7 @@ Feature: osrm-customize command line options: version
         Given the profile "testbot"
 
     Scenario: osrm-customize - Version, short
-        When I run "osrm-customize --v"
+        When I run "osrm-customize -v"
         Then stderr should be empty
         And stdout should contain 1 line
         And stdout should contain /(v\d{1,2}\.\d{1,2}\.\d{1,2}|\w*-\d+-\w+)/

--- a/features/options/extract/version.feature
+++ b/features/options/extract/version.feature
@@ -8,7 +8,7 @@ Feature: osrm-extract command line options: version
         Given the profile "testbot"
     
     Scenario: osrm-extract - Version, short
-        When I run "osrm-extract --v"
+        When I run "osrm-extract -v"
         Then stderr should be empty
         And stdout should contain 1 line
         And stdout should contain /(v\d{1,2}\.\d{1,2}\.\d{1,2}|\w*-\d+-\w+)/

--- a/features/options/partition/version.feature
+++ b/features/options/partition/version.feature
@@ -5,7 +5,7 @@ Feature: osrm-partition command line options: version
         Given the profile "testbot"
 
     Scenario: osrm-partition - Version, short
-        When I run "osrm-partition --v"
+        When I run "osrm-partition -v"
         Then stderr should be empty
         And stdout should contain 1 line
         And stdout should contain /(v\d{1,2}\.\d{1,2}\.\d{1,2}|\w*-\d+-\w+)/

--- a/features/options/routed/version.feature
+++ b/features/options/routed/version.feature
@@ -8,7 +8,7 @@ Feature: osrm-routed command line options: version
         Given the profile "testbot"
     
     Scenario: osrm-routed - Version, short
-        When I run "osrm-routed --v"
+        When I run "osrm-routed -v"
         Then stderr should be empty
         And stdout should contain 1 line
         And stdout should contain /(v\d{1,2}\.\d{1,2}\.\d{1,2}|\w*-\d+-\w+)/


### PR DESCRIPTION
# Issue

`version.feature` executed programs with `--v` as short form of `--version`, instead of `-v`.

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations

Discovered while testing #4451 with proposal of `--verbosity, -l` options, where `--v` is reported as ambiguous option matching `--version` or `--verbosity`.
