### PR TITLE
Add microtar to executables in unit tests CMakeLists

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -62,12 +62,12 @@ file(GLOB UtilTestsSources
 add_executable(engine-tests
 	EXCLUDE_FROM_ALL
 	${EngineTestsSources}
-	$<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL>)
+        $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:MICROTAR>)
 
 add_executable(contractor-tests
 	EXCLUDE_FROM_ALL
     ${ContractorTestsSources}
-    $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UPDATER> $<TARGET_OBJECTS:UTIL>)
+    $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UPDATER> $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:MICROTAR>)
 
 add_executable(extractor-tests
 	EXCLUDE_FROM_ALL
@@ -122,7 +122,7 @@ add_executable(server-tests
 add_executable(util-tests
 	EXCLUDE_FROM_ALL
 	${UtilTestsSources}
-	$<TARGET_OBJECTS:UTIL>)
+        $<TARGET_OBJECTS:UTIL> $<TARGET_OBJECTS:MICROTAR>)
 
 
 if(NOT WIN32 AND NOT Boost_USE_STATIC_LIBS)
@@ -160,7 +160,7 @@ target_include_directories(updater-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(contractor-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(storage-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(engine-tests ${ENGINE_LIBRARIES} $<TARGET_OBJECTS:MICROTAR> ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+target_link_libraries(engine-tests ${ENGINE_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 target_link_libraries(extractor-tests osrm_extract osrm_guidance ${EXTRACTOR_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 target_link_libraries(partitioner-tests osrm_partition ${PARTITIONER_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 target_link_libraries(customizer-tests osrm_customize ${CUSTOMIZER_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
@@ -171,8 +171,8 @@ target_link_libraries(library-contract-tests osrm_contract ${Boost_UNIT_TEST_FRA
 target_link_libraries(library-customize-tests osrm_customize ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 target_link_libraries(library-partition-tests osrm_partition ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 target_link_libraries(server-tests osrm ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-target_link_libraries(util-tests ${UTIL_LIBRARIES} $<TARGET_OBJECTS:MICROTAR> ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-target_link_libraries(contractor-tests osrm_contract ${CONTRACTOR_LIBRARIES} $<TARGET_OBJECTS:MICROTAR> ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+target_link_libraries(util-tests ${UTIL_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+target_link_libraries(contractor-tests osrm_contract ${CONTRACTOR_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 target_link_libraries(storage-tests osrm_store ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
 add_custom_target(tests


### PR DESCRIPTION
# Issue

Follow up bugfix to https://github.com/Project-OSRM/osrm-backend/pull/4960

On Ubuntu 16, Cmake 3.5.1, I get these errors running `cmake`
```
CMake Error at unit_tests/CMakeLists.txt:174 (target_link_libraries):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:MICROTAR>

  The evaluation of the TARGET_OBJECTS generator expression is only suitable
  for consumption by CMake.  It is not suitable for writing out elsewhere.


CMake Error at unit_tests/CMakeLists.txt:163 (target_link_libraries):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:MICROTAR>

  The evaluation of the TARGET_OBJECTS generator expression is only suitable
  for consumption by CMake.  It is not suitable for writing out elsewhere.


CMake Error at unit_tests/CMakeLists.txt:175 (target_link_libraries):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:MICROTAR>

  The evaluation of the TARGET_OBJECTS generator expression is only suitable
  for consumption by CMake.  It is not suitable for writing out elsewhere.
```

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
