### PR TITLE
Gracefully handle no shared memory regions found

### DIFF
--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -117,6 +117,17 @@ template <typename Data> struct SharedMonitor
 #endif
 
     static void remove() { bi::shared_memory_object::remove(Data::name); }
+    static bool exists() {
+        try
+        {
+            bi::shared_memory_object shmem_open = bi::shared_memory_object(bi::open_only, Data::name, bi::read_only);
+        }
+        catch (const bi::interprocess_exception &exception)
+        {
+            return false;
+        }
+        return true;
+    }
 
   private:
 #if USE_BOOST_INTERPROCESS_CONDITION

--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -117,10 +117,12 @@ template <typename Data> struct SharedMonitor
 #endif
 
     static void remove() { bi::shared_memory_object::remove(Data::name); }
-    static bool exists() {
+    static bool exists()
+    {
         try
         {
-            bi::shared_memory_object shmem_open = bi::shared_memory_object(bi::open_only, Data::name, bi::read_only);
+            bi::shared_memory_object shmem_open =
+                bi::shared_memory_object(bi::open_only, Data::name, bi::read_only);
         }
         catch (const bi::interprocess_exception &exception)
         {

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -27,9 +27,9 @@ void deleteRegion(const storage::SharedRegionRegister::ShmKey key)
 
 void listRegions()
 {
+    osrm::util::Log() << "name\tshm key\ttimestamp\tsize";
     if (!storage::SharedMonitor<storage::SharedRegionRegister>::exists())
     {
-        osrm::util::Log() << "No shared memory regions found. Try running osrm-datastore";
         return;
     }
     storage::SharedMonitor<storage::SharedRegionRegister> monitor;

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -27,7 +27,11 @@ void deleteRegion(const storage::SharedRegionRegister::ShmKey key)
 
 void listRegions()
 {
-
+    if (!storage::SharedMonitor<storage::SharedRegionRegister>::exists())
+    {
+        osrm::util::Log() << "No shared memory regions found. Try running osrm-datastore";
+        return;
+    }
     storage::SharedMonitor<storage::SharedRegionRegister> monitor;
     std::vector<std::string> names;
     const auto &shared_register = monitor.data();
@@ -105,8 +109,7 @@ bool generateDataStoreOptions(const int argc,
          boost::program_options::value<bool>(&list_datasets)
              ->default_value(false)
              ->implicit_value(true),
-         "Name of the dataset to load into memory. This allows having multiple datasets in memory "
-         "at the same time.") //
+         "List all OSRM datasets currently in memory") //
         ("only-metric",
          boost::program_options::value<bool>(&only_metric)
              ->default_value(false)


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/5024

I'm going to forgo adding a test for now - adding a test here would require first clearing all shared memory regions in the environment where osrm-datastore is being run, which is a bit dangerous. Maybe we can consider setting up a very robust isolated testing environment someday that is convenient to run for osrm-datastore.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch
