### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Pre-process the extract with the car profile and start a routing engine HTTP ser
 
     docker run -t -v $(pwd):/data osrm/osrm-backend osrm-extract -p /opt/car.lua /data/berlin-latest.osm.pbf
 
-The flag `-v $(pwd):/data` creates the directory `/data` inside the docker container, and makes the current working directory `$(pwd)` available there. The file `/data/berlin-latest.osm.pbf` inside the container is referring to `berlin-latest.osm.pbf` on the host.
+The flag `-v $(pwd):/data` creates the directory `/data` inside the docker container and makes the current working directory `$(pwd)` available there. The file `/data/berlin-latest.osm.pbf` inside the container is referring to `$(pwd)/berlin-latest.osm.pbf` on the host.
 
     docker run -t -v $(pwd):/data osrm/osrm-backend osrm-partition /data/berlin-latest.osrm
     docker run -t -v $(pwd):/data osrm/osrm-backend osrm-customize /data/berlin-latest.osrm


### PR DESCRIPTION
This PR makes the path of host `.osm.pbf` file clearer.
Also, I was thinking if we could clarify the line `and makes the current working directory $(pwd) available there`. If behind the scene it is using symlink, we should make it clear.
