### PR TITLE
Use the correct driving_side property on the arrive step.

### DIFF
--- a/features/car/side_bias.feature
+++ b/features/car/side_bias.feature
@@ -129,17 +129,15 @@ Feature: Testbot - side bias
             | b    | 0   | 1.5  |
             | c    | 0   | 2.5  |
             | d    | 0   | 3.5  |
-            | e    | 0   | 4.5  |
 
         And the ways
             | nodes |
             | ab    |
             | bc    |
             | cd    |
-            | de    |
 
         And the extract extra arguments "--location-dependent-data test/data/regions/null-island.geojson"
         When I route I should get
-            | from | to | route          | driving_side                 |
-            | e    | a  | de,cd,bc,ab,ab | right,right,right,left,left  |
-            | a    | e  | ab,bc,cd,de,de | left,right,right,right,right |
+            | from | to | route       | driving_side           |
+            | d    | a  | cd,bc,ab,ab | right,right,left,left  |
+            | a    | d  | ab,bc,cd,cd | left,right,right,right |

--- a/features/car/side_bias.feature
+++ b/features/car/side_bias.feature
@@ -116,3 +116,30 @@ Feature: Testbot - side bias
             | from | to | route    | driving_side      | time       |
             | d    | a  | bd,ab,ab | right,right,right | 27s +-1    |
             | d    | c  | bd,bc,bc | right,right,right | 24s +-1    |
+
+    Scenario: changing sides
+        Given the profile "car"
+
+        # Note - the boundary in null-island.geojson is at lon = 2.0,
+        # and we use the "last node of the way" as the heuristic to detect
+        # whether the way is in our out of the driving_side polygon
+        And the node locations
+            | node | lat | lon  |
+            | a    | 0   | 0.5  |
+            | b    | 0   | 1.5  |
+            | c    | 0   | 2.5  |
+            | d    | 0   | 3.5  |
+            | e    | 0   | 4.5  |
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | cd    |
+            | de    |
+
+        And the extract extra arguments "--location-dependent-data test/data/regions/null-island.geojson"
+        When I route I should get
+            | from | to | route          | driving_side                 |
+            | e    | a  | de,cd,bc,ab,ab | right,right,right,left,left  |
+            | a    | e  | ab,bc,cd,de,de | left,right,right,right,right |

--- a/include/engine/guidance/assemble_steps.hpp
+++ b/include/engine/guidance/assemble_steps.hpp
@@ -312,7 +312,7 @@ inline std::vector<RouteStep> assembleSteps(const datafacade::BaseDataFacade &fa
                               leg_geometry.locations.size() - 1,
                               leg_geometry.locations.size(),
                               {intersection},
-                              facade.IsLeftHandDriving(source_node_id)});
+                              facade.IsLeftHandDriving(target_node_id)});
 
     BOOST_ASSERT(steps.front().intersections.size() == 1);
     BOOST_ASSERT(steps.front().intersections.front().bearings.size() == 1);


### PR DESCRIPTION
# Issue

The [driving side PR](https://github.com/Project-OSRM/osrm-backend/pull/4649) used the wrong node for the `arrive` step if the route ends close to a border.

This PR adds a test case, and fixes the `driving_side` value used for the last step of a RouteLeg.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)