### PR TITLE
Make unbuffered log verbosity-aware

### DIFF
--- a/features/options/extract/verbosity.feature
+++ b/features/options/extract/verbosity.feature
@@ -1,0 +1,32 @@
+@extract
+Feature: osrm-extract must be silent with NONE
+
+    Background:
+        Given the node map
+            """
+            a b
+            """
+        And the ways
+            | nodes |
+            | ab    |
+        And the data has been saved to disk
+
+    Scenario: osrm-extract - Passing base file with verbosity NONE
+        Given the profile file
+        """
+        functions = require('testbot')
+
+        function way_function(profile, way, result)
+          result.forward_mode = mode.driving
+          result.forward_speed = 1
+        end
+
+        functions.process_way = way_function
+        return functions
+        """
+        When I run "osrm-extract --profile {profile_file} {osm_file} --verbosity NONE"
+        Then it should exit successfully
+        And stdout should not contain "[info]"
+        And stdout should not contain "[error]"
+        And stdout should not contain "10%"
+        And stderr should be empty

--- a/include/util/log.hpp
+++ b/include/util/log.hpp
@@ -53,10 +53,40 @@ class Log
     virtual ~Log();
     std::mutex &get_mutex();
 
-    template <typename T> inline std::ostream &operator<<(const T &data) { return stream << data; }
+    template <typename T> inline Log &operator<<(const T &data)
+    {
+        const auto &policy = LogPolicy::GetInstance();
+        if (!policy.IsMute() && level <= policy.GetLevel())
+        {
+            stream << data;
+        }
+        return *this;
+    }
+
+    template <typename T> inline Log &operator<<(const std::atomic<T> &data)
+    {
+        const auto &policy = LogPolicy::GetInstance();
+        if (!policy.IsMute() && level <= policy.GetLevel())
+        {
+            stream << T(data);
+        }
+        return *this;
+    }
+
+    typedef std::ostream &(manip)(std::ostream &);
+
+    inline Log &operator<<(manip &m)
+    {
+        const auto &policy = LogPolicy::GetInstance();
+        if (!policy.IsMute() && level <= policy.GetLevel())
+        {
+            stream << m;
+        }
+        return *this;
+    }
 
   protected:
-    LogLevel level;
+    const LogLevel level;
     std::ostringstream buffer;
     std::ostream &stream;
 };

--- a/include/util/percent.hpp
+++ b/include/util/percent.hpp
@@ -83,7 +83,7 @@ class Percent
             // When not on a TTY, print newlines after each progress indicator so
             // so that progress is visible to line-buffered logging systems
             if (!IsStdoutATTY())
-                log << "" << std::endl;
+                log << std::endl;
         }
     }
 };

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -48,7 +48,7 @@ void LogPolicy::SetLevel(std::string const &level)
     else if (boost::iequals(level, "DEBUG"))
         m_level = logDEBUG;
     else
-        ;
+        m_level = logINFO;
 }
 
 LogPolicy &LogPolicy::GetInstance()


### PR DESCRIPTION
# Issue

The verbosity level is not checked in unbuffered loggers, so using NONE, ERROR, WARNING levels is interleaved with some unrelated output. The PR adds checks for unbuffered loggers.


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
