### PR TITLE
Update profiles.md to reflect the latest version

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -68,7 +68,7 @@ If you want to prioritize certain streets, increase the rate on these.
 
 ## Elements
 ### api_version
-A profile should set `api_version` at the top of your profile. This is done to ensure that older profiles are still supported when the api changes. If `api_version` is not defined, 0 will be assumed. The current api version is 2.
+A profile should set `api_version` at the top of your profile. This is done to ensure that older profiles are still supported when the api changes. If `api_version` is not defined, 0 will be assumed. The current api version is 4.
 
 ### Library files
 The folder [profiles/lib/](../profiles/lib/) contains LUA library files for handling many common processing tasks.


### PR DESCRIPTION
# Issue

The [car profile](../profiles/car.lua) defines `api_version` 4, yet the documentation mentions `api_version: 2` as current one.

## Tasklist

 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
