### PR TITLE
Speed up generation of step geometries when there are lots of legs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
       - CHANGED #4845: Updated segregated intersection identification
     - Documentation:
       - ADDED: Add documentation about OSM node ids in nearest service response [#4436](https://github.com/Project-OSRM/osrm-backend/pull/4436)
+    - Performance
+      - FIXED: Speed up response time when lots of legs exist and geojson is used with `steps=true` [#4936](https://github.com/Project-OSRM/osrm-backend/pull/4936)
 
 
 # 5.16.0

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -211,11 +211,15 @@ class RouteAPI : public BaseAPI
         }
 
         std::vector<util::json::Value> step_geometries;
+        const auto total_step_count =
+            std::accumulate(legs.begin(), legs.end(), 0, [](const auto &v, const auto &leg) {
+                return v + leg.steps.size();
+            });
+        step_geometries.reserve(total_step_count);
+
         for (const auto idx : util::irange<std::size_t>(0UL, legs.size()))
         {
             auto &leg_geometry = leg_geometries[idx];
-
-            step_geometries.reserve(step_geometries.size() + legs[idx].steps.size());
 
             std::transform(
                 legs[idx].steps.begin(),


### PR DESCRIPTION
# Issue

While profiling the `match` plugin, I noticed that performance was about 10x worse when returning step geometries in GeoJSON format compared to returning `polyline` or `polyline6` geometries.

A little bit of digging revealed that we were [resizing the `step_geometries`](https://github.com/Project-OSRM/osrm-backend/blob/0fc8b6289c8293788e6b2441e540d5d5b3df2b0b/include/engine/api/route_api.hpp#L218) vector for every leg in the route.  For long map-matches, there are lots and lots of legs.

Combine this with the fact that `util::json::Value` is quite expensive to copy (we should probably look at that separately), it looks like if you do `steps=true&geometries=geojson` on any `match` request, the response time is completely dominated by calls to `.reserve()` at the link above.

This change simply pre-allocates the whole vector before looping over all the legs, avoiding the repeated `.reserve()` calls and all the copies of the data within the `step_geometries` vector.

There will be little to no performance change on requests with only 1 leg (i.e. simple `/route` requests).

For the 1200 coordinate `/match` request I was testing, this simple change reduces the query time from 7854ms down to 560ms.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch