### PR TITLE
Makes MLD default algorithm in example to avoid confusion, see #4702

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -422,7 +422,7 @@ install:
 script:
   - if [[ $TARGET_ARCH == armhf ]] ; then echo "Skip tests for $TARGET_ARCH" && exit 0 ; fi
   - make -C test/data benchmark
-  - ./example/build/osrm-example test/data/ch/monaco.osrm
+  - ./example/build/osrm-example test/data/mld/monaco.osrm
   # All tests assume to be run from the build directory
   - pushd ${OSRM_BUILD_DIR}
   - ./unit_tests/library-tests

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -30,8 +30,16 @@ int main(int argc, const char *argv[])
 
     // Configure based on a .osrm base path, and no datasets in shared mem from osrm-datastore
     EngineConfig config;
+
     config.storage_config = {argv[1]};
     config.use_shared_memory = false;
+
+    // We support two routing speed up techniques:
+    // - Contraction Hierarchies (CH): requires extract+contract pre-processing
+    // - Multi-Level Dijkstra (MLD): requires extract+partition+customize pre-processing
+    //
+    // config.algorithm = EngineConfig::Algorithm::CH;
+    config.algorithm = EngineConfig::Algorithm::MLD;
 
     // Routing machine with several services (such as Route, Table, Nearest, Trip, Match)
     const OSRM osrm{config};


### PR DESCRIPTION
We ported our readme and docs to MLD by default. The example was using CH and therefore required CH-specific pre-processing:

https://github.com/Project-OSRM/osrm-backend#quick-start

Let's switch the example to MLD and make the algorithm option explicit for users (see #4702).