### PR TITLE
Tune alternatives parameters for MLD

### DIFF
--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -47,13 +47,13 @@ struct Parameters
     double kAtMostLongerBy = 0.25;
     // Alternative paths similarity requirement (sharing).
     // At least 15% different than the shortest path.
-    double kAtLeastDifferentBy = 0.85;
+    double kAtMostSameBy = 0.85;
     // Alternative paths are still reasonable around the via node candidate (local optimality).
     // At least optimal around 10% sub-paths around the via node candidate.
     double kAtLeastOptimalAroundViaBy = 0.1;
     // Alternative paths similarity requirement (sharing) based on calles.
     // At least 15% different than the shortest path.
-    double kCellsAtLeastDifferentBy = 0.85;
+    double kCellsAtMostSameBy = 0.85;
 };
 
 // Represents a via middle node where forward (from s) and backward (from t)
@@ -140,27 +140,30 @@ Parameters parametersFromRequest(const PhantomNodes &phantom_node_pair)
     if (distance < 10000.)
     {
         parameters.kAlternativesToUnpackFactor = 10.0;
-        parameters.kCellsAtLeastDifferentBy = 1.0;
+        parameters.kCellsAtMostSameBy = 1.0;
         parameters.kAtLeastOptimalAroundViaBy = 0.2;
+        parameters.kAtMostSameBy = 0.50;
     }
     // 20km
     else if (distance < 20000.)
     {
         parameters.kAlternativesToUnpackFactor = 8.0;
-        parameters.kCellsAtLeastDifferentBy = 1.0;
+        parameters.kCellsAtMostSameBy = 1.0;
         parameters.kAtLeastOptimalAroundViaBy = 0.2;
+        parameters.kAtMostSameBy = 0.60;
     }
     // 50km
     else if (distance < 50000.)
     {
         parameters.kAlternativesToUnpackFactor = 6.0;
-        parameters.kCellsAtLeastDifferentBy = 0.95;
+        parameters.kCellsAtMostSameBy = 0.95;
+        parameters.kAtMostSameBy = 0.70;
     }
     // 100km
     else if (distance < 100000.)
     {
         parameters.kAlternativesToUnpackFactor = 4.0;
-        parameters.kCellsAtLeastDifferentBy = 0.75;
+        parameters.kCellsAtMostSameBy = 0.75;
     }
 
     return parameters;
@@ -256,7 +259,7 @@ RandIt filterPackedPathsByCellSharing(RandIt first,
                                       const Parameters &parameters)
 {
     // In this case we don't need to calculate sharing, because it would not filter anything
-    if (parameters.kCellsAtLeastDifferentBy >= 1.0)
+    if (parameters.kCellsAtMostSameBy >= 1.0)
         return last;
 
     util::static_assert_iter_category<RandIt, std::random_access_iterator_tag>();
@@ -311,7 +314,7 @@ RandIt filterPackedPathsByCellSharing(RandIt first,
 
         const auto sharing = 1. - difference;
 
-        if (sharing > parameters.kCellsAtLeastDifferentBy)
+        if (sharing > parameters.kCellsAtMostSameBy)
         {
             return true;
         }
@@ -491,7 +494,7 @@ RandIt filterUnpackedPathsBySharing(RandIt first,
         BOOST_ASSERT(sharing >= 0.);
         BOOST_ASSERT(sharing <= 1.);
 
-        if (sharing > parameters.kAtLeastDifferentBy)
+        if (sharing > parameters.kAtMostSameBy)
         {
             return true;
         }

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -473,21 +473,21 @@ RandIt filterUnpackedPathsBySharing(RandIt first,
             return false;
         }
 
-        EdgeWeight total_weight = 0;
-        const auto add_if_seen = [&](const EdgeWeight weight, const EdgeID edge) {
-            auto edge_weight = facade.GetEdgeData(edge).weight;
-            total_weight += edge_weight;
+        EdgeWeight total_duration = 0;
+        const auto add_if_seen = [&](const EdgeWeight duration, const EdgeID edge) {
+            auto edge_duration = facade.GetEdgeData(edge).duration;
+            total_duration += edge_duration;
             if (edges.count(edge) > 0)
             {
-                return weight + edge_weight;
+                return duration + edge_duration;
             }
-            return weight;
+            return duration;
         };
 
         const auto shared_weight =
             std::accumulate(begin(unpacked.edges), end(unpacked.edges), 0, add_if_seen);
 
-        const auto sharing = shared_weight / static_cast<double>(total_weight);
+        const auto sharing = shared_weight / static_cast<double>(total_duration);
         BOOST_ASSERT(sharing >= 0.);
         BOOST_ASSERT(sharing <= 1.);
 

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -46,14 +46,14 @@ struct Parameters
     // At most 25% longer then the shortest path.
     double kAtMostLongerBy = 0.25;
     // Alternative paths similarity requirement (sharing).
-    // At least 15% different than the shortest path.
-    double kAtMostSameBy = 0.85;
+    // At least 25% different than the shortest path.
+    double kAtMostSameBy = 0.75;
     // Alternative paths are still reasonable around the via node candidate (local optimality).
     // At least optimal around 10% sub-paths around the via node candidate.
     double kAtLeastOptimalAroundViaBy = 0.1;
     // Alternative paths similarity requirement (sharing) based on calles.
     // At least 15% different than the shortest path.
-    double kCellsAtMostSameBy = 0.85;
+    double kCellsAtMostSameBy = 0.95;
 };
 
 // Represents a via middle node where forward (from s) and backward (from t)
@@ -103,7 +103,7 @@ double getLongerByFactorBasedOnDuration(const EdgeWeight duration)
     //       return a + b/(xs-d) + c/(xs-d)**3
     //
     // xs = np.array([5 * 60, 10 * 60, 30 * 60, 60 * 60, 3 * 60 * 60, 10 * 60 * 60])
-    // ys = np.array([1.0,    0.75,    0.5,     0.3,     0.2,          0.1])
+    // ys = np.array([1.0,    0.75,    0.5,     0.4,     0.3,          0.2])
     //
     // xs_interp = np.arange(5*60, 10*60*60, 5*60)
     // ys_interp = np.interp(xs_interp, xs, ys)
@@ -112,10 +112,10 @@ double getLongerByFactorBasedOnDuration(const EdgeWeight duration)
     //
     // The hyperbolic shape was chosen because it interpolated well between
     // the given datapoints and drops off for large durations.
-    const constexpr auto a = 9.49571282e-02;
-    const constexpr auto b = 1.25440191e+03;
-    const constexpr auto c = 2.06152165e+09;
-    const constexpr auto d = -1.71666881e+03;
+    const constexpr auto a = 1.91578463e-01;
+    const constexpr auto b = 1.35118442e+03;
+    const constexpr auto c = 2.45437877e+09;
+    const constexpr auto d = -2.07944571e+03;
 
     if (duration < EdgeWeight(5 * 60))
     {
@@ -123,7 +123,7 @@ double getLongerByFactorBasedOnDuration(const EdgeWeight duration)
     }
     else if (duration > EdgeWeight(10 * 60 * 60))
     {
-        return 0.10;
+        return 0.20;
     }
 
     // Bigger than 10 minutes but smaller than 10 hours
@@ -160,13 +160,14 @@ Parameters parametersFromRequest(const PhantomNodes &phantom_node_pair)
     {
         parameters.kAlternativesToUnpackFactor = 6.0;
         parameters.kCellsAtMostSameBy = 0.95;
-        parameters.kAtMostSameBy = 0.70;
+        parameters.kAtMostSameBy = 0.65;
     }
     // 100km
     else if (distance < 100000.)
     {
         parameters.kAlternativesToUnpackFactor = 4.0;
-        parameters.kCellsAtMostSameBy = 0.75;
+        parameters.kCellsAtMostSameBy = 0.95;
+        parameters.kAtMostSameBy = 0.70;
     }
 
     return parameters;
@@ -868,7 +869,6 @@ InternalManyRoutesResult alternativePathSearch(SearchEngineData<Algorithm> &sear
                                                                 begin(weighted_packed_paths) + 1,
                                                                 alternative_paths_last,
                                                                 parameters);
-
     alternative_paths_last = filterPackedPathsByCellSharing(
         begin(weighted_packed_paths), alternative_paths_last, partition, parameters);
 

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -402,7 +402,7 @@ template <typename RandIt> RandIt filterUnpackedPathsBySharing(RandIt first, Ran
     std::unordered_set<EdgeID> edges;
     edges.reserve(size * shortest_path.edges.size() * (1. + kAtMostLongerBy));
 
-    edges.insert(begin(shortest_path.edges), begin(shortest_path.edges));
+    edges.insert(begin(shortest_path.edges), end(shortest_path.edges));
 
     const auto over_sharing_limit = [&](const auto &unpacked) {
 


### PR DESCRIPTION
# Issue

This PR fixes some bugs in the MLD code that reduced the quality fo alternatives and uses different parameters based on route distance.

### Number of alternatives on `master`

![image](https://user-images.githubusercontent.com/606968/39157193-3fe47e2e-4749-11e8-8c4b-7ce854cfa99a.png)

![image](https://user-images.githubusercontent.com/606968/39157196-450e0848-4749-11e8-91f5-bbcefd0ab8c6.png)

### Number of alternatives on this branch

![image](https://user-images.githubusercontent.com/606968/39157149-16bc4b6c-4749-11e8-8077-b8600153b8fa.png)

![image](https://user-images.githubusercontent.com/606968/39157157-1c6432e6-4749-11e8-8983-d213c037b453.png)

## Tasklist

 - [x] measurements for different route lengths
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch
