### PR TITLE
Expose waypoints parameter in match interface

### DIFF
--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -145,6 +145,8 @@ inline InternalRouteResult CollapseInternalRouteResult(const InternalRouteResult
             BOOST_ASSERT(!collapsed.segment_end_coordinates.empty());
             collapsed.segment_end_coordinates.back().target_phantom =
                 leggy_result.segment_end_coordinates[i].target_phantom;
+            collapsed.target_traversed_in_reverse.back() =
+                leggy_result.target_traversed_in_reverse[i];
             // copy path segments into current leg
             last_segment.insert(last_segment.end(),
                                 leggy_result.unpacked_path_segments[i].begin(),

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -1267,14 +1267,10 @@ argumentsToMatchParameter(const Nan::FunctionCallbackInfo<v8::Value> &args,
             const auto index = Nan::To<std::uint32_t>(waypoint_value).FromJust();
             if (index >= coords_size)
             {
-                std::cout << "index " << index << std::endl;
-                std::cout << "coords_size " << coords_size << std::endl;
                 Nan::ThrowError("Waypoints must correspond with the index of an input coordinate");
                 return match_parameters_ptr();
             }
             params->waypoints.emplace_back(static_cast<unsigned>(waypoint_value->NumberValue()));
-            std::cout << "waypoints params size " << params->waypoints.size() << std::endl;
-            std::cout << "waypoints params capacity " << params->waypoints.capacity() << std::endl;
         }
     }
 

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -1269,8 +1269,7 @@ argumentsToMatchParameter(const Nan::FunctionCallbackInfo<v8::Value> &args,
             {
                 std::cout << "index " << index << std::endl;
                 std::cout << "coords_size " << coords_size << std::endl;
-                Nan::ThrowError(
-                    "Waypoints must correspond with the index of an input coordinate");
+                Nan::ThrowError("Waypoints must correspond with the index of an input coordinate");
                 return match_parameters_ptr();
             }
             params->waypoints.emplace_back(static_cast<unsigned>(waypoint_value->NumberValue()));

--- a/test/nodejs/match.js
+++ b/test/nodejs/match.js
@@ -239,8 +239,72 @@ test('match: match in Monaco without motorways', function(assert) {
     });
 });
 
+test('match: throws on invalid waypoints values needs at least two', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates,
+        waypoints: [0]
+    };
+    assert.throws(function() { osrm.match(options, function(err, response) {}); },
+        'At least two waypoints must be provided');
+});
+
+test('match: throws on invalid waypoints values, needs first and last coordinate indices', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates,
+        waypoints: [1, 2]
+    };
+    assert.throws(function() { osrm.match(options, function(err, response) {console.log(err);}); },
+        'First and last waypoints values must correspond to first and last coordinate indices');
+});
+
+test('match: throws on invalid waypoints values, order matters', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates,
+        waypoints: [2, 0]
+    };
+    assert.throws(function() { osrm.match(options, function(err, response) {console.log(err);}); },
+        'First and last waypoints values must correspond to first and last coordinate indices');
+});
+
+test('match: throws on invalid waypoints values, waypoints must correspond with a coordinate index', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates,
+        waypoints: [0, 3, 2]
+    };
+    assert.throws(function() { osrm.match(options, function(err, response) {console.log(err);}); },
+        'Waypoints must correspond with the index of an input coordinate');
+});
+
+test('match: error on split trace', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var four_coords = Array.from(three_test_coordinates);
+    four_coords.push([7.41902,43.73487]);
+    var options = {
+        steps: true,
+        coordinates: four_coords,
+        timestamps: [1700, 1750, 1424684616, 1424684620],
+        waypoints: [0,3]
+    };
+    osrm.match(options, function(err, response) {
+        assert.ok(err, 'Errors with NoMatch');
+    });
+});
+
 test('match: match in Monaco with waypoints', function(assert) {
-    assert.plan(5);
+    assert.plan(6);
     var osrm = new OSRM(data_path);
     var options = {
         steps: true,
@@ -249,8 +313,8 @@ test('match: match in Monaco with waypoints', function(assert) {
     };
     osrm.match(options, function(err, response) {
         assert.ifError(err);
-        console.log(JSON.stringify(response, null, 4));
         assert.equal(response.matchings.length, 1);
+        assert.equal(response.matchings[0].legs.length, 1);
         assert.ok(response.matchings.every(function(m) {
             return !!m.distance && !!m.duration && Array.isArray(m.legs) && !!m.geometry && m.confidence > 0;
         }))
@@ -260,4 +324,3 @@ test('match: match in Monaco with waypoints', function(assert) {
         }));
     });
 });
-

--- a/test/nodejs/match.js
+++ b/test/nodejs/match.js
@@ -238,3 +238,26 @@ test('match: match in Monaco without motorways', function(assert) {
         assert.equal(response.matchings.length, 1);
     });
 });
+
+test('match: match in Monaco with waypoints', function(assert) {
+    assert.plan(5);
+    var osrm = new OSRM(data_path);
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates,
+        waypoints: [0,2]
+    };
+    osrm.match(options, function(err, response) {
+        assert.ifError(err);
+        console.log(JSON.stringify(response, null, 4));
+        assert.equal(response.matchings.length, 1);
+        assert.ok(response.matchings.every(function(m) {
+            return !!m.distance && !!m.duration && Array.isArray(m.legs) && !!m.geometry && m.confidence > 0;
+        }))
+        assert.equal(response.tracepoints.length, 3);
+        assert.ok(response.tracepoints.every(function(t) {
+            return !!t.hint && !isNaN(t.matchings_index) && !isNaN(t.waypoint_index) && !!t.name;
+        }));
+    });
+});
+


### PR DESCRIPTION
# Issue
I implemented leg collapsing in the match plugin's response generation for the libosrm interface but forgot to expose it in the nodejs bindings. Here it is!

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
5.15.2
