### PR TITLE
Count actual roundabout exits, not just passed steps

### DIFF
--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -845,3 +845,34 @@ Feature: Basic Roundabout
             | from | to | route                      | turns                                                   | distance |
             | e    | k  | ebds,ufghl,ufghl,jhik,jhik | depart,rstur-exit-2,exit rotary right,turn right,arrive | 189.1m   |
             | 1    | k  | ebds,ufghl,ufghl,jhik,jhik | depart,rstur-exit-2,exit rotary right,turn right,arrive | 159.1m   |
+
+
+    Scenario: count exit numbers properly when multiple exits from a single node
+        Given the node map
+            """
+                 f-----e
+                /       \
+            g--a     l   d-----h
+                \     \ /
+                 b-----c
+                        \\\
+                         ijk
+
+            """
+
+        And the ways
+            | nodes   | highway  | junction   | oneway |
+            | abcdefa | tertiary | roundabout | yes    |
+            | ga      | tertiary |            |        |
+            | ci      | tertiary |            |        |
+            | cj      | tertiary |            |        |
+            | ck      | tertiary |            |        |
+            | cl      | tertiary |            |        |
+            | dh      | tertiary |            |        |
+
+        When I route I should get
+            | from | to | route       | turns                                          |
+            | g    | i  | ga,ci,ci,ci | depart,abcdefa-exit-1,exit rotary right,arrive |
+            | g    | j  | ga,cj,cj,cj | depart,abcdefa-exit-2,exit rotary right,arrive |
+            | g    | k  | ga,ck,ck,ck | depart,abcdefa-exit-3,exit rotary right,arrive |
+            | g    | h  | ga,dh,dh,dh | depart,abcdefa-exit-5,exit rotary right,arrive |


### PR DESCRIPTION
# Issue

When a node on a roundabout has multiple exits directly connected, we only count it as one exit from the roundabout, which throws off the exit number counting for following exits.

*Usually* this is a result of weird modeling in OSM - multiple exits from the same point on the roundabout is kind of odd, but we found one at http://www.openstreetmap.org/node/49861176, which was where http://www.openstreetmap.org/way/528145111 was connected until @willwhite adjusted it.

This PR looks at the actual exit counts at each step around the roundabout and tallies them up, rather than just counting the number of steps between the entry and the exit.

This could also be a precursor to fixing https://github.com/Project-OSRM/osrm-backend/issues/2533 - one idea I had was possibly not counting exits that also have a mode change.

@MoKob can you eyeball this and see if my logic is sound?  Also open to suggestions if there is a more elegant approach to iterating around the `entry[]` array :-)

TODO: proper left/right driving side lookup from the profile.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
