### PR TITLE
Split shared memory into updatable and non-updatable section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@
       - ADDED: Maneuver relation now supports `straight` as a direction [#4995](https://github.com/Project-OSRM/osrm-backend/pull/4995)
     - Tools:
       - ADDED: `osrm-routed` accepts a new property `--memory_file` to store memory in a file on disk. [#4881](https://github.com/Project-OSRM/osrm-backend/pull/4881)
+      - ADDED: `osrm-datastore` accepts a new parameter `--dataset-name` to select the name of the dataset. [#4982](https://github.com/Project-OSRM/osrm-backend/pull/4982)
+      - ADDED: `osrm-datastore` accepts a new parameter `--list` to list all datasets loaded into memory. [#4982](https://github.com/Project-OSRM/osrm-backend/pull/4982)
+      - ADDED: `osrm-routed` accepts a new parameter `--dataset-name` to select the shared-memory dataset to use. [#4982](https://github.com/Project-OSRM/osrm-backend/pull/4982)
     - NodeJS:
       - ADDED: `OSRM` object accepts a new option `memory_file` that stores the memory in a file on disk. [#4881](https://github.com/Project-OSRM/osrm-backend/pull/4881)
+      - ADDED: `OSRM` object accepts a new option `dataset_name` to select the shared-memory dataset. [#4982](https://github.com/Project-OSRM/osrm-backend/pull/4982)
     - Internals
       - CHANGED: Updated segregated intersection identification [#4845](https://github.com/Project-OSRM/osrm-backend/pull/4845) [#4968](https://github.com/Project-OSRM/osrm-backend/pull/4968)
       - REMOVED: Remove `.timestamp` file since it was unused [#4960](https://github.com/Project-OSRM/osrm-backend/pull/4960)

--- a/features/lib/osrm_loader.js
+++ b/features/lib/osrm_loader.js
@@ -107,7 +107,8 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
     }
 
     loadData (callback) {
-        this.scope.runBin('osrm-datastore', this.inputFile, this.scope.environment, (err) => {
+        const command_arguments = util.format('--dataset-name=%s %s', this.scope.DATASET_NAME, this.inputFile);
+        this.scope.runBin('osrm-datastore', command_arguments, this.scope.environment, (err) => {
             if (err) return callback(new Error('*** osrm-datastore exited with ' + err.code + ': ' + err));
             callback();
         });
@@ -116,7 +117,7 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
     osrmUp (callback) {
         if (this.osrmIsRunning()) return callback();
 
-        const command_arguments = util.format('--shared-memory=1 -i %s -p %d -a %s', this.scope.OSRM_IP, this.scope.OSRM_PORT, this.scope.ROUTING_ALGORITHM);
+        const command_arguments = util.format('--dataset-name=%s -s -i %s -p %d -a %s', this.scope.DATASET_NAME, this.scope.OSRM_IP, this.scope.OSRM_PORT, this.scope.ROUTING_ALGORITHM);
         this.child = this.scope.runBin('osrm-routed', command_arguments, this.scope.environment, (err) => {
             if (err && err.signal !== 'SIGINT') {
                 this.child = null;

--- a/features/options/datastore/datastore.feature
+++ b/features/options/datastore/datastore.feature
@@ -1,0 +1,20 @@
+@datastore @options @help
+Feature: osrm-datastore command line options: list
+
+    Background:
+        Given the profile "testbot"
+        And the node map
+            """
+            a b
+            """
+        And the ways
+            | nodes |
+            | ab    |
+        And the data has been contracted
+
+    Scenario: osrm-datastore - Help should be shown when no options are passed
+        When I try to run "osrm-datastore --dataset-name test_dataset_42 {processed_file}"
+        Then it should exit successfully
+        When I try to run "osrm-datastore --list"
+        Then it should exit successfully
+        And stdout should contain "test_dataset_42/data"

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -27,6 +27,7 @@ module.exports = function () {
             return callback(new Error('*** '+stxxl_config+ 'does not exist'));
         }
 
+        this.DATASET_NAME = 'cucumber';
         this.PLATFORM_WINDOWS = process.platform.match(/^win.*/);
         this.DEFAULT_ENVIRONMENT = Object.assign({STXXLCFG: stxxl_config}, process.env);
         this.DEFAULT_PROFILE = 'bicycle';

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -46,8 +46,8 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
             auto region_id = shared_register.Find(dataset_name + "/data");
             if (region_id == storage::SharedRegionRegister::INVALID_REGION_ID)
             {
-                throw util::exception(
-                    "Could not find shared memory region for \"" + dataset_name +"/data\". Did you run osrm-datastore?");
+                throw util::exception("Could not find shared memory region for \"" + dataset_name +
+                                      "/data\". Did you run osrm-datastore?");
             }
             shared_region = &shared_register.GetRegion(region_id);
             region = *shared_region;
@@ -94,8 +94,8 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
                 facade_factory =
                     DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
                         std::make_shared<datafacade::SharedMemoryAllocator>(region.shm_key));
-                util::Log() << "updated facade to region " << (int) region.shm_key << " with timestamp "
-                            << region.timestamp;
+                util::Log() << "updated facade to region " << (int)region.shm_key
+                            << " with timestamp " << region.timestamp;
             }
         }
 

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -47,7 +47,7 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
             if (region_id == storage::SharedRegionRegister::INVALID_REGION_ID)
             {
                 throw util::exception(
-                    "Could not find shared memory region. Did you run osrm-datastore?");
+                    "Could not find shared memory region for \"" + dataset_name +"/data\". Did you run osrm-datastore?");
             }
             shared_region = &shared_register.GetRegion(region_id);
             region = *shared_region;
@@ -94,7 +94,7 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
                 facade_factory =
                     DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
                         std::make_shared<datafacade::SharedMemoryAllocator>(region.shm_key));
-                util::Log() << "updated facade to region " << region.shm_key << " with timestamp "
+                util::Log() << "updated facade to region " << (int) region.shm_key << " with timestamp "
                             << region.timestamp;
             }
         }

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -43,18 +43,23 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
             boost::interprocess::scoped_lock<mutex_type> current_region_lock(barrier.get_mutex());
 
             auto &shared_register = barrier.data();
-            auto region_id = shared_register.Find(dataset_name + "/data");
-            if (region_id == storage::SharedRegionRegister::INVALID_REGION_ID)
+            auto static_region_id = shared_register.Find(dataset_name + "/static");
+            auto updatable_region_id = shared_register.Find(dataset_name + "/updatable");
+            if (static_region_id == storage::SharedRegionRegister::INVALID_REGION_ID ||
+                updatable_region_id == storage::SharedRegionRegister::INVALID_REGION_ID)
             {
                 throw util::exception("Could not find shared memory region for \"" + dataset_name +
                                       "/data\". Did you run osrm-datastore?");
             }
-            shared_region = &shared_register.GetRegion(region_id);
-            region = *shared_region;
+            static_shared_region = &shared_register.GetRegion(static_region_id);
+            updatable_shared_region = &shared_register.GetRegion(updatable_region_id);
+            static_region = *static_shared_region;
+            updatable_region = *updatable_shared_region;
 
             facade_factory =
                 DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
-                    std::make_shared<datafacade::SharedMemoryAllocator>(region.shm_key));
+                    std::make_shared<datafacade::SharedMemoryAllocator>(static_region.shm_key),
+                    std::make_shared<datafacade::SharedMemoryAllocator>(updatable_region.shm_key));
         }
 
         watcher = std::thread(&DataWatchdogImpl::Run, this);
@@ -83,20 +88,36 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
         {
             boost::interprocess::scoped_lock<mutex_type> current_region_lock(barrier.get_mutex());
 
-            while (active && region.timestamp == shared_region->timestamp)
+            while (active && static_region.timestamp == static_shared_region->timestamp &&
+                   updatable_region.timestamp == updatable_shared_region->timestamp)
             {
                 barrier.wait(current_region_lock);
             }
 
-            if (region.timestamp != shared_region->timestamp)
+            if (!active)
+                break;
+
+            if (static_region.timestamp != static_shared_region->timestamp)
             {
-                region = *shared_region;
-                facade_factory =
-                    DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
-                        std::make_shared<datafacade::SharedMemoryAllocator>(region.shm_key));
-                util::Log() << "updated facade to region " << (int)region.shm_key
-                            << " with timestamp " << region.timestamp;
+                static_region = *static_shared_region;
             }
+            else if (updatable_region.timestamp != updatable_shared_region->timestamp)
+            {
+                updatable_region = *updatable_shared_region;
+            }
+            else
+            {
+                BOOST_ASSERT_MSG(false, "One region always needs to update");
+            }
+
+            util::Log() << "updated facade to regions " << (int)static_region.shm_key << " and "
+                        << (int)updatable_region.shm_key << " with timestamps "
+                        << static_region.timestamp << " and " << updatable_region.timestamp;
+
+            facade_factory =
+                DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
+                    std::make_shared<datafacade::SharedMemoryAllocator>(static_region.shm_key),
+                    std::make_shared<datafacade::SharedMemoryAllocator>(updatable_region.shm_key));
         }
 
         util::Log() << "DataWatchdog thread stopped";
@@ -106,8 +127,10 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
     storage::SharedMonitor<storage::SharedRegionRegister> barrier;
     std::thread watcher;
     bool active;
-    storage::SharedRegion region;
-    storage::SharedRegion *shared_region;
+    storage::SharedRegion static_region;
+    storage::SharedRegion updatable_region;
+    storage::SharedRegion *static_shared_region;
+    storage::SharedRegion *updatable_shared_region;
     DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT> facade_factory;
 };
 }

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -61,13 +61,13 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
             allocator->GetLayout(), allocator->GetMemory(), metric_name, exclude_index);
     }
 
