### PR TITLE
Slightly decreases roundabout turn max radius from 25m to 15m

### DIFF
--- a/include/extractor/guidance/constants.hpp
+++ b/include/extractor/guidance/constants.hpp
@@ -26,7 +26,7 @@ const double constexpr DISTINCTION_RATIO = 2;
 const double constexpr MAX_ROUNDABOUT_RADIUS = 15;
 // Unnamed small roundabouts that look like intersections are announced as turns,
 // guard against data issues or such roundabout intersections getting too large.
-const double constexpr MAX_ROUNDABOUT_INTERSECTION_RADIUS = 25;
+const double constexpr MAX_ROUNDABOUT_INTERSECTION_RADIUS = 15;
 
 const double constexpr INCREASES_BY_FOURTY_PERCENT = 1.4;
 


### PR DESCRIPTION
Roundabout turns are meant for situations like the following:

[![real-life](https://c1.staticflickr.com/5/4003/4483170372_7c0b268708_z.jpg)](https://www.flickr.com/photos/23136132@N04/4483170372)

Quoting @1ec5:

> In general, neighborhood roundabouts should have the same dimensions as mini roundabouts, the only difference being a planter instead of a traversable bump. For example, the City of Sacramento’s [street design standards](https://www.cityofsacramento.org/-/media/Corporate/Files/Public-Works/Publications/Engineering/Development-Engineering/Design-Procedures-Manual/section15-street-design-standards.pdf?la=en#page=18) specify an inscribed circle diameter of 120&nbsp;feet (36&nbsp;meters) for standard single-lane roundabouts. The FHWA [recommends](https://safety.fhwa.dot.gov/intersection/innovative/roundabouts/fhwasa10006/) a diameter of 90–180&nbsp;ft. (27–55&nbsp;m) for standard roundabouts and 45–90&nbsp;ft. (13–27&nbsp;m) for mini roundabouts.