### PR TITLE
Check required tags of `maneuver` relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
       - CHANGED #4842: Lower priority links from a motorway now are used as motorway links [#4842](https://github.com/Project-OSRM/osrm-backend/pull/4842)
       - CHANGED #4895: Use ramp bifurcations as fork intersections [#4895](https://github.com/Project-OSRM/osrm-backend/issues/4895)
       - CHANGED #4893: Handle motorway forks with links as normal motorway intersections[#4893](https://github.com/Project-OSRM/osrm-backend/issues/4893)
+      - FIXED #4905: Check required tags of `maneuver` relations [#4905](https://github.com/Project-OSRM/osrm-backend/pull/4905)
     - Profile:
       - FIXED: `highway=service` will now be used for restricted access, `access=private` is still disabled for snapping.
       - ADDED #4775: Exposes more information to the turn function, now being able to set turn weights with highway and access information of the turn as well as other roads at the intersection [#4775](https://github.com/Project-OSRM/osrm-backend/issues/4775)

--- a/features/guidance/maneuver-tag.feature
+++ b/features/guidance/maneuver-tag.feature
@@ -30,7 +30,7 @@ Feature: Maneuver tag support
 
         When I route I should get
             | waypoints | route                               | turns                                    |
-        # Testing directly connected from/to 
+        # Testing directly connected from/to
             | a,j       | A Street,C Street,J Street,J Street | depart,turn sharp right,turn left,arrive |
             | b,g       | A Street,C Street,C Street          | depart,turn sharp right,arrive           |
         # Testing re-awakening suppressed turns
@@ -198,11 +198,26 @@ Feature: Maneuver tag support
             | pt    | 395     | no     | primary       |
 
         And the relations
-            | type     | way:from | node:via | way:via | way:to | maneuver  |
-            | maneuver | zy       | p        | yp      | pt     | suppress  |
+            | type     | way:from | node:via | way:via | way:to | maneuver | #                                                     |
+            | maneuver | zy       | p        | yp      | pt     | suppress | original: depart,on ramp left,fork slight left,arrive |
+
+        And the relations
+            | type     | way:from | way:via | way:to | maneuver | #                                  |
+            | maneuver | zy       | yp      | pb     | suppress | invalid relation: missing node:via |
+
+        And the relations
+            | type     | node:via | way:via | way:to | maneuver | #                                  |
+            | maneuver | p        | yp      | pb     | suppress | invalid relation: missing way:from |
+
+        And the relations
+            | type     | way:from | node:via | way:via | maneuver | #                                |
+            | maneuver | zy       | p        | yp      | suppress | invalid relation: missing way:to |
+
+        And the relations
+            | type     | way:from | node:via | way:via | way:to | maneuver | #                                   |
+            | maneuver | zy       | y, p     | yp      | pb     | suppress | invalid relation: multiple node:via |
 
         When I route I should get
-            | waypoints | route           | turns                      |
-            | z,t       | NY Ave,395,395  | depart,on ramp left,arrive |
-  #original | z,t       | NY Ave,,395,395 | depart,on ramp left,fork slight left,arrive |
-
+            | waypoints | route                 | turns                                        |
+            | z,t       | NY Ave,395,395        | depart,on ramp left,arrive                   |
+            | z,b       | NY Ave,,4th St,4th St | depart,on ramp left,fork slight right,arrive |


### PR DESCRIPTION
# Issue

Accordingly to https://github.com/Project-OSRM/osrm-backend/wiki/Maneuver-override-tag ways `from`, `to` and node `via` roles are required in relations with `type=maneuver`.

PR adds an additional check for `via_node` ids to  filter out invalid `maneuver` relations.

/cc @karenzshea @TheMarex 

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
