### PR TITLE
Collect stats on MLD and CH performance in computing table plugin annotations with a cache by implementing a dummy cache

### DIFF
--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -46,6 +46,7 @@ module.exports = function () {
         // setup output logging
         let logDir = path.join(this.LOGS_PATH, this.featureID);
         this.scenarioLogFile = path.join(logDir, this.scenarioID) + '.log';
+        console.log(this.scenarioLogFile);
         d3.queue(1)
             .defer(mkdirp, logDir)
             .defer(rimraf, this.scenarioLogFile)

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -233,7 +233,7 @@ void unpackPath(const DataFacade<Algorithm> &facade,
                 Callback &&callback)
 {
     UnpackingStatistics unpacking_cache(0);
-    unpackPath(facade,packed_path_begin,packed_path_end, unpacking_cache, callback);
+    unpackPath(facade, packed_path_begin, packed_path_end, unpacking_cache, callback);
 }
 template <typename BidirectionalIterator, typename Callback>
 void unpackPath(const DataFacade<Algorithm> &facade,
@@ -246,35 +246,46 @@ void unpackPath(const DataFacade<Algorithm> &facade,
     if (packed_path_begin == packed_path_end)
         return;
 
-    std::stack<std::pair<NodeID, NodeID>> recursion_stack;
+    std::stack<std::tuple<NodeID, NodeID, bool>> recursion_stack;
 
     // We have to push the path in reverse order onto the stack because it's LIFO.
     for (auto current = std::prev(packed_path_end); current != packed_path_begin;
          current = std::prev(current))
     {
-        recursion_stack.emplace(*std::prev(current), *current);
+        recursion_stack.emplace(*std::prev(current), *current, false);
     }
 
-    std::pair<NodeID, NodeID> edge;
+    std::tuple<NodeID, NodeID, bool> edge;
     while (!recursion_stack.empty())
     {
         edge = recursion_stack.top();
-
-        unpacking_cache.CollectStats(edge);
-
         recursion_stack.pop();
+
+        if (!std::get<2>(edge))
+        {
+
+            if (unpacking_cache.EdgeInCache(std::make_pair(std::get<0>(edge), std::get<1>(edge))))
+            {
+                std::get<2>(edge) = true;
+            }
+
+            if (!std::get<2>(edge))
+                unpacking_cache.CollectStats(std::make_pair(std::get<0>(edge), std::get<1>(edge)));
+        }
 
         // Look for an edge on the forward CH graph (.forward)
         EdgeID smaller_edge_id = facade.FindSmallestEdge(
-            edge.first, edge.second, [](const auto &data) { return data.forward; });
+            std::get<0>(edge), std::get<1>(edge), [](const auto &data) { return data.forward; });
 
         // If we didn't find one there, the we might be looking at a part of the path that
         // was found using the backward search.  Here, we flip the node order (.second, .first)
         // and only consider edges with the `.backward` flag.
         if (SPECIAL_EDGEID == smaller_edge_id)
         {
-            smaller_edge_id = facade.FindSmallestEdge(
-                edge.second, edge.first, [](const auto &data) { return data.backward; });
+            smaller_edge_id =
+                facade.FindSmallestEdge(std::get<1>(edge), std::get<0>(edge), [](const auto &data) {
+                    return data.backward;
+                });
         }
 
         // If we didn't find anything *still*, then something is broken and someone has
@@ -291,13 +302,14 @@ void unpackPath(const DataFacade<Algorithm> &facade,
             const NodeID middle_node_id = data.turn_id;
             // Note the order here - we're adding these to a stack, so we
             // want the first->middle to get visited before middle->second
-            recursion_stack.emplace(middle_node_id, edge.second);
-            recursion_stack.emplace(edge.first, middle_node_id);
+            recursion_stack.emplace(middle_node_id, std::get<1>(edge), std::get<2>(edge));
+            recursion_stack.emplace(std::get<0>(edge), middle_node_id, std::get<2>(edge));
         }
         else
         {
+            auto temp = std::make_pair(std::get<0>(edge), std::get<1>(edge));
             // We found an original edge, call our callback.
-            std::forward<Callback>(callback)(edge, smaller_edge_id);
+            std::forward<Callback>(callback)(temp, smaller_edge_id);
         }
     }
 }

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -5,6 +5,7 @@
 #include "engine/datafacade.hpp"
 #include "engine/routing_algorithms/routing_base.hpp"
 #include "engine/search_engine_data.hpp"
+#include "engine/unpacking_statistics.hpp"
 
 #include "util/typedefs.hpp"
 
@@ -231,6 +232,16 @@ void unpackPath(const DataFacade<Algorithm> &facade,
                 BidirectionalIterator packed_path_end,
                 Callback &&callback)
 {
+    UnpackingStatistics unpacking_cache(0);
+    unpackPath(facade,packed_path_begin,packed_path_end, unpacking_cache, callback);
+}
+template <typename BidirectionalIterator, typename Callback>
+void unpackPath(const DataFacade<Algorithm> &facade,
+                BidirectionalIterator packed_path_begin,
+                BidirectionalIterator packed_path_end,
+                UnpackingStatistics &unpacking_cache,
+                Callback &&callback)
+{
     // make sure we have at least something to unpack
     if (packed_path_begin == packed_path_end)
         return;
@@ -248,6 +259,9 @@ void unpackPath(const DataFacade<Algorithm> &facade,
     while (!recursion_stack.empty())
     {
         edge = recursion_stack.top();
+
+        unpacking_cache.CollectStats(edge);
+
         recursion_stack.pop();
 
         // Look for an edge on the forward CH graph (.forward)
@@ -295,6 +309,7 @@ void unpackPath(const FacadeT &facade,
                 const PhantomNodes &phantom_nodes,
                 std::vector<PathData> &unpacked_path)
 {
+    std::cout << "RandomIter" << std::endl;
     const auto nodes_number = std::distance(packed_path_begin, packed_path_end);
     BOOST_ASSERT(nodes_number > 0);
 

--- a/include/engine/routing_algorithms/routing_base_ch.hpp
+++ b/include/engine/routing_algorithms/routing_base_ch.hpp
@@ -232,7 +232,7 @@ void unpackPath(const DataFacade<Algorithm> &facade,
                 BidirectionalIterator packed_path_end,
                 Callback &&callback)
 {
-    UnpackingStatistics unpacking_cache(0);
+    UnpackingStatistics unpacking_cache;
     unpackPath(facade, packed_path_begin, packed_path_end, unpacking_cache, callback);
 }
 template <typename BidirectionalIterator, typename Callback>
@@ -264,13 +264,12 @@ void unpackPath(const DataFacade<Algorithm> &facade,
         if (!std::get<2>(edge))
         {
 
-            if (unpacking_cache.EdgeInCache(std::make_pair(std::get<0>(edge), std::get<1>(edge))))
+            if (unpacking_cache.IsEdgeInCache(std::make_pair(std::get<0>(edge), std::get<1>(edge))))
             {
                 std::get<2>(edge) = true;
             }
 
-            if (!std::get<2>(edge))
-                unpacking_cache.CollectStats(std::make_pair(std::get<0>(edge), std::get<1>(edge)));
+            unpacking_cache.CollectStats(std::make_pair(std::get<0>(edge), std::get<1>(edge)));
         }
 
         // Look for an edge on the forward CH graph (.forward)

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -364,12 +364,15 @@ UnpackedPath search(SearchEngineData<Algorithm> &engine_working_data,
         bool overlay_edge;
         std::tie(source, target, overlay_edge) = packed_edge;
 
+        bool child_is_in_cache = false;
+
         if (!already_in_cache)
         {
             if (engine_working_data.unpacking_cache.get()->IsEdgeInCache(std::make_pair(source, target)))
             {
-                already_in_cache = true;
+                child_is_in_cache = true;
             }
+            // if(!already_in_cache)std::cout << facade.GetCoordinateOfNode(source) << ", "<< facade.GetCoordinateOfNode(target);
             engine_working_data.unpacking_cache.get()->CollectStats(std::make_pair(source, target));
         }
 
@@ -404,7 +407,7 @@ UnpackedPath search(SearchEngineData<Algorithm> &engine_working_data,
                                                                             reverse_heap,
                                                                             force_loop_forward,
                                                                             force_loop_reverse,
-                                                                            already_in_cache,
+                                                                            child_is_in_cache,
                                                                             INVALID_EDGE_WEIGHT,
                                                                             sublevel,
                                                                             parent_cell_id);

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -1,8 +1,8 @@
 #ifndef SEARCH_ENGINE_DATA_HPP
 #define SEARCH_ENGINE_DATA_HPP
 
-#include "engine/unpacking_statistics.hpp"
 #include "engine/algorithm.hpp"
+#include "engine/unpacking_statistics.hpp"
 #include "util/query_heap.hpp"
 #include "util/typedefs.hpp"
 

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -1,6 +1,7 @@
 #ifndef SEARCH_ENGINE_DATA_HPP
 #define SEARCH_ENGINE_DATA_HPP
 
+#include "engine/unpacking_statistics.hpp"
 #include "engine/algorithm.hpp"
 #include "util/query_heap.hpp"
 #include "util/typedefs.hpp"
@@ -46,6 +47,7 @@ template <> struct SearchEngineData<routing_algorithms::ch::Algorithm>
 
     using SearchEngineHeapPtr = boost::thread_specific_ptr<QueryHeap>;
     using ManyToManyHeapPtr = boost::thread_specific_ptr<ManyToManyQueryHeap>;
+    using UnpackingStatisticsPtr = boost::thread_specific_ptr<UnpackingStatistics>;
 
     static SearchEngineHeapPtr forward_heap_1;
     static SearchEngineHeapPtr reverse_heap_1;
@@ -54,6 +56,7 @@ template <> struct SearchEngineData<routing_algorithms::ch::Algorithm>
     static SearchEngineHeapPtr forward_heap_3;
     static SearchEngineHeapPtr reverse_heap_3;
     static ManyToManyHeapPtr many_to_many_heap;
+    static UnpackingStatisticsPtr unpacking_cache;
 
     void InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
 
@@ -62,6 +65,8 @@ template <> struct SearchEngineData<routing_algorithms::ch::Algorithm>
     void InitializeOrClearThirdThreadLocalStorage(unsigned number_of_nodes);
 
     void InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
+
+    void InitializeOrClearUnpackingStatisticsThreadLocalStorage(unsigned number_of_nodes);
 };
 
 struct MultiLayerDijkstraHeapData

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -106,14 +106,18 @@ template <> struct SearchEngineData<routing_algorithms::mld::Algorithm>
 
     using SearchEngineHeapPtr = boost::thread_specific_ptr<QueryHeap>;
     using ManyToManyHeapPtr = boost::thread_specific_ptr<ManyToManyQueryHeap>;
+    using UnpackingStatisticsPtr = boost::thread_specific_ptr<UnpackingStatistics>;
 
     static SearchEngineHeapPtr forward_heap_1;
     static SearchEngineHeapPtr reverse_heap_1;
     static ManyToManyHeapPtr many_to_many_heap;
+    static UnpackingStatisticsPtr unpacking_cache;
 
     void InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes);
 
     void InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
+
+    void InitializeOrClearUnpackingStatisticsThreadLocalStorage();
 };
 }
 }

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -66,7 +66,7 @@ template <> struct SearchEngineData<routing_algorithms::ch::Algorithm>
 
     void InitializeOrClearManyToManyThreadLocalStorage(unsigned number_of_nodes);
 
-    void InitializeOrClearUnpackingStatisticsThreadLocalStorage(unsigned number_of_nodes);
+    void InitializeOrClearUnpackingStatisticsThreadLocalStorage();
 };
 
 struct MultiLayerDijkstraHeapData

--- a/include/engine/unpacking_statistics.hpp
+++ b/include/engine/unpacking_statistics.hpp
@@ -3,23 +3,22 @@
 
 #include "util/typedefs.hpp"
 
-#include <utility>
 #include <unordered_map>
+#include <utility>
 
 namespace std
 {
-	template<> struct hash<std::pair<NodeID, NodeID>>
+template <> struct hash<std::pair<NodeID, NodeID>>
+{
+    typedef std::pair<NodeID, NodeID> argument_type;
+    typedef std::size_t result_type;
+    result_type operator()(argument_type const &pair) const noexcept
     {
-        typedef std::pair<NodeID, NodeID> argument_type;
-        typedef std::size_t result_type;
-        result_type operator()(argument_type const& pair) const noexcept
-        {
-            result_type const h1 ( std::hash<unsigned int>{}(pair.first) );
-            result_type const h2 ( std::hash<unsigned int>{}(pair.second) );
-            return h1 ^ (h2 << 1); // or use boost::hash_combine (see Discussion)
-        }
-    };
-
+        result_type const h1(std::hash<unsigned int>{}(pair.first));
+        result_type const h2(std::hash<unsigned int>{}(pair.second));
+        return h1 ^ (h2 << 1); // or use boost::hash_combine (see Discussion)
+    }
+};
 }
 namespace osrm
 {
@@ -27,18 +26,20 @@ namespace engine
 {
 class UnpackingStatistics
 {
-	std::pair<NodeID, NodeID> edge;
-	unsigned number_of_nodes;
+    std::pair<NodeID, NodeID> edge;
+    unsigned number_of_nodes;
 
-
-	std::unordered_map<std::pair<NodeID, NodeID>, int> cache;
-	int number_of_lookups;
-	int number_of_finds;
-	int number_of_misses;
+    std::unordered_map<std::pair<NodeID, NodeID>, int> cache;
+    int number_of_lookups;
+    int number_of_finds;
+    int number_of_misses;
 
   public:
-    UnpackingStatistics(unsigned number_of_nodes) :
-		number_of_nodes(number_of_nodes), number_of_lookups(0), number_of_finds(0), number_of_misses(0) {}
+    UnpackingStatistics(unsigned number_of_nodes)
+        : number_of_nodes(number_of_nodes), number_of_lookups(0), number_of_finds(0),
+          number_of_misses(0)
+    {
+    }
     // UnpackingStatistics(std::pair<NodeID, NodeID> edge) : edge(edge) {}
 
     // UnpackingStatistics() : edge(std::make_pair(SPECIAL_NODEID, SPECIAL_NODEID)) {}
@@ -51,39 +52,43 @@ class UnpackingStatistics
         number_of_misses = 0;
     }
 
+    bool EdgeInCache(std::pair<NodeID, NodeID> edge) { return cache.find(edge) != cache.end(); }
+
     void CollectStats(std::pair<NodeID, NodeID> edge)
     {
 
-		// check if edge is in the map
-		// if edge is in the map :
-		// 		- increment number_of_lookups, number_of_finds
-		// 		- update cache with edge:number_of_times to edge:number_of_times++
-		// if edge is not in map:
-		//		- increment number_of_lookups, number_of_misses
-		//		- insert edge into map with value 1
+        // check if edge is in the map
+        // if edge is in the map :
+        // 		- increment number_of_lookups, number_of_finds
+        // 		- update cache with edge:number_of_times to edge:number_of_times++
+        // if edge is not in map:
+        //		- increment number_of_lookups, number_of_misses
+        //		- insert edge into map with value 1
 
         number_of_lookups = number_of_lookups + 1;
 
-        if (cache.find(edge) == cache.end()) {
-			++number_of_misses;
-        } else {
-			++number_of_finds;
+        if (cache.find(edge) == cache.end())
+        {
+            ++number_of_misses;
+        }
+        else
+        {
+            ++number_of_finds;
         }
         ++cache[edge];
-
-        std::cout << "Misses :" << number_of_misses << " Finds: " << number_of_finds << " Total Lookups So Far: " << number_of_lookups << std::endl;
     }
 
     void PrintStats()
     {
-        std::cout << "Total Misses :" << number_of_misses << " Total Finds: " << number_of_finds << " Total Lookups: " << number_of_lookups << std::endl;
+        std::cout << "Total Misses :" << number_of_misses << " Total Finds: " << number_of_finds
+                  << " Total Lookups: " << number_of_lookups << std::endl;
     }
 
     void PrintEdgeLookups(std::pair<NodeID, NodeID> edge)
     {
-    	if (cache.find(edge) == cache.end()) {
-
-    	}
+        if (cache.find(edge) == cache.end())
+        {
+        }
         std::cout << "{I'm heeeear}" << std::endl;
     }
 };

--- a/include/engine/unpacking_statistics.hpp
+++ b/include/engine/unpacking_statistics.hpp
@@ -79,8 +79,9 @@ class UnpackingStatistics
 
     void PrintStats()
     {
-        std::cout << "Total Misses :" << number_of_misses << " Total Finds: " << number_of_finds
-                  << " Total Lookups: " << number_of_lookups << std::endl;
+        // std::cout << "Total Misses :" << number_of_misses << " Total Finds: " << number_of_finds
+        //           << " Total Lookups: " << number_of_lookups << " Cache size: " << cache.size() << std::endl;
+        std::cout << number_of_misses << "," << number_of_finds << "," << number_of_lookups << "," << cache.size() << std::endl;
     }
 
     // void PrintEdgeLookups(std::pair<NodeID, NodeID> edge)

--- a/include/engine/unpacking_statistics.hpp
+++ b/include/engine/unpacking_statistics.hpp
@@ -1,0 +1,93 @@
+#ifndef UNPACKING_STATISTICS_HPP
+#define UNPACKING_STATISTICS_HPP
+
+#include "util/typedefs.hpp"
+
+#include <utility>
+#include <unordered_map>
+
+namespace std
+{
+	template<> struct hash<std::pair<NodeID, NodeID>>
+    {
+        typedef std::pair<NodeID, NodeID> argument_type;
+        typedef std::size_t result_type;
+        result_type operator()(argument_type const& pair) const noexcept
+        {
+            result_type const h1 ( std::hash<unsigned int>{}(pair.first) );
+            result_type const h2 ( std::hash<unsigned int>{}(pair.second) );
+            return h1 ^ (h2 << 1); // or use boost::hash_combine (see Discussion)
+        }
+    };
+
+}
+namespace osrm
+{
+namespace engine
+{
+class UnpackingStatistics
+{
+	std::pair<NodeID, NodeID> edge;
+	unsigned number_of_nodes;
+
+
+	std::unordered_map<std::pair<NodeID, NodeID>, int> cache;
+	int number_of_lookups;
+	int number_of_finds;
+	int number_of_misses;
+
+  public:
+    UnpackingStatistics(unsigned number_of_nodes) :
+		number_of_nodes(number_of_nodes), number_of_lookups(0), number_of_finds(0), number_of_misses(0) {}
+    // UnpackingStatistics(std::pair<NodeID, NodeID> edge) : edge(edge) {}
+
+    // UnpackingStatistics() : edge(std::make_pair(SPECIAL_NODEID, SPECIAL_NODEID)) {}
+
+    void Clear()
+    {
+        cache.clear();
+        number_of_lookups = 0;
+        number_of_finds = 0;
+        number_of_misses = 0;
+    }
+
+    void CollectStats(std::pair<NodeID, NodeID> edge)
+    {
+
+		// check if edge is in the map
+		// if edge is in the map :
+		// 		- increment number_of_lookups, number_of_finds
+		// 		- update cache with edge:number_of_times to edge:number_of_times++
+		// if edge is not in map:
+		//		- increment number_of_lookups, number_of_misses
+		//		- insert edge into map with value 1
+
+        number_of_lookups = number_of_lookups + 1;
+
+        if (cache.find(edge) == cache.end()) {
+			++number_of_misses;
+        } else {
+			++number_of_finds;
+        }
+        ++cache[edge];
+
+        std::cout << "Misses :" << number_of_misses << " Finds: " << number_of_finds << " Total Lookups So Far: " << number_of_lookups << std::endl;
+    }
+
+    void PrintStats()
+    {
+        std::cout << "Total Misses :" << number_of_misses << " Total Finds: " << number_of_finds << " Total Lookups: " << number_of_lookups << std::endl;
+    }
+
+    void PrintEdgeLookups(std::pair<NodeID, NodeID> edge)
+    {
+    	if (cache.find(edge) == cache.end()) {
+
+    	}
+        std::cout << "{I'm heeeear}" << std::endl;
+    }
+};
+} // engine
+} // osrm
+
+#endif // UNPACKING_STATISTICS_HPP

--- a/include/engine/unpacking_statistics.hpp
+++ b/include/engine/unpacking_statistics.hpp
@@ -27,22 +27,13 @@ namespace engine
 class UnpackingStatistics
 {
     std::pair<NodeID, NodeID> edge;
-    unsigned number_of_nodes;
-
     std::unordered_map<std::pair<NodeID, NodeID>, int> cache;
     int number_of_lookups;
     int number_of_finds;
     int number_of_misses;
 
   public:
-    UnpackingStatistics(unsigned number_of_nodes)
-        : number_of_nodes(number_of_nodes), number_of_lookups(0), number_of_finds(0),
-          number_of_misses(0)
-    {
-    }
-    // UnpackingStatistics(std::pair<NodeID, NodeID> edge) : edge(edge) {}
-
-    // UnpackingStatistics() : edge(std::make_pair(SPECIAL_NODEID, SPECIAL_NODEID)) {}
+    UnpackingStatistics() : number_of_lookups(0), number_of_finds(0), number_of_misses(0) {}
 
     void Clear()
     {
@@ -52,7 +43,17 @@ class UnpackingStatistics
         number_of_misses = 0;
     }
 
-    bool EdgeInCache(std::pair<NodeID, NodeID> edge) { return cache.find(edge) != cache.end(); }
+    bool IsEdgeInCache(std::pair<NodeID, NodeID> edge)
+    {
+        ++number_of_lookups;
+        bool edge_is_in_cache = cache.find(edge) != cache.end();
+        // if (edge_is_in_cache) {
+        // 	std::cout << edge.first << ", " << edge.second << " true" << std::endl;
+        // } else {
+        // 	std::cout << edge.first << ", " << edge.second << " false" << std::endl;
+        // }
+        return edge_is_in_cache;
+    }
 
     void CollectStats(std::pair<NodeID, NodeID> edge)
     {
@@ -64,8 +65,6 @@ class UnpackingStatistics
         // if edge is not in map:
         //		- increment number_of_lookups, number_of_misses
         //		- insert edge into map with value 1
-
-        number_of_lookups = number_of_lookups + 1;
 
         if (cache.find(edge) == cache.end())
         {
@@ -84,13 +83,9 @@ class UnpackingStatistics
                   << " Total Lookups: " << number_of_lookups << std::endl;
     }
 
-    void PrintEdgeLookups(std::pair<NodeID, NodeID> edge)
-    {
-        if (cache.find(edge) == cache.end())
-        {
-        }
-        std::cout << "{I'm heeeear}" << std::endl;
-    }
+    // void PrintEdgeLookups(std::pair<NodeID, NodeID> edge)
+    // {
+    // }
 };
 } // engine
 } // osrm

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -544,6 +544,7 @@ void unpackPackedPaths(InputIt first,
                                                                                 reverse_heap,
                                                                                 DO_NOT_FORCE_LOOPS,
                                                                                 DO_NOT_FORCE_LOOPS,
+                                                                                false,
                                                                                 INVALID_EDGE_WEIGHT,
                                                                                 sublevel,
                                                                                 parent_cell_id);

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -53,6 +53,7 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<ch::Algorithm> &en
         ch::unpackPath(facade,
                        packed_leg.begin(),
                        packed_leg.end(),
+                       *engine_working_data.unpacking_cache.get(),
                        [&unpacked_nodes, &unpacked_edges](std::pair<NodeID, NodeID> &edge,
                                                           const auto &edge_id) {
                            BOOST_ASSERT(edge.first == unpacked_nodes.back());

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -60,6 +60,7 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<ch::Algorithm> &en
                            unpacked_nodes.push_back(edge.second);
                            unpacked_edges.push_back(edge_id);
                        });
+        engine_working_data.unpacking_cache.get()->PrintStats();
     }
 
     return extractRoute(facade, weight, phantom_nodes, unpacked_nodes, unpacked_edges);

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -57,13 +57,22 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<ch::Algorithm> &en
                        [&unpacked_nodes, &unpacked_edges](std::pair<NodeID, NodeID> &edge,
                                                           const auto &edge_id) {
                            BOOST_ASSERT(edge.first == unpacked_nodes.back());
-                           unpacked_nodes.push_back(edge.second);
-                           unpacked_edges.push_back(edge_id);
+                           unpacked_nodes.push_back(edge.second); // edge.second is edge based node ids
+                           unpacked_edges.push_back(edge_id); 
                        });
         engine_working_data.unpacking_cache.get()->PrintStats();
     }
 
     return extractRoute(facade, weight, phantom_nodes, unpacked_nodes, unpacked_edges);
+    // a function that takes the endge based node ids and returns to you the duration 
+    // takes path returns duration
+    // path is made of Edge based edges == turns that are unpacked edges and unpacked nodes
+    //
+    //     / \     get the duration of the street segment , get the duration of the turn segment and add them up for total duration
+    //      |
+    // - - - 
+    //
+    // what I should really do first is read extractRoute implementation and understand what is happenin in there
 }
 
 template <>

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -90,6 +90,7 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<mld::Algorithm> &e
                                                                    false,
                                                                    INVALID_EDGE_WEIGHT,
                                                                    phantom_nodes);
+    engine_working_data.unpacking_cache.get()->PrintStats();
 
     return extractRoute(facade, weight, phantom_nodes, unpacked_nodes, unpacked_edges);
 }

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -87,6 +87,7 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<mld::Algorithm> &e
                                                                    reverse_heap,
                                                                    DO_NOT_FORCE_LOOPS,
                                                                    DO_NOT_FORCE_LOOPS,
+                                                                   false,
                                                                    INVALID_EDGE_WEIGHT,
                                                                    phantom_nodes);
 

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -169,11 +169,11 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
     std::vector<EdgeWeight> weights_table(number_of_entries, INVALID_EDGE_WEIGHT);
     std::vector<EdgeDuration> durations_table(number_of_entries, MAXIMAL_EDGE_DURATION);
 
