### PR TITLE
Set type of trivial intersections where classes change to Suppressed

### DIFF
--- a/features/car/classes.feature
+++ b/features/car/classes.feature
@@ -119,6 +119,25 @@ Feature: Car - Mode flag
             | from | to | route       | turns                                      | classes                   |
             | a    | d  | ab,bc,cd,cd | depart,new name right,new name left,arrive | [()],[(tunnel)],[()],[()] |
 
+    Scenario: Car - We tag classes without intersections
+        Background:
+            Given a grid size of 200 meters
+
+        Given the node map
+            """
+            a b c d
+            """
+
+        And the ways
+            | nodes | name | tunnel |
+            | ab    | road |        |
+            | bc    | road | yes    |
+            | cd    | road |        |
+
+        When I route I should get
+          | from | to | route     | turns         | classes               |
+          | a    | d  | road,road | depart,arrive | [(),(tunnel),()],[()] |
+
     Scenario: Car - From roundabout on toll road
         Given the node map
             """
@@ -144,4 +163,3 @@ Feature: Car - Mode flag
         When I route I should get
             | from | to | route       | turns                                                        | classes                                     |
             | a    | f  | ab,df,df,df | depart,roundabout-exit-2,exit roundabout slight right,arrive | [()],[(),(motorway)],[(toll,motorway)],[()] |
-

--- a/features/guidance/bridges_and_tunnels.feature
+++ b/features/guidance/bridges_and_tunnels.feature
@@ -98,11 +98,11 @@ Feature: Car - Guidance - Bridges and Tunnels
             | dce   | primary |        | Nebenstraße        |
 
         When I route I should get
-            | from | to | route                                      | turns                    |
-            | a    | d  | Hauptstraße,Nebenstraße,Nebenstraße        | depart,turn left,arrive  |
-            | a    | e  | Hauptstraße,Nebenstraße,Nebenstraße        | depart,turn right,arrive |
-            | e    | a  | Nebenstraße,Hauptstraßentunnel,Hauptstraße | depart,turn left,arrive  |
-            | d    | a  | Nebenstraße,Hauptstraßentunnel,Hauptstraße | depart,turn right,arrive |
+            | from | to | route                                      | turns                           |
+            | a    | d  | Hauptstraße,Nebenstraße,Nebenstraße        | depart,end of road left,arrive  |
+            | a    | e  | Hauptstraße,Nebenstraße,Nebenstraße        | depart,end of road right,arrive |
+            | e    | a  | Nebenstraße,Hauptstraßentunnel,Hauptstraße | depart,turn left,arrive         |
+            | d    | a  | Nebenstraße,Hauptstraßentunnel,Hauptstraße | depart,turn right,arrive        |
 
     Scenario: Tunnel with Immediate Turn Front and Back
         Given the node map
@@ -129,4 +129,3 @@ Feature: Car - Guidance - Bridges and Tunnels
             | e    | g  | Nebenstraße,Hauptstraßentunnel,Anderestraße,Anderestraße | depart,turn left,turn left,arrive   |
             | d    | f  | Nebenstraße,Hauptstraßentunnel,Anderestraße,Anderestraße | depart,turn right,turn right,arrive |
             | d    | g  | Nebenstraße,Hauptstraßentunnel,Anderestraße,Anderestraße | depart,turn right,turn left,arrive  |
-

--- a/include/extractor/guidance/intersection_handler.hpp
+++ b/include/extractor/guidance/intersection_handler.hpp
@@ -67,6 +67,8 @@ class IntersectionHandler
     // Decide on a basic turn types
     TurnType::Enum findBasicTurnType(const EdgeID via_edge, const ConnectedRoad &candidate) const;
 
+    TurnType::Enum areSameClasses(const EdgeID via_edge, const ConnectedRoad &road) const;
+
     // Find the most obvious turn to follow. The function returns an index into the intersection
     // determining whether there is a road that can be seen as obvious turn in the presence of many
     // other possible turns. The function will consider road categories and other inputs like the

--- a/src/extractor/guidance/intersection_handler.cpp
+++ b/src/extractor/guidance/intersection_handler.cpp
@@ -102,6 +102,19 @@ TurnType::Enum IntersectionHandler::findBasicTurnType(const EdgeID via_edge,
     return TurnType::Turn;
 }
 
+TurnType::Enum IntersectionHandler::areSameClasses(const EdgeID via_edge,
+                                                   const ConnectedRoad &road) const
+{
+    const auto &in_classes =
+        node_data_container.GetAnnotation(node_based_graph.GetEdgeData(via_edge).annotation_data)
+            .classes;
+    const auto &out_classes =
+        node_data_container.GetAnnotation(node_based_graph.GetEdgeData(road.eid).annotation_data)
+            .classes;
+
+    return in_classes == out_classes;
+}
+
 TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t num_roads,
                                                               const EdgeID via_edge,
                                                               const bool through_street,
@@ -195,7 +208,8 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
             if (needs_notification)
                 return {TurnType::Notification, getTurnDirection(road.angle)};
             else
-                return {num_roads == 2 ? TurnType::NoTurn : TurnType::Suppressed,
+                return {num_roads == 2 && areSameClasses(via_edge, road) ? TurnType::NoTurn
+                                                                         : TurnType::Suppressed,
                         getTurnDirection(road.angle)};
         }
     }
@@ -204,7 +218,7 @@ TurnInstruction IntersectionHandler::getInstructionForObvious(const std::size_t 
     {
         return {TurnType::Notification, getTurnDirection(road.angle)};
     }
-    if (num_roads > 2)
+    if (num_roads > 2 || !areSameClasses(via_edge, road))
     {
         return {TurnType::Suppressed, getTurnDirection(road.angle)};
     }


### PR DESCRIPTION
# Issue

In some cases like tunnels or bridges way classes may change at trivial intersections of degree two.
Maneuvers at such intersections have turn types `NoTurn` and intersections will be removed from  response intersections arrays. 


## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations
#4812
