### PR TITLE
Refactor JSON generation for nearest plugin

### DIFF
--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -3,14 +3,15 @@
 
 #include "extractor/guidance/turn_instruction.hpp"
 #include "extractor/travel_mode.hpp"
+#include "engine/api/nearest_result.hpp"
+#include "engine/api/table_result.hpp"
+#include "engine/error.hpp"
 #include "engine/guidance/leg_geometry.hpp"
 #include "engine/guidance/route.hpp"
 #include "engine/guidance/route_leg.hpp"
 #include "engine/guidance/route_step.hpp"
 #include "engine/guidance/step_maneuver.hpp"
 #include "engine/polyline_compressor.hpp"
-#include "engine/api/nearest_result.hpp"
-#include "engine/error.hpp"
 #include "util/coordinate.hpp"
 #include "util/json_container.hpp"
 
@@ -100,9 +101,10 @@ util::json::Array makeRouteLegs(std::vector<guidance::RouteLeg> legs,
                                 std::vector<util::json::Value> step_geometries,
                                 std::vector<util::json::Object> annotations);
 
-util::json::Object toJSON(const NearestResult&);
+util::json::Object toJSON(const NearestResult &);
+util::json::Object toJSON(const TableResult &);
 
-util::json::Object toJSON(const Error&);
+util::json::Object toJSON(const Error &);
 }
 }
 } // namespace engine

--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -9,6 +9,8 @@
 #include "engine/guidance/route_step.hpp"
 #include "engine/guidance/step_maneuver.hpp"
 #include "engine/polyline_compressor.hpp"
+#include "engine/api/nearest_result.hpp"
+#include "engine/error.hpp"
 #include "util/coordinate.hpp"
 #include "util/json_container.hpp"
 
@@ -97,6 +99,10 @@ util::json::Object makeRouteLeg(guidance::RouteLeg leg, util::json::Array steps)
 util::json::Array makeRouteLegs(std::vector<guidance::RouteLeg> legs,
                                 std::vector<util::json::Value> step_geometries,
                                 std::vector<util::json::Object> annotations);
+
+util::json::Object toJSON(const NearestResult&);
+
+util::json::Object toJSON(const Error&);
 }
 }
 } // namespace engine

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -3,8 +3,8 @@
 
 #include "engine/api/base_api.hpp"
 #include "engine/api/nearest_parameters.hpp"
+#include "engine/api/nearest_result.hpp"
 
-#include "engine/api/json_factory.hpp"
 #include "engine/phantom_node.hpp"
 
 #include <boost/assert.hpp>
@@ -26,67 +26,66 @@ class NearestAPI final : public BaseAPI
     {
     }
 
-    void MakeResponse(const std::vector<std::vector<PhantomNodeWithDistance>> &phantom_nodes,
-                      util::json::Object &response) const
+    NearestResult
+    MakeResponse(const std::vector<std::vector<PhantomNodeWithDistance>> &phantom_nodes) const
     {
         BOOST_ASSERT(phantom_nodes.size() == 1);
         BOOST_ASSERT(parameters.coordinates.size() == 1);
 
-        util::json::Array waypoints;
-        waypoints.values.resize(phantom_nodes.front().size());
-        std::transform(phantom_nodes.front().begin(),
-                       phantom_nodes.front().end(),
-                       waypoints.values.begin(),
-                       [this](const PhantomNodeWithDistance &phantom_with_distance) {
-                           auto &phantom_node = phantom_with_distance.phantom_node;
-                           auto waypoint = MakeWaypoint(phantom_node);
-                           waypoint.values["distance"] = phantom_with_distance.distance;
+        NearestResult result;
+        result.waypoints.resize(phantom_nodes.size());
+        std::transform(
+            phantom_nodes.front().begin(),
+            phantom_nodes.front().end(),
+            result.waypoints.begin(),
+            [this](const PhantomNodeWithDistance &phantom_with_distance) {
+                auto &phantom_node = phantom_with_distance.phantom_node;
 
-                           util::json::Array nodes;
+                util::json::Array nodes;
 
-                           std::uint64_t from_node = 0;
-                           std::uint64_t to_node = 0;
+                std::uint64_t from_node = 0;
+                std::uint64_t to_node = 0;
 
-                           std::vector<NodeID> forward_geometry;
-                           if (phantom_node.forward_segment_id.enabled)
-                           {
-                               auto segment_id = phantom_node.forward_segment_id.id;
-                               const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
-                               forward_geometry =
-                                   facade.GetUncompressedForwardGeometry(geometry_id);
+                std::vector<NodeID> forward_geometry;
+                if (phantom_node.forward_segment_id.enabled)
+                {
+                    auto segment_id = phantom_node.forward_segment_id.id;
+                    const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
+                    forward_geometry = facade.GetUncompressedForwardGeometry(geometry_id);
 
-                               auto osm_node_id = facade.GetOSMNodeIDOfNode(
-                                   forward_geometry[phantom_node.fwd_segment_position]);
-                               to_node = static_cast<std::uint64_t>(osm_node_id);
-                           }
+                    auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                        forward_geometry[phantom_node.fwd_segment_position]);
+                    to_node = static_cast<std::uint64_t>(osm_node_id);
+                }
 
-                           if (phantom_node.reverse_segment_id.enabled)
-                           {
-                               auto segment_id = phantom_node.reverse_segment_id.id;
-                               const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
-                               std::vector<NodeID> geometry =
-                                   facade.GetUncompressedForwardGeometry(geometry_id);
-                               auto osm_node_id = facade.GetOSMNodeIDOfNode(
-                                   geometry[phantom_node.fwd_segment_position + 1]);
-                               from_node = static_cast<std::uint64_t>(osm_node_id);
-                           }
-                           else if (phantom_node.forward_segment_id.enabled &&
-                                    phantom_node.fwd_segment_position > 0)
-                           {
-                               // In the case of one way, rely on forward segment only
-                               auto osm_node_id = facade.GetOSMNodeIDOfNode(
-                                   forward_geometry[phantom_node.fwd_segment_position - 1]);
-                               from_node = static_cast<std::uint64_t>(osm_node_id);
-                           }
-                           nodes.values.push_back(from_node);
-                           nodes.values.push_back(to_node);
-                           waypoint.values["nodes"] = std::move(nodes);
+                if (phantom_node.reverse_segment_id.enabled)
+                {
+                    auto segment_id = phantom_node.reverse_segment_id.id;
+                    const auto geometry_id = facade.GetGeometryIndex(segment_id).id;
+                    std::vector<NodeID> geometry =
+                        facade.GetUncompressedForwardGeometry(geometry_id);
+                    auto osm_node_id =
+                        facade.GetOSMNodeIDOfNode(geometry[phantom_node.fwd_segment_position + 1]);
+                    from_node = static_cast<std::uint64_t>(osm_node_id);
+                }
+                else if (phantom_node.forward_segment_id.enabled &&
+                         phantom_node.fwd_segment_position > 0)
+                {
+                    // In the case of one way, rely on forward segment only
+                    auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                        forward_geometry[phantom_node.fwd_segment_position - 1]);
+                    from_node = static_cast<std::uint64_t>(osm_node_id);
+                }
 
-                           return waypoint;
-                       });
+                auto name = facade.GetNameForID(
+                    facade.GetNameIndex(phantom_with_distance.phantom_node.forward_segment_id.id));
+                return Waypoint{phantom_with_distance.distance,
+                                name.data(),
+                                phantom_with_distance.phantom_node.location,
+                                {{{from_node}, {to_node}}}};
+            });
 
-        response.values["code"] = "Ok";
-        response.values["waypoints"] = std::move(waypoints);
+        return result;
     }
 
     const NearestParameters &parameters;

--- a/include/engine/api/nearest_result.hpp
+++ b/include/engine/api/nearest_result.hpp
@@ -16,7 +16,6 @@ struct NearestResult
 {
     std::vector<Waypoint> waypoints;
 };
-
 }
 }
 }

--- a/include/engine/api/nearest_result.hpp
+++ b/include/engine/api/nearest_result.hpp
@@ -1,0 +1,24 @@
+#ifndef OSRM_ENGINE_API_NEAREST_RESULT_HPP
+#define OSRM_ENGINE_API_NEAREST_RESULT_HPP
+
+#include "engine/api/waypoint.hpp"
+
+#include <vector>
+
+namespace osrm
+{
+namespace engine
+{
+namespace api
+{
+
+struct NearestResult
+{
+    std::vector<Waypoint> waypoints;
+};
+
+}
+}
+}
+
+#endif

--- a/include/engine/api/table_result.hpp
+++ b/include/engine/api/table_result.hpp
@@ -1,0 +1,24 @@
+#ifndef OSRM_ENGINE_API_TABLE_RESULT
+#define OSRM_ENGINE_API_TABLE_RESULT
+
+#include "engine/api/waypoint.hpp"
+#include "util/typedefs.hpp"
+
+#include <vector>
+
+namespace osrm
+{
+namespace engine
+{
+namespace api
+{
+struct TableResult
+{
+    std::vector<Waypoint> sources;
+    std::vector<Waypoint> destinations;
+    std::vector<EdgeWeight> durations;
+};
+}
+}
+}
+#endif

--- a/include/engine/api/waypoint.hpp
+++ b/include/engine/api/waypoint.hpp
@@ -1,0 +1,26 @@
+#ifndef OSRM_ENGINE_API_WAYPOINT_HPP
+#define OSRM_ENGINE_API_WAYPOINT_HPP
+
+#include "util/coordinate.hpp"
+#include "util/typedefs.hpp"
+
+#include <array>
+
+namespace osrm
+{
+namespace engine
+{
+namespace api
+{
+struct Waypoint
+{
+    double distance;
+    const char *name;
+    util::Coordinate location;
+    std::array<OSMNodeID, 2> nodes = {{SPECIAL_OSM_NODEID, SPECIAL_OSM_NODEID}};
+};
+}
+}
+}
+
+#endif

--- a/include/engine/error.hpp
+++ b/include/engine/error.hpp
@@ -1,0 +1,96 @@
+#ifndef OSRM_ENGINE_ERROR_HPP
+#define OSRM_ENGINE_ERROR_HPP
+
+#include "util/exception.hpp"
+
+#include <string>
+#include <array>
+
+namespace osrm
+{
+namespace engine
+{
+
+enum class ErrorCode
+{
+    NO_ERROR = 0,
+    NOT_IMPLEMENTED,
+    INVALID_VALUE,
+    INVALID_OPTIONS,
+    TOO_BIG,
+    NO_ROUTE,
+    NO_SEGMENT,
+    NO_TABLE,
+    NO_TRIP,
+    NO_MATCH,
+    NUM_ERROR,
+};
+
+inline std::string codeToString(ErrorCode code)
+{
+    static std::array<const char *, static_cast<std::size_t>(ErrorCode::NUM_ERROR)> names{
+        {"Ok",
+         "NotImplemented",
+         "InvalidValue",
+         "InvalidOptions",
+         "TooBig",
+         "NoRoute",
+         "NoSegment",
+         "NoTable",
+         "NoTrip",
+         "NoMatch"}};
+
+    return names[static_cast<std::size_t>(code)];
+}
+
+struct Error
+{
+    ErrorCode code = ErrorCode::NO_ERROR;
+    std::string message;
+
+    auto throwException() const
+    {
+        throw util::exception(std::string(codeToString(code)) + ":" + message);
+    }
+};
+
+template<typename ResultT>
+struct MaybeResult
+{
+    MaybeResult(Error error_)
+        : error(std::move(error_))
+    {
+    }
+
+    MaybeResult(ResultT result_)
+        : result(std::move(result_))
+    {
+        BOOST_ASSERT(error.code == ErrorCode::NO_ERROR);
+    }
+
+    operator bool() const {
+        return error.code == ErrorCode::NO_ERROR;
+    }
+
+    operator const Error &() const {
+        return error;
+    }
+
+    operator const ResultT &() const {
+        if (error.code != ErrorCode::NO_ERROR)
+        {
+            error.throwException();
+        }
+
+        return result;
+    }
+
+private:
+    Error error;
+    ResultT result;
+};
+
+}
+}
+
+#endif

--- a/include/engine/error.hpp
+++ b/include/engine/error.hpp
@@ -48,6 +48,8 @@ struct Error
     ErrorCode code = ErrorCode::NO_ERROR;
     std::string message;
 
+    static auto NO_ERROR() { return Error{}; }
+
     auto throwException() const
     {
         throw util::exception(std::string(codeToString(code)) + ":" + message);

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -20,6 +20,7 @@ class NearestPlugin final : public BasePlugin
   public:
     explicit NearestPlugin(const int max_results);
 
+    // to remove in v6.0
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,
                          util::json::Object &result) const;

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -2,6 +2,7 @@
 #define NEAREST_HPP
 
 #include "engine/api/nearest_parameters.hpp"
+#include "engine/api/nearest_result.hpp"
 #include "engine/datafacade/contiguous_internalmem_datafacade.hpp"
 #include "engine/plugins/plugin_base.hpp"
 #include "engine/routing_algorithms.hpp"
@@ -23,7 +24,10 @@ class NearestPlugin final : public BasePlugin
                          const api::NearestParameters &params,
                          util::json::Object &result) const;
 
