### PR TITLE
Don't suppress fork instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
       - New function to support relations: `process_relation`. Read more in profiles documentation.
     - Infrastructure:
       - Lua 5.1 support is removed due to lack of support in sol2 https://github.com/ThePhD/sol2/issues/302
+    - Guidance
+      - treat forks from link-typed roads as forks to avoid turn-like instructions suppression
 
 # 5.12.0
     - Guidance

--- a/features/guidance/fork.feature
+++ b/features/guidance/fork.feature
@@ -385,3 +385,21 @@ Feature: Fork Instructions
             | waypoints | route      | turns                    |
             | a,j       | on,xbcj    | depart,arrive            |
             | a,i       | on,off,off | depart,turn right,arrive |
+
+     # https://www.openstreetmap.org/node/619615462
+     Scenario: Fork on links - don't suppress as obvious turns
+        Given the node map
+            """
+            a . . . . . b . . . . . c
+                          `  .   .  d
+            """
+
+        And the ways
+            | nodes | highway       |
+            | abc   | motorway_link |
+            | bd    | motorway_link |
+
+        When I route I should get
+            | waypoints | route     | turns                           |
+            | a,c       | abc,abc   | depart,arrive                   |
+            | a,d       | abc,bd,bd | depart,turn slight right,arrive |

--- a/features/guidance/fork.feature
+++ b/features/guidance/fork.feature
@@ -400,6 +400,6 @@ Feature: Fork Instructions
             | bd    | motorway_link |
 
         When I route I should get
-            | waypoints | route     | turns                           |
-            | a,c       | abc,abc   | depart,arrive                   |
-            | a,d       | abc,bd,bd | depart,turn slight right,arrive |
+            | waypoints | route       | turns                           |
+            | a,c       | abc,abc,abc | depart,fork slight left,arrive  |
+            | a,d       | abc,bd,bd   | depart,fork slight right,arrive |

--- a/src/extractor/guidance/turn_handler.cpp
+++ b/src/extractor/guidance/turn_handler.cpp
@@ -230,27 +230,29 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
     BOOST_ASSERT(intersection.size() == 3);
     const auto obvious_index = findObviousTurn(via_edge, intersection);
     BOOST_ASSERT(intersection[0].angle < 0.001);
-    /* Two nearly straight turns -> FORK
-               OOOOOOO
-             /
-      IIIIII
-             \
-               OOOOOOO
-     */
 
+    // Two nearly straight turns -> FORK
+    //            OOOOOOO
+    //          /
+    //   IIIIII
+    //          \
+    //            OOOOOOO
+    //
+    // If a fork has no obvious direction or is from a link (IIIIII)
+    // then don't suppress instructions as for a T-intersection or a turn
     auto fork = findFork(via_edge, intersection);
-    if (fork && obvious_index == 0)
+    if (fork && (obvious_index == 0 ||
+                 node_based_graph.GetEdgeData(via_edge).road_classification.IsLinkClass()))
     {
         assignFork(via_edge, fork->getLeft(), fork->getRight());
     }
 
-    /*  T Intersection
-
-        OOOOOOO T OOOOOOOO
-                I
-                I
-                I
-     */
+    // T Intersection
+    //
+    //   OOOOOOO T OOOOOOOO
+    //           I
+    //           I
+    //           I
     else if (isEndOfRoad(intersection[0], intersection[1], intersection[2]) && obvious_index == 0)
     {
         if (intersection[1].entry_allowed)


### PR DESCRIPTION
# Issue

In cases of links like [osrm](http://map.project-osrm.org/?z=18&center=37.587649%2C-77.473070&loc=37.588977%2C-77.470720&loc=37.588157%2C-77.473134&hl=en&alt=0) forks detection uses condition of "no obvious direction" https://github.com/Project-OSRM/osrm-backend/blob/4ea3f33376eb9dc3da069b295b7a9c2688a940ad/src/extractor/guidance/turn_handler.cpp#L661-L663 and https://github.com/Project-OSRM/osrm-backend/blob/4ea3f33376eb9dc3da069b295b7a9c2688a940ad/src/extractor/guidance/turn_handler.cpp#L677

But forks have other obvious direction detection as turns. The condition
https://github.com/Project-OSRM/osrm-backend/blob/4ea3f33376eb9dc3da069b295b7a9c2688a940ad/src/extractor/guidance/turn_handler.cpp#L242 uses `obvious_index` from `findObviousTurn`, so if there is no no obvious direction detected by the fork handler, but `findObviousTurn` returns non-obvious direction (obvious_index != 0 ) the fork will be handled as a turn. This behavior is used for non-links highway types, but potentially wrong for links. 

The PR adds a fallback to non-obvious conditional branch for forks links.
So the above route will be
![screenshot from 2017-09-13 08-33-54](https://user-images.githubusercontent.com/4421046/30363205-9ae539b0-985f-11e7-8830-7327711b870c.png)

Map of fork intersections where instructions will be handled by `assignFork`
https://api.mapbox.com/styles/v1/oxidase/cj7ip8d1i5kzz2rq53gd97k7y.html?title=true&access_token=pk.eyJ1Ijoib3hpZGFzZSIsImEiOiJjaXcxNWMxYmswMDRlMnlxOWtlem0yamU3In0.PjtHAtgQDzxhZ1BE484Sqw#17.36/37.41387/-121.8803

/cc @daniel-j-h 



## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
