### PR TITLE
Fix/adjust angles

### DIFF
--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -63,8 +63,8 @@ Feature: Simple Turns
 
         When I route I should get
             | waypoints | turns                    | route          | intersections                               |
-            | f,a       | depart,arrive            | road,road      | true:0,true:15 false:90 false:180;true:180   |
-            | e,a       | depart,turn right,arrive | turn,road,road | true:270;true:15 false:90 false:180;true:180 |
+            | f,a       | depart,arrive            | road,road      | true:0,true:0 false:90 false:180;true:180   |
+            | e,a       | depart,turn right,arrive | turn,road,road | true:270;true:0 false:90 false:180;true:180 |
 
     Scenario: Turning into splitting road
         Given the node map

--- a/features/guidance/perception.feature
+++ b/features/guidance/perception.feature
@@ -36,6 +36,36 @@ Feature: Simple Turns
             | f,a       | depart,arrive                   | road,road      | true:0,true:0 false:150 false:180;true:180   |
             | e,a       | depart,turn slight right,arrive | turn,road,road | true:333;true:0 false:150 false:180;true:180 |
 
+    Scenario: Turning into splitting road - no improvement
+        Given the node map
+            """
+                a
+                b
+              / |
+            c   d - e
+            |   |
+            |   |
+            |   |
+            |   |
+            |   |
+            |   |
+            |   |
+            |   |
+            g   f
+            """
+
+        And the ways
+            | nodes | name | highway | oneway |
+            | ab    | road | primary | no     |
+            | bcg   | road | primary | yes    |
+            | fdb   | road | primary | yes    |
+            | ed    | turn | primary | yes    |
+
+        When I route I should get
+            | waypoints | turns                    | route          | intersections                               |
+            | f,a       | depart,arrive            | road,road      | true:0,true:15 false:90 false:180;true:180   |
+            | e,a       | depart,turn right,arrive | turn,road,road | true:270;true:15 false:90 false:180;true:180 |
+
     Scenario: Turning into splitting road
         Given the node map
         """

--- a/include/util/geojson_debug_logger.hpp
+++ b/include/util/geojson_debug_logger.hpp
@@ -2,6 +2,7 @@
 #define OSRM_GEOJSON_DEBUG_LOGGER_HPP
 
 #include <fstream>
+#include <iomanip>
 #include <mutex>
 #include <string>
 
@@ -104,6 +105,8 @@ class GeojsonLogger
         // and we don't want deadlocks
         std::lock_guard<std::mutex> guard(lock);
         ofs.open(logfile, std::ios::binary);
+
+        ofs << std::setprecision(12);
 
         // set up a feature collection
         ofs << "{\n\t\"type\": \"FeatureCollection\",\n\t\"features\": [\n\t";


### PR DESCRIPTION
# Issue

The result is best visualised by comparing the testcases in perception.feature.
This PR changes the behaviour of how we adjust angles at an intersection right before a merge.
It turns out that we can introduce worse turn-angles, if the straightest turn out of the intersection isn't improved.

This is a changed branched out from https://github.com/Project-OSRM/osrm-backend/pull/4426

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 A map for all affected locations can be found [here](https://api.mapbox.com/styles/v1/mokob/cj8zz60q41gca2rmorux3qgx4.html?fresh=true&title=true&access_token=pk.eyJ1IjoibW9rb2IiLCJhIjoiY2lnaTJqczFyMHN2bHZpa3I0dTdwbGlqYSJ9.B8zhP12x93OLT7tHv0xSXw#18.9/37.805402/-122.427971/0). In all of these cases, the angle isn't messed with. It is hard to clearly visualise what happens, but the angles would reflect most turn angles better.