-    for (std::uint32_t column_idx = 0; column_idx < target_indices.size(); ++column_idx)
+    for (std::uint32_t column_idx = 0; column_idx < number_of_targets; ++column_idx)
     {
         const auto &target = phantom_nodes[target_indices[column_idx]];
 
-        for (std::uint32_t row_idx = 0; row_idx < source_indices.size(); ++row_idx)
+        for (std::uint32_t row_idx = 0; row_idx < number_of_sources; ++row_idx)
         {
             const auto &source = phantom_nodes[source_indices[row_idx]];
 
@@ -188,8 +188,18 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
             std::cout << " weight: " << result.shortest_path_weight << std::endl;
             std::cout << " duration: " << result.duration() <<"\n" << std::endl << std::endl;
 
-            weights_table.emplace_back(result.shortest_path_weight);
-            durations_table.emplace_back(result.duration());
+            weights_table[row_idx * number_of_targets + column_idx] = result.shortest_path_weight;
+            durations_table[row_idx * number_of_targets + column_idx] = result.duration();
+            // weights_table.emplace_back(result.shortest_path_weight);
+            // durations_table.emplace_back(result.duration());
+
+
+// targets   0 1 2 3 4  5
+// sources 0 0 1 2 3 4  5
+//         1 6 7 8 9 10 11
+//         2
+//         3
+//         4
 
         }
     }

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -1,5 +1,6 @@
 #include "engine/routing_algorithms/many_to_many.hpp"
 #include "engine/routing_algorithms/routing_base_ch.hpp"
