### PR TITLE
Remove superflous sentinel in DynamicGraph

### DIFF
--- a/include/contractor/contracted_edge_container.hpp
+++ b/include/contractor/contracted_edge_container.hpp
@@ -108,7 +108,7 @@ struct ContractedEdgeContainer
         edges.insert(edges.end(), new_edges.begin(), new_end);
         auto edges_size = edges.size();
         auto new_edges_size = std::distance(new_edges.begin(), new_end);
-        BOOST_ASSERT(edges_size >= new_edges_size);
+        BOOST_ASSERT(static_cast<int>(edges_size) >= new_edges_size);
         flags.resize(edges_size);
         std::fill(flags.begin() + edges_size - new_edges_size, flags.end(), flag);
 

--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -384,7 +384,7 @@ void RenumberData(std::vector<RemainingNodeData> &remaining_nodes,
     // we need to make a copy here because we are going to modify it
     auto to_orig = new_to_old_node_id;
 
-    auto new_node_id = 0;
+    auto new_node_id = 0u;
 
     // All remaining nodes get the low IDs
     for (auto &remaining : remaining_nodes)


### PR DESCRIPTION
# Issue

This PR removes a superfluous sentinel node that caused an inconsistency between the `number_of_nodes` and `node_array` size of `DynamicGraph`. Fixes issue #4738.

## Tasklist
 - [x] review
 - [x] adjust for comments