### PR TITLE
Handle motorway forks with links as normal motorway intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
       - CHANGED #4835: MAXIMAL_ALLOWED_SEPARATION_WIDTH increased to 12 meters
       - CHANGED #4842: Lower priority links from a motorway now are used as motorway links [#4842](https://github.com/Project-OSRM/osrm-backend/pull/4842)
       - CHANGED #4895: Use ramp bifurcations as fork intersections [#4895](https://github.com/Project-OSRM/osrm-backend/issues/4895)
+      - CHANGED #4893: Handle motorway forks with links as normal motorway intersections[#4893](https://github.com/Project-OSRM/osrm-backend/issues/4893)
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -341,7 +341,7 @@ Feature: Motorway Guidance
             | cd    | motorway_link |
 
        When I route I should get
-            | waypoints | route          | turns                           |
-            | a,d       | abce,cd,cd     | depart,turn straight,arrive     |
-            | a,e       | abce,abce,abce | depart,fork slight left,arrive  |
-            | a,f       | abce,cf,cf     | depart,fork slight right,arrive |
+            | waypoints | route      | turns                              |
+            | a,d       | abce,cd,cd | depart,off ramp slight left,arrive |
+            | a,e       | abce,abce  | depart,arrive                      |
+            | a,f       | abce,cf,cf | depart,turn slight right,arrive |

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -323,3 +323,25 @@ Feature: Motorway Guidance
             | a,c       | ,,    | depart,fork slight left,arrive                   |
             | a,e       | ,,,   | depart,fork slight right,fork slight left,arrive  |
             | a,f       | ,,,   | depart,fork slight right,fork slight right,arrive |
+
+
+    # https://www.openstreetmap.org/#map=19/53.46186/-2.24509
+    Scenario: Highway Fork with a Link
+        Given the node map
+            """
+                 /-----------d
+            a-b-c------------e
+                 \-----------f
+            """
+
+        And the ways
+            | nodes | highway       |
+            | abce  | motorway      |
+            | cf    | motorway      |
+            | cd    | motorway_link |
+
+       When I route I should get
+            | waypoints | route          | turns                           |
+            | a,d       | abce,cd,cd     | depart,turn straight,arrive     |
+            | a,e       | abce,abce,abce | depart,fork slight left,arrive  |
+            | a,f       | abce,cf,cf     | depart,fork slight right,arrive |


### PR DESCRIPTION
# Issue

If a motorway fork intersection has links the motorway handler can assign incorrect `Left` modifier
![screenshot from 2018-02-16 11-54-20](https://user-images.githubusercontent.com/4421046/36304530-4dfcb1c4-1310-11e8-9d3d-64f0df7d253d.png)
http://map.project-osrm.org/?z=18&center=53.461582%2C-2.244827&loc=53.461383%2C-2.245116&loc=53.462187%2C-2.245100&hl=en&alt=0

PR changes handling of motorway intersections to a case of a normal motorway passing some ramps if `exiting_motorways` is not equal to `valid_exits`.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
