### PR TITLE
Use node weights instead of edge weights in MLD algorithm

### DIFF
--- a/include/customizer/customizer_config.hpp
+++ b/include/customizer/customizer_config.hpp
@@ -21,7 +21,8 @@ struct CustomizationConfig final : storage::IOConfig
                     ".osrm.partition",
                     ".osrm.cells",
                     ".osrm.ebg_nodes",
-                    ".osrm.properties"},
+                    ".osrm.properties",
+                    ".osrm.enw"},
                    {},
                    {".osrm.cell_metrics", ".osrm.mldgr"}),
           requested_num_threads(0)

--- a/include/customizer/edge_based_graph.hpp
+++ b/include/customizer/edge_based_graph.hpp
@@ -76,6 +76,8 @@ class MultiLevelGraph : public partitioner::MultiLevelGraph<EdgeDataT, Ownership
 
     EdgeWeight GetNodeWeight(NodeID node) const { return node_weights[node]; }
 
+    EdgeWeight GetNodeDuration(NodeID node) const { return node_durations[node]; }
+
     friend void
     serialization::read<EdgeDataT, Ownership>(storage::tar::FileReader &reader,
                                               const std::string &name,

--- a/include/customizer/edge_based_graph.hpp
+++ b/include/customizer/edge_based_graph.hpp
@@ -74,6 +74,8 @@ class MultiLevelGraph : public partitioner::MultiLevelGraph<EdgeDataT, Ownership
         // TODO: add EdgeArrayEntry shaving
     }
 
+    EdgeWeight GetNodeWeight(NodeID node) const { return node_weights[node]; }
+
     friend void
     serialization::read<EdgeDataT, Ownership>(storage::tar::FileReader &reader,
                                               const std::string &name,

--- a/include/customizer/edge_based_graph.hpp
+++ b/include/customizer/edge_based_graph.hpp
@@ -16,28 +16,82 @@ namespace osrm
 namespace customizer
 {
 
+// TODO: Change to turn_id only
 using EdgeBasedGraphEdgeData = partitioner::EdgeBasedGraphEdgeData;
 
-struct MultiLevelEdgeBasedGraph
-    : public partitioner::MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::Container>
+template <typename EdgeDataT, storage::Ownership Ownership> class MultiLevelGraph;
+
+namespace serialization
 {
-    using Base =
-        partitioner::MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::Container>;
-    using Base::Base;
+template <typename EdgeDataT, storage::Ownership Ownership>
+void read(storage::tar::FileReader &reader,
+          const std::string &name,
+          MultiLevelGraph<EdgeDataT, Ownership> &graph);
+
+template <typename EdgeDataT, storage::Ownership Ownership>
+void write(storage::tar::FileWriter &writer,
+           const std::string &name,
+           const MultiLevelGraph<EdgeDataT, Ownership> &graph);
+}
+
+template <typename EdgeDataT, storage::Ownership Ownership>
+class MultiLevelGraph : public partitioner::MultiLevelGraph<EdgeDataT, Ownership>
+{
+  private:
+    using SuperT = partitioner::MultiLevelGraph<EdgeDataT, Ownership>;
+    using SuperC = partitioner::MultiLevelGraph<partitioner::EdgeBasedGraphEdgeData,
+                                                storage::Ownership::Container>;
+    template <typename T> using Vector = util::ViewOrVector<T, Ownership>;
+
+  public:
+    MultiLevelGraph() = default;
+    MultiLevelGraph(MultiLevelGraph &&) = default;
+    MultiLevelGraph(const MultiLevelGraph &) = default;
+    MultiLevelGraph &operator=(MultiLevelGraph &&) = default;
+    MultiLevelGraph &operator=(const MultiLevelGraph &) = default;
+
+    // TODO: add constructor for EdgeBasedGraphEdgeData
+    MultiLevelGraph(SuperC &&graph,
+                    Vector<EdgeWeight> node_weights_,
+                    Vector<EdgeDuration> node_durations_)
+        : node_weights(std::move(node_weights_)), node_durations(std::move(node_durations_))
+    {
+        std::tie(SuperT::node_array,
+                 SuperT::edge_array,
+                 SuperT::node_to_edge_offset,
+                 SuperT::connectivity_checksum) = std::move(graph).data();
+        // TODO: add EdgeArrayEntry shaving
+    }
+
+    MultiLevelGraph(Vector<typename SuperT::NodeArrayEntry> node_array_,
+                    Vector<typename SuperT::EdgeArrayEntry> edge_array_,
+                    Vector<typename SuperT::EdgeOffset> node_to_edge_offset_,
+                    Vector<EdgeWeight> node_weights_,
+                    Vector<EdgeDuration> node_durations_)
+        : SuperT(std::move(node_array_), std::move(edge_array_), std::move(node_to_edge_offset_)),
+          node_weights(std::move(node_weights_)), node_durations(std::move(node_durations_))
+    {
+        // TODO: add EdgeArrayEntry shaving
+    }
+
+    friend void
+    serialization::read<EdgeDataT, Ownership>(storage::tar::FileReader &reader,
+                                              const std::string &name,
+                                              MultiLevelGraph<EdgeDataT, Ownership> &graph);
+    friend void
+    serialization::write<EdgeDataT, Ownership>(storage::tar::FileWriter &writer,
+                                               const std::string &name,
+                                               const MultiLevelGraph<EdgeDataT, Ownership> &graph);
+
+  protected:
+    Vector<EdgeWeight> node_weights;
+    Vector<EdgeDuration> node_durations;
 };
 
-struct MultiLevelEdgeBasedGraphView
-    : public partitioner::MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::View>
-{
-    using Base = partitioner::MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::View>;
-    using Base::Base;
-};
-
-struct StaticEdgeBasedGraphEdge : MultiLevelEdgeBasedGraph::InputEdge
-{
-    using Base = MultiLevelEdgeBasedGraph::InputEdge;
-    using Base::Base;
-};
+using MultiLevelEdgeBasedGraph =
+    MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::Container>;
+using MultiLevelEdgeBasedGraphView =
+    MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::View>;
 }
 }
 

--- a/include/customizer/edge_based_graph.hpp
+++ b/include/customizer/edge_based_graph.hpp
@@ -46,6 +46,10 @@ class MultiLevelGraph : public partitioner::MultiLevelGraph<EdgeDataT, Ownership
     template <typename T> using Vector = util::ViewOrVector<T, Ownership>;
 
   public:
+    using NodeArrayEntry = typename SuperT::NodeArrayEntry;
+    using EdgeArrayEntry = typename SuperT::EdgeArrayEntry;
+    using EdgeOffset = typename SuperT::EdgeOffset;
+
     MultiLevelGraph() = default;
     MultiLevelGraph(MultiLevelGraph &&) = default;
     MultiLevelGraph(const MultiLevelGraph &) = default;
@@ -74,9 +78,9 @@ class MultiLevelGraph : public partitioner::MultiLevelGraph<EdgeDataT, Ownership
         }
     }
 
-    MultiLevelGraph(Vector<typename SuperT::NodeArrayEntry> node_array_,
-                    Vector<typename SuperT::EdgeArrayEntry> edge_array_,
-                    Vector<typename SuperT::EdgeOffset> node_to_edge_offset_,
+    MultiLevelGraph(Vector<NodeArrayEntry> node_array_,
+                    Vector<EdgeArrayEntry> edge_array_,
+                    Vector<EdgeOffset> node_to_edge_offset_,
                     Vector<EdgeWeight> node_weights_,
                     Vector<EdgeDuration> node_durations_,
                     Vector<bool> is_forward_edge_,

--- a/include/customizer/files.hpp
+++ b/include/customizer/files.hpp
@@ -73,6 +73,39 @@ writeCellMetrics(const boost::filesystem::path &path,
         }
     }
 }
+
+// reads .osrm.mldgr file
+template <typename MultiLevelGraphT>
+inline void readGraph(const boost::filesystem::path &path,
+                      MultiLevelGraphT &graph,
+                      std::uint32_t &connectivity_checksum)
+{
+    static_assert(std::is_same<customizer::MultiLevelEdgeBasedGraphView, MultiLevelGraphT>::value ||
+                      std::is_same<customizer::MultiLevelEdgeBasedGraph, MultiLevelGraphT>::value,
+                  "");
+
+    storage::tar::FileReader reader{path, storage::tar::FileReader::VerifyFingerprint};
+
+    reader.ReadInto("/mld/connectivity_checksum", connectivity_checksum);
+    serialization::read(reader, "/mld/multilevelgraph", graph);
+}
+
+// writes .osrm.mldgr file
+template <typename MultiLevelGraphT>
+inline void writeGraph(const boost::filesystem::path &path,
+                       const MultiLevelGraphT &graph,
+                       const std::uint32_t connectivity_checksum)
+{
+    static_assert(std::is_same<customizer::MultiLevelEdgeBasedGraphView, MultiLevelGraphT>::value ||
+                      std::is_same<customizer::MultiLevelEdgeBasedGraph, MultiLevelGraphT>::value,
+                  "");
+
+    storage::tar::FileWriter writer{path, storage::tar::FileWriter::GenerateFingerprint};
+
+    writer.WriteElementCount64("/mld/connectivity_checksum", 1);
+    writer.WriteFrom("/mld/connectivity_checksum", connectivity_checksum);
+    serialization::write(writer, "/mld/multilevelgraph", graph);
+}
 }
 }
 }

--- a/include/customizer/serialization.hpp
+++ b/include/customizer/serialization.hpp
@@ -1,6 +1,8 @@
 #ifndef OSRM_CUSTOMIZER_SERIALIZATION_HPP
 #define OSRM_CUSTOMIZER_SERIALIZATION_HPP
 
+#include "customizer/edge_based_graph.hpp"
+
 #include "partitioner/cell_storage.hpp"
 
 #include "storage/serialization.hpp"
@@ -30,6 +32,30 @@ inline void write(storage::tar::FileWriter &writer,
 {
     storage::serialization::write(writer, name + "/weights", metric.weights);
     storage::serialization::write(writer, name + "/durations", metric.durations);
+}
+
+template <typename EdgeDataT, storage::Ownership Ownership>
+inline void read(storage::tar::FileReader &reader,
+                 const std::string &name,
+                 MultiLevelGraph<EdgeDataT, Ownership> &graph)
+{
+    storage::serialization::read(reader, name + "/node_array", graph.node_array);
+    storage::serialization::read(reader, name + "/node_weights", graph.node_weights);
+    storage::serialization::read(reader, name + "/node_durations", graph.node_durations);
+    storage::serialization::read(reader, name + "/edge_array", graph.edge_array);
+    storage::serialization::read(reader, name + "/node_to_edge_offset", graph.node_to_edge_offset);
+}
+
+template <typename EdgeDataT, storage::Ownership Ownership>
+inline void write(storage::tar::FileWriter &writer,
+                  const std::string &name,
+                  const MultiLevelGraph<EdgeDataT, Ownership> &graph)
+{
+    storage::serialization::write(writer, name + "/node_array", graph.node_array);
+    storage::serialization::write(writer, name + "/node_weights", graph.node_weights);
+    storage::serialization::write(writer, name + "/node_durations", graph.node_durations);
+    storage::serialization::write(writer, name + "/edge_array", graph.edge_array);
+    storage::serialization::write(writer, name + "/node_to_edge_offset", graph.node_to_edge_offset);
 }
 }
 }

--- a/include/customizer/serialization.hpp
+++ b/include/customizer/serialization.hpp
@@ -43,6 +43,8 @@ inline void read(storage::tar::FileReader &reader,
     storage::serialization::read(reader, name + "/node_weights", graph.node_weights);
     storage::serialization::read(reader, name + "/node_durations", graph.node_durations);
     storage::serialization::read(reader, name + "/edge_array", graph.edge_array);
+    storage::serialization::read(reader, name + "/is_forward_edge", graph.is_forward_edge);
+    storage::serialization::read(reader, name + "/is_backward_edge", graph.is_backward_edge);
     storage::serialization::read(reader, name + "/node_to_edge_offset", graph.node_to_edge_offset);
 }
 
@@ -55,6 +57,8 @@ inline void write(storage::tar::FileWriter &writer,
     storage::serialization::write(writer, name + "/node_weights", graph.node_weights);
     storage::serialization::write(writer, name + "/node_durations", graph.node_durations);
     storage::serialization::write(writer, name + "/edge_array", graph.edge_array);
+    storage::serialization::write(writer, name + "/is_forward_edge", graph.is_forward_edge);
+    storage::serialization::write(writer, name + "/is_backward_edge", graph.is_backward_edge);
     storage::serialization::write(writer, name + "/node_to_edge_offset", graph.node_to_edge_offset);
 }
 }

--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -71,11 +71,15 @@ template <> class AlgorithmDataFacade<MLD>
 
     virtual unsigned GetOutDegree(const NodeID n) const = 0;
 
+    virtual EdgeRange GetAdjacentEdgeRange(const NodeID node) const = 0;
+
+    virtual EdgeWeight GetNodeWeight(const NodeID node) const = 0;
+
+    virtual EdgeWeight GetNodeDuration(const NodeID node) const = 0; // TODO: to be removed
+
     virtual NodeID GetTarget(const EdgeID e) const = 0;
 
     virtual const EdgeData &GetEdgeData(const EdgeID e) const = 0;
-
-    virtual EdgeRange GetAdjacentEdgeRange(const NodeID node) const = 0;
 
     virtual const partitioner::MultiLevelPartitionView &GetMultiLevelPartition() const = 0;
 

--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -2,6 +2,7 @@
 #define OSRM_ENGINE_DATAFACADE_ALGORITHM_DATAFACADE_HPP
 
 #include "contractor/query_edge.hpp"
+#include "customizer/edge_based_graph.hpp"
 #include "extractor/edge_based_edge.hpp"
 #include "engine/algorithm.hpp"
 
@@ -59,7 +60,7 @@ template <> class AlgorithmDataFacade<CH>
 template <> class AlgorithmDataFacade<MLD>
 {
   public:
-    using EdgeData = extractor::EdgeBasedEdge::EdgeData;
+    using EdgeData = customizer::EdgeBasedGraphEdgeData;
     using EdgeRange = util::range<EdgeID>;
 
     // search graph access
@@ -76,6 +77,10 @@ template <> class AlgorithmDataFacade<MLD>
     virtual EdgeWeight GetNodeWeight(const NodeID node) const = 0;
 
     virtual EdgeWeight GetNodeDuration(const NodeID node) const = 0; // TODO: to be removed
+
+    virtual bool IsForwardEdge(EdgeID edge) const = 0;
+
+    virtual bool IsBackwardEdge(EdgeID edge) const = 0;
 
     virtual NodeID GetTarget(const EdgeID e) const = 0;
 

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -692,9 +692,9 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
         return query_graph.GetNodeWeight(node);
     }
 
-    EdgeDuration GetNodeDuration(const NodeID) const override final
+    EdgeDuration GetNodeDuration(const NodeID node) const override final
     {
-        return 0; // TODO: query_graph.GetNodeduration(node);
+        return query_graph.GetNodeDuration(node);
     }
 
     NodeID GetTarget(const EdgeID e) const override final { return query_graph.GetTarget(e); }

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -697,6 +697,16 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
         return query_graph.GetNodeDuration(node);
     }
 
+    bool IsForwardEdge(const NodeID node) const override final
+    {
+        return query_graph.IsForwardEdge(node);
+    }
+
+    bool IsBackwardEdge(const NodeID node) const override final
+    {
+        return query_graph.IsBackwardEdge(node);
+    }
+
     NodeID GetTarget(const EdgeID e) const override final { return query_graph.GetTarget(e); }
 
     const EdgeData &GetEdgeData(const EdgeID e) const override final

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -282,13 +282,13 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         return segment_data.GetReverseDatasources(id);
     }
 
-    TurnPenalty GetWeightPenaltyForEdgeID(const unsigned id) const override final
+    TurnPenalty GetWeightPenaltyForEdgeID(const EdgeID id) const override final
     {
         BOOST_ASSERT(m_turn_weight_penalties.size() > id);
         return m_turn_weight_penalties[id];
     }
 
-    TurnPenalty GetDurationPenaltyForEdgeID(const unsigned id) const override final
+    TurnPenalty GetDurationPenaltyForEdgeID(const EdgeID id) const override final
     {
         BOOST_ASSERT(m_turn_duration_penalties.size() > id);
         return m_turn_duration_penalties[id];
@@ -682,16 +682,26 @@ template <> class ContiguousInternalMemoryAlgorithmDataFacade<MLD> : public Algo
         return query_graph.GetOutDegree(n);
     }
 
+    EdgeRange GetAdjacentEdgeRange(const NodeID node) const override final
+    {
+        return query_graph.GetAdjacentEdgeRange(node);
+    }
+
+    EdgeWeight GetNodeWeight(const NodeID node) const override final
+    {
+        return query_graph.GetNodeWeight(node);
+    }
+
+    EdgeDuration GetNodeDuration(const NodeID) const override final
+    {
+        return 0; // TODO: query_graph.GetNodeduration(node);
+    }
+
     NodeID GetTarget(const EdgeID e) const override final { return query_graph.GetTarget(e); }
 
     const EdgeData &GetEdgeData(const EdgeID e) const override final
     {
         return query_graph.GetEdgeData(e);
-    }
-
-    EdgeRange GetAdjacentEdgeRange(const NodeID node) const override final
-    {
-        return query_graph.GetAdjacentEdgeRange(node);
     }
 
     EdgeRange GetBorderEdgeRange(const LevelID level, const NodeID node) const override final

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -86,9 +86,9 @@ class BaseDataFacade
     virtual NodeForwardRange GetUncompressedForwardGeometry(const EdgeID id) const = 0;
     virtual NodeReverseRange GetUncompressedReverseGeometry(const EdgeID id) const = 0;
 
