### PR TITLE
Don't force loops in MLD

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -3,5 +3,5 @@ module.exports = {
     verify: '--strict --tags ~@stress --tags ~@mld --tags ~@todo -f progress --require features/support --require features/step_definitions',
     todo: '--strict --tags @todo --require features/support --require features/step_definitions',
     all: '--strict --require features/support --require features/step_definitions',
-    mld: '--strict --tags ~@stress --tags ~@todo --tags ~@alternative --tags ~@ch --require features/support --require features/step_definitions -f progress'
+    mld: '--strict --tags ~@stress --tags ~@todo --tags ~@ch --require features/support --require features/step_definitions -f progress'
 };

--- a/features/testbot/alternative.feature
+++ b/features/testbot/alternative.feature
@@ -12,6 +12,9 @@ Feature: Alternative route
               g h i j
             """
 
+        # enforce multiple cells for filterUnpackedPathsBySharing check
+        And the partition extra arguments "--small-component-size 1 --max-cell-sizes 2,4,8,16"
+
         And the ways
             | nodes |
             | ab    |

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -255,7 +255,8 @@ void routingStep(const DataFacade<Algorithm> &facade,
         auto reverse_weight = reverse_heap.GetKey(node);
         auto path_weight = weight + reverse_weight;
 
-        // if loops are forced, they are so at the source
+        // MLD uses loops forcing only to prune single node paths in forward and/or
+        // backward direction (there is no need to force loops in MLD but in CH)
         if (!(force_loop_forward && forward_heap.GetData(node).parent == node) &&
             !(force_loop_reverse && reverse_heap.GetData(node).parent == node) &&
             (path_weight >= 0) && (path_weight < path_upper_bound))

--- a/scripts/gdb_printers.py
+++ b/scripts/gdb_printers.py
@@ -146,6 +146,7 @@ class SVGPrinter (gdb.Command):
             'const osrm::engine::datafacade::ContiguousInternalMemoryDataFacade<osrm::engine::routing_algorithms::ch::Algorithm> &': self.Facade,
             'const osrm::engine::datafacade::ContiguousInternalMemoryDataFacade<osrm::engine::routing_algorithms::corech::Algorithm> &': self.Facade,
             'const osrm::engine::datafacade::ContiguousInternalMemoryDataFacade<osrm::engine::routing_algorithms::mld::Algorithm> &': self.Facade,
+            'osrm::engine::routing_algorithms::Facade': self.Facade,
             'osrm::engine::DataFacade': self.Facade}
 
 

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -456,9 +456,6 @@ void unpackPackedPaths(InputIt first,
     util::static_assert_iter_category<OutIt, std::output_iterator_tag>();
     util::static_assert_iter_value<InputIt, WeightedViaNodePackedPath>();
 
-    const bool force_loop_forward = needsLoopForward(phantom_node_pair);
-    const bool force_loop_backward = needsLoopBackwards(phantom_node_pair);
-
     const Partition &partition = facade.GetMultiLevelPartition();
 
     Heap &forward_heap = *search_engine_data.forward_heap_1;
@@ -530,8 +527,8 @@ void unpackPackedPaths(InputIt first,
                                                                                 facade,
                                                                                 forward_heap,
                                                                                 reverse_heap,
-                                                                                force_loop_forward,
-                                                                                force_loop_backward,
+                                                                                DO_NOT_FORCE_LOOPS,
+                                                                                DO_NOT_FORCE_LOOPS,
                                                                                 INVALID_EDGE_WEIGHT,
                                                                                 sublevel,
                                                                                 parent_cell_id);
@@ -587,9 +584,6 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
     // we're over factor * weight. We have to set the weight for routingStep to INVALID_EDGE_WEIGHT
     // so that stepping will continue even after we reached the shortest path upper bound.
 
-    const bool force_loop_forward = needsLoopForward(phantom_node_pair);
-    const bool force_loop_backward = needsLoopBackwards(phantom_node_pair);
-
     EdgeWeight forward_heap_min = forward_heap.MinKey();
     EdgeWeight reverse_heap_min = reverse_heap.MinKey();
 
@@ -615,8 +609,8 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
                                            reverse_heap,
                                            overlap_via,
                                            overlap_weight,
-                                           force_loop_forward,
-                                           force_loop_backward,
+                                           DO_NOT_FORCE_LOOPS,
+                                           DO_NOT_FORCE_LOOPS,
                                            phantom_node_pair);
 
             if (!forward_heap.Empty())
@@ -641,8 +635,8 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
                                            forward_heap,
                                            overlap_via,
                                            overlap_weight,
-                                           force_loop_forward,
-                                           force_loop_backward,
+                                           DO_NOT_FORCE_LOOPS,
+                                           DO_NOT_FORCE_LOOPS,
                                            phantom_node_pair);
 
             if (!reverse_heap.Empty())


### PR DESCRIPTION
# Issue

MLD shortcuts are not suffer from self-loops as CH, so MLD [`routingStep`](https://github.com/Project-OSRM/osrm-backend/blob/3755046c940dfe79e03cd1401572653403ec4adf/include/engine/routing_algorithms/routing_base_mld.hpp#L260-L262) does not check special "single-node" paths. This was removed in 0972ec9115b912a76692b5c59e3d711b1f84af91 

This PR removes using of loops forcing in MLD alternatives code, but keeps naming as is.

Potential problems that are fixed by the PR
![screenshot from 2017-10-02 11-56-12](https://user-images.githubusercontent.com/4421046/31078700-681df7b4-a783-11e7-9c40-84f9c5a3c26b.png)

```
curl -s 'localhost:5000/route/v1/driving/-122.454852,37.790617;-122.455153,37.790544?alternatives=true' | jq ".routes[].weight"
194.6
curl -s 'localhost:5000/route/v1/driving/-122.454852,37.790617;-122.455153,37.790544' | jq ".routes[].weight"
3.1
```

In addition alternative feature tests are enabled by the PR.


## Tasklist
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
