### PR TITLE
Adds cardinal_directions flag to profiles and disables ref-rewriting by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # UNRELEASED
   - Changes from 5.12:
     - Profile:
-      - Append cardinal directions from route relations to ref fields to improve instructions
+      - Append cardinal directions from route relations to ref fields to improve instructions; off by default see `profile.cardinal_directions`
       - Support of `distance` weight in foot and bicycle profiles
       - Support of relations processing
       - Added `way:get_location_tag(key)` method to get location-dependent tags https://github.com/Project-OSRM/osrm-backend/wiki/Using-location-dependent-data-in-profiles

--- a/features/car/route_relations.feature
+++ b/features/car/route_relations.feature
@@ -4,6 +4,11 @@ Feature: Car - route relations
         Given the profile "car"
 
     Scenario: Assignment using relation membership roles
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -26,7 +31,63 @@ Feature: Car - route relations
             | b,a       | westbound,westbound  | I 80 $west,I 80 $west                            |
             | c,d       | eastbound,eastbound  | I 80 $east; CO 93 $east,I 80 $east; CO 93 $east  |
 
+    Scenario: No cardinal directions by default
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = false
+        """
+        Given the node map
+            """
+              a----------------b
+              c----------------d
+            """
+
+        And the ways
+            | nodes | name        | highway  | ref         |
+            | ba    | westbound   | motorway | I 80        |
+            | cd    | eastbound   | motorway | I 80;CO 93  |
+
+        And the relations
+            | type        | way:east | way:west | route | ref | network |
+            | route       | cd       | ba       | road  | 80  | US:I    |
+            | route       | cd       | ba       | road  | 93  | US:CO   |
+
+
+        When I route I should get
+            | waypoints | route                | ref                     |
+            | b,a       | westbound,westbound  | I 80,I 80               |
+            | c,d       | eastbound,eastbound  | I 80; CO 93,I 80; CO 93 |
+
+    Scenario: No cardinal directions by default
+        Given the node map
+            """
+              a----------------b
+              c----------------d
+            """
+
+        And the ways
+            | nodes | name        | highway  | ref         |
+            | ba    | westbound   | motorway | I 80        |
+            | cd    | eastbound   | motorway | I 80;CO 93  |
+
+        And the relations
+            | type        | way:east | way:west | route | ref | network |
+            | route       | cd       | ba       | road  | 80  | US:I    |
+            | route       | cd       | ba       | road  | 93  | US:CO   |
+
+
+        When I route I should get
+            | waypoints | route                | ref                     |
+            | b,a       | westbound,westbound  | I 80,I 80               |
+            | c,d       | eastbound,eastbound  | I 80; CO 93,I 80; CO 93 |
+
+
     Scenario: Assignment using relation direction property (no role on members)
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -51,6 +112,11 @@ Feature: Car - route relations
 
 
     Scenario: Forward assignment on one-way roads using relation direction property
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -75,6 +141,11 @@ Feature: Car - route relations
 
 
     Scenario: Forward/backward assignment on non-divided roads with role direction tag
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -99,6 +170,11 @@ Feature: Car - route relations
 
 
     Scenario: Conflict between role and direction
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -118,6 +194,11 @@ Feature: Car - route relations
 
 
     Scenario: Conflict between role and superrelation direction
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -140,6 +221,11 @@ Feature: Car - route relations
             | a,b       | eastbound,eastbound | I 80,I 80 |
 
     Scenario: Conflict between role and superrelation role
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -162,6 +248,11 @@ Feature: Car - route relations
             | a,b       | eastbound,eastbound  | I 80,I 80 |
 
     Scenario: Direction only available via superrelation role
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -184,6 +275,11 @@ Feature: Car - route relations
             | a,b       | eastbound,eastbound  | I 80 $east,I 80 $east |
 
     Scenario: Direction only available via superrelation direction
+        Given the profile file "car" initialized with
+        """
+        profile.cardinal_directions = true
+        """
+
         Given the node map
             """
               a----------------b
@@ -204,6 +300,7 @@ Feature: Car - route relations
         When I route I should get
             | waypoints | route                | ref                   |
             | a,b       | eastbound,eastbound  | I 80 $east,I 80 $east |
+
 
 #    Scenario: Three levels of indirection
 #        Given the node map

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -35,6 +35,7 @@ function setup()
     turn_penalty              = 7.5,
     speed_reduction           = 0.8,
     turn_bias                 = 1.075,
+    cardinal_directions       = false,
 
     -- a list of suffixes to suppress in name change instructions. The suffixes also include common substrings of each other
     suffix_list = {
@@ -403,7 +404,9 @@ function process_way(profile, way, result, relations)
 
   WayHandlers.run(profile, way, result, data, handlers, relations)
 
-  Relations.process_way_refs(way, relations, result)
+  if profile.cardinal_directions then
+      Relations.process_way_refs(way, relations, result)
+  end
 end
 
 function process_turn(profile, turn)

--- a/profiles/lib/relations.lua
+++ b/profiles/lib/relations.lua
@@ -65,7 +65,7 @@ function Relations.match_to_ref(relations, ref)
     if direction then
       local best_score = -1
       local best_ref = nil
-      
+
       function find_best(scores)
         if scores then
           for k ,v in pairs(scores) do
@@ -79,7 +79,7 @@ function Relations.match_to_ref(relations, ref)
 
       find_best(name_scores)
       find_best(ref_scores)
-      
+
       if best_ref then
         local result_direction = result_match[best_ref]
 
@@ -230,7 +230,7 @@ function Relations.process_way_refs(way, relations, result)
   local matched_refs = nil;
   if result.ref then
     local match_res = Relations.match_to_ref(parsed_rel_list, result.ref)
- 
+
     function gen_ref(is_forward)
       local ref = ''
       for _, m in pairs(match_res) do
@@ -252,7 +252,7 @@ function Relations.process_way_refs(way, relations, result)
 
       return ref
     end
-    
+
     result.forward_ref = gen_ref(true)
     result.backward_ref = gen_ref(false)
   end


### PR DESCRIPTION
At the moment we append cardinal directions based on relations to the `ref` field, e.g. `I-80 $north`. This breaks compatibility with all existing clients.

This changeset adds a `cardinal_directions = false` flag to the default car profile disabling cardinal direction re-writing by default.