### PR TITLE
[msvc] Fix quoting of OSRM_PROJECT_DIR as preprocessor define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,11 @@ set(OSRM_VERSION_MINOR 16)
 set(OSRM_VERSION_PATCH 0)
 set(OSRM_VERSION "${OSRM_VERSION_MAJOR}.${OSRM_VERSION_MINOR}.${OSRM_VERSION_PATCH}")
 
-add_definitions(-DOSRM_PROJECT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+if (MSVC)
+  add_definitions("-DOSRM_PROJECT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
+else()
+  add_definitions(-DOSRM_PROJECT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
 
 # these two functions build up custom variables:
 #   DEPENDENCIES_INCLUDE_DIRS and OSRM_DEFINES


### PR DESCRIPTION
It looks MSVC still special handling, no quotoing as well as
additional quoting like `add_definitions(-DFOO="\\"foo\\"")`
as per https://cmake.org/pipermail/cmake/2007-June/014611.html
does not seem to handle CMake variables correctly.

This Visual C++ specific fix is based on this solution
https://cmake.org/pipermail/cmake/2006-September/011292.html

## Example

The define generated for `CL.EXE` command line is quoted as this `/D "OSRM_PROJECT_DIR=\"D:/osrm-backend\""`

## Tasklist

 - [x] review
 - [x] adjust for comments
 - [x] cherry pick to release branch