+#include "engine/routing_algorithms/direct_shortest_path.hpp"
 
 #include <boost/assert.hpp>
 #include <boost/range/iterator_range_core.hpp>
@@ -167,6 +168,31 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
 
     std::vector<EdgeWeight> weights_table(number_of_entries, INVALID_EDGE_WEIGHT);
     std::vector<EdgeDuration> durations_table(number_of_entries, MAXIMAL_EDGE_DURATION);
+
+    for (std::uint32_t column_idx = 0; column_idx < target_indices.size(); ++column_idx)
+    {
+        const auto &target = phantom_nodes[target_indices[column_idx]];
+
+        for (std::uint32_t row_idx = 0; row_idx < source_indices.size(); ++row_idx)
+        {
+            const auto &source = phantom_nodes[source_indices[row_idx]];
+
+            PhantomNodes pair = {source, target};
+
+            InternalRouteResult result = directShortestPathSearch(engine_working_data, facade, pair);
+
+            std::cout << "column_idx: " << column_idx << std::endl;
+            std::cout << " row_idx: " << row_idx << std::endl;
+            std::cout << " source: " << source << std::endl;
+            std::cout << " target: " << target << std::endl;
+            std::cout << " weight: " << result.shortest_path_weight << std::endl;
+            std::cout << " duration: " << result.duration() <<"\n" << std::endl << std::endl;
+
+            weights_table.emplace_back(result.shortest_path_weight);
+            durations_table.emplace_back(result.duration());
+
+        }
+    }
 
     std::vector<NodeBucket> search_space_with_buckets;
 

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -1,6 +1,6 @@
 #include "engine/routing_algorithms/many_to_many.hpp"
