### PR TITLE
osrm-routed only on localhost during tests

### DIFF
--- a/features/lib/osrm_loader.js
+++ b/features/lib/osrm_loader.js
@@ -47,7 +47,7 @@ class OSRMBaseLoader{
           if (err) {
             if (retryCount < 10) {
               retryCount++;
-              setTimeout(() => { tryConnect(this.scope.OSRM_PORT, retry); }, 10);
+              setTimeout(() => { tryConnect(this.scope.OSRM_IP, this.scope.OSRM_PORT, retry); }, 10);
             } else {
               callback(new Error("Could not connect to osrm-routed after ten retries."));
             }
@@ -58,7 +58,7 @@ class OSRMBaseLoader{
           }
         };
 
-        tryConnect(this.scope.OSRM_PORT, retry);
+        tryConnect(this.scope.OSRM_IP, this.scope.OSRM_PORT, retry);
     }
 };
 
@@ -77,7 +77,7 @@ class OSRMDirectLoader extends OSRMBaseLoader {
     osrmUp (callback) {
         if (this.osrmIsRunning()) return callback(new Error("osrm-routed already running!"));
 
-        const command_arguments = util.format('%s -p %d -a %s', this.inputFile, this.scope.OSRM_PORT, this.scope.ROUTING_ALGORITHM);
+        const command_arguments = util.format('%s -p %d -i %s -a %s', this.inputFile, this.scope.OSRM_PORT, this.scope.OSRM_HOST, this.scope.ROUTING_ALGORITHM);
         this.child = this.scope.runBin('osrm-routed', command_arguments, this.scope.environment, (err) => {
             if (err && err.signal !== 'SIGINT') {
                 this.child = null;
@@ -116,7 +116,7 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
     osrmUp (callback) {
         if (this.osrmIsRunning()) return callback();
 
-        const command_arguments = util.format('--shared-memory=1 -p %d -a %s', this.scope.OSRM_PORT, this.scope.ROUTING_ALGORITHM);
+        const command_arguments = util.format('--shared-memory=1 -i %s -p %d -a %s', this.scope.OSRM_IP, this.scope.OSRM_PORT, this.scope.ROUTING_ALGORITHM);
         this.child = this.scope.runBin('osrm-routed', command_arguments, this.scope.environment, (err) => {
             if (err && err.signal !== 'SIGINT') {
                 this.child = null;

--- a/features/lib/try_connect.js
+++ b/features/lib/try_connect.js
@@ -3,8 +3,8 @@
 const net = require('net');
 const Timeout = require('node-timeout');
 
-module.exports = function tryConnect(port, callback) {
-  net.connect({ port: port, host: '127.0.0.1' })
+module.exports = function tryConnect(host, port, callback) {
+  net.connect({ port: port, host: host })
     .on('connect', () => { callback(); })
     .on('error', () => {
         callback(new Error('Could not connect.'));

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -43,7 +43,8 @@ module.exports = function () {
         this.TIMEZONE_NAMES = this.PLATFORM_WINDOWS ? 'win' : 'iana';
 
         this.OSRM_PORT = process.env.OSRM_PORT && parseInt(process.env.OSRM_PORT) || 5000;
-        this.HOST = 'http://127.0.0.1:' + this.OSRM_PORT;
+        this.OSRM_IP = process.env.OSRM_IP || '127.0.0.1';
+        this.HOST = `http://${this.OSRM_IP}:${this.OSRM_PORT}`;
 
         this.OSRM_PROFILE = process.env.OSRM_PROFILE;
 
@@ -93,7 +94,7 @@ module.exports = function () {
     };
 
     this.verifyOSRMIsNotRunning = (callback) => {
-        tryConnect(this.OSRM_PORT, (err) => {
+        tryConnect(this.OSRM_IP, this.OSRM_PORT, (err) => {
             if (!err) return callback(new Error('*** osrm-routed is already running.'));
             else callback();
         });


### PR DESCRIPTION
This PR changes the cucumber test suite to start `osrm-routed` only listening on `127.0.0.1` by default.  This achieves:

  1. Your work-in-progress `osrm-routed` with bugs won't be listening on an open public port by default.
  2. If you're like me and subject to a corporate firewall policy on your dev machine, you won't be plagued by annoying popups that ask you to approve the latest `osrm-routed` binary for incoming network connections on a public network interface.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch