### PR TITLE
Don't apply U-Turn penalty on non-turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Changes from 5.14.1:
     - Bugfixes:
       - FIXED #4727: Erroring when a old .core file is present.
+      - FIXED #4754: U-Turn penalties are applied to straight turns.
     - Node.js Bindings:
       - ADDED: Exposed new `max_radiuses_map_matching` option from `EngingConfig` options
     - Tools:

--- a/features/guidance/roundabout.feature
+++ b/features/guidance/roundabout.feature
@@ -745,12 +745,15 @@ Feature: Basic Roundabout
 
 
      Scenario: Drive through roundabout
+        Given a grid size of 5 meters
         Given the node map
            """
-              a
-            b e d  f
-              c
-            g   h
+                . a .
+              .       .
+            b     e --- d ---- f
+              .        .
+                 .c.
+               g     h
            """
 
         And the ways
@@ -760,12 +763,12 @@ Feature: Basic Roundabout
            | gch   |            | yes    |
 
         When I route I should get
-           | waypoints | bearings | route           | turns                                                      |
-           | e,f       | 90 90    | edf,edf         | depart,arrive                                              |
-           | e,h       | 90 135   | edf,gch,gch,gch | depart,roundabout-exit-2,exit roundabout straight,arrive   |
-           | g,f       | 45 90    | gch,edf,edf,edf | depart,roundabout-exit-2,exit roundabout right,arrive      |
-           | g,h       | 45 135   | gch,gch,gch     | depart,exit roundabout right,arrive                        |
-           | e,e       | 90 270   | edf,edf,edf     | depart,continue uturn,arrive                               |
+           | waypoints | bearings | route           | turns                                                        |
+           | e,f       | 90 90    | edf,edf         | depart,arrive                                                |
+           | e,h       | 90 130   | edf,gch,gch,gch | depart,roundabout-exit-2,exit roundabout straight,arrive     |
+           | g,f       | 50 90    | gch,edf,edf,edf | depart,roundabout-exit-2,exit roundabout slight right,arrive |
+           | g,h       | 50 130   | gch,gch,gch     | depart,exit roundabout right,arrive                          |
+           | e,e       | 90 270   | edf,edf,edf,edf | depart,roundabout-exit-3,exit roundabout sharp left,arrive   |
 
     Scenario: CCW and CW roundabouts with overlaps
         Given the node map

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -80,7 +80,7 @@ struct TurnInstruction
 
     bool IsUTurn() const
     {
-        return type == TurnType::Turn && direction_modifier == DirectionModifier::UTurn;
+        return type != TurnType::NoTurn && direction_modifier == DirectionModifier::UTurn;
     }
 
     static TurnInstruction INVALID() { return {TurnType::Invalid, DirectionModifier::UTurn}; }

--- a/include/extractor/guidance/turn_instruction.hpp
+++ b/include/extractor/guidance/turn_instruction.hpp
@@ -77,7 +77,11 @@ struct TurnInstruction
 
     TurnType::Enum type : 5;
     DirectionModifier::Enum direction_modifier : 3;
-    // the lane tupel that is used for the turn
+
+    bool IsUTurn() const
+    {
+        return type == TurnType::Turn && direction_modifier == DirectionModifier::UTurn;
+    }
 
     static TurnInstruction INVALID() { return {TurnType::Invalid, DirectionModifier::UTurn}; }
 

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -580,7 +580,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
             ExtractionTurn extracted_turn(
                 turn.angle,
                 m_node_based_graph.GetOutDegree(node_at_center_of_intersection),
-                turn.instruction.direction_modifier == guidance::DirectionModifier::UTurn,
+                turn.instruction.IsUTurn(),
                 is_traffic_light,
                 edge_data1.flags.restricted,
                 edge_data2.flags.restricted,


### PR DESCRIPTION
# Issue

This PR fixes issue #4754 that caused detours when the route would lead over degree 2 nodes that were classified as U-Turns. This is a result of the somewhat confusing `TurnInstruction` data structure, where the turn modifier is `U-Turn` for all non-`Turn` turn types (like `NoTurn` or `Suppress`).

## Tasklist
 - [x] review
 - [x] adjust for comments

