### PR TITLE
Remove deduplication of unpacked_path_segments in MM collapsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNRELEASED
   - Changes from 5.16.0:
+    - Bugfixes: fix deduplication of route steps when waypoints are used [#4909](https://github.com/Project-OSRM/osrm-backend/issues/4909)
 
 # 5.16.0
   - Changes from 5.15.2:

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -627,6 +627,8 @@ Feature: Basic Map Matching
         | abbecd   | 10 11 27 1516914902 1516914913 1516914952    | ab,ecd     | Ok   |
 
     Scenario: Regression test - waypoints trimming too much geometry
+        # fixes bug in map matching collapsing that was dropping path geometries
+        # after segments that had 0 distance in internal route results
         Given the node map
             """
             ad
@@ -651,3 +653,34 @@ Feature: Basic Map Matching
         When I match I should get
             | trace    | geometry                           | code |
             | defgh    | 1,1,1,0.999461,1.000674,0.999461   | Ok   |
+
+    @match @testbot
+    Scenario: Regression test - waypoints trimming too much geometry
+        Given the profile "testbot"
+        Given a grid size of 10 meters
+        Given the query options
+          | geometries | geojson |
+        Given the node map
+          """
+            bh
+             |
+             |
+             |
+             c
+             g\
+               \k
+                \
+                 \
+                  \
+                 j f
+          """
+        And the ways
+          | nodes |
+          | hc    |
+          | cf    |
+        Given the query options
+          | waypoints | 0;3  |
+          | overview  | full |
+        When I match I should get
+          | trace | geometry                                      | code |
+          | bgkj  | 1.000135,1,1.000135,0.99964,1.000387,0.999137 | Ok   |

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -626,3 +626,28 @@ Feature: Basic Map Matching
         | trace    | timestamps                                   | matchings  | code |
         | abbecd   | 10 11 27 1516914902 1516914913 1516914952    | ab,ecd     | Ok   |
 
+    Scenario: Regression test - waypoints trimming too much geometry
+        Given the node map
+            """
+            ad
+            |
+            |
+            |
+            |
+            |e   g
+            b--------------c
+            f              h
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+
+        Given the query options
+            | waypoints | 0;4   |
+            | overview  | full  |
+
+        When I match I should get
+            | trace    | geometry                           | code |
+            | defgh    | 1,1,1,0.999461,1.000674,0.999461   | Ok   |

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -139,11 +139,6 @@ inline InternalRouteResult CollapseInternalRouteResult(const InternalRouteResult
         {
             BOOST_ASSERT(!collapsed.unpacked_path_segments.empty());
             auto &last_segment = collapsed.unpacked_path_segments.back();
-            // deduplicate last segment (needs to be checked for empty for the same node query edge
-            // case)
-            if (!last_segment.empty())
-                last_segment.pop_back();
-            // update target phantom node of leg
             BOOST_ASSERT(!collapsed.segment_end_coordinates.empty());
             collapsed.segment_end_coordinates.back().target_phantom =
                 leggy_result.segment_end_coordinates[i].target_phantom;

--- a/unit_tests/engine/collapse_internal_route_result.cpp
+++ b/unit_tests/engine/collapse_internal_route_result.cpp
@@ -38,6 +38,10 @@ BOOST_AUTO_TEST_CASE(unchanged_collapse_route_result)
 
 BOOST_AUTO_TEST_CASE(two_legs_to_one_leg)
 {
+    // from_edge_based_node, turn_via_node, name_id, is_segregated, weight_until_turn,
+    // weight_of_turn,
+    // duration_until_turn, duration_of_turn, turn_instruction, lane_data, travel_mode, classes,
+    // entry_class, datasource_id, pre_turn_bearing, post_turn_bearing, left_hand
     PathData pathy{0, 2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
     PathData kathy{0, 1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
     PathData cathy{0, 3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
@@ -61,10 +65,11 @@ BOOST_AUTO_TEST_CASE(two_legs_to_one_leg)
     BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].target_phantom.forward_segment_id.id,
                       12);
     BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[0].source_phantom.forward_segment_id.id, 1);
-    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0].size(), 3);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0].size(), 4);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][0].turn_via_node, 2);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][1].turn_via_node, 1);
-    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][2].turn_via_node, 3);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][2].turn_via_node, 1);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][3].turn_via_node, 3);
 }
 
 BOOST_AUTO_TEST_CASE(three_legs_to_two_legs)
@@ -101,13 +106,14 @@ BOOST_AUTO_TEST_CASE(three_legs_to_two_legs)
     BOOST_CHECK_EQUAL(collapsed.segment_end_coordinates[1].target_phantom.forward_segment_id.id,
                       18);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0].size(), 2);
-    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1].size(), 4);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1].size(), 5);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][0].turn_via_node, 2);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[0][1].turn_via_node, 1);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][0].turn_via_node, 1);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][1].turn_via_node, 5);
     BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][2].turn_via_node, 3);
-    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][3].turn_via_node, 4);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][3].turn_via_node, 3);
+    BOOST_CHECK_EQUAL(collapsed.unpacked_path_segments[1][4].turn_via_node, 4);
 }
 
 BOOST_AUTO_TEST_CASE(two_legs_to_two_legs)


### PR DESCRIPTION
# Issue

Fixes the issue in indicated by https://github.com/Project-OSRM/osrm-backend/issues/4909
![image](https://user-images.githubusercontent.com/5521326/36594612-24711c66-189f-11e8-86b2-e5e56eaec4fd.png)

## Bug
Leg collapsing for some traces with high sample rates, resulted in dropped geometries like shown by the red line in the image above, particularly around corners.

## Root cause
The bug was caused by a mishandling of `unpacked_path_segments` collapsing. The scenario arose when two points in a trace were located on the same edge, resulting in a 0 length segment, which, because the leg collapsing was incorrectly removing the last `unpacked_path_segment` value from the previously last collapsed segment, would sometimes result in missing coordinates in the end result.

## Tasklist

 - [x] CHANGELOG.md entry
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

5.16 cc @chaupow 
