### PR TITLE
Allow single edge paths in MLD alternatives, #4691

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,6 +1,6 @@
 module.exports = {
-    default: '--strict --tags ~@stress --tags ~@todo --require features/support --require features/step_definitions',
-    verify: '--strict --tags ~@stress --tags ~@todo -f progress --require features/support --require features/step_definitions',
+    default: '--strict --tags ~@stress --tags ~@todo --tags ~@mld-only --require features/support --require features/step_definitions',
+    verify: '--strict --tags ~@stress --tags ~@todo --tags ~@mld-only -f progress --require features/support --require features/step_definitions',
     todo: '--strict --tags @todo --require features/support --require features/step_definitions',
     all: '--strict --require features/support --require features/step_definitions',
     mld: '--strict --tags ~@stress --tags ~@todo --require features/support --require features/step_definitions -f progress'

--- a/features/testbot/alternative_loop.feature
+++ b/features/testbot/alternative_loop.feature
@@ -31,40 +31,32 @@ Feature: Alternative route
             | 5    | 6  | dc,ca,ab,bd,dc,dc |             |
             | 7    | 8  | ca,ab,bd,dc,ca,ca |             |
 
-    # This test case does not work in a platform independent way
-    # since it depends on a specific CH structure that is only
-    # present on linux it seems.
-    @4111 @todo
-    Scenario: Alternative Loop Paths with single node path
+
+    @mld-only
+    Scenario: Alternative loop paths on a single node with an asymmetric circle
+        # The test checks only MLD implementation, alternatives results are unpredictable for CH on windows (#4691, #4693)
+        Given a grid size of 10 meters
         Given the node map
             """
-            a1b2c3d
-
-
-            e     f
+              a b  c
+            l       d
+            k       e
+            j       f
+              i h g
             """
 
+        And the nodes
+            | node | barrier |
+            | i    | bollard |
+            | g    | bollard |
+
         And the ways
-            | nodes | maxspeed |
-            | ab    |      30  |
-            | bc    |       3  |
-            | cd    |      30  |
-            | ae    |      30  |
-            | ef    |      30  |
-            | fd    |      30  |
+            | nodes         | oneway |
+            | abcdefghijkla | no     |
 
         And the query options
             | alternatives | true |
 
         When I route I should get
-            | from | to | route    | alternative       |
-            | b    | c  | bc,bc    | ab,ae,ef,fd,cd,cd |
-            #| c    | b  | bc,bc    | cd,fd,ef,ae,ab,ab | # alternative path depends on phantom snapping order
-            | 1    | c  | ab,bc,bc | ab,ae,ef,fd,cd,cd |
-            #| c    | 1  | bc,ab    | cd,fd,ef,ae,ab    | # alternative path depends on phantom snapping order
-            | 2 | c | bc,bc          |                   |
-            | c | 2 | bc,bc          |                   |
-            | 1 | 3 | ab,ae,ef,fd,cd | ab,bc,cd          |
-            #| 3 | 1 | cd,fd,ef,ae,ab | cd,bc,ab          | # alternative path depends on phantom snapping order
-            | b | 3 | bc,cd          | ab,ae,ef,fd,cd    |
-            #| 3 | b | cd,bc,bc       | cd,fd,ef,ae,ab,ab | # alternative path depends on phantom snapping order
+            | from | to | route                       | alternative                 | weight |
+            | e    | k  | abcdefghijkla,abcdefghijkla | abcdefghijkla,abcdefghijkla |    6.8 |


### PR DESCRIPTION
# Issue

The PR  fixes #4691, by allowing alternative routes with `packed.path.empty()`. 
Also an additional check `node != fst.GetData(node).parent` was added to prevent infinite loops if `has_plateaux_at_node(node, fst, snd)` and `node` is the first (last) node of the route.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments
