### PR TITLE
Downgrade libstdc++ so we can run inside old glibc environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev']
+          packages: ['libstdc++-4.9-dev']
       env: CLANG_VERSION='4.0.0' BUILD_TYPE='Release' ENABLE_MASON=ON ENABLE_SANITIZER=ON LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/scripts/travis/leaksanitizer.conf"
 
     # Release Builds
@@ -103,7 +103,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev']
+          packages: ['libstdc++-4.9-dev']
       env: CLANG_VERSION='4.0.0' BUILD_TYPE='Release' ENABLE_MASON=ON RUN_CLANG_FORMAT=ON ENABLE_LTO=ON
 
     - os: linux
@@ -186,7 +186,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev']
+          packages: ['libstdc++-4.9-dev']
       env: CLANG_VERSION='4.0.0' BUILD_TYPE='Release' ENABLE_MASON=ON ENABLE_LTO=ON JOBS=3
       install:
         - pushd ${OSRM_BUILD_DIR}
@@ -195,7 +195,8 @@ matrix:
               -DENABLE_MASON=${ENABLE_MASON:-OFF} \
               -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
               -DENABLE_CCACHE=ON \
-              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR} \
+              -DENABLE_GLIBC_WORKAROUND=ON
         - make --jobs=${JOBS}
         - popd
       script:
@@ -209,7 +210,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev']
+          packages: ['libstdc++-4.9-dev']
       env: CLANG_VERSION='4.0.0' BUILD_TYPE='Debug' ENABLE_MASON=ON ENABLE_LTO=ON JOBS=3
       install:
         - pushd ${OSRM_BUILD_DIR}
@@ -218,7 +219,8 @@ matrix:
               -DENABLE_MASON=${ENABLE_MASON:-OFF} \
               -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
               -DENABLE_CCACHE=ON \
-              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR} \
+              -DENABLE_GLIBC_WORKAROUND=ON
         - make --jobs=${JOBS}
         - popd
       script:
@@ -232,7 +234,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev']
+          packages: ['libstdc++-4.9-dev']
       env: CLANG_VERSION='4.0.0' BUILD_TYPE='Release' ENABLE_MASON=ON ENABLE_LTO=ON JOBS=3 NODE="6"
       install:
         - pushd ${OSRM_BUILD_DIR}
@@ -241,7 +243,8 @@ matrix:
               -DENABLE_MASON=${ENABLE_MASON:-OFF} \
               -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
               -DENABLE_CCACHE=ON \
-              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR} \
+              -DENABLE_GLIBC_WORKAROUND=ON
         - make --jobs=${JOBS}
         - popd
       script:
@@ -255,7 +258,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev']
+          packages: ['libstdc++-4.9-dev']
       env: CLANG_VERSION='4.0.0' BUILD_TYPE='Debug' ENABLE_MASON=ON ENABLE_LTO=ON JOBS=3 NODE="6"
       install:
         - pushd ${OSRM_BUILD_DIR}
@@ -264,7 +267,8 @@ matrix:
               -DENABLE_MASON=${ENABLE_MASON:-OFF} \
               -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
               -DENABLE_CCACHE=ON \
-              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+              -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR} \
+              -DENABLE_GLIBC_WORKAROUND=ON
         - make --jobs=${JOBS}
         - popd
       script:
@@ -338,7 +342,8 @@ install:
              -DENABLE_STXXL=${ENABLE_STXXL:-OFF} \
              -DBUILD_TOOLS=ON \
              -DENABLE_CCACHE=ON \
-             -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+             -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR} \
+             -DENABLE_GLIBC_WORKAROUND=${ENABLE_GLIBC_WORKAROUND:-OFF}
   - echo "travis_fold:start:MAKE"
   - make --jobs=${JOBS}
   - make tests --jobs=${JOBS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,13 @@ option(ENABLE_LTO "Use LTO if available" OFF)
 option(ENABLE_FUZZING "Fuzz testing using LLVM's libFuzzer" OFF)
 option(ENABLE_GOLD_LINKER "Use GNU gold linker if available" ON)
 option(ENABLE_NODE_BINDINGS "Build NodeJs bindings" OFF)
+option(ENABLE_GLIBC_WORKAROUND "Workaround GLIBC symbol exports" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 if(ENABLE_MASON)
   # versions in use
-  set(MASON_BOOST_VERSION "1.63.0")
+  set(MASON_BOOST_VERSION "1.65.1")
   set(MASON_STXXL_VERSION "1.4.1-1")
   set(MASON_EXPAT_VERSION "2.2.0")
   set(MASON_LUA_VERSION "5.2.4")
@@ -60,7 +61,7 @@ if (POLICY CMP0048)
 endif()
 project(OSRM C CXX)
 set(OSRM_VERSION_MAJOR 5)
-set(OSRM_VERSION_MINOR 12)
+set(OSRM_VERSION_MINOR 13)
 set(OSRM_VERSION_PATCH 0)
 set(OSRM_VERSION "${OSRM_VERSION_MAJOR}.${OSRM_VERSION_MINOR}.${OSRM_VERSION_PATCH}")
 
@@ -809,6 +810,10 @@ add_custom_target(uninstall
 # Modular build system: each directory registered here provides its own CMakeLists.txt
 add_subdirectory(unit_tests)
 add_subdirectory(src/benchmarks)
+
+if (ENABLE_GLIBC_WORKAROUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGLIBC_WORKAROUND")
+endif()
 
 if (ENABLE_NODE_BINDINGS)
   add_subdirectory(src/nodejs)

--- a/src/util/glibc_workaround.cpp
+++ b/src/util/glibc_workaround.cpp
@@ -1,0 +1,31 @@
+#ifdef GLIBC_WORKAROUND
+#include <stdexcept>
+
+// https://github.com/bitcoin/bitcoin/pull/4042
+// allows building against libstdc++-dev-4.9 while avoiding
+// GLIBCXX_3.4.20 dep
+// This is needed because libstdc++ itself uses this API - its not
+// just an issue of your code using it, ughhh
+
+// Note: only necessary on Linux
+#ifdef __linux__
+#define _ENABLE_GLIBC_WORKAROUND
+#warning building with workaround
+#else
+#warning not building with workaround
+#endif
+
+#ifdef _ENABLE_GLIBC_WORKAROUND
+namespace std
+{
+
+void __throw_out_of_range_fmt(const char *, ...) __attribute__((__noreturn__));
+void __throw_out_of_range_fmt(const char *err, ...)
+{
+    // Safe and over-simplified version. Ignore the format and print it as-is.
+    __throw_out_of_range(err);
+}
+}
+#endif // _ENABLE_GLIBC_WORKAROUND
+
+#endif // GLIBC_WORKAROUND


### PR DESCRIPTION
# Issue

When trying to use the published OSRM node modules inside some environments (i.e. AWS Lambda), we get errors like:

```
Error: /usr/local/lib64/node-v4.3.x/lib/libstdc++.so.6: version 'GLIBCXX_3.4.21' not found (required by /var/task/node_modules/osrm/lib/binding/node_osrm.node)
```

This PR downgrades us to `libstdc++-4.9-dev`, and adds an override for a libstdc++ internal symbol that we don't use (but which causes a dependency on GLIBCXX_3.9.20, which is higher than we want).

The goal is to only use symbols from GLIBCXX_3.4.19 or below, allowing us to run on environments with libstdc++-4.8 (which is quite a lot of them).  We can't build directly against libstdc++-4.8 any more (we use newer language features), but we can effectively cross-compile for it, which is what this PR does.

## Tasklist
 - [x] review
 - [x] adjust for comments