### PR TITLE
ability to force profile when running cuke tests

### DIFF
--- a/features/lib/hash.js
+++ b/features/lib/hash.js
@@ -20,11 +20,11 @@ module.exports =  {
         });
     },
 
-     hashOfFile: (path, cb) => {
+     hashOfFile: (path, additional_content, cb) => {
         fs.readFile(path, (err, result) => {
             if (err) return cb(err);
             let checksum = crypto.createHash('md5');
-            checksum.update(result);
+            checksum.update(result + (additional_content || "") );
             cb(null, checksum.digest('hex'));
         });
     }

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -8,7 +8,7 @@ var OSM = require('../lib/osm');
 
 module.exports = function () {
     this.Given(/^the profile "([^"]*)"$/, (profile, callback) => {
-        this.profile = profile;
+        this.profile = this.OSRM_PROFILE || profile;
         this.profileFile = path.join(this.PROFILES_PATH, this.profile + '.lua');
         callback();
     });

--- a/features/support/cache.js
+++ b/features/support/cache.js
@@ -28,13 +28,16 @@ module.exports = function() {
             let uri = feature.getUri();
 
             // setup cache for feature data
-            hash.hashOfFile(uri, (err, hash) => {
+            // if OSRM_PROFILE is set to force a specific profile, then
+             // include the profile name in the hash of the profile file
+            hash.hashOfFile(uri, this.OSRM_PROFILE, (err, hash) => {
                 if (err) return callback(err);
 
                 // shorten uri to be realtive to 'features/'
                 let featurePath = path.relative(path.resolve('./features'), uri);
                 // bicycle/bollards/{HASH}/
-                let featureID = path.join(featurePath, hash);
+                let featureID = path.join(featurePath, hash);                    
+                
                 let featureCacheDirectory = this.getFeatureCacheDirectory(featureID);
                 let featureProcessedCacheDirectory = this.getFeatureProcessedCacheDirectory(featureCacheDirectory, this.osrmHash);
                 this.featureIDs[uri] = featureID;

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -44,6 +44,8 @@ module.exports = function () {
 
         this.OSRM_PORT = process.env.OSRM_PORT && parseInt(process.env.OSRM_PORT) || 5000;
         this.HOST = 'http://127.0.0.1:' + this.OSRM_PORT;
+        
+        this.OSRM_PROFILE = process.env.PROFILE
 
         if (this.PLATFORM_WINDOWS) {
             this.TERMSIGNAL = 9;

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -45,7 +45,7 @@ module.exports = function () {
         this.OSRM_PORT = process.env.OSRM_PORT && parseInt(process.env.OSRM_PORT) || 5000;
         this.HOST = 'http://127.0.0.1:' + this.OSRM_PORT;
         
-        this.OSRM_PROFILE = process.env.PROFILE
+        this.OSRM_PROFILE = process.env.OSRM_PROFILE
 
         if (this.PLATFORM_WINDOWS) {
             this.TERMSIGNAL = 9;

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -45,7 +45,7 @@ module.exports = function () {
         this.OSRM_PORT = process.env.OSRM_PORT && parseInt(process.env.OSRM_PORT) || 5000;
         this.HOST = 'http://127.0.0.1:' + this.OSRM_PORT;
         
-        this.OSRM_PROFILE = process.env.OSRM_PROFILE
+        this.OSRM_PROFILE = process.env.OSRM_PROFILE;
 
         if (this.PLATFORM_WINDOWS) {
             this.TERMSIGNAL = 9;

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -22,7 +22,7 @@ module.exports = function () {
     });
 
     this.BeforeFeature((feature, callback) => {
-        this.profile = this.DEFAULT_PROFILE;
+        this.profile = this.OSRM_PROFILE || this.DEFAULT_PROFILE;
         this.profileFile = path.join(this.PROFILES_PATH, this.profile + '.lua');
         this.setupFeatureCache(feature);
         callback();


### PR DESCRIPTION
Version 2 of the profile API makes it easier to build a variation of a profile based on an existing one that you require. For example, you can create a profile for cargo bikes, based on the standard bicycle profile.

In situations like this, it's helpful to be able to run existing test with your new profile.

This PR lets you force the profile used when running cucumber tests by setting the OSRM_PROFILE environment variable, e.g:

```
OSRM_PROFILE=cargo_bike node_modules/cucumber/bin/cucumber.js features/bicycle
```
An annoyance is that the caching mechanism means that changing the OSRM_PROFILE env has no effect unless one of the .feature files are changed as well. I'm a bit unsure how the caching mechanism detects changes in the profile name, and thus how to fix this.