-#include "engine/routing_algorithms/routing_base_ch.hpp"
 #include "engine/routing_algorithms/direct_shortest_path.hpp"
+#include "engine/routing_algorithms/routing_base_ch.hpp"
 
 #include <boost/assert.hpp>
 #include <boost/range/iterator_range_core.hpp>
@@ -170,7 +170,7 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
     std::vector<EdgeDuration> durations_table(number_of_entries, MAXIMAL_EDGE_DURATION);
 
     engine_working_data.InitializeOrClearUnpackingStatisticsThreadLocalStorage(
-            facade.GetNumberOfNodes());
+        facade.GetNumberOfNodes());
 
     for (std::uint32_t column_idx = 0; column_idx < number_of_targets; ++column_idx)
     {
@@ -182,41 +182,45 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
 
             PhantomNodes pair = {source, target};
 
-            InternalRouteResult result = directShortestPathSearch(engine_working_data, facade, pair);
+            InternalRouteResult result =
+                directShortestPathSearch(engine_working_data, facade, pair);
 
             // std::cout << "column_idx: " << column_idx << std::endl;
             // std::cout << " row_idx: " << row_idx << std::endl;
             // std::cout << " source: " << source << std::endl;
             // std::cout << " target: " << target << std::endl;
-            // std::cout << " row_idx * number_of_targets + column_idx: " << row_idx * number_of_targets + column_idx << std::endl;
+            // std::cout << " row_idx * number_of_targets + column_idx: " << row_idx *
+            // number_of_targets + column_idx << std::endl;
             // std::cout << " number_of_entries: " << number_of_entries << std::endl;
 
             weights_table[row_idx * number_of_targets + column_idx] = result.shortest_path_weight;
             durations_table[row_idx * number_of_targets + column_idx] = result.duration();
 
-            // std::cout << " duration: " <<  durations_table[row_idx * number_of_targets + column_idx] << std::endl;
-            // std::cout << " weight: " << weights_table[row_idx * number_of_targets + column_idx] << std::endl;
+            // std::cout << " duration: " <<  durations_table[row_idx * number_of_targets +
+            // column_idx] << std::endl;
+            // std::cout << " weight: " << weights_table[row_idx * number_of_targets + column_idx]
+            // << std::endl;
         }
     }
 
-    std::cout << "Duration Table" << std::endl;
-    for (auto i = 0; i < number_of_entries; ++i) {
-        std::cout << durations_table[i] << " ";
-        if ((i + 1) % number_of_targets == 0) {
-            std:: cout << std::endl;
-        }
-    }
-    std::cout << "Weight Table" << std::endl;
-    for (auto i = 0; i < number_of_entries; ++i) {
-        std::cout << weights_table[i] << " ";
-        if ((i + 1) % number_of_targets == 0) {
-            std:: cout << std::endl;
-        }
-    }
-
+    // std::cout << "Duration Table" << std::endl;
+    // for (auto i = 0; i < number_of_entries; ++i) {
+    //     std::cout << durations_table[i] << " ";
+    //     if ((i + 1) % number_of_targets == 0) {
+    //         std:: cout << std::endl;
+    //     }
+    // }
+    // std::cout << "Weight Table" << std::endl;
+    // for (auto i = 0; i < number_of_entries; ++i) {
+    //     std::cout << weights_table[i] << " ";
+    //     if ((i + 1) % number_of_targets == 0) {
+    //         std:: cout << std::endl;
+    //     }
+    // }
 
     // Resets the weights_table and the durations_table
-    for (auto i = 0; i < number_of_entries; ++i) {
+    for (auto i = 0; i < number_of_entries; ++i)
+    {
         weights_table[i] = INVALID_EDGE_WEIGHT;
         durations_table[i] = MAXIMAL_EDGE_DURATION;
     }
@@ -270,20 +274,20 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
         }
     }
 
-    std::cout << "Duration Table" << std::endl;
-    for (auto i = 0; i < number_of_entries; ++i) {
-        std::cout << durations_table[i] << " ";
-        if ((i + 1) % number_of_targets == 0) {
-            std:: cout << std::endl;
-        }
-    }
-    std::cout << "Weight Table" << std::endl;
-    for (auto i = 0; i < number_of_entries; ++i) {
-        std::cout << weights_table[i] << " ";
-        if ((i + 1) % number_of_targets == 0) {
-            std:: cout << std::endl;
-        }
-    }
+    // std::cout << "Duration Table" << std::endl;
+    // for (auto i = 0; i < number_of_entries; ++i) {
+    //     std::cout << durations_table[i] << " ";
+    //     if ((i + 1) % number_of_targets == 0) {
+    //         std:: cout << std::endl;
+    //     }
+    // }
+    // std::cout << "Weight Table" << std::endl;
+    // for (auto i = 0; i < number_of_entries; ++i) {
+    //     std::cout << weights_table[i] << " ";
+    //     if ((i + 1) % number_of_targets == 0) {
+    //         std:: cout << std::endl;
+    //     }
+    // }
 
     return durations_table;
 }

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -169,8 +169,7 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
     std::vector<EdgeWeight> weights_table(number_of_entries, INVALID_EDGE_WEIGHT);
     std::vector<EdgeDuration> durations_table(number_of_entries, MAXIMAL_EDGE_DURATION);
 
-    engine_working_data.InitializeOrClearUnpackingStatisticsThreadLocalStorage(
-        facade.GetNumberOfNodes());
+    engine_working_data.InitializeOrClearUnpackingStatisticsThreadLocalStorage();
 
     for (std::uint32_t column_idx = 0; column_idx < number_of_targets; ++column_idx)
     {
@@ -203,20 +202,7 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
         }
     }
 
-    // std::cout << "Duration Table" << std::endl;
-    // for (auto i = 0; i < number_of_entries; ++i) {
-    //     std::cout << durations_table[i] << " ";
-    //     if ((i + 1) % number_of_targets == 0) {
-    //         std:: cout << std::endl;
-    //     }
-    // }
-    // std::cout << "Weight Table" << std::endl;
-    // for (auto i = 0; i < number_of_entries; ++i) {
-    //     std::cout << weights_table[i] << " ";
-    //     if ((i + 1) % number_of_targets == 0) {
-    //         std:: cout << std::endl;
-    //     }
-    // }
+    return durations_table;
 
     // Resets the weights_table and the durations_table
     for (auto i = 0; i < number_of_entries; ++i)

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -169,6 +169,9 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
     std::vector<EdgeWeight> weights_table(number_of_entries, INVALID_EDGE_WEIGHT);
     std::vector<EdgeDuration> durations_table(number_of_entries, MAXIMAL_EDGE_DURATION);
 
+    engine_working_data.InitializeOrClearUnpackingStatisticsThreadLocalStorage(
+            facade.GetNumberOfNodes());
+
     for (std::uint32_t column_idx = 0; column_idx < number_of_targets; ++column_idx)
     {
         const auto &target = phantom_nodes[target_indices[column_idx]];
@@ -181,27 +184,41 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
 
             InternalRouteResult result = directShortestPathSearch(engine_working_data, facade, pair);
 
-            std::cout << "column_idx: " << column_idx << std::endl;
-            std::cout << " row_idx: " << row_idx << std::endl;
-            std::cout << " source: " << source << std::endl;
-            std::cout << " target: " << target << std::endl;
-            std::cout << " weight: " << result.shortest_path_weight << std::endl;
-            std::cout << " duration: " << result.duration() <<"\n" << std::endl << std::endl;
+            // std::cout << "column_idx: " << column_idx << std::endl;
+            // std::cout << " row_idx: " << row_idx << std::endl;
+            // std::cout << " source: " << source << std::endl;
+            // std::cout << " target: " << target << std::endl;
+            // std::cout << " row_idx * number_of_targets + column_idx: " << row_idx * number_of_targets + column_idx << std::endl;
+            // std::cout << " number_of_entries: " << number_of_entries << std::endl;
 
             weights_table[row_idx * number_of_targets + column_idx] = result.shortest_path_weight;
             durations_table[row_idx * number_of_targets + column_idx] = result.duration();
-            // weights_table.emplace_back(result.shortest_path_weight);
-            // durations_table.emplace_back(result.duration());
 
-
-// targets   0 1 2 3 4  5
-// sources 0 0 1 2 3 4  5
-//         1 6 7 8 9 10 11
-//         2
-//         3
-//         4
-
+            // std::cout << " duration: " <<  durations_table[row_idx * number_of_targets + column_idx] << std::endl;
+            // std::cout << " weight: " << weights_table[row_idx * number_of_targets + column_idx] << std::endl;
         }
+    }
+
+    std::cout << "Duration Table" << std::endl;
+    for (auto i = 0; i < number_of_entries; ++i) {
+        std::cout << durations_table[i] << " ";
+        if ((i + 1) % number_of_targets == 0) {
+            std:: cout << std::endl;
+        }
+    }
+    std::cout << "Weight Table" << std::endl;
+    for (auto i = 0; i < number_of_entries; ++i) {
+        std::cout << weights_table[i] << " ";
+        if ((i + 1) % number_of_targets == 0) {
+            std:: cout << std::endl;
+        }
+    }
+
+
+    // Resets the weights_table and the durations_table
+    for (auto i = 0; i < number_of_entries; ++i) {
+        weights_table[i] = INVALID_EDGE_WEIGHT;
+        durations_table[i] = MAXIMAL_EDGE_DURATION;
     }
 
     std::vector<NodeBucket> search_space_with_buckets;
@@ -250,6 +267,21 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<ch::Algorithm> &engi
                                weights_table,
                                durations_table,
                                phantom);
+        }
+    }
+
+    std::cout << "Duration Table" << std::endl;
+    for (auto i = 0; i < number_of_entries; ++i) {
+        std::cout << durations_table[i] << " ";
+        if ((i + 1) % number_of_targets == 0) {
+            std:: cout << std::endl;
+        }
+    }
+    std::cout << "Weight Table" << std::endl;
+    for (auto i = 0; i < number_of_entries; ++i) {
+        std::cout << weights_table[i] << " ";
+        if ((i + 1) % number_of_targets == 0) {
+            std:: cout << std::endl;
         }
     }
 

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -1,5 +1,6 @@
 #include "engine/routing_algorithms/many_to_many.hpp"
 #include "engine/routing_algorithms/routing_base.hpp"
+#include "engine/routing_algorithms/direct_shortest_path.hpp"
 
 #include <boost/assert.hpp>
 #include <boost/range/iterator_range_core.hpp>
