### PR TITLE
CanMergeRoad missed test of rhs instance of IntersectionShapeData

### DIFF
--- a/src/extractor/guidance/mergable_road_detector.cpp
+++ b/src/extractor/guidance/mergable_road_detector.cpp
@@ -80,7 +80,7 @@ bool MergableRoadDetector::CanMergeRoad(const NodeID intersection_node,
     };
 
     // TODO might have to skip over trivial intersections
-    if (road_target(lhs) == intersection_node || road_target(lhs) == intersection_node)
+    if (road_target(lhs) == intersection_node || road_target(rhs) == intersection_node)
         return false;
 
     // Don't merge turning circles/traffic loops


### PR DESCRIPTION
# Issue

Avoids identical sub-expressions `road_target(lhs) == intersection_node` on both sides of `||` and corrects missing condition.

## Tasklist

 - [x] review
 - [x] adjust for comments
