### PR TITLE
Preserve edge weights when blank rate provided in traffic data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
       - New property for profile table: `excludable` that can be used to configure which classes are excludable at query time.
       - New optional property for profile table: `classes` that allows you to specify which classes you expect to be used.
         We recommend this for better error messages around classes, otherwise the possible class names are infered automatically.
+    - Traffic:
+      - If traffic data files contain an empty 4th column, they will update edge durations but not modify the edge weight.  This is useful for
+        updating ETAs returned, without changing route selection (for example, in a distance-based profile with traffic data loaded).
     - Infrastructure:
       - New file `.osrm.cell_metrics` created by `osrm-customize`.
 

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -402,8 +402,8 @@ Feature: Weight tests
         And the speed file
             """
             1,2,100,
-            1,3,5,
-            3,4,5,
+            1,3,5,,junk
+            3,4,5,,
             4,2,5,
             """
         And the contract extra arguments "--segment-speed-file {speeds_file}"

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -379,3 +379,36 @@ Feature: Weight tests
             | a,d       | abcd,abcd  | 59.9m    | 6.996,0       | 7s,0s    |
             | a,e       | abcd,ce,ce | 60.1m    | 6.005,2.002,0 | 6s,2s,0s |
             | d,e       | abcd,ce,ce | 39.9m    | 1.991,2.002,0 | 2s,2s,0s |
+
+    @traffic @speed
+    Scenario: Updating speeds without affecting weights.
+        Given the profile file "testbot" initialized with
+        """
+        profile.properties.weight_precision = 3
+        """
+
+        And the node map
+            """
+            a-----------b
+             \         /
+                c----d
+            """
+        And the ways
+            | nodes | highway       | maxspeed |
+            | ab    | living_street | 5        |
+            | acdb  | motorway      | 100      |
+
+        # Note the comma on the last column - this indicates 'keep existing weight value'
+        And the speed file
+            """
+            1,2,100,
+            1,3,5,
+            3,4,5,
+            4,2,5,
+            """
+        And the contract extra arguments "--segment-speed-file {speeds_file}"
+        And the customize extra arguments "--segment-speed-file {speeds_file}"
+
+        When I route I should get
+            | waypoints | route      | distance | weights       | times    |
+            | a,b       | acdb,acdb  | 78.3m    | 11.744,0      | 56.4s,0s  |

--- a/include/updater/source.hpp
+++ b/include/updater/source.hpp
@@ -49,9 +49,9 @@ struct Segment final
 
 struct SpeedSource final
 {
-    SpeedSource() : speed(0), rate(std::numeric_limits<double>::quiet_NaN()) {}
+    SpeedSource() : speed(0), rate() {}
     unsigned speed;
-    double rate;
+    boost::optional<double> rate;
     std::uint8_t source;
 };
 

--- a/src/updater/csv_source.cpp
+++ b/src/updater/csv_source.cpp
@@ -33,10 +33,11 @@ namespace csv
 {
 SegmentLookupTable readSegmentValues(const std::vector<std::string> &paths)
 {
+    static const auto value_if_blank = std::numeric_limits<double>::quiet_NaN();
     CSVFilesParser<Segment, SpeedSource> parser(
         1,
         qi::ulong_long >> ',' >> qi::ulong_long,
-        qi::uint_ >> -(',' >> (qi::double_ | qi::attr(std::numeric_limits<double>::quiet_NaN()))));
+        qi::uint_ >> -(',' >> (qi::double_ | qi::attr(value_if_blank))));
 
     // Check consistency of keys in the result lookup table
     auto result = parser(paths);

--- a/src/updater/csv_source.cpp
+++ b/src/updater/csv_source.cpp
@@ -34,7 +34,9 @@ namespace csv
 SegmentLookupTable readSegmentValues(const std::vector<std::string> &paths)
 {
     CSVFilesParser<Segment, SpeedSource> parser(
-        1, qi::ulong_long >> ',' >> qi::ulong_long, qi::uint_ >> -(',' >> qi::double_));
+        1,
+        qi::ulong_long >> ',' >> qi::ulong_long,
+        qi::uint_ >> -(',' >> (qi::double_ | qi::attr(std::numeric_limits<double>::quiet_NaN()))));
 
     // Check consistency of keys in the result lookup table
     auto result = parser(paths);


### PR DESCRIPTION
# Issue

This change makes it possible to preserve existing `weight` values on edges, while updating the `duration`.

If traffic data CSV files include a blank 4th column:

```
nodeA,nodeB,speed        <- (1) weight will be calculated from speed
nodeA,nodeB,speed,rate   <- (2) weight will be calculated from rate
nodeA,nodeB,speed,       <- (3) weight will be preserved
```

Currently, we support (1) and (2).  This change adds (3), which makes it easy to update the durations on edges without affecting the routing weights.  This is useful, for example, if you're using a distance-based profile, but want to update speed values to track accurate ETAs.

## Tasklist
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments