### PR TITLE
Use links with lower priority in the motorway handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - ADDED #4676: Support for maneuver override relation, allowing data-driven overrides for turn-by-turn instructions [#4676](https://github.com/Project-OSRM/osrm-backend/pull/4676)
       - CHANGED #4830: Announce reference change if names are empty
       - CHANGED #4835: MAXIMAL_ALLOWED_SEPARATION_WIDTH increased to 12 meters
+      - CHANGED #4842: Lower priority links from a motorway now are used as motorway links [#4842](https://github.com/Project-OSRM/osrm-backend/pull/4842)
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -81,7 +81,7 @@ Feature: Motorway Guidance
             """
                  ,g,e
                ,f,d
-            a-b-c 
+            a-b-c
             """
 
         And the ways
@@ -281,3 +281,21 @@ Feature: Motorway Guidance
             | waypoints | route | turns         |
             | a,d       | ,     | depart,arrive |
             | b,d       | ,     | depart,arrive |
+
+
+    Scenario: Ramp Exit with Lower Priority
+        Given the node map
+            """
+            a-b-c-d-e
+               `--f-g
+            """
+
+        And the ways
+            | nodes | highway      | oneway |
+            | abcde | trunk        |        |
+            | bfg   | primary_link | yes    |
+
+       When I route I should get
+            | waypoints | route         | turns                               |
+            | a,e       | abcde,abcde   | depart,arrive                       |
+            | a,g       | abcde,bfg,bfg | depart,off ramp slight right,arrive |

--- a/src/guidance/motorway_handler.cpp
+++ b/src/guidance/motorway_handler.cpp
@@ -31,9 +31,13 @@ inline extractor::RoadClassification roadClass(const ConnectedRoad &road,
     return graph.GetEdgeData(road.eid).flags.road_classification;
 }
 
-inline bool isRampClass(EdgeID eid, const util::NodeBasedDynamicGraph &node_based_graph)
+inline bool isRampClass(EdgeID eid,
+                        const util::NodeBasedDynamicGraph &node_based_graph,
+                        bool from_motorway = true)
 {
-    return node_based_graph.GetEdgeData(eid).flags.road_classification.IsRampClass();
+    return node_based_graph.GetEdgeData(eid).flags.road_classification.IsRampClass() ||
+           (from_motorway &&
+            node_based_graph.GetEdgeData(eid).flags.road_classification.IsLinkClass());
 }
 
 } // namespace
@@ -63,6 +67,8 @@ bool MotorwayHandler::canProcess(const NodeID,
                                  const EdgeID via_eid,
                                  const Intersection &intersection) const
 {
+    const bool from_motorway = isMotorwayClass(via_eid, node_based_graph);
+
     bool has_motorway = false;
     bool has_normal_roads = false;
 
@@ -76,14 +82,14 @@ bool MotorwayHandler::canProcess(const NodeID,
             if (road.entry_allowed)
                 has_motorway = true;
         }
-        else if (!isRampClass(road.eid, node_based_graph))
+        else if (!isRampClass(road.eid, node_based_graph, from_motorway))
             has_normal_roads = true;
     }
 
     if (has_normal_roads)
         return false;
 
-    return has_motorway || isMotorwayClass(via_eid, node_based_graph);
+    return has_motorway || from_motorway;
 }
 
 Intersection MotorwayHandler::


### PR DESCRIPTION
# Issue

Fixes the second scenario of #4842: going from a motorway a lower priority link will be used as a motorway link
![screenshot from 2018-02-12 17-28-02](https://user-images.githubusercontent.com/4421046/36107385-1d89ff7c-101a-11e8-9c3a-023a91bd3594.png)



## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

https://wiki.openstreetmap.org/wiki/Highway_link
https://wiki.openstreetmap.org/wiki/Link_roads_between_different_highways_types


 Link any requirements here. Other pull requests this PR is based on?
