### PR TITLE
Use smaller range for U-turn angles in map-matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # UNRELEASED
   - Changes from 5.16.0:
-    - Bugfixes: fix deduplication of route steps when waypoints are used [#4909](https://github.com/Project-OSRM/osrm-backend/issues/4909)
+    - Bugfixes:
+      - fix deduplication of route steps when waypoints are used [#4909](https://github.com/Project-OSRM/osrm-backend/issues/4909)
+      - FIXED #4920: Use smaller range for U-turn angles in map-matching [#4920](https://github.com/Project-OSRM/osrm-backend/pull/4920)
     - Tools:
       - `osrm-routed` accepts a new property `--memory_file` to store memory in a file on disk.
     - NodeJS:
       - `OSRM` object accepts a new option `memory_file` that stores the memory in a file on disk.
-    - Internals 
-      - CHANGED #4845: Updated segregated intersection identification  
+    - Internals
+      - CHANGED #4845: Updated segregated intersection identification
 
 
 # 5.16.0

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -74,7 +74,7 @@ module.exports = function () {
 
                         if (headers.has('turns')) {
                             if (json.matchings.length != 1) throw new Error('*** Checking turns only supported for matchings with one subtrace');
-                            turns = this.turnList(json.matchings[0].instructions);
+                            turns = this.turnList(json.matchings[0]);
                         }
 
                         if (headers.has('route')) {

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -684,3 +684,34 @@ Feature: Basic Map Matching
         When I match I should get
           | trace | geometry                                      | code |
           | bgkj  | 1.000135,1,1.000135,0.99964,1.000387,0.999137 | Ok   |
+
+
+    @match @testbot
+    Scenario: Regression test - waypoints trimming too much geometry
+        Given the profile "testbot"
+        Given a grid size of 10 meters
+        Given the query options
+          | geometries | geojson |
+        Given the node map
+          """
+                e
+                ;
+                ;
+          a-----b-----c
+                ;
+                ;
+                d
+          """
+        And the ways
+          | nodes |
+          | abc   |
+          | bde   |
+        Given the query options
+          | waypoints | 0;2  |
+          | overview  | full |
+          | steps     | true |
+        When I match I should get
+          | trace | geometry                                   | turns                    | code |
+          | abc   | 1,0.99973,1.00027,0.99973,1.000539,0.99973 | depart,arrive            | Ok   |
+          | abd   | 1,0.99973,1.00027,0.99973,1.00027,0.999461 | depart,turn right,arrive | Ok   |
+          | abe   | 1,0.99973,1.00027,0.99973,1.00027,1        | depart,turn left,arrive  | Ok   |

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -687,7 +687,8 @@ Feature: Basic Map Matching
 
 
     @match @testbot
-    Scenario: Regression test - waypoints trimming too much geometry
+    # Regression test for issue #4919
+    Scenario: Regression test - non-uturn maneuver preferred over uturn
         Given the profile "testbot"
         Given a grid size of 10 meters
         Given the query options
@@ -697,7 +698,7 @@ Feature: Basic Map Matching
                 e
                 ;
                 ;
-          a-----b-----c
+          a----hb-----c
                 ;
                 ;
                 d
@@ -705,7 +706,7 @@ Feature: Basic Map Matching
         And the ways
           | nodes |
           | abc   |
-          | bde   |
+          | dbe   |
         Given the query options
           | waypoints | 0;2  |
           | overview  | full |
@@ -715,3 +716,5 @@ Feature: Basic Map Matching
           | abc   | 1,0.99973,1.00027,0.99973,1.000539,0.99973 | depart,arrive            | Ok   |
           | abd   | 1,0.99973,1.00027,0.99973,1.00027,0.999461 | depart,turn right,arrive | Ok   |
           | abe   | 1,0.99973,1.00027,0.99973,1.00027,1        | depart,turn left,arrive  | Ok   |
+          | ahd   | 1,0.99973,1.00027,0.99973,1.00027,0.999461 | depart,turn right,arrive | Ok   |
+          | ahe   | 1,0.99973,1.00027,0.99973,1.00027,1        | depart,turn left,arrive  | Ok   |

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -80,7 +80,9 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         prev_coordinate = coordinate;
 
         const auto osm_node_id = facade.GetOSMNodeIDOfNode(path_point.turn_via_node);
-        if (osm_node_id != geometry.osm_node_ids.back())
+
+        if (osm_node_id != geometry.osm_node_ids.back() ||
+            path_point.turn_instruction.type != osrm::guidance::TurnType::NoTurn)
         {
             geometry.annotations.emplace_back(LegGeometry::Annotation{
                 current_distance,

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -44,7 +44,7 @@ void filterCandidates(const std::vector<util::Coordinate> &coordinates,
                                                            coordinates[current_coordinate + 1]);
 
             // sharp turns indicate a possible uturn
-            if (turn_angle <= 90.0 || turn_angle >= 270.0)
+            if (turn_angle <= 45.0 || turn_angle >= 315.0)
             {
                 allow_uturn = true;
             }


### PR DESCRIPTION
# Issue

PR is a fast fix for https://github.com/Project-OSRM/osrm-backend/issues/4919 and an additional adjustment of geometry assembling.

The adjustment of U-turn range filtering works in the original case for a trace  `-73.988775,40.733969;-73.987818,40.735293;-73.986216,40.734619`, but fails for the feature test case.

/cc @karenzshea @TheMarex 


## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
