### PR TITLE
Replace use of implicit_value since that broke with boost 1.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
     - Infrastructure:
       - Lua 5.1 support is removed due to lack of support in sol2 https://github.com/ThePhD/sol2/issues/302
       - Fixed pkg-config version of OSRM
+    - Tools:
+      - Because of boost/program_options#32 with boost 1.65+ we needed to change the behavior of the following flags to not accept `={true|false}` anymore:
+        - `--use-location-cache=false` becomes `--disable-location-cache`
+        - `--parse-conditional-restrictions=true` becomes `--parse-conditional-restrictions`
+        - The deprecated options `--use-level-cache` and `--generate-edge-lookup`
     - Bugfixes:
       - Fixed #4348: Some cases of sliproads pre-processing were broken
       - Fixed #4331: Correctly compute left/right modifiers of forks in case the fork is curved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
       - Fixed pkg-config version of OSRM
     - Tools:
       - Because of boost/program_options#32 with boost 1.65+ we needed to change the behavior of the following flags to not accept `={true|false}` anymore:
-        - `--use-location-cache=false` becomes `--disable-location-cache`
+        - `--use-locations-cache=false` becomes `--disable-location-cache`
         - `--parse-conditional-restrictions=true` becomes `--parse-conditional-restrictions`
         - The deprecated options `--use-level-cache` and `--generate-edge-lookup`
     - Bugfixes:

--- a/features/car/conditional_restrictions.feature
+++ b/features/car/conditional_restrictions.feature
@@ -677,7 +677,7 @@ Feature: Car - Turn restrictions
     # https://www.openstreetmap.org/#map=18/38.91099/-77.00888
     @no_turning @conditionals
     Scenario: Car - DC North capitol situation, two on one off
-        Given the extract extra arguments "--parse-conditional-restrictions=1"
+        Given the extract extra arguments "--parse-conditional-restrictions"
         # 9pm Wed 02 May, 2017 UTC, 5pm EDT
         Given the contract extra arguments "--time-zone-file=test/data/tz/{timezone_names}/dc.geojson --parse-conditionals-from-now=1493845200"
         Given the customize extra arguments "--time-zone-file=test/data/tz/{timezone_names}/dc.geojson --parse-conditionals-from-now=1493845200"
@@ -724,7 +724,7 @@ Feature: Car - Turn restrictions
 
     @no_turning @conditionals
     Scenario: Car - DC North capitol situation, one on two off
-        Given the extract extra arguments "--parse-conditional-restrictions=1"
+        Given the extract extra arguments "--parse-conditional-restrictions"
         # 10:30am utc, wed, 6:30am est
         Given the contract extra arguments "--time-zone-file=test/data/tz/{timezone_names}/dc.geojson --parse-conditionals-from-now=1493807400"
         Given the customize extra arguments "--time-zone-file=test/data/tz/{timezone_names}/dc.geojson --parse-conditionals-from-now=1493807400"
@@ -848,7 +848,7 @@ Feature: Car - Turn restrictions
 
     @only_turning @conditionals
     Scenario: Car - Somewhere in London, the UK, GMT timezone
-        Given the extract extra arguments "--parse-conditional-restrictions=1"
+        Given the extract extra arguments "--parse-conditional-restrictions"
         # 9am UTC, 10am BST
         Given the contract extra arguments "--time-zone-file=test/data/tz/{timezone_names}/london.geojson --parse-conditionals-from-now=1493802000"
         Given the customize extra arguments "--time-zone-file=test/data/tz/{timezone_names}/london.geojson --parse-conditionals-from-now=1493802000"

--- a/features/options/extract/lua.feature
+++ b/features/options/extract/lua.feature
@@ -51,7 +51,7 @@ Feature: osrm-extract lua ways:get_nodes()
             | ab    |
         And the data has been saved to disk
 
-        When I try to run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --disable-locations-cache"
+        When I try to run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --disable-location-cache"
         Then it should exit with an error
         And stderr should contain "invalid location"
 
@@ -79,7 +79,7 @@ Feature: osrm-extract lua ways:get_nodes()
             | ab    |
         And the data has been saved to disk
 
-        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson  --disable-locations-cache"
+        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson  --disable-location-cache"
         Then it should exit successfully
         And stdout should contain "answer 42"
         And stdout should contain "boolean true"
@@ -116,7 +116,7 @@ Feature: osrm-extract lua ways:get_nodes()
             | ef    | Null Island    |
         And the data has been saved to disk
 
-        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --location-dependent-data test/data/regions/hong-kong.geojson --disable-locations-cache"
+        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --location-dependent-data test/data/regions/hong-kong.geojson --disable-location-cache"
         Then it should exit successfully
         And stdout should not contain "1 GeoJSON polygon"
         And stdout should contain "2 GeoJSON polygons"

--- a/features/options/extract/lua.feature
+++ b/features/options/extract/lua.feature
@@ -51,7 +51,7 @@ Feature: osrm-extract lua ways:get_nodes()
             | ab    |
         And the data has been saved to disk
 
-        When I try to run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --use-locations-cache=false"
+        When I try to run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --disable-locations-cache"
         Then it should exit with an error
         And stderr should contain "invalid location"
 
@@ -79,7 +79,7 @@ Feature: osrm-extract lua ways:get_nodes()
             | ab    |
         And the data has been saved to disk
 
-        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson  --use-locations-cache=false"
+        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson  --disable-locations-cache"
         Then it should exit successfully
         And stdout should contain "answer 42"
         And stdout should contain "boolean true"
@@ -116,7 +116,7 @@ Feature: osrm-extract lua ways:get_nodes()
             | ef    | Null Island    |
         And the data has been saved to disk
 
-        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --location-dependent-data test/data/regions/hong-kong.geojson --use-locations-cache=false"
+        When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson --location-dependent-data test/data/regions/hong-kong.geojson --disable-locations-cache"
         Then it should exit successfully
         And stdout should not contain "1 GeoJSON polygon"
         And stdout should contain "2 GeoJSON polygons"

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -61,7 +61,7 @@ return_code parseArguments(int argc,
             ->composing(),
         "Lookup files containing from_, to_, via_nodes, and turn penalties to adjust turn weights")(
         "level-cache,o",
-        boost::program_options::value<bool>(&contractor_config.use_cached_priority)
+        boost::program_options::bool_switch(&contractor_config.use_cached_priority)
             ->default_value(false),
         "DEPRECATED: Will always be false. Use .level file to retain the contraction level for "
         "each "

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -67,10 +67,10 @@ return_code parseArguments(int argc,
                                   &extractor_config.location_dependent_data_paths)
                                   ->composing(),
                               "GeoJSON files with location-dependent data")(
-        "use-locations-cache",
+        "disable-locations-cache",
         boost::program_options::bool_switch(&extractor_config.use_locations_cache)
-            ->implicit_value(true)
-            ->default_value(extractor_config.use_locations_cache),
+            ->implicit_value(false)
+            ->default_value(true),
         "Use internal nodes locations cache for location-dependent data lookups");
 
     bool dummy;

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -58,7 +58,7 @@ return_code parseArguments(int argc,
             ->default_value(false),
         "Use metadata during osm parsing (This can affect the extraction performance).")(
         "parse-conditional-restrictions",
-        boost::program_options::value<bool>(&extractor_config.parse_conditionals)
+        boost::program_options::bool_switch(&extractor_config.parse_conditionals)
             ->implicit_value(true)
             ->default_value(false),
         "Save conditional restrictions found during extraction to disk for use "
@@ -68,7 +68,7 @@ return_code parseArguments(int argc,
                                   ->composing(),
                               "GeoJSON files with location-dependent data")(
         "use-locations-cache",
-        boost::program_options::value<bool>(&extractor_config.use_locations_cache)
+        boost::program_options::bool_switch(&extractor_config.use_locations_cache)
             ->implicit_value(true)
             ->default_value(extractor_config.use_locations_cache),
         "Use internal nodes locations cache for location-dependent data lookups");
@@ -82,7 +82,7 @@ return_code parseArguments(int argc,
         boost::program_options::value<boost::filesystem::path>(&extractor_config.input_path),
         "Input file in .osm, .osm.bz2 or .osm.pbf format")(
         "generate-edge-lookup",
-        boost::program_options::value<bool>(&dummy)->implicit_value(true)->default_value(false),
+        boost::program_options::bool_switch(&dummy)->implicit_value(true)->default_value(false),
         "Not used anymore");
 
     // positional option

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -67,7 +67,7 @@ return_code parseArguments(int argc,
                                   &extractor_config.location_dependent_data_paths)
                                   ->composing(),
                               "GeoJSON files with location-dependent data")(
-        "disable-locations-cache",
+        "disable-location-cache",
         boost::program_options::bool_switch(&extractor_config.use_locations_cache)
             ->implicit_value(false)
             ->default_value(true),


### PR DESCRIPTION
# Issue

Fixes a problem with 5.13 that cause `osrm-extract` to throw errors even though parameters were correct before boost `1.65`.

Downside is that options that used to take `true/false` now throw an error if you provide them explicitly. (which is odd to begin with)

EDIT: Seems like we actually did that in the tests.

## Tasklist
 - [x] review
 - [x] adjust for comments
