### PR TITLE
Add to car profile missing DK:rural maxspeed_table exceptions osm-fr/osmose-backend#174

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -254,6 +254,7 @@ function setup()
       ["ch:trunk"] = 100,
       ["ch:motorway"] = 120,
       ["de:living_street"] = 7,
+      ["dk:rural"] = 80,
       ["ru:living_street"] = 20,
       ["ru:urban"] = 60,
       ["ua:urban"] = 60,


### PR DESCRIPTION
From wiki https://wiki.openstreetmap.org/wiki/Speed_limits
The DK:rural maxspeed_table exceptions is missing