### PR TITLE
Use unsigned type in percent_encoding to avoid overflow for %80..%ff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Changes from 5.14.3:
     - Bugfixes:
       - FIXED #4704: Fixed regression in bearings reordering introduced in 5.13 [#4704](https://github.com/Project-OSRM/osrm-backend/issues/4704)
+      - FIXED #4781: Fixed overflow exceptions in percent-encoding parsing
     - Guidance:
       - CHANGED #4706: Guidance refactoring step to decouple intersection connectivity analysis and turn instructions generation [#4706](https://github.com/Project-OSRM/osrm-backend/pull/4706)
 

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -27,7 +27,8 @@ struct URLParser final : qi::grammar<Iterator, Into>
         using boost::spirit::repository::qi::iter_pos;
 
         alpha_numeral = qi::char_("a-zA-Z0-9");
-        percent_encoding = qi::char_('%') > qi::uint_parser<char, 16, 2, 2>()[qi::_val = qi::_1];
+        percent_encoding =
+            qi::char_('%') > qi::uint_parser<unsigned char, 16, 2, 2>()[qi::_val = qi::_1];
         polyline_chars = qi::char_("a-zA-Z0-9_.--[]{}@?|\\~`^") | percent_encoding;
         all_chars = polyline_chars | qi::char_("=,;:&().");
 


### PR DESCRIPTION
In boost 1.67 spirit library has a [fix](https://github.com/boostorg/spirit/commit/80414bc68868b27e1fd865cbbbc1a6db229825a5) that results in an overflow exception for signed types.

The change to `unsigned char` is needed to prevent overflows for values `%80`..`%ff`.

## Tasklist
 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] review
 - [x] adjust for comments
