### PR TITLE
Add use of LUA_LIBRARY_DIRS, #4646

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+test
+build

--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -84,11 +84,15 @@ function(_lua_set_version_vars)
              lua.${CMAKE_MATCH_1}.${CMAKE_MATCH_2}
         )
         pkg_check_modules(LUA QUIET "lua${ver}")
+        list(APPEND _lua_include_subdirs ${LUA_INCLUDE_DIRS})
+        list(APPEND _lua_library_names ${LUA_LIBRARIES})
+        list(APPEND _lua_library_dirs ${LUA_LIBRARY_DIRS})
     endforeach ()
 
     set(_lua_include_subdirs "${_lua_include_subdirs}" PARENT_SCOPE)
     set(_lua_library_names "${_lua_library_names}" PARENT_SCOPE)
     set(_lua_append_versions "${_lua_append_versions}" PARENT_SCOPE)
+    set(_lua_library_dirs "${_lua_library_dirs}" PARENT_SCOPE)
 endfunction(_lua_set_version_vars)
 
 function(_lua_check_header_version _hdr_file)
@@ -161,6 +165,7 @@ find_library(LUA_LIBRARY
     ENV LUA_DIR
   PATH_SUFFIXES lib
   PATHS
+  ${_lua_library_dirs}
   ~/Library/Frameworks
   /Library/Frameworks
   /sw

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,34 +1,20 @@
-FROM alpine:3.5
+FROM alpine:3.6 as buildstage
 
-RUN mkdir /opt
-WORKDIR /opt
+ARG DOCKER_TAG
+RUN mkdir -p /src  && mkdir -p /opt
+COPY . /src
+WORKDIR /src
 
 RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk update && \
     apk upgrade && \
     apk add git cmake wget make libc-dev gcc g++ bzip2-dev boost-dev zlib-dev expat-dev lua5.2-dev libtbb@testing libtbb-dev@testing && \
-    \
-    echo "Building libstxxl" && \
-    cd /opt && \
-    git clone --depth 1 --branch 1.4.1 https://github.com/stxxl/stxxl.git && \
-    cd stxxl && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release .. && \
-    make -j${NPROC} && \
-    make install
-
-ARG DOCKER_TAG
-RUN mkdir /src
-COPY . /src
-WORKDIR /src
-
-RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
+    NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
-    mkdir build && \
+    mkdir -p build && \
     cd build && \
     BUILD_TYPE="Release" && \
     ENABLE_ASSERTIONS="Off" && \
@@ -41,13 +27,19 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     cd ../profiles && \
     cp -r * /opt && \
     \
-    echo "Cleaning up" && \
     strip /usr/local/bin/* && \
-    rm /usr/local/lib/libstxxl* && \
-    cd /opt && \
-    apk del boost-dev && \
-    apk del g++ cmake libc-dev expat-dev zlib-dev bzip2-dev lua5.2-dev git make gcc && \
-    apk add boost-filesystem boost-program_options boost-regex boost-iostreams boost-thread libgomp lua5.2 expat && \
-    rm -rf /src /opt/stxxl /usr/local/bin/stxxl_tool /usr/local/lib/libosrm*
+    rm -rf /src /usr/local/lib/libosrm*
+
+
+# Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
+# Only the content below ends up in the image, this helps remove /src from the image (which is large)
+FROM alpine:3.6 as runstage
+RUN mkdir -p /src  && mkdir -p /opt
+RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk update && \
+    apk add boost-filesystem boost-program_options boost-regex boost-iostreams boost-thread libgomp lua5.2 expat libtbb@testing
+COPY --from=buildstage /usr/local /usr/local
+COPY --from=buildstage /opt /opt
+WORKDIR /opt
 
 EXPOSE 5000


### PR DESCRIPTION
# Issue

Fixes #4646 by adding `LUA_LIBRARY_DIRS` to the `PATHS` list of  `find_library(LUA_LIBRARY` call.
Dev libs in alpine are located in `/usr/lib/lua5.2` directory that is not listed in the `PATHS` argument

/cc @danpat

## Tasklist
 - [x] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
