### PR TITLE
Separate Node-Based Graph Creation from Edge-Based Graph Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
       - Exposes `use_threads_number=Number` parameter of `EngineConfig` to limit a number of threads in a TBB internal pool
     - Internals
       - MLD uses a unidirectional Dijkstra for 1-to-N and N-to-1 matrices
+      - BREAKING: Internal file formats have changed, requiring a new pre-processing run
     - Guidance
       - Fixed some cases of sliproads pre-processing (https://github.com/Project-OSRM/osrm-backend/issues/4348)
       - don't suppress name announcements via sliproad handler

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -12,6 +12,7 @@
 #include "customizer/edge_based_graph.hpp"
 
 #include "extractor/datasources.hpp"
+#include "extractor/edge_based_node.hpp"
 #include "extractor/guidance/turn_instruction.hpp"
 #include "extractor/guidance/turn_lane_types.hpp"
 #include "extractor/intersection_bearings_container.hpp"
@@ -337,43 +338,21 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     void InitializeEdgeBasedNodeDataInformationPointers(storage::DataLayout &layout,
                                                         char *memory_ptr)
     {
-        const auto via_geometry_list_ptr =
-            layout.GetBlockPtr<GeometryID>(memory_ptr, storage::DataLayout::GEOMETRY_ID_LIST);
-        util::vector_view<GeometryID> geometry_ids(
-            via_geometry_list_ptr, layout.num_entries[storage::DataLayout::GEOMETRY_ID_LIST]);
+        const auto edge_based_node_list_ptr = layout.GetBlockPtr<extractor::EdgeBasedNode>(
+            memory_ptr, storage::DataLayout::EDGE_BASED_NODE_DATA_LIST);
+        util::vector_view<extractor::EdgeBasedNode> edge_based_node_data_list(
+            edge_based_node_list_ptr,
+            layout.num_entries[storage::DataLayout::EDGE_BASED_NODE_DATA_LIST]);
 
-        const auto name_id_list_ptr =
-            layout.GetBlockPtr<NameID>(memory_ptr, storage::DataLayout::NAME_ID_LIST);
-        util::vector_view<NameID> name_ids(name_id_list_ptr,
-                                           layout.num_entries[storage::DataLayout::NAME_ID_LIST]);
+        const auto annotation_data_list_ptr =
+            layout.GetBlockPtr<extractor::NodeBasedEdgeAnnotation>(
+                memory_ptr, storage::DataLayout::ANNOTATION_DATA_LIST);
+        util::vector_view<extractor::NodeBasedEdgeAnnotation> annotation_data(
+            annotation_data_list_ptr,
+            layout.num_entries[storage::DataLayout::ANNOTATION_DATA_LIST]);
 
-        const auto component_id_list_ptr =
-            layout.GetBlockPtr<ComponentID>(memory_ptr, storage::DataLayout::COMPONENT_ID_LIST);
-        util::vector_view<ComponentID> component_ids(
-            component_id_list_ptr, layout.num_entries[storage::DataLayout::COMPONENT_ID_LIST]);
-
-        const auto travel_mode_list_ptr = layout.GetBlockPtr<extractor::TravelMode>(
-            memory_ptr, storage::DataLayout::TRAVEL_MODE_LIST);
-        util::vector_view<extractor::TravelMode> travel_modes(
-            travel_mode_list_ptr, layout.num_entries[storage::DataLayout::TRAVEL_MODE_LIST]);
-
-        const auto classes_list_ptr =
-            layout.GetBlockPtr<extractor::ClassData>(memory_ptr, storage::DataLayout::CLASSES_LIST);
-        util::vector_view<extractor::ClassData> classes(
-            classes_list_ptr, layout.num_entries[storage::DataLayout::CLASSES_LIST]);
-
-        auto is_left_hand_driving_ptr = layout.GetBlockPtr<unsigned>(
-            memory_ptr, storage::DataLayout::IS_LEFT_HAND_DRIVING_LIST);
-        util::vector_view<bool> is_left_hand_driving(
-            is_left_hand_driving_ptr,
-            layout.num_entries[storage::DataLayout::IS_LEFT_HAND_DRIVING_LIST]);
-
-        edge_based_node_data = extractor::EdgeBasedNodeDataView(std::move(geometry_ids),
-                                                                std::move(name_ids),
-                                                                std::move(component_ids),
-                                                                std::move(travel_modes),
-                                                                std::move(classes),
-                                                                std::move(is_left_hand_driving));
+        edge_based_node_data = extractor::EdgeBasedNodeDataView(
+            std::move(edge_based_node_data_list), std::move(annotation_data));
     }
 
     void InitializeEdgeInformationPointers(storage::DataLayout &layout, char *memory_ptr)
@@ -465,7 +444,6 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
             geometries_index_ptr, data_layout.num_entries[storage::DataLayout::GEOMETRIES_INDEX]);
 
         auto num_entries = data_layout.num_entries[storage::DataLayout::GEOMETRIES_NODE_LIST];
-
         auto geometries_node_list_ptr = data_layout.GetBlockPtr<NodeID>(
             memory_block, storage::DataLayout::GEOMETRIES_NODE_LIST);
         util::vector_view<NodeID> geometry_node_list(geometries_node_list_ptr, num_entries);

--- a/include/extractor/edge_based_node.hpp
+++ b/include/extractor/edge_based_node.hpp
@@ -1,0 +1,21 @@
+#ifndef OSRM_EXTRACTOR_EDGE_BASED_NODE_HPP_
+#define OSRM_EXTRACTOR_EDGE_BASED_NODE_HPP_
+
+#include "util/typedefs.hpp"
+
+namespace osrm
+{
+namespace extractor
+{
+
+struct EdgeBasedNode
+{
+    GeometryID geometry_id;
+    ComponentID component_id;
+    AnnotationID annotation_id;
+};
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_EDGE_BASED_NODE_HPP_

--- a/include/extractor/extraction_containers.hpp
+++ b/include/extractor/extraction_containers.hpp
@@ -28,12 +28,14 @@ class ExtractionContainers
 
     void WriteNodes(storage::io::FileWriter &file_out) const;
     void WriteEdges(storage::io::FileWriter &file_out) const;
+    void WriteMetadata(storage::io::FileWriter &file_out) const;
     void WriteCharData(const std::string &file_name);
 
   public:
     using NodeIDVector = std::vector<OSMNodeID>;
     using NodeVector = std::vector<QueryNode>;
     using EdgeVector = std::vector<InternalExtractorEdge>;
+    using AnnotationDataVector = std::vector<NodeBasedEdgeAnnotation>;
     using WayIDStartEndVector = std::vector<FirstAndLastSegmentOfWay>;
     using NameCharData = std::vector<unsigned char>;
     using NameOffsets = std::vector<unsigned>;
@@ -43,6 +45,7 @@ class ExtractionContainers
     NodeIDVector used_node_id_list;
     NodeVector all_nodes_list;
     EdgeVector all_edges_list;
+    AnnotationDataVector all_edges_annotation_data_list;
     NameCharData name_char_data;
     NameOffsets name_offsets;
     // an adjacency array containing all turn lane masks

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/extractor_config.hpp"
 #include "extractor/graph_compressor.hpp"
+#include "extractor/packed_osm_ids.hpp"
 
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
@@ -61,19 +62,27 @@ class Extractor
                std::vector<ConditionalTurnRestriction>>
     ParseOSMData(ScriptingEnvironment &scripting_environment, const unsigned number_of_threads);
 
-    std::pair<std::size_t, EdgeID>
-    BuildEdgeExpandedGraph(ScriptingEnvironment &scripting_environment,
-                           std::vector<util::Coordinate> &coordinates,
-                           extractor::PackedOSMIDs &osm_node_ids,
-                           EdgeBasedNodeDataContainer &edge_based_nodes_container,
-                           std::vector<EdgeBasedNodeSegment> &edge_based_node_segments,
-                           std::vector<bool> &node_is_startpoint,
-                           std::vector<EdgeWeight> &edge_based_node_weights,
-                           util::DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list,
-                           const std::string &intersection_class_output_file,
-                           std::vector<TurnRestriction> &turn_restrictions,
-                           std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions,
-                           guidance::LaneDescriptionMap &turn_lane_map);
+    EdgeID BuildEdgeExpandedGraph(
+        // input data
+        const util::NodeBasedDynamicGraph &node_based_graph,
+        const std::vector<util::Coordinate> &coordinates,
+        const CompressedEdgeContainer &compressed_edge_container,
+        const std::unordered_set<NodeID> &barrier_nodes,
+        const std::unordered_set<NodeID> &traffic_lights,
+        const std::vector<TurnRestriction> &turn_restrictions,
+        const std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions,
+        // might have to be updated to add new lane combinations
+        guidance::LaneDescriptionMap &turn_lane_map,
+        // for calculating turn penalties
+        ScriptingEnvironment &scripting_environment,
+        // output data
+        EdgeBasedNodeDataContainer &edge_based_nodes_container,
+        std::vector<EdgeBasedNodeSegment> &edge_based_node_segments,
+        std::vector<bool> &node_is_startpoint,
+        std::vector<EdgeWeight> &edge_based_node_weights,
+        util::DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list,
+        const std::string &intersection_class_output_file);
+
     void FindComponents(unsigned max_edge_id,
                         const util::DeallocatingVector<EdgeBasedEdge> &input_edge_list,
                         const std::vector<EdgeBasedNodeSegment> &input_node_segments,
@@ -82,11 +91,6 @@ class Extractor
                     std::vector<bool> node_is_startpoint,
                     const std::vector<util::Coordinate> &coordinates);
     std::shared_ptr<RestrictionMap> LoadRestrictionMap();
-    std::shared_ptr<util::NodeBasedDynamicGraph>
-    LoadNodeBasedGraph(std::unordered_set<NodeID> &barrier_nodes,
-                       std::unordered_set<NodeID> &traffic_lights,
-                       std::vector<util::Coordinate> &coordinates,
-                       extractor::PackedOSMIDs &osm_node_ids);
 
     // Writes compressed node based graph and its embedding into a file for osrm-partition to use.
     static void WriteCompressedNodeBasedGraph(const std::string &path,

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -78,27 +78,27 @@ inline void writeProfileProperties(const boost::filesystem::path &path,
 
 template <typename EdgeBasedEdgeVector>
 void writeEdgeBasedGraph(const boost::filesystem::path &path,
-                         EdgeID const max_edge_id,
+                         EdgeID const number_of_edge_based_nodes,
                          const EdgeBasedEdgeVector &edge_based_edge_list)
 {
     static_assert(std::is_same<typename EdgeBasedEdgeVector::value_type, EdgeBasedEdge>::value, "");
 
     storage::io::FileWriter writer(path, storage::io::FileWriter::GenerateFingerprint);
 
-    writer.WriteElementCount64(max_edge_id);
+    writer.WriteElementCount64(number_of_edge_based_nodes);
     storage::serialization::write(writer, edge_based_edge_list);
 }
 
 template <typename EdgeBasedEdgeVector>
 void readEdgeBasedGraph(const boost::filesystem::path &path,
-                        EdgeID &max_edge_id,
+                        EdgeID &number_of_edge_based_nodes,
                         EdgeBasedEdgeVector &edge_based_edge_list)
 {
     static_assert(std::is_same<typename EdgeBasedEdgeVector::value_type, EdgeBasedEdge>::value, "");
 
     storage::io::FileReader reader(path, storage::io::FileReader::VerifyFingerprint);
 
-    max_edge_id = reader.ReadElementCount64();
+    number_of_edge_based_nodes = reader.ReadElementCount64();
     storage::serialization::read(reader, edge_based_edge_list);
 }
 

--- a/include/extractor/graph_compressor.hpp
+++ b/include/extractor/graph_compressor.hpp
@@ -29,6 +29,7 @@ class GraphCompressor
                   std::vector<TurnRestriction> &turn_restrictions,
                   std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions,
                   util::NodeBasedDynamicGraph &graph,
+                  const std::vector<NodeBasedEdgeAnnotation> &node_data_container,
                   CompressedEdgeContainer &geometry_compressor);
 
   private:

--- a/include/extractor/guidance/coordinate_extractor.hpp
+++ b/include/extractor/guidance/coordinate_extractor.hpp
@@ -225,7 +225,7 @@ class CoordinateExtractor
                  const std::vector<double> &segment_distances,
                  const double segment_length,
                  const double considered_lane_width,
-                 const util::NodeBasedEdgeData &edge_data) const;
+                 const extractor::NodeBasedEdgeClassification &edge_data) const;
 
     /*
      * If the very first coordinate is within lane offsets and the rest offers a near straight line,

--- a/include/extractor/guidance/driveway_handler.hpp
+++ b/include/extractor/guidance/driveway_handler.hpp
@@ -16,6 +16,7 @@ class DrivewayHandler final : public IntersectionHandler
   public:
     DrivewayHandler(const IntersectionGenerator &intersection_generator,
                     const util::NodeBasedDynamicGraph &node_based_graph,
+                    const EdgeBasedNodeDataContainer &node_data_container,
                     const std::vector<util::Coordinate> &coordinates,
                     const util::NameTable &name_table,
                     const SuffixTable &street_name_suffix_table);

--- a/include/extractor/guidance/intersection_generator.hpp
+++ b/include/extractor/guidance/intersection_generator.hpp
@@ -38,6 +38,7 @@ class IntersectionGenerator
 {
   public:
     IntersectionGenerator(const util::NodeBasedDynamicGraph &node_based_graph,
+                          const EdgeBasedNodeDataContainer &node_data_container,
                           const RestrictionMap &restriction_map,
                           const std::unordered_set<NodeID> &barrier_nodes,
                           const std::vector<util::Coordinate> &coordinates,
@@ -110,6 +111,7 @@ class IntersectionGenerator
 
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;
+    const EdgeBasedNodeDataContainer &node_data_container;
     const RestrictionMap &restriction_map;
     const std::unordered_set<NodeID> &barrier_nodes;
     const std::vector<util::Coordinate> &coordinates;

--- a/include/extractor/guidance/intersection_normalizer.hpp
+++ b/include/extractor/guidance/intersection_normalizer.hpp
@@ -43,6 +43,7 @@ class IntersectionNormalizer
         std::vector<IntersectionNormalizationOperation> performed_merges;
     };
     IntersectionNormalizer(const util::NodeBasedDynamicGraph &node_based_graph,
+                           const EdgeBasedNodeDataContainer &node_data_container,
                            const std::vector<util::Coordinate> &node_coordinates,
                            const util::NameTable &name_table,
                            const SuffixTable &street_name_suffix_table,

--- a/include/extractor/guidance/mergable_road_detector.hpp
+++ b/include/extractor/guidance/mergable_road_detector.hpp
@@ -37,6 +37,7 @@ class MergableRoadDetector
     using MergableRoadData = IntersectionShapeData;
 
     MergableRoadDetector(const util::NodeBasedDynamicGraph &node_based_graph,
+                         const EdgeBasedNodeDataContainer &node_data_container,
                          const std::vector<util::Coordinate> &node_coordinates,
                          const IntersectionGenerator &intersection_generator,
                          const CoordinateExtractor &coordinate_extractor,
@@ -77,8 +78,10 @@ class MergableRoadDetector
 
     // When it comes to merging roads, we need to find out if two ways actually represent the
     // same road. This check tries to identify roads which are the same road in opposite directions
-    bool EdgeDataSupportsMerge(const util::NodeBasedEdgeData &lhs_edge_data,
-                               const util::NodeBasedEdgeData &rhs_edge_data) const;
+    bool EdgeDataSupportsMerge(const NodeBasedEdgeClassification &lhs_flags,
+                               const NodeBasedEdgeClassification &rhs_flags,
+                               const NodeBasedEdgeAnnotation &lhs_edge_annotation,
+                               const NodeBasedEdgeAnnotation &rhs_edge_annotation) const;
 
     // Detect traffic loops.
     // Since OSRM cannot handle loop edges, we cannot directly see a connection between a node and
@@ -138,6 +141,7 @@ class MergableRoadDetector
     bool IsLinkRoad(const NodeID intersection_node, const MergableRoadData &road) const;
 
     const util::NodeBasedDynamicGraph &node_based_graph;
+    const EdgeBasedNodeDataContainer &node_data_container;
     const std::vector<util::Coordinate> &node_coordinates;
     const IntersectionGenerator &intersection_generator;
     const CoordinateExtractor &coordinate_extractor;

--- a/include/extractor/guidance/motorway_handler.hpp
+++ b/include/extractor/guidance/motorway_handler.hpp
@@ -24,6 +24,7 @@ class MotorwayHandler : public IntersectionHandler
 {
   public:
     MotorwayHandler(const util::NodeBasedDynamicGraph &node_based_graph,
+                    const EdgeBasedNodeDataContainer &node_data_container,
                     const std::vector<util::Coordinate> &coordinates,
                     const util::NameTable &name_table,
                     const SuffixTable &street_name_suffix_table,

--- a/include/extractor/guidance/node_based_graph_walker.hpp
+++ b/include/extractor/guidance/node_based_graph_walker.hpp
@@ -28,6 +28,7 @@ class NodeBasedGraphWalker
 {
   public:
     NodeBasedGraphWalker(const util::NodeBasedDynamicGraph &node_based_graph,
+                         const EdgeBasedNodeDataContainer &node_data_container,
                          const IntersectionGenerator &intersection_generator);
 
     /*
@@ -46,6 +47,7 @@ class NodeBasedGraphWalker
 
   private:
     const util::NodeBasedDynamicGraph &node_based_graph;
+    const EdgeBasedNodeDataContainer &node_data_container;
     const IntersectionGenerator &intersection_generator;
 };
 
@@ -106,7 +108,8 @@ struct SelectRoadByNameOnlyChoiceAndStraightness
     boost::optional<EdgeID> operator()(const NodeID nid,
                                        const EdgeID via_edge_id,
                                        const IntersectionView &intersection,
-                                       const util::NodeBasedDynamicGraph &node_based_graph) const;
+                                       const util::NodeBasedDynamicGraph &node_based_graph,
+                                       const EdgeBasedNodeDataContainer &node_data_container) const;
 
   private:
     const NameID desired_name_id;
@@ -131,7 +134,8 @@ struct SelectStraightmostRoadByNameAndOnlyChoice
     boost::optional<EdgeID> operator()(const NodeID nid,
                                        const EdgeID via_edge_id,
                                        const IntersectionView &intersection,
-                                       const util::NodeBasedDynamicGraph &node_based_graph) const;
+                                       const util::NodeBasedDynamicGraph &node_based_graph,
+                                       const EdgeBasedNodeDataContainer &node_data_container) const;
 
   private:
     const NameID desired_name_id;
@@ -201,8 +205,11 @@ NodeBasedGraphWalker::TraverseRoad(NodeID current_node_id,
         if (next_intersection.size() <= 1)
             return {};
 
-        auto next_edge_id =
-            selector(current_node_id, current_edge_id, next_intersection, node_based_graph);
+        auto next_edge_id = selector(current_node_id,
+                                     current_edge_id,
+                                     next_intersection,
+                                     node_based_graph,
+                                     node_data_container);
 
         if (!next_edge_id)
             return {};
@@ -224,7 +231,8 @@ struct SkipTrafficSignalBarrierRoadSelector
     boost::optional<EdgeID> operator()(const NodeID,
                                        const EdgeID,
                                        const IntersectionView &intersection,
-                                       const util::NodeBasedDynamicGraph &) const
+                                       const util::NodeBasedDynamicGraph &,
+                                       const EdgeBasedNodeDataContainer &) const
     {
         if (intersection.isTrafficSignalOrBarrier())
         {

--- a/include/extractor/guidance/roundabout_handler.hpp
+++ b/include/extractor/guidance/roundabout_handler.hpp
@@ -7,7 +7,6 @@
 #include "extractor/guidance/intersection_generator.hpp"
 #include "extractor/guidance/intersection_handler.hpp"
 #include "extractor/guidance/roundabout_type.hpp"
-#include "extractor/profile_properties.hpp"
 #include "extractor/query_node.hpp"
 
 #include "util/name_table.hpp"
@@ -41,11 +40,11 @@ class RoundaboutHandler : public IntersectionHandler
 {
   public:
     RoundaboutHandler(const util::NodeBasedDynamicGraph &node_based_graph,
+                      const EdgeBasedNodeDataContainer &node_data_container,
                       const std::vector<util::Coordinate> &coordinates,
                       const CompressedEdgeContainer &compressed_edge_container,
                       const util::NameTable &name_table,
                       const SuffixTable &street_name_suffix_table,
-                      const ProfileProperties &profile_properties,
                       const IntersectionGenerator &intersection_generator);
 
     ~RoundaboutHandler() override final = default;
@@ -86,8 +85,6 @@ class RoundaboutHandler : public IntersectionHandler
     qualifiesAsRoundaboutIntersection(const std::unordered_set<NodeID> &roundabout_nodes) const;
 
     const CompressedEdgeContainer &compressed_edge_container;
-    const ProfileProperties &profile_properties;
-
     const CoordinateExtractor coordinate_extractor;
 };
 

--- a/include/extractor/guidance/sliproad_handler.hpp
+++ b/include/extractor/guidance/sliproad_handler.hpp
@@ -26,6 +26,7 @@ class SliproadHandler final : public IntersectionHandler
   public:
     SliproadHandler(const IntersectionGenerator &intersection_generator,
                     const util::NodeBasedDynamicGraph &node_based_graph,
+                    const EdgeBasedNodeDataContainer &node_data_container,
                     const std::vector<util::Coordinate> &coordinates,
                     const util::NameTable &name_table,
                     const SuffixTable &street_name_suffix_table);

--- a/include/extractor/guidance/suppress_mode_handler.hpp
+++ b/include/extractor/guidance/suppress_mode_handler.hpp
@@ -23,6 +23,7 @@ class SuppressModeHandler final : public IntersectionHandler
   public:
     SuppressModeHandler(const IntersectionGenerator &intersection_generator,
                         const util::NodeBasedDynamicGraph &node_based_graph,
+                        const EdgeBasedNodeDataContainer &node_data_container,
                         const std::vector<util::Coordinate> &coordinates,
                         const util::NameTable &name_table,
                         const SuffixTable &street_name_suffix_table);

--- a/include/extractor/guidance/turn_analysis.hpp
+++ b/include/extractor/guidance/turn_analysis.hpp
@@ -41,13 +41,13 @@ class TurnAnalysis
 {
   public:
     TurnAnalysis(const util::NodeBasedDynamicGraph &node_based_graph,
+                 const EdgeBasedNodeDataContainer &node_data_container,
                  const std::vector<util::Coordinate> &coordinates,
                  const RestrictionMap &restriction_map,
                  const std::unordered_set<NodeID> &barrier_nodes,
                  const CompressedEdgeContainer &compressed_edge_container,
                  const util::NameTable &name_table,
-                 const SuffixTable &street_name_suffix_table,
-                 const ProfileProperties &profile_properties);
+                 const SuffixTable &street_name_suffix_table);
 
     /* Full Analysis Process for a single node/edge combination. Use with caution, as the process is
      * relatively expensive */

--- a/include/extractor/guidance/turn_handler.hpp
+++ b/include/extractor/guidance/turn_handler.hpp
@@ -28,6 +28,7 @@ class TurnHandler : public IntersectionHandler
 {
   public:
     TurnHandler(const util::NodeBasedDynamicGraph &node_based_graph,
+                const EdgeBasedNodeDataContainer &node_data_container,
                 const std::vector<util::Coordinate> &coordinates,
                 const util::NameTable &name_table,
                 const SuffixTable &street_name_suffix_table,

--- a/include/extractor/guidance/turn_lane_handler.hpp
+++ b/include/extractor/guidance/turn_lane_handler.hpp
@@ -73,6 +73,7 @@ class TurnLaneHandler
     typedef std::vector<TurnLaneData> LaneDataVector;
 
     TurnLaneHandler(const util::NodeBasedDynamicGraph &node_based_graph,
+                    const EdgeBasedNodeDataContainer &node_data_container,
                     LaneDescriptionMap &lane_description_map,
                     const TurnAnalysis &turn_analysis,
                     util::guidance::LaneDataIdMap &id_map);
@@ -88,6 +89,7 @@ class TurnLaneHandler
     // we need to be able to look at previous intersections to, in some cases, find the correct turn
     // lanes for a turn
     const util::NodeBasedDynamicGraph &node_based_graph;
+    const EdgeBasedNodeDataContainer &node_data_container;
     std::vector<std::uint32_t> turn_lane_offsets;
     std::vector<TurnLaneType::Mask> turn_lane_masks;
     LaneDescriptionMap &lane_description_map;

--- a/include/extractor/internal_extractor_edge.hpp
+++ b/include/extractor/internal_extractor_edge.hpp
@@ -58,65 +58,24 @@ struct InternalExtractorEdge
     using WeightData = detail::ByEdgeOrByMeterValue;
     using DurationData = detail::ByEdgeOrByMeterValue;
 
-    explicit InternalExtractorEdge()
-        : result(MIN_OSM_NODEID,
-                 MIN_OSM_NODEID,
-                 SPECIAL_NODEID,
-                 0,
-                 0,
-                 false, // forward
-                 false, // backward
-                 false, // roundabout
-                 false, // circular
-                 true,  // can be startpoint
-                 false, // local access only
-                 false, // is_left_hand_driving
-                 false, // split edge
-                 TRAVEL_MODE_INACCESSIBLE,
-                 0,
-                 guidance::TurnLaneType::empty,
-                 guidance::RoadClassification()),
-          weight_data(), duration_data()
-    {
-    }
+    explicit InternalExtractorEdge() : weight_data(), duration_data() {}
 
     explicit InternalExtractorEdge(OSMNodeID source,
                                    OSMNodeID target,
-                                   NodeID name_id,
                                    WeightData weight_data,
                                    DurationData duration_data,
-                                   bool forward,
-                                   bool backward,
-                                   bool roundabout,
-                                   bool circular,
-                                   bool startpoint,
-                                   bool restricted,
-                                   bool is_left_hand_driving,
-                                   bool is_split,
-                                   TravelMode travel_mode,
-                                   ClassData classes,
-                                   LaneDescriptionID lane_description,
-                                   guidance::RoadClassification road_classification,
                                    util::Coordinate source_coordinate)
-        : result(source,
-                 target,
-                 name_id,
-                 0,
-                 0,
-                 forward,
-                 backward,
-                 roundabout,
-                 circular,
-                 startpoint,
-                 restricted,
-                 is_left_hand_driving,
-                 is_split,
-                 travel_mode,
-                 classes,
-                 lane_description,
-                 std::move(road_classification)),
-          weight_data(std::move(weight_data)), duration_data(std::move(duration_data)),
-          source_coordinate(std::move(source_coordinate))
+        : result(source, target, 0, 0, {}, -1, {}), weight_data(std::move(weight_data)),
+          duration_data(std::move(duration_data)), source_coordinate(std::move(source_coordinate))
+    {
+    }
+
+    explicit InternalExtractorEdge(NodeBasedEdgeWithOSM edge,
+                                   WeightData weight_data,
+                                   DurationData duration_data,
+                                   util::Coordinate source_coordinate)
+        : result(std::move(edge)), weight_data(weight_data), duration_data(duration_data),
+          source_coordinate(source_coordinate)
     {
     }
 
@@ -132,45 +91,13 @@ struct InternalExtractorEdge
     // necessary static util functions for stxxl's sorting
     static InternalExtractorEdge min_osm_value()
     {
-        return InternalExtractorEdge(MIN_OSM_NODEID,
-                                     MIN_OSM_NODEID,
-                                     SPECIAL_NODEID,
-                                     WeightData(),
-                                     DurationData(),
-                                     false, // forward
-                                     false, // backward
-                                     false, // roundabout
-                                     false, // circular
-                                     true,  // can be startpoint
-                                     false, // local access only
-                                     false, // is_left_hand_driving
-                                     false, // split edge
-                                     TRAVEL_MODE_INACCESSIBLE,
-                                     0,
-                                     INVALID_LANE_DESCRIPTIONID,
-                                     guidance::RoadClassification(),
-                                     util::Coordinate());
+        return InternalExtractorEdge(
+            MIN_OSM_NODEID, MIN_OSM_NODEID, WeightData(), DurationData(), util::Coordinate());
     }
     static InternalExtractorEdge max_osm_value()
     {
-        return InternalExtractorEdge(MAX_OSM_NODEID,
-                                     MAX_OSM_NODEID,
-                                     SPECIAL_NODEID,
-                                     WeightData(),
-                                     DurationData(),
-                                     false, // forward
-                                     false, // backward
-                                     false, // roundabout
-                                     false, // circular
-                                     true,  // can be startpoint
-                                     false, // local access only
-                                     false, // is_left_hand_driving
-                                     false, // split edge
-                                     TRAVEL_MODE_INACCESSIBLE,
-                                     0,
-                                     INVALID_LANE_DESCRIPTIONID,
-                                     guidance::RoadClassification(),
-                                     util::Coordinate());
+        return InternalExtractorEdge(
+            MAX_OSM_NODEID, MAX_OSM_NODEID, WeightData(), DurationData(), util::Coordinate());
     }
 
     static InternalExtractorEdge min_internal_value()

--- a/include/extractor/node_based_edge.hpp
+++ b/include/extractor/node_based_edge.hpp
@@ -1,6 +1,9 @@
 #ifndef NODE_BASED_EDGE_HPP
 #define NODE_BASED_EDGE_HPP
 
+#include <cstdint>
+#include <tuple>
+
 #include "extractor/class_data.hpp"
 #include "extractor/travel_mode.hpp"
 #include "util/typedefs.hpp"
@@ -12,68 +15,97 @@ namespace osrm
 namespace extractor
 {
 
+// Flags describing the class of the road. This data is used during creation of graphs/guidance
+// generation but is not available in annotation/navigation
+struct NodeBasedEdgeClassification
+{
+    std::uint8_t forward : 1;                         // 1
+    std::uint8_t backward : 1;                        // 1
+    std::uint8_t is_split : 1;                        // 1
+    std::uint8_t roundabout : 1;                      // 1
+    std::uint8_t circular : 1;                        // 1
+    std::uint8_t startpoint : 1;                      // 1
+    std::uint8_t restricted : 1;                      // 1
+    guidance::RoadClassification road_classification; // 16 2
+
+    NodeBasedEdgeClassification();
+
+    NodeBasedEdgeClassification(const bool forward,
+                                const bool backward,
+                                const bool is_split,
+                                const bool roundabout,
+                                const bool circular,
+                                const bool startpoint,
+                                const bool restricted,
+                                guidance::RoadClassification road_classification)
+        : forward(forward), backward(backward), is_split(is_split), roundabout(roundabout),
+          circular(circular), startpoint(startpoint), restricted(restricted),
+          road_classification(road_classification)
+    {
+    }
+
+    bool operator==(const NodeBasedEdgeClassification &other) const
+    {
+        return (road_classification == other.road_classification) && (forward == other.forward) &&
+               (backward == other.backward) && (is_split) == (other.is_split) &&
+               (roundabout == other.roundabout) && (circular == other.circular) &&
+               (startpoint == other.startpoint) && (restricted == other.restricted);
+    }
+};
+
+// Annotative data, used in parts in guidance generation, in parts during navigation (classes) but
+// mostly for annotation of edges. The entry can be shared between multiple edges and usually
+// describes features present on OSM ways. This is the place to put specific data that you want to
+// see as part of the API output but that does not influence navigation
+struct NodeBasedEdgeAnnotation
+{
+    NameID name_id;                        // 32 4
+    LaneDescriptionID lane_description_id; // 16 2
+    ClassData classes;                     // 8  1
+    TravelMode travel_mode : 4;            // 4
+    bool is_left_hand_driving : 1;         // 1
+
+    bool CanCombineWith(const NodeBasedEdgeAnnotation &other) const
+    {
+        return (std::tie(name_id, classes, travel_mode, is_left_hand_driving) ==
+                std::tie(other.name_id, other.classes, other.travel_mode, is_left_hand_driving));
+    }
+};
+
 struct NodeBasedEdge
 {
     NodeBasedEdge();
 
     NodeBasedEdge(NodeID source,
                   NodeID target,
-                  NodeID name_id,
                   EdgeWeight weight,
                   EdgeDuration duration,
-                  bool forward,
-                  bool backward,
-                  bool roundabout,
-                  bool circular,
-                  bool startpoint,
-                  bool restricted,
-                  bool is_left_hand_driving,
-                  bool is_split,
-                  TravelMode travel_mode,
-                  ClassData classes,
-                  const LaneDescriptionID lane_description_id,
-                  guidance::RoadClassification road_classification);
+                  GeometryID geometry_id,
+                  AnnotationID annotation_data,
+                  NodeBasedEdgeClassification flags);
 
     bool operator<(const NodeBasedEdge &other) const;
 
-    NodeID source;                                    // 32 4
-    NodeID target;                                    // 32 4
-    NodeID name_id;                                   // 32 4
-    EdgeWeight weight;                                // 32 4
-    EdgeDuration duration;                            // 32 4
-    std::uint8_t forward : 1;                         // 1
-    std::uint8_t backward : 1;                        // 1
-    std::uint8_t roundabout : 1;                      // 1
-    std::uint8_t circular : 1;                        // 1
-    std::uint8_t startpoint : 1;                      // 1
-    std::uint8_t restricted : 1;                      // 1
-    std::uint8_t is_left_hand_driving : 1;            // 1
-    std::uint8_t is_split : 1;                        // 1
-    TravelMode travel_mode : 4;                       // 4
-    ClassData classes;                                // 8  1
-    LaneDescriptionID lane_description_id;            // 16 2
-    guidance::RoadClassification road_classification; // 16 2
+    NodeID source;                     // 32 4
+    NodeID target;                     // 32 4
+    EdgeWeight weight;                 // 32 4
+    EdgeDuration duration;             // 32 4
+    GeometryID geometry_id;            // 32 4
+    AnnotationID annotation_data;      // 32 4
+    NodeBasedEdgeClassification flags; // 32 4
 };
 
 struct NodeBasedEdgeWithOSM : NodeBasedEdge
 {
+    NodeBasedEdgeWithOSM();
+
     NodeBasedEdgeWithOSM(OSMNodeID source,
                          OSMNodeID target,
-                         NodeID name_id,
                          EdgeWeight weight,
                          EdgeDuration duration,
-                         bool forward,
-                         bool backward,
-                         bool roundabout,
-                         bool circular,
-                         bool startpoint,
-                         bool restricted,
-                         bool is_left_hand_driving,
-                         bool is_split,
-                         TravelMode travel_mode,
-                         ClassData classes,
-                         const LaneDescriptionID lane_description_id,
-                         guidance::RoadClassification road_classification);
+                         GeometryID geometry_id,
+                         AnnotationID annotation_data,
+                         NodeBasedEdgeClassification flags);
 
     OSMNodeID osm_source_id;
     OSMNodeID osm_target_id;
@@ -81,36 +113,26 @@ struct NodeBasedEdgeWithOSM : NodeBasedEdge
 
 // Impl.
 
+inline NodeBasedEdgeClassification::NodeBasedEdgeClassification()
+    : forward(false), backward(false), is_split(false), roundabout(false), circular(false),
+      startpoint(false), restricted(false)
+{
+}
+
 inline NodeBasedEdge::NodeBasedEdge()
-    : source(SPECIAL_NODEID), target(SPECIAL_NODEID), name_id(0), weight(0), duration(0),
-      forward(false), backward(false), roundabout(false), circular(false), startpoint(true),
-      restricted(false), is_left_hand_driving(false), is_split(false),
-      travel_mode(TRAVEL_MODE_INACCESSIBLE), lane_description_id(INVALID_LANE_DESCRIPTIONID)
+    : source(SPECIAL_NODEID), target(SPECIAL_NODEID), weight(0), duration(0), annotation_data(-1)
 {
 }
 
 inline NodeBasedEdge::NodeBasedEdge(NodeID source,
                                     NodeID target,
-                                    NodeID name_id,
                                     EdgeWeight weight,
                                     EdgeDuration duration,
-                                    bool forward,
-                                    bool backward,
-                                    bool roundabout,
-                                    bool circular,
-                                    bool startpoint,
-                                    bool restricted,
-                                    bool is_left_hand_driving,
-                                    bool is_split,
-                                    TravelMode travel_mode,
-                                    ClassData classes,
-                                    const LaneDescriptionID lane_description_id,
-                                    guidance::RoadClassification road_classification)
-    : source(source), target(target), name_id(name_id), weight(weight), duration(duration),
-      forward(forward), backward(backward), roundabout(roundabout), circular(circular),
-      startpoint(startpoint), restricted(restricted), is_left_hand_driving(is_left_hand_driving),
-      is_split(is_split), travel_mode(travel_mode), classes(classes),
-      lane_description_id(lane_description_id), road_classification(std::move(road_classification))
+                                    GeometryID geometry_id,
+                                    AnnotationID annotation_data,
+                                    NodeBasedEdgeClassification flags)
+    : source(source), target(target), weight(weight), duration(duration), geometry_id(geometry_id),
+      annotation_data(annotation_data), flags(flags)
 {
 }
 
@@ -122,7 +144,8 @@ inline bool NodeBasedEdge::operator<(const NodeBasedEdge &other) const
         {
             if (weight == other.weight)
             {
-                return forward && backward && ((!other.forward) || (!other.backward));
+                return flags.forward && flags.backward &&
+                       ((!other.flags.forward) || (!other.flags.backward));
             }
             return weight < other.weight;
         }
@@ -133,39 +156,19 @@ inline bool NodeBasedEdge::operator<(const NodeBasedEdge &other) const
 
 inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM(OSMNodeID source,
                                                   OSMNodeID target,
-                                                  NodeID name_id,
                                                   EdgeWeight weight,
                                                   EdgeDuration duration,
-                                                  bool forward,
-                                                  bool backward,
-                                                  bool roundabout,
-                                                  bool circular,
-                                                  bool startpoint,
-                                                  bool restricted,
-                                                  bool is_left_hand_driving,
-                                                  bool is_split,
-                                                  TravelMode travel_mode,
-                                                  ClassData classes,
-                                                  const LaneDescriptionID lane_description_id,
-                                                  guidance::RoadClassification road_classification)
-    : NodeBasedEdge(SPECIAL_NODEID,
-                    SPECIAL_NODEID,
-                    name_id,
-                    weight,
-                    duration,
-                    forward,
-                    backward,
-                    roundabout,
-                    circular,
-                    startpoint,
-                    restricted,
-                    is_left_hand_driving,
-                    is_split,
-                    travel_mode,
-                    classes,
-                    lane_description_id,
-                    std::move(road_classification)),
+                                                  GeometryID geometry_id,
+                                                  AnnotationID annotation_data,
+                                                  NodeBasedEdgeClassification flags)
+    : NodeBasedEdge(
+          SPECIAL_NODEID, SPECIAL_NODEID, weight, duration, geometry_id, annotation_data, flags),
       osm_source_id(std::move(source)), osm_target_id(std::move(target))
+{
+}
+
+inline NodeBasedEdgeWithOSM::NodeBasedEdgeWithOSM()
+    : osm_source_id(MIN_OSM_NODEID), osm_target_id(MIN_OSM_NODEID)
 {
 }
 

--- a/include/extractor/node_based_graph_factory.hpp
+++ b/include/extractor/node_based_graph_factory.hpp
@@ -1,0 +1,101 @@
+#ifndef OSRM_EXTRACTOR_NODE_BASED_GRAPH_FACTORY_HPP_
+#define OSRM_EXTRACTOR_NODE_BASED_GRAPH_FACTORY_HPP_
+
+#include "extractor/compressed_edge_container.hpp"
+#include "extractor/node_based_edge.hpp"
+#include "extractor/node_data_container.hpp"
+#include "extractor/packed_osm_ids.hpp"
+#include "extractor/scripting_environment.hpp"
+
+#include "util/coordinate.hpp"
+#include "util/node_based_graph.hpp"
+
+#include <boost/filesystem/path.hpp>
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace osrm
+{
+namespace extractor
+{
+
+// Turn the output of the extraction process into a graph that represents junctions as nodes and
+// ways as edges between these nodes. The graph forms the further input for OSRMs creation of the
+// edge-based graph and is also the basic concept for annotating paths. All information from ways
+// that is transferred into the API response is connected to the edges of the node-based graph.
+//
+// The input to the graph creation is the set of edges, traffic signals, barriers, meta-data,...
+// which is generated during extraction and stored within the extraction containers.
+class NodeBasedGraphFactory
+{
+  public:
+    // The node-based graph factory loads the *.osrm file and transforms the data within into the
+    // node-based graph to represent the OSM network. This includes geometry compression, annotation
+    // data optimisation and many other aspects. After this step, the edge-based graph factory can
+    // turn the graph into the routing graph to be used with the navigation algorithms.
+    NodeBasedGraphFactory(const boost::filesystem::path &input_file,
+                          ScriptingEnvironment &scripting_environment,
+                          std::vector<TurnRestriction> &turn_restrictions,
+                          std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions);
+
+    auto const &GetGraph() const { return compressed_output_graph; }
+    auto const &GetBarriers() const { return barriers; }
+    auto const &GetTrafficSignals() const { return traffic_signals; }
+    auto &GetCompressedEdges() { return compressed_edge_container; }
+    auto &GetCoordinates() { return coordinates; }
+    auto &GetAnnotationData() { return annotation_data; }
+    auto &GetOsmNodes() { return osm_node_ids; }
+
+    // to reduce the memory footprint, the node-based graph factory allows releasing memory after it
+    // might have been used for the last time:
+    void ReleaseOsmNodes();
+
+  private:
+    // Get the information from the *.osrm file (direct product of the extractor callback/extraction
+    // containers) and prepare the graph creation process
+    void LoadDataFromFile(const boost::filesystem::path &input_file);
+
+    // Compress the node-based graph into a compact representation of itself. This removes storing a
+    // single edge for every part of the geometry and might also combine meta-data for multiple
+    // edges into a single representative form
+    void Compress(ScriptingEnvironment &scripting_environment,
+                  std::vector<TurnRestriction> &turn_restrictions,
+                  std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions);
+
+    // Most ways are bidirectional, making the geometry in forward and backward direction the same,
+    // except for reversal. We make use of this fact by keeping only one representation of the
+    // geometry around
+    void CompressGeometry();
+
+    // After graph compression, some of the annotation entries might not be referenced anymore. We
+    // compress the annotation data by relabeling the node-based graph references and removing all
+    // unreferenced entries
+    void CompressAnnotationData();
+
+    // After produce, this will contain a compresse version of the node-based graph
+    util::NodeBasedDynamicGraph compressed_output_graph;
+    // To store the meta-data for the graph that is purely annotative / not used for the navigation
+    // itself. Since the edges of a node-based graph form the nodes of the edge based graphs, we
+    // transform this data into the EdgeBasedNodeDataContainer as output storage.
+    std::vector<NodeBasedEdgeAnnotation> annotation_data;
+
+    // General Information about the graph, not used outside of extractor
+    std::unordered_set<NodeID> barriers;
+    std::unordered_set<NodeID> traffic_signals;
+
+    std::vector<util::Coordinate> coordinates;
+
+    // data to keep in sync with the node-based graph
+    extractor::PackedOSMIDs osm_node_ids;
+
+    // for the compressed geometry
+    extractor::CompressedEdgeContainer compressed_edge_container;
+};
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_NODE_BASED_GRAPH_FACTORY_HPP_

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -96,7 +96,7 @@ class Sol2ScriptingEnvironment final : public ScriptingEnvironment
         std::vector<std::pair<const osmium::Relation &, ExtractionRelation>> &resulting_relations,
         std::vector<InputConditionalTurnRestriction> &resulting_restrictions) override;
 
-    bool HasLocationDependentData() const { return !location_dependent_data.empty(); }
+    bool HasLocationDependentData() const override { return !location_dependent_data.empty(); }
 
   private:
     LuaScriptingContext &GetSol2Context();

--- a/include/extractor/serialization.hpp
+++ b/include/extractor/serialization.hpp
@@ -120,24 +120,22 @@ template <storage::Ownership Ownership>
 inline void read(storage::io::FileReader &reader,
                  detail::EdgeBasedNodeDataContainerImpl<Ownership> &node_data_container)
 {
-    storage::serialization::read(reader, node_data_container.geometry_ids);
-    storage::serialization::read(reader, node_data_container.name_ids);
-    storage::serialization::read(reader, node_data_container.component_ids);
-    storage::serialization::read(reader, node_data_container.travel_modes);
-    storage::serialization::read(reader, node_data_container.classes);
-    storage::serialization::read(reader, node_data_container.is_left_hand_driving);
+    // read header (separate sizes for both vectors)
+    reader.ReadElementCount64();
+    reader.ReadElementCount64();
+    // read actual data
+    storage::serialization::read(reader, node_data_container.nodes);
+    storage::serialization::read(reader, node_data_container.annotation_data);
 }
 
 template <storage::Ownership Ownership>
 inline void write(storage::io::FileWriter &writer,
                   const detail::EdgeBasedNodeDataContainerImpl<Ownership> &node_data_container)
 {
-    storage::serialization::write(writer, node_data_container.geometry_ids);
-    storage::serialization::write(writer, node_data_container.name_ids);
-    storage::serialization::write(writer, node_data_container.component_ids);
-    storage::serialization::write(writer, node_data_container.travel_modes);
-    storage::serialization::write(writer, node_data_container.classes);
-    storage::serialization::write(writer, node_data_container.is_left_hand_driving);
+    writer.WriteElementCount64(node_data_container.NumberOfNodes());
+    writer.WriteElementCount64(node_data_container.NumberOfAnnotations());
+    storage::serialization::write(writer, node_data_container.nodes);
+    storage::serialization::write(writer, node_data_container.annotation_data);
 }
 
 inline void read(storage::io::FileReader &reader, NodeRestriction &restriction)

--- a/include/partition/edge_based_graph_reader.hpp
+++ b/include/partition/edge_based_graph_reader.hpp
@@ -184,14 +184,14 @@ graphToEdges(const DynamicEdgeBasedGraph &edge_based_graph)
 
 inline DynamicEdgeBasedGraph LoadEdgeBasedGraph(const boost::filesystem::path &path)
 {
-    EdgeID max_node_id;
+    EdgeID number_of_edge_based_nodes;
     std::vector<extractor::EdgeBasedEdge> edges;
-    extractor::files::readEdgeBasedGraph(path, max_node_id, edges);
+    extractor::files::readEdgeBasedGraph(path, number_of_edge_based_nodes, edges);
 
     auto directed = splitBidirectionalEdges(edges);
     auto tidied = prepareEdgesForUsageInGraph<DynamicEdgeBasedGraphEdge>(std::move(directed));
 
-    return DynamicEdgeBasedGraph(max_node_id + 1, std::move(tidied));
+    return DynamicEdgeBasedGraph(number_of_edge_based_nodes, std::move(tidied));
 }
 
 } // ns partition

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -19,12 +19,8 @@ namespace storage
 const constexpr char CANARY[4] = {'O', 'S', 'R', 'M'};
 
 const constexpr char *block_id_to_name[] = {"NAME_CHAR_DATA",
-                                            "GEOMETRY_ID_LIST",
-                                            "NAME_ID_LIST",
-                                            "COMPONENT_ID_LIST",
-                                            "TRAVEL_MODE_LIST",
-                                            "CLASSES_LIST",
-                                            "IS_LEFT_HAND_DRIVING_LIST",
+                                            "EDGE_BASED_NODE_DATA",
+                                            "ANNOTATION_DATA",
                                             "CH_GRAPH_NODE_LIST",
                                             "CH_GRAPH_EDGE_LIST",
                                             "CH_EDGE_FILTER_0",
@@ -107,12 +103,8 @@ struct DataLayout
     enum BlockID
     {
         NAME_CHAR_DATA = 0,
-        GEOMETRY_ID_LIST,
-        NAME_ID_LIST,
-        COMPONENT_ID_LIST,
-        TRAVEL_MODE_LIST,
-        CLASSES_LIST,
-        IS_LEFT_HAND_DRIVING_LIST,
+        EDGE_BASED_NODE_DATA_LIST,
+        ANNOTATION_DATA_LIST,
         CH_GRAPH_NODE_LIST,
         CH_GRAPH_EDGE_LIST,
         CH_EDGE_FILTER_0,

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -3,6 +3,7 @@
 
 #include "extractor/guidance/intersection.hpp"
 #include "extractor/guidance/turn_lane_data.hpp"
+#include "extractor/node_data_container.hpp"
 #include "extractor/query_node.hpp"
 #include "engine/guidance/route_step.hpp"
 #include "util/node_based_graph.hpp"
@@ -77,7 +78,8 @@ inline void print(const NodeBasedDynamicGraph &node_based_graph,
     for (const auto &road : intersection)
     {
         std::cout << "\t" << toString(road) << "\n";
-        std::cout << "\t\t" << node_based_graph.GetEdgeData(road.eid).road_classification.ToString()
+        std::cout << "\t\t"
+                  << node_based_graph.GetEdgeData(road.eid).flags.road_classification.ToString()
                   << "\n";
     }
     std::cout << std::flush;

--- a/include/util/dynamic_graph.hpp
+++ b/include/util/dynamic_graph.hpp
@@ -223,6 +223,7 @@ template <typename EdgeDataT> class DynamicGraph
     unsigned GetNumberOfNodes() const { return number_of_nodes; }
 
     unsigned GetNumberOfEdges() const { return number_of_edges; }
+    auto GetEdgeCapacity() const { return edge_list.size(); }
 
     unsigned GetOutDegree(const NodeIterator n) const { return node_array[n].edges; }
 

--- a/include/util/graph_loader.hpp
+++ b/include/util/graph_loader.hpp
@@ -77,7 +77,7 @@ NodeID loadNodesFromFile(storage::io::FileReader &file_reader,
 /**
  * Reads a .osrm file and produces the edges.
  */
-inline NodeID loadEdgesFromFile(storage::io::FileReader &file_reader,
+inline EdgeID loadEdgesFromFile(storage::io::FileReader &file_reader,
                                 std::vector<extractor::NodeBasedEdge> &edge_list)
 {
     auto number_of_edges = file_reader.ReadElementCount64();
@@ -104,8 +104,7 @@ inline NodeID loadEdgesFromFile(storage::io::FileReader &file_reader,
         const auto &prev_edge = edge_list[i - 1];
 
         BOOST_ASSERT_MSG(edge.weight > 0, "loaded null weight");
-        BOOST_ASSERT_MSG(edge.forward, "edge must be oriented in forward direction");
-        BOOST_ASSERT_MSG(edge.travel_mode != TRAVEL_MODE_INACCESSIBLE, "loaded non-accessible");
+        BOOST_ASSERT_MSG(edge.flags.forward, "edge must be oriented in forward direction");
 
         BOOST_ASSERT_MSG(edge.source != edge.target, "loaded edges contain a loop");
         BOOST_ASSERT_MSG(edge.source != prev_edge.source || edge.target != prev_edge.target,
@@ -116,6 +115,15 @@ inline NodeID loadEdgesFromFile(storage::io::FileReader &file_reader,
     Log() << "Graph loaded ok and has " << edge_list.size() << " edges";
 
     return number_of_edges;
+}
+
+inline EdgeID loadAnnotationData(storage::io::FileReader &file_reader,
+                                 std::vector<extractor::NodeBasedEdgeAnnotation> &metadata)
+{
+    auto const meta_data_count = file_reader.ReadElementCount64();
+    metadata.resize(meta_data_count);
+    file_reader.ReadInto(metadata.data(), meta_data_count);
+    return meta_data_count;
 }
 }
 }

--- a/include/util/graph_utils.hpp
+++ b/include/util/graph_utils.hpp
@@ -74,7 +74,7 @@ std::vector<OutputEdgeT> directedEdgesFromCompressed(const std::vector<InputEdge
     for (const auto &input_edge : input_edge_list)
     {
         // edges that are not forward get converted by flipping the end points
-        BOOST_ASSERT(input_edge.forward);
+        BOOST_ASSERT(input_edge.flags.forward);
 
         edge.source = input_edge.source;
         edge.target = input_edge.target;
@@ -86,10 +86,10 @@ std::vector<OutputEdgeT> directedEdgesFromCompressed(const std::vector<InputEdge
 
         output_edge_list.push_back(edge);
 
-        if (!input_edge.is_split)
+        if (!input_edge.flags.is_split)
         {
             std::swap(edge.source, edge.target);
-            edge.data.reversed = !input_edge.backward;
+            edge.data.reversed = !input_edge.flags.backward;
             output_edge_list.push_back(edge);
         }
     }

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -4,12 +4,14 @@
 #include "extractor/class_data.hpp"
 #include "extractor/guidance/road_classification.hpp"
 #include "extractor/node_based_edge.hpp"
+#include "extractor/node_data_container.hpp"
 #include "util/dynamic_graph.hpp"
 #include "util/graph_utils.hpp"
 
 #include <tbb/parallel_sort.h>
 
 #include <memory>
+#include <utility>
 
 namespace osrm
 {
@@ -19,70 +21,57 @@ namespace util
 struct NodeBasedEdgeData
 {
     NodeBasedEdgeData()
-        : weight(INVALID_EDGE_WEIGHT), duration(INVALID_EDGE_WEIGHT), edge_id(SPECIAL_NODEID),
-          name_id(std::numeric_limits<unsigned>::max()), reversed(false), roundabout(false),
-          circular(false), startpoint(false), restricted(false), is_left_hand_driving(false),
-          travel_mode(TRAVEL_MODE_INACCESSIBLE), lane_description_id(INVALID_LANE_DESCRIPTIONID)
+        : weight(INVALID_EDGE_WEIGHT), duration(INVALID_EDGE_WEIGHT), geometry_id({0, false}),
+          reversed(false), annotation_data(-1)
     {
     }
 
     NodeBasedEdgeData(EdgeWeight weight,
                       EdgeWeight duration,
-                      unsigned edge_id,
-                      unsigned name_id,
+                      GeometryID geometry_id,
                       bool reversed,
-                      bool roundabout,
-                      bool circular,
-                      bool startpoint,
-                      bool restricted,
-                      bool is_left_hand_driving,
-                      extractor::TravelMode travel_mode,
-                      extractor::ClassData classes,
-                      const LaneDescriptionID lane_description_id)
-        : weight(weight), duration(duration), edge_id(edge_id), name_id(name_id),
-          reversed(reversed), roundabout(roundabout), circular(circular), startpoint(startpoint),
-          restricted(restricted), is_left_hand_driving(is_left_hand_driving),
-          travel_mode(travel_mode), classes(classes), lane_description_id(lane_description_id)
+                      extractor::NodeBasedEdgeClassification flags,
+                      AnnotationID annotation_data)
+        : weight(weight), duration(duration), geometry_id(geometry_id), reversed(reversed),
+          flags(flags), annotation_data(annotation_data)
     {
     }
 
     EdgeWeight weight;
     EdgeWeight duration;
-    unsigned edge_id;
-    unsigned name_id;
+    GeometryID geometry_id;
     bool reversed : 1;
-    bool roundabout : 1;
-    bool circular : 1;
-    bool startpoint : 1;
-    bool restricted : 1;
-    bool is_left_hand_driving : 1;
-    extractor::TravelMode travel_mode : 4;
-    extractor::ClassData classes;
-    LaneDescriptionID lane_description_id;
-    extractor::guidance::RoadClassification road_classification;
-
-    bool IsCompatibleTo(const NodeBasedEdgeData &other) const
-    {
-        return (reversed == other.reversed) && (roundabout == other.roundabout) &&
-               (circular == other.circular) && (startpoint == other.startpoint) &&
-               (travel_mode == other.travel_mode) && (classes == other.classes) &&
-               (road_classification == other.road_classification) &&
-               (restricted == other.restricted) &&
-               (is_left_hand_driving == other.is_left_hand_driving);
-    }
-
-    bool CanCombineWith(const NodeBasedEdgeData &other) const
-    {
-        return (name_id == other.name_id) && IsCompatibleTo(other);
-    }
+    extractor::NodeBasedEdgeClassification flags;
+    AnnotationID annotation_data;
 };
+
+// Check if two edge data elements can be compressed into a single edge (i.e. match in terms of
+// their meta-data).
+inline bool CanBeCompressed(const NodeBasedEdgeData &lhs,
+                            const NodeBasedEdgeData &rhs,
+                            const extractor::EdgeBasedNodeDataContainer &node_data_container)
+{
+    if (!(lhs.flags == rhs.flags))
+        return false;
+
+    auto const &lhs_annotation = node_data_container.GetAnnotation(lhs.annotation_data);
+    auto const &rhs_annotation = node_data_container.GetAnnotation(rhs.annotation_data);
+
+    if (lhs_annotation.is_left_hand_driving != rhs_annotation.is_left_hand_driving)
+        return false;
+
+    if (lhs_annotation.travel_mode != rhs_annotation.travel_mode)
+        return false;
+
+    return lhs_annotation.classes == rhs_annotation.classes;
+}
 
 using NodeBasedDynamicGraph = DynamicGraph<NodeBasedEdgeData>;
 
 /// Factory method to create NodeBasedDynamicGraph from NodeBasedEdges
 /// Since DynamicGraph expects directed edges, we need to insert
 /// two edges for undirected edges.
-inline std::shared_ptr<NodeBasedDynamicGraph>
+inline NodeBasedDynamicGraph
 NodeBasedDynamicGraphFromEdges(NodeID number_of_nodes,
                                const std::vector<extractor::NodeBasedEdge> &input_edge_list)
 {
@@ -92,16 +81,8 @@ NodeBasedDynamicGraphFromEdges(NodeID number_of_nodes,
            const extractor::NodeBasedEdge &input_edge) {
             output_edge.data.weight = input_edge.weight;
             output_edge.data.duration = input_edge.duration;
-            output_edge.data.roundabout = input_edge.roundabout;
-            output_edge.data.circular = input_edge.circular;
-            output_edge.data.name_id = input_edge.name_id;
-            output_edge.data.travel_mode = input_edge.travel_mode;
-            output_edge.data.classes = input_edge.classes;
-            output_edge.data.startpoint = input_edge.startpoint;
-            output_edge.data.restricted = input_edge.restricted;
-            output_edge.data.is_left_hand_driving = input_edge.is_left_hand_driving;
-            output_edge.data.road_classification = input_edge.road_classification;
-            output_edge.data.lane_description_id = input_edge.lane_description_id;
+            output_edge.data.flags = input_edge.flags;
+            output_edge.data.annotation_data = input_edge.annotation_data;
 
             BOOST_ASSERT(output_edge.data.weight > 0);
             BOOST_ASSERT(output_edge.data.duration > 0);
@@ -109,9 +90,7 @@ NodeBasedDynamicGraphFromEdges(NodeID number_of_nodes,
 
     tbb::parallel_sort(edges_list.begin(), edges_list.end());
 
-    auto graph = std::make_shared<NodeBasedDynamicGraph>(number_of_nodes, edges_list);
-
-    return graph;
+    return NodeBasedDynamicGraph(number_of_nodes, edges_list);
 }
 }
 }

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -450,6 +450,11 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
     friend void serialization::write<T, Bits, Ownership>(storage::io::FileWriter &writer,
                                                          const PackedVector &vec);
+    inline void swap(PackedVector &other) noexcept
+    {
+        std::swap(vec, other.vec);
+        std::swap(num_elements, other.num_elements);
+    }
 
   private:
     void allocate_blocks(std::size_t num_blocks)

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -72,6 +72,7 @@ static const OSMWayID MIN_OSM_WAYID = OSMWayID{std::numeric_limits<OSMWayID::val
 using NodeID = std::uint32_t;
 using EdgeID = std::uint32_t;
 using NameID = std::uint32_t;
+using AnnotationID = std::uint32_t;
 using EdgeWeight = std::int32_t;
 using EdgeDuration = std::int32_t;
 using SegmentWeight = std::uint32_t;

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -68,7 +68,8 @@ int Contractor::Run()
     std::vector<extractor::EdgeBasedEdge> edge_based_edge_list;
 
     updater::Updater updater(config.updater_config);
-    EdgeID max_edge_id = updater.LoadAndUpdateEdgeExpandedGraph(edge_based_edge_list, node_weights);
+    EdgeID number_of_edge_based_nodes =
+        updater.LoadAndUpdateEdgeExpandedGraph(edge_based_edge_list, node_weights);
 
     // Contracting the edge-expanded graph
 
@@ -82,7 +83,8 @@ int Contractor::Run()
         extractor::ProfileProperties properties;
         extractor::files::readProfileProperties(config.GetPath(".osrm.properties"), properties);
 
-        node_filters = util::excludeFlagsToNodeFilter(max_edge_id + 1, node_data, properties);
+        node_filters =
+            util::excludeFlagsToNodeFilter(number_of_edge_based_nodes, node_data, properties);
     }
 
     RangebasedCRC32 crc32_calculator;
@@ -91,11 +93,11 @@ int Contractor::Run()
     QueryGraph query_graph;
     std::vector<std::vector<bool>> edge_filters;
     std::vector<std::vector<bool>> cores;
-    std::tie(query_graph, edge_filters, cores) =
-        contractExcludableGraph(toContractorGraph(max_edge_id + 1, std::move(edge_based_edge_list)),
-                                std::move(node_weights),
-                                std::move(node_filters),
-                                config.core_factor);
+    std::tie(query_graph, edge_filters, cores) = contractExcludableGraph(
+        toContractorGraph(number_of_edge_based_nodes, std::move(edge_based_edge_list)),
+        std::move(node_weights),
+        std::move(node_filters),
+        config.core_factor);
     TIMER_STOP(contraction);
     util::Log() << "Contracted graph has " << query_graph.GetNumberOfEdges() << " edges.";
     util::Log() << "Contraction took " << TIMER_SEC(contraction) << " sec";

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -264,6 +264,9 @@ void CompressedEdgeContainer::InitializeBothwayVector()
 
 unsigned CompressedEdgeContainer::ZipEdges(const EdgeID f_edge_id, const EdgeID r_edge_id)
 {
+    if (!segment_data)
+        InitializeBothwayVector();
+
     const auto &forward_bucket = GetBucketReference(f_edge_id);
     const auto &reverse_bucket = GetBucketReference(r_edge_id);
 

--- a/src/extractor/guidance/coordinate_extractor.cpp
+++ b/src/extractor/guidance/coordinate_extractor.cpp
@@ -122,7 +122,7 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
     // coordinate set to add a small level of fault tolerance
     const constexpr double skipping_inaccuracies_distance = 2;
 
-    const auto &turn_edge_data = node_based_graph.GetEdgeData(turn_edge);
+    const auto &turn_edge_data = node_based_graph.GetEdgeData(turn_edge).flags;
 
     // roundabouts, check early to avoid other costly checks
     if (turn_edge_data.roundabout || turn_edge_data.circular)
@@ -175,7 +175,7 @@ util::Coordinate CoordinateExtractor::ExtractRepresentativeCoordinate(
     // the lane count might not always be set. We need to assume a positive number, though. Here we
     // select the number of lanes to operate on
     const auto considered_lanes =
-        GetOffsetCorrectionFactor(node_based_graph.GetEdgeData(turn_edge).road_classification) *
+        GetOffsetCorrectionFactor(turn_edge_data.road_classification) *
         ((intersection_lanes == 0) ? ASSUMED_LANE_COUNT : intersection_lanes);
 
     /* if the very first coordinate along the road is reasonably far away from the road, we assume
@@ -644,7 +644,7 @@ bool CoordinateExtractor::IsCurve(const std::vector<util::Coordinate> &coordinat
                                   const std::vector<double> &segment_distances,
                                   const double segment_length,
                                   const double considered_lane_width,
-                                  const util::NodeBasedEdgeData &edge_data) const
+                                  const extractor::NodeBasedEdgeClassification &edge_data) const
 {
     BOOST_ASSERT(coordinates.size() > 2);
 

--- a/src/extractor/guidance/driveway_handler.cpp
+++ b/src/extractor/guidance/driveway_handler.cpp
@@ -14,10 +14,12 @@ namespace guidance
 
 DrivewayHandler::DrivewayHandler(const IntersectionGenerator &intersection_generator,
                                  const util::NodeBasedDynamicGraph &node_based_graph,
+                                 const EdgeBasedNodeDataContainer &node_data_container,
                                  const std::vector<util::Coordinate> &coordinates,
                                  const util::NameTable &name_table,
                                  const SuffixTable &street_name_suffix_table)
     : IntersectionHandler(node_based_graph,
+                          node_data_container,
                           coordinates,
                           name_table,
                           street_name_suffix_table,
@@ -38,13 +40,13 @@ bool DrivewayHandler::canProcess(const NodeID /*nid*/,
     const auto from_eid = intersection.getUTurnRoad().eid;
 
     if (intersection.size() <= 2 ||
-        node_based_graph.GetEdgeData(from_eid).road_classification.IsLowPriorityRoadClass())
+        node_based_graph.GetEdgeData(from_eid).flags.road_classification.IsLowPriorityRoadClass())
         return false;
 
     auto low_priority_count =
         std::count_if(intersection.begin(), intersection.end(), [this](const auto &road) {
             return node_based_graph.GetEdgeData(road.eid)
-                .road_classification.IsLowPriorityRoadClass();
+                .flags.road_classification.IsLowPriorityRoadClass();
         });
 
     // Process intersection if it has two edges with normal priority and one is the entry edge,
@@ -58,7 +60,7 @@ operator()(const NodeID nid, const EdgeID source_edge_id, Intersection intersect
     auto road =
         std::find_if(intersection.begin() + 1, intersection.end(), [this](const auto &road) {
             return !node_based_graph.GetEdgeData(road.eid)
-                        .road_classification.IsLowPriorityRoadClass();
+                        .flags.road_classification.IsLowPriorityRoadClass();
         });
 
     (void)nid;

--- a/src/extractor/guidance/intersection_normalizer.cpp
+++ b/src/extractor/guidance/intersection_normalizer.cpp
@@ -14,13 +14,16 @@ namespace extractor
 namespace guidance
 {
 
-IntersectionNormalizer::IntersectionNormalizer(const util::NodeBasedDynamicGraph &node_based_graph,
-                                               const std::vector<util::Coordinate> &coordinates,
-                                               const util::NameTable &name_table,
-                                               const SuffixTable &street_name_suffix_table,
-                                               const IntersectionGenerator &intersection_generator)
+IntersectionNormalizer::IntersectionNormalizer(
+    const util::NodeBasedDynamicGraph &node_based_graph,
+    const EdgeBasedNodeDataContainer &node_data_container,
+    const std::vector<util::Coordinate> &coordinates,
+    const util::NameTable &name_table,
+    const SuffixTable &street_name_suffix_table,
+    const IntersectionGenerator &intersection_generator)
     : node_based_graph(node_based_graph), intersection_generator(intersection_generator),
       mergable_road_detector(node_based_graph,
+                             node_data_container,
                              coordinates,
                              intersection_generator,
                              intersection_generator.GetCoordinateExtractor(),

--- a/src/extractor/guidance/roundabout_handler.cpp
+++ b/src/extractor/guidance/roundabout_handler.cpp
@@ -24,18 +24,19 @@ namespace guidance
 {
 
 RoundaboutHandler::RoundaboutHandler(const util::NodeBasedDynamicGraph &node_based_graph,
+                                     const EdgeBasedNodeDataContainer &node_data_container,
                                      const std::vector<util::Coordinate> &coordinates,
                                      const CompressedEdgeContainer &compressed_edge_container,
                                      const util::NameTable &name_table,
                                      const SuffixTable &street_name_suffix_table,
-                                     const ProfileProperties &profile_properties,
                                      const IntersectionGenerator &intersection_generator)
     : IntersectionHandler(node_based_graph,
+                          node_data_container,
                           coordinates,
                           name_table,
                           street_name_suffix_table,
                           intersection_generator),
-      compressed_edge_container(compressed_edge_container), profile_properties(profile_properties),
+      compressed_edge_container(compressed_edge_container),
       coordinate_extractor(node_based_graph, compressed_edge_container, coordinates)
 {
 }
@@ -70,22 +71,24 @@ detail::RoundaboutFlags RoundaboutHandler::getRoundaboutFlags(
     const NodeID from_nid, const EdgeID via_eid, const Intersection &intersection) const
 {
     const auto &in_edge_data = node_based_graph.GetEdgeData(via_eid);
-    bool on_roundabout = in_edge_data.roundabout || in_edge_data.circular;
+    const auto &in_edge_class = in_edge_data.flags;
+    bool on_roundabout = in_edge_class.roundabout || in_edge_class.circular;
     bool can_enter_roundabout = false;
     bool can_exit_roundabout_separately = false;
 
-    const bool lhs = in_edge_data.is_left_hand_driving;
+    const bool lhs =
+        node_data_container.GetAnnotation(in_edge_data.annotation_data).is_left_hand_driving;
     const int step = lhs ? -1 : 1;
     for (std::size_t cnt = 0, idx = lhs ? intersection.size() - 1 : 0; cnt < intersection.size();
          ++cnt, idx += step)
     {
         const auto &road = intersection[idx];
-        const auto &edge_data = node_based_graph.GetEdgeData(road.eid);
+        const auto &edge = node_based_graph.GetEdgeData(road.eid);
         // only check actual outgoing edges
-        if (edge_data.reversed || !road.entry_allowed)
+        if (edge.reversed || !road.entry_allowed)
             continue;
 
-        if (edge_data.roundabout || edge_data.circular)
+        if (edge.flags.roundabout || edge.flags.circular)
         {
             can_enter_roundabout = true;
         }
@@ -108,8 +111,8 @@ void RoundaboutHandler::invalidateExitAgainstDirection(const NodeID from_nid,
                                                        const EdgeID via_eid,
                                                        Intersection &intersection) const
 {
-    const auto &in_edge_data = node_based_graph.GetEdgeData(via_eid);
-    if (in_edge_data.roundabout || in_edge_data.circular)
+    const auto &in_edge_class = node_based_graph.GetEdgeData(via_eid).flags;
+    if (in_edge_class.roundabout || in_edge_class.circular)
         return;
 
     // Find range in which exits that must be invalidated (shaded areas):
@@ -136,10 +139,10 @@ void RoundaboutHandler::invalidateExitAgainstDirection(const NodeID from_nid,
     auto invalidate_from = intersection.end(), invalidate_to = intersection.end();
     for (auto road = intersection.begin(); road != intersection.end(); ++road)
     {
-        const auto &edge_data = node_based_graph.GetEdgeData(road->eid);
-        if (edge_data.roundabout || edge_data.circular)
+        const auto &edge = node_based_graph.GetEdgeData(road->eid);
+        if (edge.flags.roundabout || edge.flags.circular)
         {
-            if (edge_data.reversed)
+            if (edge.reversed)
             {
                 if (roundabout_entry_first)
                 { // invalidate turns in range exit..end
@@ -166,8 +169,8 @@ void RoundaboutHandler::invalidateExitAgainstDirection(const NodeID from_nid,
     // u-turn against the roundabout direction is invalidated.
     for (; invalidate_from != invalidate_to; ++invalidate_from)
     {
-        const auto &edge_data = node_based_graph.GetEdgeData(invalidate_from->eid);
-        if (!edge_data.roundabout && !edge_data.circular &&
+        const auto &edge = node_based_graph.GetEdgeData(invalidate_from->eid);
+        if (!edge.flags.roundabout && !edge.flags.circular &&
             node_based_graph.GetTarget(invalidate_from->eid) != from_nid)
         {
             invalidate_from->entry_allowed = false;
@@ -207,8 +210,8 @@ bool RoundaboutHandler::qualifiesAsRoundaboutIntersection(
             // can only contain a single further road
             for (const auto edge : node_based_graph.GetAdjacentEdgeRange(node))
             {
-                const auto edge_data = node_based_graph.GetEdgeData(edge);
-                if (edge_data.roundabout || edge_data.circular)
+                const auto &edge_data = node_based_graph.GetEdgeData(edge);
+                if (edge_data.flags.roundabout || edge_data.flags.circular)
                     continue;
 
                 // there is a single non-roundabout edge
@@ -222,7 +225,7 @@ bool RoundaboutHandler::qualifiesAsRoundaboutIntersection(
                     [this](const auto current_max, const auto current_eid) {
                         return std::max(current_max,
                                         node_based_graph.GetEdgeData(current_eid)
-                                            .road_classification.GetNumberOfLanes());
+                                            .flags.road_classification.GetNumberOfLanes());
                     });
 
                 const auto next_coordinate =
@@ -279,11 +282,12 @@ RoundaboutType RoundaboutHandler::getRoundaboutType(const NodeID nid) const
         const NodeID node, const bool roundabout, const bool circular) {
         BOOST_ASSERT(roundabout != circular);
         EdgeID continue_edge = SPECIAL_EDGEID;
-        for (const auto edge : node_based_graph.GetAdjacentEdgeRange(node))
+        for (const auto edge_id : node_based_graph.GetAdjacentEdgeRange(node))
         {
-            const auto &edge_data = node_based_graph.GetEdgeData(edge);
-            if (!edge_data.reversed && (edge_data.circular == circular) &&
-                (edge_data.roundabout == roundabout))
+            const auto &edge = node_based_graph.GetEdgeData(edge_id);
+            const auto &edge_data = node_data_container.GetAnnotation(edge.annotation_data);
+            if (!edge.reversed && (edge.flags.circular == circular) &&
+                (edge.flags.roundabout == roundabout))
             {
                 if (SPECIAL_EDGEID != continue_edge)
                 {
@@ -303,9 +307,9 @@ RoundaboutType RoundaboutHandler::getRoundaboutType(const NodeID nid) const
                         roundabout_name_ids.insert(edge_data.name_id);
                 }
 
-                continue_edge = edge;
+                continue_edge = edge_id;
             }
-            else if (!edge_data.roundabout && !edge_data.circular)
+            else if (!edge.flags.roundabout && !edge.flags.circular)
             {
                 // remember all connected road names
                 connected_names.insert(edge_data.name_id);
@@ -322,7 +326,7 @@ RoundaboutType RoundaboutHandler::getRoundaboutType(const NodeID nid) const
         for (const auto edge : node_based_graph.GetAdjacentEdgeRange(at_node))
         {
             const auto &edge_data = node_based_graph.GetEdgeData(edge);
-            if (edge_data.roundabout || edge_data.circular)
+            if (edge_data.flags.roundabout || edge_data.flags.circular)
                 count++;
         }
         return count;
@@ -353,7 +357,7 @@ RoundaboutType RoundaboutHandler::getRoundaboutType(const NodeID nid) const
     bool roundabout = false, circular = false;
     for (const auto eid : node_based_graph.GetAdjacentEdgeRange(nid))
     {
-        const auto data = node_based_graph.GetEdgeData(eid);
+        const auto data = node_based_graph.GetEdgeData(eid).flags;
         roundabout |= data.roundabout;
         circular |= data.circular;
     }
@@ -435,7 +439,8 @@ Intersection RoundaboutHandler::handleRoundabouts(const RoundaboutType roundabou
     NodeID node_at_center_of_intersection = node_based_graph.GetTarget(via_eid);
     const auto &in_edge_data = node_based_graph.GetEdgeData(via_eid);
 
-    const bool lhs = in_edge_data.is_left_hand_driving;
+    const bool lhs =
+        node_data_container.GetAnnotation(in_edge_data.annotation_data).is_left_hand_driving;
     const int step = lhs ? -1 : 1;
 
     if (on_roundabout)
@@ -448,7 +453,8 @@ Intersection RoundaboutHandler::handleRoundabouts(const RoundaboutType roundabou
         {
             auto &road = intersection[idx];
             auto &turn = road;
-            const auto &out_data = node_based_graph.GetEdgeData(road.eid);
+            const auto &out_data = node_based_graph.GetEdgeData(road.eid).flags;
+            ;
             if (out_data.roundabout || out_data.circular)
             {
                 // TODO can forks happen in roundabouts? E.g. required lane changes
@@ -471,11 +477,10 @@ Intersection RoundaboutHandler::handleRoundabouts(const RoundaboutType roundabou
                         for (const auto eid :
                              node_based_graph.GetAdjacentEdgeRange(node_at_center_of_intersection))
                         {
-                            const auto &data_of_leaving_edge = node_based_graph.GetEdgeData(eid);
-                            if (!data_of_leaving_edge.reversed &&
-                                !data_of_leaving_edge.roundabout &&
-                                !data_of_leaving_edge.circular &&
-                                !data_of_leaving_edge.road_classification.IsLowPriorityRoadClass())
+                            const auto &leaving_edge = node_based_graph.GetEdgeData(eid);
+                            if (!leaving_edge.reversed && !leaving_edge.flags.roundabout &&
+                                !leaving_edge.flags.circular &&
+                                !leaving_edge.flags.road_classification.IsLowPriorityRoadClass())
                                 return true;
                         }
                         return false;
@@ -511,7 +516,7 @@ Intersection RoundaboutHandler::handleRoundabouts(const RoundaboutType roundabou
              ++cnt, idx += step)
         {
             auto &turn = intersection[idx];
-            const auto &out_data = node_based_graph.GetEdgeData(turn.eid);
+            const auto &out_data = node_based_graph.GetEdgeData(turn.eid).flags;
 
             // A roundabout consists of exactly two roads at an intersection. by toggeling this
             // flag, we can switch between roads crossing the roundabout and roads that are on the

--- a/src/extractor/guidance/suppress_mode_handler.cpp
+++ b/src/extractor/guidance/suppress_mode_handler.cpp
@@ -13,10 +13,12 @@ namespace guidance
 
 SuppressModeHandler::SuppressModeHandler(const IntersectionGenerator &intersection_generator,
                                          const util::NodeBasedDynamicGraph &node_based_graph,
+                                         const EdgeBasedNodeDataContainer &node_data_container,
                                          const std::vector<util::Coordinate> &coordinates,
                                          const util::NameTable &name_table,
                                          const SuffixTable &street_name_suffix_table)
     : IntersectionHandler(node_based_graph,
+                          node_data_container,
                           coordinates,
                           name_table,
                           street_name_suffix_table,
@@ -36,14 +38,18 @@ bool SuppressModeHandler::canProcess(const NodeID,
 
     // If the approach way is not on the suppression blacklist, and not all the exit ways share that
     // mode, there are no ways to suppress by this criteria.
-    const auto in_mode = node_based_graph.GetEdgeData(via_eid).travel_mode;
+    const auto in_mode =
+        node_data_container.GetAnnotation(node_based_graph.GetEdgeData(via_eid).annotation_data)
+            .travel_mode;
     const auto suppress_in_mode = std::find(begin(suppressed), end(suppressed), in_mode);
 
     const auto first = begin(intersection);
     const auto last = end(intersection);
 
     const auto all_share_mode = std::all_of(first, last, [this, &in_mode](const auto &road) {
-        return node_based_graph.GetEdgeData(road.eid).travel_mode == in_mode;
+        return node_data_container
+                   .GetAnnotation(node_based_graph.GetEdgeData(road.eid).annotation_data)
+                   .travel_mode == in_mode;
     });
 
     return (suppress_in_mode != end(suppressed)) && all_share_mode;

--- a/src/extractor/node_based_graph_factory.cpp
+++ b/src/extractor/node_based_graph_factory.cpp
@@ -1,0 +1,205 @@
+#include "extractor/node_based_graph_factory.hpp"
+#include "extractor/graph_compressor.hpp"
+#include "storage/io.hpp"
+#include "util/graph_loader.hpp"
+
+#include "util/log.hpp"
+
+#include <boost/assert.hpp>
+
+namespace osrm
+{
+namespace extractor
+{
+
+NodeBasedGraphFactory::NodeBasedGraphFactory(
+    const boost::filesystem::path &input_file,
+    ScriptingEnvironment &scripting_environment,
+    std::vector<TurnRestriction> &turn_restrictions,
+    std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions)
+{
+    LoadDataFromFile(input_file);
+    Compress(scripting_environment, turn_restrictions, conditional_turn_restrictions);
+    CompressGeometry();
+    CompressAnnotationData();
+}
+
+// load the data serialised during the extraction run
+void NodeBasedGraphFactory::LoadDataFromFile(const boost::filesystem::path &input_file)
+{
+    // the extraction_containers serialise all data necessary to create the node-based graph into a
+    // single file, the *.osrm file. It contains nodes, basic information about which of these nodes
+    // are traffic signals/stop signs. It also contains Edges and purely annotative meta-data
+    storage::io::FileReader file_reader(input_file, storage::io::FileReader::VerifyFingerprint);
+
+    auto barriers_iter = inserter(barriers, end(barriers));
+    auto traffic_signals_iter = inserter(traffic_signals, end(traffic_signals));
+
+    const auto number_of_node_based_nodes = util::loadNodesFromFile(
+        file_reader, barriers_iter, traffic_signals_iter, coordinates, osm_node_ids);
+
+    std::vector<NodeBasedEdge> edge_list;
+    util::loadEdgesFromFile(file_reader, edge_list);
+
+    if (edge_list.empty())
+    {
+        throw util::exception("Node-based-graph (" + input_file.string() + ") contains no edges." +
+                              SOURCE_REF);
+    }
+
+    util::loadAnnotationData(file_reader, annotation_data);
+
+    // at this point, the data isn't compressed, but since we update the graph in-place, we assign
+    // it here.
+    compressed_output_graph =
+        util::NodeBasedDynamicGraphFromEdges(number_of_node_based_nodes, edge_list);
+
+    // check whether the graph is sane
+    BOOST_ASSERT([this]() {
+        for (const auto nbg_node_u : util::irange(0u, compressed_output_graph.GetNumberOfNodes()))
+        {
+            for (EdgeID nbg_edge_id : compressed_output_graph.GetAdjacentEdgeRange(nbg_node_u))
+            {
+                // we cannot have invalid edge-ids in the graph
+                if (nbg_edge_id == SPECIAL_EDGEID)
+                    return false;
+
+                const auto nbg_node_v = compressed_output_graph.GetTarget(nbg_edge_id);
+
+                auto reverse = compressed_output_graph.FindEdge(nbg_node_v, nbg_node_u);
+
+                // found an edge that is reversed in both directions, should be two distinct edges
+                if (compressed_output_graph.GetEdgeData(nbg_edge_id).reversed &&
+                    compressed_output_graph.GetEdgeData(reverse).reversed)
+                    return false;
+            }
+        }
+        return true;
+    }());
+}
+
+void NodeBasedGraphFactory::Compress(
+    ScriptingEnvironment &scripting_environment,
+    std::vector<TurnRestriction> &turn_restrictions,
+    std::vector<ConditionalTurnRestriction> &conditional_turn_restrictions)
+{
+    GraphCompressor graph_compressor;
+    graph_compressor.Compress(barriers,
+                              traffic_signals,
+                              scripting_environment,
+                              turn_restrictions,
+                              conditional_turn_restrictions,
+                              compressed_output_graph,
+                              annotation_data,
+                              compressed_edge_container);
+}
+
+void NodeBasedGraphFactory::CompressGeometry()
+{
+    for (const auto nbg_node_u : util::irange(0u, compressed_output_graph.GetNumberOfNodes()))
+    {
+        for (EdgeID nbg_edge_id : compressed_output_graph.GetAdjacentEdgeRange(nbg_node_u))
+        {
+            BOOST_ASSERT(nbg_edge_id != SPECIAL_EDGEID);
+
+            const auto &nbg_edge_data = compressed_output_graph.GetEdgeData(nbg_edge_id);
+            const auto nbg_node_v = compressed_output_graph.GetTarget(nbg_edge_id);
+            BOOST_ASSERT(nbg_node_v != SPECIAL_NODEID);
+            BOOST_ASSERT(nbg_node_u != nbg_node_v);
+
+            // pick only every other edge, since we have every edge as an outgoing
+            // and incoming egde
+            if (nbg_node_u >= nbg_node_v)
+            {
+                continue;
+            }
+
+            auto from = nbg_node_u, to = nbg_node_v;
+            // if we found a non-forward edge reverse and try again
+            if (nbg_edge_data.reversed)
+                std::swap(from, to);
+
+            // find forward edge id and
+            const EdgeID edge_id_1 = compressed_output_graph.FindEdge(from, to);
+            BOOST_ASSERT(edge_id_1 != SPECIAL_EDGEID);
+
+            // find reverse edge id and
+            const EdgeID edge_id_2 = compressed_output_graph.FindEdge(to, from);
+            BOOST_ASSERT(edge_id_2 != SPECIAL_EDGEID);
+
+            auto packed_geometry_id = compressed_edge_container.ZipEdges(edge_id_1, edge_id_2);
+
+            // remember the geometry ID for both edges in the node-based graph
+            compressed_output_graph.GetEdgeData(edge_id_1).geometry_id = {packed_geometry_id, true};
+            compressed_output_graph.GetEdgeData(edge_id_2).geometry_id = {packed_geometry_id,
+                                                                          false};
+        }
+    }
+}
+
+void NodeBasedGraphFactory::CompressAnnotationData()
+{
+    const constexpr AnnotationID INVALID_ANNOTATIONID = -1;
+    // remap all entries to find which are used
+    std::vector<AnnotationID> annotation_mapping(annotation_data.size(), INVALID_ANNOTATIONID);
+
+    // first we mark entries, by setting their mapping to 0
+    for (const auto nbg_node_u : util::irange(0u, compressed_output_graph.GetNumberOfNodes()))
+    {
+        BOOST_ASSERT(nbg_node_u != SPECIAL_NODEID);
+        for (EdgeID nbg_edge_id : compressed_output_graph.GetAdjacentEdgeRange(nbg_node_u))
+        {
+            auto const &edge = compressed_output_graph.GetEdgeData(nbg_edge_id);
+            annotation_mapping[edge.annotation_data] = 0;
+        }
+    }
+
+    // now compute a prefix sum on all entries that are 0 to find the new mapping
+    AnnotationID prefix_sum = 0;
+    for (std::size_t i = 0; i < annotation_mapping.size(); ++i)
+    {
+        if (annotation_mapping[i] == 0)
+            annotation_mapping[i] = prefix_sum++;
+        else
+        {
+            // flag for removal
+            annotation_data[i].name_id = INVALID_NAMEID;
+        }
+    }
+
+    // apply the mapping
+    for (const auto nbg_node_u : util::irange(0u, compressed_output_graph.GetNumberOfNodes()))
+    {
+        BOOST_ASSERT(nbg_node_u != SPECIAL_NODEID);
+        for (EdgeID nbg_edge_id : compressed_output_graph.GetAdjacentEdgeRange(nbg_node_u))
+        {
+            auto &edge = compressed_output_graph.GetEdgeData(nbg_edge_id);
+            edge.annotation_data = annotation_mapping[edge.annotation_data];
+            BOOST_ASSERT(edge.annotation_data != INVALID_ANNOTATIONID);
+        }
+    }
+
+    // remove unreferenced entries, shifting other entries to the front
+    const auto new_end =
+        std::remove_if(annotation_data.begin(), annotation_data.end(), [&](auto const &data) {
+            // both elements are considered equal (to remove the second
+            // one) if the annotation mapping of the second one is
+            // invalid
+            return data.name_id == INVALID_NAMEID;
+        });
+
+    const auto old_size = annotation_data.size();
+    // remove all remaining elements
+    annotation_data.erase(new_end, annotation_data.end());
+    util::Log() << " graoh compression removed " << (old_size - annotation_data.size())
+                << " annotations of " << old_size;
+}
+
+void NodeBasedGraphFactory::ReleaseOsmNodes()
+{
+    // replace with a new vector to release old memory
+    extractor::PackedOSMIDs().swap(osm_node_ids);
+}
+
+} // namespace extractor
+} // namespace osrm

--- a/src/partition/partitioner.cpp
+++ b/src/partition/partitioner.cpp
@@ -218,7 +218,7 @@ int Partitioner::Run(const PartitionConfig &config)
     files::writePartition(config.GetPath(".osrm.partition"), mlp);
     files::writeCells(config.GetPath(".osrm.cells"), storage);
     extractor::files::writeEdgeBasedGraph(config.GetPath(".osrm.ebg"),
-                                          edge_based_graph.GetNumberOfNodes() - 1,
+                                          edge_based_graph.GetNumberOfNodes(),
                                           graphToEdges(edge_based_graph));
     TIMER_STOP(writing_mld_data);
     util::Log() << "MLD data writing took " << TIMER_SEC(writing_mld_data) << " seconds";

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -55,12 +55,12 @@ std::size_t loadGraph(const std::string &path,
             continue;
         }
 
-        if (input_edge.forward)
+        if (input_edge.flags.forward)
         {
             graph_edge_list.emplace_back(input_edge.source, input_edge.target);
         }
 
-        if (input_edge.backward)
+        if (input_edge.flags.backward)
         {
             graph_edge_list.emplace_back(input_edge.target, input_edge.source);
         }

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -524,8 +524,9 @@ Updater::NumNodesAndEdges Updater::LoadAndUpdateEdgeExpandedGraph() const
 {
     std::vector<EdgeWeight> node_weights;
     std::vector<extractor::EdgeBasedEdge> edge_based_edge_list;
-    auto max_edge_id = Updater::LoadAndUpdateEdgeExpandedGraph(edge_based_edge_list, node_weights);
-    return std::make_tuple(max_edge_id + 1, std::move(edge_based_edge_list));
+    auto number_of_edge_based_nodes =
+        Updater::LoadAndUpdateEdgeExpandedGraph(edge_based_edge_list, node_weights);
+    return std::make_tuple(number_of_edge_based_nodes, std::move(edge_based_edge_list));
 }
 
 EdgeID
@@ -534,12 +535,12 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
 {
     TIMER_START(load_edges);
 
-    EdgeID max_edge_id = 0;
+    EdgeID number_of_edge_based_nodes = 0;
     std::vector<util::Coordinate> coordinates;
     extractor::PackedOSMIDs osm_node_ids;
 
     extractor::files::readEdgeBasedGraph(
-        config.GetPath(".osrm.ebg"), max_edge_id, edge_based_edge_list);
+        config.GetPath(".osrm.ebg"), number_of_edge_based_nodes, edge_based_edge_list);
     extractor::files::readNodes(config.GetPath(".osrm.nbg_nodes"), coordinates, osm_node_ids);
 
     const bool update_conditional_turns =
@@ -550,7 +551,7 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
     if (!update_edge_weights && !update_turn_penalties && !update_conditional_turns)
     {
         saveDatasourcesNames(config);
-        return max_edge_id;
+        return number_of_edge_based_nodes;
     }
 
     if (config.segment_speed_lookup_paths.size() + config.turn_penalty_lookup_paths.size() > 255)
@@ -838,7 +839,7 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
 
     TIMER_STOP(load_edges);
     util::Log() << "Done reading edges in " << TIMER_MSEC(load_edges) << "ms.";
-    return max_edge_id;
+    return number_of_edge_based_nodes;
 }
 }
 }

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -28,23 +28,33 @@ inline InputEdge MakeUnitEdge(const NodeID from, const NodeID to)
 {
     // src, tgt, dist, edge_id, name_id, fwd, bkwd, roundabout, circular, startpoint, local access,
     // split edge, travel_mode
-    return {
-        from,                      // source
-        to,                        // target
-        1,                         // weight
-        1,                         // duration
-        SPECIAL_EDGEID,            // edge_id
-        0,                         // name_id
-        false,                     // reversed
-        false,                     // roundabout
-        false,                     // circular
-        false,                     // startpoint
-        false,                     // is_left_hand_driving
-        true,                      // split edge
-        TRAVEL_MODE_INACCESSIBLE,  // travel_mode
-        0,                         // classes
-        INVALID_LANE_DESCRIPTIONID // lane_description_id
-    };
+    return {from,
+            to,
+            1,                             // weight
+            1,                             // duration
+            GeometryID{0, false},          // geometry_id
+            false,                         // reversed
+            NodeBasedEdgeClassification(), // default flags
+            0};                            // AnnotationID
+}
+
+bool compatible(Graph const &graph,
+                const std::vector<NodeBasedEdgeAnnotation> &node_data_container,
+                EdgeID const first,
+                EdgeID second)
+{
+    auto const &first_flags = graph.GetEdgeData(first).flags;
+    auto const &second_flags = graph.GetEdgeData(second).flags;
+    if (!(first_flags == second_flags))
+        return false;
+
+    if (graph.GetEdgeData(first).reversed != graph.GetEdgeData(second).reversed)
+        return false;
+
+    auto const &first_annotation = node_data_container[graph.GetEdgeData(first).annotation_data];
+    auto const &second_annotation = node_data_container[graph.GetEdgeData(second).annotation_data];
+
+    return first_annotation.CanCombineWith(second_annotation);
 }
 
 } // namespace
@@ -60,6 +70,7 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     std::unordered_set<NodeID> traffic_lights;
     std::vector<TurnRestriction> restrictions;
     std::vector<ConditionalTurnRestriction> conditional_restrictions;
+    std::vector<NodeBasedEdgeAnnotation> annotations(1);
     CompressedEdgeContainer container;
     test::MockScriptingEnvironment scripting_environment;
 
@@ -72,19 +83,19 @@ BOOST_AUTO_TEST_CASE(long_road_test)
                                     MakeUnitEdge(3, 4),
                                     MakeUnitEdge(4, 3)};
 
-    BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[2].data));
-    BOOST_ASSERT(edges[2].data.IsCompatibleTo(edges[4].data));
-    BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[6].data));
-
     Graph graph(5, edges);
+    BOOST_ASSERT(compatible(graph, annotations, 0, 2));
+    BOOST_ASSERT(compatible(graph, annotations, 2, 4));
+    BOOST_ASSERT(compatible(graph, annotations, 4, 6));
+
     compressor.Compress(barrier_nodes,
                         traffic_lights,
                         scripting_environment,
                         restrictions,
                         conditional_restrictions,
                         graph,
+                        annotations,
                         container);
-
     BOOST_CHECK_EQUAL(graph.FindEdge(0, 1), SPECIAL_EDGEID);
     BOOST_CHECK_EQUAL(graph.FindEdge(1, 2), SPECIAL_EDGEID);
     BOOST_CHECK_EQUAL(graph.FindEdge(2, 3), SPECIAL_EDGEID);
@@ -106,6 +117,7 @@ BOOST_AUTO_TEST_CASE(loop_test)
     std::vector<TurnRestriction> restrictions;
     std::vector<ConditionalTurnRestriction> conditional_restrictions;
     CompressedEdgeContainer container;
+    std::vector<NodeBasedEdgeAnnotation> annotations(1);
     test::MockScriptingEnvironment scripting_environment;
 
     std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
@@ -121,26 +133,28 @@ BOOST_AUTO_TEST_CASE(loop_test)
                                     MakeUnitEdge(5, 0),
                                     MakeUnitEdge(5, 4)};
 
-    BOOST_ASSERT(edges.size() == 12);
-    BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[1].data));
-    BOOST_ASSERT(edges[1].data.IsCompatibleTo(edges[2].data));
-    BOOST_ASSERT(edges[2].data.IsCompatibleTo(edges[3].data));
-    BOOST_ASSERT(edges[3].data.IsCompatibleTo(edges[4].data));
-    BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[5].data));
-    BOOST_ASSERT(edges[5].data.IsCompatibleTo(edges[6].data));
-    BOOST_ASSERT(edges[6].data.IsCompatibleTo(edges[7].data));
-    BOOST_ASSERT(edges[7].data.IsCompatibleTo(edges[8].data));
-    BOOST_ASSERT(edges[8].data.IsCompatibleTo(edges[9].data));
-    BOOST_ASSERT(edges[9].data.IsCompatibleTo(edges[10].data));
-    BOOST_ASSERT(edges[10].data.IsCompatibleTo(edges[11].data));
-
     Graph graph(6, edges);
+    BOOST_ASSERT(edges.size() == 12);
+    BOOST_ASSERT(compatible(graph, annotations, 0, 1));
+    BOOST_ASSERT(compatible(graph, annotations, 1, 2));
+    BOOST_ASSERT(compatible(graph, annotations, 2, 3));
+    BOOST_ASSERT(compatible(graph, annotations, 3, 4));
+    BOOST_ASSERT(compatible(graph, annotations, 4, 5));
+    BOOST_ASSERT(compatible(graph, annotations, 5, 6));
+    BOOST_ASSERT(compatible(graph, annotations, 6, 7));
+    BOOST_ASSERT(compatible(graph, annotations, 7, 8));
+    BOOST_ASSERT(compatible(graph, annotations, 8, 9));
+    BOOST_ASSERT(compatible(graph, annotations, 9, 10));
+    BOOST_ASSERT(compatible(graph, annotations, 10, 11));
+    BOOST_ASSERT(compatible(graph, annotations, 11, 0));
+
     compressor.Compress(barrier_nodes,
                         traffic_lights,
                         scripting_environment,
                         restrictions,
                         conditional_restrictions,
                         graph,
+                        annotations,
                         container);
 
     BOOST_CHECK_EQUAL(graph.FindEdge(5, 0), SPECIAL_EDGEID);
@@ -163,6 +177,7 @@ BOOST_AUTO_TEST_CASE(t_intersection)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
+    std::vector<NodeBasedEdgeAnnotation> annotations(1);
     std::vector<TurnRestriction> restrictions;
     std::vector<ConditionalTurnRestriction> conditional_restrictions;
     CompressedEdgeContainer container;
@@ -175,19 +190,20 @@ BOOST_AUTO_TEST_CASE(t_intersection)
                                     MakeUnitEdge(2, 1),
                                     MakeUnitEdge(3, 1)};
 
-    BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[1].data));
-    BOOST_ASSERT(edges[1].data.IsCompatibleTo(edges[2].data));
-    BOOST_ASSERT(edges[2].data.IsCompatibleTo(edges[3].data));
-    BOOST_ASSERT(edges[3].data.IsCompatibleTo(edges[4].data));
-    BOOST_ASSERT(edges[4].data.IsCompatibleTo(edges[5].data));
-
     Graph graph(4, edges);
+    BOOST_ASSERT(compatible(graph, annotations, 0, 1));
+    BOOST_ASSERT(compatible(graph, annotations, 1, 2));
+    BOOST_ASSERT(compatible(graph, annotations, 2, 3));
+    BOOST_ASSERT(compatible(graph, annotations, 3, 4));
+    BOOST_ASSERT(compatible(graph, annotations, 4, 5));
+
     compressor.Compress(barrier_nodes,
                         traffic_lights,
                         scripting_environment,
                         restrictions,
                         conditional_restrictions,
                         graph,
+                        annotations,
                         container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
@@ -204,6 +220,7 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
+    std::vector<NodeBasedEdgeAnnotation> annotations(2);
     std::vector<TurnRestriction> restrictions;
     std::vector<ConditionalTurnRestriction> conditional_restrictions;
     CompressedEdgeContainer container;
@@ -211,18 +228,21 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
 
     std::vector<InputEdge> edges = {
         MakeUnitEdge(0, 1), MakeUnitEdge(1, 0), MakeUnitEdge(1, 2), MakeUnitEdge(2, 1)};
-    edges[2].data.name_id = edges[3].data.name_id = 1;
 
-    BOOST_ASSERT(edges[0].data.IsCompatibleTo(edges[1].data));
-    BOOST_ASSERT(edges[2].data.IsCompatibleTo(edges[3].data));
+    annotations[1].name_id = 1;
+    edges[2].data.annotation_data = edges[3].data.annotation_data = 1;
 
     Graph graph(5, edges);
+    BOOST_ASSERT(compatible(graph, annotations, 0, 1));
+    BOOST_ASSERT(compatible(graph, annotations, 2, 3));
+
     compressor.Compress(barrier_nodes,
                         traffic_lights,
                         scripting_environment,
                         restrictions,
                         conditional_restrictions,
                         graph,
+                        annotations,
                         container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
@@ -238,6 +258,7 @@ BOOST_AUTO_TEST_CASE(direction_changes)
 
     std::unordered_set<NodeID> barrier_nodes;
     std::unordered_set<NodeID> traffic_lights;
+    std::vector<NodeBasedEdgeAnnotation> annotations(1);
     std::vector<TurnRestriction> restrictions;
     std::vector<ConditionalTurnRestriction> conditional_restrictions;
     CompressedEdgeContainer container;
@@ -255,6 +276,7 @@ BOOST_AUTO_TEST_CASE(direction_changes)
                         restrictions,
                         conditional_restrictions,
                         graph,
+                        annotations,
                         container);
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);


### PR DESCRIPTION
# Issue

Passing data from OSM through OSRM to the API requires the adjustment of a large list of files. This PR simplifies this process by using the NodeDataContainer in both pre and post processing.
In addition, it separates the creation of the node-based graph logically from the edge-based graph, letting the edge-based graph factory take care of it's mappings, not polluting the node-based graph edges.

Resolves https://github.com/Project-OSRM/osrm-backend/issues/2052

## Tasklist
 - [x] add changelog
 - [x] ticket further memory optimisations
 - [x] make performance measurements to analyse annotation speed
 - [x] review
 - [x] adjust for comments
