### PR TITLE
Validate format of changelog entries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
         - ./scripts/check_taginfo.py taginfo.json profiles/car.lua
         - ${MASON} install clang-format 3.8.1
         - PATH=$(${MASON} prefix clang-format 3.8.1)/bin:${PATH} ./scripts/format.sh && ./scripts/error_on_dirty.sh
+        - node ./scripts/validate_changelog.js
         # See issue 4043
         #- npm run docs && ./scripts/error_on_dirty.sh
       after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,25 @@
 # UNRELEASED
   - Changes from 5.16.0:
     - Bugfixes:
-      - fix deduplication of route steps when waypoints are used [#4909](https://github.com/Project-OSRM/osrm-backend/issues/4909)
-      - FIXED #4920: Use smaller range for U-turn angles in map-matching [#4920](https://github.com/Project-OSRM/osrm-backend/pull/4920)
-      - FIXED: Remove the last short annotation segment in `trimShortSegments`
+      - FIXED: deduplication of route steps when waypoints are used [#4909](https://github.com/Project-OSRM/osrm-backend/issues/4909)
+      - FIXED: Use smaller range for U-turn angles in map-matching [#4920](https://github.com/Project-OSRM/osrm-backend/pull/4920)
+      - FIXED: Remove the last short annotation segment in `trimShortSegments` [#4946](https://github.com/Project-OSRM/osrm-backend/pull/4946)
       - FIXED: Properly calculate annotations for speeds, durations and distances when waypoints are used with mapmatching [#4949](https://github.com/Project-OSRM/osrm-backend/pull/4949)
     - Profile:
-      - CHANGED #4929: Handle oneways in get_forward_backward_by_key [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
-      - FIXED #4943: Do not route against oneway road if there is a cycleway in the wrong direction; also review bike profile [#4943](https://github.com/Project-OSRM/osrm-backend/issues/4943)
+      - CHANGED: Handle oneways in get_forward_backward_by_key [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
+      - FIXED: Do not route against oneway road if there is a cycleway in the wrong direction; also review bike profile [#4943](https://github.com/Project-OSRM/osrm-backend/issues/4943)
     - Guidance:
-      - CHANGED #4929: Don't use obviousness for links bifurcations [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
-      - FIXED #4929: Adjust Straight direction modifiers of side roads in driveway handler [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
-      - CHANGED #4925: Added post process logic to collapse segregated turn instructions [#4925](https://github.com/Project-OSRM/osrm-backend/pull/4925)
+      - CHANGED: Don't use obviousness for links bifurcations [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
+      - FIXED: Adjust Straight direction modifiers of side roads in driveway handler [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
+      - CHANGED: Added post process logic to collapse segregated turn instructions [#4925](https://github.com/Project-OSRM/osrm-backend/pull/4925)
       - ADDED: Maneuver relation now supports `straight` as a direction [#4995](https://github.com/Project-OSRM/osrm-backend/pull/4995)
     - Tools:
-      - `osrm-routed` accepts a new property `--memory_file` to store memory in a file on disk.
+      - ADDED: `osrm-routed` accepts a new property `--memory_file` to store memory in a file on disk. [#4881](https://github.com/Project-OSRM/osrm-backend/pull/4881)
     - NodeJS:
-      - `OSRM` object accepts a new option `memory_file` that stores the memory in a file on disk.
+      - ADDED: `OSRM` object accepts a new option `memory_file` that stores the memory in a file on disk. [#4881](https://github.com/Project-OSRM/osrm-backend/pull/4881)
     - Internals
-      - CHANGED #4845 #4968: Updated segregated intersection identification [#4845](https://github.com/Project-OSRM/osrm-backend/pull/4845) [#4968](https://github.com/Project-OSRM/osrm-backend/pull/4968)
-      - REMOVED: Remove `.timestamp` file since it was unused.
+      - CHANGED: Updated segregated intersection identification [#4845](https://github.com/Project-OSRM/osrm-backend/pull/4845) [#4968](https://github.com/Project-OSRM/osrm-backend/pull/4968)
+      - REMOVED: Remove `.timestamp` file since it was unused [#4960](https://github.com/Project-OSRM/osrm-backend/pull/4960)
     - Documentation:
       - ADDED: Add documentation about OSM node ids in nearest service response [#4436](https://github.com/Project-OSRM/osrm-backend/pull/4436)
     - Performance

--- a/scripts/validate_changelog.js
+++ b/scripts/validate_changelog.js
@@ -1,0 +1,46 @@
+var linereader = require('readline').createInterface( {
+    input: require('fs').createReadStream(require('path').join(__dirname, '..', 'CHANGELOG.md'))
+});
+
+var done = false;
+var linenum = 0;
+var has_errors = false;
+linereader.on('line', function(line) {
+    linenum += 1;
+    // Only validate the `# UNRELEASED` section
+    if (line.match(/^# [^U]/)) done = true;
+    if (done) return;
+
+    var line_errors = [];
+
+    if (line.match(/^ {6}/)) {
+        if (!line.match(/^ {6}- (ADDED|FIXED|CHANGED|REMOVED): /)) {
+            line_errors.push("ERROR: changelog entries must start with '- (ADDED|FIXED|CHANGED|REMOVED): '");
+        }
+        if (!line.match(/\[#[0-9]+\]\(http.*\)$/)) {
+            line_errors.push("ERROR: changelog entries must end with an issue or PR link in Markdown format");
+        }
+    }
+
+    if (line_errors.length > 0) {
+      has_errors = true;
+
+      // Coloured output if it's directly on an interactive terminal
+      if (process.stdout.isTTY) {
+          console.log('\x1b[31mERROR ON LINE %d\x1b[0m: %s', linenum, line);
+          for (var i = 0; i<line_errors.length; i++) {
+              console.log('    \x1b[33m%s\x1b[0m', line_errors[i]);
+          }
+      } else {
+          console.log('ERROR ON LINE %d: %s', linenum, line);
+          for (var i = 0; i<line_errors.length; i++) {
+              console.log('    %s', line_errors[i]);
+          }
+      }
+    }
+
+});
+
+linereader.on('close', function() {
+    process.exit(has_errors ? 1 : 0);
+});


### PR DESCRIPTION
# Issue

This script adds an automated formatting check for CHANGELOG.md entries.

This is a first cut at ensuring that changelog entries are machine readable and complete.

Currently, only checks that entry lines match this pseudo-regex:

```
  - (ADDED|FIXED|CHANGED|REMOVED): .* [#num](http://link/)
```

which is roughly what we've been using.

The validation script gets run as part of the `format-taginfo-docs` Travis build, and will fail the build (with error messages) if validation of the changelog fails.

Only checks the `# UNRELEASED` section, no point in going back and fixing everything from the past, but will ensure consistency going forward.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how)) (ironically not done yet)
 - [ ] review
 - [ ] adjust for comments