### PR TITLE
Honour British spelling of manoeuvre relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
       - FIXED: Adjust Straight direction modifiers of side roads in driveway handler [#4929](https://github.com/Project-OSRM/osrm-backend/pull/4929)
       - CHANGED: Added post process logic to collapse segregated turn instructions [#4925](https://github.com/Project-OSRM/osrm-backend/pull/4925)
       - ADDED: Maneuver relation now supports `straight` as a direction [#4995](https://github.com/Project-OSRM/osrm-backend/pull/4995)
+      - FIXED: Support spelling maneuver relation with British spelling [#4950](https://github.com/Project-OSRM/osrm-backend/issues/4950)
     - Tools:
       - ADDED: `osrm-routed` accepts a new property `--memory_file` to store memory in a file on disk. [#4881](https://github.com/Project-OSRM/osrm-backend/pull/4881)
       - ADDED: `osrm-datastore` accepts a new parameter `--dataset-name` to select the name of the dataset. [#4982](https://github.com/Project-OSRM/osrm-backend/pull/4982)

--- a/features/guidance/maneuver-tag.feature
+++ b/features/guidance/maneuver-tag.feature
@@ -28,8 +28,11 @@ Feature: Maneuver tag support
             | maneuver | hij      | i        | cde    | turn     | sharp_left  |
             | maneuver | abc      | c        | cde    | turn     | slight_left |
             | maneuver | cde      | c        | cgi    | turn     | straight    |
-            | maneuver | cde      | c        | cgi    | turn     | straight    |
-            | manoeuvre | cde     | c        | abc    | fork     | right       |
+            | manoeuvre| cgi      | c        | abc    | turn     | right       |
+
+        And the relations
+            | type      | way:from | node:via | way:to | manoeuvre | maneuver | direction    |
+            | maneuver  | cgi      | c        | cde    | fork      | turn     | slight_right |
 
         When I route I should get
             | waypoints | route                               | turns                                    |
@@ -38,7 +41,9 @@ Feature: Maneuver tag support
             | b,g       | A Street,C Street,C Street          | depart,turn sharp right,arrive           |
         # Testing re-awakening suppressed turns
             | a,e       | A Street,B Street,B Street          | depart,turn slight left,arrive           |
-            | e,a       | B Street,A Street,A Street          | depart,fork right,arrive              |
+            | e,i       | B Street,C Street,C Street          | depart,turn straight,arrive              |
+            | i,e       | C Street,B Street,B Street          | depart,fork slight right,arrive          |
+            | i,a       | C Street,A Street,A Street          | depart,turn right,arrive                 |
 
     Scenario: single via-way
       Given the node map

--- a/features/guidance/maneuver-tag.feature
+++ b/features/guidance/maneuver-tag.feature
@@ -28,6 +28,8 @@ Feature: Maneuver tag support
             | maneuver | hij      | i        | cde    | turn     | sharp_left  |
             | maneuver | abc      | c        | cde    | turn     | slight_left |
             | maneuver | cde      | c        | cgi    | turn     | straight    |
+            | maneuver | cde      | c        | cgi    | turn     | straight    |
+            | manoeuvre | cde     | c        | abc    | fork     | right       |
 
         When I route I should get
             | waypoints | route                               | turns                                    |
@@ -36,7 +38,7 @@ Feature: Maneuver tag support
             | b,g       | A Street,C Street,C Street          | depart,turn sharp right,arrive           |
         # Testing re-awakening suppressed turns
             | a,e       | A Street,B Street,B Street          | depart,turn slight left,arrive           |
-            | e,i       | B Street,C Street,C Street          | depart,turn straight,arrive              |
+            | e,a       | B Street,A Street,A Street          | depart,fork right,arrive              |
 
     Scenario: single via-way
       Given the node map

--- a/src/extractor/maneuver_override_relation_parser.cpp
+++ b/src/extractor/maneuver_override_relation_parser.cpp
@@ -51,13 +51,13 @@ ManeuverOverrideRelationParser::TryParse(const osmium::Relation &relation) const
     InputManeuverOverride maneuver_override;
 
     // Handle both spellings
-    if (relation.tags().has_key("maneuver"))
+    if (relation.tags().has_key("manoeuvre"))
     {
-        maneuver_override.maneuver = relation.tags().get_value_by_key("maneuver", "");
+        maneuver_override.maneuver = relation.tags().get_value_by_key("manoeuvre", "");
     }
     else
     {
-        maneuver_override.maneuver = relation.tags().get_value_by_key("manoeuvre", "");
+        maneuver_override.maneuver = relation.tags().get_value_by_key("maneuver", "");
     }
 
     maneuver_override.direction = relation.tags().get_value_by_key("direction", "");


### PR DESCRIPTION
# Issue

OSM prefers British spelling for things.  This PR adds support for both `maneuver` and `manoeuvre` as the key for the maneuver override relation.

Fixes https://github.com/Project-OSRM/osrm-backend/issues/4950

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch