### PR TITLE
Remove unused packed path weights in MLD alternatives

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -3,5 +3,5 @@ module.exports = {
     verify: '--strict --tags ~@stress --tags ~@mld --tags ~@todo -f progress --require features/support --require features/step_definitions',
     todo: '--strict --tags @todo --require features/support --require features/step_definitions',
     all: '--strict --require features/support --require features/step_definitions',
-    mld: '--strict --tags ~@stress --tags ~@todo --tags ~@alternative --tags ~@ch --require features/support --require features/step_definitions -f progress'
+    mld: '--strict --tags ~@stress --tags ~@todo --tags ~@ch --require features/support --require features/step_definitions -f progress'
 };

--- a/features/testbot/alternative.feature
+++ b/features/testbot/alternative.feature
@@ -12,6 +12,9 @@ Feature: Alternative route
               g h i j
             """
 
+        # enforce multiple cells for filterUnpackedPathsBySharing check
+        And the partition extra arguments "--small-component-size 1 --max-cell-sizes 2,4,8,16"
+
         And the ways
             | nodes |
             | ab    |

--- a/scripts/gdb_printers.py
+++ b/scripts/gdb_printers.py
@@ -146,6 +146,7 @@ class SVGPrinter (gdb.Command):
             'const osrm::engine::datafacade::ContiguousInternalMemoryDataFacade<osrm::engine::routing_algorithms::ch::Algorithm> &': self.Facade,
             'const osrm::engine::datafacade::ContiguousInternalMemoryDataFacade<osrm::engine::routing_algorithms::corech::Algorithm> &': self.Facade,
             'const osrm::engine::datafacade::ContiguousInternalMemoryDataFacade<osrm::engine::routing_algorithms::mld::Algorithm> &': self.Facade,
+            'osrm::engine::routing_algorithms::Facade': self.Facade,
             'osrm::engine::DataFacade': self.Facade}
 
 


### PR DESCRIPTION
# Issue

PR removes `retrievePackedPathWeightsFromHeap` call and unused `WeightedViaNodePackedPath::path_weights` member.

@daniel-j-h if it is planned to use the function it must be fixed as it does not compute correctly weights of edges from the source and to the destination nodes. The assertion `BOOST_ASSERT(via.weight == edge_weights + phantom_node_weights);` always correct because weight of the the edge to via node is computed as `via.weight - (weight_from + weight_to)` that compensate incorrectness of the first and last edges weights.
 

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
