### PR TITLE
Add checkbox for changelogs to all PRs.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ What issue is this PR targeting? If there is no issue that addresses the problem
 
 ## Tasklist
  - [ ] ADD OWN TASKS HERE
+ - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
  - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
  - [ ] add regression / cucumber cases (see docs/testing.md)
  - [ ] review


### PR DESCRIPTION
One of the annoying bureaucratic parts of making an OSRM release is ensuring the `CHANGELOG.md` is useful and accurate.

In general, we do an *average* job of keeping it up-to-date - sometimes people remember to do it, sometimes they don't, sometimes reviewers notice it, sometimes they don't.

This PR updates the PR text template and adds a new checkbox to help remind everyone to make `CHANGELOG.md` entries for all changes merged to master.

I've included a link to http://keepachangelog.com/en/1.0.0/#how, which I think gives good concise advice about how to write changelog entries.

For trivial merges, or things that downstream users don't need to know about, you can, as always, simply remove the checkbox from your PR.  But I think it should be there by default, rather than missing by default.

## Tasklist
 - [ ] review
 - [ ] adjust for comments