### PR TITLE
Remove dummy edges before inplace permutation

### DIFF
--- a/include/util/dynamic_graph.hpp
+++ b/include/util/dynamic_graph.hpp
@@ -413,6 +413,11 @@ template <typename EdgeDataT> class DynamicGraph
         util::inplacePermutation(node_array.begin(), node_array.end(), old_to_new_node);
 
         // Build up edge permutation
+        if (edge_list.size() >= std::numeric_limits<EdgeID>::max())
+        {
+            throw util::exception("There are too many edges, OSRM only supports 2^32" + SOURCE_REF);
+        }
+
         EdgeID new_edge_index = 0;
         std::vector<EdgeID> old_to_new_edge(edge_list.size(), SPECIAL_EDGEID);
         for (auto node : util::irange<NodeID>(0, number_of_nodes))
@@ -421,11 +426,6 @@ template <typename EdgeDataT> class DynamicGraph
             // move all filled edges
             for (auto edge : GetAdjacentEdgeRange(node))
             {
-                if (new_edge_index == std::numeric_limits<EdgeID>::max())
-                {
-                    throw util::exception("There are too many edges, OSRM only supports 2^32" +
-                                          SOURCE_REF);
-                }
                 edge_list[edge].target = old_to_new_node[edge_list[edge].target];
                 BOOST_ASSERT(edge_list[edge].target != SPECIAL_NODEID);
                 old_to_new_edge[edge] = new_edge_index++;


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/pull/5021#discussion_r181005061 points that the check `edge_list.size() < std::numeric_limits<EdgeID>::max()` can be placed before the loop, but this check limits number of valid edges by `2^32 - #dummy_edges`. 

PR implements a removal of dummy edges before a `util::inplacePermutation` call:
:heavy_check_mark: number of edges is limited by `2^32`

❌  an additional iteration over the list of edges, but potentially linearized removal can be faster due to caching



/cc @danpat 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
