### PR TITLE
Get OSRM_VERSION_* fields from package.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
-# we depend on 2.8.11 introducing target_include_directories
+cmake_minimum_required(VERSION 3.1)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR AND NOT MSVC_IDE)
   message(FATAL_ERROR "In-source builds are not allowed.
@@ -59,10 +58,20 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 OLD)
 endif()
 project(OSRM C CXX)
-set(OSRM_VERSION_MAJOR 5)
-set(OSRM_VERSION_MINOR 16)
-set(OSRM_VERSION_PATCH 0)
-set(OSRM_VERSION "${OSRM_VERSION_MAJOR}.${OSRM_VERSION_MINOR}.${OSRM_VERSION_PATCH}")
+
+include(JSONParser)
+file(READ "package.json" packagejsonraw)
+sbeParseJson(packagejson packagejsonraw)
+
+if (packagejson.version MATCHES "^([0-9]+)\.([0-9]+)\.([0-9]+)")
+    set(OSRM_VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(OSRM_VERSION_MINOR ${CMAKE_MATCH_2})
+    set(OSRM_VERSION_PATCH ${CMAKE_MATCH_3})
+
+    set(OSRM_VERSION "${OSRM_VERSION_MAJOR}.${OSRM_VERSION_MINOR}.${OSRM_VERSION_PATCH}")
+else()
+    message(FATAL_ERROR "Version from package.json cannot be parsed, expected semver compatible X.Y.Z, but found ${packagejson.version}")
+endif()
 
 if (MSVC)
   add_definitions("-DOSRM_PROJECT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")

--- a/cmake/JSONParser.cmake
+++ b/cmake/JSONParser.cmake
@@ -1,0 +1,290 @@
+# https://github.com/sbellus/json-cmake/blob/9913da8800b95322d393894d3525d634568f305e/JSONParser.cmake
+# MIT Licensed - https://github.com/sbellus/json-cmake/blob/master/LICENSE
+
+cmake_minimum_required(VERSION 3.1)
+
+if (DEFINED JSonParserGuard)
+    return()
+endif()
+
+set(JSonParserGuard yes)
+
+macro(sbeParseJson prefix jsonString)
+    cmake_policy(PUSH)
+
+    set(json_string "${${jsonString}}")
+    string(LENGTH "${json_string}" json_jsonLen)
+    set(json_index 0)
+    set(json_AllVariables ${prefix})
+    set(json_ArrayNestingLevel 0)
+    set(json_MaxArrayNestingLevel 0)
+
+    _sbeParse(${prefix})
+    
+    unset(json_index)
+    unset(json_AllVariables)
+    unset(json_jsonLen)
+    unset(json_string)
+    unset(json_value)
+    unset(json_inValue)    
+    unset(json_name)
+    unset(json_inName)
+    unset(json_newPrefix)
+    unset(json_reservedWord)
+    unset(json_arrayIndex)
+    unset(json_char)
+    unset(json_end)
+    unset(json_ArrayNestingLevel)
+    foreach(json_nestingLevel RANGE ${json_MaxArrayNestingLevel})
+        unset(json_${json_nestingLevel}_arrayIndex)
+    endforeach()
+    unset(json_nestingLevel)
+    unset(json_MaxArrayNestingLevel)
+    
+    cmake_policy(POP)
+endmacro()
+
+macro(sbeClearJson prefix)
+    foreach(json_var ${${prefix}})
+        unset(${json_var})
+    endforeach()
+    
+    unset(${prefix})
+    unset(json_var)
+endmacro()
+
+macro(sbePrintJson prefix)
+    foreach(json_var ${${prefix}})
+        message("${json_var} = ${${json_var}}")
+    endforeach()
+endmacro()
+
+macro(_sbeParse prefix)
+
+    while(${json_index} LESS ${json_jsonLen})
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        
+        if("\"" STREQUAL "${json_char}")    
+            _sbeParseNameValue(${prefix})
+        elseif("{" STREQUAL "${json_char}")
+            _sbeMoveToNextNonEmptyCharacter()
+            _sbeParseObject(${prefix})
+        elseif("[" STREQUAL "${json_char}")
+            _sbeMoveToNextNonEmptyCharacter()
+            _sbeParseArray(${prefix})
+        endif()
+
+        if(${json_index} LESS ${json_jsonLen})
+            string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        else()
+            break()
+        endif()
+
+        if ("}" STREQUAL "${json_char}" OR "]" STREQUAL "${json_char}")
+            break()
+        endif()
+        
+        _sbeMoveToNextNonEmptyCharacter()
+    endwhile()    
+endmacro()
+
+macro(_sbeParseNameValue prefix)
+    set(json_name "")
+    set(json_inName no)
+
+    while(${json_index} LESS ${json_jsonLen})
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        
+        # check if name ends
+        if("\"" STREQUAL "${json_char}" AND json_inName)
+            set(json_inName no)
+            _sbeMoveToNextNonEmptyCharacter()
+            if(NOT ${json_index} LESS ${json_jsonLen})
+                break()
+            endif()                
+            string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+            set(json_newPrefix ${prefix}.${json_name})
+            set(json_name "")
+            
+            if(":" STREQUAL "${json_char}")
+                _sbeMoveToNextNonEmptyCharacter()
+                if(NOT ${json_index} LESS ${json_jsonLen})
+                    break()
+                endif()                
+                string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+
+                if("\"" STREQUAL "${json_char}")    
+                    _sbeParseValue(${json_newPrefix})
+                    break()
+                elseif("{" STREQUAL "${json_char}")
+                    _sbeMoveToNextNonEmptyCharacter()
+                    _sbeParseObject(${json_newPrefix})
+                    break()
+                elseif("[" STREQUAL "${json_char}")
+                    _sbeMoveToNextNonEmptyCharacter()
+                    _sbeParseArray(${json_newPrefix})
+                    break()
+                else()
+                    # reserved word starts
+                    _sbeParseReservedWord(${json_newPrefix})
+                    break()
+                endif()
+            else()
+                # name without value
+                list(APPEND ${json_AllVariables} ${json_newPrefix})
+                set(${json_newPrefix} "")
+                break()            
+            endif()           
+        endif()
+
+        if(json_inName)
+            # remove escapes
+            if("\\" STREQUAL "${json_char}")
+                math(EXPR json_index "${json_index} + 1")
+                if(NOT ${json_index} LESS ${json_jsonLen})
+                    break()
+                endif()                
+                string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+            endif()
+        
+            set(json_name "${json_name}${json_char}")
+        endif()
+        
+        # check if name starts
+        if("\"" STREQUAL "${json_char}" AND NOT json_inName)
+            set(json_inName yes)
+        endif()
+       
+        _sbeMoveToNextNonEmptyCharacter()
+    endwhile()    
+endmacro()
+
+macro(_sbeParseReservedWord prefix)
+    set(json_reservedWord "")
+    set(json_end no)
+    while(${json_index} LESS ${json_jsonLen} AND NOT json_end)
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        
+        if("," STREQUAL "${json_char}" OR "}" STREQUAL "${json_char}" OR "]" STREQUAL "${json_char}")
+            set(json_end yes)
+        else()
+            set(json_reservedWord "${json_reservedWord}${json_char}")
+            math(EXPR json_index "${json_index} + 1")
+        endif()
+    endwhile()
+
+    list(APPEND ${json_AllVariables} ${prefix})
+    string(STRIP  "${json_reservedWord}" json_reservedWord)
+    set(${prefix} ${json_reservedWord})
+endmacro()
+
+macro(_sbeParseValue prefix)
+    cmake_policy(SET CMP0054 NEW) # turn off implicit expansions in if statement
+    
+    set(json_value "")
+    set(json_inValue no)
+    
+    while(${json_index} LESS ${json_jsonLen})
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+
+        # check if json_value ends, it is ended by "
+        if("\"" STREQUAL "${json_char}" AND json_inValue)
+            set(json_inValue no)
+            
+            set(${prefix} ${json_value})
+            list(APPEND ${json_AllVariables} ${prefix})
+            _sbeMoveToNextNonEmptyCharacter()
+            break()
+        endif()
+                
+        if(json_inValue)
+             # if " is escaped consume
+            if("\\" STREQUAL "${json_char}")
+                math(EXPR json_index "${json_index} + 1")
+                if(NOT ${json_index} LESS ${json_jsonLen})
+                    break()
+                endif()                
+                string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+                if(NOT "\"" STREQUAL "${json_char}")
+                    # if it is not " then copy also escape character
+                    set(json_char "\\${json_char}")
+                endif()
+            endif()      
+              
+            _sbeAddEscapedCharacter("${json_char}")
+        endif()
+        
+        # check if value starts
+        if("\"" STREQUAL "${json_char}" AND NOT json_inValue)
+            set(json_inValue yes)
+        endif()
+        
+        math(EXPR json_index "${json_index} + 1")
+    endwhile()
+endmacro()
+
+macro(_sbeAddEscapedCharacter char)
+    string(CONCAT json_value "${json_value}" "${char}")
+endmacro()
+
+macro(_sbeParseObject prefix)
+    _sbeParse(${prefix})
+    _sbeMoveToNextNonEmptyCharacter()
+endmacro()
+
+macro(_sbeParseArray prefix)
+    math(EXPR json_ArrayNestingLevel "${json_ArrayNestingLevel} + 1")
+    set(json_${json_ArrayNestingLevel}_arrayIndex 0)
+
+    set(${prefix} "")
+    list(APPEND ${json_AllVariables} ${prefix})
+
+    while(${json_index} LESS ${json_jsonLen})
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+
+        if("\"" STREQUAL "${json_char}")
+            # simple value
+            list(APPEND ${prefix} ${json_${json_ArrayNestingLevel}_arrayIndex})
+            _sbeParseValue(${prefix}_${json_${json_ArrayNestingLevel}_arrayIndex})
+        elseif("{" STREQUAL "${json_char}")
+            # object
+            _sbeMoveToNextNonEmptyCharacter()
+            list(APPEND ${prefix} ${json_${json_ArrayNestingLevel}_arrayIndex})
+            _sbeParseObject(${prefix}_${json_${json_ArrayNestingLevel}_arrayIndex})
+        else()
+            list(APPEND ${prefix} ${json_${json_ArrayNestingLevel}_arrayIndex})
+            _sbeParseReservedWord(${prefix}_${json_${json_ArrayNestingLevel}_arrayIndex})
+        endif()
+        
+        if(NOT ${json_index} LESS ${json_jsonLen})
+            break()
+        endif()
+        
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        
+        if("]" STREQUAL "${json_char}")
+            _sbeMoveToNextNonEmptyCharacter()
+            break()
+        elseif("," STREQUAL "${json_char}")
+            math(EXPR json_${json_ArrayNestingLevel}_arrayIndex "${json_${json_ArrayNestingLevel}_arrayIndex} + 1")            
+        endif()
+                
+        _sbeMoveToNextNonEmptyCharacter()
+    endwhile()    
+    
+    if(${json_MaxArrayNestingLevel} LESS ${json_ArrayNestingLevel})
+        set(json_MaxArrayNestingLevel ${json_ArrayNestingLevel})
+    endif()
+    math(EXPR json_ArrayNestingLevel "${json_ArrayNestingLevel} - 1")
+endmacro()
+
+macro(_sbeMoveToNextNonEmptyCharacter)
+    math(EXPR json_index "${json_index} + 1")
+    if(${json_index} LESS ${json_jsonLen})
+        string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        while(${json_char} MATCHES "[ \t\n\r]" AND ${json_index} LESS ${json_jsonLen})
+            math(EXPR json_index "${json_index} + 1")
+            string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
+        endwhile()
+    endif()
+endmacro()

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,14 +43,13 @@ We may introduce forward-compatible changes: query parameters and response prope
 
 1. Check out the appropriate release branch `x.y`
 2. Make sure `CHANGELOG.md` is up to date.
-3. Make sure the OSRM version in `CMakeLists.txt` is up to date
-4. Make sure the `package.json` is up to date.
-5. Make sure all tests are passing (e.g. Travis CI gives you a :thumbs_up:)
-6. Use an annotated tag to mark the release: `git tag vx.y.z -a` Body of the tag description should be the changelog entries.
-7. Use `npm run docs` to generate the API documentation.  Copy `build/docs/*` to `https://github.com/Project-OSRM/project-osrm.github.com` in the `docs/vN.N.N/api` directory
-8. Push tags and commits: `git push; git push --tags`
-9. If not a release-candidate: Write a mailing-list post to osrm-talk@openstreetmap.org to announce the release
-10. Wait until the travis build has been completed and check if the node binaries were published by doing:
+3. Make sure the `package.json` is up to date.
+4. Make sure all tests are passing (e.g. Travis CI gives you a :thumbs_up:)
+5. Use an annotated tag to mark the release: `git tag vx.y.z -a` Body of the tag description should be the changelog entries.
+6. Use `npm run docs` to generate the API documentation.  Copy `build/docs/*` to `https://github.com/Project-OSRM/project-osrm.github.com` in the `docs/vN.N.N/api` directory
+7. Push tags and commits: `git push; git push --tags`
+8. If not a release-candidate: Write a mailing-list post to osrm-talk@openstreetmap.org to announce the release
+9. Wait until the travis build has been completed and check if the node binaries were published by doing:
     `rm -rf node_modules && npm install` locally.
-11. For final releases run `npm publish` or `npm publish --tag next` for release candidates.
-12. Bump version in `package.json` to `{MAJOR}.{MINOR+1}.0-latest.1` on the `master` branch after the release.
+10. For final releases run `npm publish` or `npm publish --tag next` for release candidates.
+11. Bump version in `package.json` to `{MAJOR}.{MINOR+1}.0-latest.1` on the `master` branch after the release.


### PR DESCRIPTION
Instead of needing to update both `package.json` and `CMakeLists.txt` to change the OSRM version number, this change adds a JSON parser to our CMake setup, and makes `package.json` the single source of truth for the current OSRM version field.

Releases now only need to update the `package.json` version field, the `CMakeLists.txt` `OSRM_VERSION_*` values are pulled in on-the-fly.

This change imports the MIT-licensed `JSONParser.cmake` from https://github.com/sbellus/json-cmake

It also bumps the minimum CMake version to 3.1 (needed by `JSONParser.cmake`) - we've been building with 3.7 on Travis for quite some time, so I don't see too many issues doing this.  Maintaining backward support for CMake 2.8 was primarily keep builds on Ubuntu 14.04 working, and that's getting a bit long in the tooth.

## Tasklist

 - [ ] review
 - [ ] adjust for comments