-    void InitializeInternalPointers(const storage::DataLayout &data_layout,
+    void InitializeInternalPointers(const storage::DataLayout &static_layout,
                                     char *memory_block,
                                     const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
         m_query_graph = make_filtered_graph_view(
-            memory_block, data_layout, "/ch/metrics/" + metric_name, exclude_index);
+            memory_block, static_layout, "/ch/metrics/" + metric_name, exclude_index);
     }
 
     // search graph access
@@ -172,7 +172,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     // allocator that keeps the allocation data
     std::shared_ptr<ContiguousBlockAllocator> allocator;
 
-    void InitializeInternalPointers(const storage::DataLayout &layout,
+    void InitializeInternalPointers(const storage::DataLayout &static_layout,
                                     char *memory_ptr,
                                     const std::string &metric_name,
                                     const std::size_t exclude_index)
@@ -180,47 +180,51 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         // TODO: For multi-metric support we need to have separate exclude classes per metric
         (void)metric_name;
 
-        m_profile_properties =
-            layout.GetBlockPtr<extractor::ProfileProperties>(memory_ptr, "/common/properties");
+        m_profile_properties = static_layout.GetBlockPtr<extractor::ProfileProperties>(
+            memory_ptr, "/common/properties");
 
         exclude_mask = m_profile_properties->excludable_classes[exclude_index];
 
         m_check_sum =
-            *layout.GetBlockPtr<std::uint32_t>(memory_ptr, "/common/connectivity_checksum");
+            *static_layout.GetBlockPtr<std::uint32_t>(memory_ptr, "/common/connectivity_checksum");
 
         std::tie(m_coordinate_list, m_osmnodeid_list) =
-            make_nbn_data_view(memory_ptr, layout, "/common/nbn_data");
+            make_nbn_data_view(memory_ptr, static_layout, "/common/nbn_data");
 
-        m_static_rtree = make_search_tree_view(memory_ptr, layout, "/common/rtree");
+        m_static_rtree = make_search_tree_view(memory_ptr, static_layout, "/common/rtree");
         m_geospatial_query.reset(
             new SharedGeospatialQuery(m_static_rtree, m_coordinate_list, *this));
 
-        edge_based_node_data = make_ebn_data_view(memory_ptr, layout, "/common/ebg_node_data");
+        edge_based_node_data =
+            make_ebn_data_view(memory_ptr, static_layout, "/common/ebg_node_data");
 
-        turn_data = make_turn_data_view(memory_ptr, layout, "/common/turn_data");
+        turn_data = make_turn_data_view(memory_ptr, static_layout, "/common/turn_data");
 
-        m_name_table = make_name_table_view(memory_ptr, layout, "/common/names");
+        m_name_table = make_name_table_view(memory_ptr, static_layout, "/common/names");
 
         std::tie(m_lane_description_offsets, m_lane_description_masks) =
-            make_turn_lane_description_views(memory_ptr, layout, "/common/turn_lanes");
-        m_lane_tupel_id_pairs = make_lane_data_view(memory_ptr, layout, "/common/turn_lanes");
+            make_turn_lane_description_views(memory_ptr, static_layout, "/common/turn_lanes");
+        m_lane_tupel_id_pairs =
+            make_lane_data_view(memory_ptr, static_layout, "/common/turn_lanes");
 
-        m_turn_weight_penalties = make_turn_weight_view(memory_ptr, layout, "/common/turn_penalty");
+        m_turn_weight_penalties =
+            make_turn_weight_view(memory_ptr, static_layout, "/common/turn_penalty");
         m_turn_duration_penalties =
-            make_turn_duration_view(memory_ptr, layout, "/common/turn_penalty");
+            make_turn_duration_view(memory_ptr, static_layout, "/common/turn_penalty");
 
-        segment_data = make_segment_data_view(memory_ptr, layout, "/common/segment_data");
+        segment_data = make_segment_data_view(memory_ptr, static_layout, "/common/segment_data");
 
-        m_datasources =
-            layout.GetBlockPtr<extractor::Datasources>(memory_ptr, "/common/data_sources_names");
+        m_datasources = static_layout.GetBlockPtr<extractor::Datasources>(
+            memory_ptr, "/common/data_sources_names");
 
-        intersection_bearings_view =
-            make_intersection_bearings_view(memory_ptr, layout, "/common/intersection_bearings");
+        intersection_bearings_view = make_intersection_bearings_view(
+            memory_ptr, static_layout, "/common/intersection_bearings");
 
-        m_entry_class_table = make_entry_classes_view(memory_ptr, layout, "/common/entry_classes");
+        m_entry_class_table =
+            make_entry_classes_view(memory_ptr, static_layout, "/common/entry_classes");
 
         std::tie(m_maneuver_overrides, m_maneuver_override_node_sequences) =
-            make_maneuver_overrides_views(memory_ptr, layout, "/common/maneuver_overrides");
+            make_maneuver_overrides_views(memory_ptr, static_layout, "/common/maneuver_overrides");
     }
 
   public:
@@ -661,16 +665,17 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
 
     QueryGraph query_graph;
 
-    void InitializeInternalPointers(const storage::DataLayout &layout,
+    void InitializeInternalPointers(const storage::DataLayout &static_layout,
                                     char *memory_ptr,
                                     const std::string &metric_name,
                                     const std::size_t exclude_index)
     {
-        mld_partition = make_partition_view(memory_ptr, layout, "/mld/multilevelpartition");
+        mld_partition = make_partition_view(memory_ptr, static_layout, "/mld/multilevelpartition");
         mld_cell_metric = make_filtered_cell_metric_view(
-            memory_ptr, layout, "/mld/metrics/" + metric_name, exclude_index);
-        mld_cell_storage = make_cell_storage_view(memory_ptr, layout, "/mld/cellstorage");
-        query_graph = make_multi_level_graph_view(memory_ptr, layout, "/mld/multilevelgraph");
+            memory_ptr, static_layout, "/mld/metrics/" + metric_name, exclude_index);
+        mld_cell_storage = make_cell_storage_view(memory_ptr, static_layout, "/mld/cellstorage");
+        query_graph =
+            make_multi_level_graph_view(memory_ptr, static_layout, "/mld/multilevelgraph");
     }
 
     // allocator that keeps the allocation data

