### PR TITLE
Don't apply unimplemented SH and PH conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
       - FIXED #4920: Use smaller range for U-turn angles in map-matching [#4920](https://github.com/Project-OSRM/osrm-backend/pull/4920)
       - FIXED: Remove the last short annotation segment in `trimShortSegments`
       - FIXED: Properly calculate annotations for speeds, durations and distances when waypoints are used with mapmatching [#4949](https://github.com/Project-OSRM/osrm-backend/pull/4949)
+      - FIXED: Don't apply unimplemented SH and PH conditions in OpeningHours and add inversed date ranges [#4992](https://github.com/Project-OSRM/osrm-backend/issues/4992)
     - Profile:
       - CHANGED #4929: Handle oneways in get_forward_backward_by_key [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
       - FIXED #4943: Do not route against oneway road if there is a cycleway in the wrong direction; also review bike profile [#4943](https://github.com/Project-OSRM/osrm-backend/issues/4943)

--- a/src/util/opening_hours.cpp
+++ b/src/util/opening_hours.cpp
@@ -303,7 +303,7 @@ struct opening_hours_grammar : qi::grammar<Iterator, Skipper, std::vector<Openin
 
         daynum
             = uint2_p[_pass = bind([](unsigned x) { return 01 <= x && x <= 31; }, _1), _val = _1]
-            >> (&~lit(':') | eoi)
+            >> !qi::no_skip[lit(':') >> uint2_p] // distinguish "daynum:.." from "hour:minute"
             ;
 
         weeknum = uint2_p[_pass = bind([](unsigned x) { return 01 <= x && x <= 53; }, _1), _val = _1];


### PR DESCRIPTION
# Issue

Fixes #4992:
* unimplemented conditions with empty ranges are not used in `OpeningHours`
* added inversed date ranges

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
