### PR TITLE
Don't use removed alternative paths in filterPackedPathsByCellSharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UNRELEASED
 
+# 5.14.1
+  - Changes from 5.14.0
+    - Bugfixes:
+      - FIXED: don't use removed alternative candidates in `filterPackedPathsByCellSharing`
+
 # 5.14.0
   - Changes from 5.13
     - API:

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -784,9 +784,8 @@ InternalManyRoutesResult alternativePathSearch(SearchEngineData<Algorithm> &sear
                                                                 begin(weighted_packed_paths) + 1,
                                                                 alternative_paths_last);
 
-    alternative_paths_last = filterPackedPathsByCellSharing(begin(weighted_packed_paths), //
-                                                            end(weighted_packed_paths),   //
-                                                            partition);                   //
+    alternative_paths_last = filterPackedPathsByCellSharing(
+        begin(weighted_packed_paths), alternative_paths_last, partition);
 
     BOOST_ASSERT(weighted_packed_paths.size() >= 1);
 


### PR DESCRIPTION
# Issue

After allowing single edge alternative path in #4693 some queries may fail because `filterPackedPathsByCellSharing` function can access alternative candidates  removed by the previous filters.

Adding a test case is questionable here, because it is not an edge-case, but a typo.

/cc @daniel-j-h 

## Tasklist
 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 -- [ ] add regression / cucumber cases (see docs/testing.md)--
 - [x] review
 - [x] adjust for comments