--- a/include/engine/datafacade/shared_memory_allocator.hpp
+++ b/include/engine/datafacade/shared_memory_allocator.hpp
@@ -23,7 +23,7 @@ namespace datafacade
 class SharedMemoryAllocator : public ContiguousBlockAllocator
 {
   public:
-    explicit SharedMemoryAllocator(storage::SharedDataType data_region);
+    explicit SharedMemoryAllocator(storage::SharedRegionRegister::ShmKey data_shm_key);
     ~SharedMemoryAllocator() override final;
 
     // interface to give access to the datafacades

--- a/include/engine/datafacade_provider.hpp
+++ b/include/engine/datafacade_provider.hpp
@@ -83,6 +83,8 @@ class WatchingProvider : public DataFacadeProvider<AlgorithmT, FacadeT>
   public:
     using Facade = typename DataFacadeProvider<AlgorithmT, FacadeT>::Facade;
 
+    WatchingProvider(const std::string &dataset_name) : watchdog(dataset_name) {}
+
     std::shared_ptr<const Facade> Get(const api::TileParameters &params) const override final
     {
         return watchdog.Get(params);

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -59,8 +59,8 @@ template <typename Algorithm> class Engine final : public EngineInterface
     {
         if (config.use_shared_memory)
         {
-            util::Log(logDEBUG) << "Using shared memory with name \"" << config.dataset_name << "\" with algorithm "
-                                << routing_algorithms::name<Algorithm>();
+            util::Log(logDEBUG) << "Using shared memory with name \"" << config.dataset_name
+                                << "\" with algorithm " << routing_algorithms::name<Algorithm>();
             facade_provider = std::make_unique<WatchingProvider<Algorithm>>(config.dataset_name);
         }
         else if (!config.memory_file.empty())

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -61,7 +61,7 @@ template <typename Algorithm> class Engine final : public EngineInterface
         {
             util::Log(logDEBUG) << "Using shared memory with algorithm "
                                 << routing_algorithms::name<Algorithm>();
-            facade_provider = std::make_unique<WatchingProvider<Algorithm>>();
+            facade_provider = std::make_unique<WatchingProvider<Algorithm>>(config.dataset_name);
         }
         else if (!config.memory_file.empty())
         {

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -59,7 +59,7 @@ template <typename Algorithm> class Engine final : public EngineInterface
     {
         if (config.use_shared_memory)
         {
-            util::Log(logDEBUG) << "Using shared memory with algorithm "
+            util::Log(logDEBUG) << "Using shared memory with name \"" << config.dataset_name << "\" with algorithm "
                                 << routing_algorithms::name<Algorithm>();
             facade_provider = std::make_unique<WatchingProvider<Algorithm>>(config.dataset_name);
         }

--- a/include/engine/engine_config.hpp
+++ b/include/engine/engine_config.hpp
@@ -91,6 +91,7 @@ struct EngineConfig final
     boost::filesystem::path memory_file;
     Algorithm algorithm = Algorithm::CH;
     std::string verbosity;
+    std::string dataset_name;
 };
 }
 }

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -142,7 +142,8 @@ inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo
     {
         if (dataset_name->IsString())
         {
-            engine_config->dataset_name = *v8::String::Utf8Value(Nan::To<v8::String>(dataset_name).ToLocalChecked());
+            engine_config->dataset_name =
+                *v8::String::Utf8Value(Nan::To<v8::String>(dataset_name).ToLocalChecked());
         }
         else
         {

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -135,6 +135,22 @@ inline engine_config_ptr argumentsToEngineConfig(const Nan::FunctionCallbackInfo
             *v8::String::Utf8Value(Nan::To<v8::String>(memory_file).ToLocalChecked());
     }
 
+    auto dataset_name = params->Get(Nan::New("dataset_name").ToLocalChecked());
+    if (dataset_name.IsEmpty())
+        return engine_config_ptr();
+    if (!dataset_name->IsUndefined())
+    {
+        if (dataset_name->IsString())
+        {
+            engine_config->dataset_name = *v8::String::Utf8Value(Nan::To<v8::String>(dataset_name).ToLocalChecked());
+        }
+        else
+        {
+            Nan::ThrowError("dataset_name needs to be a string");
+            return engine_config_ptr();
+        }
+    }
+
     if (!path->IsUndefined())
     {
         engine_config->storage_config =

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -221,6 +221,18 @@ struct SharedRegionRegister
         }
     }
 
+    template<typename OutIter>
+    void List(OutIter out) const
+    {
+        for (const auto& region : regions)
+        {
+            if (!region.IsEmpty())
+            {
+                *out++ = region.name;
+            }
+        }
+    }
+
     void Deregister(const RegionID key) { regions[key] = SharedRegion{}; }
 
     const auto &GetRegion(const RegionID key) const { return regions[key]; }

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -221,10 +221,9 @@ struct SharedRegionRegister
         }
     }
 
-    template<typename OutIter>
-    void List(OutIter out) const
+    template <typename OutIter> void List(OutIter out) const
     {
-        for (const auto& region : regions)
+        for (const auto &region : regions)
         {
             if (!region.IsEmpty())
             {

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -232,8 +232,6 @@ struct SharedRegionRegister
         }
     }
 
-    void Deregister(const RegionID key) { regions[key] = SharedRegion{}; }
-
     const auto &GetRegion(const RegionID key) const { return regions[key]; }
 
     auto &GetRegion(const RegionID key) { return regions[key]; }

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -63,7 +63,7 @@ class SharedMemory
         {
             shm = boost::interprocess::xsi_shared_memory(boost::interprocess::open_only, key);
 
-            util::Log(logDEBUG) << "opening " << (int) shm.get_shmid() << " from id " << (int) id;
+            util::Log(logDEBUG) << "opening " << (int)shm.get_shmid() << " from id " << (int)id;
 
             region = boost::interprocess::mapped_region(shm, boost::interprocess::read_only);
         }

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -63,7 +63,7 @@ class SharedMemory
         {
             shm = boost::interprocess::xsi_shared_memory(boost::interprocess::open_only, key);
 
-            util::Log(logDEBUG) << "opening " << shm.get_shmid() << " from id " << id;
+            util::Log(logDEBUG) << "opening " << (int) shm.get_shmid() << " from id " << (int) id;
 
             region = boost::interprocess::mapped_region(shm, boost::interprocess::read_only);
         }

--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -126,7 +126,6 @@ template <typename Data> struct SharedMonitor
         bi::interprocess_condition condition;
     };
 
-
 #else
     // Implement a conditional variable using a queue of semaphores.
     // OSX checks the virtual address of a mutex in pthread_cond_wait and fails with EINVAL
@@ -207,8 +206,10 @@ template <typename Data> struct SharedMonitor
     static_assert(buffer_size >= 2, "buffer size is too small");
 
 #endif
-    static constexpr int rounded_internal_size = ((sizeof(InternalData) + alignof(Data) - 1) / alignof(Data)) * alignof(Data);
-    static_assert(rounded_internal_size < sizeof(InternalData) + sizeof(Data), "Data and internal data need to fit into shared memory");
+    static constexpr int rounded_internal_size =
+        ((sizeof(InternalData) + alignof(Data) - 1) / alignof(Data)) * alignof(Data);
+    static_assert(rounded_internal_size < sizeof(InternalData) + sizeof(Data),
+                  "Data and internal data need to fit into shared memory");
 
     InternalData &internal() const
     {

--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -47,7 +47,7 @@ template <typename Data> struct SharedMonitor
         bi::offset_t size = 0;
         if (shmem.get_size(size) && size == 0)
         {
-            shmem.truncate(internal_size + sizeof(Data));
+            shmem.truncate(rounded_internal_size + sizeof(Data));
             region = bi::mapped_region(shmem, bi::read_write);
             new (&internal()) InternalData;
             new (&data()) Data(initial_data);
@@ -65,11 +65,11 @@ template <typename Data> struct SharedMonitor
             shmem = bi::shared_memory_object(bi::open_only, Data::name, bi::read_write);
 
             bi::offset_t size = 0;
-            if (!shmem.get_size(size) || size != internal_size + sizeof(Data))
+            if (!shmem.get_size(size) || size != rounded_internal_size + sizeof(Data))
             {
                 auto message =
                     boost::format("Wrong shared memory block '%1%' size %2%, expected %3% bytes") %
-                    (const char *)Data::name % size % (internal_size + sizeof(Data));
+                    (const char *)Data::name % size % (rounded_internal_size + sizeof(Data));
                 throw util::exception(message.str() + SOURCE_REF);
             }
 
@@ -87,7 +87,7 @@ template <typename Data> struct SharedMonitor
     Data &data() const
     {
         auto region_pointer = reinterpret_cast<char *>(region.get_address());
-        return *reinterpret_cast<Data *>(region_pointer + internal_size);
+        return *reinterpret_cast<Data *>(region_pointer + rounded_internal_size);
     }
 
     mutex_type &get_mutex() const { return internal().mutex; }
@@ -120,14 +120,12 @@ template <typename Data> struct SharedMonitor
 
   private:
 #if USE_BOOST_INTERPROCESS_CONDITION
-
-    static constexpr int internal_size = 128;
-
     struct InternalData
     {
         mutex_type mutex;
         bi::interprocess_condition condition;
     };
+
 
 #else
     // Implement a conditional variable using a queue of semaphores.
@@ -137,7 +135,6 @@ template <typename Data> struct SharedMonitor
     // fail if a waiter is killed.
 
     static constexpr int buffer_size = 256;
-    static constexpr int internal_size = 4 * 4096;
 
     struct InternalData
     {
@@ -210,9 +207,8 @@ template <typename Data> struct SharedMonitor
     static_assert(buffer_size >= 2, "buffer size is too small");
 
 #endif
-
-    static_assert(sizeof(InternalData) + sizeof(Data) <= internal_size, "not enough space");
-    static_assert(sizeof(InternalData) % alignof(Data) == 0, "incorrect data alignment");
+    static constexpr int rounded_internal_size = ((sizeof(InternalData) + alignof(Data) - 1) / alignof(Data)) * alignof(Data);
+    static_assert(rounded_internal_size < sizeof(InternalData) + sizeof(Data), "Data and internal data need to fit into shared memory");
 
     InternalData &internal() const
     {

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -44,7 +44,7 @@ class Storage
   public:
     Storage(StorageConfig config);
 
-    int Run(int max_wait);
+    int Run(int max_wait, const std::string &name);
 
     void PopulateLayout(DataLayout &layout);
     void PopulateData(const DataLayout &layout, char *memory_ptr);

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -46,8 +46,10 @@ class Storage
 
     int Run(int max_wait, const std::string &name);
 
-    void PopulateLayout(DataLayout &layout);
-    void PopulateData(const DataLayout &layout, char *memory_ptr);
+    void PopulateStaticLayout(DataLayout &layout);
+    void PopulateStaticData(const DataLayout &layout, char *memory_ptr);
+    void PopulateUpdatableLayout(DataLayout &layout);
+    void PopulateUpdatableData(const DataLayout &layout, char *memory_ptr);
 
   private:
     StorageConfig config;

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -13,12 +13,12 @@ namespace engine
 namespace datafacade
 {
 
-SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedDataType data_region)
+SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedRegionRegister::ShmKey data_shm_key)
 {
-    util::Log(logDEBUG) << "Loading new data for region " << regionToString(data_region);
+    util::Log(logDEBUG) << "Loading new data for region " << data_shm_key;
 
-    BOOST_ASSERT(storage::SharedMemory::RegionExists(data_region));
-    m_large_memory = storage::makeSharedMemory(data_region);
+    BOOST_ASSERT(storage::SharedMemory::RegionExists(data_shm_key));
+    m_large_memory = storage::makeSharedMemory(data_shm_key);
 
     storage::io::BufferReader reader(reinterpret_cast<char *>(m_large_memory->Ptr()),
                                      m_large_memory->Size());

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -15,7 +15,7 @@ namespace datafacade
 
 SharedMemoryAllocator::SharedMemoryAllocator(storage::SharedRegionRegister::ShmKey data_shm_key)
 {
-    util::Log(logDEBUG) << "Loading new data for region " << data_shm_key;
+    util::Log(logDEBUG) << "Loading new data for region " << (int)data_shm_key;
 
     BOOST_ASSERT(storage::SharedMemory::RegionExists(data_shm_key));
     m_large_memory = storage::makeSharedMemory(data_shm_key);

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -28,12 +28,6 @@ OSRM::OSRM(engine::EngineConfig &config)
         throw util::exception("Required files are missing, cannot continue.  Have all the "
                               "pre-processing steps been run?");
     }
-    else if (config.use_shared_memory)
-    {
-        storage::SharedMonitor<storage::SharedDataTimestamp> barrier;
-        using mutex_type = typename decltype(barrier)::mutex_type;
-        boost::interprocess::scoped_lock<mutex_type> current_region_lock(barrier.get_mutex());
-    }
 
     // Now, check that the algorithm requested can be used with the data
     // that's available.

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -65,7 +65,7 @@ using Monitor = SharedMonitor<SharedRegionRegister>;
 
 Storage::Storage(StorageConfig config_) : config(std::move(config_)) {}
 
-int Storage::Run(int max_wait)
+int Storage::Run(int max_wait, const std::string &dataset_name)
 {
     BOOST_ASSERT_MSG(config.IsValid(), "Invalid storage config");
 
@@ -161,14 +161,14 @@ int Storage::Run(int max_wait)
             lock.lock();
         }
 
-        auto region_id = shared_register.Find("data");
+        auto region_id = shared_register.Find(dataset_name + "/data");
         if (region_id == SharedRegionRegister::INVALID_REGION_ID)
         {
-            region_id = shared_register.Register("data", shm_key);
+            region_id = shared_register.Register(dataset_name + "/data", shm_key);
         }
         else
         {
-            auto& shared_region = shared_register.GetRegion(region_id);
+            auto &shared_region = shared_register.GetRegion(region_id);
             next_timestamp = shared_region.timestamp + 1;
             in_use_key = shared_region.shm_key;
             shared_region.shm_key = shm_key;

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -117,7 +117,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name)
         util::UnbufferedLog() << "ok.";
     }
 
-    util::Log() << "Loading data into " << shm_key;
+    util::Log() << "Loading data into " << static_cast<int>(shm_key);
 
     // Populate a memory layout into stack memory
     DataLayout layout;
@@ -176,8 +176,8 @@ int Storage::Run(int max_wait, const std::string &dataset_name)
         }
     }
 
-    util::Log() << "All data loaded. Notify all client about new data in " << shm_key
-                << " with timestamp " << next_timestamp;
+    util::Log() << "All data loaded. Notify all client about new data in "
+                << static_cast<int>(shm_key) << " with timestamp " << next_timestamp;
     monitor.notify_all();
 
     // SHMCTL(2): Mark the segment to be destroyed. The segment will actually be destroyed
@@ -185,7 +185,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name)
     if (in_use_key != SharedRegionRegister::MAX_SHM_KEYS &&
         storage::SharedMemory::RegionExists(in_use_key))
     {
-        util::UnbufferedLog() << "Marking old shared memory region " << in_use_key
+        util::UnbufferedLog() << "Marking old shared memory region " << static_cast<int>(in_use_key)
                               << " for removal... ";
 
         // aquire a handle for the old shared memory region before we mark it for deletion

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -42,7 +42,9 @@ namespace storage
 {
 namespace
 {
-inline void readBlocks(const boost::filesystem::path &path, DataLayout &layout)
+using Monitor = SharedMonitor<SharedRegionRegister>;
+
+void readBlocks(const boost::filesystem::path &path, DataLayout &layout)
 {
     tar::FileReader reader(path, tar::FileReader::VerifyFingerprint);
 
@@ -59,9 +61,128 @@ inline void readBlocks(const boost::filesystem::path &path, DataLayout &layout)
         }
     }
 }
+
+struct RegionHandle
+{
+    std::unique_ptr<SharedMemory> memory;
+    char *data_ptr;
+    std::uint8_t shm_key;
+};
+
+auto setupRegion(SharedRegionRegister &shared_register, const DataLayout &layout)
+{
+    // This is safe because we have an exclusive lock for all osrm-datastore processes.
+    auto shm_key = shared_register.ReserveKey();
+
+    // ensure that the shared memory region we want to write to is really removed
+    // this is only needef for failure recovery because we actually wait for all clients
+    // to detach at the end of the function
+    if (storage::SharedMemory::RegionExists(shm_key))
+    {
+        util::Log(logWARNING) << "Old shared memory region " << (int)shm_key << " still exists.";
+        util::UnbufferedLog() << "Retrying removal... ";
+        storage::SharedMemory::Remove(shm_key);
+        util::UnbufferedLog() << "ok.";
+    }
+
+    io::BufferWriter writer;
+    serialization::write(writer, layout);
+    auto encoded_static_layout = writer.GetBuffer();
+
+    // Allocate shared memory block
+    auto regions_size = encoded_static_layout.size() + layout.GetSizeOfLayout();
+    util::Log() << "Data static_layout has a size of " << encoded_static_layout.size() << " bytes";
+    util::Log() << "Allocating shared memory of " << regions_size << " bytes";
+    auto memory = makeSharedMemory(shm_key, regions_size);
+
+    // Copy memory static_layout to shared memory and populate data
+    char *shared_memory_ptr = static_cast<char *>(memory->Ptr());
+    auto data_ptr =
+        std::copy_n(encoded_static_layout.data(), encoded_static_layout.size(), shared_memory_ptr);
+
+    return RegionHandle{std::move(memory), data_ptr, shm_key};
 }
 
-using Monitor = SharedMonitor<SharedRegionRegister>;
+bool swapData(Monitor &monitor,
+              SharedRegionRegister &shared_register,
+              const std::map<std::string, RegionHandle> &handles,
+              int max_wait)
+{
+    std::vector<RegionHandle> old_handles;
+
+    { // Lock for write access shared region mutex
+        boost::interprocess::scoped_lock<Monitor::mutex_type> lock(monitor.get_mutex(),
+                                                                   boost::interprocess::defer_lock);
+
+        if (max_wait >= 0)
+        {
+            if (!lock.timed_lock(boost::posix_time::microsec_clock::universal_time() +
+                                 boost::posix_time::seconds(max_wait)))
+            {
+                util::Log(logERROR) << "Could not aquire current region lock after " << max_wait
+                                    << " seconds. Data update failed.";
+
+                for (auto &pair : handles)
+                {
+                    SharedMemory::Remove(pair.second.shm_key);
+                }
+                return false;
+            }
+        }
+        else
+        {
+            lock.lock();
+        }
+
+        for (auto &pair : handles)
+        {
+            auto region_id = shared_register.Find(pair.first);
+            if (region_id == SharedRegionRegister::INVALID_REGION_ID)
+            {
+                region_id = shared_register.Register(pair.first, pair.second.shm_key);
+            }
+            else
+            {
+                auto &shared_region = shared_register.GetRegion(region_id);
+
+                old_handles.push_back(RegionHandle{
+                    makeSharedMemory(shared_region.shm_key), nullptr, shared_region.shm_key});
+
+                shared_region.shm_key = pair.second.shm_key;
+                shared_region.timestamp++;
+            }
+        }
+    }
+
+    util::Log() << "All data loaded. Notify all client about new data in:";
+    for (const auto &pair : handles)
+    {
+        util::Log() << " " << pair.second.shm_key;
+    }
+    monitor.notify_all();
+
+    for (auto& old_handle : old_handles)
+    {
+        util::UnbufferedLog() << "Marking old shared memory region " << static_cast<int>(old_handle.shm_key)
+                              << " for removal... ";
+
+        // SHMCTL(2): Mark the segment to be destroyed. The segment will actually be destroyed
+        // only after the last process detaches it.
+        storage::SharedMemory::Remove(old_handle.shm_key);
+        util::UnbufferedLog() << "ok.";
+
+        util::UnbufferedLog() << "Waiting for clients to detach... ";
+        old_handle.memory->WaitForDetach();
+        util::UnbufferedLog() << " ok.";
+
+        shared_register.ReleaseKey(old_handle.shm_key);
+    }
+
+    util::Log() << "All clients switched.";
+
+    return true;
+}
+}
 
 Storage::Storage(StorageConfig config_) : config(std::move(config_)) {}
 
@@ -103,106 +224,23 @@ int Storage::Run(int max_wait, const std::string &dataset_name)
     Monitor monitor(SharedRegionRegister{});
     auto &shared_register = monitor.data();
 
-    // This is safe because we have an exclusive lock for all osrm-datastore processes.
-    auto shm_key = shared_register.ReserveKey();
-
-    // ensure that the shared memory region we want to write to is really removed
-    // this is only needef for failure recovery because we actually wait for all clients
-    // to detach at the end of the function
-    if (storage::SharedMemory::RegionExists(shm_key))
-    {
-        util::Log(logWARNING) << "Old shared memory region " << shm_key << " still exists.";
-        util::UnbufferedLog() << "Retrying removal... ";
-        storage::SharedMemory::Remove(shm_key);
-        util::UnbufferedLog() << "ok.";
-    }
-
-    util::Log() << "Loading data into " << static_cast<int>(shm_key);
-
-    // Populate a memory static_layout into stack memory
+    // Populate a memory layout into stack memory
     DataLayout static_layout;
-    PopulateLayout(static_layout);
+    PopulateStaticLayout(static_layout);
+    auto static_handle = setupRegion(shared_register, static_layout);
+    PopulateStaticData(static_layout, static_handle.data_ptr);
 
-    io::BufferWriter writer;
-    serialization::write(writer, static_layout);
-    auto encoded_static_layout = writer.GetBuffer();
+    DataLayout updatable_layout;
+    PopulateStaticLayout(updatable_layout);
+    auto updatable_handle = setupRegion(shared_register, updatable_layout);
+    PopulateStaticData(updatable_layout, updatable_handle.data_ptr);
 
-    // Allocate shared memory block
-    auto regions_size = encoded_static_layout.size() + static_layout.GetSizeOfLayout();
-    util::Log() << "Data static_layout has a size of " << encoded_static_layout.size() << " bytes";
-    util::Log() << "Allocating shared memory of " << regions_size << " bytes";
-    auto data_memory = makeSharedMemory(shm_key, regions_size);
+    std::map<std::string, RegionHandle> handles = {
+        {dataset_name + "/static", std::move(static_handle)},
+        {dataset_name + "/updatable", std::move(updatable_handle)},
+    };
 
-    // Copy memory static_layout to shared memory and populate data
-    char *shared_memory_ptr = static_cast<char *>(data_memory->Ptr());
-    std::copy_n(encoded_static_layout.data(), encoded_static_layout.size(), shared_memory_ptr);
-    PopulateData(static_layout, shared_memory_ptr + encoded_static_layout.size());
-
-    std::uint32_t next_timestamp = 0;
-    std::uint8_t in_use_key = SharedRegionRegister::MAX_SHM_KEYS;
-
-    { // Lock for write access shared region mutex
-        boost::interprocess::scoped_lock<Monitor::mutex_type> lock(monitor.get_mutex(),
-                                                                   boost::interprocess::defer_lock);
-
-        if (max_wait >= 0)
-        {
-            if (!lock.timed_lock(boost::posix_time::microsec_clock::universal_time() +
-                                 boost::posix_time::seconds(max_wait)))
-            {
-                util::Log(logERROR) << "Could not aquire current region lock after " << max_wait
-                                    << " seconds. Data update failed.";
-                SharedMemory::Remove(shm_key);
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            lock.lock();
-        }
-
-        auto region_id = shared_register.Find(dataset_name + "/data");
-        if (region_id == SharedRegionRegister::INVALID_REGION_ID)
-        {
-            region_id = shared_register.Register(dataset_name + "/data", shm_key);
-        }
-        else
-        {
-            auto &shared_region = shared_register.GetRegion(region_id);
-            next_timestamp = shared_region.timestamp + 1;
-            in_use_key = shared_region.shm_key;
-            shared_region.shm_key = shm_key;
-            shared_region.timestamp = next_timestamp;
-        }
-    }
-
-    util::Log() << "All data loaded. Notify all client about new data in "
-                << static_cast<int>(shm_key) << " with timestamp " << next_timestamp;
-    monitor.notify_all();
-
-    // SHMCTL(2): Mark the segment to be destroyed. The segment will actually be destroyed
-    // only after the last process detaches it.
-    if (in_use_key != SharedRegionRegister::MAX_SHM_KEYS &&
-        storage::SharedMemory::RegionExists(in_use_key))
-    {
-        util::UnbufferedLog() << "Marking old shared memory region " << static_cast<int>(in_use_key)
-                              << " for removal... ";
-
-        // aquire a handle for the old shared memory region before we mark it for deletion
-        // we will need this to wait for all users to detach
-        auto in_use_shared_memory = makeSharedMemory(in_use_key);
-
-        storage::SharedMemory::Remove(in_use_key);
-        util::UnbufferedLog() << "ok.";
-
-        util::UnbufferedLog() << "Waiting for clients to detach... ";
-        in_use_shared_memory->WaitForDetach();
-        util::UnbufferedLog() << " ok.";
-
-        shared_register.ReleaseKey(in_use_key);
-    }
-
-    util::Log() << "All clients switched.";
+    swapData(monitor, shared_register, handles, max_wait);
 
     return EXIT_SUCCESS;
 }
@@ -212,7 +250,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name)
  * memory needs to be allocated, and the position of each data structure
  * in that big block.  It updates the fields in the DataLayout parameter.
  */
