### PR TITLE
Make alternative routes tests stable by only being single-threaded

### DIFF
--- a/features/testbot/alternative.feature
+++ b/features/testbot/alternative.feature
@@ -4,6 +4,14 @@ Feature: Alternative route
     Background:
         Given the profile "testbot"
         And a grid size of 200 meters
+        # Force data preparation to single-threaded to ensure consistent
+        # results for alternative generation during tests (alternative
+        # finding is highly sensitive to graph shape, which is in turn
+        # affected by parallelism during generation)
+        And the contract extra arguments "--threads 1"
+        And the extract extra arguments "--threads 1"
+        And the customize extra arguments "--threads 1"
+        And the partition extra arguments "--threads 1"
 
         And the node map
             """

--- a/features/testbot/alternative_loop.feature
+++ b/features/testbot/alternative_loop.feature
@@ -4,6 +4,14 @@ Feature: Alternative route
     Background:
         Given the profile "testbot"
         Given a grid size of 200 meters
+        # Force data preparation to single-threaded to ensure consistent
+        # results for alternative generation during tests (alternative
+        # finding is highly sensitive to graph shape, which is in turn
+        # affected by parallelism during generation)
+        And the contract extra arguments "--threads 1"
+        And the extract extra arguments "--threads 1"
+        And the customize extra arguments "--threads 1"
+        And the partition extra arguments "--threads 1"
 
     Scenario: Alternative Loop Paths
         Given the node map


### PR DESCRIPTION
# Issue

Our code-coverage tests sometimes report a drop in coverage between builds.  Why?  Primarily because of our alternative routing tests.  Example coverage drop [here](https://codecov.io/gh/Project-OSRM/osrm-backend/compare/43f0723b73e11018acae734141322a5545d517b1...818cb46c6a7834558a889c2b149f985538748d74) where it looks like different parts of our alternative route finding logic were followed, despite no changes to this part of the code.

Depending on how the routing graph is generated, alternative routes may or may not be found, triggering different code paths.  Whether an alternative route is found depends on the shape of the graph, and in turn, the shape of the graph is primarily affected by the input data, and the amount of parallelism used when generating it.

This PR stabilizes the generation of the graph used for alternative route tests by only doing work in a single thread.  This means we should get the same output graph each time for the same input, and it means tests between each build should give consistent coverage results.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments

/cc @daniel-j-h @TheMarex 