### PR TITLE
Remove code for checking the .core file, since we do not create it anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # UNRELEASED
+ - Changes from 5.14.1:
+   - Bugfixes:
+      - FIXED #4727: Erroring when a old .core file is present.
 
 # 5.14.1
   - Changes from 5.14.0

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -48,14 +48,6 @@ const constexpr char *block_id_to_name[] = {"NAME_CHAR_DATA",
                                             "HSGR_CHECKSUM",
                                             "TIMESTAMP",
                                             "FILE_INDEX_PATH",
-                                            "CH_CORE_MARKER_0",
-                                            "CH_CORE_MARKER_1",
-                                            "CH_CORE_MARKER_2",
-                                            "CH_CORE_MARKER_3",
-                                            "CH_CORE_MARKER_4",
-                                            "CH_CORE_MARKER_5",
-                                            "CH_CORE_MARKER_6",
-                                            "CH_CORE_MARKER_7",
                                             "DATASOURCES_NAMES",
                                             "PROPERTIES",
                                             "BEARING_CLASSID",
@@ -132,14 +124,6 @@ struct DataLayout
         HSGR_CHECKSUM,
         TIMESTAMP,
         FILE_INDEX_PATH,
-        CH_CORE_MARKER_0,
-        CH_CORE_MARKER_1,
-        CH_CORE_MARKER_2,
-        CH_CORE_MARKER_3,
-        CH_CORE_MARKER_4,
-        CH_CORE_MARKER_5,
-        CH_CORE_MARKER_6,
-        CH_CORE_MARKER_7,
         DATASOURCES_NAMES,
         PROPERTIES,
         BEARING_CLASSID,
@@ -200,15 +184,7 @@ struct DataLayout
 
     inline uint64_t GetBlockEntries(BlockID bid) const { return num_entries[bid]; }
 
-    inline uint64_t GetBlockSize(BlockID bid) const
-    {
-        // special bit encoding
-        if (bid >= CH_CORE_MARKER_0 && bid <= CH_CORE_MARKER_7)
-        {
-            return (num_entries[bid] / 32 + 1) * entry_size[bid];
-        }
-        return num_entries[bid] * entry_size[bid];
-    }
+    inline uint64_t GetBlockSize(BlockID bid) const { return num_entries[bid] * entry_size[bid]; }
 
     inline uint64_t GetSizeOfLayout() const
     {

--- a/include/storage/storage_config.hpp
+++ b/include/storage/storage_config.hpp
@@ -64,7 +64,6 @@ struct StorageConfig final : IOConfig
                    {".osrm.hsgr",
                     ".osrm.nbg_nodes",
                     ".osrm.ebg_nodes",
-                    ".osrm.core",
                     ".osrm.cells",
                     ".osrm.cell_metrics",
                     ".osrm.mldgr",

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -331,43 +331,6 @@ void Storage::PopulateLayout(DataLayout &layout)
         layout.SetBlockSize<char>(DataLayout::TIMESTAMP, timestamp_size);
     }
 
-    // load core marker size
-    if (boost::filesystem::exists(config.GetPath(".osrm.core")))
-    {
-        io::FileReader core_marker_file(config.GetPath(".osrm.core"),
-                                        io::FileReader::VerifyFingerprint);
-        const auto num_metrics = core_marker_file.ReadElementCount64();
-        if (num_metrics > NUM_METRICS)
-        {
-            throw util::exception("Only " + std::to_string(NUM_METRICS) +
-                                  " metrics are supported at the same time.");
-        }
-
-        const auto number_of_core_markers = core_marker_file.ReadElementCount64();
-        for (const auto index : util::irange<std::size_t>(0, num_metrics))
-        {
-            layout.SetBlockSize<unsigned>(
-                static_cast<DataLayout::BlockID>(DataLayout::CH_CORE_MARKER_0 + index),
-                number_of_core_markers);
-        }
-        for (const auto index : util::irange<std::size_t>(num_metrics, NUM_METRICS))
-        {
-            layout.SetBlockSize<unsigned>(
-                static_cast<DataLayout::BlockID>(DataLayout::CH_CORE_MARKER_0 + index), 0);
-        }
-    }
-    else
-    {
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_0, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_1, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_2, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_3, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_4, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_5, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_6, 0);
-        layout.SetBlockSize<unsigned>(DataLayout::CH_CORE_MARKER_7, 0);
-    }
-
     // load turn weight penalties
     {
         io::FileReader turn_weight_penalties_file(config.GetPath(".osrm.turn_weight_penalties"),


### PR DESCRIPTION
# Issue

This PR fixes issue https://github.com/Project-OSRM/osrm-backend/issues/4727 where an old .core file can cause an error.

## Tasklist
 - [x] CHANGELOG.md entry
 - [x] review
 - [x] adjust for comments