### PR TITLE
Use consistent EBG node weights in duplicated via nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Bugfixes:
       - FIXED #4754: U-Turn penalties are applied to straight turns.
       - FIXED #4756: Removed too restrictive road name check in the sliproad handler
+      - FIXED #4731: Use correct weights for edge-based graph duplicated via nodes.
 
 # 5.14.2
   - Changes from 5.14.1:

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -375,7 +375,9 @@ EdgeBasedGraphFactory::GenerateEdgeExpandedNodes(const WayRestrictionMap &way_re
             m_edge_based_node_container.nodes[edge_based_node_id].segregated =
                 segregated_edges.count(eid) > 0;
 
-            m_edge_based_node_weights.push_back(m_edge_based_node_weights[eid]);
+            const auto ebn_weight = m_edge_based_node_weights[nbe_to_ebn_mapping[eid]];
+            BOOST_ASSERT(ebn_weight == INVALID_EDGE_WEIGHT || ebn_weight == edge_data.weight);
+            m_edge_based_node_weights.push_back(ebn_weight);
 
             edge_based_node_id++;
             progress.PrintStatus(progress_counter++);


### PR DESCRIPTION
# Issue

PR fixes #4731 as  `m_edge_based_node_weights` must be indexed with `nbe_to_ebn_mapping[eid]`.

Additional assertion checks internal consistency of duplicated EBG nodes weights and NBG edges weights 
( EBG node weight can be set to `INVALID_EDGE_WEIGHT` at [`InsertEdgeBasedNode`](
https://github.com/Project-OSRM/osrm-backend/blob/17f25ccbc3687171a91ca2c9422e68e3e035fd07/src/extractor/edge_based_graph_factory.cpp#L134) before expanding via-way turn restrictions).

## Tasklist
 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 ~- [ ] add regression / cucumber cases (see docs/testing.md)~
 - [x] review
 - [ ] adjust for comments
