### PR TITLE
Use default maxspeed value for ua:urban

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -282,7 +282,6 @@ function setup()
       ["ru:living_street"] = 20,
       ["ru:urban"] = 60,
       ["ru:motorway"] = 110,
-      ["ua:urban"] = 50,
       ["uk:nsl_single"] = (60*1609)/1000,
       ["uk:nsl_dual"] = (70*1609)/1000,
       ["uk:motorway"] = (70*1609)/1000,

--- a/taginfo.json
+++ b/taginfo.json
@@ -172,7 +172,6 @@
         {"key": "maxspeed", "value": "RU:living_street"},
         {"key": "maxspeed", "value": "RU:urban"},
         {"key": "maxspeed", "value": "RU:motorway"},
-        {"key": "maxspeed", "value": "UA:urban"},
         {"key": "maxspeed", "value": "UK:nsl_single"},
         {"key": "maxspeed", "value": "UK:nsl_dual"},
         {"key": "maxspeed", "value": "UK:motorway"},


### PR DESCRIPTION
# Issue

From https://github.com/Project-OSRM/osrm-backend/commit/5133f39d761b765de847619ae21d91032a8bc9ec#commitcomment-26595688
use default value for `ua:urban` 

## Requirements / Relations
#4765