### PR TITLE
Remove prefix `v` in pkg-config version string

### DIFF
--- a/cmake/pkgconfig.in
+++ b/cmake/pkgconfig.in
@@ -4,7 +4,7 @@ libdir=@PKGCONFIG_LIBRARY_DIR@
 
 Name: libOSRM
 Description: Project OSRM library
-Version: v@OSRM_VERSION@
+Version: @OSRM_VERSION@
 Requires:
 Libs: -L${libdir} -losrm @PKGCONFIG_OSRM_LDFLAGS@
 Libs.private: @PKGCONFIG_OSRM_DEPENDENT_LIBRARIES@


### PR DESCRIPTION
# Issue

Fixes libosrm versioning  in pkg-config

Before
```
pkg-config --modversion "libosrm >= 5.12.0"
Requested 'libosrm >= 5.12.0' but version of libOSRM is v5.13.0
```

after
```
pkg-config --modversion "libosrm >= 5.12.0"
5.13.0
```

## Tasklist
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