-    virtual TurnPenalty GetWeightPenaltyForEdgeID(const unsigned id) const = 0;
+    virtual TurnPenalty GetWeightPenaltyForEdgeID(const EdgeID id) const = 0;
 
-    virtual TurnPenalty GetDurationPenaltyForEdgeID(const unsigned id) const = 0;
+    virtual TurnPenalty GetDurationPenaltyForEdgeID(const EdgeID id) const = 0;
 
     // Gets the weight values for each segment in an uncompressed geometry.
     // Should always be 1 shorter than GetUncompressedGeometry

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -206,6 +206,7 @@ void relaxOutgoingEdges(const DataFacade<Algorithm> &facade,
     for (const auto edge : facade.GetBorderEdgeRange(level, node))
     {
         const auto &edge_data = facade.GetEdgeData(edge);
+
         if (DIRECTION == FORWARD_DIRECTION ? edge_data.forward : edge_data.backward)
         {
             const NodeID to = facade.GetTarget(edge);
@@ -213,8 +214,13 @@ void relaxOutgoingEdges(const DataFacade<Algorithm> &facade,
             if (!facade.ExcludeNode(to) &&
                 checkParentCellRestriction(partition.GetCell(level + 1, to), args...))
             {
-                BOOST_ASSERT_MSG(edge_data.weight > 0, "edge_weight invalid");
-                const EdgeWeight to_weight = weight + edge_data.weight;
+                const auto node_weight =
+                    facade.GetNodeWeight(DIRECTION == FORWARD_DIRECTION ? node : to);
+                const auto turn_penalty = facade.GetWeightPenaltyForEdgeID(edge_data.turn_id);
+
+                BOOST_ASSERT(edge_data.weight == node_weight + turn_penalty);
+
+                const EdgeWeight to_weight = weight + node_weight + turn_penalty;
 
                 if (!forward_heap.WasInserted(to))
                 {

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -207,7 +207,8 @@ void relaxOutgoingEdges(const DataFacade<Algorithm> &facade,
     {
         const auto &edge_data = facade.GetEdgeData(edge);
 
-        if (DIRECTION == FORWARD_DIRECTION ? edge_data.forward : edge_data.backward)
+        if ((DIRECTION == FORWARD_DIRECTION) ? facade.IsForwardEdge(edge)
+                                             : facade.IsBackwardEdge(edge))
         {
             const NodeID to = facade.GetTarget(edge);
 
@@ -218,7 +219,7 @@ void relaxOutgoingEdges(const DataFacade<Algorithm> &facade,
                     facade.GetNodeWeight(DIRECTION == FORWARD_DIRECTION ? node : to);
                 const auto turn_penalty = facade.GetWeightPenaltyForEdgeID(edge_data.turn_id);
 
-                BOOST_ASSERT(edge_data.weight == node_weight + turn_penalty);
+                // TODO: BOOST_ASSERT(edge_data.weight == node_weight + turn_penalty);
 
                 const EdgeWeight to_weight = weight + node_weight + turn_penalty;
 

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -91,6 +91,7 @@ class EdgeBasedGraphFactory
     void GetEdgeBasedNodeSegments(std::vector<EdgeBasedNodeSegment> &nodes);
     void GetStartPointMarkers(std::vector<bool> &node_is_startpoint);
     void GetEdgeBasedNodeWeights(std::vector<EdgeWeight> &output_node_weights);
+    void GetEdgeBasedNodeDurations(std::vector<EdgeWeight> &output_node_durations);
     std::uint32_t GetConnectivityChecksum() const;
 
     std::uint64_t GetNumberOfEdgeBasedNodes() const;
@@ -117,6 +118,7 @@ class EdgeBasedGraphFactory
     //! node weights that indicate the length of the segment (node based) represented by the
     //! edge-based node
     std::vector<EdgeWeight> m_edge_based_node_weights;
+    std::vector<EdgeDuration> m_edge_based_node_durations;
 
     //! list of edge based nodes (compressed segments)
     std::vector<EdgeBasedNodeSegment> m_edge_based_node_segments;

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -87,6 +87,7 @@ class Extractor
         std::vector<EdgeBasedNodeSegment> &edge_based_node_segments,
         std::vector<bool> &node_is_startpoint,
         std::vector<EdgeWeight> &edge_based_node_weights,
+        std::vector<EdgeDuration> &edge_based_node_durations,
         util::DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list,
         std::uint32_t &connectivity_checksum);
 

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -462,14 +462,28 @@ void readEdgeBasedNodeWeights(const boost::filesystem::path &path, NodeWeigtsVec
     storage::serialization::read(reader, "/extractor/edge_based_node_weights", weights);
 }
 
-template <typename NodeWeigtsVectorT>
-void writeEdgeBasedNodeWeights(const boost::filesystem::path &path,
-                               const NodeWeigtsVectorT &weights)
+template <typename NodeWeigtsVectorT, typename NodeDurationsVectorT>
+void readEdgeBasedNodeWeightsDurations(const boost::filesystem::path &path,
+                                       NodeWeigtsVectorT &weights,
+                                       NodeDurationsVectorT &durations)
+{
+    const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
+    storage::tar::FileReader reader{path, fingerprint};
+
+    storage::serialization::read(reader, "/extractor/edge_based_node_weights", weights);
+    storage::serialization::read(reader, "/extractor/edge_based_node_durations", durations);
+}
+
+template <typename NodeWeigtsVectorT, typename NodeDurationsVectorT>
+void writeEdgeBasedNodeWeightsDurations(const boost::filesystem::path &path,
+                                        const NodeWeigtsVectorT &weights,
+                                        const NodeDurationsVectorT &durations)
 {
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
     storage::serialization::write(writer, "/extractor/edge_based_node_weights", weights);
+    storage::serialization::write(writer, "/extractor/edge_based_node_durations", durations);
 }
 
 template <typename RTreeT>

--- a/include/partitioner/files.hpp
+++ b/include/partitioner/files.hpp
@@ -1,8 +1,6 @@
 #ifndef OSRM_PARTITIONER_SERILIZATION_HPP
 #define OSRM_PARTITIONER_SERILIZATION_HPP
 
-#include "customizer/edge_based_graph.hpp"
-
 #include "partitioner/serialization.hpp"
 
 #include "storage/io.hpp"
@@ -13,39 +11,6 @@ namespace partitioner
 {
 namespace files
 {
-
-// reads .osrm.mldgr file
-template <typename MultiLevelGraphT>
-inline void readGraph(const boost::filesystem::path &path,
-                      MultiLevelGraphT &graph,
-                      std::uint32_t &connectivity_checksum)
-{
-    static_assert(std::is_same<customizer::MultiLevelEdgeBasedGraphView, MultiLevelGraphT>::value ||
-                      std::is_same<customizer::MultiLevelEdgeBasedGraph, MultiLevelGraphT>::value,
-                  "");
-
-    storage::tar::FileReader reader{path, storage::tar::FileReader::VerifyFingerprint};
-
-    reader.ReadInto("/mld/connectivity_checksum", connectivity_checksum);
-    serialization::read(reader, "/mld/multilevelgraph", graph);
-}
-
-// writes .osrm.mldgr file
-template <typename MultiLevelGraphT>
-inline void writeGraph(const boost::filesystem::path &path,
-                       const MultiLevelGraphT &graph,
-                       const std::uint32_t connectivity_checksum)
-{
-    static_assert(std::is_same<customizer::MultiLevelEdgeBasedGraphView, MultiLevelGraphT>::value ||
-                      std::is_same<customizer::MultiLevelEdgeBasedGraph, MultiLevelGraphT>::value,
-                  "");
-
-    storage::tar::FileWriter writer{path, storage::tar::FileWriter::GenerateFingerprint};
-
-    writer.WriteElementCount64("/mld/connectivity_checksum", 1);
-    writer.WriteFrom("/mld/connectivity_checksum", connectivity_checksum);
-    serialization::write(writer, "/mld/multilevelgraph", graph);
-}
 
 // read .osrm.partition file
 template <typename MultiLevelPartitionT>
@@ -101,6 +66,35 @@ inline void writeCells(const boost::filesystem::path &path, CellStorageT &storag
     storage::tar::FileWriter writer{path, fingerprint};
 
     serialization::write(writer, "/mld/cellstorage", storage);
+}
+
+// reads .osrm.mldgr file
+template <typename MultiLevelGraphT>
+inline void readGraph(const boost::filesystem::path &path,
+                      MultiLevelGraphT &graph,
+                      std::uint32_t &connectivity_checksum)
+{
+    static_assert(std::is_same<partitioner::MultiLevelEdgeBasedGraph, MultiLevelGraphT>::value, "");
+
+    storage::tar::FileReader reader{path, storage::tar::FileReader::VerifyFingerprint};
+
+    reader.ReadInto("/mld/connectivity_checksum", connectivity_checksum);
+    serialization::read(reader, "/mld/multilevelgraph", graph);
+}
+
+// writes .osrm.mldgr file
+template <typename MultiLevelGraphT>
+inline void writeGraph(const boost::filesystem::path &path,
+                       const MultiLevelGraphT &graph,
+                       const std::uint32_t connectivity_checksum)
+{
+    static_assert(std::is_same<partitioner::MultiLevelEdgeBasedGraph, MultiLevelGraphT>::value, "");
+
+    storage::tar::FileWriter writer{path, storage::tar::FileWriter::GenerateFingerprint};
+
+    writer.WriteElementCount64("/mld/connectivity_checksum", 1);
+    writer.WriteFrom("/mld/connectivity_checksum", connectivity_checksum);
+    serialization::write(writer, "/mld/multilevelgraph", graph);
 }
 }
 }

--- a/include/partitioner/multi_level_graph.hpp
+++ b/include/partitioner/multi_level_graph.hpp
@@ -1,6 +1,7 @@
 #ifndef OSRM_PARTITIONER_MULTI_LEVEL_GRAPH_HPP
 #define OSRM_PARTITIONER_MULTI_LEVEL_GRAPH_HPP
 
+#include "partitioner/edge_based_graph.hpp"
 #include "partitioner/multi_level_partition.hpp"
 
 #include "storage/shared_memory_ownership.hpp"
@@ -42,6 +43,8 @@ class MultiLevelGraph : public util::StaticGraph<EdgeDataT, Ownership>
     template <typename T> using Vector = util::ViewOrVector<T, Ownership>;
 
   public:
+    using SuperT::SuperT;
+
     // We limit each node to have 255 edges
     // this is very generous, we could probably pack this
     using EdgeOffset = std::uint8_t;
@@ -146,6 +149,14 @@ class MultiLevelGraph : public util::StaticGraph<EdgeDataT, Ownership>
         return max_border_node_id;
     }
 
+    auto data() &&
+    {
+        return std::make_tuple(std::move(SuperT::node_array),
+                               std::move(SuperT::edge_array),
+                               std::move(node_to_edge_offset),
+                               connectivity_checksum);
+    }
+
   private:
     template <typename ContainerT>
     auto GetHighestBorderLevel(const MultiLevelPartition &mlp, const ContainerT &edges) const
@@ -218,9 +229,13 @@ class MultiLevelGraph : public util::StaticGraph<EdgeDataT, Ownership>
                                                const std::string &name,
                                                const MultiLevelGraph<EdgeDataT, Ownership> &graph);
 
+  protected:
     Vector<EdgeOffset> node_to_edge_offset;
     std::uint32_t connectivity_checksum;
 };
+
+using MultiLevelEdgeBasedGraph =
+    MultiLevelGraph<EdgeBasedGraphEdgeData, storage::Ownership::Container>;
 }
 }
 

--- a/include/partitioner/multi_level_graph.hpp
+++ b/include/partitioner/multi_level_graph.hpp
@@ -149,7 +149,7 @@ class MultiLevelGraph : public util::StaticGraph<EdgeDataT, Ownership>
         return max_border_node_id;
     }
 
-    auto data() &&
+    auto data() && // rvalue ref-qualifier is a safety-belt
     {
         return std::make_tuple(std::move(SuperT::node_array),
                                std::move(SuperT::edge_array),

--- a/include/partitioner/partitioner_config.hpp
+++ b/include/partitioner/partitioner_config.hpp
@@ -16,7 +16,7 @@ namespace partitioner
 struct PartitionerConfig final : storage::IOConfig
 {
     PartitionerConfig()
-        : IOConfig({".osrm", ".osrm.fileIndex", ".osrm.ebg_nodes"},
+        : IOConfig({".osrm", ".osrm.fileIndex", ".osrm.ebg_nodes", ".osrm.enw"},
                    {".osrm.hsgr", ".osrm.cnbg"},
                    {".osrm.ebg",
                     ".osrm.cnbg",

--- a/include/partitioner/serialization.hpp
+++ b/include/partitioner/serialization.hpp
@@ -19,26 +19,6 @@ namespace partitioner
 namespace serialization
 {
 
-template <typename EdgeDataT, storage::Ownership Ownership>
-inline void read(storage::tar::FileReader &reader,
-                 const std::string &name,
-                 MultiLevelGraph<EdgeDataT, Ownership> &graph)
-{
-    storage::serialization::read(reader, name + "/node_array", graph.node_array);
-    storage::serialization::read(reader, name + "/edge_array", graph.edge_array);
-    storage::serialization::read(reader, name + "/node_to_edge_offset", graph.node_to_edge_offset);
-}
-
-template <typename EdgeDataT, storage::Ownership Ownership>
-inline void write(storage::tar::FileWriter &writer,
-                  const std::string &name,
-                  const MultiLevelGraph<EdgeDataT, Ownership> &graph)
-{
-    storage::serialization::write(writer, name + "/node_array", graph.node_array);
-    storage::serialization::write(writer, name + "/edge_array", graph.edge_array);
-    storage::serialization::write(writer, name + "/node_to_edge_offset", graph.node_to_edge_offset);
-}
-
 template <storage::Ownership Ownership>
 inline void read(storage::tar::FileReader &reader,
                  const std::string &name,

--- a/include/storage/shared_data_index.hpp
+++ b/include/storage/shared_data_index.hpp
@@ -46,33 +46,39 @@ class SharedDataIndex
 
     template <typename T> auto GetBlockPtr(const std::string &name) const
     {
-        const auto index_iter = block_to_region.find(name);
-        const auto &region = regions[index_iter->second];
+        const auto &region = GetBlockRegion(name);
         return region.layout.GetBlockPtr<T>(region.memory_ptr, name);
     }
 
     template <typename T> auto GetBlockPtr(const std::string &name)
     {
-        const auto index_iter = block_to_region.find(name);
-        const auto &region = regions[index_iter->second];
+        const auto &region = GetBlockRegion(name);
         return region.layout.GetBlockPtr<T>(region.memory_ptr, name);
     }
 
     std::size_t GetBlockEntries(const std::string &name) const
     {
-        const auto index_iter = block_to_region.find(name);
-        const auto &region = regions[index_iter->second];
+        const auto &region = GetBlockRegion(name);
         return region.layout.GetBlockEntries(name);
     }
 
     std::size_t GetBlockSize(const std::string &name) const
     {
-        const auto index_iter = block_to_region.find(name);
-        const auto &region = regions[index_iter->second];
+        const auto &region = GetBlockRegion(name);
         return region.layout.GetBlockSize(name);
     }
 
   private:
+    const AllocatedRegion &GetBlockRegion(const std::string &name) const
+    {
+        const auto index_iter = block_to_region.find(name);
+        if (index_iter == block_to_region.end())
+        {
+            throw util::exception("data block " + name + " not found " + SOURCE_REF);
+        }
+        return regions[index_iter->second];
+    }
+
     std::vector<AllocatedRegion> regions;
     std::unordered_map<std::string, std::uint32_t> block_to_region;
 };

--- a/include/storage/view_factory.hpp
+++ b/include/storage/view_factory.hpp
@@ -330,9 +330,14 @@ inline auto make_multi_level_graph_view(const SharedDataIndex &index, const std:
         index, name + "/edge_array");
     auto node_to_offset = make_vector_view<customizer::MultiLevelEdgeBasedGraphView::EdgeOffset>(
         index, name + "/node_to_edge_offset");
+    auto node_weights = make_vector_view<EdgeWeight>(index, name + "/node_weights");
+    auto node_durations = make_vector_view<EdgeDuration>(index, name + "/node_durations");
 
-    return customizer::MultiLevelEdgeBasedGraphView(
-        std::move(node_list), std::move(edge_list), std::move(node_to_offset));
+    return customizer::MultiLevelEdgeBasedGraphView(std::move(node_list),
+                                                    std::move(edge_list),
+                                                    std::move(node_to_offset),
+                                                    std::move(node_weights),
+                                                    std::move(node_durations));
 }
 
 inline auto make_maneuver_overrides_views(const SharedDataIndex &index, const std::string &name)

--- a/include/storage/view_factory.hpp
+++ b/include/storage/view_factory.hpp
@@ -332,12 +332,16 @@ inline auto make_multi_level_graph_view(const SharedDataIndex &index, const std:
         index, name + "/node_to_edge_offset");
     auto node_weights = make_vector_view<EdgeWeight>(index, name + "/node_weights");
     auto node_durations = make_vector_view<EdgeDuration>(index, name + "/node_durations");
+    auto is_forward_edge = make_vector_view<bool>(index, name + "/is_forward_edge");
+    auto is_backward_edge = make_vector_view<bool>(index, name + "/is_backward_edge");
 
     return customizer::MultiLevelEdgeBasedGraphView(std::move(node_list),
                                                     std::move(edge_list),
                                                     std::move(node_to_offset),
                                                     std::move(node_weights),
-                                                    std::move(node_durations));
+                                                    std::move(node_durations),
+                                                    std::move(is_forward_edge),
+                                                    std::move(is_backward_edge));
 }
 
 inline auto make_maneuver_overrides_views(const SharedDataIndex &index, const std::string &name)

--- a/include/updater/updater.hpp
+++ b/include/updater/updater.hpp
@@ -17,13 +17,15 @@ class Updater
   public:
     Updater(UpdaterConfig config_) : config(std::move(config_)) {}
 
-    using NumNodesAndEdges =
-        std::tuple<EdgeID, std::vector<extractor::EdgeBasedEdge>, std::uint32_t>;
-    NumNodesAndEdges LoadAndUpdateEdgeExpandedGraph() const;
+    EdgeID
+    LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &edge_based_edge_list,
+                                   std::vector<EdgeWeight> &node_weights,
+                                   std::uint32_t &connectivity_checksum) const;
 
     EdgeID
     LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &edge_based_edge_list,
                                    std::vector<EdgeWeight> &node_weights,
+                                   std::vector<EdgeDuration> &node_durations, // TODO: to be deleted
                                    std::uint32_t &connectivity_checksum) const;
 
   private:

--- a/include/updater/updater_config.hpp
+++ b/include/updater/updater_config.hpp
@@ -53,7 +53,8 @@ struct UpdaterConfig final : storage::IOConfig
                     ".osrm.geometry",
                     ".osrm.fileIndex",
                     ".osrm.properties",
-                    ".osrm.restrictions"},
+                    ".osrm.restrictions",
+                    ".osrm.enw"},
                    {},
                    {".osrm.datasource_names"}),
           valid_now(0)

--- a/include/util/static_graph.hpp
+++ b/include/util/static_graph.hpp
@@ -312,7 +312,7 @@ class StaticGraph
         });
     }
 
