### PR TITLE
Remove correctly the last segment in annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Bugfixes:
       - fix deduplication of route steps when waypoints are used [#4909](https://github.com/Project-OSRM/osrm-backend/issues/4909)
       - FIXED #4920: Use smaller range for U-turn angles in map-matching [#4920](https://github.com/Project-OSRM/osrm-backend/pull/4920)
+      - FIXED: Remove the last short annotation segment in `trimShortSegments`
     - Profile:
       - CHANGED #4929: Handle oneways in get_forward_backward_by_key [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
     - Guidance:

--- a/features/testbot/annotations.feature
+++ b/features/testbot/annotations.feature
@@ -11,7 +11,7 @@ Feature: Annotations
             """
 
         And the query options
-          | annotations | duration,speed,weight |
+          | annotations | duration,speed,weight,nodes |
 
         And the ways
             | nodes | highway     |
@@ -22,10 +22,10 @@ Feature: Annotations
             | lm    | residential |
 
         When I route I should get
-            | from | to | route    | a:speed     | a:weight |
-            | h    | j  | hk,jk,jk | 6.7:6.7     | 15:15    |
-            | i    | m  | il,lm,lm | 6.7:6.7     | 15:15    |
-            | j    | m  | jk,lm    | 6.7:6.7:6.7 | 15:15:15 |
+            | from | to | route    | a:speed     | a:weight | a:nodes |
+            | h    | j  | hk,jk,jk | 6.7:6.7     | 15:15    | 1:4:3   |
+            | i    | m  | il,lm,lm | 6.7:6.7     | 15:15    | 2:5:6   |
+            | j    | m  | jk,lm    | 6.7:6.7:6.7 | 15:15:15 | 3:4:5:6 |
 
 
     Scenario: There should be different forward/reverse datasources
@@ -81,5 +81,5 @@ Feature: Annotations
           | bearings    | 90,5;180,5                    |
 
         When I route I should get
-            | from | to | route    | a:speed   | a:distance              | a:duration | a:nodes |
-            | a    | c  | abc,abc  | 10:10:10  | 249.998641:299.931643:0 | 25:30:0    | 1:2:3   |
+            | from | to | route    | a:speed | a:distance            | a:duration | a:nodes |
+            | a    | c  | abc,abc  | 10:10   | 249.998641:299.931643 | 25:30      | 1:2:3   |

--- a/features/testbot/traffic_speeds.feature
+++ b/features/testbot/traffic_speeds.feature
@@ -48,10 +48,10 @@ Feature: Traffic - speeds
 
         When I route I should get
           | from | to | route       | speed   | weights              | a:datasources |
-          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0:0       |
+          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0         |
           | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       | 1:0           |
-          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1:0           |
-          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1:0           |
+          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1             |
+          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1             |
           | d    | c  | dc,dc       | 36 km/h | 956.8,0              | 0             |
           | g    | b  | fb,fb       | 36 km/h | 164.7,0              | 0             |
           | a    | g  | ad,df,fb,fb | 30 km/h | 1275.7,487.5,304.7,0 | 1:0:0         |
@@ -74,12 +74,12 @@ Feature: Traffic - speeds
 
         When I route I should get
           | from | to | route       | speed   | weights              | a:datasources |
-          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0:0       |
+          | a    | b  | ad,de,eb,eb | 30 km/h | 1275.7,400.4,378.2,0 | 1:0:0         |
           | a    | c  | ad,dc,dc    | 31 km/h | 1275.7,956.8,0       | 1:0           |
-          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1:0           |
-          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1:0           |
+          | b    | c  | bc,bc       | 27 km/h | 741.5,0              | 1             |
+          | a    | d  | ad,ad       | 27 km/h | 1275.7,0             | 1             |
           | d    | c  | dc,dc       | 36 km/h | 956.8,0              | 0             |
-          | g    | b  | ab,ab       | 1 km/h  | 10010.4,0            | 1:0           |
+          | g    | b  | ab,ab       | 1 km/h  | 10010.4,0            | 1             |
           | a    | g  | ab,ab       | 1 km/h  | 10010.3,0            | 1             |
 
 
@@ -106,14 +106,14 @@ Feature: Traffic - speeds
 
         When I route I should get
           | from | to | route       | speed   | weights                  | a:datasources |
-          | a    | b  | ab,ab       | 1 km/h  | 20020.73,0               | 1:0           |
-          | a    | c  | ab,bc,bc    | 2 km/h  | 20020.73,741.51,0        | 1:1:0         |
-          | b    | c  | bc,bc       | 27 km/h | 741.51,0                 | 1:0           |
+          | a    | b  | ab,ab       | 1 km/h  | 20020.73,0               | 1             |
+          | a    | c  | ab,bc,bc    | 2 km/h  | 20020.73,741.51,0        | 1:1           |
+          | b    | c  | bc,bc       | 27 km/h | 741.51,0                 | 1             |
           | a    | d  | ab,eb,de,de | 2 km/h  | 20020.73,378.17,400.41,0 | 1:0:0         |
           | d    | c  | dc,dc       | 36 km/h | 956.8,0                  | 0             |
-          | g    | b  | ab,ab       | 1 km/h  | 10010.37,0               | 1:0           |
+          | g    | b  | ab,ab       | 1 km/h  | 10010.37,0               | 1             |
           | a    | g  | ab,ab       | 1 km/h  | 10010.36,0               | 1             |
-          | g    | a  | ab,ab       | 1 km/h  | 10010.36,0               | 1:1           |
+          | g    | a  | ab,ab       | 1 km/h  | 10010.36,0               | 1             |
 
 
     Scenario: Speeds that isolate a single node (a)
@@ -135,14 +135,14 @@ Feature: Traffic - speeds
           | annotations | true |
 
         When I route I should get
-          | from | to | route    | speed   | weights       | a:datasources |
-          | a    | b  | fb,fb    | 36 km/h | 329.4,0       | 0             |
-          | a    | c  | fb,bc,bc | 30 km/h | 329.4,741.5,0 | 0:1:0         |
-          | b    | c  | bc,bc    | 27 km/h | 741.5,0       | 1:0           |
-          | a    | d  | fb,df,df | 36 km/h | 140,487.5,0   | 0:0:0         |
-          | d    | c  | dc,dc    | 36 km/h | 956.8,0       | 0             |
-          | g    | b  | fb,fb    | 36 km/h | 164.7,0       | 0             |
-          | a    | g  | fb,fb    | 36 km/h | 164.7,0       | 0             |
+          | from | to | route    | speed   | weights       | a:datasources | a:speed | a:nodes|
+          | a    | b  | fb,fb    | 36 km/h | 329.4,0       | 0             | 7       | 6:2    |
+          | a    | c  | fb,bc,bc | 30 km/h | 329.4,741.5,0 | 0:1           | 10:7.5  | 6:2:3  |
+          | b    | c  | bc,bc    | 27 km/h | 741.5,0       | 1             | 7.5     | 2:3    |
+          | a    | d  | fb,df,df | 36 km/h | 140,487.5,0   | 0:0           | 10:10   | 2:6:4  |
+          | d    | c  | dc,dc    | 36 km/h | 956.8,0       | 0             | 10      | 4:3    |
+          | g    | b  | fb,fb    | 36 km/h | 164.7,0       | 0             | 3.5     | 6:2    |
+          | a    | g  | fb,fb    | 36 km/h | 164.7,0       | 0             | 5.4     | 6:2    |
 
 
     Scenario: Verify that negative values cause an error, they're not valid at all

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -376,7 +376,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
         geometry.segment_offsets.pop_back();
         // remove all the last coordinates from the geometry
         geometry.locations.resize(geometry.segment_offsets.back() + 1);
-        geometry.annotations.resize(geometry.segment_offsets.back() + 1);
+        geometry.annotations.resize(geometry.segment_offsets.back());
         geometry.osm_node_ids.resize(geometry.segment_offsets.back() + 1);
 
         BOOST_ASSERT(geometry.segment_distances.back() <= 1);
@@ -434,6 +434,10 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
         last_step.maneuver.bearing_before = bearing;
         last_step.intersections.front().bearings.front() = util::bearing::reverse(bearing);
     }
+
+    BOOST_ASSERT(geometry.segment_offsets.back() + 1 == geometry.locations.size());
+    BOOST_ASSERT(geometry.segment_offsets.back() + 1 == geometry.osm_node_ids.size());
+    BOOST_ASSERT(geometry.segment_offsets.back() == geometry.annotations.size());
 
     BOOST_ASSERT(steps.back().geometry_end == geometry.locations.size());
 


### PR DESCRIPTION
# Issue

Remove the last trimmed segment in annotations array. 

/cc @freenerd @danpat 

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