@@ -455,6 +456,41 @@ std::vector<EdgeDuration> manyToManySearch(SearchEngineData<Algorithm> &engine_w
 
     std::vector<EdgeWeight> weights_table(number_of_entries, INVALID_EDGE_WEIGHT);
     std::vector<EdgeDuration> durations_table(number_of_entries, MAXIMAL_EDGE_DURATION);
+
+    engine_working_data.InitializeOrClearUnpackingStatisticsThreadLocalStorage();
+
+    for (std::uint32_t column_idx = 0; column_idx < number_of_targets; ++column_idx)
+    {
+        const auto &target = phantom_nodes[target_indices[column_idx]];
+
+        for (std::uint32_t row_idx = 0; row_idx < number_of_sources; ++row_idx)
+        {
+            const auto &source = phantom_nodes[source_indices[row_idx]];
+
+            PhantomNodes pair = {source, target};
+
+            InternalRouteResult result =
+                directShortestPathSearch(engine_working_data, facade, pair);
+
+            // std::cout << "column_idx: " << column_idx << std::endl;
+            // std::cout << " row_idx: " << row_idx << std::endl;
+            // std::cout << " source: " << source << std::endl;
+            // std::cout << " target: " << target << std::endl;
+            // std::cout << " row_idx * number_of_targets + column_idx: " << row_idx *
+            // number_of_targets + column_idx << std::endl;
+            // std::cout << " number_of_entries: " << number_of_entries << std::endl;
+
+            weights_table[row_idx * number_of_targets + column_idx] = result.shortest_path_weight;
+            durations_table[row_idx * number_of_targets + column_idx] = result.duration();
+
+            // std::cout << " duration: " <<  durations_table[row_idx * number_of_targets +
+            // column_idx] << std::endl;
+            // std::cout << " weight: " << weights_table[row_idx * number_of_targets + column_idx]
+            // << std::endl;
+        }
+    }
+
+    return durations_table;
 
     std::vector<NodeBucket> search_space_with_buckets;
 

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -91,7 +91,8 @@ void SearchEngineData<CH>::InitializeOrClearManyToManyThreadLocalStorage(unsigne
     }
 }
 
-void SearchEngineData<CH>::InitializeOrClearUnpackingStatisticsThreadLocalStorage(unsigned number_of_nodes)
+void SearchEngineData<CH>::InitializeOrClearUnpackingStatisticsThreadLocalStorage(
+    unsigned number_of_nodes)
 {
     if (unpacking_cache.get())
     {

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -14,6 +14,7 @@ SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::reverse_heap_2;
 SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::forward_heap_3;
 SearchEngineData<CH>::SearchEngineHeapPtr SearchEngineData<CH>::reverse_heap_3;
 SearchEngineData<CH>::ManyToManyHeapPtr SearchEngineData<CH>::many_to_many_heap;
+SearchEngineData<CH>::UnpackingStatisticsPtr SearchEngineData<CH>::unpacking_cache;
 
 void SearchEngineData<CH>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes)
 {
@@ -87,6 +88,18 @@ void SearchEngineData<CH>::InitializeOrClearManyToManyThreadLocalStorage(unsigne
     else
     {
         many_to_many_heap.reset(new ManyToManyQueryHeap(number_of_nodes));
+    }
+}
+
+void SearchEngineData<CH>::InitializeOrClearUnpackingStatisticsThreadLocalStorage(unsigned number_of_nodes)
+{
+    if (unpacking_cache.get())
+    {
+        unpacking_cache->Clear();
+    }
+    else
+    {
+        unpacking_cache.reset(new UnpackingStatistics(number_of_nodes));
     }
 }
 

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -91,16 +91,15 @@ void SearchEngineData<CH>::InitializeOrClearManyToManyThreadLocalStorage(unsigne
     }
 }
 
-void SearchEngineData<CH>::InitializeOrClearUnpackingStatisticsThreadLocalStorage(
-    unsigned number_of_nodes)
+void SearchEngineData<CH>::InitializeOrClearUnpackingStatisticsThreadLocalStorage()
 {
     if (unpacking_cache.get())
     {
-        unpacking_cache->Clear();
+        // unpacking_cache->Clear();
     }
     else
     {
-        unpacking_cache.reset(new UnpackingStatistics(number_of_nodes));
+        unpacking_cache.reset(new UnpackingStatistics());
     }
 }
 

--- a/src/engine/search_engine_data.cpp
+++ b/src/engine/search_engine_data.cpp
@@ -108,6 +108,7 @@ using MLD = routing_algorithms::mld::Algorithm;
 SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::forward_heap_1;
 SearchEngineData<MLD>::SearchEngineHeapPtr SearchEngineData<MLD>::reverse_heap_1;
 SearchEngineData<MLD>::ManyToManyHeapPtr SearchEngineData<MLD>::many_to_many_heap;
+SearchEngineData<MLD>::UnpackingStatisticsPtr SearchEngineData<MLD>::unpacking_cache;
 
 void SearchEngineData<MLD>::InitializeOrClearFirstThreadLocalStorage(unsigned number_of_nodes)
 {
@@ -139,6 +140,19 @@ void SearchEngineData<MLD>::InitializeOrClearManyToManyThreadLocalStorage(unsign
     else
     {
         many_to_many_heap.reset(new ManyToManyQueryHeap(number_of_nodes));
+    }
+}
+
+
+void SearchEngineData<MLD>::InitializeOrClearUnpackingStatisticsThreadLocalStorage()
+{
+    if (unpacking_cache.get())
+    {
+        // unpacking_cache->Clear();
+    }
+    else
+    {
+        unpacking_cache.reset(new UnpackingStatistics());
     }
 }
 }


### PR DESCRIPTION
# Issue

Implementing the second comment in this issue: [Compute annotations for table plugin at runtime](https://github.com/Project-OSRM/osrm-backend/issues/4798)

## Tasklist
 - [ ] CHANGELOG.md entry
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations
 Link any requirements here. Other pull requests this PR is based on?
