### PR TITLE
Prefer logical punctuators instead of named operator keywords

### DIFF
--- a/include/engine/base64.hpp
+++ b/include/engine/base64.hpp
@@ -87,7 +87,7 @@ inline std::string encodeBase64(const std::string &x) { return encodeBase64(x.da
 // Encode any sufficiently trivial object to Base64.
 template <typename T> std::string encodeBase64Bytewise(const T &x)
 {
-#if not defined __GNUC__ or __GNUC__ > 4
+#if !defined(__GNUC__) || (__GNUC__ > 4)
     static_assert(std::is_trivially_copyable<T>::value, "requires a trivially copyable type");
 #endif
 
@@ -124,7 +124,7 @@ inline std::string decodeBase64(const std::string &encoded)
 // Decodes from Base 64 to any sufficiently trivial object.
 template <typename T> T decodeBase64Bytewise(const std::string &encoded)
 {
-#if not defined __GNUC__ or __GNUC__ > 4
+#if !defined(__GNUC__) || (__GNUC__ > 4)
     static_assert(std::is_trivially_copyable<T>::value, "requires a trivially copyable type");
 #endif
 

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -96,7 +96,7 @@ class FileReader
     /* Read count objects of type T into pointer dest */
     template <typename T> void ReadInto(T *dest, const std::size_t count)
     {
-#if not defined __GNUC__ or __GNUC__ > 4
+#if !defined(__GNUC__) || (__GNUC__ > 4)
         static_assert(!std::is_pointer<T>::value, "saving pointer types is not allowed");
         static_assert(std::is_trivially_copyable<T>::value,
                       "bytewise reading requires trivially copyable type");
@@ -214,7 +214,7 @@ class FileWriter
     /* Write count objects of type T from pointer src to output stream */
     template <typename T> void WriteFrom(const T *src, const std::size_t count)
     {
-#if not defined __GNUC__ or __GNUC__ > 4
+#if !defined(__GNUC__) || (__GNUC__ > 4)
         static_assert(std::is_trivially_copyable<T>::value,
                       "bytewise writing requires trivially copyable type");
 #endif

--- a/include/util/guidance/entry_class.hpp
+++ b/include/util/guidance/entry_class.hpp
@@ -64,7 +64,7 @@ class EntryClass
     friend std::size_t std::hash<EntryClass>::operator()(const EntryClass &) const;
 };
 
-#if not defined __GNUC__ or __GNUC__ > 4
+#if !defined(__GNUC__) || (__GNUC__ > 4)
 static_assert(std::is_trivially_copyable<EntryClass>::value,
               "Class is serialized trivially in "
               "the datafacades. Bytewise writing "


### PR DESCRIPTION
Some compilers (eg. MSVC) still require inclusion of `<ciso646>` in order to import named operator keywords.
It is easier to stick with traditional punctuators.

## Tasklist

 - [x] review
 - [x] adjust for comments
