### PR TITLE
Belarus speed limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
     - Bugfixes:
       - FIXED #4754: U-Turn penalties are applied to straight turns.
       - FIXED #4756: Removed too restrictive road name check in the sliproad handler
+    - Profile:
+      - CHANGED: added Belarus speed limits
 
 # 5.14.2
   - Changes from 5.14.1:

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -257,6 +257,8 @@ function setup()
       ["at:rural"] = 100,
       ["at:trunk"] = 100,
       ["be:motorway"] = 120,
+      ["by:urban"] = 60,
+      ["by:motorway"] = 110,
       ["ch:rural"] = 80,
       ["ch:trunk"] = 100,
       ["ch:motorway"] = 120,

--- a/taginfo.json
+++ b/taginfo.json
@@ -147,6 +147,8 @@
         {"key": "maxspeed", "value": "AT:rural"},
         {"key": "maxspeed", "value": "AT:trunk"},
         {"key": "maxspeed", "value": "BE:motorway"},
+        {"key": "maxspeed", "value": "BY:urban"},
+        {"key": "maxspeed", "value": "BY:motorway"},
         {"key": "maxspeed", "value": "CH:rural"},
         {"key": "maxspeed", "value": "CH:trunk"},
         {"key": "maxspeed", "value": "CH:motorway"},


### PR DESCRIPTION
Speed limits in Belarus currently match the ones in Russia.

https://en.wikipedia.org/wiki/Speed_limits_in_Belarus
