### PR TITLE
improve handling of route tags in profiles

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -171,13 +171,41 @@ function setup()
       'minor',
     },
 
-    route_speeds = {
-      ferry = 5,
-      shuttle_train = 10
-    },
-
-    bridge_speeds = {
-      movable = 5
+    routes = {
+      access_required = false,
+      keys = {
+        railway = {
+          mode = mode.train,
+          speed = 10,
+          values = Set {
+            'train',
+            'railway',
+            'subway',
+            'light_rail',
+            'monorail',
+            'tram'
+          }
+        },
+        route = {
+          values = {
+            ferry = {
+            speed = 5,
+            mode = mode.ferry
+            },
+            shuttle_train = {
+              mode = mode.train,
+              speed = 10
+           }
+          }
+        },
+        bridge = {
+          values = {
+            movable = {
+              speed = 5
+            }
+          }
+        }
+      }
     },
 
     -- surface/trackype/smoothness
@@ -356,8 +384,7 @@ function process_way(profile, way, result)
     WayHandlers.destinations,
 
     -- check whether we're using a special transport mode
-    WayHandlers.ferries,
-    WayHandlers.movables,
+    WayHandlers.routes,
 
     -- handle service road restrictions
     WayHandlers.service,

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -116,11 +116,37 @@ function setup()
       }
     },
 
-    route_speeds = {
-      ferry = 5
-    },
-
-    bridge_speeds = {
+    routes = {
+      access_required = false,
+      keys = {
+        railway = {
+          mode = mode.train,
+          speed = 10,
+          values = Set {
+            'train',
+            'railway',
+            'subway',
+            'light_rail',
+            'monorail',
+            'tram'
+          }
+        },
+        route = {
+          values = {
+            ferry = {
+            speed = 5,
+            mode = mode.ferry
+            }
+          }
+        },
+        bridge = {
+          values = {
+            movable = {
+              speed = 5
+            }
+          }
+        }
+      }
     },
 
     surface_speeds = {
@@ -222,8 +248,7 @@ function process_way(profile, way, result)
     WayHandlers.destinations,
 
     -- check whether we're using a special transport mode
-    WayHandlers.ferries,
-    WayHandlers.movables,
+    WayHandlers.routes,
 
     -- compute speed taking into account way type, maxspeed tags, etc.
     WayHandlers.speed,

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -108,24 +108,6 @@ function WayHandlers.destinations(profile,way,result,data)
   end
 end
 
--- handling ferries and piers
-function WayHandlers.ferries(profile,way,result,data)
-  local route = data.route
-  if route then
-    local route_speed = profile.route_speeds[route]
-    if route_speed and route_speed > 0 then
-     local duration  = way:get_value_by_key("duration")
-     if duration and durationIsValid(duration) then
-       result.duration = math.max( parseDuration(duration), 1 )
-     end
-     result.forward_mode = mode.ferry
-     result.backward_mode = mode.ferry
-     result.forward_speed = route_speed
-     result.backward_speed = route_speed
-    end
-  end
-end
-
 -- handling movable bridges
 function WayHandlers.movables(profile,way,result,data)
   local bridge = data.bridge
@@ -143,6 +125,76 @@ function WayHandlers.movables(profile,way,result,data)
           result.forward_speed = bridge_speed
           result.backward_speed = bridge_speed
         end
+      end
+    end
+  end
+end
+
+-- handling routes with durations, including ferries and railway
+function WayHandlers.routes(profile,way,result,data)
+
+  function select_first_value(values)
+    for i=1,#values, 1
+    do
+      local v = values[i]
+       if v ~= nil then
+        return v
+      end
+    end
+  end
+
+  local default_mode = profile.routes.mode or profile.default_mode
+  local default_speed = profile.routes.speed or profile.default_speed
+  local default_rate = profile.routes.rate or 1
+  local default_access_required = profile.routes.access_required or false
+
+  for k,k_settings in pairs(profile.routes.keys) do
+    local k_mode = k_settings.mode
+    local k_speed = k_settings.speed
+    local k_rate = k_settings.rate
+    local k_access_required = k_settings.access_required
+
+    for v,v_settings in pairs(k_settings.values) do
+      if type(v_settings) == "table" then
+        v_mode = v_settings.mode
+        v_speed = v_settings.speed
+        v_rate = v_settings.rate
+        v_access_required = v_settings.access_required
+      end
+
+      if way:get_value_by_key(k) == v then
+        local access_required = select_first_value( {v_access_required, k_access_required, default_access_required} )
+
+        if access_required then
+          if data.backward_access ~= "yes" or data.backward_access ~= "yes" then
+            return
+          end
+        end
+
+        local speed
+
+        local duration  = way:get_value_by_key("duration")
+        if duration and durationIsValid(duration) then
+          result.duration = math.max( parseDuration(duration), 1 )
+          result.weight = result.duration
+          speed = 0
+        else
+          speed = select_first_value( {v_speed, k_speed, default_speed } )
+          result.forward_rate = 1
+          result.backward_rate = 1
+        end
+        result.forward_speed = speed
+        result.backward_speed = speed
+
+        local mode = select_first_value( {v_mode, k_mode, default_mode} )
+        result.forward_mode = mode
+        result.backward_mode = mode
+
+        local rate = select_first_value( {v_rate, k_rate, default_rate} )
+        result.forward_rate = rate
+        result.backward_rate = rate
+
+        return true
       end
     end
   end


### PR DESCRIPTION
WayHandler includes separate handlers for ferries, trains and movable bridges, that had very similar code. This PR replaced them with WayHandler.routes(), which handles all these. It read profile.routes, where you can setup what tag combinations to route on, as well as the speed and mode. You can also control whether specific access is required, e.g. car=yes, before the route is used.

Settings are organized as a hierachy. You can set defaults in the parent struct (profiles.route) and override them for specific tag combinations. If they are not set at all, the profile defaults are used.

The handler also allows you to set the rate. However, this is currently overridden later in WayHandler.penalties. I think the way penalties() and weight() handlers work are not optimal, but that's outside the scope of this PR.

In general it seems the speeds of routes are not set very realistically, e.g. trains are set to 10 km/h. This is a rudiment from the time where rate was not available. We should support rates for routes and set the speed to realistic values. It can be handled in a separate PR.

The foot profile was not handling trains - is that on purpose? If we handle rate, we could it it with realistic speeds and a low rate.

This PR is an extract from #4314, which was getting too big.