### PR TITLE
Merge unused 3 bits of PhantomNode into bearing

### DIFF
--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -181,8 +181,7 @@ struct PhantomNode
     unsigned short is_valid_forward_target : 1;
     unsigned short is_valid_reverse_source : 1;
     unsigned short is_valid_reverse_target : 1;
-    unsigned short bearing : 9;
-    unsigned short : 3; // Unused padding out to 16 bits (2 bytes)
+    unsigned short bearing : 12;
 };
 
 static_assert(sizeof(PhantomNode) == 64, "PhantomNode has more padding then expected");


### PR DESCRIPTION
# Issue

Fixes #4574, removes uncertainty in hints and prevents memcheck  reports
```
==23434== Use of uninitialised value of size 8
==23434==    at 0x15CAFB5: boost::archive::iterators::detail::from_6_bit<char>::operator()(char) const (base64_from_binary.hpp:50)
==23434==    by 0x15CB6BE: boost::iterators::transform_iterator<boost::archive::iterators::detail::from_6_bit<char>, boost::archive::iterators::transform_width<char const*, 6, 8, char>, boost::iterators::use_default, boost::iterators::use_default>::dereference() const (transform_iterator.hpp:126)
==23434==    by 0x15CB6CE: boost::iterators::transform_iterator<boost::archive::iterators::detail::from_6_bit<char>, boost::archive::iterators::transform_width<char const*, 6, 8, char>, boost::iterators::use_default, boost::iterators::use_default>::reference boost::iterators::iterator_core_access::dereference<boost::iterators::transform_iterator<boost::archive::iterators::detail::from_6_bit<char>, boost::archive::iterators::transform_width<char const*, 6, 8, char>, boost::iterators::use_default, boost::iterators::use_default> >(boost::iterators::transform_iterator<boost::archive::iterators::detail::from_6_bit<char>, boost::archive::iterators::transform_width<char const*, 6, 8, char>, boost::iterators::use_default, boost::iterators::use_default> const&) (iterator_facade.hpp:550)
==23434==    by 0x15CB6E2: boost::iterators::detail::iterator_facade_base<boost::iterators::transform_iterator<boost::archive::iterators::detail::from_6_bit<char>, boost::archive::iterators::transform_width<char const*, 6, 8, char>, boost::iterators::use_default, boost::iterators::use_default>, char, boost::iterators::single_pass_traversal_tag, char, long, false, false>::operator*() const (iterator_facade.hpp:656)
==23434==    by 0x15CB7F4: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char> >(boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, std::input_iterator_tag) (basic_string.tcc:190)
==23434==    by 0x15CB89F: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char> >(boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, std::__false_type) (basic_string.h:196)
==23434==    by 0x15CB91B: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char> >(boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>) (basic_string.h:215)
==23434==    by 0x15CB9AA: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, void>(boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, boost::archive::iterators::base64_from_binary<boost::archive::iterators::transform_width<char const*, 6, 8, char>, char>, std::allocator<char> const&) (basic_string.h:552)
==23434==    by 0x15CBB0F: osrm::engine::encodeBase64[abi:cxx11](unsigned char const*, unsigned long) (base64.hpp:65)
==23434==    by 0x15CBC01: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > osrm::engine::encodeBase64Bytewise<osrm::engine::Hint>(osrm::engine::Hint const&) (base64.hpp:94)
==23434==    by 0x15CBC45: osrm::engine::Hint::ToBase64[abi:cxx11]() const (hint.cpp:30)
==23434==    by 0x16596DC: osrm::engine::api::json::makeWaypoint(osrm::util::Coordinate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, osrm::engine::Hint const&) (json_factory.cpp:359)
```



## Tasklist
 - [x] review
 - [x] adjust for comments

