### PR TITLE
Only run step collapsing based on original waypoints parameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
   - Changes from 5.15.0:
+    - Bugfixes:
+      - FIXED: Segfault in map matching when RouteLeg collapsing code is run on a match with multiple submatches
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -603,3 +603,26 @@ Feature: Basic Map Matching
         When I match I should get
             | trace | timestamps | code    |
             | ab1d  | 0 1 2 3    | NoMatch |
+
+    Scenario: Regression test - avoid collapsing legs of a tidied split trace
+        Given a grid size of 20 meters
+        Given the node map
+            """
+            a--b--f
+               |
+               |
+               e--c---d--g
+            """
+        Given the query options
+        | tidy | true |
+
+        And the ways
+            | nodes | oneway |
+            | abf   | no     |
+            | be    | no     |
+            | ecdg  | no     |
+
+        When I match I should get
+        | trace    | timestamps                                   | matchings  | code |
+        | abbecd   | 10 11 27 1516914902 1516914913 1516914952    | ab,ecd     | Ok   |
+

--- a/include/engine/api/match_parameters_tidy.hpp
+++ b/include/engine/api/match_parameters_tidy.hpp
@@ -48,12 +48,14 @@ inline Result keep_all(const MatchParameters &params)
 
     result.can_be_removed.resize(params.coordinates.size(), false);
     result.was_waypoint.resize(params.coordinates.size(), true);
+    // by default all input coordinates are treated as waypoints
     if (!params.waypoints.empty())
     {
         for (const auto p : params.waypoints)
         {
             result.was_waypoint.set(p, false);
         }
+        // logic is a little funny, uses inversion to set the bitfield
         result.was_waypoint.flip();
     }
     result.tidied_to_original.reserve(params.coordinates.size());

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -248,6 +248,7 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
     }
 
     // Error: Check if user-supplied waypoints can be found in the resulting matches
+    if (!parameters.waypoints.empty())
     {
         std::set<std::size_t> tidied_waypoints(tidied.parameters.waypoints.begin(),
                                                tidied.parameters.waypoints.end());

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -162,7 +162,6 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
             "InvalidValue", "Timestamps need to be monotonically increasing.", json_result);
     }
 
-    bool collapse_legs = false;
     SubMatchingList sub_matchings;
     api::tidy::Result tidied;
     if (parameters.tidy)
@@ -264,8 +263,9 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                 "NoMatch", "Requested waypoint parameter could not be matched.", json_result);
         }
     }
-    // we haven't errored yet, only allow leg collapsing if we meet this criteria
-    collapse_legs = sub_matchings.size() == 1 && !parameters.waypoints.empty();
+    // we haven't errored yet, only allow leg collapsing if it was originally requested
+    BOOST_ASSERT(parameters.waypoints.empty() || sub_matchings.size() == 1);
+    const auto collapse_legs = !parameters.waypoints.empty();
 
     // each sub_route will correspond to a MatchObject
     std::vector<InternalRouteResult> sub_routes(sub_matchings.size());


### PR DESCRIPTION
# Issue

There is a segfault producing bug in the new RouteLeg collapsing code in 5.15.0. The bug appears to only be triggered by map matching requests with the criteria:
- `tidy=true` parameter
- the map matched result has been split into submatches in the Match object

The actual point of failure for a request with the above criteria happens when the RouteLeg collapsing code attempts to collapse the `unpacked_path_segments` of a submatch into an empty vector.

However, this only happens when collapsing is run on a match with multiple submatches because one of the fundamental assumptions of leg collapsing is that the Match result is a continuous match. Fixing the actual issue here involves adding a more robust check that leg collapsing is never run on a match with multiple submatches.

## Tasklist
 - [x] add regression / cucumber cases (see docs/testing.md)
-  [ ] Debug the return of the `Could not match the trace with the given waypoints.` error when the `waypoints` param has not been passed in
 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] review
 - [x] adjust for comments
 - [ ] Make bug fix release

## Requirements / Relations
5.15.1
