### PR TITLE
Add support of distance in foot and bicycle profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
     - Profile:
       - New function to support relations: `process_relation`. Read more in profiles documentation.
+      - Support of `distance` weight in foot and bicycle profiles
     - Infrastructure:
       - Lua 5.1 support is removed due to lack of support in sol2 https://github.com/ThePhD/sol2/issues/302
     - Node.js Bindings:

--- a/features/bicycle/distance.feature
+++ b/features/bicycle/distance.feature
@@ -1,0 +1,35 @@
+@routing @bicycle
+Feature: Bike - Use distance weight
+
+    Background:
+        Given a grid size of 200 meters
+
+    Scenario: Bike - Check distance weight
+        Given the profile file
+        """
+        local functions = require('bicycle')
+        functions.setup_testbot = functions.setup
+
+        functions.setup = function()
+          local profile = functions.setup_testbot()
+          profile.properties.weight_name = 'distance'
+          return profile
+        end
+
+        return functions
+        """
+
+        Given the node map
+            """
+            a-b-c
+            """
+
+
+        And the ways
+            | nodes | highway     |
+            | abc   | residential |
+
+        When I route I should get
+            | from | to | route   | weight | time | distance |
+            | a    | b  | abc,abc |    200 | 48s  | 200m +-1 |
+            | a    | c  | abc,abc |    400 | 96s  | 400m +-1 |

--- a/features/foot/distance.feature
+++ b/features/foot/distance.feature
@@ -1,0 +1,35 @@
+@routing @foot
+Feature: Foot - Use distance weight
+
+    Background:
+        Given a grid size of 200 meters
+
+    Scenario: Foot - Check distance weight
+        Given the profile file
+        """
+        local functions = require('foot')
+        functions.setup_testbot = functions.setup
+
+        functions.setup = function()
+          local profile = functions.setup_testbot()
+          profile.properties.weight_name = 'distance'
+          return profile
+        end
+
+        return functions
+        """
+
+        Given the node map
+            """
+            a-b-c
+            """
+
+
+        And the ways
+            | nodes | highway     |
+            | abc   | residential |
+
+        When I route I should get
+            | from | to | route   | weight | time | distance |
+            | a    | b  | abc,abc |    200 | 144s | 200m +-1 |
+            | a    | c  | abc,abc |    400 | 288s | 400m +-1 |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -536,7 +536,7 @@ function process_way(profile, way, result)
 
     -- handle turn lanes and road classification, used for guidance
     WayHandlers.classification,
-    
+
     -- handle allowed start/end modes
     WayHandlers.startpoint,
 
@@ -544,7 +544,10 @@ function process_way(profile, way, result)
     WayHandlers.roundabouts,
 
     -- set name, ref and pronunciation
-    WayHandlers.names
+    WayHandlers.names,
+
+    -- set weight properties of the way
+    WayHandlers.weights
   }
 
   WayHandlers.run(profile,way,result,data,handlers)

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -237,7 +237,10 @@ function process_way(profile, way, result)
     WayHandlers.startpoint,
 
     -- set name, ref and pronunciation
-    WayHandlers.names
+    WayHandlers.names,
+
+    -- set weight properties of the way
+    WayHandlers.weights
   }
 
   WayHandlers.run(profile,way,result,data,handlers)


### PR DESCRIPTION
# Issue

PR  adds missing `WayHandlers.weights` call in foot and bicycle profiles. Fixes  #4513

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
