### PR TITLE
Don't compute new modifiers during collapsing merge instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # UNRELEASED
 
-- Profile:
-  - Remove dependency on turn types and turn modifier in the process_turn function in the `car.lua` profile. Guidance instruction types are not used to influence turn penalty anymore so this will break backward compatibility between profile version 3 and 4.
+  - Changes from 5.13:
+    - Profile:
+      - Remove dependency on turn types and turn modifier in the process_turn function in the `car.lua` profile. Guidance instruction types are not used to influence turn penalty anymore so this will break backward compatibility between profile version 3 and 4.
+    - Bugfixes:
+      - Fixed #4670: Fix bug where merge instructions got the wrong direction modifier
 
 # 5.13.0
   - Changes from 5.12:

--- a/features/guidance/merge.feature
+++ b/features/guidance/merge.feature
@@ -126,3 +126,24 @@ Feature: Merging
         When I route I should get
             | waypoints | route      | turns                            |
             | d,c       | ,A100,A100 | depart,merge slight right,arrive |
+
+
+    # https://www.openstreetmap.org/way/254299122
+    @merge
+    Scenario: Merge onto a motorway with junction references
+        Given the node map
+            """
+            a     b      c     d
+            e                  f
+            """
+
+        And the ways
+            | nodes | name | junction:ref | highway       | oneway |
+            | abc   | A100 |              | motorway      | yes    |
+            | cd    | A100 | 1A           | motorway      | yes    |
+            | eb    |      |              | motorway_link | yes    |
+            | cf    |      | 1B           | motorway_link | yes    |
+
+        When I route I should get
+            | waypoints | route      | turns                        |
+            | e,d       | ,A100,A100 | depart,merge straight,arrive |

--- a/features/guidance/merge.feature
+++ b/features/guidance/merge.feature
@@ -145,5 +145,5 @@ Feature: Merging
             | cf    |      | 1B           | motorway_link | yes    |
 
         When I route I should get
-            | waypoints | route      | turns                        |
-            | e,d       | ,A100,A100 | depart,merge straight,arrive |
+            | waypoints | route      | turns                           |
+            | e,d       | ,A100,A100 | depart,merge slight left,arrive |

--- a/src/engine/guidance/collapse_turns.cpp
+++ b/src/engine/guidance/collapse_turns.cpp
@@ -186,8 +186,9 @@ void AdjustToCombinedTurnStrategy::operator()(RouteStep &step_at_turn_location,
 {
     const auto angle = findTotalTurnAngle(step_at_turn_location, transfer_from_step);
 
-    // Forks point to left/right. By doing a combined angle, we would risk ending up with
-    // unreasonable fork instrucitons. The direction of a fork only depends on the forking location,
+    // Forks and merges point to left/right. By doing a combined angle, we would risk ending up with
+    // unreasonable fork instrucitons. The direction of a fork or a merge only depends on the
+    // location,
     // not further angles coming up
     //
     //          d
@@ -195,7 +196,8 @@ void AdjustToCombinedTurnStrategy::operator()(RouteStep &step_at_turn_location,
     // a - b
     //
     // could end up as `fork left` for `a-b-c`, instead of fork-right
-    const auto new_modifier = hasTurnType(step_at_turn_location, TurnType::Fork)
+    const auto new_modifier = hasTurnType(step_at_turn_location, TurnType::Fork) ||
+                                      hasTurnType(step_at_turn_location, TurnType::Merge)
                                   ? step_at_turn_location.maneuver.instruction.direction_modifier
                                   : getTurnDirection(angle);
 


### PR DESCRIPTION
# Issue

Collapsing of a merge instruction with a new-name instruction updates the direction modifier, so it is posible to get `{Merge, Straight}` instruction.

This PR prevents updates of directions modifiers.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
