### PR TITLE
Fix hard-coded hint strings in unit-tests

### DIFF
--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -22,7 +22,7 @@ namespace util
 inline std::ostream &operator<<(std::ostream &out, const Coordinate &coordinate)
 {
     out << std::setprecision(12) << "{" << toFloating(coordinate.lon) << ", "
-        << toFloating(coordinate.lon) << "}";
+        << toFloating(coordinate.lat) << "}";
     return out;
 }
 }


### PR DESCRIPTION
# Issue

Currently we hard-code the hints string which is ugly an break for every change of `PhantomNode`. This doesn't hard code the string but dynamically constructs them.

## Tasklist

 - [x] review
 - [x] adjust for comments