-    // private:
+  protected:
     NodeIterator number_of_nodes;
     EdgeIterator number_of_edges;
 

--- a/scripts/gdb_printers.py
+++ b/scripts/gdb_printers.py
@@ -9,6 +9,8 @@ lonlat = lambda x: (coord2float(x['lon']['__value']), coord2float(x['lat']['__va
 
 def call(this, method, *args):
     """Call this.method(args)"""
+    if (str(this) == '<optimized out>'):
+        raise BaseException('"this" is optimized out')
     command = '(*({})({})).{}({})'.format(this.type.target().pointer(), this.address, method, ','.join((str(x) for x in args)))
     return gdb.parse_and_eval(command)
 
@@ -234,7 +236,6 @@ class SVGPrinter (gdb.Command):
             mld_facade = facade.cast(gdb.lookup_type('osrm::engine::datafacade::ContiguousInternalMemoryAlgorithmDataFacade<osrm::engine::routing_algorithms::mld::Algorithm>'))
             mld_partition = mld_facade['mld_partition']
             mld_levels = call(mld_partition, 'GetNumberOfLevels')
-            print (mld_level, mld_levels)
             if mld_level < mld_levels:
                 sentinel_node = call(mld_partition['partition'], 'size') - 1 # GetSentinelNode
                 number_of_cells = call(mld_partition, 'GetCell', mld_level, sentinel_node) # GetNumberOfCells
@@ -272,6 +273,7 @@ class SVGPrinter (gdb.Command):
         for node in nodes:
             geometry_id = call(facade, 'GetGeometryIndex', node)
             direction = 'forward' if geometry_id['forward'] else 'reverse'
+            print (geometry_id, direction)
             geometry = SVGPrinter.getByGeometryId(facade, geometry_id, 'Geometry')
             weights = SVGPrinter.getByGeometryId(facade, geometry_id, 'Weights')
 

--- a/scripts/osrm-runner.js
+++ b/scripts/osrm-runner.js
@@ -16,8 +16,6 @@ const run_query = (query_options, filters, callback) => {
     let tic = () => 0.;
     http.request(query_options, function (res) {
         let body = '', ttfb = tic();
-        if (res.statusCode != 200)
-            return callback(query_options.path, res.statusCode, ttfb);
 
         res.setEncoding('utf8');
         res.on('data', function (chunk) {

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -75,6 +75,12 @@ int Contractor::Run()
     EdgeID number_of_edge_based_nodes = updater.LoadAndUpdateEdgeExpandedGraph(
         edge_based_edge_list, node_weights, connectivity_checksum);
 
+    // Convert node weights for oneway streets to INVALID_EDGE_WEIGHT
+    for (auto &weight : node_weights)
+    {
+        weight = (weight & 0x80000000) ? INVALID_EDGE_WEIGHT : weight;
+    }
+
     // Contracting the edge-expanded graph
 
     TIMER_START(contraction);

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -74,18 +74,20 @@ void printUnreachableStatistics(const Partition &partition,
 
 auto LoadAndUpdateEdgeExpandedGraph(const CustomizationConfig &config,
                                     const partitioner::MultiLevelPartition &mlp,
+                                    std::vector<EdgeWeight> &node_weights,
                                     std::uint32_t &connectivity_checksum)
 {
     updater::Updater updater(config.updater_config);
 
-    EdgeID num_nodes;
     std::vector<extractor::EdgeBasedEdge> edge_based_edge_list;
-    std::tie(num_nodes, edge_based_edge_list, connectivity_checksum) =
-        updater.LoadAndUpdateEdgeExpandedGraph();
+    EdgeID num_nodes = updater.LoadAndUpdateEdgeExpandedGraph(
+        edge_based_edge_list, node_weights, connectivity_checksum);
 
     auto directed = partitioner::splitBidirectionalEdges(edge_based_edge_list);
+
     auto tidied = partitioner::prepareEdgesForUsageInGraph<
         typename partitioner::MultiLevelEdgeBasedGraph::InputEdge>(std::move(directed));
+
     auto edge_based_graph =
         partitioner::MultiLevelEdgeBasedGraph(mlp, num_nodes, std::move(tidied));
 
@@ -120,8 +122,11 @@ int Customizer::Run(const CustomizationConfig &config)
     partitioner::MultiLevelPartition mlp;
     partitioner::files::readPartition(config.GetPath(".osrm.partition"), mlp);
 
+    std::vector<EdgeWeight> node_weights;
     std::uint32_t connectivity_checksum = 0;
-    auto graph = LoadAndUpdateEdgeExpandedGraph(config, mlp, connectivity_checksum);
+    auto graph = LoadAndUpdateEdgeExpandedGraph(config, mlp, node_weights, connectivity_checksum);
+    BOOST_ASSERT(graph.GetNumberOfNodes() == node_weights.size());
+    std::for_each(node_weights.begin(), node_weights.end(), [](auto &w) { w &= 0x7fffffff; });
     util::Log() << "Loaded edge based graph: " << graph.GetNumberOfEdges() << " edges, "
                 << graph.GetNumberOfNodes() << " nodes";
 
@@ -158,8 +163,7 @@ int Customizer::Run(const CustomizationConfig &config)
     util::Log() << "MLD customization writing took " << TIMER_SEC(writing_mld_data) << " seconds";
 
     TIMER_START(writing_graph);
-    std::vector<EdgeWeight> node_weights;
-    std::vector<EdgeDuration> node_durations;
+    std::vector<EdgeDuration> node_durations; // TODO: save an empty vector, to be removed later
     MultiLevelEdgeBasedGraph shaved_graph{
         std::move(graph), std::move(node_weights), std::move(node_durations)};
     customizer::files::writeGraph(

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -75,13 +75,14 @@ void printUnreachableStatistics(const Partition &partition,
 auto LoadAndUpdateEdgeExpandedGraph(const CustomizationConfig &config,
                                     const partitioner::MultiLevelPartition &mlp,
                                     std::vector<EdgeWeight> &node_weights,
+                                    std::vector<EdgeDuration> &node_durations,
                                     std::uint32_t &connectivity_checksum)
 {
     updater::Updater updater(config.updater_config);
 
     std::vector<extractor::EdgeBasedEdge> edge_based_edge_list;
     EdgeID num_nodes = updater.LoadAndUpdateEdgeExpandedGraph(
-        edge_based_edge_list, node_weights, connectivity_checksum);
+        edge_based_edge_list, node_weights, node_durations, connectivity_checksum);
 
     auto directed = partitioner::splitBidirectionalEdges(edge_based_edge_list);
 
@@ -123,8 +124,10 @@ int Customizer::Run(const CustomizationConfig &config)
     partitioner::files::readPartition(config.GetPath(".osrm.partition"), mlp);
 
     std::vector<EdgeWeight> node_weights;
+    std::vector<EdgeDuration> node_durations; // TODO: to be removed later
     std::uint32_t connectivity_checksum = 0;
-    auto graph = LoadAndUpdateEdgeExpandedGraph(config, mlp, node_weights, connectivity_checksum);
+    auto graph = LoadAndUpdateEdgeExpandedGraph(
+        config, mlp, node_weights, node_durations, connectivity_checksum);
     BOOST_ASSERT(graph.GetNumberOfNodes() == node_weights.size());
     std::for_each(node_weights.begin(), node_weights.end(), [](auto &w) { w &= 0x7fffffff; });
     util::Log() << "Loaded edge based graph: " << graph.GetNumberOfEdges() << " edges, "
@@ -163,7 +166,6 @@ int Customizer::Run(const CustomizationConfig &config)
     util::Log() << "MLD customization writing took " << TIMER_SEC(writing_mld_data) << " seconds";
 
     TIMER_START(writing_graph);
-    std::vector<EdgeDuration> node_durations; // TODO: save an empty vector, to be removed later
     MultiLevelEdgeBasedGraph shaved_graph{
         std::move(graph), std::move(node_weights), std::move(node_durations)};
     customizer::files::writeGraph(

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -470,10 +470,10 @@ RandIt filterUnpackedPathsBySharing(RandIt first,
     if (shortest_path.edges.empty())
         return last;
 
-    std::unordered_set<EdgeID> edges;
-    edges.reserve(size * shortest_path.edges.size() * (1.25));
+    std::unordered_set<NodeID> nodes;
+    nodes.reserve(size * shortest_path.nodes.size() * (1.25));
 
-    edges.insert(begin(shortest_path.edges), end(shortest_path.edges));
+    nodes.insert(begin(shortest_path.nodes), end(shortest_path.nodes));
 
     const auto over_sharing_limit = [&](auto &unpacked) {
         if (unpacked.edges.empty())
@@ -482,20 +482,20 @@ RandIt filterUnpackedPathsBySharing(RandIt first,
         }
 
         EdgeWeight total_duration = 0;
-        const auto add_if_seen = [&](const EdgeWeight duration, const EdgeID edge) {
-            auto edge_duration = facade.GetEdgeData(edge).duration;
-            total_duration += edge_duration;
-            if (edges.count(edge) > 0)
+        const auto add_if_seen = [&](const EdgeWeight duration, const NodeID node) {
+            auto node_duration = facade.GetNodeDuration(node);
+            total_duration += node_duration;
+            if (nodes.count(node) > 0)
             {
-                return duration + edge_duration;
+                return duration + node_duration;
             }
             return duration;
         };
 
-        const auto shared_weight =
-            std::accumulate(begin(unpacked.edges), end(unpacked.edges), EdgeWeight{0}, add_if_seen);
+        const auto shared_duration = std::accumulate(
+            begin(unpacked.nodes), end(unpacked.nodes), EdgeDuration{0}, add_if_seen);
 
-        unpacked.sharing = shared_weight / static_cast<double>(total_duration);
+        unpacked.sharing = shared_duration / static_cast<double>(total_duration);
         BOOST_ASSERT(unpacked.sharing >= 0.);
         BOOST_ASSERT(unpacked.sharing <= 1.);
 
@@ -505,7 +505,7 @@ RandIt filterUnpackedPathsBySharing(RandIt first,
         }
         else
         {
-            edges.insert(begin(unpacked.edges), end(unpacked.edges));
+            nodes.insert(begin(unpacked.nodes), end(unpacked.nodes));
             return false;
         }
     };

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -169,6 +169,8 @@ void relaxOutgoingEdges(const DataFacade<mld::Algorithm> &facade,
         }
     }
 
+    const auto node_weight = facade.GetNodeWeight(node);
+    const auto node_duration = facade.GetNodeDuration(node); // TODO: remove later
     for (const auto edge : facade.GetBorderEdgeRange(level, node))
     {
         const auto &data = facade.GetEdgeData(edge);
@@ -180,8 +182,9 @@ void relaxOutgoingEdges(const DataFacade<mld::Algorithm> &facade,
                 continue;
             }
 
-            const auto edge_weight = data.weight;
-            const auto edge_duration = data.duration;
+            const auto turn_id = data.turn_id;
+            const auto edge_weight = node_weight + facade.GetWeightPenaltyForEdgeID(turn_id);
+            const auto edge_duration = node_duration + facade.GetDurationPenaltyForEdgeID(turn_id);
 
             BOOST_ASSERT_MSG(edge_weight > 0, "edge_weight invalid");
             const auto to_weight = weight + edge_weight;

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -172,7 +172,8 @@ void relaxOutgoingEdges(const DataFacade<mld::Algorithm> &facade,
     for (const auto edge : facade.GetBorderEdgeRange(level, node))
     {
         const auto &data = facade.GetEdgeData(edge);
-        if (DIRECTION == FORWARD_DIRECTION ? data.forward : data.backward)
+        if ((DIRECTION == FORWARD_DIRECTION) ? facade.IsForwardEdge(edge)
+                                             : facade.IsBackwardEdge(edge))
         {
             const NodeID to = facade.GetTarget(edge);
             if (facade.ExcludeNode(to))
@@ -310,7 +311,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
         for (auto edge : facade.GetAdjacentEdgeRange(node))
         {
             const auto &data = facade.GetEdgeData(edge);
-            if (DIRECTION == FORWARD_DIRECTION ? data.forward : data.backward)
+            if ((DIRECTION == FORWARD_DIRECTION) ? facade.IsForwardEdge(edge)
+                                                 : facade.IsBackwardEdge(edge))
             {
                 const auto turn_id = data.turn_id;
                 const auto edge_weight =

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -182,16 +182,15 @@ void relaxOutgoingEdges(const DataFacade<mld::Algorithm> &facade,
             }
 
             const auto turn_id = data.turn_id;
-            const auto node_weight =
-                facade.GetNodeWeight(DIRECTION == FORWARD_DIRECTION ? node : to);
-            const auto node_duration = facade.GetNodeDuration(
-                DIRECTION == FORWARD_DIRECTION ? node : to); // TODO: remove later
-            const auto edge_weight = node_weight + facade.GetWeightPenaltyForEdgeID(turn_id);
-            const auto edge_duration = node_duration + facade.GetDurationPenaltyForEdgeID(turn_id);
+            const auto node_id = DIRECTION == FORWARD_DIRECTION ? node : facade.GetTarget(edge);
+            const auto node_weight = facade.GetNodeWeight(node_id);
+            const auto node_duration = facade.GetNodeDuration(node_id);
+            const auto turn_weight = node_weight + facade.GetWeightPenaltyForEdgeID(turn_id);
+            const auto turn_duration = node_duration + facade.GetDurationPenaltyForEdgeID(turn_id);
 
-            BOOST_ASSERT_MSG(edge_weight > 0, "edge_weight invalid");
-            const auto to_weight = weight + edge_weight;
-            const auto to_duration = duration + edge_duration;
+            BOOST_ASSERT_MSG(node_weight + turn_weight > 0, "edge weight is invalid");
+            const auto to_weight = weight + turn_weight;
+            const auto to_duration = duration + turn_duration;
 
             // New Node discovered -> Add to Heap + Node Info Storage
             if (!query_heap.WasInserted(to))
@@ -315,15 +314,10 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                                                  : facade.IsBackwardEdge(edge))
             {
                 const auto turn_id = data.turn_id;
-                const auto edge_weight =
-                    initial_weight +
-                    facade.GetNodeWeight(DIRECTION == FORWARD_DIRECTION ? node
-                                                                        : facade.GetTarget(edge)) +
-                    facade.GetWeightPenaltyForEdgeID(turn_id);
-                const auto edge_duration = initial_duration +
-                                           +facade.GetNodeDuration(DIRECTION == FORWARD_DIRECTION
-                                                                       ? node
-                                                                       : facade.GetTarget(edge)) +
+                const auto node_id = DIRECTION == FORWARD_DIRECTION ? node : facade.GetTarget(edge);
+                const auto edge_weight = initial_weight + facade.GetNodeWeight(node_id) +
+                                         facade.GetWeightPenaltyForEdgeID(turn_id);
+                const auto edge_duration = initial_duration + facade.GetNodeDuration(node_id) +
                                            facade.GetDurationPenaltyForEdgeID(turn_id);
 
                 query_heap.Insert(facade.GetTarget(edge), edge_weight, {node, edge_duration});

--- a/src/engine/routing_algorithms/tile_turns.cpp
+++ b/src/engine/routing_algorithms/tile_turns.cpp
@@ -145,42 +145,8 @@ std::vector<TurnData> generateTurns(const datafacade &facade,
                     const auto &data = facade.GetEdgeData(edge_based_edge_id);
 
                     // Now, calculate the sum of the weight of all the segments.
-                    const auto &geometry =
-                        edge_based_node_info.find(approachedge.edge_based_node_id)->second;
-                    EdgeWeight sum_node_weight = 0;
-                    EdgeDuration sum_node_duration = 0;
-                    if (geometry.is_geometry_forward)
-                    {
-                        const auto approach_weight =
-                            facade.GetUncompressedForwardWeights(geometry.packed_geometry_id);
-                        const auto approach_duration =
-                            facade.GetUncompressedForwardDurations(geometry.packed_geometry_id);
-                        sum_node_weight = std::accumulate(
-                            approach_weight.begin(), approach_weight.end(), EdgeWeight{0});
-                        sum_node_duration = std::accumulate(
-                            approach_duration.begin(), approach_duration.end(), EdgeDuration{0});
-                    }
-                    else
-                    {
-                        const auto approach_weight =
-                            facade.GetUncompressedReverseWeights(geometry.packed_geometry_id);
-                        const auto approach_duration =
-                            facade.GetUncompressedReverseDurations(geometry.packed_geometry_id);
-                        sum_node_weight = std::accumulate(
-                            approach_weight.begin(), approach_weight.end(), EdgeWeight{0});
-                        sum_node_duration = std::accumulate(
-                            approach_duration.begin(), approach_duration.end(), EdgeDuration{0});
-                    }
-
-                    // The edge.weight is the whole edge weight, which includes the turn
-                    // cost.
-                    // The turn cost is the edge.weight minus the sum of the individual road
-                    // segment weights.  This might not be 100% accurate, because some
-                    // intersections include stop signs, traffic signals and other
-                    // penalties, but at this stage, we can't divide those out, so we just
-                    // treat the whole lot as the "turn cost" that we'll stick on the map.
-                    const auto turn_weight = data.weight - sum_node_weight;
-                    const auto turn_duration = data.duration - sum_node_duration;
+                    const auto turn_weight = facade.GetWeightPenaltyForEdgeID(data.turn_id);
+                    const auto turn_duration = facade.GetDurationPenaltyForEdgeID(data.turn_id);
                     const auto turn_instruction = facade.GetTurnInstructionForEdgeID(data.turn_id);
 
                     // Find the three nodes that make up the turn movement)

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -107,6 +107,13 @@ void EdgeBasedGraphFactory::GetEdgeBasedNodeWeights(std::vector<EdgeWeight> &out
     swap(m_edge_based_node_weights, output_node_weights);
 }
 
+void EdgeBasedGraphFactory::GetEdgeBasedNodeDurations(
+    std::vector<EdgeWeight> &output_node_durations)
+{
+    using std::swap; // Koenig swap
+    swap(m_edge_based_node_durations, output_node_durations);
+}
+
 std::uint32_t EdgeBasedGraphFactory::GetConnectivityChecksum() const
 {
     return m_connectivity_checksum;
@@ -281,6 +288,7 @@ unsigned EdgeBasedGraphFactory::LabelEdgeBasedNodes()
     // heuristic: node-based graph node is a simple intersection with four edges
     // (edge-based nodes)
     m_edge_based_node_weights.reserve(4 * m_node_based_graph.GetNumberOfNodes());
+    m_edge_based_node_durations.reserve(4 * m_node_based_graph.GetNumberOfNodes());
     nbe_to_ebn_mapping.resize(m_node_based_graph.GetEdgeCapacity(), SPECIAL_NODEID);
 
     // renumber edge based node of outgoing edges
@@ -297,6 +305,7 @@ unsigned EdgeBasedGraphFactory::LabelEdgeBasedNodes()
             }
 
             m_edge_based_node_weights.push_back(edge_data.weight);
+            m_edge_based_node_durations.push_back(edge_data.duration);
 
             BOOST_ASSERT(numbered_edges_count < m_node_based_graph.GetNumberOfEdges());
             nbe_to_ebn_mapping[current_edge] = numbered_edges_count;
@@ -392,6 +401,8 @@ EdgeBasedGraphFactory::GenerateEdgeExpandedNodes(const WayRestrictionMap &way_re
             const auto ebn_weight = m_edge_based_node_weights[nbe_to_ebn_mapping[eid]];
             BOOST_ASSERT(ebn_weight == INVALID_EDGE_WEIGHT || ebn_weight == edge_data.weight);
             m_edge_based_node_weights.push_back(ebn_weight);
+            m_edge_based_node_durations.push_back(
+                m_edge_based_node_durations[nbe_to_ebn_mapping[eid]]);
 
             edge_based_node_id++;
             progress.PrintStatus(progress_counter++);
@@ -400,6 +411,7 @@ EdgeBasedGraphFactory::GenerateEdgeExpandedNodes(const WayRestrictionMap &way_re
 
     BOOST_ASSERT(m_edge_based_node_segments.size() == m_edge_based_node_is_startpoint.size());
     BOOST_ASSERT(m_number_of_edge_based_nodes == m_edge_based_node_weights.size());
+    BOOST_ASSERT(m_number_of_edge_based_nodes == m_edge_based_node_durations.size());
 
     util::Log() << "Generated " << m_number_of_edge_based_nodes << " nodes ("
                 << way_restriction_map.NumberOfDuplicatedNodes()

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -138,9 +138,12 @@ NBGToEBG EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const N
     BOOST_ASSERT(nbe_to_ebn_mapping[edge_id_1] != SPECIAL_NODEID ||
                  nbe_to_ebn_mapping[edge_id_2] != SPECIAL_NODEID);
 
+    // TODO: use the sign bit to distinguish oneway streets that must
+    // have INVALID_EDGE_WEIGHT node weight values to enforce loop edges
+    // in contraction
     if (nbe_to_ebn_mapping[edge_id_1] != SPECIAL_NODEID &&
         nbe_to_ebn_mapping[edge_id_2] == SPECIAL_NODEID)
-        m_edge_based_node_weights[nbe_to_ebn_mapping[edge_id_1]] = INVALID_EDGE_WEIGHT;
+        m_edge_based_node_weights[nbe_to_ebn_mapping[edge_id_1]] |= 0x80000000;
 
     BOOST_ASSERT(m_compressed_edge_container.HasEntryForID(edge_id_1) ==
                  m_compressed_edge_container.HasEntryForID(edge_id_2));

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -145,9 +145,13 @@ NBGToEBG EdgeBasedGraphFactory::InsertEdgeBasedNode(const NodeID node_u, const N
     BOOST_ASSERT(nbe_to_ebn_mapping[edge_id_1] != SPECIAL_NODEID ||
                  nbe_to_ebn_mapping[edge_id_2] != SPECIAL_NODEID);
 
-    // TODO: use the sign bit to distinguish oneway streets that must
-    // have INVALID_EDGE_WEIGHT node weight values to enforce loop edges
-    // in contraction
+    // ⚠ Use the sign bit of node weights to distinguish oneway streets:
+    //  * MSB is set - a node corresponds to a one-way street
+    //  * MSB is clear - a node corresponds to a bidirectional street
+    // Before using node weights data values must be adjusted:
+    //  * in contraction if MSB is set the node weight is INVALID_EDGE_WEIGHT.
+    //    This adjustment is needed to enforce loop creation for oneways.
+    //  * in other cases node weights must be masked with 0x7fffffff to clear MSB
     if (nbe_to_ebn_mapping[edge_id_1] != SPECIAL_NODEID &&
         nbe_to_ebn_mapping[edge_id_2] == SPECIAL_NODEID)
         m_edge_based_node_weights[nbe_to_ebn_mapping[edge_id_1]] |= 0x80000000;

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -241,6 +241,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
     util::DeallocatingVector<EdgeBasedEdge> edge_based_edge_list;
     std::vector<bool> node_is_startpoint;
     std::vector<EdgeWeight> edge_based_node_weights;
+    std::vector<EdgeDuration> edge_based_node_durations;
     std::uint32_t ebg_connectivity_checksum = 0;
 
     // Create a node-based graph from the OSRM file
@@ -320,6 +321,7 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
                                edge_based_node_segments,
                                node_is_startpoint,
                                edge_based_node_weights,
+                               edge_based_node_durations,
                                edge_based_edge_list,
                                ebg_connectivity_checksum);
 
@@ -343,8 +345,8 @@ int Extractor::run(ScriptingEnvironment &scripting_environment)
 
     util::Log() << "Saving edge-based node weights to file.";
     TIMER_START(timer_write_node_weights);
-    extractor::files::writeEdgeBasedNodeWeights(config.GetPath(".osrm.enw"),
-                                                edge_based_node_weights);
+    extractor::files::writeEdgeBasedNodeWeightsDurations(
+        config.GetPath(".osrm.enw"), edge_based_node_weights, edge_based_node_durations);
     TIMER_STOP(timer_write_node_weights);
     util::Log() << "Done writing. (" << TIMER_SEC(timer_write_node_weights) << ")";
 
@@ -733,6 +735,7 @@ EdgeID Extractor::BuildEdgeExpandedGraph(
     std::vector<EdgeBasedNodeSegment> &edge_based_node_segments,
     std::vector<bool> &node_is_startpoint,
     std::vector<EdgeWeight> &edge_based_node_weights,
+    std::vector<EdgeDuration> &edge_based_node_durations,
     util::DeallocatingVector<EdgeBasedEdge> &edge_based_edge_list,
     std::uint32_t &connectivity_checksum)
 {
@@ -782,6 +785,7 @@ EdgeID Extractor::BuildEdgeExpandedGraph(
     edge_based_graph_factory.GetEdgeBasedNodeSegments(edge_based_node_segments);
     edge_based_graph_factory.GetStartPointMarkers(node_is_startpoint);
     edge_based_graph_factory.GetEdgeBasedNodeWeights(edge_based_node_weights);
+    edge_based_graph_factory.GetEdgeBasedNodeDurations(edge_based_node_durations);
     connectivity_checksum = edge_based_graph_factory.GetConnectivityChecksum();
 
     return number_of_edge_based_nodes;

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -145,6 +145,12 @@ int Partitioner::Run(const PartitionerConfig &config)
         extractor::files::writeNodeData(config.GetPath(".osrm.ebg_nodes"), node_data);
     }
     {
+        std::vector<EdgeWeight> node_weights;
+        extractor::files::readEdgeBasedNodeWeights(config.GetPath(".osrm.enw"), node_weights);
+        util::inplacePermutation(node_weights.begin(), node_weights.end(), permutation);
+        extractor::files::writeEdgeBasedNodeWeights(config.GetPath(".osrm.enw"), node_weights);
+    }
+    {
         const auto &filename = config.GetPath(".osrm.maneuver_overrides");
         std::vector<extractor::StorageManeuverOverride> maneuver_overrides;
         std::vector<NodeID> node_sequences;

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -146,9 +146,13 @@ int Partitioner::Run(const PartitionerConfig &config)
     }
     {
         std::vector<EdgeWeight> node_weights;
-        extractor::files::readEdgeBasedNodeWeights(config.GetPath(".osrm.enw"), node_weights);
+        std::vector<EdgeDuration> node_durations;
+        extractor::files::readEdgeBasedNodeWeightsDurations(
+            config.GetPath(".osrm.enw"), node_weights, node_durations);
         util::inplacePermutation(node_weights.begin(), node_weights.end(), permutation);
-        extractor::files::writeEdgeBasedNodeWeights(config.GetPath(".osrm.enw"), node_weights);
+        util::inplacePermutation(node_durations.begin(), node_durations.end(), permutation);
+        extractor::files::writeEdgeBasedNodeWeightsDurations(
+            config.GetPath(".osrm.enw"), node_weights, node_durations);
     }
     {
         const auto &filename = config.GetPath(".osrm.maneuver_overrides");

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -554,7 +554,7 @@ void Storage::PopulateUpdatableData(const SharedDataIndex &index)
     {
         auto graph_view = make_multi_level_graph_view(index, "/mld/multilevelgraph");
         std::uint32_t graph_connectivity_checksum = 0;
-        partitioner::files::readGraph(
+        customizer::files::readGraph(
             config.GetPath(".osrm.mldgr"), graph_view, graph_connectivity_checksum);
 
         auto turns_connectivity_checksum =

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -517,24 +517,12 @@ updateConditionalTurns(std::vector<TurnPenalty> &turn_weight_penalties,
     {
         if (IsRestrictionValid(time_zone_handler, penalty))
         {
-            std::cout << "Disabling: " << penalty.turn_offset << std::endl;
             turn_weight_penalties[penalty.turn_offset] = INVALID_TURN_PENALTY;
             updated_turns.push_back(penalty.turn_offset);
         }
     }
     return updated_turns;
 }
-}
-
-Updater::NumNodesAndEdges Updater::LoadAndUpdateEdgeExpandedGraph() const
-{
-    std::vector<EdgeWeight> node_weights;
-    std::vector<extractor::EdgeBasedEdge> edge_based_edge_list;
-    std::uint32_t connectivity_checksum;
-    auto number_of_edge_based_nodes = Updater::LoadAndUpdateEdgeExpandedGraph(
-        edge_based_edge_list, node_weights, connectivity_checksum);
-    return std::make_tuple(
-        number_of_edge_based_nodes, std::move(edge_based_edge_list), connectivity_checksum);
 }
 
 EdgeID
@@ -547,6 +535,8 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
     EdgeID number_of_edge_based_nodes = 0;
     std::vector<util::Coordinate> coordinates;
     extractor::PackedOSMIDs osm_node_ids;
+
+    extractor::files::readEdgeBasedNodeWeights(config.GetPath(".osrm.enw"), node_weights);
 
     extractor::files::readEdgeBasedGraph(config.GetPath(".osrm.ebg"),
                                          number_of_edge_based_nodes,

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -743,12 +743,11 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
                 accumulated_segment_data[updated_iter - updated_segments.begin()];
 
             // Update the node-weight cache. This is the weight of the edge-based-node
-            // only,
-            // it doesn't include the turn. We may visit the same node multiple times,
-            // but
-            // we should always assign the same value here.
-            if (node_weights.size() > 0)
-                node_weights[edge.source] = new_weight;
+            // only, it doesn't include the turn. We may visit the same node multiple times,
+            // but we should always assign the same value here.
+            BOOST_ASSERT(edge.source < node_weights.size());
+            node_weights[edge.source] =
+                node_weights[edge.source] & 0x80000000 ? new_weight | 0x80000000 : new_weight;
 
             // We found a zero-speed edge, so we'll skip this whole edge-based-edge
             // which

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -530,13 +530,25 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
                                         std::vector<EdgeWeight> &node_weights,
                                         std::uint32_t &connectivity_checksum) const
 {
+    std::vector<EdgeDuration> node_durations(node_weights.size());
+    return LoadAndUpdateEdgeExpandedGraph(
+        edge_based_edge_list, node_weights, node_durations, connectivity_checksum);
+}
+
+EdgeID
+Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &edge_based_edge_list,
+                                        std::vector<EdgeWeight> &node_weights,
+                                        std::vector<EdgeDuration> &node_durations,
+                                        std::uint32_t &connectivity_checksum) const
+{
     TIMER_START(load_edges);
 
     EdgeID number_of_edge_based_nodes = 0;
     std::vector<util::Coordinate> coordinates;
     extractor::PackedOSMIDs osm_node_ids;
 
-    extractor::files::readEdgeBasedNodeWeights(config.GetPath(".osrm.enw"), node_weights);
+    extractor::files::readEdgeBasedNodeWeightsDurations(
+        config.GetPath(".osrm.enw"), node_weights, node_durations);
 
     extractor::files::readEdgeBasedGraph(config.GetPath(".osrm.ebg"),
                                          number_of_edge_based_nodes,
@@ -738,6 +750,7 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
             BOOST_ASSERT(edge.source < node_weights.size());
             node_weights[edge.source] =
                 node_weights[edge.source] & 0x80000000 ? new_weight | 0x80000000 : new_weight;
+            node_durations[edge.source] = new_duration;
 
             // We found a zero-speed edge, so we'll skip this whole edge-based-edge
             // which

--- a/unit_tests/engine/offline_facade.cpp
+++ b/unit_tests/engine/offline_facade.cpp
@@ -325,6 +325,11 @@ class ContiguousInternalMemoryDataFacade<routing_algorithms::offline::Algorithm>
         return {};
     }
 
+    EdgeWeight GetNodeWeight(const NodeID /*node*/) const
+    {
+        return 0;
+    }
+
     bool HasLaneData(const EdgeID /*id*/) const override { return false; }
     NameID GetNameIndex(const NodeID /*nodeID*/) const override { return EMPTY_NAMEID; }
     StringView GetNameForID(const NameID /*id*/) const override { return StringView{}; }

--- a/unit_tests/engine/offline_facade.cpp
+++ b/unit_tests/engine/offline_facade.cpp
@@ -325,10 +325,11 @@ class ContiguousInternalMemoryDataFacade<routing_algorithms::offline::Algorithm>
         return {};
     }
 
-    EdgeWeight GetNodeWeight(const NodeID /*node*/) const
-    {
-        return 0;
-    }
+    EdgeWeight GetNodeWeight(const NodeID /*node*/) const { return 0; }
+
+    bool IsForwardEdge(const NodeID /*edge*/) const { return true; }
+
+    bool IsBackwardEdge(const NodeID /*edge*/) const { return true; }
 
     bool HasLaneData(const EdgeID /*id*/) const override { return false; }
     NameID GetNameIndex(const NodeID /*nodeID*/) const override { return EMPTY_NAMEID; }


### PR DESCRIPTION
# Issue

PR implements issue #5027 and can be merged after review, but if #4876 will be merged before then the commit 061a314c3 won't be required.

PR  removes `weight` and `duration`, `forward`, `backward` members from `EdgeBasedGraphEdgeData` and adds a new `customizer::MultiLevelGraph` that has `node_weights`, `node_weights`, `is_forward_edge`, `is_backward_edge` vectors that are used now to compute edge weights and durations as a sum of node weights and turn penalties. The size of `.osrm.mldgr` files for `california-latest.osm.pbf` changes from 382468608 to 254924800 bytes or 33% reduction.

Performance check on `california-latest.osm.pbf` with random A->B routes does not show regression:
![compare](https://user-images.githubusercontent.com/4421046/39135679-c6b1027c-4719-11e8-9a0b-de6188c80ea0.png)

In addition PR fixes two issues:
* e637d6963 adds an exception throw if a shared region is not found to prevent UB
* cda8b1b28 uses the sign bit of node weight to mark oneway streets and correctly set node weight value to `INVALID_EDGE_WEIGHT` if the value was updated. The change must fix bugs with missing routes after traffic updates in CH algorithm.

/cc @TheMarex @freenerd 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

#4876
