### PR TITLE
Refactor shared memory data layout to use named identifiers

### DIFF
--- a/include/contractor/contracted_metric.hpp
+++ b/include/contractor/contracted_metric.hpp
@@ -1,0 +1,26 @@
+#ifndef OSMR_CONTRACTOR_CONTRACTED_METRIC_HPP
+#define OSMR_CONTRACTOR_CONTRACTED_METRIC_HPP
+
+#include "contractor/query_graph.hpp"
+
+namespace osrm
+{
+namespace contractor
+{
+
+namespace detail
+{
+template<storage::Ownership Ownership>
+struct ContractedMetric
+{
+    detail::QueryGraph<Ownership> graph;
+    std::vector<util::ViewOrVector<bool, Ownership>> edge_filter;
+};
+}
+
+using ContractedMetric = detail::ContractedMetric<storage::Ownership::Container>;
+using ContractedMetricView = detail::ContractedMetric<storage::Ownership::View>;
+}
+}
+
+#endif

--- a/include/contractor/contracted_metric.hpp
+++ b/include/contractor/contracted_metric.hpp
@@ -10,8 +10,7 @@ namespace contractor
 
 namespace detail
 {
-template<storage::Ownership Ownership>
-struct ContractedMetric
+template <storage::Ownership Ownership> struct ContractedMetric
 {
     detail::QueryGraph<Ownership> graph;
     std::vector<util::ViewOrVector<bool, Ownership>> edge_filter;

--- a/include/contractor/files.hpp
+++ b/include/contractor/files.hpp
@@ -1,12 +1,9 @@
 #ifndef OSRM_CONTRACTOR_FILES_HPP
 #define OSRM_CONTRACTOR_FILES_HPP
 
-#include "contractor/query_graph.hpp"
+#include "contractor/serialization.hpp"
 
-#include "util/serialization.hpp"
-
-#include "storage/serialization.hpp"
-#include "storage/tar.hpp"
+#include <unordered_map>
 
 namespace osrm
 {
@@ -15,67 +12,51 @@ namespace contractor
 namespace files
 {
 // reads .osrm.hsgr file
-template <typename QueryGraphT, typename EdgeFilterT>
+template <typename ContractedMetricT>
 inline void readGraph(const boost::filesystem::path &path,
                       unsigned &checksum,
-                      QueryGraphT &graph,
-                      std::vector<EdgeFilterT> &edge_filter,
+                      std::unordered_map<std::string, ContractedMetricT> &metrics,
                       std::uint32_t &connectivity_checksum)
 {
-    static_assert(std::is_same<QueryGraphView, QueryGraphT>::value ||
-                      std::is_same<QueryGraph, QueryGraphT>::value,
-                  "graph must be of type QueryGraph<>");
-    static_assert(std::is_same<EdgeFilterT, std::vector<bool>>::value ||
-                      std::is_same<EdgeFilterT, util::vector_view<bool>>::value,
-                  "edge_filter must be a container of vector<bool> or vector_view<bool>");
+    static_assert(std::is_same<ContractedMetric, ContractedMetricT>::value ||
+                      std::is_same<ContractedMetricView, ContractedMetricT>::value,
+                  "metric must be of type ContractedMetric<>");
 
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
     reader.ReadInto("/ch/checksum", checksum);
-    util::serialization::read(reader, "/ch/contracted_graph", graph);
+    reader.ReadInto("/ch/connectivity_checksum", connectivity_checksum);
 
-    auto count = reader.ReadElementCount64("/ch/edge_filter");
-    edge_filter.resize(count);
-    for (const auto index : util::irange<std::size_t>(0, count))
+    for (auto &pair : metrics)
     {
-        storage::serialization::read(
-            reader, "/ch/edge_filter/" + std::to_string(index), edge_filter[index]);
+        serialization::read(reader, "/ch/metrics/" + pair.first, pair.second);
     }
 
-    reader.ReadInto("/ch/connectivity_checksum", connectivity_checksum);
 }
 
 // writes .osrm.hsgr file
-template <typename QueryGraphT, typename EdgeFilterT>
+template <typename ContractedMetricT>
 inline void writeGraph(const boost::filesystem::path &path,
                        unsigned checksum,
-                       const QueryGraphT &graph,
-                       const std::vector<EdgeFilterT> &edge_filter,
+                       const std::unordered_map<std::string, ContractedMetricT> &metrics,
                        const std::uint32_t connectivity_checksum)
 {
-    static_assert(std::is_same<QueryGraphView, QueryGraphT>::value ||
-                      std::is_same<QueryGraph, QueryGraphT>::value,
-                  "graph must be of type QueryGraph<>");
-    static_assert(std::is_same<EdgeFilterT, std::vector<bool>>::value ||
-                      std::is_same<EdgeFilterT, util::vector_view<bool>>::value,
-                  "edge_filter must be a container of vector<bool> or vector_view<bool>");
+    static_assert(std::is_same<ContractedMetric, ContractedMetricT>::value ||
+                      std::is_same<ContractedMetricView, ContractedMetricT>::value,
+                  "metric must be of type ContractedMetric<>");
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
     writer.WriteElementCount64("/ch/checksum", 1);
     writer.WriteFrom("/ch/checksum", checksum);
-    util::serialization::write(writer, "/ch/contracted_graph", graph);
-
-    writer.WriteElementCount64("/ch/edge_filter", edge_filter.size());
-    for (const auto index : util::irange<std::size_t>(0, edge_filter.size()))
-    {
-        storage::serialization::write(
-            writer, "/ch/edge_filter/" + std::to_string(index), edge_filter[index]);
-    }
-
     writer.WriteElementCount64("/ch/connectivity_checksum", 1);
     writer.WriteFrom("/ch/connectivity_checksum", connectivity_checksum);
+
+    for (const auto &pair : metrics)
+    {
+        serialization::write(writer, "/ch/metrics/" + pair.first, pair.second);
+    }
 }
 }
 }

--- a/include/contractor/files.hpp
+++ b/include/contractor/files.hpp
@@ -14,7 +14,6 @@ namespace files
 // reads .osrm.hsgr file
 template <typename ContractedMetricT>
 inline void readGraph(const boost::filesystem::path &path,
-                      unsigned &checksum,
                       std::unordered_map<std::string, ContractedMetricT> &metrics,
                       std::uint32_t &connectivity_checksum)
 {
@@ -25,7 +24,6 @@ inline void readGraph(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    reader.ReadInto("/ch/checksum", checksum);
     reader.ReadInto("/ch/connectivity_checksum", connectivity_checksum);
 
     for (auto &pair : metrics)
@@ -38,7 +36,6 @@ inline void readGraph(const boost::filesystem::path &path,
 // writes .osrm.hsgr file
 template <typename ContractedMetricT>
 inline void writeGraph(const boost::filesystem::path &path,
-                       unsigned checksum,
                        const std::unordered_map<std::string, ContractedMetricT> &metrics,
                        const std::uint32_t connectivity_checksum)
 {
@@ -48,8 +45,6 @@ inline void writeGraph(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
-    writer.WriteElementCount64("/ch/checksum", 1);
-    writer.WriteFrom("/ch/checksum", checksum);
     writer.WriteElementCount64("/ch/connectivity_checksum", 1);
     writer.WriteFrom("/ch/connectivity_checksum", connectivity_checksum);
 

--- a/include/contractor/files.hpp
+++ b/include/contractor/files.hpp
@@ -30,7 +30,6 @@ inline void readGraph(const boost::filesystem::path &path,
     {
         serialization::read(reader, "/ch/metrics/" + pair.first, pair.second);
     }
-
 }
 
 // writes .osrm.hsgr file

--- a/include/contractor/serialization.hpp
+++ b/include/contractor/serialization.hpp
@@ -1,0 +1,53 @@
+#ifndef OSRM_CONTRACTOR_SERIALIZATION_HPP
+#define OSRM_CONTRACTOR_SERIALIZATION_HPP
+
+#include "contractor/contracted_metric.hpp"
+
+#include "util/serialization.hpp"
+
+#include "storage/serialization.hpp"
+#include "storage/tar.hpp"
+
+namespace osrm
+{
+namespace contractor
+{
+namespace serialization
+{
+
+template <storage::Ownership Ownership>
+void write(storage::tar::FileWriter &writer,
+           const std::string &name,
+           const detail::ContractedMetric<Ownership> &metric)
+{
+    util::serialization::write(writer, name + "/contracted_graph", metric.graph);
+
+    writer.WriteElementCount64(name + "/exclude", metric.edge_filter.size());
+    for (const auto index : util::irange<std::size_t>(0, metric.edge_filter.size()))
+    {
+        storage::serialization::write(writer,
+                                      name + "/exclude/" + std::to_string(index) + "/edge_filter",
+                                      metric.edge_filter[index]);
+    }
+}
+
+template <storage::Ownership Ownership>
+void read(storage::tar::FileReader &reader,
+          const std::string &name,
+          detail::ContractedMetric<Ownership> &metric)
+{
+    util::serialization::read(reader, name + "/contracted_graph", metric.graph);
+
+    metric.edge_filter.resize(reader.ReadElementCount64(name + "/exclude"));
+    for (const auto index : util::irange<std::size_t>(0, metric.edge_filter.size()))
+    {
+        storage::serialization::read(reader,
+                                     name + "/exclude/" + std::to_string(index) + "/edge_filter",
+                                     metric.edge_filter[index]);
+    }
+}
+}
+}
+}
+
+#endif

--- a/include/customizer/files.hpp
+++ b/include/customizer/files.hpp
@@ -18,7 +18,8 @@ namespace files
 
 // reads .osrm.cell_metrics file
 template <typename CellMetricT>
-inline void readCellMetrics(const boost::filesystem::path &path, std::unordered_map<std::string, std::vector<CellMetricT>> &metrics)
+inline void readCellMetrics(const boost::filesystem::path &path,
+                            std::unordered_map<std::string, std::vector<CellMetricT>> &metrics)
 {
     static_assert(std::is_same<CellMetricView, CellMetricT>::value ||
                       std::is_same<CellMetric, CellMetricT>::value,
@@ -27,10 +28,10 @@ inline void readCellMetrics(const boost::filesystem::path &path, std::unordered_
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    for (auto& pair : metrics)
+    for (auto &pair : metrics)
     {
-        const auto& metric_name = pair.first;
-        auto& metric_exclude_classes = pair.second;
+        const auto &metric_name = pair.first;
+        auto &metric_exclude_classes = pair.second;
 
         auto prefix = "/mld/metrics/" + metric_name + "/exclude";
         auto num_exclude_classes = reader.ReadElementCount64(prefix);
@@ -46,8 +47,9 @@ inline void readCellMetrics(const boost::filesystem::path &path, std::unordered_
 
 // writes .osrm.cell_metrics file
 template <typename CellMetricT>
-inline void writeCellMetrics(const boost::filesystem::path &path,
-                             const std::unordered_map<std::string, std::vector<CellMetricT>> &metrics)
+inline void
+writeCellMetrics(const boost::filesystem::path &path,
+                 const std::unordered_map<std::string, std::vector<CellMetricT>> &metrics)
 {
     static_assert(std::is_same<CellMetricView, CellMetricT>::value ||
                       std::is_same<CellMetric, CellMetricT>::value,
@@ -56,10 +58,10 @@ inline void writeCellMetrics(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
-    for (const auto& pair : metrics)
+    for (const auto &pair : metrics)
     {
-        const auto& metric_name = pair.first;
-        const auto& metric_exclude_classes = pair.second;
+        const auto &metric_name = pair.first;
+        const auto &metric_exclude_classes = pair.second;
 
         auto prefix = "/mld/metrics/" + metric_name + "/exclude";
         writer.WriteElementCount64(prefix, metric_exclude_classes.size());

--- a/include/customizer/files.hpp
+++ b/include/customizer/files.hpp
@@ -7,6 +7,8 @@
 
 #include "util/integer_range.hpp"
 
+#include <unordered_map>
+
 namespace osrm
 {
 namespace customizer
@@ -16,7 +18,7 @@ namespace files
 
 // reads .osrm.cell_metrics file
 template <typename CellMetricT>
-inline void readCellMetrics(const boost::filesystem::path &path, std::vector<CellMetricT> &metrics)
+inline void readCellMetrics(const boost::filesystem::path &path, std::unordered_map<std::string, std::vector<CellMetricT>> &metrics)
 {
     static_assert(std::is_same<CellMetricView, CellMetricT>::value ||
                       std::is_same<CellMetric, CellMetricT>::value,
@@ -25,20 +27,27 @@ inline void readCellMetrics(const boost::filesystem::path &path, std::vector<Cel
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    auto num_metrics = reader.ReadElementCount64("/mld/metrics");
-    metrics.resize(num_metrics);
-
-    auto id = 0;
-    for (auto &metric : metrics)
+    for (auto& pair : metrics)
     {
-        serialization::read(reader, "/mld/metrics/" + std::to_string(id++), metric);
+        const auto& metric_name = pair.first;
+        auto& metric_exclude_classes = pair.second;
+
+        auto prefix = "/mld/metrics/" + metric_name + "/exclude";
+        auto num_exclude_classes = reader.ReadElementCount64(prefix);
+        metric_exclude_classes.resize(num_exclude_classes);
+
+        auto id = 0;
+        for (auto &metric : metric_exclude_classes)
+        {
+            serialization::read(reader, prefix + "/" + std::to_string(id++), metric);
+        }
     }
 }
 
 // writes .osrm.cell_metrics file
 template <typename CellMetricT>
 inline void writeCellMetrics(const boost::filesystem::path &path,
-                             const std::vector<CellMetricT> &metrics)
+                             const std::unordered_map<std::string, std::vector<CellMetricT>> &metrics)
 {
     static_assert(std::is_same<CellMetricView, CellMetricT>::value ||
                       std::is_same<CellMetric, CellMetricT>::value,
@@ -47,12 +56,19 @@ inline void writeCellMetrics(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
-    writer.WriteElementCount64("/mld/metrics", metrics.size());
-
-    auto id = 0;
-    for (const auto &metric : metrics)
+    for (const auto& pair : metrics)
     {
-        serialization::write(writer, "/mld/metrics/" + std::to_string(id++), metric);
+        const auto& metric_name = pair.first;
+        const auto& metric_exclude_classes = pair.second;
+
+        auto prefix = "/mld/metrics/" + metric_name + "/exclude";
+        writer.WriteElementCount64(prefix, metric_exclude_classes.size());
+
+        auto id = 0;
+        for (auto &exclude_metric : metric_exclude_classes)
+        {
+            serialization::write(writer, prefix + "/" + std::to_string(id++), exclude_metric);
+        }
     }
 }
 }

--- a/include/engine/algorithm.hpp
+++ b/include/engine/algorithm.hpp
@@ -30,6 +30,11 @@ template <typename AlgorithmT> const char *name();
 template <> inline const char *name<ch::Algorithm>() { return "CH"; }
 template <> inline const char *name<mld::Algorithm>() { return "MLD"; }
 
+// Algorithm identifier
+template <typename AlgorithmT> const char *identifier();
+template <> inline const char *identifier<ch::Algorithm>() { return "ch"; }
+template <> inline const char *identifier<mld::Algorithm>() { return "mld"; }
+
 template <typename AlgorithmT> struct HasAlternativePathSearch final : std::false_type
 {
 };

--- a/include/engine/datafacade/contiguous_block_allocator.hpp
+++ b/include/engine/datafacade/contiguous_block_allocator.hpp
@@ -16,7 +16,7 @@ class ContiguousBlockAllocator
     virtual ~ContiguousBlockAllocator() = default;
 
     // interface to give access to the datafacades
-    virtual storage::DataLayout &GetLayout() = 0;
+    virtual const storage::DataLayout &GetLayout() = 0;
     virtual char *GetMemory() = 0;
 };
 

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -9,44 +9,13 @@
 #include "engine/approach.hpp"
 #include "engine/geospatial_query.hpp"
 
-#include "customizer/edge_based_graph.hpp"
-
-#include "extractor/datasources.hpp"
-#include "extractor/edge_based_node.hpp"
-#include "extractor/intersection_bearings_container.hpp"
-#include "extractor/maneuver_override.hpp"
-#include "extractor/name_table.hpp"
-#include "extractor/node_data_container.hpp"
-#include "extractor/packed_osm_ids.hpp"
-#include "extractor/profile_properties.hpp"
-#include "extractor/segment_data_container.hpp"
-#include "extractor/turn_lane_types.hpp"
-
-#include "guidance/turn_bearing.hpp"
-#include "guidance/turn_data_container.hpp"
-#include "guidance/turn_instruction.hpp"
-
-#include "contractor/query_graph.hpp"
-
-#include "partitioner/cell_storage.hpp"
-#include "partitioner/multi_level_partition.hpp"
-
 #include "storage/shared_datatype.hpp"
 #include "storage/shared_memory_ownership.hpp"
+#include "storage/view_factory.hpp"
 
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
-#include "util/filtered_graph.hpp"
-#include "util/guidance/bearing_class.hpp"
-#include "util/guidance/entry_class.hpp"
-#include "util/guidance/turn_lanes.hpp"
 #include "util/log.hpp"
-#include "util/packed_vector.hpp"
-#include "util/range_table.hpp"
-#include "util/rectangle.hpp"
-#include "util/static_graph.hpp"
-#include "util/static_rtree.hpp"
-#include "util/typedefs.hpp"
 
 #include <boost/assert.hpp>
 
@@ -81,36 +50,6 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
     // allocator that keeps the allocation data
     std::shared_ptr<ContiguousBlockAllocator> allocator;
 
-    void InitializeGraphPointer(const storage::DataLayout &data_layout,
-                                char *memory_block,
-                                const std::string &metric_name,
-                                const std::size_t exclude_index)
-    {
-        const std::string metric_prefix = "/ch/metrics/" + metric_name;
-        auto graph_nodes_ptr = data_layout.GetBlockPtr<GraphNode>(
-            memory_block, metric_prefix + "/contracted_graph/node_array");
-
-        auto graph_edges_ptr = data_layout.GetBlockPtr<GraphEdge>(
-            memory_block, metric_prefix + "/contracted_graph/edge_array");
-
-        auto exclude_prefix = metric_prefix + "/exclude/" + std::to_string(exclude_index);
-        auto filter_block_id = exclude_prefix + "/edge_filter";
-
-        auto edge_filter_ptr =
-            data_layout.GetBlockPtr<util::vector_view<bool>::Word>(memory_block, filter_block_id);
-
-        util::vector_view<GraphNode> node_list(
-            graph_nodes_ptr,
-            data_layout.GetBlockEntries(metric_prefix + "/contracted_graph/node_array"));
-        util::vector_view<GraphEdge> edge_list(
-            graph_edges_ptr,
-            data_layout.GetBlockEntries(metric_prefix + "/contracted_graph/edge_array"));
-
-        util::vector_view<bool> edge_filter(edge_filter_ptr,
-                                            data_layout.GetBlockEntries(filter_block_id));
-        m_query_graph = QueryGraph({node_list, edge_list}, edge_filter);
-    }
-
   public:
     ContiguousInternalMemoryAlgorithmDataFacade(
         std::shared_ptr<ContiguousBlockAllocator> allocator_,
@@ -127,7 +66,8 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
                                     const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
-        InitializeGraphPointer(data_layout, memory_block, metric_name, exclude_index);
+        m_query_graph = make_filtered_graph_view(
+            memory_block, data_layout, "/ch/metrics/" + metric_name, exclude_index);
     }
 
     // search graph access
@@ -218,7 +158,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     util::vector_view<extractor::StorageManeuverOverride> m_maneuver_overrides;
     util::vector_view<NodeID> m_maneuver_override_node_sequences;
 
-    std::unique_ptr<SharedRTree> m_static_rtree;
+    SharedRTree m_static_rtree;
     std::unique_ptr<SharedGeospatialQuery> m_geospatial_query;
     boost::filesystem::path file_index_path;
 
@@ -232,330 +172,55 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     // allocator that keeps the allocation data
     std::shared_ptr<ContiguousBlockAllocator> allocator;
 
-    void InitializeProfilePropertiesPointer(const storage::DataLayout &data_layout,
-                                            char *memory_block,
-                                            const std::string &metric_name,
-                                            const std::size_t exclude_index)
-    {
-        // TODO: For multi-metric support we need to have separate exclude classes per metric
-        (void)metric_name;
-        m_profile_properties = data_layout.GetBlockPtr<extractor::ProfileProperties>(
-            memory_block, "/common/properties");
-
-        exclude_mask = m_profile_properties->excludable_classes[exclude_index];
-    }
-
-    void InitializeChecksumPointer(const storage::DataLayout &data_layout, char *memory_block)
-    {
-        m_check_sum =
-            *data_layout.GetBlockPtr<std::uint32_t>(memory_block, "/common/connectivity_checksum");
-        util::Log() << "set checksum: " << m_check_sum;
-    }
-
-    void InitializeRTreePointers(const storage::DataLayout &data_layout, char *memory_block)
-    {
-        BOOST_ASSERT_MSG(!m_coordinate_list.empty(), "coordinates must be loaded before r-tree");
-
-        const auto file_index_ptr =
-            data_layout.GetBlockPtr<char>(memory_block, "/common/rtree/file_index_path");
-        file_index_path = boost::filesystem::path(file_index_ptr);
-        if (!boost::filesystem::exists(file_index_path))
-        {
-            util::Log(logDEBUG) << "Leaf file name " << file_index_path.string();
-            throw util::exception("Could not load " + file_index_path.string() +
-                                  "Is any data loaded into shared memory?" + SOURCE_REF);
-        }
-
-        const auto rtree_ptr =
-            data_layout.GetBlockPtr<RTreeNode>(memory_block, "/common/rtree/search_tree");
-        util::vector_view<RTreeNode> search_tree(
-            rtree_ptr, data_layout.GetBlockEntries("/common/rtree/search_tree"));
-
-        const auto rtree_levelstarts_ptr = data_layout.GetBlockPtr<std::uint64_t>(
-            memory_block, "/common/rtree/search_tree_level_starts");
-        util::vector_view<std::uint64_t> rtree_level_starts(
-            rtree_levelstarts_ptr,
-            data_layout.GetBlockEntries("/common/rtree/search_tree_level_starts"));
-
-        m_static_rtree.reset(new SharedRTree{std::move(search_tree),
-                                             std::move(rtree_level_starts),
-                                             file_index_path,
-                                             m_coordinate_list});
-        m_geospatial_query.reset(
-            new SharedGeospatialQuery(*m_static_rtree, m_coordinate_list, *this));
-    }
-
-    void InitializeNodeInformationPointers(const storage::DataLayout &layout, char *memory_ptr)
-    {
-        const auto coordinate_list_ptr =
-            layout.GetBlockPtr<util::Coordinate>(memory_ptr, "/common/coordinates");
-        m_coordinate_list.reset(coordinate_list_ptr, layout.GetBlockEntries("/common/coordinates"));
-
-        const auto osmnodeid_ptr = layout.GetBlockPtr<extractor::PackedOSMIDsView::block_type>(
-            memory_ptr, "/common/osm_node_ids/packed");
-        m_osmnodeid_list = extractor::PackedOSMIDsView(
-            util::vector_view<extractor::PackedOSMIDsView::block_type>(
-                osmnodeid_ptr, layout.GetBlockEntries("/common/osm_node_ids/packed")),
-            // We (ab)use the number of coordinates here because we know we have the same amount of
-            // ids
-            layout.GetBlockEntries("/common/coordinates"));
-    }
-
-    void InitializeEdgeBasedNodeDataInformationPointers(const storage::DataLayout &layout,
-                                                        char *memory_ptr)
-    {
-        const auto edge_based_node_list_ptr =
-            layout.GetBlockPtr<extractor::EdgeBasedNode>(memory_ptr, "/common/ebg_node_data/nodes");
-        util::vector_view<extractor::EdgeBasedNode> edge_based_node_data_list(
-            edge_based_node_list_ptr, layout.GetBlockEntries("/common/ebg_node_data/nodes"));
-
-        const auto annotation_data_list_ptr =
-            layout.GetBlockPtr<extractor::NodeBasedEdgeAnnotation>(
-                memory_ptr, "/common/ebg_node_data/annotations");
-        util::vector_view<extractor::NodeBasedEdgeAnnotation> annotation_data(
-            annotation_data_list_ptr, layout.GetBlockEntries("/common/ebg_node_data/annotations"));
-
-        edge_based_node_data = extractor::EdgeBasedNodeDataView(
-            std::move(edge_based_node_data_list), std::move(annotation_data));
-    }
-
-    void InitializeEdgeInformationPointers(const storage::DataLayout &layout, char *memory_ptr)
-    {
-        const auto lane_data_id_ptr =
-            layout.GetBlockPtr<LaneDataID>(memory_ptr, "/common/turn_data/lane_data_ids");
-        util::vector_view<LaneDataID> lane_data_ids(
-            lane_data_id_ptr, layout.GetBlockEntries("/common/turn_data/lane_data_ids"));
-
-        const auto turn_instruction_list_ptr = layout.GetBlockPtr<guidance::TurnInstruction>(
-            memory_ptr, "/common/turn_data/turn_instructions");
-        util::vector_view<guidance::TurnInstruction> turn_instructions(
-            turn_instruction_list_ptr,
-            layout.GetBlockEntries("/common/turn_data/turn_instructions"));
-
-        const auto entry_class_id_list_ptr =
-            layout.GetBlockPtr<EntryClassID>(memory_ptr, "/common/turn_data/entry_class_ids");
-        util::vector_view<EntryClassID> entry_class_ids(
-            entry_class_id_list_ptr, layout.GetBlockEntries("/common/turn_data/entry_class_ids"));
-
-        const auto pre_turn_bearing_ptr = layout.GetBlockPtr<guidance::TurnBearing>(
-            memory_ptr, "/common/turn_data/pre_turn_bearings");
-        util::vector_view<guidance::TurnBearing> pre_turn_bearings(
-            pre_turn_bearing_ptr, layout.GetBlockEntries("/common/turn_data/pre_turn_bearings"));
-
-        const auto post_turn_bearing_ptr = layout.GetBlockPtr<guidance::TurnBearing>(
-            memory_ptr, "/common/turn_data/post_turn_bearings");
-        util::vector_view<guidance::TurnBearing> post_turn_bearings(
-            post_turn_bearing_ptr, layout.GetBlockEntries("/common/turn_data/post_turn_bearings"));
-
-        turn_data = guidance::TurnDataView(std::move(turn_instructions),
-                                           std::move(lane_data_ids),
-                                           std::move(entry_class_ids),
-                                           std::move(pre_turn_bearings),
-                                           std::move(post_turn_bearings));
-    }
-
-    void InitializeNamePointers(const storage::DataLayout &data_layout, char *memory_block)
-    {
-        const auto name_blocks_ptr =
-            data_layout.GetBlockPtr<extractor::NameTableView::IndexedData::BlockReference>(
-                memory_block, "/common/names/blocks");
-        const auto name_values_ptr =
-            data_layout.GetBlockPtr<extractor::NameTableView::IndexedData::ValueType>(
-                memory_block, "/common/names/values");
-
-        util::vector_view<extractor::NameTableView::IndexedData::BlockReference> blocks(
-            name_blocks_ptr, data_layout.GetBlockEntries("/common/names/blocks"));
-        util::vector_view<extractor::NameTableView::IndexedData::ValueType> values(
-            name_values_ptr, data_layout.GetBlockEntries("/common/names/values"));
-
-        extractor::NameTableView::IndexedData index_data_view{std::move(blocks), std::move(values)};
-        m_name_table = extractor::NameTableView{std::move(index_data_view)};
-    }
-
-    void InitializeTurnLaneDescriptionsPointers(const storage::DataLayout &data_layout,
-                                                char *memory_block)
-    {
-        auto offsets_ptr =
-            data_layout.GetBlockPtr<std::uint32_t>(memory_block, "/common/turn_lanes/offsets");
-        util::vector_view<std::uint32_t> offsets(
-            offsets_ptr, data_layout.GetBlockEntries("/common/turn_lanes/offsets"));
-        m_lane_description_offsets = std::move(offsets);
-
-        auto masks_ptr = data_layout.GetBlockPtr<extractor::TurnLaneType::Mask>(
-            memory_block, "/common/turn_lanes/masks");
-
-        util::vector_view<extractor::TurnLaneType::Mask> masks(
-            masks_ptr, data_layout.GetBlockEntries("/common/turn_lanes/masks"));
-        m_lane_description_masks = std::move(masks);
-
-        const auto lane_tupel_id_pair_ptr =
-            data_layout.GetBlockPtr<util::guidance::LaneTupleIdPair>(memory_block,
-                                                                     "/common/turn_lanes/data");
-        util::vector_view<util::guidance::LaneTupleIdPair> lane_tupel_id_pair(
-            lane_tupel_id_pair_ptr, data_layout.GetBlockEntries("/common/turn_lanes/data"));
-        m_lane_tupel_id_pairs = std::move(lane_tupel_id_pair);
-    }
-
-    void InitializeTurnPenalties(const storage::DataLayout &data_layout, char *memory_block)
-    {
-        auto turn_weight_penalties_ptr =
-            data_layout.GetBlockPtr<TurnPenalty>(memory_block, "/common/turn_penalty/weight");
-        m_turn_weight_penalties = util::vector_view<TurnPenalty>(
-            turn_weight_penalties_ptr, data_layout.GetBlockEntries("/common/turn_penalty/weight"));
-        auto turn_duration_penalties_ptr =
-            data_layout.GetBlockPtr<TurnPenalty>(memory_block, "/common/turn_penalty/duration");
-        m_turn_duration_penalties = util::vector_view<TurnPenalty>(
-            turn_duration_penalties_ptr,
-            data_layout.GetBlockEntries("/common/turn_penalty/duration"));
-    }
-
-    void InitializeGeometryPointers(const storage::DataLayout &data_layout, char *memory_block)
-    {
-        auto geometries_index_ptr =
-            data_layout.GetBlockPtr<unsigned>(memory_block, "/common/segment_data/index");
-        util::vector_view<unsigned> geometry_begin_indices(
-            geometries_index_ptr, data_layout.GetBlockEntries("/common/segment_data/index"));
-
-        auto num_entries = data_layout.GetBlockEntries("/common/segment_data/nodes");
-        auto geometries_node_list_ptr =
-            data_layout.GetBlockPtr<NodeID>(memory_block, "/common/segment_data/nodes");
-        util::vector_view<NodeID> geometry_node_list(geometries_node_list_ptr, num_entries);
-
-        auto geometries_fwd_weight_list_ptr =
-            data_layout.GetBlockPtr<extractor::SegmentDataView::SegmentWeightVector::block_type>(
-                memory_block, "/common/segment_data/forward_weights/packed");
-        extractor::SegmentDataView::SegmentWeightVector geometry_fwd_weight_list(
-            util::vector_view<extractor::SegmentDataView::SegmentWeightVector::block_type>(
-                geometries_fwd_weight_list_ptr,
-                data_layout.GetBlockEntries("/common/segment_data/forward_weights/packed")),
-            num_entries);
-
-        auto geometries_rev_weight_list_ptr =
-            data_layout.GetBlockPtr<extractor::SegmentDataView::SegmentWeightVector::block_type>(
-                memory_block, "/common/segment_data/reverse_weights/packed");
-        extractor::SegmentDataView::SegmentWeightVector geometry_rev_weight_list(
-            util::vector_view<extractor::SegmentDataView::SegmentWeightVector::block_type>(
-                geometries_rev_weight_list_ptr,
-                data_layout.GetBlockEntries("/common/segment_data/reverse_weights/packed")),
-            num_entries);
-
-        auto geometries_fwd_duration_list_ptr =
-            data_layout.GetBlockPtr<extractor::SegmentDataView::SegmentDurationVector::block_type>(
-                memory_block, "/common/segment_data/forward_durations/packed");
-        extractor::SegmentDataView::SegmentDurationVector geometry_fwd_duration_list(
-            util::vector_view<extractor::SegmentDataView::SegmentDurationVector::block_type>(
-                geometries_fwd_duration_list_ptr,
-                data_layout.GetBlockEntries("/common/segment_data/forward_durations/packed")),
-            num_entries);
-
-        auto geometries_rev_duration_list_ptr =
-            data_layout.GetBlockPtr<extractor::SegmentDataView::SegmentDurationVector::block_type>(
-                memory_block, "/common/segment_data/reverse_durations/packed");
-        extractor::SegmentDataView::SegmentDurationVector geometry_rev_duration_list(
-            util::vector_view<extractor::SegmentDataView::SegmentDurationVector::block_type>(
-                geometries_rev_duration_list_ptr,
-                data_layout.GetBlockEntries("/common/segment_data/reverse_durations/packed")),
-            num_entries);
-
-        auto geometries_fwd_datasources_list_ptr = data_layout.GetBlockPtr<DatasourceID>(
-            memory_block, "/common/segment_data/forward_data_sources");
-        util::vector_view<DatasourceID> geometry_fwd_datasources_list(
-            geometries_fwd_datasources_list_ptr,
-            data_layout.GetBlockEntries("/common/segment_data/forward_data_sources"));
-
-        auto geometries_rev_datasources_list_ptr = data_layout.GetBlockPtr<DatasourceID>(
-            memory_block, "/common/segment_data/reverse_data_sources");
-        util::vector_view<DatasourceID> geometry_rev_datasources_list(
-            geometries_rev_datasources_list_ptr,
-            data_layout.GetBlockEntries("/common/segment_data/reverse_data_sources"));
-
-        segment_data = extractor::SegmentDataView{std::move(geometry_begin_indices),
-                                                  std::move(geometry_node_list),
-                                                  std::move(geometry_fwd_weight_list),
-                                                  std::move(geometry_rev_weight_list),
-                                                  std::move(geometry_fwd_duration_list),
-                                                  std::move(geometry_rev_duration_list),
-                                                  std::move(geometry_fwd_datasources_list),
-                                                  std::move(geometry_rev_datasources_list)};
-
-        m_datasources = data_layout.GetBlockPtr<extractor::Datasources>(
-            memory_block, "/common/data_sources_names");
-    }
-
-    void InitializeIntersectionClassPointers(const storage::DataLayout &data_layout,
-                                             char *memory_block)
-    {
-        auto bearing_class_id_ptr = data_layout.GetBlockPtr<BearingClassID>(
-            memory_block, "/common/intersection_bearings/node_to_class_id");
-        util::vector_view<BearingClassID> bearing_class_id(
-            bearing_class_id_ptr,
-            data_layout.GetBlockEntries("/common/intersection_bearings/node_to_class_id"));
-
-        auto bearing_values_ptr = data_layout.GetBlockPtr<DiscreteBearing>(
-            memory_block, "/common/intersection_bearings/bearing_values");
-        util::vector_view<DiscreteBearing> bearing_values(
-            bearing_values_ptr,
-            data_layout.GetBlockEntries("/common/intersection_bearings/bearing_values"));
-
-        auto offsets_ptr = data_layout.GetBlockPtr<unsigned>(
-            memory_block, "/common/intersection_bearings/class_id_to_ranges/block_offsets");
-        auto blocks_ptr = data_layout.GetBlockPtr<IndexBlock>(
-            memory_block, "/common/intersection_bearings/class_id_to_ranges/diff_blocks");
-        util::vector_view<unsigned> bearing_offsets(
-            offsets_ptr,
-            data_layout.GetBlockEntries(
-                "/common/intersection_bearings/class_id_to_ranges/block_offsets"));
-        util::vector_view<IndexBlock> bearing_blocks(
-            blocks_ptr,
-            data_layout.GetBlockEntries(
-                "/common/intersection_bearings/class_id_to_ranges/diff_blocks"));
-
-        util::RangeTable<16, storage::Ownership::View> bearing_range_table(
-            bearing_offsets, bearing_blocks, static_cast<unsigned>(bearing_values.size()));
-
-        intersection_bearings_view = extractor::IntersectionBearingsView{
-            std::move(bearing_values), std::move(bearing_class_id), std::move(bearing_range_table)};
-
-        auto entry_class_ptr = data_layout.GetBlockPtr<util::guidance::EntryClass>(
-            memory_block, "/common/entry_classes");
-        util::vector_view<util::guidance::EntryClass> entry_class_table(
-            entry_class_ptr, data_layout.GetBlockEntries("/common/entry_classes"));
-        m_entry_class_table = std::move(entry_class_table);
-    }
-
-    void InitializeManeuverOverridePointers(const storage::DataLayout &data_layout,
-                                            char *memory_block)
-    {
-        auto maneuver_overrides_ptr = data_layout.GetBlockPtr<extractor::StorageManeuverOverride>(
-            memory_block, "/common/maneuver_overrides/overrides");
-        m_maneuver_overrides = util::vector_view<extractor::StorageManeuverOverride>(
-            maneuver_overrides_ptr,
-            data_layout.GetBlockEntries("/common/maneuver_overrides/overrides"));
-
-        auto maneuver_override_node_sequences_ptr = data_layout.GetBlockPtr<NodeID>(
-            memory_block, "/common/maneuver_overrides/node_sequences");
-        m_maneuver_override_node_sequences = util::vector_view<NodeID>(
-            maneuver_override_node_sequences_ptr,
-            data_layout.GetBlockEntries("/common/maneuver_overrides/node_sequences"));
-    }
-
-    void InitializeInternalPointers(const storage::DataLayout &data_layout,
-                                    char *memory_block,
+    void InitializeInternalPointers(const storage::DataLayout &layout,
+                                    char *memory_ptr,
                                     const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
-        InitializeChecksumPointer(data_layout, memory_block);
-        InitializeNodeInformationPointers(data_layout, memory_block);
-        InitializeEdgeBasedNodeDataInformationPointers(data_layout, memory_block);
-        InitializeEdgeInformationPointers(data_layout, memory_block);
-        InitializeTurnPenalties(data_layout, memory_block);
-        InitializeGeometryPointers(data_layout, memory_block);
-        InitializeNamePointers(data_layout, memory_block);
-        InitializeTurnLaneDescriptionsPointers(data_layout, memory_block);
-        InitializeProfilePropertiesPointer(data_layout, memory_block, metric_name, exclude_index);
-        InitializeRTreePointers(data_layout, memory_block);
-        InitializeIntersectionClassPointers(data_layout, memory_block);
-        InitializeManeuverOverridePointers(data_layout, memory_block);
+        // TODO: For multi-metric support we need to have separate exclude classes per metric
+        (void)metric_name;
+
+        m_profile_properties =
+            layout.GetBlockPtr<extractor::ProfileProperties>(memory_ptr, "/common/properties");
+
+        exclude_mask = m_profile_properties->excludable_classes[exclude_index];
+
+        m_check_sum =
+            *layout.GetBlockPtr<std::uint32_t>(memory_ptr, "/common/connectivity_checksum");
+
+        std::tie(m_coordinate_list, m_osmnodeid_list) =
+            make_nbn_data_view(memory_ptr, layout, "/common/nbn_data");
+
+        m_static_rtree = make_search_tree_view(memory_ptr, layout, "/common/rtree");
+        m_geospatial_query.reset(
+            new SharedGeospatialQuery(m_static_rtree, m_coordinate_list, *this));
+
+        edge_based_node_data = make_ebn_data_view(memory_ptr, layout, "/common/ebg_node_data");
+
+        turn_data = make_turn_data_view(memory_ptr, layout, "/common/turn_data");
+
+        m_name_table = make_name_table_view(memory_ptr, layout, "/common/names");
+
+        std::tie(m_lane_description_offsets, m_lane_description_masks) =
+            make_turn_lane_description_views(memory_ptr, layout, "/common/turn_lanes");
+        m_lane_tupel_id_pairs = make_lane_data_view(memory_ptr, layout, "/common/turn_lanes");
+
+        m_turn_weight_penalties = make_turn_weight_view(memory_ptr, layout, "/common/turn_penalty");
+        m_turn_duration_penalties =
+            make_turn_duration_view(memory_ptr, layout, "/common/turn_penalty");
+
+        segment_data = make_segment_data_view(memory_ptr, layout, "/common/segment_data");
+
+        m_datasources =
+            layout.GetBlockPtr<extractor::Datasources>(memory_ptr, "/common/data_sources_names");
+
+        intersection_bearings_view =
+            make_intersection_bearings_view(memory_ptr, layout, "/common/intersection_bearings");
+
+        m_entry_class_table = make_entry_classes_view(memory_ptr, layout, "/common/entry_classes");
+
+        std::tie(m_maneuver_overrides, m_maneuver_override_node_sequences) =
+            make_maneuver_overrides_views(memory_ptr, layout, "/common/maneuver_overrides");
     }
 
   public:
@@ -996,122 +661,16 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
 
     QueryGraph query_graph;
 
-    void InitializeInternalPointers(const storage::DataLayout &data_layout,
-                                    char *memory_block,
+    void InitializeInternalPointers(const storage::DataLayout &layout,
+                                    char *memory_ptr,
                                     const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
-        InitializeMLDDataPointers(data_layout, memory_block, metric_name, exclude_index);
-        InitializeGraphPointer(data_layout, memory_block);
-    }
-
-    void InitializeMLDDataPointers(const storage::DataLayout &data_layout,
-                                   char *memory_block,
-                                   const std::string &metric_name,
-                                   const std::size_t exclude_index)
-    {
-        if (data_layout.GetBlockSize("/mld/multilevelpartition/partition") > 0)
-        {
-            BOOST_ASSERT(data_layout.GetBlockSize("/mld/multilevelpartition/level_data") > 0);
-            BOOST_ASSERT(data_layout.GetBlockSize("/mld/multilevelpartition/cell_to_children") > 0);
-
-            auto level_data =
-                data_layout.GetBlockPtr<partitioner::MultiLevelPartitionView::LevelData>(
-                    memory_block, "/mld/multilevelpartition/level_data");
-
-            auto mld_partition_ptr = data_layout.GetBlockPtr<PartitionID>(
-                memory_block, "/mld/multilevelpartition/partition");
-            auto partition_entries_count =
-                data_layout.GetBlockEntries("/mld/multilevelpartition/partition");
-            util::vector_view<PartitionID> partition(mld_partition_ptr, partition_entries_count);
-
-            auto mld_chilren_ptr = data_layout.GetBlockPtr<CellID>(
-                memory_block, "/mld/multilevelpartition/cell_to_children");
-            auto children_entries_count =
-                data_layout.GetBlockEntries("/mld/multilevelpartition/cell_to_children");
-            util::vector_view<CellID> cell_to_children(mld_chilren_ptr, children_entries_count);
-
-            mld_partition =
-                partitioner::MultiLevelPartitionView{level_data, partition, cell_to_children};
-        }
-
-        const auto exclude_prefix =
-            "/mld/metrics/" + metric_name + "/exclude/" + std::to_string(exclude_index);
-        const auto weights_block_id = exclude_prefix + "/weights";
-        const auto durations_block_id = exclude_prefix + "/durations";
-
-        if (data_layout.GetBlockSize(weights_block_id) > 0)
-        {
-            auto mld_cell_weights_ptr =
-                data_layout.GetBlockPtr<EdgeWeight>(memory_block, weights_block_id);
-            auto mld_cell_durations_ptr =
-                data_layout.GetBlockPtr<EdgeDuration>(memory_block, durations_block_id);
-            auto weight_entries_count = data_layout.GetBlockEntries(weights_block_id);
-            auto duration_entries_count = data_layout.GetBlockEntries(durations_block_id);
-            BOOST_ASSERT(weight_entries_count == duration_entries_count);
-            util::vector_view<EdgeWeight> weights(mld_cell_weights_ptr, weight_entries_count);
-            util::vector_view<EdgeDuration> durations(mld_cell_durations_ptr,
-                                                      duration_entries_count);
-
-            mld_cell_metric = customizer::CellMetricView{std::move(weights), std::move(durations)};
-        }
-
-        if (data_layout.GetBlockSize("/mld/cellstorage/cells") > 0)
-        {
-
-            auto mld_source_boundary_ptr =
-                data_layout.GetBlockPtr<NodeID>(memory_block, "/mld/cellstorage/source_boundary");
-            auto mld_destination_boundary_ptr = data_layout.GetBlockPtr<NodeID>(
-                memory_block, "/mld/cellstorage/destination_boundary");
-            auto mld_cells_ptr = data_layout.GetBlockPtr<partitioner::CellStorageView::CellData>(
-                memory_block, "/mld/cellstorage/cells");
-            auto mld_cell_level_offsets_ptr = data_layout.GetBlockPtr<std::uint64_t>(
-                memory_block, "/mld/cellstorage/level_to_cell_offset");
-
-            auto source_boundary_entries_count =
-                data_layout.GetBlockEntries("/mld/cellstorage/source_boundary");
-            auto destination_boundary_entries_count =
-                data_layout.GetBlockEntries("/mld/cellstorage/destination_boundary");
-            auto cells_entries_counts = data_layout.GetBlockEntries("/mld/cellstorage/cells");
-            auto cell_level_offsets_entries_count =
-                data_layout.GetBlockEntries("/mld/cellstorage/level_to_cell_offset");
-
-            util::vector_view<NodeID> source_boundary(mld_source_boundary_ptr,
-                                                      source_boundary_entries_count);
-            util::vector_view<NodeID> destination_boundary(mld_destination_boundary_ptr,
-                                                           destination_boundary_entries_count);
-            util::vector_view<partitioner::CellStorageView::CellData> cells(mld_cells_ptr,
-                                                                            cells_entries_counts);
-            util::vector_view<std::uint64_t> level_offsets(mld_cell_level_offsets_ptr,
-                                                           cell_level_offsets_entries_count);
-
-            mld_cell_storage = partitioner::CellStorageView{std::move(source_boundary),
-                                                            std::move(destination_boundary),
-                                                            std::move(cells),
-                                                            std::move(level_offsets)};
-        }
-    }
-    void InitializeGraphPointer(const storage::DataLayout &data_layout, char *memory_block)
-    {
-        auto graph_nodes_ptr =
-            data_layout.GetBlockPtr<GraphNode>(memory_block, "/mld/multilevelgraph/node_array");
-
-        auto graph_edges_ptr =
-            data_layout.GetBlockPtr<GraphEdge>(memory_block, "/mld/multilevelgraph/edge_array");
-
-        auto graph_node_to_offset_ptr = data_layout.GetBlockPtr<QueryGraph::EdgeOffset>(
-            memory_block, "/mld/multilevelgraph/node_to_edge_offset");
-
-        util::vector_view<GraphNode> node_list(
-            graph_nodes_ptr, data_layout.GetBlockEntries("/mld/multilevelgraph/node_array"));
-        util::vector_view<GraphEdge> edge_list(
-            graph_edges_ptr, data_layout.GetBlockEntries("/mld/multilevelgraph/edge_array"));
-        util::vector_view<QueryGraph::EdgeOffset> node_to_offset(
-            graph_node_to_offset_ptr,
-            data_layout.GetBlockEntries("/mld/multilevelgraph/node_to_edge_offset"));
-
-        query_graph =
-            QueryGraph(std::move(node_list), std::move(edge_list), std::move(node_to_offset));
+        mld_partition = make_partition_view(memory_ptr, layout, "/mld/multilevelpartition");
+        mld_cell_metric = make_filtered_cell_metric_view(
+            memory_ptr, layout, "/mld/metrics/" + metric_name, exclude_index);
+        mld_cell_storage = make_cell_storage_view(memory_ptr, layout, "/mld/cellstorage");
+        query_graph = make_multi_level_graph_view(memory_ptr, layout, "/mld/multilevelgraph");
     }
 
     // allocator that keeps the allocation data

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -194,7 +194,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     extractor::ProfileProperties *m_profile_properties;
     extractor::Datasources *m_datasources;
 
-    unsigned m_check_sum;
+    std::uint32_t m_check_sum;
     util::vector_view<util::Coordinate> m_coordinate_list;
     extractor::PackedOSMIDsView m_osmnodeid_list;
     util::vector_view<std::uint32_t> m_lane_description_offsets;
@@ -242,7 +242,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
     void InitializeChecksumPointer(const storage::DataLayout &data_layout, char *memory_block)
     {
-        m_check_sum = *data_layout.GetBlockPtr<unsigned>(memory_block, "/ch/checksum");
+        m_check_sum = *data_layout.GetBlockPtr<std::uint32_t>(memory_block, "/common/connectivity_checksum");
         util::Log() << "set checksum: " << m_check_sum;
     }
 
@@ -779,7 +779,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
             input_coordinate, bearing, bearing_range, approach);
     }
 
-    unsigned GetCheckSum() const override final { return m_check_sum; }
+    std::uint32_t GetCheckSum() const override final { return m_check_sum; }
 
     GeometryID GetGeometryIndex(const NodeID id) const override final
     {

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -83,15 +83,15 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
 
     void InitializeGraphPointer(const storage::DataLayout &data_layout,
                                 char *memory_block,
-                                const std::string& metric_name,
+                                const std::string &metric_name,
                                 const std::size_t exclude_index)
     {
         const std::string metric_prefix = "/ch/metrics/" + metric_name;
-        auto graph_nodes_ptr =
-            data_layout.GetBlockPtr<GraphNode>(memory_block, metric_prefix + "/contracted_graph/node_array");
+        auto graph_nodes_ptr = data_layout.GetBlockPtr<GraphNode>(
+            memory_block, metric_prefix + "/contracted_graph/node_array");
 
-        auto graph_edges_ptr =
-            data_layout.GetBlockPtr<GraphEdge>(memory_block, metric_prefix + "/contracted_graph/edge_array");
+        auto graph_edges_ptr = data_layout.GetBlockPtr<GraphEdge>(
+            memory_block, metric_prefix + "/contracted_graph/edge_array");
 
         auto exclude_prefix = metric_prefix + "/exclude/" + std::to_string(exclude_index);
         auto filter_block_id = exclude_prefix + "/edge_filter";
@@ -100,9 +100,11 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
             data_layout.GetBlockPtr<util::vector_view<bool>::Word>(memory_block, filter_block_id);
 
         util::vector_view<GraphNode> node_list(
-            graph_nodes_ptr, data_layout.GetBlockEntries(metric_prefix + "/contracted_graph/node_array"));
+            graph_nodes_ptr,
+            data_layout.GetBlockEntries(metric_prefix + "/contracted_graph/node_array"));
         util::vector_view<GraphEdge> edge_list(
-            graph_edges_ptr, data_layout.GetBlockEntries(metric_prefix + "/contracted_graph/edge_array"));
+            graph_edges_ptr,
+            data_layout.GetBlockEntries(metric_prefix + "/contracted_graph/edge_array"));
 
         util::vector_view<bool> edge_filter(edge_filter_ptr,
                                             data_layout.GetBlockEntries(filter_block_id));
@@ -111,15 +113,18 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
 
   public:
     ContiguousInternalMemoryAlgorithmDataFacade(
-        std::shared_ptr<ContiguousBlockAllocator> allocator_, const std::string& metric_name, std::size_t exclude_index)
+        std::shared_ptr<ContiguousBlockAllocator> allocator_,
+        const std::string &metric_name,
+        std::size_t exclude_index)
         : allocator(std::move(allocator_))
     {
-        InitializeInternalPointers(allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
+        InitializeInternalPointers(
+            allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
     }
 
     void InitializeInternalPointers(const storage::DataLayout &data_layout,
                                     char *memory_block,
-                                    const std::string& metric_name,
+                                    const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
         InitializeGraphPointer(data_layout, memory_block, metric_name, exclude_index);
@@ -229,11 +234,11 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
     void InitializeProfilePropertiesPointer(const storage::DataLayout &data_layout,
                                             char *memory_block,
-                                            const std::string& metric_name,
+                                            const std::string &metric_name,
                                             const std::size_t exclude_index)
     {
         // TODO: For multi-metric support we need to have separate exclude classes per metric
-        (void) metric_name;
+        (void)metric_name;
         m_profile_properties = data_layout.GetBlockPtr<extractor::ProfileProperties>(
             memory_block, "/common/properties");
 
@@ -242,7 +247,8 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
     void InitializeChecksumPointer(const storage::DataLayout &data_layout, char *memory_block)
     {
-        m_check_sum = *data_layout.GetBlockPtr<std::uint32_t>(memory_block, "/common/connectivity_checksum");
+        m_check_sum =
+            *data_layout.GetBlockPtr<std::uint32_t>(memory_block, "/common/connectivity_checksum");
         util::Log() << "set checksum: " << m_check_sum;
     }
 
@@ -535,7 +541,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
     void InitializeInternalPointers(const storage::DataLayout &data_layout,
                                     char *memory_block,
-                                    const std::string& metric_name,
+                                    const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
         InitializeChecksumPointer(data_layout, memory_block);
@@ -556,11 +562,12 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     // allows switching between process_memory/shared_memory datafacade, based on the type of
     // allocator
     ContiguousInternalMemoryDataFacadeBase(std::shared_ptr<ContiguousBlockAllocator> allocator_,
-                                            const std::string& metric_name,
+                                           const std::string &metric_name,
                                            const std::size_t exclude_index)
         : allocator(std::move(allocator_))
     {
-        InitializeInternalPointers(allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
+        InitializeInternalPointers(
+            allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
     }
 
     // node and edge information access
@@ -946,7 +953,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         auto found_range = std::equal_range(
             m_maneuver_overrides.begin(), m_maneuver_overrides.end(), edge_based_node_id, Comp{});
 
-        std::for_each(found_range.first, found_range.second, [&](const auto &override) {
+        std::for_each(found_range.first, found_range.second, [&](const auto & override) {
             std::vector<NodeID> sequence(
                 m_maneuver_override_node_sequences.begin() + override.node_sequence_offset_begin,
                 m_maneuver_override_node_sequences.begin() + override.node_sequence_offset_end);
@@ -968,7 +975,7 @@ class ContiguousInternalMemoryDataFacade<CH>
 {
   public:
     ContiguousInternalMemoryDataFacade(std::shared_ptr<ContiguousBlockAllocator> allocator,
-            const std::string& metric_name,
+                                       const std::string &metric_name,
                                        const std::size_t exclude_index)
         : ContiguousInternalMemoryDataFacadeBase(allocator, metric_name, exclude_index),
           ContiguousInternalMemoryAlgorithmDataFacade<CH>(allocator, metric_name, exclude_index)
@@ -991,7 +998,7 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
 
     void InitializeInternalPointers(const storage::DataLayout &data_layout,
                                     char *memory_block,
-                                    const std::string& metric_name,
+                                    const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
         InitializeMLDDataPointers(data_layout, memory_block, metric_name, exclude_index);
@@ -1000,7 +1007,7 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
 
     void InitializeMLDDataPointers(const storage::DataLayout &data_layout,
                                    char *memory_block,
-                                   const std::string& metric_name,
+                                   const std::string &metric_name,
                                    const std::size_t exclude_index)
     {
         if (data_layout.GetBlockSize("/mld/multilevelpartition/partition") > 0)
@@ -1028,7 +1035,8 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
                 partitioner::MultiLevelPartitionView{level_data, partition, cell_to_children};
         }
 
-        const auto exclude_prefix = "/mld/metrics/" + metric_name + "/exclude/" + std::to_string(exclude_index);
+        const auto exclude_prefix =
+            "/mld/metrics/" + metric_name + "/exclude/" + std::to_string(exclude_index);
         const auto weights_block_id = exclude_prefix + "/weights";
         const auto durations_block_id = exclude_prefix + "/durations";
 
@@ -1111,10 +1119,13 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
 
   public:
     ContiguousInternalMemoryAlgorithmDataFacade(
-        std::shared_ptr<ContiguousBlockAllocator> allocator_, const std::string& metric_name, const std::size_t exclude_index)
+        std::shared_ptr<ContiguousBlockAllocator> allocator_,
+        const std::string &metric_name,
+        const std::size_t exclude_index)
         : allocator(std::move(allocator_))
     {
-        InitializeInternalPointers(allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
+        InitializeInternalPointers(
+            allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
     }
 
     const partitioner::MultiLevelPartitionView &GetMultiLevelPartition() const override
@@ -1168,7 +1179,7 @@ class ContiguousInternalMemoryDataFacade<MLD> final
   private:
   public:
     ContiguousInternalMemoryDataFacade(std::shared_ptr<ContiguousBlockAllocator> allocator,
-                                       const std::string& metric_name,
+                                       const std::string &metric_name,
                                        const std::size_t exclude_index)
         : ContiguousInternalMemoryDataFacadeBase(allocator, metric_name, exclude_index),
           ContiguousInternalMemoryAlgorithmDataFacade<MLD>(allocator, metric_name, exclude_index)

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -53,7 +53,7 @@ class BaseDataFacade
     BaseDataFacade() {}
     virtual ~BaseDataFacade() {}
 
-    virtual unsigned GetCheckSum() const = 0;
+    virtual std::uint32_t GetCheckSum() const = 0;
 
     // node and edge information access
     virtual util::Coordinate GetCoordinateOfNode(const NodeID id) const = 0;

--- a/include/engine/datafacade/process_memory_allocator.hpp
+++ b/include/engine/datafacade/process_memory_allocator.hpp
@@ -27,12 +27,12 @@ class ProcessMemoryAllocator : public ContiguousBlockAllocator
     ~ProcessMemoryAllocator() override final;
 
     // interface to give access to the datafacades
-    storage::DataLayout &GetLayout() override final;
+    const storage::DataLayout &GetLayout() override final;
     char *GetMemory() override final;
 
   private:
+    storage::DataLayout internal_layout;
     std::unique_ptr<char[]> internal_memory;
-    std::unique_ptr<storage::DataLayout> internal_layout;
 };
 
 } // namespace datafacade

--- a/include/engine/datafacade/shared_memory_allocator.hpp
+++ b/include/engine/datafacade/shared_memory_allocator.hpp
@@ -27,10 +27,12 @@ class SharedMemoryAllocator : public ContiguousBlockAllocator
     ~SharedMemoryAllocator() override final;
 
     // interface to give access to the datafacades
-    storage::DataLayout &GetLayout() override final;
+    const storage::DataLayout &GetLayout() override final;
     char *GetMemory() override final;
 
   private:
+    std::size_t layout_size;
+    storage::DataLayout data_layout;
     std::unique_ptr<storage::SharedMemory> m_large_memory;
 };
 

--- a/include/engine/datafacade_factory.hpp
+++ b/include/engine/datafacade_factory.hpp
@@ -51,7 +51,7 @@ template <template <typename A> class FacadeT, typename AlgorithmT> class DataFa
         }
 
         properties = allocator->GetLayout().template GetBlockPtr<extractor::ProfileProperties>(
-            allocator->GetMemory(), storage::DataLayout::PROPERTIES);
+            allocator->GetMemory(), "/common/properties");
 
         for (const auto index : util::irange<std::size_t>(0, properties->class_names.size()))
         {

--- a/include/engine/datafacade_factory.hpp
+++ b/include/engine/datafacade_factory.hpp
@@ -57,6 +57,13 @@ template <template <typename A> class FacadeT, typename AlgorithmT> class DataFa
         layout.List(exclude_path, std::back_inserter(exclude_prefixes));
         facades.resize(exclude_prefixes.size());
 
+        if (facades.empty())
+        {
+            throw util::exception(std::string("Could not find any metrics for ") +
+                                  routing_algorithms::name<AlgorithmT>() +
+                                  " in the data. Did you load the right dataset?");
+        }
+
         for (const auto &exclude_prefix : exclude_prefixes)
         {
             auto index_begin = exclude_prefix.find_last_of("/");

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -152,8 +152,8 @@ bool Engine<routing_algorithms::ch::Algorithm>::CheckCompatibility(const EngineC
 
         auto mem = storage::makeSharedMemory(barrier.data().region);
         auto layout = reinterpret_cast<storage::DataLayout *>(mem->Ptr());
-        return layout->GetBlockSize(storage::DataLayout::CH_GRAPH_NODE_LIST) > 4 &&
-               layout->GetBlockSize(storage::DataLayout::CH_GRAPH_EDGE_LIST) > 4;
+        return layout->GetBlockSize("/ch/contracted_graph/node_array") > 4 &&
+               layout->GetBlockSize("/ch/contracted_graph/edge_array") > 4;
     }
     else
     {
@@ -173,19 +173,19 @@ bool Engine<routing_algorithms::mld::Algorithm>::CheckCompatibility(const Engine
         auto mem = storage::makeSharedMemory(barrier.data().region);
         auto layout = reinterpret_cast<storage::DataLayout *>(mem->Ptr());
         // checks that all the needed memory blocks are populated
-        // DataLayout::MLD_CELL_SOURCE_BOUNDARY and DataLayout::MLD_CELL_DESTINATION_BOUNDARY
+        // "/mld/cellstorage/source_boundary" and "/mld/cellstorage/destination_boundary"
         // are not checked, because in situations where there are so few nodes in the graph that
         // they all fit into one cell, they can be empty.
-        bool empty_data = layout->GetBlockSize(storage::DataLayout::MLD_LEVEL_DATA) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_PARTITION) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_CELL_TO_CHILDREN) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_CELLS) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_CELL_LEVEL_OFFSETS) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_GRAPH_NODE_LIST) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_GRAPH_EDGE_LIST) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_CELL_WEIGHTS_0) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_CELL_DURATIONS_0) > 0 &&
-                          layout->GetBlockSize(storage::DataLayout::MLD_GRAPH_NODE_TO_OFFSET) > 0;
+        bool empty_data = layout->GetBlockSize("/mld/multilevelpartition/level_data") > 0 &&
+                          layout->GetBlockSize("/mld/multilevelpartition/partition") > 0 &&
+                          layout->GetBlockSize("/mld/multilevelpartition/cell_to_children") > 0 &&
+                          layout->GetBlockSize("/mld/cellstorage/cells") > 0 &&
+                          layout->GetBlockSize("/mld/cellstorage/level_to_cell_offset") > 0 &&
+                          layout->GetBlockSize("/mld/multilevelgraph/node_array") > 0 &&
+                          layout->GetBlockSize("/mld/multilevelgraph/edge_array") > 0 &&
+                          layout->GetBlockSize("/mld/metrics/0/weights") > 0 &&
+                          layout->GetBlockSize("/mld/metrics/0/durations") > 0 &&
+                          layout->GetBlockSize("/mld/multilevelgraph/node_to_edge_offset") > 0;
         return empty_data;
     }
     else

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -122,8 +122,8 @@ inline void readNodes(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    storage::serialization::read(reader, "/common/coordinates", coordinates);
-    util::serialization::read(reader, "/common/osm_node_ids", osm_node_ids);
+    storage::serialization::read(reader, "/common/nbn_data/coordinates", coordinates);
+    util::serialization::read(reader, "/common/nbn_data/osm_node_ids", osm_node_ids);
 }
 
 // reads only coordinates from .osrm.nbg_nodes
@@ -135,7 +135,7 @@ inline void readNodeCoordinates(const boost::filesystem::path &path, Coordinates
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    storage::serialization::read(reader, "/common/coordinates", coordinates);
+    storage::serialization::read(reader, "/common/nbn_data/coordinates", coordinates);
 }
 
 // writes .osrm.nbg_nodes
@@ -150,8 +150,8 @@ inline void writeNodes(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
-    storage::serialization::write(writer, "/common/coordinates", coordinates);
-    util::serialization::write(writer, "/common/osm_node_ids", osm_node_ids);
+    storage::serialization::write(writer, "/common/nbn_data/coordinates", coordinates);
+    util::serialization::write(writer, "/common/nbn_data/osm_node_ids", osm_node_ids);
 }
 
 // reads .osrm.cnbg_to_ebg

--- a/include/guidance/files.hpp
+++ b/include/guidance/files.hpp
@@ -30,7 +30,8 @@ inline void readTurnData(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    serialization::read(reader, "/common/turn_data", turn_data, connectivity_checksum);
+    reader.ReadInto("/common/connectivity_checksum", connectivity_checksum);
+    serialization::read(reader, "/common/turn_data", turn_data);
 }
 
 // writes .osrm.edges
@@ -46,7 +47,9 @@ inline void writeTurnData(const boost::filesystem::path &path,
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
-    serialization::write(writer, "/common/turn_data", turn_data, connectivity_checksum);
+    writer.WriteElementCount64("/common/connectivity_checksum", 1);
+    writer.WriteFrom("/common/connectivity_checksum", connectivity_checksum);
+    serialization::write(writer, "/common/turn_data", turn_data);
 }
 }
 }

--- a/include/guidance/serialization.hpp
+++ b/include/guidance/serialization.hpp
@@ -19,8 +19,7 @@ namespace serialization
 template <storage::Ownership Ownership>
 inline void read(storage::tar::FileReader &reader,
                  const std::string &name,
-                 guidance::detail::TurnDataContainerImpl<Ownership> &turn_data_container,
-                 std::uint32_t &connectivity_checksum)
+                 guidance::detail::TurnDataContainerImpl<Ownership> &turn_data_container)
 {
     storage::serialization::read(
         reader, name + "/turn_instructions", turn_data_container.turn_instructions);
@@ -32,14 +31,12 @@ inline void read(storage::tar::FileReader &reader,
         reader, name + "/pre_turn_bearings", turn_data_container.pre_turn_bearings);
     storage::serialization::read(
         reader, name + "/post_turn_bearings", turn_data_container.post_turn_bearings);
-    reader.ReadInto(name + "/connectivity_checksum", connectivity_checksum);
 }
 
 template <storage::Ownership Ownership>
 inline void write(storage::tar::FileWriter &writer,
                   const std::string &name,
-                  const guidance::detail::TurnDataContainerImpl<Ownership> &turn_data_container,
-                  const std::uint32_t connectivity_checksum)
+                  const guidance::detail::TurnDataContainerImpl<Ownership> &turn_data_container)
 {
     storage::serialization::write(
         writer, name + "/turn_instructions", turn_data_container.turn_instructions);
@@ -51,8 +48,6 @@ inline void write(storage::tar::FileWriter &writer,
         writer, name + "/pre_turn_bearings", turn_data_container.pre_turn_bearings);
     storage::serialization::write(
         writer, name + "/post_turn_bearings", turn_data_container.post_turn_bearings);
-    writer.WriteElementCount64(name + "/connectivity_checksum", 1);
-    writer.WriteFrom(name + "/connectivity_checksum", connectivity_checksum);
 }
 }
 }

--- a/include/guidance/turn_data_container.hpp
+++ b/include/guidance/turn_data_container.hpp
@@ -26,14 +26,12 @@ namespace serialization
 template <storage::Ownership Ownership>
 void read(storage::tar::FileReader &reader,
           const std::string &name,
-          detail::TurnDataContainerImpl<Ownership> &turn_data,
-          std::uint32_t &connectivity_checksum);
+          detail::TurnDataContainerImpl<Ownership> &turn_data);
 
 template <storage::Ownership Ownership>
 void write(storage::tar::FileWriter &writer,
            const std::string &name,
-           const detail::TurnDataContainerImpl<Ownership> &turn_data,
-           const std::uint32_t connectivity_checksum);
+           const detail::TurnDataContainerImpl<Ownership> &turn_data);
 }
 
 struct TurnData
@@ -101,12 +99,10 @@ template <storage::Ownership Ownership> class TurnDataContainerImpl
 
     friend void serialization::read<Ownership>(storage::tar::FileReader &reader,
                                                const std::string &name,
-                                               TurnDataContainerImpl &turn_data_container,
-                                               std::uint32_t &connectivity_checksum);
+                                               TurnDataContainerImpl &turn_data_container);
     friend void serialization::write<Ownership>(storage::tar::FileWriter &writer,
                                                 const std::string &name,
-                                                const TurnDataContainerImpl &turn_data_container,
-                                                const std::uint32_t connectivity_checksum);
+                                                const TurnDataContainerImpl &turn_data_container);
 
   private:
     Vector<TurnInstruction> turn_instructions;

--- a/include/partitioner/files.hpp
+++ b/include/partitioner/files.hpp
@@ -26,7 +26,8 @@ inline void readGraph(const boost::filesystem::path &path,
 
     storage::tar::FileReader reader{path, storage::tar::FileReader::VerifyFingerprint};
 
-    serialization::read(reader, "/mld/multilevelgraph", graph, connectivity_checksum);
+    reader.ReadInto("/mld/connectivity_checksum", connectivity_checksum);
+    serialization::read(reader, "/mld/multilevelgraph", graph);
 }
 
 // writes .osrm.mldgr file
@@ -41,7 +42,9 @@ inline void writeGraph(const boost::filesystem::path &path,
 
     storage::tar::FileWriter writer{path, storage::tar::FileWriter::GenerateFingerprint};
 
-    serialization::write(writer, "/mld/multilevelgraph", graph, connectivity_checksum);
+    writer.WriteElementCount64("/mld/connectivity_checksum", 1);
+    writer.WriteFrom("/mld/connectivity_checksum", connectivity_checksum);
+    serialization::write(writer, "/mld/multilevelgraph", graph);
 }
 
 // read .osrm.partition file

--- a/include/partitioner/multi_level_graph.hpp
+++ b/include/partitioner/multi_level_graph.hpp
@@ -26,14 +26,12 @@ namespace serialization
 template <typename EdgeDataT, storage::Ownership Ownership>
 void read(storage::tar::FileReader &reader,
           const std::string &name,
-          MultiLevelGraph<EdgeDataT, Ownership> &graph,
-          std::uint32_t &connectivity_checksum);
+          MultiLevelGraph<EdgeDataT, Ownership> &graph);
 
 template <typename EdgeDataT, storage::Ownership Ownership>
 void write(storage::tar::FileWriter &writer,
            const std::string &name,
-           const MultiLevelGraph<EdgeDataT, Ownership> &graph,
-           const std::uint32_t connectivity_checksum);
+           const MultiLevelGraph<EdgeDataT, Ownership> &graph);
 }
 
 template <typename EdgeDataT, storage::Ownership Ownership>
@@ -206,13 +204,11 @@ class MultiLevelGraph : public util::StaticGraph<EdgeDataT, Ownership>
     friend void
     serialization::read<EdgeDataT, Ownership>(storage::tar::FileReader &reader,
                                               const std::string &name,
-                                              MultiLevelGraph<EdgeDataT, Ownership> &graph,
-                                              std::uint32_t &connectivity_checksum);
+                                              MultiLevelGraph<EdgeDataT, Ownership> &graph);
     friend void
     serialization::write<EdgeDataT, Ownership>(storage::tar::FileWriter &writer,
                                                const std::string &name,
-                                               const MultiLevelGraph<EdgeDataT, Ownership> &graph,
-                                               const std::uint32_t connectivity_checksum);
+                                               const MultiLevelGraph<EdgeDataT, Ownership> &graph);
 
     Vector<EdgeOffset> node_to_edge_offset;
     std::uint32_t connectivity_checksum;

--- a/include/partitioner/serialization.hpp
+++ b/include/partitioner/serialization.hpp
@@ -22,26 +22,21 @@ namespace serialization
 template <typename EdgeDataT, storage::Ownership Ownership>
 inline void read(storage::tar::FileReader &reader,
                  const std::string &name,
-                 MultiLevelGraph<EdgeDataT, Ownership> &graph,
-                 std::uint32_t &connectivity_checksum)
+                 MultiLevelGraph<EdgeDataT, Ownership> &graph)
 {
     storage::serialization::read(reader, name + "/node_array", graph.node_array);
     storage::serialization::read(reader, name + "/edge_array", graph.edge_array);
     storage::serialization::read(reader, name + "/node_to_edge_offset", graph.node_to_edge_offset);
-    reader.ReadInto(name + "/connectivity_checksum", connectivity_checksum);
 }
 
 template <typename EdgeDataT, storage::Ownership Ownership>
 inline void write(storage::tar::FileWriter &writer,
                   const std::string &name,
-                  const MultiLevelGraph<EdgeDataT, Ownership> &graph,
-                  const std::uint32_t connectivity_checksum)
+                  const MultiLevelGraph<EdgeDataT, Ownership> &graph)
 {
     storage::serialization::write(writer, name + "/node_array", graph.node_array);
     storage::serialization::write(writer, name + "/edge_array", graph.edge_array);
     storage::serialization::write(writer, name + "/node_to_edge_offset", graph.node_to_edge_offset);
-    writer.WriteElementCount64(name + "/connectivity_checksum", 1);
-    writer.WriteFrom(name + "/connectivity_checksum", connectivity_checksum);
 }
 
 template <storage::Ownership Ownership>

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -11,9 +11,9 @@
 #include "util/version.hpp"
 
 #include <boost/filesystem/fstream.hpp>
+#include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/seek.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/iostreams/device/array.hpp>
 
 #include <cerrno>
 #include <cstring>
@@ -296,11 +296,10 @@ class FileWriter
 class BufferReader
 {
   public:
-    BufferReader(const std::string &buffer) : BufferReader(buffer.data(), buffer.size())
-    {
-    }
+    BufferReader(const std::string &buffer) : BufferReader(buffer.data(), buffer.size()) {}
 
-    BufferReader(const char* buffer, const std::size_t size) : input_stream(boost::iostreams::array_source(buffer, size))
+    BufferReader(const char *buffer, const std::size_t size)
+        : input_stream(boost::iostreams::array_source(buffer, size))
     {
         if (!input_stream)
         {
@@ -309,9 +308,7 @@ class BufferReader
         }
     }
 
-    std::size_t GetPosition() {
-        return input_stream.tellg();
-    }
+    std::size_t GetPosition() { return input_stream.tellg(); }
 
     template <typename T> void ReadInto(T *dest, const std::size_t count)
     {

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -12,6 +12,8 @@
 
 #include <boost/filesystem/fstream.hpp>
 #include <boost/iostreams/seek.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/device/array.hpp>
 
 #include <cerrno>
 #include <cstring>
@@ -294,7 +296,11 @@ class FileWriter
 class BufferReader
 {
   public:
-    BufferReader(const std::string &buffer) : input_stream(buffer, std::ios::binary)
+    BufferReader(const std::string &buffer) : BufferReader(buffer.data(), buffer.size())
+    {
+    }
+
+    BufferReader(const char* buffer, const std::size_t size) : input_stream(boost::iostreams::array_source(buffer, size))
     {
         if (!input_stream)
         {
@@ -342,7 +348,7 @@ class BufferReader
     }
 
   private:
-    std::istringstream input_stream;
+    boost::iostreams::stream<boost::iostreams::array_source> input_stream;
 };
 
 class BufferWriter

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -303,6 +303,10 @@ class BufferReader
         }
     }
 
+    std::size_t GetPosition() {
+        return input_stream.tellg();
+    }
+
     template <typename T> void ReadInto(T *dest, const std::size_t count)
     {
 #if !defined(__GNUC__) || (__GNUC__ > 4)

--- a/include/storage/serialization.hpp
+++ b/include/storage/serialization.hpp
@@ -6,8 +6,8 @@
 #include "util/vector_view.hpp"
 
 #include "storage/io.hpp"
-#include "storage/tar.hpp"
 #include "storage/shared_datatype.hpp"
+#include "storage/tar.hpp"
 
 #include <boost/function_output_iterator.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
@@ -92,7 +92,6 @@ void writeBoolVector(tar::FileWriter &writer, const std::string &name, const Vec
 }
 }
 
-
 /* All vector formats here use the same on-disk format.
  * This is important because we want to be able to write from a vector
  * of one kind, but read it into a vector of another kind.
@@ -149,17 +148,12 @@ template <typename T> void write(io::BufferWriter &writer, const std::vector<T> 
     writer.WriteFrom(data.data(), count);
 }
 
-template<typename T>
-inline void write(io::BufferWriter &writer, const T &data)
+template <typename T> inline void write(io::BufferWriter &writer, const T &data)
 {
     writer.WriteFrom(data);
 }
 
-template<typename T>
-inline void read(io::BufferReader &reader, T &data)
-{
-    reader.ReadInto(data);
-}
+template <typename T> inline void read(io::BufferReader &reader, T &data) { reader.ReadInto(data); }
 
 inline void write(io::BufferWriter &writer, const std::string &data)
 {
@@ -254,7 +248,7 @@ template <typename K, typename V> void read(io::BufferReader &reader, std::map<K
     std::pair<K, V> pair;
     for (auto index : util::irange<std::size_t>(0, count))
     {
-        (void) index;
+        (void)index;
         read(reader, pair.first);
         read(reader, pair.second);
         data.insert(pair);
@@ -272,17 +266,12 @@ template <typename K, typename V> void write(io::BufferWriter &writer, const std
     }
 }
 
-inline void read(io::BufferReader &reader, DataLayout &layout)
-{
-    read(reader, layout.blocks);
-}
+inline void read(io::BufferReader &reader, DataLayout &layout) { read(reader, layout.blocks); }
 
 inline void write(io::BufferWriter &writer, const DataLayout &layout)
 {
     write(writer, layout.blocks);
 }
-
-
 }
 }
 }

--- a/include/storage/serialization.hpp
+++ b/include/storage/serialization.hpp
@@ -245,10 +245,10 @@ write<bool>(tar::FileWriter &writer, const std::string &name, const std::vector<
 template <typename K, typename V> void read(io::BufferReader &reader, std::map<K, V> &data)
 {
     const auto count = reader.ReadElementCount64();
-    std::pair<K, V> pair;
     for (auto index : util::irange<std::size_t>(0, count))
     {
         (void)index;
+        std::pair<K, V> pair;
         read(reader, pair.first);
         read(reader, pair.second);
         data.insert(pair);

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -2,6 +2,7 @@
 #define SHARED_DATA_TYPE_HPP
 
 #include "storage/block.hpp"
+#include "storage/io_fwd.hpp"
 
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
@@ -11,219 +12,91 @@
 
 #include <array>
 #include <cstdint>
+#include <map>
 
 namespace osrm
 {
 namespace storage
 {
 
+class DataLayout;
+namespace serialization
+{
+inline void read(io::BufferReader &reader, DataLayout &layout);
+
+inline void write(io::BufferWriter &writer, const DataLayout &layout);
+}
+
 // Added at the start and end of each block as sanity check
 const constexpr char CANARY[4] = {'O', 'S', 'R', 'M'};
-
-const constexpr char *block_id_to_name[] = {"IGNORE_BLOCK",
-                                            "NAME_BLOCKS",
-                                            "NAME_VALUES",
-                                            "EDGE_BASED_NODE_DATA",
-                                            "ANNOTATION_DATA",
-                                            "CH_GRAPH_NODE_LIST",
-                                            "CH_GRAPH_EDGE_LIST",
-                                            "CH_EDGE_FILTER_0",
-                                            "CH_EDGE_FILTER_1",
-                                            "CH_EDGE_FILTER_2",
-                                            "CH_EDGE_FILTER_3",
-                                            "CH_EDGE_FILTER_4",
-                                            "CH_EDGE_FILTER_5",
-                                            "CH_EDGE_FILTER_6",
-                                            "CH_EDGE_FILTER_7",
-                                            "COORDINATE_LIST",
-                                            "OSM_NODE_ID_LIST",
-                                            "TURN_INSTRUCTION",
-                                            "ENTRY_CLASSID",
-                                            "R_SEARCH_TREE",
-                                            "R_SEARCH_TREE_LEVEL_STARTS",
-                                            "GEOMETRIES_INDEX",
-                                            "GEOMETRIES_NODE_LIST",
-                                            "GEOMETRIES_FWD_WEIGHT_LIST",
-                                            "GEOMETRIES_REV_WEIGHT_LIST",
-                                            "GEOMETRIES_FWD_DURATION_LIST",
-                                            "GEOMETRIES_REV_DURATION_LIST",
-                                            "GEOMETRIES_FWD_DATASOURCES_LIST",
-                                            "GEOMETRIES_REV_DATASOURCES_LIST",
-                                            "HSGR_CHECKSUM",
-                                            "FILE_INDEX_PATH",
-                                            "DATASOURCES_NAMES",
-                                            "PROPERTIES",
-                                            "BEARING_CLASSID",
-                                            "BEARING_OFFSETS",
-                                            "BEARING_BLOCKS",
-                                            "BEARING_VALUES",
-                                            "ENTRY_CLASS",
-                                            "LANE_DATA_ID",
-                                            "PRE_TURN_BEARING",
-                                            "POST_TURN_BEARING",
-                                            "TURN_LANE_DATA",
-                                            "LANE_DESCRIPTION_OFFSETS",
-                                            "LANE_DESCRIPTION_MASKS",
-                                            "TURN_WEIGHT_PENALTIES",
-                                            "TURN_DURATION_PENALTIES",
-                                            "MLD_LEVEL_DATA",
-                                            "MLD_PARTITION",
-                                            "MLD_CELL_TO_CHILDREN",
-                                            "MLD_CELL_WEIGHTS_0",
-                                            "MLD_CELL_WEIGHTS_1",
-                                            "MLD_CELL_WEIGHTS_2",
-                                            "MLD_CELL_WEIGHTS_3",
-                                            "MLD_CELL_WEIGHTS_4",
-                                            "MLD_CELL_WEIGHTS_5",
-                                            "MLD_CELL_WEIGHTS_6",
-                                            "MLD_CELL_WEIGHTS_7",
-                                            "MLD_CELL_DURATIONS_0",
-                                            "MLD_CELL_DURATIONS_1",
-                                            "MLD_CELL_DURATIONS_2",
-                                            "MLD_CELL_DURATIONS_3",
-                                            "MLD_CELL_DURATIONS_4",
-                                            "MLD_CELL_DURATIONS_5",
-                                            "MLD_CELL_DURATIONS_6",
-                                            "MLD_CELL_DURATIONS_7",
-                                            "MLD_CELL_SOURCE_BOUNDARY",
-                                            "MLD_CELL_DESTINATION_BOUNDARY",
-                                            "MLD_CELLS",
-                                            "MLD_CELL_LEVEL_OFFSETS",
-                                            "MLD_GRAPH_NODE_LIST",
-                                            "MLD_GRAPH_EDGE_LIST",
-                                            "MLD_GRAPH_NODE_TO_OFFSET",
-                                            "MANEUVER_OVERRIDES",
-                                            "MANEUVER_OVERRIDE_NODE_SEQUENCES"};
 
 class DataLayout
 {
   public:
-    enum BlockID
-    {
-        IGNORE_BLOCK = 0,
-        NAME_BLOCKS,
-        NAME_VALUES,
-        EDGE_BASED_NODE_DATA_LIST,
-        ANNOTATION_DATA_LIST,
-        CH_GRAPH_NODE_LIST,
-        CH_GRAPH_EDGE_LIST,
-        CH_EDGE_FILTER_0,
-        CH_EDGE_FILTER_1,
-        CH_EDGE_FILTER_2,
-        CH_EDGE_FILTER_3,
-        CH_EDGE_FILTER_4,
-        CH_EDGE_FILTER_5,
-        CH_EDGE_FILTER_6,
-        CH_EDGE_FILTER_7,
-        COORDINATE_LIST,
-        OSM_NODE_ID_LIST,
-        TURN_INSTRUCTION,
-        ENTRY_CLASSID,
-        R_SEARCH_TREE,
-        R_SEARCH_TREE_LEVEL_STARTS,
-        GEOMETRIES_INDEX,
-        GEOMETRIES_NODE_LIST,
-        GEOMETRIES_FWD_WEIGHT_LIST,
-        GEOMETRIES_REV_WEIGHT_LIST,
-        GEOMETRIES_FWD_DURATION_LIST,
-        GEOMETRIES_REV_DURATION_LIST,
-        GEOMETRIES_FWD_DATASOURCES_LIST,
-        GEOMETRIES_REV_DATASOURCES_LIST,
-        HSGR_CHECKSUM,
-        FILE_INDEX_PATH,
-        DATASOURCES_NAMES,
-        PROPERTIES,
-        BEARING_CLASSID,
-        BEARING_OFFSETS,
-        BEARING_BLOCKS,
-        BEARING_VALUES,
-        ENTRY_CLASS,
-        LANE_DATA_ID,
-        PRE_TURN_BEARING,
-        POST_TURN_BEARING,
-        TURN_LANE_DATA,
-        LANE_DESCRIPTION_OFFSETS,
-        LANE_DESCRIPTION_MASKS,
-        TURN_WEIGHT_PENALTIES,
-        TURN_DURATION_PENALTIES,
-        MLD_LEVEL_DATA,
-        MLD_PARTITION,
-        MLD_CELL_TO_CHILDREN,
-        MLD_CELL_WEIGHTS_0,
-        MLD_CELL_WEIGHTS_1,
-        MLD_CELL_WEIGHTS_2,
-        MLD_CELL_WEIGHTS_3,
-        MLD_CELL_WEIGHTS_4,
-        MLD_CELL_WEIGHTS_5,
-        MLD_CELL_WEIGHTS_6,
-        MLD_CELL_WEIGHTS_7,
-        MLD_CELL_DURATIONS_0,
-        MLD_CELL_DURATIONS_1,
-        MLD_CELL_DURATIONS_2,
-        MLD_CELL_DURATIONS_3,
-        MLD_CELL_DURATIONS_4,
-        MLD_CELL_DURATIONS_5,
-        MLD_CELL_DURATIONS_6,
-        MLD_CELL_DURATIONS_7,
-        MLD_CELL_SOURCE_BOUNDARY,
-        MLD_CELL_DESTINATION_BOUNDARY,
-        MLD_CELLS,
-        MLD_CELL_LEVEL_OFFSETS,
-        MLD_GRAPH_NODE_LIST,
-        MLD_GRAPH_EDGE_LIST,
-        MLD_GRAPH_NODE_TO_OFFSET,
-        MANEUVER_OVERRIDES,
-        MANEUVER_OVERRIDE_NODE_SEQUENCES,
-        NUM_BLOCKS
-    };
-
     DataLayout() : blocks{} {}
 
-    inline void SetBlock(BlockID bid, Block block) { blocks[bid] = std::move(block); }
+    inline void SetBlock(const std::string &name, Block block) { blocks[name] = std::move(block); }
 
-    inline uint64_t GetBlockEntries(BlockID bid) const { return blocks[bid].num_entries; }
+    inline uint64_t GetBlockEntries(const std::string &name) const
+    {
+        auto iter = blocks.find(name);
+        if (iter == blocks.end())
+        {
+            throw util::exception("Could not find block " + name);
+        }
 
-    inline uint64_t GetBlockSize(BlockID bid) const { return blocks[bid].byte_size; }
+        return iter->second.num_entries;
+    }
+
+    inline uint64_t GetBlockSize(const std::string &name) const
+    {
+        auto iter = blocks.find(name);
+        if (iter == blocks.end())
+        {
+            throw util::exception("Could not find block " + name);
+        }
+
+        return iter->second.byte_size;
+    }
 
     inline uint64_t GetSizeOfLayout() const
     {
         uint64_t result = 0;
-        for (auto i = 0; i < NUM_BLOCKS; i++)
+        for (const auto &name_and_block : blocks)
         {
-            result += 2 * sizeof(CANARY) + GetBlockSize(static_cast<BlockID>(i)) + BLOCK_ALIGNMENT;
+            result += 2 * sizeof(CANARY) + GetBlockSize(name_and_block.first) + BLOCK_ALIGNMENT;
         }
         return result;
     }
 
     template <typename T, bool WRITE_CANARY = false>
-    inline T *GetBlockPtr(char *shared_memory, BlockID bid) const
+    inline T *GetBlockPtr(char *shared_memory, const std::string &name) const
     {
         static_assert(BLOCK_ALIGNMENT % std::alignment_of<T>::value == 0,
                       "Datatype does not fit alignment constraints.");
 
-        char *ptr = (char *)GetAlignedBlockPtr(shared_memory, bid);
+        char *ptr = (char *)GetAlignedBlockPtr(shared_memory, name);
         if (WRITE_CANARY)
         {
             char *start_canary_ptr = ptr - sizeof(CANARY);
-            char *end_canary_ptr = ptr + GetBlockSize(bid);
+            char *end_canary_ptr = ptr + GetBlockSize(name);
             std::copy(CANARY, CANARY + sizeof(CANARY), start_canary_ptr);
             std::copy(CANARY, CANARY + sizeof(CANARY), end_canary_ptr);
         }
         else
         {
             char *start_canary_ptr = ptr - sizeof(CANARY);
-            char *end_canary_ptr = ptr + GetBlockSize(bid);
+            char *end_canary_ptr = ptr + GetBlockSize(name);
             bool start_canary_alive = std::equal(CANARY, CANARY + sizeof(CANARY), start_canary_ptr);
             bool end_canary_alive = std::equal(CANARY, CANARY + sizeof(CANARY), end_canary_ptr);
             if (!start_canary_alive)
             {
-                throw util::exception("Start canary of block corrupted. (" +
-                                      std::string(block_id_to_name[bid]) + ")" + SOURCE_REF);
+                throw util::exception("Start canary of block corrupted. (" + name + ")" +
+                                      SOURCE_REF);
             }
             if (!end_canary_alive)
             {
-                throw util::exception("End canary of block corrupted. (" +
-                                      std::string(block_id_to_name[bid]) + ")" + SOURCE_REF);
+                throw util::exception("End canary of block corrupted. (" + name + ")" + SOURCE_REF);
             }
         }
 
@@ -231,6 +104,9 @@ class DataLayout
     }
 
   private:
+    friend void serialization::read(io::BufferReader &reader, DataLayout &layout);
+    friend void serialization::write(io::BufferWriter &writer, const DataLayout &layout);
+
     // Fit aligned storage in buffer to 64 bytes to conform with AVX 512 types
     inline void *align(void *&ptr) const noexcept
     {
@@ -239,13 +115,13 @@ class DataLayout
         return ptr = reinterpret_cast<void *>(aligned);
     }
 
-    inline void *GetAlignedBlockPtr(void *ptr, BlockID bid) const
+    inline void *GetAlignedBlockPtr(void *ptr, const std::string &name) const
     {
-        for (auto i = 0; i < bid; i++)
+        for (auto iter = blocks.begin(); iter != blocks.end() && iter->first != name; ++iter)
         {
             ptr = static_cast<char *>(ptr) + sizeof(CANARY);
             ptr = align(ptr);
-            ptr = static_cast<char *>(ptr) + GetBlockSize((BlockID)i);
+            ptr = static_cast<char *>(ptr) + GetBlockSize(name);
             ptr = static_cast<char *>(ptr) + sizeof(CANARY);
         }
 
@@ -254,14 +130,14 @@ class DataLayout
         return ptr;
     }
 
-    template <typename T> inline T *GetBlockEnd(char *shared_memory, BlockID bid) const
+    template <typename T> inline T *GetBlockEnd(char *shared_memory, const std::string &name) const
     {
-        auto begin = GetBlockPtr<T>(shared_memory, bid);
-        return begin + GetBlockEntries(bid);
+        auto begin = GetBlockPtr<T>(shared_memory, name);
+        return begin + GetBlockEntries(name);
     }
 
     static constexpr std::size_t BLOCK_ALIGNMENT = 64;
-    std::array<Block, NUM_BLOCKS> blocks;
+    std::map<std::string, Block> blocks;
 };
 
 enum SharedDataType
@@ -298,9 +174,6 @@ inline std::string regionToString(const SharedDataType region)
         return "INVALID_REGION";
     }
 }
-
-static_assert(sizeof(block_id_to_name) / sizeof(*block_id_to_name) == DataLayout::NUM_BLOCKS,
-              "Number of blocks needs to match the number of Block names.");
 }
 }
 

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -35,7 +35,7 @@ namespace detail
 inline std::string trimName(const std::string &name_prefix, const std::string &name)
 {
     // list directory and
-    if (name_prefix.back() == '/')
+    if (!name_prefix.empty() && name_prefix.back() == '/')
     {
         auto directory_position = name.find_first_of("/", name_prefix.length());
         // this is a "file" in the directory of name_prefix

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -94,8 +94,6 @@ class DataLayout
         {
             char *start_canary_ptr = ptr - sizeof(CANARY);
             char *end_canary_ptr = ptr + GetBlockSize(name);
-            std::cout << name << ": " << (long)(start_canary_ptr - shared_memory) << " -> "
-                      << (long)(end_canary_ptr - shared_memory) << std::endl;
             std::copy(CANARY, CANARY + sizeof(CANARY), start_canary_ptr);
             std::copy(CANARY, CANARY + sizeof(CANARY), end_canary_ptr);
         }

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -4,10 +4,10 @@
 #include "storage/block.hpp"
 #include "storage/io_fwd.hpp"
 
-#include "util/vector_view.hpp"
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
 #include "util/log.hpp"
+#include "util/vector_view.hpp"
 
 #include <boost/assert.hpp>
 
@@ -88,15 +88,16 @@ class DataLayout
     }
 
     template <typename T>
-    util::vector_view<T> GetVector(char* shared_memory, const std::string& name) const
+    util::vector_view<T> GetVector(char *shared_memory, const std::string &name) const
     {
         return util::vector_view<T>(GetBlockPtr<T>(shared_memory, name), GetBlockEntries(name));
     }
 
     template <typename T>
-    util::vector_view<T> GetWritableVector(char* shared_memory, const std::string& name) const
+    util::vector_view<T> GetWritableVector(char *shared_memory, const std::string &name) const
     {
-        return util::vector_view<T>(GetBlockPtr<T, true>(shared_memory, name), GetBlockEntries(name));
+        return util::vector_view<T>(GetBlockPtr<T, true>(shared_memory, name),
+                                    GetBlockEntries(name));
     }
 
     template <typename T, bool WRITE_CANARY = false>
@@ -203,6 +204,15 @@ class DataLayout
     static constexpr std::size_t BLOCK_ALIGNMENT = 64;
     std::map<std::string, Block> blocks;
 };
+
+template <>
+inline util::vector_view<bool> DataLayout::GetWritableVector<bool>(char *shared_memory,
+                                                                   const std::string &name) const
+{
+    return util::vector_view<bool>(
+        GetBlockPtr<util::vector_view<bool>::Word, true>(shared_memory, name),
+        GetBlockEntries(name));
+}
 
 enum SharedDataType
 {

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -71,6 +71,8 @@ class DataLayout
 
     inline uint64_t GetBlockSize(const std::string &name) const { return GetBlock(name).byte_size; }
 
+    inline bool HasBlock(const std::string &name) const { return blocks.find(name) != blocks.end(); }
+
     inline uint64_t GetSizeOfLayout() const
     {
         uint64_t result = 0;

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -71,7 +71,10 @@ class DataLayout
 
     inline uint64_t GetBlockSize(const std::string &name) const { return GetBlock(name).byte_size; }
 
-    inline bool HasBlock(const std::string &name) const { return blocks.find(name) != blocks.end(); }
+    inline bool HasBlock(const std::string &name) const
+    {
+        return blocks.find(name) != blocks.end();
+    }
 
     inline uint64_t GetSizeOfLayout() const
     {

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -4,6 +4,7 @@
 #include "storage/block.hpp"
 #include "storage/io_fwd.hpp"
 
+#include "util/vector_view.hpp"
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
 #include "util/log.hpp"
@@ -84,6 +85,18 @@ class DataLayout
             result += 2 * sizeof(CANARY) + GetBlockSize(name_and_block.first) + BLOCK_ALIGNMENT;
         }
         return result;
+    }
+
+    template <typename T>
+    util::vector_view<T> GetVector(char* shared_memory, const std::string& name) const
+    {
+        return util::vector_view<T>(GetBlockPtr<T>(shared_memory, name), GetBlockEntries(name));
+    }
+
+    template <typename T>
+    util::vector_view<T> GetWritableVector(char* shared_memory, const std::string& name) const
+    {
+        return util::vector_view<T>(GetBlockPtr<T, true>(shared_memory, name), GetBlockEntries(name));
     }
 
     template <typename T, bool WRITE_CANARY = false>

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -47,6 +47,7 @@ class SharedMemory
 {
   public:
     void *Ptr() const { return region.get_address(); }
+    std::size_t Size() const { return region.get_size(); }
 
     SharedMemory(const SharedMemory &) = delete;
     SharedMemory &operator=(const SharedMemory &) = delete;
@@ -200,6 +201,7 @@ class SharedMemory
 
   public:
     void *Ptr() const { return region.get_address(); }
+    std::size_t Size() const { return region.get_size(); }
 
     SharedMemory(const boost::filesystem::path &lock_file, const int id, const uint64_t size = 0)
     {

--- a/include/storage/view_factory.hpp
+++ b/include/storage/view_factory.hpp
@@ -3,6 +3,39 @@
 
 #include "storage/shared_datatype.hpp"
 
+#include "contractor/contracted_metric.hpp"
+#include "contractor/query_graph.hpp"
+
+#include "customizer/edge_based_graph.hpp"
+
+#include "extractor/class_data.hpp"
+#include "extractor/compressed_edge_container.hpp"
+#include "extractor/edge_based_edge.hpp"
+#include "extractor/edge_based_node.hpp"
+#include "extractor/edge_based_node_segment.hpp"
+#include "extractor/maneuver_override.hpp"
+#include "extractor/name_table.hpp"
+#include "extractor/packed_osm_ids.hpp"
+#include "extractor/query_node.hpp"
+#include "extractor/travel_mode.hpp"
+
+#include "guidance/turn_bearing.hpp"
+#include "guidance/turn_data_container.hpp"
+#include "guidance/turn_instruction.hpp"
+
+#include "partitioner/cell_storage.hpp"
+#include "partitioner/edge_based_graph_reader.hpp"
+#include "partitioner/multi_level_partition.hpp"
+
+#include "util/coordinate.hpp"
+#include "util/packed_vector.hpp"
+#include "util/range_table.hpp"
+#include "util/static_graph.hpp"
+#include "util/static_rtree.hpp"
+#include "util/typedefs.hpp"
+#include "util/vector_view.hpp"
+
+#include "util/packed_vector.hpp"
 #include "util/vector_view.hpp"
 
 namespace osrm
@@ -11,7 +44,8 @@ namespace storage
 {
 
 template <typename T>
-util::vector_view<T> make_vector_view(char *memory_ptr, DataLayout layout, const std::string &name)
+util::vector_view<T>
+make_vector_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
 {
     return util::vector_view<T>(layout.GetBlockPtr<T>(memory_ptr, name),
                                 layout.GetBlockEntries(name));
@@ -19,11 +53,289 @@ util::vector_view<T> make_vector_view(char *memory_ptr, DataLayout layout, const
 
 template <>
 inline util::vector_view<bool>
-make_vector_view(char *memory_ptr, DataLayout layout, const std::string &name)
+make_vector_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
 {
     return util::vector_view<bool>(
         layout.GetBlockPtr<util::vector_view<bool>::Word>(memory_ptr, name),
         layout.GetBlockEntries(name));
+}
+
+template <typename T, std::size_t Bits>
+util::PackedVectorView<T, Bits>
+make_packed_vector_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    using V = util::PackedVectorView<T, Bits>;
+    auto packed_internal = util::vector_view<typename V::block_type>(
+        layout.GetBlockPtr<typename V::block_type>(memory_ptr, name + "/packed"),
+        layout.GetBlockEntries(name + "/packed"));
+    // the real size needs to come from an external source
+    return V{packed_internal, std::numeric_limits<std::size_t>::max()};
+}
+
+auto make_name_table_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    auto blocks = make_vector_view<extractor::NameTableView::IndexedData::BlockReference>(
+        memory_ptr, layout, name + "/blocks");
+    auto values = make_vector_view<extractor::NameTableView::IndexedData::ValueType>(
+        memory_ptr, layout, name + "/values");
+
+    extractor::NameTableView::IndexedData index_data_view{std::move(blocks), std::move(values)};
+    return extractor::NameTableView{index_data_view};
+}
+
+auto make_lane_data_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    return make_vector_view<util::guidance::LaneTupleIdPair>(memory_ptr, layout, name + "/data");
+}
+
+auto make_turn_lane_description_views(char *memory_ptr,
+                                      const DataLayout &layout,
+                                      const std::string &name)
+{
+    auto offsets = make_vector_view<std::uint32_t>(memory_ptr, layout, name + "/offsets");
+    auto masks =
+        make_vector_view<extractor::TurnLaneType::Mask>(memory_ptr, layout, name + "/masks");
+
+    return std::make_tuple(offsets, masks);
+}
+
+auto make_ebn_data_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    auto edge_based_node_data =
+        make_vector_view<extractor::EdgeBasedNode>(memory_ptr, layout, name + "/nodes");
+    auto annotation_data = make_vector_view<extractor::NodeBasedEdgeAnnotation>(
+        memory_ptr, layout, name + "/annotations");
+
+    return extractor::EdgeBasedNodeDataView(std::move(edge_based_node_data),
+                                            std::move(annotation_data));
+}
+
+auto make_turn_data_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    auto lane_data_ids = make_vector_view<LaneDataID>(memory_ptr, layout, name + "/lane_data_ids");
+
+    const auto turn_instructions = make_vector_view<guidance::TurnInstruction>(
+        memory_ptr, layout, name + "/turn_instructions");
+
+    const auto entry_class_ids =
+        make_vector_view<EntryClassID>(memory_ptr, layout, name + "/entry_class_ids");
+
+    const auto pre_turn_bearings =
+        make_vector_view<guidance::TurnBearing>(memory_ptr, layout, name + "/pre_turn_bearings");
+
+    const auto post_turn_bearings =
+        make_vector_view<guidance::TurnBearing>(memory_ptr, layout, name + "/post_turn_bearings");
+
+    return guidance::TurnDataView(std::move(turn_instructions),
+                                  std::move(lane_data_ids),
+                                  std::move(entry_class_ids),
+                                  std::move(pre_turn_bearings),
+                                  std::move(post_turn_bearings));
+}
+
+auto make_segment_data_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    auto geometry_begin_indices = make_vector_view<unsigned>(memory_ptr, layout, name + "/index");
+
+    auto node_list = make_vector_view<NodeID>(memory_ptr, layout, name + "/nodes");
+
+    auto num_entries = layout.GetBlockEntries(name + "/nodes");
+
+    extractor::SegmentDataView::SegmentWeightVector fwd_weight_list(
+        make_vector_view<extractor::SegmentDataView::SegmentWeightVector::block_type>(
+            memory_ptr, layout, name + "/forward_weights/packed"),
+        num_entries);
+
+    extractor::SegmentDataView::SegmentWeightVector rev_weight_list(
+        make_vector_view<extractor::SegmentDataView::SegmentWeightVector::block_type>(
+            memory_ptr, layout, name + "/reverse_weights/packed"),
+        num_entries);
+
+    extractor::SegmentDataView::SegmentDurationVector fwd_duration_list(
+        make_vector_view<extractor::SegmentDataView::SegmentDurationVector::block_type>(
+            memory_ptr, layout, name + "/forward_durations/packed"),
+        num_entries);
+
+    extractor::SegmentDataView::SegmentDurationVector rev_duration_list(
+        make_vector_view<extractor::SegmentDataView::SegmentDurationVector::block_type>(
+            memory_ptr, layout, name + "/reverse_durations/packed"),
+        num_entries);
+
+    auto fwd_datasources_list =
+        make_vector_view<DatasourceID>(memory_ptr, layout, name + "/forward_data_sources");
+
+    auto rev_datasources_list =
+        make_vector_view<DatasourceID>(memory_ptr, layout, name + "/reverse_data_sources");
+
+    return extractor::SegmentDataView{std::move(geometry_begin_indices),
+                                      std::move(node_list),
+                                      std::move(fwd_weight_list),
+                                      std::move(rev_weight_list),
+                                      std::move(fwd_duration_list),
+                                      std::move(rev_duration_list),
+                                      std::move(fwd_datasources_list),
+                                      std::move(rev_datasources_list)};
+}
+
+auto make_coordinates_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    return make_vector_view<util::Coordinate>(memory_ptr, layout, name);
+}
+
+auto make_osm_ids_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    return make_packed_vector_view<extractor::PackedOSMIDsView::value_type,
+                                   extractor::PackedOSMIDsView::value_size>(
+        memory_ptr, layout, name);
+}
+
+auto make_turn_duration_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    return make_vector_view<TurnPenalty>(memory_ptr, layout, name + "/weight");
+}
+
+auto make_turn_penalties_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    return make_vector_view<TurnPenalty>(memory_ptr, layout, name + "/duration");
+}
+
+auto make_search_tree_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    using RTreeLeaf = extractor::EdgeBasedNodeSegment;
+    using RTreeNode = util::StaticRTree<RTreeLeaf, storage::Ownership::View>::TreeNode;
+
+    const auto search_tree = make_vector_view<RTreeNode>(memory_ptr, layout, name + "/search_tree");
+
+    const auto rtree_level_starts =
+        make_vector_view<std::uint64_t>(memory_ptr, layout, name + "/search_tree_level_starts");
+
+    const auto coordinates = make_coordinates_view(memory_ptr, layout, "/common/coordinates");
+
+    const char *path = layout.GetBlockPtr<char>(memory_ptr, name + "/file_index_path");
+
+    return util::StaticRTree<RTreeLeaf, storage::Ownership::View>{
+        std::move(search_tree), std::move(rtree_level_starts), path, std::move(coordinates)};
+}
+
+auto make_intersection_bearings_view(char *memory_ptr,
+                                     const DataLayout &layout,
+                                     const std::string &name)
+{
+    auto bearing_offsets =
+        make_vector_view<unsigned>(memory_ptr, layout, name + "/class_id_to_ranges/block_offsets");
+    auto bearing_blocks = make_vector_view<util::RangeTable<16, storage::Ownership::View>::BlockT>(
+        memory_ptr, layout, name + "/class_id_to_ranges/diff_blocks");
+    auto bearing_values =
+        make_vector_view<DiscreteBearing>(memory_ptr, layout, name + "/bearing_values");
+    util::RangeTable<16, storage::Ownership::View> bearing_range_table(
+        std::move(bearing_offsets),
+        std::move(bearing_blocks),
+        static_cast<unsigned>(bearing_values.size()));
+
+    auto bearing_class_id =
+        make_vector_view<BearingClassID>(memory_ptr, layout, name + "/node_to_class_id");
+    return extractor::IntersectionBearingsView{
+        std::move(bearing_values), std::move(bearing_class_id), std::move(bearing_range_table)};
+}
+
+auto make_entry_classes_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    return make_vector_view<util::guidance::EntryClass>(memory_ptr, layout, name);
+}
+
+auto make_contracted_metric_view(char *memory_ptr,
+                                 const DataLayout &layout,
+                                 const std::string &name)
+{
+    auto node_list = make_vector_view<contractor::QueryGraphView::NodeArrayEntry>(
+        memory_ptr, layout, name + "/contracted_graph/node_array");
+    auto edge_list = make_vector_view<contractor::QueryGraphView::EdgeArrayEntry>(
+        memory_ptr, layout, name + "/contracted_graph/edge_array");
+
+    std::vector<util::vector_view<bool>> edge_filter;
+    layout.List(name + "/exclude",
+                boost::make_function_output_iterator([&](const auto &filter_name) {
+                    edge_filter.push_back(make_vector_view<bool>(memory_ptr, layout, filter_name));
+                }));
+
+    return contractor::ContractedMetricView{{std::move(node_list), std::move(edge_list)},
+                                            std::move(edge_filter)};
+}
+
+auto make_partition_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    auto level_data_ptr = layout.GetBlockPtr<partitioner::MultiLevelPartitionView::LevelData>(
+        memory_ptr, name + "/level_data");
+    auto partition = make_vector_view<PartitionID>(memory_ptr, layout, name + "/partition");
+    auto cell_to_children =
+        make_vector_view<CellID>(memory_ptr, layout, name + "/cell_to_children");
+
+    return partitioner::MultiLevelPartitionView{
+        level_data_ptr, std::move(partition), std::move(cell_to_children)};
+}
+
+auto make_cell_storage_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    auto source_boundary = make_vector_view<NodeID>(memory_ptr, layout, name + "/source_boundary");
+    auto destination_boundary =
+        make_vector_view<NodeID>(memory_ptr, layout, name + "/destination_boundary");
+    auto cells = make_vector_view<partitioner::CellStorageView::CellData>(
+        memory_ptr, layout, name + "/cells");
+    auto level_offsets =
+        make_vector_view<std::uint64_t>(memory_ptr, layout, name + "/level_to_cell_offset");
+
+    return partitioner::CellStorageView{std::move(source_boundary),
+                                        std::move(destination_boundary),
+                                        std::move(cells),
+                                        std::move(level_offsets)};
+}
+
+auto make_cell_metric_view(char *memory_ptr, const DataLayout &layout, const std::string &name)
+{
+    std::vector<customizer::CellMetricView> cell_metric_excludes;
+
+    std::vector<std::string> metric_prefix_names;
+    layout.List(name + "/exclude/", std::back_inserter(metric_prefix_names));
+    for (const auto &prefix : metric_prefix_names)
+    {
+        auto weights_block_id = prefix + "/weights";
+        auto durations_block_id = prefix + "/durations";
+
+        auto weights = make_vector_view<EdgeWeight>(memory_ptr, layout, weights_block_id);
+        auto durations = make_vector_view<EdgeDuration>(memory_ptr, layout, durations_block_id);
+
+        cell_metric_excludes.push_back(
+            customizer::CellMetricView{std::move(weights), std::move(durations)});
+    }
+
+    return cell_metric_excludes;
+}
+
+auto make_multi_level_graph_view(char *memory_ptr,
+                                 const DataLayout &layout,
+                                 const std::string &name)
+{
+    auto node_list = make_vector_view<customizer::MultiLevelEdgeBasedGraphView::NodeArrayEntry>(
+        memory_ptr, layout, name + "/node_array");
+    auto edge_list = make_vector_view<customizer::MultiLevelEdgeBasedGraphView::EdgeArrayEntry>(
+        memory_ptr, layout, name + "/edge_array");
+    auto node_to_offset = make_vector_view<customizer::MultiLevelEdgeBasedGraphView::EdgeOffset>(
+        memory_ptr, layout, name + "/node_to_edge_offset");
+
+    return customizer::MultiLevelEdgeBasedGraphView(
+        std::move(node_list), std::move(edge_list), std::move(node_to_offset));
+}
+
+auto make_maneuver_overrides_views(char *memory_ptr,
+                                   const DataLayout &layout,
+                                   const std::string &name)
+{
+    auto maneuver_overrides = make_vector_view<extractor::StorageManeuverOverride>(
+        memory_ptr, layout, name + "/overrides");
+    auto maneuver_override_node_sequences =
+        make_vector_view<NodeID>(memory_ptr, layout, name + "/node_sequences");
+
+    return std::make_tuple(maneuver_overrides, maneuver_override_node_sequences);
 }
 }
 }

--- a/include/storage/view_factory.hpp
+++ b/include/storage/view_factory.hpp
@@ -1,0 +1,31 @@
+#ifndef OSRM_STOARGE_VIEW_FACTORY_HPP
+#define OSRM_STOARGE_VIEW_FACTORY_HPP
+
+#include "storage/shared_datatype.hpp"
+
+#include "util/vector_view.hpp"
+
+namespace osrm
+{
+namespace storage
+{
+
+template <typename T>
+util::vector_view<T> make_vector_view(char *memory_ptr, DataLayout layout, const std::string &name)
+{
+    return util::vector_view<T>(layout.GetBlockPtr<T>(memory_ptr, name),
+                                layout.GetBlockEntries(name));
+}
+
+template <>
+inline util::vector_view<bool>
+make_vector_view(char *memory_ptr, DataLayout layout, const std::string &name)
+{
+    return util::vector_view<bool>(
+        layout.GetBlockPtr<util::vector_view<bool>::Word>(memory_ptr, name),
+        layout.GetBlockEntries(name));
+}
+}
+}
+
+#endif

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -243,6 +243,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
   public:
     using value_type = T;
+    static constexpr std::size_t value_size = Bits;
     using block_type = WordT;
 
     class internal_reference

--- a/include/util/range_table.hpp
+++ b/include/util/range_table.hpp
@@ -55,14 +55,12 @@ template <unsigned BLOCK_SIZE, storage::Ownership Ownership> class RangeTable
     RangeTable() : sum_lengths(0) {}
 
     // for loading from shared memory
-    explicit RangeTable(OffsetContainerT &external_offsets,
-                        BlockContainerT &external_blocks,
+    explicit RangeTable(OffsetContainerT offsets_,
+                        BlockContainerT blocks_,
                         const unsigned sum_lengths)
-        : sum_lengths(sum_lengths)
+        : block_offsets(std::move(offsets_)), diff_blocks(std::move(blocks_)),
+          sum_lengths(sum_lengths)
     {
-        using std::swap;
-        swap(block_offsets, external_offsets);
-        swap(diff_blocks, external_blocks);
     }
 
     // construct table from length vector

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -255,7 +255,7 @@ class StaticRTree
     // Representation of the in-memory search tree
     Vector<TreeNode> m_search_tree;
     // Reference to the actual lon/lat data we need for doing math
-    const Vector<Coordinate> &m_coordinate_list;
+    util::vector_view<const Coordinate> m_coordinate_list;
     // Holds the start indexes of each level in m_search_tree
     Vector<std::uint64_t> m_tree_level_starts;
     // mmap'd .fileIndex file
@@ -264,6 +264,7 @@ class StaticRTree
     util::vector_view<const EdgeDataT> m_objects;
 
   public:
+    StaticRTree() = default;
     StaticRTree(const StaticRTree &) = delete;
     StaticRTree &operator=(const StaticRTree &) = delete;
     StaticRTree(StaticRTree &&) = default;
@@ -273,7 +274,7 @@ class StaticRTree
     explicit StaticRTree(const std::vector<EdgeDataT> &input_data_vector,
                          const Vector<Coordinate> &coordinate_list,
                          const boost::filesystem::path &on_disk_file_name)
-        : m_coordinate_list(coordinate_list)
+        : m_coordinate_list(coordinate_list.data(), coordinate_list.size())
     {
         const auto element_count = input_data_vector.size();
         std::vector<WrappedInputElement> input_wrapper_vector(element_count);
@@ -460,7 +461,7 @@ class StaticRTree
     template <typename = std::enable_if<Ownership == storage::Ownership::Container>>
     explicit StaticRTree(const boost::filesystem::path &on_disk_file_name,
                          const Vector<Coordinate> &coordinate_list)
-        : m_coordinate_list(coordinate_list)
+        : m_coordinate_list(coordinate_list.data(), coordinate_list.size())
     {
         m_objects = mmapFile<EdgeDataT>(on_disk_file_name, m_objects_region);
     }
@@ -475,7 +476,8 @@ class StaticRTree
                          Vector<std::uint64_t> tree_level_starts,
                          const boost::filesystem::path &on_disk_file_name,
                          const Vector<Coordinate> &coordinate_list)
-        : m_search_tree(std::move(search_tree_)), m_coordinate_list(coordinate_list),
+        : m_search_tree(std::move(search_tree_)),
+          m_coordinate_list(coordinate_list.data(), coordinate_list.size()),
           m_tree_level_starts(std::move(tree_level_starts))
     {
         BOOST_ASSERT(m_tree_level_starts.size() >= 2);

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -79,6 +79,7 @@ int Contractor::Run()
 
     TIMER_START(contraction);
 
+    std::string metric_name;
     std::vector<std::vector<bool>> node_filters;
     {
         extractor::EdgeBasedNodeDataContainer node_data;
@@ -86,6 +87,7 @@ int Contractor::Run()
 
         extractor::ProfileProperties properties;
         extractor::files::readProfileProperties(config.GetPath(".osrm.properties"), properties);
+        metric_name = properties.GetWeightName();
 
         node_filters =
             util::excludeFlagsToNodeFilter(number_of_edge_based_nodes, node_data, properties);
@@ -105,8 +107,10 @@ int Contractor::Run()
     util::Log() << "Contracted graph has " << query_graph.GetNumberOfEdges() << " edges.";
     util::Log() << "Contraction took " << TIMER_SEC(contraction) << " sec";
 
-    files::writeGraph(
-        config.GetPath(".osrm.hsgr"), checksum, query_graph, edge_filters, connectivity_checksum);
+    std::unordered_map<std::string, ContractedMetric> metrics = {
+        {metric_name, {std::move(query_graph), std::move(edge_filters)}}};
+
+    files::writeGraph(config.GetPath(".osrm.hsgr"), checksum, metrics, connectivity_checksum);
 
     TIMER_STOP(preparing);
 

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -93,9 +93,6 @@ int Contractor::Run()
             util::excludeFlagsToNodeFilter(number_of_edge_based_nodes, node_data, properties);
     }
 
-    RangebasedCRC32 crc32_calculator;
-    const unsigned checksum = crc32_calculator(edge_based_edge_list);
-
     QueryGraph query_graph;
     std::vector<std::vector<bool>> edge_filters;
     std::vector<std::vector<bool>> cores;
@@ -110,7 +107,7 @@ int Contractor::Run()
     std::unordered_map<std::string, ContractedMetric> metrics = {
         {metric_name, {std::move(query_graph), std::move(edge_filters)}}};
 
-    files::writeGraph(config.GetPath(".osrm.hsgr"), checksum, metrics, connectivity_checksum);
+    files::writeGraph(config.GetPath(".osrm.hsgr"), metrics, connectivity_checksum);
 
     TIMER_STOP(preparing);
 

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -153,7 +153,10 @@ int Customizer::Run(const CustomizationConfig &config)
     util::Log() << "Cells customization took " << TIMER_SEC(cell_customize) << " seconds";
 
     TIMER_START(writing_mld_data);
-    files::writeCellMetrics(config.GetPath(".osrm.cell_metrics"), metrics);
+    std::unordered_map<std::string, std::vector<CellMetric>> metric_exclude_classes = {
+        {properties.GetWeightName(), std::move(metrics)},
+    };
+    files::writeCellMetrics(config.GetPath(".osrm.cell_metrics"), metric_exclude_classes);
     TIMER_STOP(writing_mld_data);
     util::Log() << "MLD customization writing took " << TIMER_SEC(writing_mld_data) << " seconds";
 

--- a/src/engine/datafacade/process_memory_allocator.cpp
+++ b/src/engine/datafacade/process_memory_allocator.cpp
@@ -15,17 +15,16 @@ ProcessMemoryAllocator::ProcessMemoryAllocator(const storage::StorageConfig &con
     storage::Storage storage(config);
 
     // Calculate the layout/size of the memory block
-    internal_layout = std::make_unique<storage::DataLayout>();
-    storage.PopulateLayout(*internal_layout);
+    storage.PopulateLayout(internal_layout);
 
     // Allocate the memory block, then load data from files into it
-    internal_memory = std::make_unique<char[]>(internal_layout->GetSizeOfLayout());
-    storage.PopulateData(*internal_layout, internal_memory.get());
+    internal_memory = std::make_unique<char[]>(internal_layout.GetSizeOfLayout());
+    storage.PopulateData(internal_layout, internal_memory.get());
 }
 
 ProcessMemoryAllocator::~ProcessMemoryAllocator() {}
 
-storage::DataLayout &ProcessMemoryAllocator::GetLayout() { return *internal_layout.get(); }
+const storage::DataLayout &ProcessMemoryAllocator::GetLayout() { return internal_layout; }
 char *ProcessMemoryAllocator::GetMemory() { return internal_memory.get(); }
 
 } // namespace datafacade

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -1,4 +1,7 @@
 #include "engine/datafacade/shared_memory_allocator.hpp"
+
+#include "storage/serialization.hpp"
+
 #include "util/log.hpp"
 
 #include "boost/assert.hpp"
@@ -16,17 +19,21 @@ SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedDataType data_region
 
     BOOST_ASSERT(storage::SharedMemory::RegionExists(data_region));
     m_large_memory = storage::makeSharedMemory(data_region);
+
+    storage::io::BufferReader reader(GetMemory());
+    storage::serialization::read(reader, data_layout);
+    layout_size = reader.GetPosition();
 }
 
 SharedMemoryAllocator::~SharedMemoryAllocator() {}
 
-storage::DataLayout &SharedMemoryAllocator::GetLayout()
+const storage::DataLayout &SharedMemoryAllocator::GetLayout()
 {
-    return *reinterpret_cast<storage::DataLayout *>(m_large_memory->Ptr());
+    return data_layout;
 }
 char *SharedMemoryAllocator::GetMemory()
 {
-    return reinterpret_cast<char *>(m_large_memory->Ptr()) + sizeof(storage::DataLayout);
+    return reinterpret_cast<char *>(m_large_memory->Ptr()) + layout_size;
 }
 
 } // namespace datafacade

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -23,6 +23,7 @@ SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedDataType data_region
     storage::io::BufferReader reader(GetMemory());
     storage::serialization::read(reader, data_layout);
     layout_size = reader.GetPosition();
+    util::Log(logDEBUG) << "Data layout has size " << layout_size;
 }
 
 SharedMemoryAllocator::~SharedMemoryAllocator() {}

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -20,7 +20,7 @@ SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedDataType data_region
     BOOST_ASSERT(storage::SharedMemory::RegionExists(data_region));
     m_large_memory = storage::makeSharedMemory(data_region);
 
-    storage::io::BufferReader reader(GetMemory());
+    storage::io::BufferReader reader(reinterpret_cast<char *>(m_large_memory->Ptr()), m_large_memory->Size());
     storage::serialization::read(reader, data_layout);
     layout_size = reader.GetPosition();
     util::Log(logDEBUG) << "Data layout has size " << layout_size;

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -20,7 +20,8 @@ SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedDataType data_region
     BOOST_ASSERT(storage::SharedMemory::RegionExists(data_region));
     m_large_memory = storage::makeSharedMemory(data_region);
 
-    storage::io::BufferReader reader(reinterpret_cast<char *>(m_large_memory->Ptr()), m_large_memory->Size());
+    storage::io::BufferReader reader(reinterpret_cast<char *>(m_large_memory->Ptr()),
+                                     m_large_memory->Size());
     storage::serialization::read(reader, data_layout);
     layout_size = reader.GetPosition();
     util::Log(logDEBUG) << "Data layout has size " << layout_size;
@@ -28,10 +29,7 @@ SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedDataType data_region
 
 SharedMemoryAllocator::~SharedMemoryAllocator() {}
 
-const storage::DataLayout &SharedMemoryAllocator::GetLayout()
-{
-    return data_layout;
-}
+const storage::DataLayout &SharedMemoryAllocator::GetLayout() { return data_layout; }
 char *SharedMemoryAllocator::GetMemory()
 {
     return reinterpret_cast<char *>(m_large_memory->Ptr()) + layout_size;

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -32,12 +32,6 @@ OSRM::OSRM(engine::EngineConfig &config)
         storage::SharedMonitor<storage::SharedDataTimestamp> barrier;
         using mutex_type = typename decltype(barrier)::mutex_type;
         boost::interprocess::scoped_lock<mutex_type> current_region_lock(barrier.get_mutex());
-
-        auto mem = storage::makeSharedMemory(barrier.data().region);
-        auto layout = reinterpret_cast<storage::DataLayout *>(mem->Ptr());
-        if (layout->GetBlockSize("/common/names/values") == 0)
-            throw util::exception(
-                "No name data loaded, cannot continue.  Have you run osrm-datastore to load data?");
     }
 
     // Now, check that the algorithm requested can be used with the data

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -1,4 +1,5 @@
 #include "osrm/osrm.hpp"
+
 #include "engine/algorithm.hpp"
 #include "engine/api/match_parameters.hpp"
 #include "engine/api/nearest_parameters.hpp"
@@ -37,30 +38,10 @@ OSRM::OSRM(engine::EngineConfig &config)
     // Now, check that the algorithm requested can be used with the data
     // that's available.
 
-    if (config.algorithm == EngineConfig::Algorithm::CH ||
-        config.algorithm == EngineConfig::Algorithm::CoreCH)
+    if (config.algorithm == EngineConfig::Algorithm::CoreCH)
     {
-        if (config.algorithm == EngineConfig::Algorithm::CoreCH)
-        {
-            util::Log(logWARNING) << "Using CoreCH is deprecated. Falling back to CH";
-            config.algorithm = EngineConfig::Algorithm::CH;
-        }
-        bool ch_compatible = engine::Engine<CH>::CheckCompatibility(config);
-
-        // throw error if dataset is not usable with CH
-        if (config.algorithm == EngineConfig::Algorithm::CH && !ch_compatible)
-        {
-            throw util::exception("Dataset is not compatible with CH");
-        }
-    }
-    else if (config.algorithm == EngineConfig::Algorithm::MLD)
-    {
-        bool mld_compatible = engine::Engine<MLD>::CheckCompatibility(config);
-        // throw error if dataset is not usable with MLD
-        if (!mld_compatible)
-        {
-            throw util::exception("Dataset is not compatible with MLD.");
-        }
+        util::Log(logWARNING) << "Using CoreCH is deprecated. Falling back to CH";
+        config.algorithm = EngineConfig::Algorithm::CH;
     }
 
     switch (config.algorithm)

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -35,7 +35,7 @@ OSRM::OSRM(engine::EngineConfig &config)
 
         auto mem = storage::makeSharedMemory(barrier.data().region);
         auto layout = reinterpret_cast<storage::DataLayout *>(mem->Ptr());
-        if (layout->GetBlockSize(storage::DataLayout::NAME_VALUES) == 0)
+        if (layout->GetBlockSize("/common/names/values") == 0)
             throw util::exception(
                 "No name data loaded, cannot continue.  Have you run osrm-datastore to load data?");
     }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -89,8 +89,6 @@ inline void readBlocks(const boost::filesystem::path &path, DataLayout &layout)
 }
 }
 
-static constexpr std::size_t NUM_METRICS = 8;
-
 using RTreeLeaf = engine::datafacade::BaseDataFacade::RTreeLeaf;
 using RTreeNode = util::StaticRTree<RTreeLeaf, storage::Ownership::View>::TreeNode;
 using QueryGraph = util::StaticGraph<contractor::QueryEdge::EdgeData>;

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -165,6 +165,7 @@ int Storage::Run(int max_wait)
 
     // Allocate shared memory block
     auto regions_size = encoded_layout.size() + layout.GetSizeOfLayout();
+    util::Log() << "Data layout has a size of " << encoded_layout.size() << " bytes";
     util::Log() << "Allocating shared memory of " << regions_size << " bytes";
     auto data_memory = makeSharedMemory(next_region, regions_size);
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -344,7 +344,7 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
     {
         auto edge_based_node_data = layout.GetWritableVector<extractor::EdgeBasedNode>(
             memory_ptr, "/common/ebg_node_data/nodes");
-        auto  annotation_data = layout.GetWritableVector<extractor::NodeBasedEdgeAnnotation>(
+        auto annotation_data = layout.GetWritableVector<extractor::NodeBasedEdgeAnnotation>(
             memory_ptr, "/common/ebg_node_data/annotations");
 
         extractor::EdgeBasedNodeDataView node_data(std::move(edge_based_node_data),
@@ -355,26 +355,20 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Load original edge data
     {
-        auto lane_data_ids = layout.GetWritableVector<LaneDataID>(
-            memory_ptr, "/common/turn_data/lane_data_ids");
+        auto lane_data_ids =
+            layout.GetWritableVector<LaneDataID>(memory_ptr, "/common/turn_data/lane_data_ids");
 
         const auto turn_instructions = layout.GetWritableVector<guidance::TurnInstruction>(
             memory_ptr, "/common/turn_data/turn_instructions");
 
-        const auto entry_class_id_list_ptr =
-            layout.GetBlockPtr<EntryClassID, true>(memory_ptr, "/common/turn_data/entry_class_ids");
-        util::vector_view<EntryClassID> entry_class_ids(
-            entry_class_id_list_ptr, layout.GetBlockEntries("/common/turn_data/entry_class_ids"));
+        const auto entry_class_ids =
+            layout.GetWritableVector<EntryClassID>(memory_ptr, "/common/turn_data/entry_class_ids");
 
-        const auto pre_turn_bearing_ptr = layout.GetBlockPtr<guidance::TurnBearing, true>(
+        const auto pre_turn_bearings = layout.GetWritableVector<guidance::TurnBearing>(
             memory_ptr, "/common/turn_data/pre_turn_bearings");
-        util::vector_view<guidance::TurnBearing> pre_turn_bearings(
-            pre_turn_bearing_ptr, layout.GetBlockEntries("/common/turn_data/pre_turn_bearings"));
 
-        const auto post_turn_bearing_ptr = layout.GetBlockPtr<guidance::TurnBearing, true>(
+        const auto post_turn_bearings = layout.GetWritableVector<guidance::TurnBearing>(
             memory_ptr, "/common/turn_data/post_turn_bearings");
-        util::vector_view<guidance::TurnBearing> post_turn_bearings(
-            post_turn_bearing_ptr, layout.GetBlockEntries("/common/turn_data/post_turn_bearings"));
 
         guidance::TurnDataView turn_data(std::move(turn_instructions),
                                          std::move(lane_data_ids),
@@ -392,73 +386,47 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // load compressed geometry
     {
-        auto geometries_index_ptr =
-            layout.GetBlockPtr<unsigned, true>(memory_ptr, "/common/segment_data/index");
-        util::vector_view<unsigned> geometry_begin_indices(
-            geometries_index_ptr, layout.GetBlockEntries("/common/segment_data/index"));
+        auto geometry_begin_indices =
+            layout.GetWritableVector<unsigned>(memory_ptr, "/common/segment_data/index");
+
+        auto node_list = layout.GetWritableVector<NodeID>(memory_ptr, "/common/segment_data/nodes");
 
         auto num_entries = layout.GetBlockEntries("/common/segment_data/nodes");
 
-        auto geometries_node_list_ptr =
-            layout.GetBlockPtr<NodeID, true>(memory_ptr, "/common/segment_data/nodes");
-        util::vector_view<NodeID> geometry_node_list(geometries_node_list_ptr, num_entries);
-
-        auto geometries_fwd_weight_list_ptr =
-            layout.GetBlockPtr<extractor::SegmentDataView::SegmentWeightVector::block_type, true>(
-                memory_ptr, "/common/segment_data/forward_weights/packed");
-        extractor::SegmentDataView::SegmentWeightVector geometry_fwd_weight_list(
-            util::vector_view<extractor::SegmentDataView::SegmentWeightVector::block_type>(
-                geometries_fwd_weight_list_ptr,
-                layout.GetBlockEntries("/common/segment_data/forward_weights/packed")),
+        extractor::SegmentDataView::SegmentWeightVector fwd_weight_list(
+            layout.GetWritableVector<extractor::SegmentDataView::SegmentWeightVector::block_type>(
+                memory_ptr, "/common/segment_data/forward_weights/packed"),
             num_entries);
 
-        auto geometries_rev_weight_list_ptr =
-            layout.GetBlockPtr<extractor::SegmentDataView::SegmentWeightVector::block_type, true>(
-                memory_ptr, "/common/segment_data/reverse_weights/packed");
-        extractor::SegmentDataView::SegmentWeightVector geometry_rev_weight_list(
-            util::vector_view<extractor::SegmentDataView::SegmentWeightVector::block_type>(
-                geometries_rev_weight_list_ptr,
-                layout.GetBlockEntries("/common/segment_data/reverse_weights/packed")),
+        extractor::SegmentDataView::SegmentWeightVector rev_weight_list(
+            layout.GetWritableVector<extractor::SegmentDataView::SegmentWeightVector::block_type>(
+                memory_ptr, "/common/segment_data/reverse_weights/packed"),
             num_entries);
 
-        auto geometries_fwd_duration_list_ptr =
-            layout.GetBlockPtr<extractor::SegmentDataView::SegmentDurationVector::block_type, true>(
-                memory_ptr, "/common/segment_data/forward_durations/packed");
-        extractor::SegmentDataView::SegmentDurationVector geometry_fwd_duration_list(
-            util::vector_view<extractor::SegmentDataView::SegmentDurationVector::block_type>(
-                geometries_fwd_duration_list_ptr,
-                layout.GetBlockEntries("/common/segment_data/forward_durations/packed")),
+        extractor::SegmentDataView::SegmentDurationVector fwd_duration_list(
+            layout.GetWritableVector<extractor::SegmentDataView::SegmentDurationVector::block_type>(
+                memory_ptr, "/common/segment_data/forward_durations/packed"),
             num_entries);
 
-        auto geometries_rev_duration_list_ptr =
-            layout.GetBlockPtr<extractor::SegmentDataView::SegmentDurationVector::block_type, true>(
-                memory_ptr, "/common/segment_data/reverse_durations/packed");
-        extractor::SegmentDataView::SegmentDurationVector geometry_rev_duration_list(
-            util::vector_view<extractor::SegmentDataView::SegmentDurationVector::block_type>(
-                geometries_rev_duration_list_ptr,
-                layout.GetBlockEntries("/common/segment_data/reverse_durations/packed")),
+        extractor::SegmentDataView::SegmentDurationVector rev_duration_list(
+            layout.GetWritableVector<extractor::SegmentDataView::SegmentDurationVector::block_type>(
+                memory_ptr, "/common/segment_data/reverse_durations/packed"),
             num_entries);
 
-        auto geometries_fwd_datasources_list_ptr = layout.GetBlockPtr<DatasourceID, true>(
+        auto fwd_datasources_list = layout.GetWritableVector<DatasourceID>(
             memory_ptr, "/common/segment_data/forward_data_sources");
-        util::vector_view<DatasourceID> geometry_fwd_datasources_list(
-            geometries_fwd_datasources_list_ptr,
-            layout.GetBlockEntries("/common/segment_data/forward_data_sources"));
 
-        auto geometries_rev_datasources_list_ptr = layout.GetBlockPtr<DatasourceID, true>(
+        auto rev_datasources_list = layout.GetWritableVector<DatasourceID>(
             memory_ptr, "/common/segment_data/reverse_data_sources");
-        util::vector_view<DatasourceID> geometry_rev_datasources_list(
-            geometries_rev_datasources_list_ptr,
-            layout.GetBlockEntries("/common/segment_data/reverse_data_sources"));
 
         extractor::SegmentDataView segment_data{std::move(geometry_begin_indices),
-                                                std::move(geometry_node_list),
-                                                std::move(geometry_fwd_weight_list),
-                                                std::move(geometry_rev_weight_list),
-                                                std::move(geometry_fwd_duration_list),
-                                                std::move(geometry_rev_duration_list),
-                                                std::move(geometry_fwd_datasources_list),
-                                                std::move(geometry_rev_datasources_list)};
+                                                std::move(node_list),
+                                                std::move(fwd_weight_list),
+                                                std::move(rev_weight_list),
+                                                std::move(fwd_duration_list),
+                                                std::move(rev_duration_list),
+                                                std::move(fwd_datasources_list),
+                                                std::move(rev_datasources_list)};
 
         extractor::files::readSegmentData(config.GetPath(".osrm.geometry"), segment_data);
     }
@@ -472,37 +440,29 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Loading list of coordinates
     {
-        const auto coordinates_ptr =
-            layout.GetBlockPtr<util::Coordinate, true>(memory_ptr, "/common/coordinates");
-        const auto osmnodeid_ptr =
-            layout.GetBlockPtr<extractor::PackedOSMIDsView::block_type, true>(
-                memory_ptr, "/common/osm_node_ids/packed");
-        util::vector_view<util::Coordinate> coordinates(
-            coordinates_ptr, layout.GetBlockEntries("/common/coordinates"));
-        extractor::PackedOSMIDsView osm_node_ids(
-            util::vector_view<extractor::PackedOSMIDsView::block_type>(
-                osmnodeid_ptr, layout.GetBlockEntries("/common/osm_node_ids/packed")),
-            layout.GetBlockEntries("/common/coordinates"));
+        auto coordinates =
+            layout.GetWritableVector<util::Coordinate>(memory_ptr, "/common/coordinates");
+
+        auto osm_node_ids = extractor::PackedOSMIDsView{
+            layout.GetWritableVector<extractor::PackedOSMIDsView::block_type>(
+                memory_ptr, "/common/osm_node_ids/packed"),
+            coordinates.size()};
 
         extractor::files::readNodes(config.GetPath(".osrm.nbg_nodes"), coordinates, osm_node_ids);
     }
 
     // load turn weight penalties
     {
-        auto turn_duration_penalties_ptr =
-            layout.GetBlockPtr<TurnPenalty, true>(memory_ptr, "/common/turn_penalty/weight");
-        util::vector_view<TurnPenalty> turn_duration_penalties(
-            turn_duration_penalties_ptr, layout.GetBlockEntries("/common/turn_penalty/weight"));
+        auto turn_duration_penalties =
+            layout.GetWritableVector<TurnPenalty>(memory_ptr, "/common/turn_penalty/weight");
         extractor::files::readTurnWeightPenalty(config.GetPath(".osrm.turn_weight_penalties"),
                                                 turn_duration_penalties);
     }
 
     // load turn duration penalties
     {
-        auto turn_duration_penalties_ptr =
-            layout.GetBlockPtr<TurnPenalty, true>(memory_ptr, "/common/turn_penalty/duration");
-        util::vector_view<TurnPenalty> turn_duration_penalties(
-            turn_duration_penalties_ptr, layout.GetBlockEntries("/common/turn_penalty/duration"));
+        auto turn_duration_penalties =
+            layout.GetWritableVector<TurnPenalty>(memory_ptr, "/common/turn_penalty/duration");
         extractor::files::readTurnDurationPenalty(config.GetPath(".osrm.turn_duration_penalties"),
                                                   turn_duration_penalties);
     }
@@ -510,16 +470,11 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
     // store search tree portion of rtree
     {
 
-        const auto rtree_ptr =
-            layout.GetBlockPtr<RTreeNode, true>(memory_ptr, "/common/rtree/search_tree");
-        util::vector_view<RTreeNode> search_tree(
-            rtree_ptr, layout.GetBlockEntries("/common/rtree/search_tree"));
+        const auto search_tree =
+            layout.GetWritableVector<RTreeNode>(memory_ptr, "/common/rtree/search_tree");
 
-        const auto rtree_levelstarts_ptr = layout.GetBlockPtr<std::uint64_t, true>(
+        const auto rtree_level_starts = layout.GetWritableVector<std::uint64_t>(
             memory_ptr, "/common/rtree/search_tree_level_starts");
-        util::vector_view<std::uint64_t> rtree_level_starts(
-            rtree_levelstarts_ptr,
-            layout.GetBlockEntries("/common/rtree/search_tree_level_starts"));
 
         // we need this purely for the interface
         util::vector_view<util::Coordinate> empty_coords;
@@ -546,42 +501,25 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Load intersection data
     {
-        auto bearing_class_id_ptr = layout.GetBlockPtr<BearingClassID, true>(
-            memory_ptr, "/common/intersection_bearings/node_to_class_id");
-        util::vector_view<BearingClassID> bearing_class_id(
-            bearing_class_id_ptr,
-            layout.GetBlockEntries("/common/intersection_bearings/node_to_class_id"));
-
-        auto bearing_values_ptr = layout.GetBlockPtr<DiscreteBearing, true>(
-            memory_ptr, "/common/intersection_bearings/bearing_values");
-        util::vector_view<DiscreteBearing> bearing_values(
-            bearing_values_ptr,
-            layout.GetBlockEntries("/common/intersection_bearings/bearing_values"));
-
-        auto offsets_ptr = layout.GetBlockPtr<unsigned, true>(
+        auto bearing_offsets = layout.GetWritableVector<unsigned>(
             memory_ptr, "/common/intersection_bearings/class_id_to_ranges/block_offsets");
-        auto blocks_ptr =
-            layout.GetBlockPtr<util::RangeTable<16, storage::Ownership::View>::BlockT, true>(
+        auto bearing_blocks =
+            layout.GetWritableVector<util::RangeTable<16, storage::Ownership::View>::BlockT>(
                 memory_ptr, "/common/intersection_bearings/class_id_to_ranges/diff_blocks");
-        util::vector_view<unsigned> bearing_offsets(
-            offsets_ptr,
-            layout.GetBlockEntries(
-                "/common/intersection_bearings/class_id_to_ranges/block_offsets"));
-        util::vector_view<util::RangeTable<16, storage::Ownership::View>::BlockT> bearing_blocks(
-            blocks_ptr,
-            layout.GetBlockEntries("/common/intersection_bearings/class_id_to_ranges/diff_blocks"));
-
+        auto bearing_values = layout.GetWritableVector<DiscreteBearing>(
+            memory_ptr, "/common/intersection_bearings/bearing_values");
         util::RangeTable<16, storage::Ownership::View> bearing_range_table(
-            bearing_offsets, bearing_blocks, static_cast<unsigned>(bearing_values.size()));
+            std::move(bearing_offsets),
+            std::move(bearing_blocks),
+            static_cast<unsigned>(bearing_values.size()));
 
+        auto bearing_class_id = layout.GetWritableVector<BearingClassID>(
+            memory_ptr, "/common/intersection_bearings/node_to_class_id");
         extractor::IntersectionBearingsView intersection_bearings_view{
             std::move(bearing_values), std::move(bearing_class_id), std::move(bearing_range_table)};
 
-        auto entry_class_ptr = layout.GetBlockPtr<util::guidance::EntryClass, true>(
+        auto entry_classes = layout.GetWritableVector<util::guidance::EntryClass>(
             memory_ptr, "/common/entry_classes");
-        util::vector_view<util::guidance::EntryClass> entry_classes(
-            entry_class_ptr, layout.GetBlockEntries("/common/entry_classes"));
-
         extractor::files::readIntersections(
             config.GetPath(".osrm.icd"), intersection_bearings_view, entry_classes);
     }
@@ -589,26 +527,17 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
     if (boost::filesystem::exists(config.GetPath(".osrm.hsgr")))
     {
         const std::string metric_prefix = "/ch/metrics/" + metric_name;
-        auto graph_nodes_ptr = layout.GetBlockPtr<contractor::QueryGraphView::NodeArrayEntry, true>(
+
+        auto node_list = layout.GetWritableVector<contractor::QueryGraphView::NodeArrayEntry>(
             memory_ptr, metric_prefix + "/contracted_graph/node_array");
-        auto graph_edges_ptr = layout.GetBlockPtr<contractor::QueryGraphView::EdgeArrayEntry, true>(
+        auto edge_list = layout.GetWritableVector<contractor::QueryGraphView::EdgeArrayEntry>(
             memory_ptr, metric_prefix + "/contracted_graph/edge_array");
 
-        util::vector_view<contractor::QueryGraphView::NodeArrayEntry> node_list(
-            graph_nodes_ptr,
-            layout.GetBlockEntries(metric_prefix + "/contracted_graph/node_array"));
-        util::vector_view<contractor::QueryGraphView::EdgeArrayEntry> edge_list(
-            graph_edges_ptr,
-            layout.GetBlockEntries(metric_prefix + "/contracted_graph/edge_array"));
-
         std::vector<util::vector_view<bool>> edge_filter;
-        layout.List(
-            metric_prefix + "/exclude", boost::make_function_output_iterator([&](const auto &name) {
-                auto data_ptr =
-                    layout.GetBlockPtr<util::vector_view<bool>::Word, true>(memory_ptr, name);
-                auto num_entries = layout.GetBlockEntries(name);
-                edge_filter.emplace_back(data_ptr, num_entries);
-            }));
+        layout.List(metric_prefix + "/exclude",
+                    boost::make_function_output_iterator([&](const auto &name) {
+                        edge_filter.push_back(layout.GetWritableVector<bool>(memory_ptr, name));
+                    }));
 
         std::uint32_t graph_connectivity_checksum = 0;
         std::unordered_map<std::string, contractor::ContractedMetricView> metrics = {
@@ -632,22 +561,16 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
         BOOST_ASSERT(layout.GetBlockSize("/mld/multilevelpartition/cell_to_children") > 0);
         BOOST_ASSERT(layout.GetBlockSize("/mld/multilevelpartition/partition") > 0);
 
-        auto level_data = layout.GetBlockPtr<partitioner::MultiLevelPartitionView::LevelData, true>(
-            memory_ptr, "/mld/multilevelpartition/level_data");
-
-        auto mld_partition_ptr =
-            layout.GetBlockPtr<PartitionID, true>(memory_ptr, "/mld/multilevelpartition/partition");
-        auto partition_entries_count = layout.GetBlockEntries("/mld/multilevelpartition/partition");
-        util::vector_view<PartitionID> partition(mld_partition_ptr, partition_entries_count);
-
-        auto mld_chilren_ptr = layout.GetBlockPtr<CellID, true>(
+        auto level_data_ptr =
+            layout.GetBlockPtr<partitioner::MultiLevelPartitionView::LevelData, true>(
+                memory_ptr, "/mld/multilevelpartition/level_data");
+        auto partition =
+            layout.GetWritableVector<PartitionID>(memory_ptr, "/mld/multilevelpartition/partition");
+        auto cell_to_children = layout.GetWritableVector<CellID>(
             memory_ptr, "/mld/multilevelpartition/cell_to_children");
-        auto children_entries_count =
-            layout.GetBlockEntries("/mld/multilevelpartition/cell_to_children");
-        util::vector_view<CellID> cell_to_children(mld_chilren_ptr, children_entries_count);
 
         partitioner::MultiLevelPartitionView mlp{
-            std::move(level_data), std::move(partition), std::move(cell_to_children)};
+            level_data_ptr, std::move(partition), std::move(cell_to_children)};
         partitioner::files::readPartition(config.GetPath(".osrm.partition"), mlp);
     }
 
@@ -656,31 +579,14 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
         BOOST_ASSERT(layout.GetBlockSize("/mld/cellstorage/cells") > 0);
         BOOST_ASSERT(layout.GetBlockSize("/mld/cellstorage/level_to_cell_offset") > 0);
 
-        auto mld_source_boundary_ptr =
-            layout.GetBlockPtr<NodeID, true>(memory_ptr, "/mld/cellstorage/source_boundary");
-        auto mld_destination_boundary_ptr =
-            layout.GetBlockPtr<NodeID, true>(memory_ptr, "/mld/cellstorage/destination_boundary");
-        auto mld_cells_ptr = layout.GetBlockPtr<partitioner::CellStorageView::CellData, true>(
+        auto source_boundary =
+            layout.GetWritableVector<NodeID>(memory_ptr, "/mld/cellstorage/source_boundary");
+        auto destination_boundary =
+            layout.GetWritableVector<NodeID>(memory_ptr, "/mld/cellstorage/destination_boundary");
+        auto cells = layout.GetWritableVector<partitioner::CellStorageView::CellData>(
             memory_ptr, "/mld/cellstorage/cells");
-        auto mld_cell_level_offsets_ptr = layout.GetBlockPtr<std::uint64_t, true>(
+        auto level_offsets = layout.GetWritableVector<std::uint64_t>(
             memory_ptr, "/mld/cellstorage/level_to_cell_offset");
-
-        auto source_boundary_entries_count =
-            layout.GetBlockEntries("/mld/cellstorage/source_boundary");
-        auto destination_boundary_entries_count =
-            layout.GetBlockEntries("/mld/cellstorage/destination_boundary");
-        auto cells_entries_counts = layout.GetBlockEntries("/mld/cellstorage/cells");
-        auto cell_level_offsets_entries_count =
-            layout.GetBlockEntries("/mld/cellstorage/level_to_cell_offset");
-
-        util::vector_view<NodeID> source_boundary(mld_source_boundary_ptr,
-                                                  source_boundary_entries_count);
-        util::vector_view<NodeID> destination_boundary(mld_destination_boundary_ptr,
-                                                       destination_boundary_entries_count);
-        util::vector_view<partitioner::CellStorageView::CellData> cells(mld_cells_ptr,
-                                                                        cells_entries_counts);
-        util::vector_view<std::uint64_t> level_offsets(mld_cell_level_offsets_ptr,
-                                                       cell_level_offsets_entries_count);
 
         partitioner::CellStorageView storage{std::move(source_boundary),
                                              std::move(destination_boundary),
@@ -706,15 +612,8 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
             auto weights_block_id = prefix + "/weights";
             auto durations_block_id = prefix + "/durations";
 
-            auto weight_entries_count = layout.GetBlockEntries(weights_block_id);
-            auto duration_entries_count = layout.GetBlockEntries(durations_block_id);
-            auto mld_cell_weights_ptr =
-                layout.GetBlockPtr<EdgeWeight, true>(memory_ptr, weights_block_id);
-            auto mld_cell_duration_ptr =
-                layout.GetBlockPtr<EdgeDuration, true>(memory_ptr, durations_block_id);
-            util::vector_view<EdgeWeight> weights(mld_cell_weights_ptr, weight_entries_count);
-            util::vector_view<EdgeDuration> durations(mld_cell_duration_ptr,
-                                                      duration_entries_count);
+            auto weights = layout.GetWritableVector<EdgeWeight>(memory_ptr, weights_block_id);
+            auto durations = layout.GetWritableVector<EdgeDuration>(memory_ptr, durations_block_id);
 
             metrics[metric_name].push_back(
                 customizer::CellMetricView{std::move(weights), std::move(durations)});
@@ -725,24 +624,15 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     if (boost::filesystem::exists(config.GetPath(".osrm.mldgr")))
     {
-
-        auto graph_nodes_ptr =
-            layout.GetBlockPtr<customizer::MultiLevelEdgeBasedGraphView::NodeArrayEntry, true>(
+        auto node_list =
+            layout.GetWritableVector<customizer::MultiLevelEdgeBasedGraphView::NodeArrayEntry>(
                 memory_ptr, "/mld/multilevelgraph/node_array");
-        auto graph_edges_ptr =
-            layout.GetBlockPtr<customizer::MultiLevelEdgeBasedGraphView::EdgeArrayEntry, true>(
+        auto edge_list =
+            layout.GetWritableVector<customizer::MultiLevelEdgeBasedGraphView::EdgeArrayEntry>(
                 memory_ptr, "/mld/multilevelgraph/edge_array");
-        auto graph_node_to_offset_ptr =
-            layout.GetBlockPtr<customizer::MultiLevelEdgeBasedGraphView::EdgeOffset, true>(
+        auto node_to_offset =
+            layout.GetWritableVector<customizer::MultiLevelEdgeBasedGraphView::EdgeOffset>(
                 memory_ptr, "/mld/multilevelgraph/node_to_edge_offset");
-
-        util::vector_view<customizer::MultiLevelEdgeBasedGraphView::NodeArrayEntry> node_list(
-            graph_nodes_ptr, layout.GetBlockEntries("/mld/multilevelgraph/node_array"));
-        util::vector_view<customizer::MultiLevelEdgeBasedGraphView::EdgeArrayEntry> edge_list(
-            graph_edges_ptr, layout.GetBlockEntries("/mld/multilevelgraph/edge_array"));
-        util::vector_view<customizer::MultiLevelEdgeBasedGraphView::EdgeOffset> node_to_offset(
-            graph_node_to_offset_ptr,
-            layout.GetBlockEntries("/mld/multilevelgraph/node_to_edge_offset"));
 
         std::uint32_t graph_connectivity_checksum = 0;
         customizer::MultiLevelEdgeBasedGraphView graph_view(
@@ -762,17 +652,10 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // load maneuver overrides
     {
-        const auto maneuver_overrides_ptr =
-            layout.GetBlockPtr<extractor::StorageManeuverOverride, true>(
-                memory_ptr, "/common/maneuver_overrides/overrides");
-        const auto maneuver_override_node_sequences_ptr = layout.GetBlockPtr<NodeID, true>(
+        auto maneuver_overrides = layout.GetWritableVector<extractor::StorageManeuverOverride>(
+            memory_ptr, "/common/maneuver_overrides/overrides");
+        auto maneuver_override_node_sequences = layout.GetWritableVector<NodeID>(
             memory_ptr, "/common/maneuver_overrides/node_sequences");
-
-        util::vector_view<extractor::StorageManeuverOverride> maneuver_overrides(
-            maneuver_overrides_ptr, layout.GetBlockEntries("/common/maneuver_overrides/overrides"));
-        util::vector_view<NodeID> maneuver_override_node_sequences(
-            maneuver_override_node_sequences_ptr,
-            layout.GetBlockEntries("/common/maneuver_overrides/node_sequences"));
 
         extractor::files::readManeuverOverrides(config.GetPath(".osrm.maneuver_overrides"),
                                                 maneuver_overrides,

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -405,7 +405,8 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
                                          std::move(entry_class_ids),
                                          std::move(pre_turn_bearings),
                                          std::move(post_turn_bearings));
-        auto connectivity_checksum_ptr = layout.GetBlockPtr<std::uint32_t, true>(memory_ptr, "/common/connectivity_checksum");
+        auto connectivity_checksum_ptr =
+            layout.GetBlockPtr<std::uint32_t, true>(memory_ptr, "/common/connectivity_checksum");
 
         guidance::files::readTurnData(
             config.GetPath(".osrm.edges"), turn_data, *connectivity_checksum_ptr);

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -329,21 +329,15 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Loading list of coordinates
     {
-        auto coordinates =
-            make_vector_view<util::Coordinate>(memory_ptr, layout, "/common/coordinates");
-
-        auto osm_node_ids =
-            extractor::PackedOSMIDsView{make_vector_view<extractor::PackedOSMIDsView::block_type>(
-                                            memory_ptr, layout, "/common/osm_node_ids/packed"),
-                                        coordinates.size()};
-
-        extractor::files::readNodes(config.GetPath(".osrm.nbg_nodes"), coordinates, osm_node_ids);
+        auto views = make_nbn_data_view(memory_ptr, layout, "/common/nbn_data");
+        extractor::files::readNodes(
+            config.GetPath(".osrm.nbg_nodes"), std::get<0>(views), std::get<1>(views));
     }
 
     // load turn weight penalties
     {
         auto turn_duration_penalties =
-            make_vector_view<TurnPenalty>(memory_ptr, layout, "/common/turn_penalty/weight");
+            make_turn_weight_view(memory_ptr, layout, "/common/turn_penalty");
         extractor::files::readTurnWeightPenalty(config.GetPath(".osrm.turn_weight_penalties"),
                                                 turn_duration_penalties);
     }
@@ -351,7 +345,7 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
     // load turn duration penalties
     {
         auto turn_duration_penalties =
-            make_vector_view<TurnPenalty>(memory_ptr, layout, "/common/turn_penalty/duration");
+            make_turn_duration_view(memory_ptr, layout, "/common/turn_penalty");
         extractor::files::readTurnDurationPenalty(config.GetPath(".osrm.turn_duration_penalties"),
                                                   turn_duration_penalties);
     }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -727,10 +727,12 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
             std::vector<customizer::CellMetricView> metrics;
 
-            for (auto index : util::irange<std::size_t>(0, NUM_METRICS))
+            std::vector<std::string> metric_prefix_names;
+            layout.List("/mld/metrics/", std::back_inserter(metric_prefix_names));
+            for (const auto &prefix : metric_prefix_names)
             {
-                auto weights_block_id = "/mld/metrics/" + std::to_string(index) + "/weights";
-                auto durations_block_id = "/mld/metrics/" + std::to_string(index) + "/durations";
+                auto weights_block_id = prefix + "/weights";
+                auto durations_block_id = prefix + "/durations";
 
                 auto weight_entries_count = layout.GetBlockEntries(weights_block_id);
                 auto duration_entries_count = layout.GetBlockEntries(durations_block_id);

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -311,17 +311,11 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Name data
     {
-        const auto name_blocks_ptr =
-            layout.GetBlockPtr<extractor::NameTableView::IndexedData::BlockReference, true>(
+        auto blocks =
+            layout.GetWritableVector<extractor::NameTableView::IndexedData::BlockReference>(
                 memory_ptr, "/common/names/blocks");
-        const auto name_values_ptr =
-            layout.GetBlockPtr<extractor::NameTableView::IndexedData::ValueType, true>(
-                memory_ptr, "/common/names/values");
-
-        util::vector_view<extractor::NameTableView::IndexedData::BlockReference> blocks(
-            name_blocks_ptr, layout.GetBlockEntries("/common/names/blocks"));
-        util::vector_view<extractor::NameTableView::IndexedData::ValueType> values(
-            name_values_ptr, layout.GetBlockEntries("/common/names/values"));
+        auto values = layout.GetWritableVector<extractor::NameTableView::IndexedData::ValueType>(
+            memory_ptr, "/common/names/values");
 
         extractor::NameTableView::IndexedData index_data_view{std::move(blocks), std::move(values)};
         extractor::NameTableView name_table{index_data_view};
@@ -330,41 +324,28 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Turn lane data
     {
-        const auto turn_lane_data_ptr = layout.GetBlockPtr<util::guidance::LaneTupleIdPair, true>(
+        auto turn_lane_data = layout.GetWritableVector<util::guidance::LaneTupleIdPair>(
             memory_ptr, "/common/turn_lanes/data");
-        util::vector_view<util::guidance::LaneTupleIdPair> turn_lane_data(
-            turn_lane_data_ptr, layout.GetBlockEntries("/common/turn_lanes/data"));
 
         extractor::files::readTurnLaneData(config.GetPath(".osrm.tld"), turn_lane_data);
     }
 
     // Turn lane descriptions
     {
-        auto offsets_ptr =
-            layout.GetBlockPtr<std::uint32_t, true>(memory_ptr, "/common/turn_lanes/offsets");
-        util::vector_view<std::uint32_t> offsets(
-            offsets_ptr, layout.GetBlockEntries("/common/turn_lanes/offsets"));
-
-        auto masks_ptr = layout.GetBlockPtr<extractor::TurnLaneType::Mask, true>(
+        auto offsets =
+            layout.GetWritableVector<std::uint32_t>(memory_ptr, "/common/turn_lanes/offsets");
+        auto masks = layout.GetWritableVector<extractor::TurnLaneType::Mask>(
             memory_ptr, "/common/turn_lanes/masks");
-        util::vector_view<extractor::TurnLaneType::Mask> masks(
-            masks_ptr, layout.GetBlockEntries("/common/turn_lanes/masks"));
 
         extractor::files::readTurnLaneDescriptions(config.GetPath(".osrm.tls"), offsets, masks);
     }
 
     // Load edge-based nodes data
     {
-        auto edge_based_node_data_list_ptr = layout.GetBlockPtr<extractor::EdgeBasedNode, true>(
+        auto edge_based_node_data = layout.GetWritableVector<extractor::EdgeBasedNode>(
             memory_ptr, "/common/ebg_node_data/nodes");
-        util::vector_view<extractor::EdgeBasedNode> edge_based_node_data(
-            edge_based_node_data_list_ptr, layout.GetBlockEntries("/common/ebg_node_data/nodes"));
-
-        auto annotation_data_list_ptr =
-            layout.GetBlockPtr<extractor::NodeBasedEdgeAnnotation, true>(
-                memory_ptr, "/common/ebg_node_data/annotations");
-        util::vector_view<extractor::NodeBasedEdgeAnnotation> annotation_data(
-            annotation_data_list_ptr, layout.GetBlockEntries("/common/ebg_node_data/annotations"));
+        auto  annotation_data = layout.GetWritableVector<extractor::NodeBasedEdgeAnnotation>(
+            memory_ptr, "/common/ebg_node_data/annotations");
 
         extractor::EdgeBasedNodeDataView node_data(std::move(edge_based_node_data),
                                                    std::move(annotation_data));
@@ -374,16 +355,11 @@ void Storage::PopulateData(const DataLayout &layout, char *memory_ptr)
 
     // Load original edge data
     {
-        const auto lane_data_id_ptr =
-            layout.GetBlockPtr<LaneDataID, true>(memory_ptr, "/common/turn_data/lane_data_ids");
-        util::vector_view<LaneDataID> lane_data_ids(
-            lane_data_id_ptr, layout.GetBlockEntries("/common/turn_data/lane_data_ids"));
+        auto lane_data_ids = layout.GetWritableVector<LaneDataID>(
+            memory_ptr, "/common/turn_data/lane_data_ids");
 
-        const auto turn_instruction_list_ptr = layout.GetBlockPtr<guidance::TurnInstruction, true>(
+        const auto turn_instructions = layout.GetWritableVector<guidance::TurnInstruction>(
             memory_ptr, "/common/turn_data/turn_instructions");
-        util::vector_view<guidance::TurnInstruction> turn_instructions(
-            turn_instruction_list_ptr,
-            layout.GetBlockEntries("/common/turn_data/turn_instructions"));
 
         const auto entry_class_id_list_ptr =
             layout.GetBlockPtr<EntryClassID, true>(memory_ptr, "/common/turn_data/entry_class_ids");

--- a/unit_tests/contractor/files.cpp
+++ b/unit_tests/contractor/files.cpp
@@ -42,9 +42,7 @@ BOOST_AUTO_TEST_CASE(read_write_hsgr)
     unsigned checksum;
     unsigned connectivity_checksum;
 
-    std::unordered_map<std::string, ContractedMetric> metrics = {
-        {"duration", {}}
-    };
+    std::unordered_map<std::string, ContractedMetric> metrics = {{"duration", {}}};
     contractor::files::readGraph(tmp.path, checksum, metrics, connectivity_checksum);
 
     BOOST_CHECK_EQUAL(checksum, reference_checksum);

--- a/unit_tests/contractor/files.cpp
+++ b/unit_tests/contractor/files.cpp
@@ -32,26 +32,33 @@ BOOST_AUTO_TEST_CASE(read_write_hsgr)
         {true, true, true, true, true, true, true},
     };
 
+    std::unordered_map<std::string, ContractedMetric> reference_metrics = {
+        {"duration", {std::move(reference_graph), std::move(reference_filters)}}};
+
     TemporaryFile tmp{TEST_DATA_DIR "/read_write_hsgr_test.osrm.hsgr"};
-    contractor::files::writeGraph(tmp.path,
-                                  reference_checksum,
-                                  reference_graph,
-                                  reference_filters,
-                                  reference_connectivity_checksum);
+    contractor::files::writeGraph(
+        tmp.path, reference_checksum, reference_metrics, reference_connectivity_checksum);
 
     unsigned checksum;
     unsigned connectivity_checksum;
-    QueryGraph graph;
-    std::vector<std::vector<bool>> filters;
-    contractor::files::readGraph(tmp.path, checksum, graph, filters, connectivity_checksum);
+
+    std::unordered_map<std::string, ContractedMetric> metrics = {
+        {"duration", {}}
+    };
+    contractor::files::readGraph(tmp.path, checksum, metrics, connectivity_checksum);
 
     BOOST_CHECK_EQUAL(checksum, reference_checksum);
     BOOST_CHECK_EQUAL(connectivity_checksum, reference_connectivity_checksum);
-    BOOST_CHECK_EQUAL(filters.size(), reference_filters.size());
-    CHECK_EQUAL_COLLECTIONS(filters[0], reference_filters[0]);
-    CHECK_EQUAL_COLLECTIONS(filters[1], reference_filters[1]);
-    CHECK_EQUAL_COLLECTIONS(filters[2], reference_filters[2]);
-    CHECK_EQUAL_COLLECTIONS(filters[3], reference_filters[3]);
+    BOOST_CHECK_EQUAL(metrics["duration"].edge_filter.size(),
+                      reference_metrics["duration"].edge_filter.size());
+    CHECK_EQUAL_COLLECTIONS(metrics["duration"].edge_filter[0],
+                            reference_metrics["duration"].edge_filter[0]);
+    CHECK_EQUAL_COLLECTIONS(metrics["duration"].edge_filter[1],
+                            reference_metrics["duration"].edge_filter[1]);
+    CHECK_EQUAL_COLLECTIONS(metrics["duration"].edge_filter[2],
+                            reference_metrics["duration"].edge_filter[2]);
+    CHECK_EQUAL_COLLECTIONS(metrics["duration"].edge_filter[3],
+                            reference_metrics["duration"].edge_filter[3]);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/contractor/files.cpp
+++ b/unit_tests/contractor/files.cpp
@@ -15,7 +15,6 @@ using namespace osrm::unit_test;
 
 BOOST_AUTO_TEST_CASE(read_write_hsgr)
 {
-    auto reference_checksum = 0xFF00FF00;
     auto reference_connectivity_checksum = 0xDEADBEEF;
     std::vector<TestEdge> edges = {TestEdge{0, 1, 3},
                                    TestEdge{0, 5, 1},
@@ -36,16 +35,13 @@ BOOST_AUTO_TEST_CASE(read_write_hsgr)
         {"duration", {std::move(reference_graph), std::move(reference_filters)}}};
 
     TemporaryFile tmp{TEST_DATA_DIR "/read_write_hsgr_test.osrm.hsgr"};
-    contractor::files::writeGraph(
-        tmp.path, reference_checksum, reference_metrics, reference_connectivity_checksum);
+    contractor::files::writeGraph(tmp.path, reference_metrics, reference_connectivity_checksum);
 
-    unsigned checksum;
     unsigned connectivity_checksum;
 
     std::unordered_map<std::string, ContractedMetric> metrics = {{"duration", {}}};
-    contractor::files::readGraph(tmp.path, checksum, metrics, connectivity_checksum);
+    contractor::files::readGraph(tmp.path, metrics, connectivity_checksum);
 
-    BOOST_CHECK_EQUAL(checksum, reference_checksum);
     BOOST_CHECK_EQUAL(connectivity_checksum, reference_connectivity_checksum);
     BOOST_CHECK_EQUAL(metrics["duration"].edge_filter.size(),
                       reference_metrics["duration"].edge_filter.size());

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -197,7 +197,7 @@ class MockBaseDataFacade : public engine::datafacade::BaseDataFacade
         return {};
     }
 
-    unsigned GetCheckSum() const override { return 0; }
+    std::uint32_t GetCheckSum() const override { return 0; }
 
     extractor::TravelMode GetTravelMode(const NodeID /* id */) const override
     {

--- a/unit_tests/storage/data_layout.cpp
+++ b/unit_tests/storage/data_layout.cpp
@@ -8,7 +8,7 @@
 
 #include <cmath>
 
-BOOST_AUTO_TEST_SUITE(serialization)
+BOOST_AUTO_TEST_SUITE(data_layout)
 
 using namespace osrm;
 using namespace osrm::storage;
@@ -17,16 +17,17 @@ BOOST_AUTO_TEST_CASE(layout_write_test)
 {
     DataLayout layout;
 
-    Block block_1 {20, 8*20};
-    Block block_2 {1, 4*1};
-    Block block_3 {100, static_cast<std::uint64_t>(std::ceil(100/8.))};
+    Block block_1{20, 8 * 20};
+    Block block_2{1, 4 * 1};
+    Block block_3{100, static_cast<std::uint64_t>(std::ceil(100 / 64.))};
 
     layout.SetBlock("block1", block_1);
     layout.SetBlock("block2", block_2);
     layout.SetBlock("block3", block_3);
 
     // Canary and alignment change layout size
-    BOOST_CHECK_GT(layout.GetSizeOfLayout(), block_1.byte_size + block_2.byte_size + block_3.byte_size);
+    BOOST_CHECK_GT(layout.GetSizeOfLayout(),
+                   block_1.byte_size + block_2.byte_size + block_3.byte_size);
 
     BOOST_CHECK_EQUAL(layout.GetBlockSize("block1"), block_1.byte_size);
     BOOST_CHECK_EQUAL(layout.GetBlockSize("block2"), block_2.byte_size);
@@ -39,16 +40,27 @@ BOOST_AUTO_TEST_CASE(layout_write_test)
     {
         auto block_1_ptr = layout.GetBlockPtr<std::uint64_t, true>(buffer.data(), "block1");
         auto block_2_ptr = layout.GetBlockPtr<std::uint32_t, true>(buffer.data(), "block2");
-        auto block_3_ptr = layout.GetBlockPtr<unsigned char, true>(buffer.data(), "block3");
+        auto block_3_ptr = layout.GetBlockPtr<std::uint64_t, true>(buffer.data(), "block3");
 
-        BOOST_CHECK_LT(smallest_addr, block_1_ptr);
-        BOOST_CHECK_GT(biggest_addr, block_1_ptr + layout.GetBlockEntries("block1"));
-        BOOST_CHECK_LT(smallest_addr, block_2_ptr);
-        BOOST_CHECK_GT(biggest_addr, block_2_ptr + layout.GetBlockEntries("block3"));
-        BOOST_CHECK_LT(smallest_addr, block_3_ptr);
-        BOOST_CHECK_GT(biggest_addr, block_3_ptr + layout.GetBlockEntries("block3"));
+        BOOST_CHECK_LT(reinterpret_cast<std::size_t>(smallest_addr),
+                       reinterpret_cast<std::size_t>(block_1_ptr));
+        BOOST_CHECK_GT(
+            reinterpret_cast<std::size_t>(biggest_addr),
+            reinterpret_cast<std::size_t>(block_1_ptr + layout.GetBlockEntries("block1")));
+
+        BOOST_CHECK_LT(reinterpret_cast<std::size_t>(smallest_addr),
+                       reinterpret_cast<std::size_t>(block_2_ptr));
+        BOOST_CHECK_GT(
+            reinterpret_cast<std::size_t>(biggest_addr),
+            reinterpret_cast<std::size_t>(block_2_ptr + layout.GetBlockEntries("block2")));
+
+        BOOST_CHECK_LT(reinterpret_cast<std::size_t>(smallest_addr),
+                       reinterpret_cast<std::size_t>(block_3_ptr));
+        BOOST_CHECK_GT(reinterpret_cast<std::size_t>(biggest_addr),
+                       reinterpret_cast<std::size_t>(
+                           block_3_ptr + static_cast<std::size_t>(
+                                             std::ceil(layout.GetBlockEntries("block3") / 64))));
     }
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/storage/data_layout.cpp
+++ b/unit_tests/storage/data_layout.cpp
@@ -93,6 +93,10 @@ BOOST_AUTO_TEST_CASE(layout_list_test)
     layout.List("/mld/metrics/", std::back_inserter(results_5));
     layout.List("/mld/", std::back_inserter(results_6));
 
+    std::vector<std::string> results_7;
+    layout.List("", std::back_inserter(results_7));
+    BOOST_CHECK_EQUAL(results_7.size(), 7);
+
     CHECK_EQUAL_RANGE(
         results_1, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
     CHECK_EQUAL_RANGE(

--- a/unit_tests/storage/data_layout.cpp
+++ b/unit_tests/storage/data_layout.cpp
@@ -93,10 +93,16 @@ BOOST_AUTO_TEST_CASE(layout_list_test)
     layout.List("/mld/metrics/", std::back_inserter(results_5));
     layout.List("/mld/", std::back_inserter(results_6));
 
-    CHECK_EQUAL_RANGE(results_1, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
-    CHECK_EQUAL_RANGE(results_2, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
+    CHECK_EQUAL_RANGE(
+        results_1, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
+    CHECK_EQUAL_RANGE(
+        results_2, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
     CHECK_EQUAL_RANGE(results_3, "/ch/edge_filter");
-    CHECK_EQUAL_RANGE(results_4, "/mld/metrics/0/durations", "/mld/metrics/0/weights", "/mld/metrics/1/durations", "/mld/metrics/1/weights");
+    CHECK_EQUAL_RANGE(results_4,
+                      "/mld/metrics/0/durations",
+                      "/mld/metrics/0/weights",
+                      "/mld/metrics/1/durations",
+                      "/mld/metrics/1/weights");
     CHECK_EQUAL_RANGE(results_5, "/mld/metrics/0", "/mld/metrics/1");
     CHECK_EQUAL_RANGE(results_6, "/mld/metrics");
 }

--- a/unit_tests/storage/data_layout.cpp
+++ b/unit_tests/storage/data_layout.cpp
@@ -1,0 +1,54 @@
+#include "storage/shared_datatype.hpp"
+
+#include "../common/range_tools.hpp"
+#include "../common/temporary_file.hpp"
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <cmath>
+
+BOOST_AUTO_TEST_SUITE(serialization)
+
+using namespace osrm;
+using namespace osrm::storage;
+
+BOOST_AUTO_TEST_CASE(layout_write_test)
+{
+    DataLayout layout;
+
+    Block block_1 {20, 8*20};
+    Block block_2 {1, 4*1};
+    Block block_3 {100, static_cast<std::uint64_t>(std::ceil(100/8.))};
+
+    layout.SetBlock("block1", block_1);
+    layout.SetBlock("block2", block_2);
+    layout.SetBlock("block3", block_3);
+
+    // Canary and alignment change layout size
+    BOOST_CHECK_GT(layout.GetSizeOfLayout(), block_1.byte_size + block_2.byte_size + block_3.byte_size);
+
+    BOOST_CHECK_EQUAL(layout.GetBlockSize("block1"), block_1.byte_size);
+    BOOST_CHECK_EQUAL(layout.GetBlockSize("block2"), block_2.byte_size);
+    BOOST_CHECK_EQUAL(layout.GetBlockSize("block3"), block_3.byte_size);
+
+    std::vector<char> buffer(layout.GetSizeOfLayout());
+    auto smallest_addr = buffer.data();
+    auto biggest_addr = buffer.data() + buffer.size();
+
+    {
+        auto block_1_ptr = layout.GetBlockPtr<std::uint64_t, true>(buffer.data(), "block1");
+        auto block_2_ptr = layout.GetBlockPtr<std::uint32_t, true>(buffer.data(), "block2");
+        auto block_3_ptr = layout.GetBlockPtr<unsigned char, true>(buffer.data(), "block3");
+
+        BOOST_CHECK_LT(smallest_addr, block_1_ptr);
+        BOOST_CHECK_GT(biggest_addr, block_1_ptr + layout.GetBlockEntries("block1"));
+        BOOST_CHECK_LT(smallest_addr, block_2_ptr);
+        BOOST_CHECK_GT(biggest_addr, block_2_ptr + layout.GetBlockEntries("block3"));
+        BOOST_CHECK_LT(smallest_addr, block_3_ptr);
+        BOOST_CHECK_GT(biggest_addr, block_3_ptr + layout.GetBlockEntries("block3"));
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/storage/data_layout.cpp
+++ b/unit_tests/storage/data_layout.cpp
@@ -38,9 +38,9 @@ BOOST_AUTO_TEST_CASE(layout_write_test)
     auto biggest_addr = buffer.data() + buffer.size();
 
     {
-        auto block_1_ptr = layout.GetBlockPtr<std::uint64_t, true>(buffer.data(), "block1");
-        auto block_2_ptr = layout.GetBlockPtr<std::uint32_t, true>(buffer.data(), "block2");
-        auto block_3_ptr = layout.GetBlockPtr<std::uint64_t, true>(buffer.data(), "block3");
+        auto block_1_ptr = layout.GetBlockPtr<std::uint64_t>(buffer.data(), "block1");
+        auto block_2_ptr = layout.GetBlockPtr<std::uint32_t>(buffer.data(), "block2");
+        auto block_3_ptr = layout.GetBlockPtr<std::uint64_t>(buffer.data(), "block3");
 
         BOOST_CHECK_LT(reinterpret_cast<std::size_t>(smallest_addr),
                        reinterpret_cast<std::size_t>(block_1_ptr));

--- a/unit_tests/storage/data_layout.cpp
+++ b/unit_tests/storage/data_layout.cpp
@@ -63,4 +63,42 @@ BOOST_AUTO_TEST_CASE(layout_write_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(layout_list_test)
+{
+    DataLayout layout;
+
+    Block block_1{20, 8 * 20};
+    Block block_2{1, 4 * 1};
+    Block block_3{100, static_cast<std::uint64_t>(std::ceil(100 / 64.))};
+
+    layout.SetBlock("/ch/edge_filter/block1", block_1);
+    layout.SetBlock("/ch/edge_filter/block2", block_2);
+    layout.SetBlock("/ch/edge_filter/block3", block_3);
+    layout.SetBlock("/mld/metrics/0/durations", block_2);
+    layout.SetBlock("/mld/metrics/0/weights", block_3);
+    layout.SetBlock("/mld/metrics/1/durations", block_2);
+    layout.SetBlock("/mld/metrics/1/weights", block_3);
+
+    std::vector<std::string> results_1;
+    std::vector<std::string> results_2;
+    std::vector<std::string> results_3;
+    layout.List("/ch/edge_filter", std::back_inserter(results_1));
+    layout.List("/ch/edge_filter/", std::back_inserter(results_2));
+    layout.List("/ch/", std::back_inserter(results_3));
+
+    std::vector<std::string> results_4;
+    std::vector<std::string> results_5;
+    std::vector<std::string> results_6;
+    layout.List("/mld/metrics", std::back_inserter(results_4));
+    layout.List("/mld/metrics/", std::back_inserter(results_5));
+    layout.List("/mld/", std::back_inserter(results_6));
+
+    CHECK_EQUAL_RANGE(results_1, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
+    CHECK_EQUAL_RANGE(results_2, "/ch/edge_filter/block1", "/ch/edge_filter/block2", "/ch/edge_filter/block3");
+    CHECK_EQUAL_RANGE(results_3, "/ch/edge_filter");
+    CHECK_EQUAL_RANGE(results_4, "/mld/metrics/0/durations", "/mld/metrics/0/weights", "/mld/metrics/1/durations", "/mld/metrics/1/weights");
+    CHECK_EQUAL_RANGE(results_5, "/mld/metrics/0", "/mld/metrics/1");
+    CHECK_EQUAL_RANGE(results_6, "/mld/metrics");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/storage/serialization.cpp
+++ b/unit_tests/storage/serialization.cpp
@@ -118,18 +118,14 @@ BOOST_AUTO_TEST_CASE(tar_serialize_deallocting_vector)
 BOOST_AUTO_TEST_CASE(buffer_serialize_map)
 {
     std::map<std::string, std::int32_t> map = {
-        {"foo", 1},
-        {"barrrr", 2},
-        {"bal", 3},
-        {"bazbar", 4},
-        {"foofofofo", 5},
+        {"foo", 1}, {"barrrr", 2}, {"bal", 3}, {"bazbar", 4}, {"foofofofo", 5},
     };
 
     std::string buffer;
     {
-    io::BufferWriter writer;
-    storage::serialization::write(writer, map);
-    buffer = writer.GetBuffer();
+        io::BufferWriter writer;
+        storage::serialization::write(writer, map);
+        buffer = writer.GetBuffer();
     }
 
     std::map<std::string, std::int32_t> result;

--- a/unit_tests/storage/serialization.cpp
+++ b/unit_tests/storage/serialization.cpp
@@ -115,4 +115,33 @@ BOOST_AUTO_TEST_CASE(tar_serialize_deallocting_vector)
     }
 }
 
+BOOST_AUTO_TEST_CASE(buffer_serialize_map)
+{
+    std::map<std::string, std::int32_t> map = {
+        {"foo", 1},
+        {"barrrr", 2},
+        {"bal", 3},
+        {"bazbar", 4},
+        {"foofofofo", 5},
+    };
+
+    std::string buffer;
+    {
+    io::BufferWriter writer;
+    storage::serialization::write(writer, map);
+    buffer = writer.GetBuffer();
+    }
+
+    std::map<std::string, std::int32_t> result;
+    {
+        io::BufferReader reader(buffer);
+        storage::serialization::read(reader, result);
+    }
+
+    for (auto &pair : map)
+    {
+        BOOST_CHECK_EQUAL(pair.second, result[pair.first]);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

This works towards https://github.com/Project-OSRM/osrm-backend/issues/4952 by using the string identifiers everywhere to reference to the data. This makes `DataLayout` quite "stupid" as it does not know about the data anymore and can have a variable number of entries.

## Tasklist

 - [x] Merge #4960 
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments

## Requirements / Relations

This PR is based on #4960.