-void Storage::PopulateLayout(DataLayout &static_layout)
+void Storage::PopulateStaticLayout(DataLayout &static_layout)
 {
     {
         auto absolute_file_index_path =
@@ -225,22 +263,15 @@ void Storage::PopulateLayout(DataLayout &static_layout)
     constexpr bool REQUIRED = true;
     constexpr bool OPTIONAL = false;
     std::vector<std::pair<bool, boost::filesystem::path>> tar_files = {
-        {OPTIONAL, config.GetPath(".osrm.mldgr")},
         {OPTIONAL, config.GetPath(".osrm.cells")},
         {OPTIONAL, config.GetPath(".osrm.partition")},
-        {OPTIONAL, config.GetPath(".osrm.cell_metrics")},
-        {OPTIONAL, config.GetPath(".osrm.hsgr")},
         {REQUIRED, config.GetPath(".osrm.icd")},
         {REQUIRED, config.GetPath(".osrm.properties")},
         {REQUIRED, config.GetPath(".osrm.nbg_nodes")},
-        {REQUIRED, config.GetPath(".osrm.datasource_names")},
-        {REQUIRED, config.GetPath(".osrm.geometry")},
         {REQUIRED, config.GetPath(".osrm.ebg_nodes")},
         {REQUIRED, config.GetPath(".osrm.tls")},
         {REQUIRED, config.GetPath(".osrm.tld")},
         {REQUIRED, config.GetPath(".osrm.maneuver_overrides")},
-        {REQUIRED, config.GetPath(".osrm.turn_weight_penalties")},
-        {REQUIRED, config.GetPath(".osrm.turn_duration_penalties")},
         {REQUIRED, config.GetPath(".osrm.edges")},
         {REQUIRED, config.GetPath(".osrm.names")},
         {REQUIRED, config.GetPath(".osrm.ramIndex")},
@@ -263,7 +294,38 @@ void Storage::PopulateLayout(DataLayout &static_layout)
     }
 }
 
-void Storage::PopulateData(const DataLayout &static_layout, char *memory_ptr)
+void Storage::PopulateUpdatableLayout(DataLayout &updatable_layout)
+{
+    constexpr bool REQUIRED = true;
+    constexpr bool OPTIONAL = false;
+    std::vector<std::pair<bool, boost::filesystem::path>> tar_files = {
+        {OPTIONAL, config.GetPath(".osrm.mldgr")},
+        {OPTIONAL, config.GetPath(".osrm.cell_metrics")},
+        {OPTIONAL, config.GetPath(".osrm.hsgr")},
+        {REQUIRED, config.GetPath(".osrm.datasource_names")},
+        {REQUIRED, config.GetPath(".osrm.geometry")},
+        {REQUIRED, config.GetPath(".osrm.turn_weight_penalties")},
+        {REQUIRED, config.GetPath(".osrm.turn_duration_penalties")},
+    };
+
+    for (const auto &file : tar_files)
+    {
+        if (boost::filesystem::exists(file.second))
+        {
+            readBlocks(file.second, updatable_layout);
+        }
+        else
+        {
+            if (file.first == REQUIRED)
+            {
+                throw util::exception("Could not find required filed: " +
+                                      std::get<1>(file).string());
+            }
+        }
+    }
+}
+
+void Storage::PopulateStaticData(const DataLayout &static_layout, char *memory_ptr)
 {
     BOOST_ASSERT(memory_ptr != nullptr);
 
@@ -460,6 +522,104 @@ void Storage::PopulateData(const DataLayout &static_layout, char *memory_ptr)
             make_maneuver_overrides_views(memory_ptr, static_layout, "/common/maneuver_overrides");
         extractor::files::readManeuverOverrides(
             config.GetPath(".osrm.maneuver_overrides"), std::get<0>(views), std::get<1>(views));
+    }
+}
+
+void Storage::PopulateUpdatableData(const DataLayout &updatable_layout, char *memory_ptr)
+{
+    BOOST_ASSERT(memory_ptr != nullptr);
+
+    // Connectivity matrix checksum
+    std::uint32_t turns_connectivity_checksum = 0;
+
+    // load compressed geometry
+    {
+        auto segment_data =
+            make_segment_data_view(memory_ptr, updatable_layout, "/common/segment_data");
+        extractor::files::readSegmentData(config.GetPath(".osrm.geometry"), segment_data);
+    }
+
+    {
+        const auto datasources_names_ptr = updatable_layout.GetBlockPtr<extractor::Datasources>(
+            memory_ptr, "/common/data_sources_names");
+        extractor::files::readDatasources(config.GetPath(".osrm.datasource_names"),
+                                          *datasources_names_ptr);
+    }
+
+    // load turn weight penalties
+    {
+        auto turn_duration_penalties =
+            make_turn_weight_view(memory_ptr, updatable_layout, "/common/turn_penalty");
+        extractor::files::readTurnWeightPenalty(config.GetPath(".osrm.turn_weight_penalties"),
+                                                turn_duration_penalties);
+    }
+
+    // load turn duration penalties
+    {
+        auto turn_duration_penalties =
+            make_turn_duration_view(memory_ptr, updatable_layout, "/common/turn_penalty");
+        extractor::files::readTurnDurationPenalty(config.GetPath(".osrm.turn_duration_penalties"),
+                                                  turn_duration_penalties);
+    }
+
+    // FIXME we only need to get the weight name
+    std::string metric_name;
+    // load profile properties
+    {
+        extractor::ProfileProperties properties;
+        extractor::files::readProfileProperties(config.GetPath(".osrm.properties"), properties);
+
+        metric_name = properties.GetWeightName();
+    }
+
+    if (boost::filesystem::exists(config.GetPath(".osrm.hsgr")))
+    {
+        const std::string metric_prefix = "/ch/metrics/" + metric_name;
+        auto contracted_metric =
+            make_contracted_metric_view(memory_ptr, updatable_layout, metric_prefix);
+        std::unordered_map<std::string, contractor::ContractedMetricView> metrics = {
+            {metric_name, std::move(contracted_metric)}};
+
+        std::uint32_t graph_connectivity_checksum = 0;
+        contractor::files::readGraph(
+            config.GetPath(".osrm.hsgr"), metrics, graph_connectivity_checksum);
+
+        if (turns_connectivity_checksum != graph_connectivity_checksum)
+        {
+            throw util::exception(
+                "Connectivity checksum " + std::to_string(graph_connectivity_checksum) + " in " +
+                config.GetPath(".osrm.hsgr").string() + " does not equal to checksum " +
+                std::to_string(turns_connectivity_checksum) + " in " +
+                config.GetPath(".osrm.edges").string());
+        }
+    }
+
+    if (boost::filesystem::exists(config.GetPath(".osrm.cell_metrics")))
+    {
+        auto exclude_metrics =
+            make_cell_metric_view(memory_ptr, updatable_layout, "/mld/metrics/" + metric_name);
+        std::unordered_map<std::string, std::vector<customizer::CellMetricView>> metrics = {
+            {metric_name, std::move(exclude_metrics)},
+        };
+        customizer::files::readCellMetrics(config.GetPath(".osrm.cell_metrics"), metrics);
+    }
+
+    if (boost::filesystem::exists(config.GetPath(".osrm.mldgr")))
+    {
+        auto graph_view =
+            make_multi_level_graph_view(memory_ptr, updatable_layout, "/mld/multilevelgraph");
+        std::uint32_t graph_connectivity_checksum = 0;
+        partitioner::files::readGraph(
+            config.GetPath(".osrm.mldgr"), graph_view, graph_connectivity_checksum);
+
+        if (turns_connectivity_checksum != graph_connectivity_checksum)
+        {
+            throw util::exception(
+                "Connectivity checksum " + std::to_string(graph_connectivity_checksum) + " in " +
+                config.GetPath(".osrm.mldgr").string() + " does not equal to checksum " +
+                std::to_string(turns_connectivity_checksum) + " in " +
+                config.GetPath(".osrm.edges").string());
+        }
     }
 }
 }

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -115,6 +115,9 @@ inline unsigned generateServerProgramOptions(const int argc,
         ("memory_file",
          value<boost::filesystem::path>(&config.memory_file),
          "Store data in a memory mapped file rather than in process memory.") //
+        ("dataset-name",
+         value<std::string>(&config.dataset_name),
+         "Name of the shared memory dataset to connect to.") //
         ("algorithm,a",
          value<EngineConfig::Algorithm>(&config.algorithm)
              ->default_value(EngineConfig::Algorithm::CH, "CH"),

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -90,12 +90,17 @@ inline unsigned generateServerProgramOptions(const int argc,
 
     // declare a group of options that will be allowed only on command line
     boost::program_options::options_description generic_options("Options");
-    generic_options.add_options() //
-        ("version,v", "Show version")("help,h", "Show this help message")(
-            "verbosity,l",
-            boost::program_options::value<std::string>(&config.verbosity)->default_value("INFO"),
-            std::string("Log verbosity level: " + util::LogPolicy::GetLevels()).c_str())(
-            "trial", value<bool>(&trial)->implicit_value(true), "Quit after initialization");
+    generic_options.add_options()            //
+        ("version,v", "Show version")        //
+        ("help,h", "Show this help message") //
+        ("verbosity,l",
+#ifdef NDEBUG
+         boost::program_options::value<std::string>(&config.verbosity)->default_value("INFO"),
+#else
+         boost::program_options::value<std::string>(&config.verbosity)->default_value("DEBUG"),
+#endif
+         std::string("Log verbosity level: " + util::LogPolicy::GetLevels()).c_str()) //
+        ("trial", value<bool>(&trial)->implicit_value(true), "Quit after initialization");
 
     // declare a group of options that will be allowed on command line
     boost::program_options::options_description config_options("Configuration");

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -37,8 +37,7 @@ void listRegions()
     {
         auto id = shared_register.Find(name);
         auto region = shared_register.GetRegion(id);
-        osrm::util::Log() << name << "\t"
-                          << (int) region.shm_key << "\t" << region.timestamp;
+        osrm::util::Log() << name << "\t" << (int)region.shm_key << "\t" << region.timestamp;
     }
 }
 
@@ -98,7 +97,9 @@ bool generateDataStoreOptions(const int argc,
          "Name of the dataset to load into memory. This allows having multiple datasets in memory "
          "at the same time.") //
         ("list",
-         boost::program_options::value<bool>(&list_datasets)->default_value(false)->implicit_value(true),
+         boost::program_options::value<bool>(&list_datasets)
+             ->default_value(false)
+             ->implicit_value(true),
          "Name of the dataset to load into memory. This allows having multiple datasets in memory "
          "at the same time.");
 

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -15,14 +15,13 @@
 
 using namespace osrm;
 
-void removeLocks() { storage::SharedMonitor<storage::SharedDataTimestamp>::remove(); }
+void removeLocks() { storage::SharedMonitor<storage::SharedRegionRegister>::remove(); }
 
-void deleteRegion(const storage::SharedDataType region)
+void deleteRegion(const storage::SharedRegionRegister::ShmKey key)
 {
-    if (storage::SharedMemory::RegionExists(region) && !storage::SharedMemory::Remove(region))
+    if (storage::SharedMemory::RegionExists(key) && !storage::SharedMemory::Remove(key))
     {
-        util::Log(logWARNING) << "could not delete shared memory region "
-                              << storage::regionToString(region);
+        util::Log(logWARNING) << "could not delete shared memory region " << key;
     }
 }
 
@@ -43,8 +42,10 @@ void springClean()
     }
     else
     {
-        deleteRegion(storage::REGION_1);
-        deleteRegion(storage::REGION_2);
+        for (auto key : util::irange<std::uint8_t>(0, storage::SharedRegionRegister::MAX_SHM_KEYS))
+        {
+            deleteRegion(key);
+        }
         removeLocks();
     }
 }

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -100,9 +100,16 @@ test('constructor: autoswitches to CoreCH for a CH dataset if capable', function
 
 test('constructor: throws if data doesn\'t match algorithm', function(assert) {
     assert.plan(3);
-    assert.throws(function() { new OSRM({algorithm: 'CoreCH', path: monaco_mld_path}); }, 'CoreCH with MLD data');
-    assert.ok(function() { new OSRM({algorithm: 'CoreCH', path: monaco_path}); }, 'CoreCH with CH data');
-    assert.throws(function() { new OSRM({algorithm: 'MLD', path: monaco_path}); }, 'MLD with CH data');
+    assert.throws(function() { new OSRM({algorithm: 'CoreCH', path: monaco_mld_path}); }, /Could not find any metrics for CH/, 'CoreCH with MLD data');
+    assert.ok(new OSRM({algorithm: 'CoreCH', path: monaco_path}), 'CoreCH with CH data');
+    assert.throws(function() { new OSRM({algorithm: 'MLD', path: monaco_path}); }, /Could not find any metrics for MLD/, 'MLD with CH data');
+});
+
+test('constructor: throws if dataset_name is not a string', function(assert) {
+    assert.plan(3);
+    assert.throws(function() { new OSRM({dataset_name: 1337, path: monaco_mld_path}); }, /dataset_name needs to be a string/, 'Does not accept int');
+    assert.ok(new OSRM({dataset_name: "", shared_memory: true}), 'Does accept string');
+    assert.throws(function() { new OSRM({dataset_name: "unsued_name___", shared_memory: true}); }, /Could not find shared memory region/, 'Does not accept wrong name');
 });
 
 test('constructor: parses custom limits', function(assert) {


### PR DESCRIPTION
# Issue

This is a simple version of #4873 that still works on per-file granularity. To make this more effective we need to split the weights from the MLD graph and refactor the way we update speeds (to work on a graph not an edge list).

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Based on #4982 
