### PR TITLE
Increase MAXIMAL_ALLOWED_SEPARATION_WIDTH to 12 meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - FIXED: Segfault in map matching when RouteLeg collapsing code is run on a match with multiple submatches
     - Guidance
       - CHANGED #4830: Announce reference change if names are empty
+      - CHANGED #4835: MAXIMAL_ALLOWED_SEPARATION_WIDTH increased to 12 meters
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)

--- a/src/extractor/guidance/mergable_road_detector.cpp
+++ b/src/extractor/guidance/mergable_road_detector.cpp
@@ -469,7 +469,7 @@ bool MergableRoadDetector::HaveSameDirection(const NodeID intersection_node,
         1, node_based_graph.GetEdgeData(rhs.eid).flags.road_classification.GetNumberOfLanes());
 
     const auto combined_road_width = 0.5 * (lane_count_lhs + lane_count_rhs) * ASSUMED_LANE_WIDTH;
-    const auto constexpr MAXIMAL_ALLOWED_SEPARATION_WIDTH = 8;
+    const auto constexpr MAXIMAL_ALLOWED_SEPARATION_WIDTH = 12;
 
     return distance_between_roads <= combined_road_width + MAXIMAL_ALLOWED_SEPARATION_WIDTH;
 }


### PR DESCRIPTION
# Issue

[The check](https://github.com/Project-OSRM/osrm-backend/blob/8fea99445ddd69f07139c5281c7c97a5b54ac264/src/extractor/guidance/mergable_road_detector.cpp#L474) should cover merging of roads at intersections similar
to https://www.openstreetmap.org/node/53020993#map=18/37.86590/-122.25083

Modified instruction for `MAXIMAL_ALLOWED_SEPARATION_WIDTH`:

* 10 meters http://bl.ocks.org/d/6d9a3d1f3f74e512db584f1812682895
* 12 meters http://bl.ocks.org/d/547fe1cae6514c3c0373d36fadfb5db3
* 14 meters http://bl.ocks.org/d/fffcffd67cb914ad9bdf8ab6aae87d44
* 16 meters http://bl.ocks.org/d/2d030df715606c780f8ef813e93ca2c4



## Tasklist
 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add regression / cucumber cases (see docs/testing.md)
 - [ ] review
 - [ ] adjust for comments

