### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,11 @@
     "xmlbuilder": "^4.2.1"
   },
   "bundleDependencies": [
+    "mkdirp",
     "nan",
     "node-cmake",
-    "node-pre-gyp"
+    "node-pre-gyp",
+    "rimraf"
   ],
   "main": "lib/index.js",
   "binary": {


### PR DESCRIPTION
When releasing OSRM 5.16 we ran into troubles with npm and node 4.

Copy-pasting trouble-shoot per chat:
```
when running npm install we ran into the problem of Error: Cannot find module 'nopt'

I ran yarn install, before publishing but yarn is facebooky and fast and great and notices 
if we have the same modules multiple times. nopt is a modules that was used by several modules: 
node-pre-gyp and other modules too.

so:
yarn removes nopt from osrm/node_modules/node-pre-gyp/node_modules/nopt and
yarn removes nopt from osrm/node_modules/other_modules_xyz/node_modules/nopt 
and just moves it to

osrm/node_modules/nopt

problem: When I npm publish, it still uses package.json which expects nopt to be here: 
osrm/node_modules/node-pre-gyp/node_modules/nopt but it isn’t, because yarn removed it 
and therefore leads to the error message

I am guessing this problem does not occur with node 8, because node 8 uses other 
node_modules folder hierarchies.
the fix maybe this one: Do not use yarn install before running npm publish
```

not using `yarn install` solved the problem for `nopt`, but `mkdirp` and `rimraf` encounter the same problems as described. 

My guess is that `mkdirp` and `rimraf` are devdependencies, therefore they will not be installed in `node_modules/node-pre-gyp/node_modules` which causes missing  modules when packing and publishing the node module.

This PR should fix this problem.