### PR TITLE
Allow excluding ferries on bicycle profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
     - Infrastructure:
       - ADDED: Updated libosmium and added protozero and vtzero libraries [#5037](https://github.com/Project-OSRM/osrm-backend/pull/5037)
       - CHANGED: Use vtzero library in tile plugin [#4686](https://github.com/Project-OSRM/osrm-backend/pull/4686)
+    - Profile:
+      - ADDED: Bicycle profile now returns classes for ferry and tunnel routes. [#5054](https://github.com/Project-OSRM/osrm-backend/pull/5054)
+      - ADDED: Bicycle profile allows to exclude ferry routes (default to not enabled) [#5054](https://github.com/Project-OSRM/osrm-backend/pull/5054)
 
 # 5.17.1
   - Changes from 5.17.0:

--- a/features/bicycle/classes.feature
+++ b/features/bicycle/classes.feature
@@ -1,0 +1,92 @@
+@routing @bicycle @mode
+Feature: Bicycle - Mode flag
+    Background:
+        Given the profile "bicycle"
+
+    Scenario: Bicycle - We tag ferries with a class
+        Given the node map
+            """
+            a b
+              c d
+            """
+
+        And the ways
+            | nodes | highway | route |
+            | ab    | primary |       |
+            | bc    |         | ferry |
+            | cd    | primary |       |
+
+        When I route I should get
+            | from | to | route       | turns                                              | classes                  |
+            | a    | d  | ab,bc,cd,cd | depart,notification right,notification left,arrive | [()],[(ferry)],[()],[()] |
+            | d    | a  | cd,bc,ab,ab | depart,notification right,notification left,arrive | [()],[(ferry)],[()],[()] |
+            | c    | a  | bc,ab,ab    | depart,notification left,arrive                    | [(ferry)],[()],[()]      |
+            | d    | b  | cd,bc,bc    | depart,notification right,arrive                   | [()],[(ferry)],[()]      |
+            | a    | c  | ab,bc,bc    | depart,notification right,arrive                   | [()],[(ferry)],[()]      |
+            | b    | d  | bc,cd,cd    | depart,notification left,arrive                    | [(ferry)],[()],[()]      |
+
+    Scenario: Bicycle - We tag tunnel with a class
+        Background:
+            Given a grid size of 200 meters
+
+        Given the node map
+            """
+            a b
+              c d
+            """
+
+        And the ways
+            | nodes | tunnel               |
+            | ab    | no                   |
+            | bc    | yes                  |
+            | cd    |                      |
+
+        When I route I should get
+            | from | to | route       | turns                                      | classes                   |
+            | a    | d  | ab,bc,cd,cd | depart,new name right,new name left,arrive | [()],[(tunnel)],[()],[()] |
+
+    Scenario: Bicycle - We tag classes without intersections
+        Background:
+            Given a grid size of 200 meters
+
+        Given the node map
+            """
+            a b c d
+            """
+
+        And the ways
+            | nodes | name | tunnel |
+            | ab    | road |        |
+            | bc    | road | yes    |
+            | cd    | road |        |
+
+        When I route I should get
+          | from | to | route     | turns         | classes               |
+          | a    | d  | road,road | depart,arrive | [(),(tunnel),()],[()] |
+
+    Scenario: Bicycle - From roundabout on ferry
+        Given the node map
+            """
+                     c
+                  /     \
+            a---b         d---f--h
+                  \     /
+                     e
+                     |
+                     g
+            """
+
+        And the ways
+            | nodes | oneway | highway | junction   | route    |
+            | ab    | yes    | service |            |          |
+            | cb    | yes    | service | roundabout |          |
+            | dc    | yes    | service | roundabout |          |
+            | be    | yes    | service | roundabout |          |
+            | ed    | yes    | service | roundabout |          |
+            | eg    | yes    | service |            |          |
+            | df    |        |         |            | ferry    |
+            | fh    | yes    | service |            |          |
+
+        When I route I should get
+            | from | to | route          | turns                                                                              | classes                          |
+            | a    | h  | ab,df,df,fh,fh | depart,roundabout-exit-2,exit roundabout slight right,notification straight,arrive | [()],[(),()],[(ferry)],[()],[()] |

--- a/features/bicycle/exclude.feature
+++ b/features/bicycle/exclude.feature
@@ -1,0 +1,55 @@
+@routing @bicycle @exclude
+Feature: Bicycle - Exclude flags
+    Background:
+        Given the profile file "bicycle" initialized with
+        """
+        profile.excludable = Sequence { Set { 'ferry' } }
+        """
+        Given the node map
+            """
+            a....b~~~~~c...f
+                 :     :
+                 d.....e
+            """
+
+        And the ways
+            | nodes | highway  | route | duration | #                                           |
+            | ab    | service  |       |          | always drivable                             |
+            | bc    |          | ferry | 00:00:01 | not drivable for exclude=ferry, but fast.   |
+            | bd    | service  |       |          | always drivable                             |
+            | de    | service  |       |          | always drivable                             |
+            | ec    | service  |       |          | always drivable                             |
+            | cf    | service  |       |          | always drivable                             |
+
+    Scenario: Bicycle - exclude nothing
+        When I route I should get
+            | from | to | route          |
+            | a    | f  | ab,bc,cf,cf    |
+
+        When I match I should get
+            | trace | matchings | duration |
+            | abcf  | abcf      | 109      |
+
+        When I request a travel time matrix I should get
+            |   | a   | f   |
+            | a | 0   | 109 |
+            | f | 109 | 0   |
+
+    Scenario: Bicycle - exclude ferry
+        Given the query options
+            | exclude  | ferry        |
+
+        When I route I should get
+            | from | to | route             |
+            | a    | f  | ab,bd,de,ec,cf,cf |
+
+        When I match I should get
+            | trace | matchings | duration |
+            | abcf  | abcf      | 301.2    |
+
+        When I request a travel time matrix I should get
+            |   | a          | f        |
+            | a | 0          | 301 +- 1 |
+            | f | 301.2 +- 1 | 0        |
+
+

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -193,6 +193,16 @@ function setup()
       sett = 10
     },
 
+    classes = Sequence {
+        'ferry', 'tunnel'
+    },
+
+    -- Which classes should be excludable
+    -- This increases memory usage so its disabled by default.
+    excludable = Sequence {
+--        Set {'ferry'}
+    },
+
     tracktype_speeds = {
     },
 
@@ -649,6 +659,9 @@ function process_way(profile, way, result)
 
     -- set name, ref and pronunciation
     WayHandlers.names,
+
+    -- set classes
+    WayHandlers.classes,
 
     -- set weight properties of the way
     WayHandlers.weights

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -306,37 +306,46 @@ end
 
 -- add class information
 function WayHandlers.classes(profile,way,result,data)
+    if not profile.classes then
+        return
+    end
+
+    local allowed_classes = Set {}
+    for k, v in pairs(profile.classes) do
+        allowed_classes[v] = true
+    end
+
     local forward_toll, backward_toll = Tags.get_forward_backward_by_key(way, data, "toll")
     local forward_route, backward_route = Tags.get_forward_backward_by_key(way, data, "route")
     local tunnel = way:get_value_by_key("tunnel")
 
-    if tunnel and tunnel ~= "no" then
+    if allowed_classes["tunnel"] and tunnel and tunnel ~= "no" then
       result.forward_classes["tunnel"] = true
       result.backward_classes["tunnel"] = true
     end
 
-    if forward_toll == "yes" then
+    if allowed_classes["toll"] and forward_toll == "yes" then
         result.forward_classes["toll"] = true
     end
-    if backward_toll == "yes" then
+    if allowed_classes["toll"] and backward_toll == "yes" then
         result.backward_classes["toll"] = true
     end
 
-    if forward_route == "ferry" then
+    if allowed_classes["ferry"] and forward_route == "ferry" then
         result.forward_classes["ferry"] = true
     end
-    if backward_route == "ferry" then
+    if allowed_classes["ferry"] and backward_route == "ferry" then
         result.backward_classes["ferry"] = true
     end
 
-    if result.forward_restricted then
+    if allowed_classes["restricted"] and result.forward_restricted then
         result.forward_classes["restricted"] = true
     end
-    if result.backward_restricted then
+    if allowed_classes["restricted"] and result.backward_restricted then
         result.backward_classes["restricted"] = true
     end
 
-    if data.highway == "motorway" or data.highway == "motorway_link" then
+    if allowed_classes["motorway"] and (data.highway == "motorway" or data.highway == "motorway_link") then
         result.forward_classes["motorway"] = true
         result.backward_classes["motorway"] = true
     end


### PR DESCRIPTION
# Issue

This PR allows excluding ferries for bicycle routes. This is not enabled by default, just another option for the bicycle profile. A side-effect is that we now also return classes for the bicycle profile which is helpful for navigation.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] review
 - [x] adjust for comments
