### PR TITLE
Add suppression of libtbb memory leaks checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-6', 'libbz2-dev', 'libxml2-dev', 'libzip-dev', 'liblua5.2-dev', 'libtbb-dev', 'libgdal-dev', 'libboost-all-dev']
-      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_SANITIZER=ON CUCUMBER_TIMEOUT=20000
+      env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6' BUILD_TYPE='Debug' TARGET_ARCH='x86_64-asan' ENABLE_SANITIZER=ON CUCUMBER_TIMEOUT=20000 LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/scripts/travis/leaksanitizer.conf"
 
     - os: linux
       compiler: "clang-4.0-debug"
@@ -95,7 +95,7 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['libstdc++-5-dev']
-      env: CLANG_VERSION='4.0.0' BUILD_TYPE='Release' ENABLE_MASON=ON ENABLE_SANITIZER=ON
+      env: CLANG_VERSION='4.0.0' BUILD_TYPE='Release' ENABLE_MASON=ON ENABLE_SANITIZER=ON LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/scripts/travis/leaksanitizer.conf"
 
     # Release Builds
     - os: linux

--- a/scripts/travis/leaksanitizer.conf
+++ b/scripts/travis/leaksanitizer.conf
@@ -1,0 +1,8 @@
+# Configuration file for LeakSanitizer run on the Travis CI
+
+# TBB leaks some memory allocated in singleton depending on deinitialization order
+# Direct leak of 1560 byte(s) in 3 object(s) allocated from:
+#     #0 0x7f7ae72a80a0 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc80a0)
+#     #1 0x7f7ae595d13e  (/usr/lib/x86_64-linux-gnu/libtbb.so.2+0x2213e)
+
+leak:libtbb.so


### PR DESCRIPTION
# Issue

Hides memory leaks in TBB and fixes random fails of `mason-linux-debug-asan` and `gcc-6-debug-asan` jobs https://github.com/Project-OSRM/osrm-backend/issues/4347

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