-  private:
+    MaybeResult<api::NearestResult> HandleRequest(const RoutingAlgorithmsInterface &algorithms,
+                                                  const api::NearestParameters &params) const;
+
+ private:
     const int max_results;
 };
 }

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -44,7 +44,7 @@ class BasePlugin
     {
         if (algorithms.IsValid())
         {
-            return engine::Error { ErrorCode::NO_ERROR, {}};
+            return engine::Error::NO_ERROR();
         }
 
         if (!algorithms.HasExcludeFlags() && !params.exclude.empty())

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -4,6 +4,8 @@
 #include "engine/plugins/plugin_base.hpp"
 
 #include "engine/api/table_parameters.hpp"
+#include "engine/api/table_result.hpp"
+#include "engine/error.hpp"
 #include "engine/routing_algorithms.hpp"
 
 #include "util/json_container.hpp"
@@ -20,9 +22,13 @@ class TablePlugin final : public BasePlugin
   public:
     explicit TablePlugin(const int max_locations_distance_table);
 
+    // to be removed in v6.0
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TableParameters &params,
                          util::json::Object &result) const;
+
+    MaybeResult<api::TableResult> HandleRequest(const RoutingAlgorithmsInterface &algorithms,
+                                                const api::TableParameters &params) const;
 
   private:
     const int max_locations_distance_table;

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -2,6 +2,7 @@
 #include "extractor/travel_mode.hpp"
 
 #include "engine/api/json_factory.hpp"
+#include "engine/api/table_result.hpp"
 #include "engine/hint.hpp"
 #include "engine/polyline_compressor.hpp"
 #include "util/integer_range.hpp"
@@ -299,16 +300,59 @@ util::json::Object toJSON(const Waypoint &waypoint)
     return json_waypoint;
 }
 
+// convert a cpp vector of cpp Waypoints into a JSON array of JSON waypoints
+auto waypointsToJSON(const std::vector<Waypoint> &waypoints)
+{
+    util::json::Array json_waypoints;
+    json_waypoints.values.resize(waypoints.size());
+    std::transform(waypoints.begin(),
+                   waypoints.end(),
+                   json_waypoints.values.begin(),
+                   [](const auto &w) { return toJSON(w); });
+    return json_waypoints;
+}
+
 util::json::Object toJSON(const NearestResult &result)
 {
     util::json::Object json_result;
-    util::json::Array json_waypoints;
-    json_waypoints.values.resize(result.waypoints.size());
-    std::transform(result.waypoints.begin(),
-                   result.waypoints.end(),
-                   json_waypoints.values.begin(),
-                   [](const auto &w) { return toJSON(w); });
-    json_result.values["waypoints"] = json_waypoints;
+    json_result.values["code"] = "Ok";
+    json_result.values["waypoints"] = waypointsToJSON(result.waypoints);
+    return json_result;
+}
+
+util::json::Object toJSON(const TableResult &result)
+{
+    util::json::Object json_result;
+    json_result.values["code"] = "Ok";
+
+    // array of waypoints
+    json_result.values["sources"] = waypointsToJSON(result.sources);
+    json_result.values["destinations"] = waypointsToJSON(result.destinations);
+    // array of arrays, holding durations (int32)
+    util::json::Array json_durations;
+    const std::size_t number_of_rows = result.sources.size();
+    const std::size_t number_of_columns = result.destinations.size();
+    for (const auto row : util::irange<std::size_t>(0UL, number_of_rows))
+    {
+        util::json::Array json_row;
+        auto row_begin_iterator = result.durations.begin() + (row * number_of_columns);
+        auto row_end_iterator = result.durations.begin() + ((row + 1) * number_of_columns);
+        json_row.values.resize(number_of_columns);
+        std::transform(row_begin_iterator,
+                       row_end_iterator,
+                       json_row.values.begin(),
+                       [](const EdgeWeight duration) {
+                           // no route between source and destination
+                           if (duration == MAXIMAL_EDGE_DURATION)
+                           {
+                               return util::json::Value(util::json::Null());
+                           }
+                           // convert values from deciseconds to seconds
+                           return util::json::Value(util::json::Number(duration / 10.));
+                       });
+        json_durations.values.push_back(std::move(json_row));
+    }
+    json_result.values["durations"] = json_durations;
     return json_result;
 }
 

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -289,6 +289,37 @@ util::json::Array makeRouteLegs(std::vector<guidance::RouteLeg> legs,
     }
     return json_legs;
 }
