### PR TITLE
Don't use obvious directions at ramp bifurcations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
       - CHANGED #4830: Announce reference change if names are empty
       - CHANGED #4835: MAXIMAL_ALLOWED_SEPARATION_WIDTH increased to 12 meters
       - CHANGED #4842: Lower priority links from a motorway now are used as motorway links [#4842](https://github.com/Project-OSRM/osrm-backend/pull/4842)
+      - CHANGED #4895: Use ramp bifurcations as fork intersections [#4895](https://github.com/Project-OSRM/osrm-backend/issues/4895)
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -321,5 +321,5 @@ Feature: Motorway Guidance
        When I route I should get
             | waypoints | route | turns                                            |
             | a,c       | ,,    | depart,fork slight left,arrive                   |
-            | a,e       | ,,,   | depart,fork slight right,turn slight left,arrive |
-            | a,f       | ,,    | depart,fork slight right,arrive                  |
+            | a,e       | ,,,   | depart,fork slight right,fork slight left,arrive  |
+            | a,f       | ,,,   | depart,fork slight right,fork slight right,arrive |

--- a/features/guidance/motorway.feature
+++ b/features/guidance/motorway.feature
@@ -299,3 +299,27 @@ Feature: Motorway Guidance
             | waypoints | route         | turns                               |
             | a,e       | abcde,abcde   | depart,arrive                       |
             | a,g       | abcde,bfg,bfg | depart,off ramp slight right,arrive |
+
+
+    # https://www.openstreetmap.org/node/67366428#map=18/33.64613/-84.44425
+    Scenario: Ramp Bifurcations should not be suppressed
+        Given the node map
+            """
+                 /-----------c      /-----------e
+            a---b------------------d------------f
+            """
+
+        And the ways
+            | nodes | highway       | name | destination                                         |
+            | ab    | motorway      |      |                                                     |
+            | bc    | motorway_link |      | City 17                                             |
+            | bd    | motorway_link |      |                                                     |
+            | de    | motorway_link |      | Domestic Terminal;Camp Creek Parkway;Riverdale Road |
+            | df    | motorway_link |      | Montgomery                                          |
+
+
+       When I route I should get
+            | waypoints | route | turns                                            |
+            | a,c       | ,,    | depart,fork slight left,arrive                   |
+            | a,e       | ,,,   | depart,fork slight right,turn slight left,arrive |
+            | a,f       | ,,    | depart,fork slight right,arrive                  |

--- a/src/guidance/turn_handler.cpp
+++ b/src/guidance/turn_handler.cpp
@@ -249,8 +249,13 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
                OOOOOOO
      */
 
+    const auto all_ramps =
+        std::all_of(intersection.begin(), intersection.end(), [this](const auto &road) {
+            return node_based_graph.GetEdgeData(road.eid).flags.road_classification.IsRampClass();
+        });
+
     auto fork = findFork(via_edge, intersection);
-    if (fork && obvious_index == 0)
+    if (fork && (all_ramps || obvious_index == 0))
     {
         assignFork(via_edge, fork->getLeft(), fork->getRight());
     }


### PR DESCRIPTION
# Issue

Fixes #4895 as
![screenshot from 2018-02-19 12-00-50](https://user-images.githubusercontent.com/4421046/36374710-9cdec026-156c-11e8-9f68-4898d1b2e19c.png)

"before-after" comparison in SF-area http://bl.ocks.org/d/1f6b51ce1cafff2463d913cd05d40f73 

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
