### PR TITLE
Run tests for double-u-turns

### DIFF
--- a/features/testbot/via.feature
+++ b/features/testbot/via.feature
@@ -309,7 +309,7 @@ Feature: Via points
             | waypoints | route |
             | a,b,e     |       |
 
-    @todo @3359
+     @3359
      Scenario: U-Turn In Bearings
         Given the node map
             """


### PR DESCRIPTION
# Issue

This issue: https://github.com/Project-OSRM/osrm-backend/issues/3359 noted a problem with unpacking u-turns - behaviour was dependent on graph construction order.

Since that issue was raised, somebody fixed it (I'm not going to bother sleuthing to figure out which commit fixed things), but this test was never uncommented.

This PR simply enables the test so we don't regress this behaviour in the future.  Importantly, this PR does *not* fix #3359, it was fixed at some point in the past, possibly as a side-effect of other work.