### PR TITLE
Add OSM node barrier=height_restrictor handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)
-      - FIXED: #4763: Add support for non-numerical units in car profile for maxheight [#4763](https://github.com/Project-OSRM/osrm-backend/issues/4763)
+      - FIXED #4763: Add support for non-numerical units in car profile for maxheight [#4763](https://github.com/Project-OSRM/osrm-backend/issues/4763)
+      - ADDED #4872: Handling of `barrier=height_restrictor` nodes [#4872](https://github.com/Project-OSRM/osrm-backend/pull/4872)
 
 # 5.15.1
   - Changes from 5.15.0:

--- a/features/car/barrier.feature
+++ b/features/car/barrier.feature
@@ -45,3 +45,11 @@ Feature: Car - Barriers
             | bollard      |               |       |
             | bollard      | rising        | x     |
             | bollard      | removable     |       |
+
+    Scenario: Car - Height restrictions
+        Then routability should be
+            | node/barrier      | node/maxheight | bothw |
+            | height_restrictor |                | x     |
+            | height_restrictor |              1 |       |
+            | height_restrictor |              3 | x     |
+            | height_restrictor |        default | x     |

--- a/features/options/extract/lua.feature
+++ b/features/options/extract/lua.feature
@@ -129,8 +129,12 @@ Feature: osrm-extract lua ways:get_nodes()
         """
         functions = require('testbot')
 
+        functions.process_node = function(profile, node, result, relations)
+           print ('node ' .. tostring(node:get_location_tag('answer')))
+        end
+
         functions.process_way = function(profile, way, result, relations)
-           print ('answer ' .. tostring(way:get_location_tag('answer')))
+           print ('way ' .. tostring(way:get_location_tag('answer')))
            result.forward_mode = mode.driving
            result.forward_speed = 1
         end
@@ -148,4 +152,5 @@ Feature: osrm-extract lua ways:get_nodes()
 
         When I run "osrm-extract --profile {profile_file} {osm_file} --location-dependent-data test/data/regions/null-island.geojson"
         Then it should exit successfully
-        And stdout should contain "answer 42"
+        And stdout should contain "node 42"
+        And stdout should contain "way 42"

--- a/profiles/lib/measure.lua
+++ b/profiles/lib/measure.lua
@@ -62,11 +62,11 @@ local height_non_numerical_values = Set { "default", "none", "no-sign", "unsigne
 
 --- Get maxheight of specified way in meters. If there are no
 --- max height, then return nil
-function Measure.get_max_height(raw_value,way)
+function Measure.get_max_height(raw_value, element)
   if raw_value then
     if height_non_numerical_values[raw_value] then
-      if way then
-        return way:get_location_tag('maxheight') or default_maxheight
+      if element then
+        return element:get_location_tag('maxheight') or default_maxheight
       else
         return default_maxheight
       end

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -218,6 +218,22 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                  "valid",
                                                  &osmium::Location::valid);
 
+    auto get_location_tag = [](auto &context, const auto &location, const char *key) {
+        if (context.location_dependent_data.empty())
+            return sol::object(sol::nil);
+
+        const LocationDependentData::point_t point{location.lon(), location.lat()};
+        if (!boost::geometry::equals(context.last_location_point, point))
+        {
+            context.last_location_point = point;
+            context.last_location_indexes =
+                context.location_dependent_data.GetPropertyIndexes(point);
+        }
+
+        auto value = context.location_dependent_data.FindByKey(context.last_location_indexes, key);
+        return boost::apply_visitor(to_lua_object(context.state), value);
+    };
+
     context.state.new_usertype<osmium::Way>(
         "Way",
         "get_value_by_key",
@@ -229,37 +245,29 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "get_nodes",
         [](const osmium::Way &way) { return sol::as_table(way.nodes()); },
         "get_location_tag",
-        [&context](const osmium::Way &way, const char *key) {
-            if (context.location_dependent_data.empty())
-                return sol::object(sol::nil);
+        [&context, &get_location_tag](const osmium::Way &way, const char *key) {
             // HEURISTIC: use a single node (last) of the way to localize the way
             // For more complicated scenarios a proper merging of multiple tags
             // at one or many locations must be provided
             const auto &nodes = way.nodes();
             const auto &location = nodes.back().location();
-            const LocationDependentData::point_t point{location.lon(), location.lat()};
-
-            if (!boost::geometry::equals(context.last_location_point, point))
-            {
-                context.last_location_point = point;
-                context.last_location_indexes =
-                    context.location_dependent_data.GetPropertyIndexes(point);
-            }
-
-            auto value =
-                context.location_dependent_data.FindByKey(context.last_location_indexes, key);
-            return boost::apply_visitor(to_lua_object(context.state), value);
+            return get_location_tag(context, location, key);
         });
 
-    context.state.new_usertype<osmium::Node>("Node",
-                                             "location",
-                                             &osmium::Node::location,
-                                             "get_value_by_key",
-                                             &get_value_by_key<osmium::Node>,
-                                             "id",
-                                             &osmium::Node::id,
-                                             "version",
-                                             &osmium::Node::version);
+    context.state.new_usertype<osmium::Node>(
+        "Node",
+        "location",
+        &osmium::Node::location,
+        "get_value_by_key",
+        &get_value_by_key<osmium::Node>,
+        "id",
+        &osmium::Node::id,
+        "version",
+        &osmium::Node::version,
+        "get_location_tag",
+        [&context, &get_location_tag](const osmium::Node &node, const char *key) {
+            return get_location_tag(context, node.location(), key);
+        });
 
     context.state.new_usertype<ExtractionNode>("ResultNode",
                                                "traffic_lights",

--- a/taginfo.json
+++ b/taginfo.json
@@ -139,6 +139,7 @@
         {"key": "access", "value": "emergency"},
         {"key": "access", "value": "psv"},
         {"key": "access", "value": "delivery"},
+        {"key": "maxheight", "object_types": ["node", "way"]},
         {"key": "maxspeed", "value": "none"},
         {"key": "maxspeed", "value": "urban"},
         {"key": "maxspeed", "value": "rural"},


### PR DESCRIPTION
# Issue

Nodes with `barrier=height_restrictor` tags are not handled in `car.lua` profile, for example, [a barrier node](https://www.openstreetmap.org/node/2733546066) leads  to a detour with misleading instructions:
![screenshot from 2018-02-12 09-03-54](https://user-images.githubusercontent.com/4421046/36087703-07e86f50-0fd4-11e8-9aca-c0700279e568.png)
http://map.project-osrm.org/?z=17&center=48.075609%2C11.099442&loc=48.074136%2C11.092565&loc=48.075369%2C11.102929&hl=en&alt=0

PR adds `height_restrictor` tag to `barrier_whitelist` and a check of `maxheight` tag in `process_node` function. Also PR adds `get_location_tag` method to the `osmium::Node` interface.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
