### PR TITLE
Move setting up task_scheduler_init from executables to library

### DIFF
--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -35,6 +35,9 @@
 #include <memory>
 #include <vector>
 
+#include <boost/assert.hpp>
+
+#include <tbb/task_scheduler_init.h>
 namespace osrm
 {
 namespace contractor
@@ -42,6 +45,9 @@ namespace contractor
 
 int Contractor::Run()
 {
+    tbb::task_scheduler_init init(config.requested_num_threads);
+    BOOST_ASSERT(init.is_active());
+
     if (config.core_factor != 1.0)
     {
         util::Log(logWARNING)

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -18,6 +18,10 @@
 #include "util/log.hpp"
 #include "util/timing_util.hpp"
 
+#include <boost/assert.hpp>
+
+#include <tbb/task_scheduler_init.h>
+
 namespace osrm
 {
 namespace customizer
@@ -115,6 +119,9 @@ std::vector<CellMetric> customizeFilteredMetrics(const MultiLevelEdgeBasedGraph 
 
 int Customizer::Run(const CustomizationConfig &config)
 {
+    tbb::task_scheduler_init init(config.requested_num_threads);
+    BOOST_ASSERT(init.is_active());
+
     TIMER_START(loading_data);
 
     partitioner::MultiLevelPartition mlp;

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -37,6 +37,7 @@
 
 #include "extractor/tarjan_scc.hpp"
 
+#include <boost/assert.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
@@ -193,6 +194,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
     const auto number_of_threads = std::min(recommended_num_threads, config.requested_num_threads);
     tbb::task_scheduler_init init(number_of_threads ? number_of_threads
                                                     : tbb::task_scheduler_init::automatic);
+    BOOST_ASSERT(init.is_active());
 
     guidance::LaneDescriptionMap turn_lane_map;
     std::vector<TurnRestriction> turn_restrictions;

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -27,6 +27,8 @@
 #include <boost/assert.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#include <tbb/task_scheduler_init.h>
+
 #include "util/geojson_debug_logger.hpp"
 #include "util/geojson_debug_policies.hpp"
 #include "util/json_container.hpp"
@@ -128,6 +130,9 @@ auto getGraphBisection(const PartitionerConfig &config)
 
 int Partitioner::Run(const PartitionerConfig &config)
 {
+    tbb::task_scheduler_init init(config.requested_num_threads);
+    BOOST_ASSERT(init.is_active());
+
     const std::vector<BisectionID> &node_based_partition_ids = getGraphBisection(config);
 
     // Up until now we worked on the compressed node based graph.

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -187,8 +187,6 @@ int main(int argc, char *argv[]) try
     util::Log() << "Input file: " << contractor_config.base_path.string() << ".osrm";
     util::Log() << "Threads: " << contractor_config.requested_num_threads;
 
-    tbb::task_scheduler_init init(contractor_config.requested_num_threads);
-
     osrm::contract(contractor_config);
 
     util::DumpSTXXLStats();

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -166,8 +166,6 @@ int main(int argc, char *argv[]) try
         return EXIT_FAILURE;
     }
 
-    tbb::task_scheduler_init init(customization_config.requested_num_threads);
-
     auto exitcode = customizer::Customizer().Run(customization_config);
 
     util::DumpMemoryStats();

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -10,7 +10,6 @@
 #include <tbb/task_scheduler_init.h>
 
 #include <boost/algorithm/string/join.hpp>
-#include <boost/assert.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/range/adaptor/transformed.hpp>
@@ -235,8 +234,6 @@ int main(int argc, char *argv[]) try
         return EXIT_FAILURE;
     }
 
-    tbb::task_scheduler_init init(partition_config.requested_num_threads);
-    BOOST_ASSERT(init.is_active());
     util::Log() << "Computing recursive bisection";
 
     TIMER_START(bisect);


### PR DESCRIPTION
# Issue

Make entry points of individual pipeline stages responsible for configuring the task scheduler with requested number of threads passed in corresponding configuration bundle (ie. follow extractor).

This clears up the general pattern of task scheduler responsibility between core implementation (library) and tools (client).

## Tasklist

 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch
