### PR TITLE
Fixed the order of lon/lat in osrm.route() example

### DIFF
--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -61,7 +61,7 @@ Returns the fastest route between two or more coordinates while visiting the way
 
 ```javascript
 var osrm = new OSRM("berlin-latest.osrm");
-osrm.route({coordinates: [[52.519930,13.438640], [52.513191,13.415852]]}, function(err, result) {
+osrm.route({coordinates: [[13.438640,52.519930], [13.415852,52.513191]]}, function(err, result) {
   if(err) throw err;
   console.log(result.waypoints); // array of Waypoint objects representing all waypoints in order
   console.log(result.routes); // array of Route objects ordered by descending recommendation rank


### PR DESCRIPTION
# Issue

I just changed the order of the latitude / longitude pair in the NodeJS example for the osrm.route() call. 

I think this is such a minor change, that's not worth opening an issue for. But it led me the wrong way for quite some time while programming.
