### PR TITLE
Implement `waypoints` parameter in match plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 # 5.14.3
   - Changes from 5.14.2:
+    - Features:
+      - Added a `waypoints` parameter to the match service plugin that accepts indices to input coordinates and treats only those points as waypoints in the response format.
     - Bugfixes:
       - FIXED #4754: U-Turn penalties are applied to straight turns.
       - FIXED #4756: Removed too restrictive road name check in the sliproad handler

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -480,3 +480,126 @@ Feature: Basic Map Matching
             | trace | a:nodes     |
             | 12    | 1:2:3:4:5:6 |
             | 21    | 6:5:4:3:2:1 |
+
+
+    Scenario: Matching with waypoints param for start/end
+        Given the node map
+            """
+            a-----b---c
+                  |
+                  |
+                  d
+                  |
+                  |
+                  e
+            """
+        And the ways
+            | nodes | oneway |
+            | abc   | no     |
+            | bde   | no     |
+
+        Given the query options
+            | waypoints | 0;3   |
+
+        When I match I should get
+            | trace | code    | matchings | waypoints |
+            | abde  | Ok      | abde      | ae        |
+
+    Scenario: Matching with waypoints param that were tidied away
+        Given the node map
+            """
+            a - b - c - e
+                    |
+                    f
+                    |
+                    g
+            """
+        And the ways
+            | nodes | oneway |
+            | abce  | no     |
+            | cfg   | no     |
+
+        Given the query options
+            | tidy      | true    |
+            | waypoints | 0;2;5   |
+
+        When I match I should get
+            | trace  | code    | matchings | waypoints |
+            | abccfg | Ok      | abcfg     | acg       |
+
+    Scenario: Testbot - Map matching refuses to use waypoints with trace splitting
+        Given the node map
+            """
+            a b c d
+                e
+            """
+        Given the query options
+            | waypoints | 0;3   |
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | timestamps | code     |
+            | abcd  | 0 1 62 63  | NoMatch  |
+
+    Scenario: Testbot - Map matching invalid waypoints
+        Given the node map
+            """
+            a b c d
+                e
+            """
+        Given the query options
+            | waypoints | 0;4   |
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | code           |
+            | abcd  | InvalidOptions |
+
+    Scenario: Matching fail with waypoints param missing start/end
+        Given the node map
+            """
+            a-----b---c
+                  |
+                  |
+                  d
+                  |
+                  |
+                  e
+            """
+        And the ways
+            | nodes | oneway |
+            | abc   | no     |
+            | bde   | no     |
+
+        Given the query options
+            | waypoints | 1;3   |
+
+        When I match I should get
+            | trace | code         |
+            | abde  | InvalidValue |
+
+    Scenario: Testbot - Map matching with outlier that has no candidate and waypoint parameter
+        Given a grid size of 100 meters
+        Given the node map
+            """
+            a b c d
+
+                1
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        Given the query options
+            | waypoints | 0;2;3   |
+
+        When I match I should get
+            | trace | timestamps | code    |
+            | ab1d  | 0 1 2 3    | NoMatch |

--- a/include/engine/api/match_api.hpp
+++ b/include/engine/api/match_api.hpp
@@ -86,6 +86,10 @@ class MatchAPI final : public RouteAPI
             for (auto point_index : util::irange(
                      0u, static_cast<unsigned>(sub_matchings[sub_matching_index].indices.size())))
             {
+                // tidied_to_original: index of the input coordinate that a tidied coordinate
+                // corresponds to
+                // sub_matching indices: index of the coordinate passed to map matching plugin that
+                // a matched node corresponds to
                 trace_idx_to_matching_idx[tidy_result
                                               .tidied_to_original[sub_matchings[sub_matching_index]
                                                                       .indices[point_index]]] =
@@ -93,6 +97,7 @@ class MatchAPI final : public RouteAPI
             }
         }
 
+        std::size_t was_waypoint_idx = 0;
         for (auto trace_index : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
         {
             if (tidy_result.can_be_removed[trace_index])
@@ -110,10 +115,18 @@ class MatchAPI final : public RouteAPI
                 sub_matchings[matching_index.sub_matching_index].nodes[matching_index.point_index];
             auto waypoint = BaseAPI::MakeWaypoint(phantom);
             waypoint.values["matchings_index"] = matching_index.sub_matching_index;
-            waypoint.values["waypoint_index"] = matching_index.point_index;
             waypoint.values["alternatives_count"] =
                 sub_matchings[matching_index.sub_matching_index]
                     .alternatives_count[matching_index.point_index];
+            if (tidy_result.was_waypoint[trace_index])
+            {
+                waypoint.values["waypoint_index"] = was_waypoint_idx;
+                was_waypoint_idx++;
+            }
+            else
+            {
+                waypoint.values["waypoint_index"] = util::json::Null();
+            }
             waypoints.values.push_back(std::move(waypoint));
         }
 

--- a/include/engine/api/match_parameters_tidy.hpp
+++ b/include/engine/api/match_parameters_tidy.hpp
@@ -37,6 +37,9 @@ struct Result
     Mask can_be_removed;
     // Maps the MatchParameter's original items to items which should not be removed.
     Mapping tidied_to_original;
+    // Masking the MatchParameter coordinates for items whose indices were present in the
+    // `waypoints` parameter.
+    Mask was_waypoint;
 };
 
 inline Result keep_all(const MatchParameters &params)
@@ -44,6 +47,15 @@ inline Result keep_all(const MatchParameters &params)
     Result result;
 
     result.can_be_removed.resize(params.coordinates.size(), false);
+    result.was_waypoint.resize(params.coordinates.size(), true);
+    if (!params.waypoints.empty())
+    {
+        for (const auto p : params.waypoints)
+        {
+            result.was_waypoint.set(p, false);
+        }
+        result.was_waypoint.flip();
+    }
     result.tidied_to_original.reserve(params.coordinates.size());
     for (std::size_t current = 0; current < params.coordinates.size(); ++current)
     {
@@ -61,6 +73,8 @@ inline Result keep_all(const MatchParameters &params)
         {
             result.parameters.coordinates.push_back(params.coordinates[i]);
 
+            if (result.was_waypoint[i])
+                result.parameters.waypoints.push_back(result.parameters.coordinates.size() - 1);
             if (!params.hints.empty())
                 result.parameters.hints.push_back(params.hints[i]);
 
@@ -74,6 +88,8 @@ inline Result keep_all(const MatchParameters &params)
                 result.parameters.timestamps.push_back(params.timestamps[i]);
         }
     }
+    if (params.waypoints.empty())
+        result.parameters.waypoints.clear();
 
     return result;
 }
@@ -85,6 +101,15 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
     Result result;
 
     result.can_be_removed.resize(params.coordinates.size(), false);
+    result.was_waypoint.resize(params.coordinates.size(), true);
+    if (!params.waypoints.empty())
+    {
+        for (const auto p : params.waypoints)
+        {
+            result.was_waypoint.set(p, false);
+        }
+        result.was_waypoint.flip();
+    }
 
     result.tidied_to_original.push_back(0);
 
@@ -138,13 +163,14 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
 
     // We have to filter parallel arrays that may be empty or the exact same size.
     // result.parameters contains an empty MatchParameters at this point: conditionally fill.
-
     for (std::size_t i = 0; i < result.can_be_removed.size(); ++i)
     {
         if (!result.can_be_removed[i])
         {
             result.parameters.coordinates.push_back(params.coordinates[i]);
 
+            if (result.was_waypoint[i])
+                result.parameters.waypoints.push_back(result.parameters.coordinates.size() - 1);
             if (!params.hints.empty())
                 result.parameters.hints.push_back(params.hints[i]);
 
@@ -157,8 +183,17 @@ inline Result tidy(const MatchParameters &params, Thresholds cfg = {15., 5})
             if (!params.timestamps.empty())
                 result.parameters.timestamps.push_back(params.timestamps[i]);
         }
+        else
+        {
+            // one of the coordinates meant to be used as a waypoint was marked for removal
+            // update the original waypoint index to the new representative coordinate
+            const auto last_idx = result.parameters.coordinates.size() - 1;
+            if (result.was_waypoint[i] && (result.parameters.waypoints.back() != last_idx))
+            {
+                result.parameters.waypoints.push_back(last_idx);
+            }
+        }
     }
-    BOOST_ASSERT(result.tidied_to_original.size() == result.parameters.coordinates.size());
 
     return result;
 }

--- a/include/server/api/match_parameter_grammar.hpp
+++ b/include/server/api/match_parameter_grammar.hpp
@@ -28,10 +28,23 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
 
     MatchParametersGrammar() : BaseGrammar(root_rule)
     {
+#ifdef BOOST_HAS_LONG_LONG
+        if (std::is_same<std::size_t, unsigned long long>::value)
+            size_t_ = qi::ulong_long;
+        else
+            size_t_ = qi::ulong_;
+#else
+        size_t_ = qi::ulong_;
+#endif
+
         timestamps_rule =
             qi::lit("timestamps=") >
             (qi::uint_ %
              ';')[ph::bind(&engine::api::MatchParameters::timestamps, qi::_r1) = qi::_1];
+
+        waypoints_rule =
+            qi::lit("waypoints=") >
+            (size_t_ % ';')[ph::bind(&engine::api::MatchParameters::waypoints, qi::_r1) = qi::_1];
 
         gaps_type.add("split", engine::api::MatchParameters::GapsType::Split)(
             "ignore", engine::api::MatchParameters::GapsType::Ignore);
@@ -39,6 +52,7 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
         root_rule =
             BaseGrammar::query_rule(qi::_r1) > -qi::lit(".json") >
             -('?' > (timestamps_rule(qi::_r1) | BaseGrammar::base_rule(qi::_r1) |
+                     waypoints_rule(qi::_r1) |
                      (qi::lit("gaps=") >
                       gaps_type[ph::bind(&engine::api::MatchParameters::gaps, qi::_r1) = qi::_1]) |
                      (qi::lit("tidy=") >
@@ -49,6 +63,8 @@ struct MatchParametersGrammar final : public RouteParametersGrammar<Iterator, Si
   private:
     qi::rule<Iterator, Signature> root_rule;
     qi::rule<Iterator, Signature> timestamps_rule;
+    qi::rule<Iterator, Signature> waypoints_rule;
+    qi::rule<Iterator, std::size_t()> size_t_;
 
     qi::symbols<char, engine::api::MatchParameters::GapsType> gaps_type;
 };

--- a/unit_tests/engine/collapse_internal_route_result.cpp
+++ b/unit_tests/engine/collapse_internal_route_result.cpp
@@ -1,0 +1,148 @@
+#include "engine/internal_route_result.hpp"
+#include "engine/phantom_node.hpp"
+
+#include <boost/test/test_case_template.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(collapse_test)
+
+using namespace osrm;
+using namespace osrm::util;
+using namespace osrm::engine;
+
+BOOST_AUTO_TEST_CASE(unchanged_collapse_route_result)
+{
+    PhantomNode source;
+    PhantomNode target;
+    source.forward_segment_id = {1, true};
+    target.forward_segment_id = {6, true};
+    PathData pathy{2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
+    PathData kathy{1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    InternalRouteResult one_leg_result;
+    one_leg_result.unpacked_path_segments = {{pathy, kathy}};
+    one_leg_result.segment_end_coordinates = {PhantomNodes{source, target}};
+    one_leg_result.source_traversed_in_reverse = {true};
+    one_leg_result.target_traversed_in_reverse = {true};
+    one_leg_result.shortest_path_weight = 50;
+
+    auto collapsed = CollapseInternalRouteResult(one_leg_result, {true, true});
+    BOOST_CHECK_EQUAL(one_leg_result.unpacked_path_segments[0].front().turn_via_node,
+                      collapsed.unpacked_path_segments[0].front().turn_via_node);
+    BOOST_CHECK_EQUAL(one_leg_result.unpacked_path_segments[0].back().turn_via_node,
+                      collapsed.unpacked_path_segments[0].back().turn_via_node);
+}
+
+BOOST_AUTO_TEST_CASE(two_legs_to_one_leg)
+{
+    PathData pathy{2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
+    PathData kathy{1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData cathy{3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PhantomNode node_1;
+    PhantomNode node_2;
+    PhantomNode node_3;
+    node_1.forward_segment_id = {1, true};
+    node_2.forward_segment_id = {6, true};
+    node_3.forward_segment_id = {12, true};
+    InternalRouteResult two_leg_result;
+    two_leg_result.unpacked_path_segments = {{pathy, kathy}, {kathy, cathy}};
+    two_leg_result.segment_end_coordinates = {PhantomNodes{node_1, node_2},
+                                              PhantomNodes{node_2, node_3}};
+    two_leg_result.source_traversed_in_reverse = {true, false};
+    two_leg_result.target_traversed_in_reverse = {true, false};
+    two_leg_result.shortest_path_weight = 80;
+
+    auto collapsed = CollapseInternalRouteResult(two_leg_result, {true, false, true, true});
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments.size(), 1);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates.size(), 1);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].target_phantom.forward_segment_id.id,
+                      12);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].source_phantom.forward_segment_id.id, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0].size(), 3);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][0].turn_via_node, 2);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][1].turn_via_node, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][2].turn_via_node, 3);
+}
+
+BOOST_AUTO_TEST_CASE(three_legs_to_two_legs)
+{
+    PathData pathy{2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
+    PathData kathy{1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData qathy{5, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData cathy{3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData mathy{4, 18, false, 8, 9, 13, 4, 2, {}, 4, 2, {}, 2, {3.0}, {1.0}, false};
+    PhantomNode node_1;
+    PhantomNode node_2;
+    PhantomNode node_3;
+    PhantomNode node_4;
+    node_1.forward_segment_id = {1, true};
+    node_2.forward_segment_id = {6, true};
+    node_3.forward_segment_id = {12, true};
+    node_4.forward_segment_id = {18, true};
+    InternalRouteResult three_leg_result;
+    three_leg_result.unpacked_path_segments = {std::vector<PathData>{pathy, kathy},
+                                               std::vector<PathData>{kathy, qathy, cathy},
+                                               std::vector<PathData>{cathy, mathy}};
+    three_leg_result.segment_end_coordinates = {
+        PhantomNodes{node_1, node_2}, PhantomNodes{node_2, node_3}, PhantomNodes{node_3, node_4}};
+    three_leg_result.source_traversed_in_reverse = {true, false, true},
+    three_leg_result.target_traversed_in_reverse = {true, false, true},
+    three_leg_result.shortest_path_weight = 140;
+
+    auto collapsed = CollapseInternalRouteResult(three_leg_result, {true, true, false, true});
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments.size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates.size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].source_phantom.forward_segment_id.id, 1);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].target_phantom.forward_segment_id.id, 6);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[1].source_phantom.forward_segment_id.id, 6);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[1].target_phantom.forward_segment_id.id,
+                      18);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0].size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1].size(), 4);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][0].turn_via_node, 2);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][1].turn_via_node, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][0].turn_via_node, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][1].turn_via_node, 5);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][2].turn_via_node, 3);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][3].turn_via_node, 4);
+}
+
+BOOST_AUTO_TEST_CASE(two_legs_to_two_legs)
+{
+    PathData pathy{2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
+    PathData kathy{1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData cathy{3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PhantomNode node_1;
+    PhantomNode node_2;
+    PhantomNode node_3;
+    node_1.forward_segment_id = {1, true};
+    node_2.forward_segment_id = {6, true};
+    node_3.forward_segment_id = {12, true};
+    InternalRouteResult two_leg_result;
+    two_leg_result.unpacked_path_segments = {{pathy, kathy}, {kathy, cathy}};
+    two_leg_result.segment_end_coordinates = {PhantomNodes{node_1, node_2},
+                                              PhantomNodes{node_2, node_3}};
+    two_leg_result.source_traversed_in_reverse = {true, false};
+    two_leg_result.target_traversed_in_reverse = {true, false};
+    two_leg_result.shortest_path_weight = 80;
+
+    auto collapsed = CollapseInternalRouteResult(two_leg_result, {true, true, true});
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments.size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates.size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].source_phantom.forward_segment_id.id, 1);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].target_phantom.forward_segment_id.id, 6);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[1].source_phantom.forward_segment_id.id, 6);
+    BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[1].target_phantom.forward_segment_id.id,
+                      12);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0].size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1].size(), 2);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][0].turn_via_node, 2);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][1].turn_via_node, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][0].turn_via_node, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][1].turn_via_node, 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -555,6 +555,22 @@ BOOST_AUTO_TEST_CASE(valid_match_urls)
     CHECK_EQUAL_RANGE(reference_2.radiuses, result_2->radiuses);
     CHECK_EQUAL_RANGE(reference_2.approaches, result_2->approaches);
     CHECK_EQUAL_RANGE(reference_2.coordinates, result_2->coordinates);
+
+    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}},
+                                              {util::FloatLongitude{5}, util::FloatLatitude{6}}};
+
+    MatchParameters reference_3{};
+    reference_3.coordinates = coords_2;
+    reference_3.waypoints = {0, 2};
+    auto result_3 = parseParameters<MatchParameters>("1,2;3,4;5,6?waypoints=0;2");
+    BOOST_CHECK(result_3);
+    CHECK_EQUAL_RANGE(reference_3.waypoints, result_3->waypoints);
+    CHECK_EQUAL_RANGE(reference_3.timestamps, result_3->timestamps);
+    CHECK_EQUAL_RANGE(reference_3.bearings, result_3->bearings);
+    CHECK_EQUAL_RANGE(reference_3.radiuses, result_3->radiuses);
+    CHECK_EQUAL_RANGE(reference_3.approaches, result_3->approaches);
+    CHECK_EQUAL_RANGE(reference_3.coordinates, result_3->coordinates);
 }
 
 BOOST_AUTO_TEST_CASE(invalid_match_urls)
@@ -571,6 +587,15 @@ BOOST_AUTO_TEST_CASE(invalid_match_urls)
     BOOST_CHECK(reference_1.radiuses != result_1->radiuses);
     CHECK_EQUAL_RANGE(reference_1.approaches, result_1->approaches);
     CHECK_EQUAL_RANGE(reference_1.coordinates, result_1->coordinates);
+
+    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
+                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+
+    MatchParameters reference_2{};
+    reference_2.coordinates = coords_2;
+    BOOST_CHECK_EQUAL(testInvalidOptions<MatchParameters>("1,2;3,4?waypoints=0,4"), 19UL);
+    BOOST_CHECK_EQUAL(testInvalidOptions<MatchParameters>("1,2;3,4?waypoints=x;4"), 18UL);
+    BOOST_CHECK_EQUAL(testInvalidOptions<MatchParameters>("1,2;3,4?waypoints=0;3.5"), 21UL);
 }
 
 BOOST_AUTO_TEST_CASE(valid_nearest_urls)


### PR DESCRIPTION
# Issue

Closes https://github.com/Project-OSRM/osrm-backend/issues/4669

This adds a parameter to the match service plugin, `&waypoints`, that will allow users to specify which input coordinates should be treated as `waypoints` in the response. Current behavior is to treat all input coordinates as waypoints. Implementation details [here](https://github.com/Project-OSRM/osrm-backend/issues/4669#issuecomment-349706768) 

## Tasklist
 - [x] Write unit tests for parameter
   - [x] CollapseInternalRouteResult
   - [x] valid map matching parameters
   - [x] invalid map matching parameters
   - [x] integration tests map matching
 - [x] Add support for map matching results in cucumber support code
 - [ ] ~Debug why `waypoints` crashes when trace splitting happens~ Don't support trace splitting and waypoints together
 - [x] Add waypoints handling into tracepoint generation
 - [x] Add parameter parsing to match plugin interface
 - [x] Add handling into trace tidying
 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] write documentation
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
nerp
