### PR TITLE
Remove maneuverSucceededBySuppressedDirection collapsing scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
   - Changes from 5.15.1:
     - Guidance
+      - CHANGED #4854: Removed maneuverSucceededBySuppressedDirection collapsing scenario
       - CHANGED #4830: Announce reference change if names are empty
       - CHANGED #4835: MAXIMAL_ALLOWED_SEPARATION_WIDTH increased to 12 meters
     - Profile:

--- a/features/guidance/turn-angles.feature
+++ b/features/guidance/turn-angles.feature
@@ -1221,7 +1221,7 @@ Feature: Simple Turns
             | a,c       | rose,trift,trift  | depart,turn slight left,arrive  |
             | a,k       | rose,muhle,muhle  | depart,turn slight right,arrive |
             | d,f       | trift,rose        | depart,arrive                   |
-            | d,k       | trift,muhle,muhle | depart,turn sharp left,arrive   |
+            | d,k       | trift,muhle,muhle | depart,turn left,arrive         |
             | d,c       | trift,trift,trift | depart,continue uturn,arrive    |
 
     #http://www.openstreetmap.org/#map=19/52.50740/13.44824

--- a/src/engine/guidance/collapse_scenario_detection.cpp
+++ b/src/engine/guidance/collapse_scenario_detection.cpp
@@ -346,28 +346,6 @@ bool maneuverSucceededByNameChange(const RouteStepIterator step_entering_interse
            followed_by_name_change && is_maneuver;
 }
 
-bool maneuverSucceededBySuppressedDirection(const RouteStepIterator step_entering_intersection,
-                                            const RouteStepIterator step_leaving_intersection)
-{
-    if (!basicCollapsePreconditions(step_entering_intersection, step_leaving_intersection))
-        return false;
-
-    const auto short_and_undisturbed = isShortAndUndisturbed(*step_entering_intersection);
-
-    const auto followed_by_suppressed_direction =
-        hasTurnType(*step_leaving_intersection, TurnType::Suppressed) &&
-        !hasModifier(*step_leaving_intersection, DirectionModifier::Straight);
-
-    const auto is_maneuver = hasTurnType(*step_entering_intersection) &&
-                             !hasTurnType(*step_entering_intersection, TurnType::Suppressed);
-
-    const auto keeps_direction =
-        areSameSide(*step_entering_intersection, *step_leaving_intersection);
-
-    return short_and_undisturbed && followed_by_suppressed_direction && is_maneuver &&
-           keeps_direction;
-}
-
 bool nameChangeImmediatelyAfterSuppressed(const RouteStepIterator step_entering_intersection,
                                           const RouteStepIterator step_leaving_intersection)
 {

--- a/src/engine/guidance/collapse_turns.cpp
+++ b/src/engine/guidance/collapse_turns.cpp
@@ -410,7 +410,6 @@ RouteSteps collapseTurnInstructions(RouteSteps steps)
         }
         else if (maneuverSucceededByNameChange(current_step, next_step) ||
                  nameChangeImmediatelyAfterSuppressed(current_step, next_step) ||
-                 maneuverSucceededBySuppressedDirection(current_step, next_step) ||
                  closeChoicelessTurnAfterTurn(current_step, next_step))
         {
             combineRouteSteps(*current_step,


### PR DESCRIPTION
# Issue

In some cases `maneuverSucceededBySuppressedDirection` scenario collapses incorrectly instructions. Compare 
http://map.project-osrm.org/?z=18&center=47.503176%2C-122.324824&loc=47.502772%2C-122.324583&loc=47.503569%2C-122.324352&hl=en&alt=0
![screenshot from 2018-02-05 16-52-14](https://user-images.githubusercontent.com/4421046/35813878-037fa0d0-0a95-11e8-8df7-c198868334c9.png)

and
![screenshot from 2018-02-05 16-53-21](https://user-images.githubusercontent.com/4421046/35813914-1a9a3d2a-0a95-11e8-8444-e58407ac0634.png)
 http://map.project-osrm.org/?z=18&center=47.502364%2C-122.326718&loc=47.502874%2C-122.323628&loc=47.503569%2C-122.324352&hl=en&alt=0

The difference between two cases is only in segment lengths: the left segment is ~ 25 meters and the right segment is ~ 32 meters with the threshold `MAX_COLLAPSE_DISTANCE`.

Removing the scenario fixes the issue and does not introduce significant regressions in feature tests.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
