### PR TITLE
Process route relation in car.lua

### DIFF
--- a/features/car/route_relations.feature
+++ b/features/car/route_relations.feature
@@ -1,0 +1,68 @@
+@routing @car @relations
+Feature: Car - route relations
+    Background:
+        Given the profile "car"
+
+    @sliproads
+    Scenario: Cardinal direction assignment to refs
+        Given the node map
+            """
+                     a  b
+                     |  |
+              c------+--+------d
+              e------+--+------f
+                     |  |
+                     g  h
+
+              i----------------j
+              k----------------l
+
+              x----------------y
+              z----------------w
+            """
+
+        And the ways
+            | nodes | name        | highway  | ref         |
+            | ag    | southbound  | motorway | I 80        |
+            | hb    | northbound  | motorway | I 80        |
+            | dc    | westbound   | motorway | I 85;CO 93  |
+            | ef    | eastbound   | motorway | I 85;US 12  |
+            | ij    | westbound-2 | motorway | I 99        |
+            | ji    | eastbound-2 | motorway | I 99        |
+            | kl    | eastbound-2 | motorway | I 99        |
+            | lk    | eastbound-2 | motorway | I 99        |
+            | xy    | watermill   | motorway | I 45M; US 3 |
+
+        And the relations
+            | type        | way:south | route | ref |
+            | route       | ag        | road  | 80  |
+            | route       | ef        | road  | 12  |
+
+        And the relations
+            | type        | way:north | route | ref |
+            | route       | hb        | road  | 80  |
+            | route       | cd        | road  | 93  |
+
+        And the relations
+            | type        | way:west | route | ref  |
+            | route       | dc       | road  | 85   |
+            | route       | ij       | road  | 99   |
+            | route       | xy       | road  | I 45 |
+
+        And the relations
+            | type        | way:east | route | ref   |
+            | route       | lk       | road  | I 99  |
+
+        And the relations
+            | type        | way:east | route | ref   |
+            | route       | xy       | road  | US 3  |
+
+        When I route I should get
+            | waypoints | route                   | ref                                               |
+            | a,g       | southbound,southbound   | I 80 $south,I 80 $south                           |
+            | h,b       | northbound,northbound   | I 80 $north,I 80 $north                           |
+            | d,c       | westbound,westbound     | I 85 $west; CO 93 $north,I 85 $west; CO 93 $north |
+            | e,f       | eastbound,eastbound     | I 85; US 12 $south,I 85; US 12 $south             |
+            | i,j       | westbound-2,westbound-2 | I 99 $west,I 99 $west                             |
+            | l,k       | eastbound-2,eastbound-2 | I 99 $east,I 99 $east                             |
+            | x,y       | watermill,watermill     | I 45M $west; US 3 $east,I 45M $west; US 3 $east   |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -396,10 +396,14 @@ function process_way(profile, way, result, relations)
   -- now process relations data
   local matched_refs = nil;
   if result.ref then
-    matched_refs = Relations.MatchToRef(relations, result.ref)
+    local match_res = Relations.match_to_ref(relations, result.ref)
+
+    order = match_res['order']
+    matched_refs = match_res['match']
 
     local ref = ''
-    for k, v in pairs(matched_refs) do
+    for _, k in pairs(order) do
+      local v = matched_refs[k]
       if ref ~= '' then
         ref = ref .. '; '
       end

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -399,7 +399,7 @@ function process_way(profile, way, result, relations)
     matched_refs = Relations.MatchToRef(relations, result.ref)
 
     local ref = ''
-    for k ,v in pairs(matched_refs) do
+    for k, v in pairs(matched_refs) do
       if ref ~= '' then
         ref = ref .. '; '
       end
@@ -407,24 +407,12 @@ function process_way(profile, way, result, relations)
       if v then
         ref = ref .. k .. ' $' .. v
       else
-        print(ref)
         ref = ref .. k
       end
     end
 
     result.ref = ref
-    -- count = 0
-    -- for k, v in pairs(matched_refs) do
-    --   count = count + 1
-    -- end
-    -- if count > 1 then
-    --   print('---', way:id())
-    --   for k, v in pairs(matched_refs) do
-    --     print(k, v)
-    --   end
-    -- end
   end
-
 
 end
 

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -398,20 +398,16 @@ function process_way(profile, way, result, relations)
   if result.ref then
     local match_res = Relations.match_to_ref(relations, result.ref)
 
-    order = match_res['order']
-    matched_refs = match_res['match']
-
     local ref = ''
-    for _, k in pairs(order) do
-      local v = matched_refs[k]
+    for _, m in pairs(match_res) do
       if ref ~= '' then
         ref = ref .. '; '
       end
 
-      if v then
-        ref = ref .. k .. ' $' .. v
+      if m.dir then
+        ref = ref .. m.ref .. ' $' .. m.dir
       else
-        ref = ref .. k
+        ref = ref .. m.ref
       end
     end
 
@@ -426,35 +422,35 @@ function process_relation(profile, relation, result)
   function add_extra_data(m)
     local name = relation:get_value_by_key("name")
     if name then
-      result[m]["route_name"] = name
+      result[m]['route_name'] = name
     end
 
     local ref = relation:get_value_by_key("ref")
     if ref then
-      result[m]["route_ref"] = ref
+      result[m]['route_ref'] = ref
     end
   end
 
-  if t == "route" then
+  if t == 'route' then
     local route = relation:get_value_by_key("route")
-    if route == "road" then
+    if route == 'road' then
       for _, m in ipairs(relation:members()) do
         -- process case, where directions set as role
         local role = string.lower(m:role())
-        if role == "north" or role == "south" or role == "west" or role == "east" then
-          result[m]["route_direction"] = role
+        if role == 'north' or role == 'south' or role == 'west' or role == 'east' then
+          result[m]['route_direction'] = role
           add_extra_data(m)
         end
       end
     end
 
-    local direction = relation:get_value_by_key("direction")
+    local direction = relation:get_value_by_key('direction')
     if direction then
       direction = string.lower(direction)
-      if direction == "north" or direction == "south" or direction == "west" or direction == "east" then
+      if direction == 'north' or direction == 'south' or direction == 'west' or direction == 'east' then
         for _, m in ipairs(relation:members()) do
-          if m:role() == "forward" then
-            result[m]["route_direction"] = direction
+          if m:role() == 'forward' then
+            result[m]['route_direction'] = direction
             add_extra_data(m)
           end
         end

--- a/profiles/lib/relations.lua
+++ b/profiles/lib/relations.lua
@@ -1,0 +1,20 @@
+-- Profile functions dealing with various aspects of relation parsing
+--
+-- You can run a selection you find useful in your profile,
+-- or do you own processing if/when required.
+
+Relations = {}
+
+function Relations.Merge(relations)
+  local result = {}
+
+  for _, r in ipairs(relations) do
+    for k, v in pairs(r) do
+      result[k] = v
+    end
+  end
+
+  return result
+end
+
+return Relations

--- a/profiles/lib/relations.lua
+++ b/profiles/lib/relations.lua
@@ -7,18 +7,6 @@ Utils = require('lib/utils')
 
 Relations = {}
 
-function Relations.Merge(relations)
-  local result = {}
-
-  for _, r in ipairs(relations) do
-    for k, v in pairs(r) do
-      result[k] = v
-    end
-  end
-
-  return result
-end
-
 -- match ref values to relations data
 function Relations.match_to_ref(relations, ref)
 
@@ -96,8 +84,9 @@ function Relations.match_to_ref(relations, ref)
   end
 
   local result = {}
-  result['order'] = order
-  result['match'] = result_match
+  for i, r in ipairs(order) do
+    result[i] = { ref = r, dir = result_match[r] };
+  end
 
   return result
 end

--- a/profiles/lib/relations.lua
+++ b/profiles/lib/relations.lua
@@ -49,7 +49,7 @@ function Relations.MatchToRef(relations, ref)
   local result_match = {}
 
   for _, r in ipairs(references) do
-    result_match[r] = nil
+    result_match[r] = false
   end
 
   for _, rel in ipairs(relations) do

--- a/profiles/lib/relations.lua
+++ b/profiles/lib/relations.lua
@@ -20,7 +20,7 @@ function Relations.Merge(relations)
 end
 
 -- match ref values to relations data
-function Relations.MatchToRef(relations, ref)
+function Relations.match_to_ref(relations, ref)
 
   function calculate_scores(refs, tag_value)
     local tag_tokens = Set(Utils.tokenize_common(tag_value))
@@ -47,12 +47,13 @@ function Relations.MatchToRef(relations, ref)
 
   local references = Utils.string_list_tokens(ref)
   local result_match = {}
-
-  for _, r in ipairs(references) do
+  local order = {}
+  for i, r in ipairs(references) do
     result_match[r] = false
+    order[i] = r
   end
 
-  for _, rel in ipairs(relations) do
+  for i, rel in ipairs(relations) do
     local name_scores = nil
     local name_tokens = {}
     local route_name = rel["route_name"]
@@ -94,7 +95,11 @@ function Relations.MatchToRef(relations, ref)
 
   end
 
-  return result_match
+  local result = {}
+  result['order'] = order
+  result['match'] = result_match
+
+  return result
 end
 
 return Relations

--- a/profiles/lib/relations.lua
+++ b/profiles/lib/relations.lua
@@ -3,6 +3,8 @@
 -- You can run a selection you find useful in your profile,
 -- or do you own processing if/when required.
 
+Utils = require('lib/utils')
+
 Relations = {}
 
 function Relations.Merge(relations)
@@ -15,6 +17,84 @@ function Relations.Merge(relations)
   end
 
   return result
