### PR TITLE
Remove LTO disabling for builds with Mason, #3978

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,13 +181,6 @@ if(ENABLE_GOLD_LINKER)
     endif()
 endif()
 
-# Disable LTO when mason+gcc is detected before testing for / setting any flags.
-# Mason builds libraries with Clang, mixing does not work in the context of lto.
-if(ENABLE_MASON AND CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ENABLE_LTO)
-  set(ENABLE_LTO OFF)
-  message(WARNING "Mason and GCC's LTO not work together. Disabling LTO.")
-endif()
-
 # Explicitly set the build type to Release if no other type is specified
 # on the command line.  Without this, cmake defaults to an unoptimized,
 # non-debug build, which almost nobody wants.
@@ -292,11 +285,6 @@ if(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES MinRelSize OR CM
       set(ENABLE_LTO Off)
     endif()
   endif()
-endif()
-
-if(UNIX AND NOT APPLE AND ENABLE_MASON AND (LTO_WORKS OR ENABLE_GOLD_LINKER))
-  message(WARNING "ENABLE_MASON and ENABLE_LTO/ENABLE_GOLD_LINKER may not work on all linux systems currently")
-  message(WARNING "For more details see: https://github.com/Project-OSRM/osrm-backend/issues/3202")
 endif()
 
 set(MAYBE_COVERAGE_LIBRARIES "")


### PR DESCRIPTION
# Issue

After mason packages update it is possible to use LTO with Mason,  reference issue #3978
Tested with `cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_NODE_BINDINGS=On -DENABLE_MASON=On -DENABLE_LTO=On` on Debian Jessie as
```
docker run -it debian:jessie /bin/bash

apt update
apt install -y git curl g++ make zlib1g-dev
git clone https://github.com/Project-OSRM/osrm-backend.git
cd osrm-backend
curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
nvm install v6
mkdir build
cd build
curl https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.tar.gz -o cmake-3.8.0-Linux-x86_64.tar.gz
tar xf cmake-3.8.0-Linux-x86_64.tar.gz
./cmake-3.8.0-Linux-x86_64/bin/cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_NODE_BINDINGS=On -DENABLE_MASON=On  -DENABLE_LTO=On
make
```

/cc @springmeyer 

## Tasklist
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
