### PR TITLE
Add documentation about OSM node ids in nearest service response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
       - `OSRM` object accepts a new option `memory_file` that stores the memory in a file on disk.
     - Internals
       - CHANGED #4845: Updated segregated intersection identification
+    - Documentation:
+      - ADDED: Add documentation about OSM node ids in nearest service response [#4436](https://github.com/Project-OSRM/osrm-backend/pull/4436)
 
 
 # 5.16.0

--- a/docs/http.md
+++ b/docs/http.md
@@ -120,6 +120,7 @@ In addition to the [general options](#general-options) the following options are
 - `code` if the request was successful `Ok` otherwise see the service dependent and general status codes.
 - `waypoints` array of `Waypoint` objects sorted by distance to the input coordinate. Each object has at least the following additional properties:
   - `distance`: Distance in meters to the supplied input coordinate.
+  - `nodes`: Array of OpenStreetMap node ids.
 
 #### Example Requests
 
@@ -134,6 +135,10 @@ curl 'http://router.project-osrm.org/nearest/v1/driving/13.388860,52.517037?numb
 {
    "waypoints" : [
       {
+         "nodes": [
+            2264199819,
+            0
+         ],
          "hint" : "KSoKADRYroqUBAEAEAAAABkAAAAGAAAAAAAAABhnCQCLtwAA_0vMAKlYIQM8TMwArVghAwEAAQH1a66g",
          "distance" : 4.152629,
          "name" : "Friedrichstraße",
@@ -143,6 +148,10 @@ curl 'http://router.project-osrm.org/nearest/v1/driving/13.388860,52.517037?numb
          ]
       },
       {
+         "nodes": [
+            2045820592,
+            0
+         ],
          "hint" : "KSoKADRYroqUBAEABgAAAAAAAAAAAAAAKQAAABhnCQCLtwAA7kvMAAxZIQM8TMwArVghAwAAAQH1a66g",
          "distance" : 11.811961,
          "name" : "Friedrichstraße",
@@ -152,6 +161,10 @@ curl 'http://router.project-osrm.org/nearest/v1/driving/13.388860,52.517037?numb
          ]
       },
       {
+         "nodes": [
+            0,
+            21487242
+         ],
          "hint" : "KioKgDbbDgCUBAEAAAAAABoAAAAAAAAAPAAAABlnCQCLtwAA50vMADJZIQM8TMwArVghAwAAAQH1a66g",
          "distance" : 15.872438,
          "name" : "Friedrichstraße",


### PR DESCRIPTION
# Issue
Documentation about nearest service is lacking nodes attribute within the response.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
Related PR: #4436 