### PR TITLE
Bugfix ? Avoid-Set should take precedence over Speeds

### DIFF
--- a/features/car/avoid.feature
+++ b/features/car/avoid.feature
@@ -1,0 +1,23 @@
+@routing @car @way
+Feature: Car - Avoid defined areas
+
+    Background:
+        Given the profile file "car" initialized with
+        """
+        profile.avoid = Set { 'motorway', 'motorway_link' }
+        profile.speeds = Sequence {
+            highway = {
+                motorway      = 90,
+                motorway_link = 45,
+                primary       = 50
+            }
+        }
+        """
+
+    Scenario: Car - Avoid motorways
+        Then routability should be
+            | highway        | bothw |
+            | motorway       |       |
+            | motorway_link  |       |
+            | primary        | x     |
+

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -356,6 +356,7 @@ function process_way(profile, way, result, relations)
     -- routable. this includes things like status=impassable,
     -- toll=yes and oneway=reversible
     WayHandlers.blocked_ways,
+    WayHandlers.avoid_ways,
 
     -- determine access status by checking our hierarchy of
     -- access tags, e.g: motorcar, motor_vehicle, vehicle

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -490,6 +490,15 @@ function WayHandlers.weights(profile,way,result,data)
   end
 end
 
+
+-- handle general avoid rules
+
+function WayHandlers.avoid_ways(profile,way,result,data)
+  if profile.avoid[data.highway] then
+    return false
+  end
+end
+
 -- handle various that can block access
 function WayHandlers.blocked_ways(profile,way,result,data)
 


### PR DESCRIPTION
# Issue

When specifying road classes in the `Avoid Set` of a profile, they will not be taken into consideration as long as speeds for those classes are defined.

Example:
```
avoid = Set {
  'trunk'
},

speeds = Sequence {
  highway = {
    motorway        = 90,
    motorway_link   = 45,
    trunk           = 85,
    ...
  }
}
```

With this PR, a new `WayHandler` is added to simply discard the road class if it is defined in the set.

Note: The same could be accomplished by just removing the speed entries for the specific roads, so I am not quite sure if this PR would actually fix something.

## Tasklist
 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

