### PR TITLE
Documentation for Multi-Level Dijkstra Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Related [Project-OSRM](https://github.com/Project-OSRM) repositories:
 
 The easiest and quickest way to setup your own routing engine is to use Docker images we provide.
 
+There are two pre-processing pipelines available:
+- Contraction Hierarchies (CH)
+- Multi-Level Dijkstra (MLD)
+
+we recommend using MLD by default except for special use-cases such as very large distance matrices where CH is still a better fit for the time being.
+In the following we explain the MLD pipeline.
+If you want to use the CH pipeline instead replace `osrm-partition` and `osrm-customize` with a single `osrm-customize` and change the algorithm option for `osrm-routed`.
+
 ### Using Docker
 
 We base our Docker images ([backend](https://hub.docker.com/r/osrm/osrm-backend/), [frontend](https://hub.docker.com/r/osrm/osrm-frontend/)) on Alpine Linux and make sure they are as lightweight as possible.
@@ -52,9 +60,10 @@ Download OpenStreetMap extracts for example from [Geofabrik](http://download.geo
 Pre-process the extract with the car profile and start a routing engine HTTP server on port 5000
 
     docker run -t -v $(pwd):/data osrm/osrm-backend osrm-extract -p /opt/car.lua /data/berlin-latest.osm.pbf
-    docker run -t -v $(pwd):/data osrm/osrm-backend osrm-contract /data/berlin-latest.osrm
+    docker run -t -v $(pwd):/data osrm/osrm-backend osrm-partition /data/berlin-latest.osrm
+    docker run -t -v $(pwd):/data osrm/osrm-backend osrm-customize /data/berlin-latest.osrm
 
-    docker run -t -i -p 5000:5000 -v $(pwd):/data osrm/osrm-backend osrm-routed /data/berlin-latest.osrm
+    docker run -t -i -p 5000:5000 -v $(pwd):/data osrm/osrm-backend osrm-routed --algorithm mld /data/berlin-latest.osrm
 
 Make requests against the HTTP server
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are two pre-processing pipelines available:
 
 we recommend using MLD by default except for special use-cases such as very large distance matrices where CH is still a better fit for the time being.
 In the following we explain the MLD pipeline.
-If you want to use the CH pipeline instead replace `osrm-partition` and `osrm-customize` with a single `osrm-customize` and change the algorithm option for `osrm-routed`.
+If you want to use the CH pipeline instead replace `osrm-partition` and `osrm-customize` with a single `osrm-contract` and change the algorithm option for `osrm-routed` to `--algorithm ch`.
 
 ### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Install dependencies
 
 ```bash
 sudo apt install build-essential git cmake pkg-config \
-libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev \
-libzip-dev libboost-all-dev lua5.2 liblua5.2-dev libtbb-dev
+libbz2-dev libxml2-dev libzip-dev libboost-all-dev \
+lua5.2 liblua5.2-dev libtbb-dev
 ```
 
 Compile and install OSRM binaries

--- a/README.md
+++ b/README.md
@@ -113,26 +113,6 @@ cmake --build .
 sudo cmake --build . --target install
 ```
 
-Grab a `.osm.pbf` extract from [Geofabrik](http://download.geofabrik.de/index.html) or [Mapzen's Metro Extracts](https://mapzen.com/data/metro-extracts/)
-
-```bash
-wget http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
-```
-
-Pre-process the extract and start the HTTP server
-
-```
-osrm-extract berlin-latest.osm.pbf -p profiles/car.lua
-osrm-contract berlin-latest.osrm
-osrm-routed berlin-latest.osrm
-```
-
-Running Queries
-
-```
-curl "http://127.0.0.1:5000/route/v1/driving/13.388860,52.517037;13.385983,52.496891?steps=true"
-```
-
 ### Request Against the Demo Server
 
 Read the [API usage policy](https://github.com/Project-OSRM/osrm-backend/wiki/Api-usage-policy).


### PR DESCRIPTION
In https://github.com/Project-OSRM/osrm-backend/issues/4584#issuecomment-335927807 a user was asking for docs about CH vs. MLD. Turns out we never documented the MLD pipeline in our readme or in the wiki. Oops.

This changeset switches our docs to MLD by default: it's production-ready by now and we want users to use the MLD pipeline (except maybe for very large distance matrices cc @jcoupey)

Preview: https://github.com/Project-OSRM/osrm-backend/tree/mld-docs#quick-start

- [x] switch readme to mld
- [x] update https://github.com/Project-OSRM/osrm-backend/wiki/Running-OSRM