### PR TITLE
Backport 5.16 release fixes into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,6 +161,14 @@ matrix:
       after_success:
         - ./scripts/travis/publish.sh
 
+    - os: osx
+      osx_image: xcode9.2
+      compiler: "mason-osx-release-node-4"
+      # we use the xcode provides clang and don't install our own
+      env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="4"
+      after_success:
+        - ./scripts/travis/publish.sh
+
     # Shared Library
     - os: linux
       compiler: "gcc-7-release-shared"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # UNRELEASED
+
+# 5.16.0
   - Changes from 5.15.2:
     - Guidance
       - ADDED #4676: Support for maneuver override relation, allowing data-driven overrides for turn-by-turn instructions [#4676](https://github.com/Project-OSRM/osrm-backend/pull/4676)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osrm",
-  "version": "5.16.0-latest.1",
+  "version": "5.17.0-latest.1",
   "private": false,
   "description": "The Open Source Routing Machine is a high performance routing engine written in C++14 designed to run on OpenStreetMap data.",
   "dependencies": {


### PR DESCRIPTION
# Issue

Supercedes https://github.com/Project-OSRM/osrm-backend/pull/4912, resets the `master` branch version numbers/changelog, and backports some build fixes from the 5.16 release branch.