+end
+
+-- match ref values to relations data
+function Relations.MatchToRef(relations, ref)
+
+  function calculate_scores(refs, tag_value)
+    local tag_tokens = Set(Utils.tokenize_common(tag_value))
+    local result = {}
+    for i, r in ipairs(refs) do
+      local ref_tokens = Utils.tokenize_common(r)
+      local score = 0
+
+      for _, t in ipairs(ref_tokens) do
+        if tag_tokens[t] then
+          if Utils.is_number(t) then
+            score = score + 2
+          else
+            score = score + 1
+          end
+        end
+      end
+
+      result[r] = score
+    end
+
+    return result
+  end
+
+  local references = Utils.string_list_tokens(ref)
+  local result_match = {}
+
+  for _, r in ipairs(references) do
+    result_match[r] = nil
+  end
+
+  for _, rel in ipairs(relations) do
+    local name_scores = nil
+    local name_tokens = {}
+    local route_name = rel["route_name"]
+    if route_name then
+      name_scores = calculate_scores(references, route_name)
+    end
+
+    local ref_scores = nil
+    local ref_tokens = {}
+    local route_ref = rel["route_ref"]
+    if route_ref then
+      ref_scores = calculate_scores(references, route_ref)
+    end
+
+    -- merge scores
+    local direction = rel["route_direction"]
+    if direction then
+      local best_score = -1
+      local best_ref = nil
+      
+      function find_best(scores)
+        if scores then
+          for k ,v in pairs(scores) do
+            if v > best_score then
+              best_ref = k
+              best_score = v
+            end
+          end
+        end
+      end
+
+      find_best(name_scores)
+      find_best(ref_scores)
+      
+      if best_ref then
+        result_match[best_ref] = direction
+      end
+    end
+
+  end
+
+  return result_match
 end
 
 return Relations

--- a/profiles/lib/utils.lua
+++ b/profiles/lib/utils.lua
@@ -13,7 +13,7 @@ function Utils.string_list_tokens(str)
   for s in str.gmatch(str, "([^;]*)") do
     if s ~= nil and s ~= '' then
       idx = idx + 1
-      table.insert(result, idx, (s:gsub("^%s*(.-)%s*$", "%1")))
+      result[idx] = s:gsub("^%s*(.-)%s*$", "%1")
     end
   end
 
@@ -28,7 +28,7 @@ function Utils.tokenize_common(str)
   for s in str.gmatch(str, "%S+") do
     if s ~= nil and s ~= '' then
       idx = idx + 1
-      table.insert(result, idx, (s:gsub("^%s*(.-)%s*$", "%1")))
+      result[idx] = s:gsub("^%s*(.-)%s*$", "%1")
     end
   end
 

--- a/profiles/lib/utils.lua
+++ b/profiles/lib/utils.lua
@@ -1,0 +1,43 @@
+-- Profile functions to implement common algorithms of data processing
+--
+-- You can run a selection you find useful in your profile,
+-- or do you own processing if/when required.
+
+Utils = {}
+
+-- split string 'a; b; c' to table with values ['a', 'b', 'c']
+-- so it use just one separator ';'
+function Utils.string_list_tokens(str)
+  result = {}
+  local idx = 0
+  for s in str.gmatch(str, "([^;]*)") do
+    if s ~= nil and s ~= '' then
+      idx = idx + 1
+      table.insert(result, idx, (s:gsub("^%s*(.-)%s*$", "%1")))
+    end
+  end
+
+  return result
+end
+
+-- same as Utils.StringListTokens, but with many possible separators:
+-- ',' | ';' | ' '| '(' | ')'
+function Utils.tokenize_common(str)
+  result = {}
+  local idx = 0
+  for s in str.gmatch(str, "%S+") do
+    if s ~= nil and s ~= '' then
+      idx = idx + 1
+      table.insert(result, idx, (s:gsub("^%s*(.-)%s*$", "%1")))
+    end
+  end
+
+  return result
+end
+
+-- returns true, if string contains a number
+function Utils.is_number(str)
+  return (tonumber(str) ~= nil)
+end
+
+return Utils


### PR DESCRIPTION
# Issue

## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Improvements
- [ ] Support more separators in common tokenizer
- [ ] Add more scores for 65M refs (like for a numbers)
- [x] Improve code: return ref match result in specified order from match funciton (replace two containers, that used right now)

## Requirements / Relations
Based on PR: #4438 (merge after)

Support multiref's: https://github.com/Project-OSRM/osrm-text-instructions/issues/119#issuecomment-328053084

## Decsription
It appends route direction value to ref with prefix `$`. 
As example `ref` = `I75 $north`
So `$north`, `$south`, `$west`, `$east` can be processed by UI in useful way

## Problems
Also there is a very strange bug for way http://www.openstreetmap.org/way/19026367
I'm pretty sure, that return correct ref for it in LUA:
```sh
SR 16; SR 83  # source ref
west                # role in one relation
south               # role in second relation
SR 83	south  # matched ref to role
SR 16	west   # matched ref to role
SR 83 $south; SR 16 $west  # final result.ref
```

But in JSON it took value: `SR 83 $west; SR 16 $east`

**Update**: problem wasn't reproduced. It looks like confusion in way id's in LUA and osrm-frontend route during test.

