### PR TITLE
Ignore CMakeSettings.json for CMake integration with VS2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ Thumbs.db
 ######################################
 /.vs*
 /*.local.bat
+/CMakeSettings.json
 
 # stxxl related files #
 #######################


### PR DESCRIPTION
CMakeSettings.json is an auxiliary file used to customize [CMake configuration while building from within VS2017](https://go.microsoft.com//fwlink//?linkid=834763).