+
+util::json::Object toJSON(const Waypoint &waypoint)
+{
+    util::json::Object json_waypoint;
+    json_waypoint.values["name"] = waypoint.name;
+    json_waypoint.values["distance"] = waypoint.distance;
+    json_waypoint.values["location"] = detail::coordinateToLonLat(waypoint.location);
+    return json_waypoint;
+}
+
+util::json::Object toJSON(const NearestResult &result)
+{
+    util::json::Object json_result;
+    util::json::Array json_waypoints;
+    json_waypoints.values.resize(result.waypoints.size());
+    std::transform(result.waypoints.begin(),
+                   result.waypoints.end(),
+                   json_waypoints.values.begin(),
+                   [](const auto &w) { return toJSON(w); });
+    json_result.values["waypoints"] = json_waypoints;
+    return json_result;
+}
+
+util::json::Object toJSON(const Error &error)
+{
+    util::json::Object json_error;
+    json_error.values["code"] = codeToString(error.code);
+    json_error.values["message"] = error.message;
+    return json_error;
+}
+
 } // namespace json
 } // namespace api
 } // namespace engine

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -2,6 +2,7 @@
 #include "engine/api/nearest_api.hpp"
 #include "engine/api/nearest_parameters.hpp"
 #include "engine/phantom_node.hpp"
+#include "engine/error.hpp"
 #include "util/integer_range.hpp"
 
 #include <cstddef>
@@ -23,42 +24,57 @@ Status NearestPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms
                                     const api::NearestParameters &params,
                                     util::json::Object &json_result) const
 {
+    auto maybe_result = HandleRequest(algorithms, params);
+    if (maybe_result)
+    {
+        json_result = api::json::toJSON(static_cast<const api::NearestResult&>(maybe_result));
+        return Status::Ok;
+    }
+    else
+    {
+        json_result = api::json::toJSON(static_cast<const engine::Error&>(maybe_result));
+        return Status::Error;
+    }
+}
+
+MaybeResult<api::NearestResult> NearestPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms, const api::NearestParameters &params) const
+{
     BOOST_ASSERT(params.IsValid());
 
-    if (!CheckAlgorithms(params, algorithms, json_result))
-        return Status::Error;
+    auto error = CheckAlgorithms(params, algorithms);
+    if (error.code != ErrorCode::NO_ERROR)
+        return error;
 
     const auto &facade = algorithms.GetFacade();
 
     if (max_results > 0 &&
         (boost::numeric_cast<std::int64_t>(params.number_of_results) > max_results))
     {
-        return Error("TooBig",
-                     "Number of results " + std::to_string(params.number_of_results) +
-                         " is higher than current maximum (" + std::to_string(max_results) + ")",
-                     json_result);
+        return engine::Error {ErrorCode::TOO_BIG, "Number of results " + std::to_string(params.number_of_results) +
+                         " is higher than current maximum (" + std::to_string(max_results) + ")"};
     }
 
     if (!CheckAllCoordinates(params.coordinates))
-        return Error("InvalidOptions", "Coordinates are invalid", json_result);
+    {
+        return engine::Error {ErrorCode::INVALID_OPTIONS, "Coordinates are invalid"};
+    }
 
     if (params.coordinates.size() != 1)
     {
-        return Error("InvalidOptions", "Only one input coordinate is supported", json_result);
+        return engine::Error {ErrorCode::INVALID_OPTIONS, "Only one input coordinate is supported"};
     }
 
     auto phantom_nodes = GetPhantomNodes(facade, params, params.number_of_results);
 
     if (phantom_nodes.front().size() == 0)
     {
-        return Error("NoSegment", "Could not find a matching segments for coordinate", json_result);
+        return engine::Error {ErrorCode::NO_SEGMENT, "Could not find a matching segments for coordinate"};
     }
     BOOST_ASSERT(phantom_nodes.front().size() > 0);
 
     api::NearestAPI nearest_api(facade, params);
-    nearest_api.MakeResponse(phantom_nodes, json_result);
-
-    return Status::Ok;
+    auto result = nearest_api.MakeResponse(phantom_nodes);
+    return result;
 }
 }
 }


### PR DESCRIPTION
# Issue

This PR is the firs step to doing refactors to implement #4612. As example I ported the `nearest` plugin because it is very atomic and has a simple API.

Important goals of this refactor are:
- Contain JSON-specific part to `json_factory.cpp` / `toJSON` function.
- Add a better way of transporting errors without relying on the JSON object structure (`MaybeResult`)

## Tasklist
- [x] PR refactor for nearest plugin
- [x] PR refactor for table plugin
- [ ] PR refactor for match plugin
- [ ] PR refactor for trip plugin
- [ ] PR refactor for viaroute plugin
- [ ] PR refactor for tile plugin ?
- [ ] Template error types
 - [ ] review
 - [ ] adjust for comments
