### PR TITLE
Fixed segregated identification code to not mark `circular` edges as segregated

### DIFF
--- a/src/guidance/segregated_intersection_classification.cpp
+++ b/src/guidance/segregated_intersection_classification.cpp
@@ -118,8 +118,8 @@ std::unordered_set<EdgeID> findSegregatedNodes(const extractor::NodeBasedGraphFa
         // Also they must be a road use (not footway, cycleway, etc.)
         // TODO - consider whether alleys, cul-de-sacs, and other road uses
         // are candidates to be marked as internal intersection edges.
-        // TODO adjust length as needed with lamda
-        if (edge_length > INTERNAL_LENGTH_MAX || current.flags.roundabout)
+        // TODO adjust length as needed with lambda
+        if (edge_length > INTERNAL_LENGTH_MAX || current.flags.roundabout || current.flags.circular)
         {
             return false;
         }


### PR DESCRIPTION
# Issue

We missed excluding `circular` edges when marking segregated edges.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments

Fixed test
Before:
![before_circular_ignore](https://user-images.githubusercontent.com/7515853/37718223-9cdfb69a-2cf8-11e8-9012-6bce320bf7ad.png)

After:
![after_circuler_ignore](https://user-images.githubusercontent.com/7515853/37718235-a2bfabb0-2cf8-11e8-867c-6f4253cc4184.png)
