### PR TITLE
Refactor shared memory layout to expose Block as interface

### DIFF
--- a/include/partitioner/serialization.hpp
+++ b/include/partitioner/serialization.hpp
@@ -6,6 +6,7 @@
 #include "partitioner/multi_level_graph.hpp"
 #include "partitioner/multi_level_partition.hpp"
 
+#include "storage/block.hpp"
 #include "storage/io.hpp"
 #include "storage/serialization.hpp"
 #include "storage/shared_memory_ownership.hpp"

--- a/include/storage/block.hpp
+++ b/include/storage/block.hpp
@@ -1,0 +1,31 @@
+#ifndef OSRM_STORAGE_BLOCK_HPP
+#define OSRM_STORAGE_BLOCK_HPP
+
+#include "storage/io.hpp"
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+namespace osrm
+{
+namespace storage
+{
+
+struct Block
+{
+    std::uint64_t num_entries;
+    std::uint64_t byte_size;
+    std::uint64_t entry_size;
+    std::uint64_t entry_align;
+};
+
+template <typename T> Block make_block(uint64_t num_entries)
+{
+    static_assert(sizeof(T) % alignof(T) == 0, "aligned T* can't be used as an array pointer");
+    return Block{num_entries, sizeof(T) * num_entries, sizeof(T), alignof(T)};
+}
+}
+}
+
+#endif

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -67,7 +67,7 @@ class FileReader
 
     std::size_t GetSize()
     {
-        const boost::filesystem::ifstream::pos_type positon = input_stream.tellg();
+        const boost::filesystem::ifstream::pos_type position = input_stream.tellg();
         input_stream.seekg(0, std::ios::end);
         const boost::filesystem::ifstream::pos_type file_size = input_stream.tellg();
 
@@ -81,7 +81,7 @@ class FileReader
         }
 
         // restore the current position
-        input_stream.seekg(positon, std::ios::beg);
+        input_stream.seekg(position, std::ios::beg);
 
         if (fingerprint == FingerprintFlag::VerifyFingerprint)
         {


### PR DESCRIPTION
# Issue

This PR was a first step towards #4952 that makes the interface of `DataLayout` cleaner.

## Tasklist

 - [x] review
 - [x] adjust for comments
