### PR TITLE
Improve speed of Map Matching

### DIFF
--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -321,24 +321,10 @@ void annotatePath(const FacadeT &facade,
     }
 }
 
-template <typename Algorithm>
-double getPathDistance(const DataFacade<Algorithm> &facade,
-                       const std::vector<PathData> &unpacked_path,
-                       const PhantomNode &source_phantom,
-                       const PhantomNode &target_phantom)
-{
-    double distance = 0;
-    auto prev_coordinate = source_phantom.location;
-    for (const auto &p : unpacked_path)
-    {
-        const auto current_coordinate = facade.GetCoordinateOfNode(p.turn_via_node);
-        distance += util::coordinate_calculation::fccApproximateDistance(prev_coordinate, current_coordinate);
-        prev_coordinate = current_coordinate;
-    }
-    distance += util::coordinate_calculation::fccApproximateDistance(prev_coordinate, target_phantom.location);
-
-    return distance;
-}
+void adjustPathDistanceToPhantomNodes(const std::vector<NodeID> &path,
+                                      const PhantomNode &source_phantom,
+                                      const PhantomNode &target_phantom,
+                                      EdgeDistance &distance);
 
 template <typename AlgorithmT>
 InternalRouteResult extractRoute(const DataFacade<AlgorithmT> &facade,

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -44,50 +44,18 @@ bool needsLoopBackwards(const PhantomNode &source_phantom, const PhantomNode &ta
 bool needsLoopForward(const PhantomNodes &phantoms);
 bool needsLoopBackwards(const PhantomNodes &phantoms);
 
-template <typename Heap>
-void insertNodesInHeaps(Heap &forward_heap, Heap &reverse_heap, const PhantomNodes &nodes)
+namespace detail
 {
-    const auto &source = nodes.source_phantom;
-    if (source.IsValidForwardSource())
-    {
-        forward_heap.Insert(source.forward_segment_id.id,
-                            -source.GetForwardWeightPlusOffset(),
-                            source.forward_segment_id.id);
-    }
-
-    if (source.IsValidReverseSource())
-    {
-        forward_heap.Insert(source.reverse_segment_id.id,
-                            -source.GetReverseWeightPlusOffset(),
-                            source.reverse_segment_id.id);
-    }
-
-    const auto &target = nodes.target_phantom;
-    if (target.IsValidForwardTarget())
-    {
-        reverse_heap.Insert(target.forward_segment_id.id,
-                            target.GetForwardWeightPlusOffset(),
-                            target.forward_segment_id.id);
-    }
-
-    if (target.IsValidReverseTarget())
-    {
-        reverse_heap.Insert(target.reverse_segment_id.id,
-                            target.GetReverseWeightPlusOffset(),
-                            target.reverse_segment_id.id);
-    }
-}
-
-template <typename ManyToManyQueryHeap>
-void insertSourceInHeap(ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+template <typename Algorithm>
+void insertSourceInHeap(typename SearchEngineData<Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
 {
-    if (phantom_node.IsValidForwardSource())
+    if (phantom_node.IsValidForwardTarget())
     {
         heap.Insert(phantom_node.forward_segment_id.id,
                     -phantom_node.GetForwardWeightPlusOffset(),
                     {phantom_node.forward_segment_id.id, -phantom_node.GetForwardDuration()});
     }
-    if (phantom_node.IsValidReverseSource())
+    if (phantom_node.IsValidReverseTarget())
     {
         heap.Insert(phantom_node.reverse_segment_id.id,
                     -phantom_node.GetReverseWeightPlusOffset(),
@@ -95,8 +63,8 @@ void insertSourceInHeap(ManyToManyQueryHeap &heap, const PhantomNode &phantom_no
     }
 }
 
-template <typename ManyToManyQueryHeap>
-void insertTargetInHeap(ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+template <typename Algorithm>
+void insertTargetInHeap(typename SearchEngineData<Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
 {
     if (phantom_node.IsValidForwardTarget())
     {
@@ -109,6 +77,98 @@ void insertTargetInHeap(ManyToManyQueryHeap &heap, const PhantomNode &phantom_no
         heap.Insert(phantom_node.reverse_segment_id.id,
                     phantom_node.GetReverseWeightPlusOffset(),
                     {phantom_node.reverse_segment_id.id, phantom_node.GetReverseDuration()});
+    }
+}
+
+template <typename Algorithm>
+void insertSourceInHeap(typename SearchEngineData<Algorithm>::QueryHeap &heap, const PhantomNode &phantom_node)
+{
+    if (phantom_node.IsValidForwardSource())
+    {
+        heap.Insert(phantom_node.forward_segment_id.id,
+                    -phantom_node.GetForwardWeightPlusOffset(),
+                    phantom_node.forward_segment_id.id);
+    }
+    if (phantom_node.IsValidReverseSource())
+    {
+        heap.Insert(phantom_node.reverse_segment_id.id,
+                    -phantom_node.GetReverseWeightPlusOffset(),
+                    phantom_node.reverse_segment_id.id);
+    }
+}
+
+template <typename Algorithm>
+void insertTargetInHeap(typename SearchEngineData<Algorithm>::QueryHeap &heap, const PhantomNode &phantom_node)
+{
+    if (phantom_node.IsValidForwardTarget())
+    {
+        heap.Insert(phantom_node.forward_segment_id.id,
+                    phantom_node.GetForwardWeightPlusOffset(),
+                    phantom_node.forward_segment_id.id);
+    }
+    if (phantom_node.IsValidReverseTarget())
+    {
+        heap.Insert(phantom_node.reverse_segment_id.id,
+                    phantom_node.GetReverseWeightPlusOffset(),
+                    phantom_node.reverse_segment_id.id);
+    }
+}
+}
+
+inline void insertTargetInHeap(typename SearchEngineData<mld::Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertTargetInHeap<mld::Algorithm>(heap, phantom_node);
+}
+inline void insertTargetInHeap(typename SearchEngineData<ch::Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertTargetInHeap<ch::Algorithm>(heap, phantom_node);
+}
+inline void insertTargetInHeap(typename SearchEngineData<mld::Algorithm>::QueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertTargetInHeap<mld::Algorithm>(heap, phantom_node);
+}
+inline void insertTargetInHeap(typename SearchEngineData<ch::Algorithm>::QueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertTargetInHeap<ch::Algorithm>(heap, phantom_node);
+}
+inline void insertSourceInHeap(typename SearchEngineData<mld::Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertSourceInHeap<mld::Algorithm>(heap, phantom_node);
+}
+inline void insertSourceInHeap(typename SearchEngineData<ch::Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertSourceInHeap<ch::Algorithm>(heap, phantom_node);
+}
+inline void insertSourceInHeap(typename SearchEngineData<mld::Algorithm>::QueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertSourceInHeap<mld::Algorithm>(heap, phantom_node);
+}
+inline void insertSourceInHeap(typename SearchEngineData<ch::Algorithm>::QueryHeap &heap, const PhantomNode &phantom_node)
+{
+    detail::insertSourceInHeap<ch::Algorithm>(heap, phantom_node);
+}
+
+template <typename Heap>
+void insertNodesInHeaps(Heap &forward_heap, Heap &reverse_heap, const PhantomNodes &nodes)
+{
+    insertSourceInHeap(forward_heap, nodes.source_phantom);
+    insertTargetInHeap(reverse_heap, nodes.target_phantom);
+}
+
+template <typename Algorithm>
+void insertSourceInHeap(typename SearchEngineData<Algorithm>::ManyToManyQueryHeap &heap, const PhantomNode &phantom_node)
+{
+    if (phantom_node.IsValidForwardSource())
+    {
+        heap.Insert(phantom_node.forward_segment_id.id,
+                    -phantom_node.GetForwardWeightPlusOffset(),
+                    {phantom_node.forward_segment_id.id, -phantom_node.GetForwardDuration()});
+    }
+    if (phantom_node.IsValidReverseSource())
+    {
+        heap.Insert(phantom_node.reverse_segment_id.id,
+                    -phantom_node.GetReverseWeightPlusOffset(),
+                    {phantom_node.reverse_segment_id.id, -phantom_node.GetReverseDuration()});
     }
 }
 

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -323,53 +323,19 @@ void annotatePath(const FacadeT &facade,
 
 template <typename Algorithm>
 double getPathDistance(const DataFacade<Algorithm> &facade,
-                       const std::vector<PathData> unpacked_path,
+                       const std::vector<PathData> &unpacked_path,
                        const PhantomNode &source_phantom,
                        const PhantomNode &target_phantom)
 {
-    using util::coordinate_calculation::detail::DEGREE_TO_RAD;
-    using util::coordinate_calculation::detail::EARTH_RADIUS;
-
     double distance = 0;
-    double prev_lat =
-        static_cast<double>(util::toFloating(source_phantom.location.lat)) * DEGREE_TO_RAD;
-    double prev_lon =
-        static_cast<double>(util::toFloating(source_phantom.location.lon)) * DEGREE_TO_RAD;
-    double prev_cos = std::cos(prev_lat);
+    auto prev_coordinate = source_phantom.location;
     for (const auto &p : unpacked_path)
     {
         const auto current_coordinate = facade.GetCoordinateOfNode(p.turn_via_node);
-
-        const double current_lat =
-            static_cast<double>(util::toFloating(current_coordinate.lat)) * DEGREE_TO_RAD;
-        const double current_lon =
-            static_cast<double>(util::toFloating(current_coordinate.lon)) * DEGREE_TO_RAD;
-        const double current_cos = std::cos(current_lat);
-
-        const double sin_dlon = std::sin((prev_lon - current_lon) / 2.0);
-        const double sin_dlat = std::sin((prev_lat - current_lat) / 2.0);
-
-        const double aharv = sin_dlat * sin_dlat + prev_cos * current_cos * sin_dlon * sin_dlon;
-        const double charv = 2. * std::atan2(std::sqrt(aharv), std::sqrt(1.0 - aharv));
-        distance += EARTH_RADIUS * charv;
-
-        prev_lat = current_lat;
-        prev_lon = current_lon;
-        prev_cos = current_cos;
+        distance += util::coordinate_calculation::fccApproximateDistance(prev_coordinate, current_coordinate);
+        prev_coordinate = current_coordinate;
     }
-
-    const double current_lat =
-        static_cast<double>(util::toFloating(target_phantom.location.lat)) * DEGREE_TO_RAD;
-    const double current_lon =
-        static_cast<double>(util::toFloating(target_phantom.location.lon)) * DEGREE_TO_RAD;
-    const double current_cos = std::cos(current_lat);
-
-    const double sin_dlon = std::sin((prev_lon - current_lon) / 2.0);
-    const double sin_dlat = std::sin((prev_lat - current_lat) / 2.0);
-
-    const double aharv = sin_dlat * sin_dlat + prev_cos * current_cos * sin_dlon * sin_dlon;
-    const double charv = 2. * std::atan2(std::sqrt(aharv), std::sqrt(1.0 - aharv));
-    distance += EARTH_RADIUS * charv;
+    distance += util::coordinate_calculation::fccApproximateDistance(prev_coordinate, target_phantom.location);
 
     return distance;
 }

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -65,7 +65,7 @@ inline bool checkParentCellRestriction(CellID cell, LevelID, CellID parent)
 {
     return cell == parent;
 }
-}
+} // namespace
 
 // Heaps only record for each node its predecessor ("parent") on the shortest path.
 // For re-constructing the actual path we need to trace back all parent "pointers".
@@ -494,11 +494,20 @@ double getNetworkDistance(SearchEngineData<Algorithm> &engine_working_data,
         return std::numeric_limits<double>::max();
     }
 
-    std::vector<PathData> unpacked_path;
+    EdgeDistance distance = 0;
 
-    annotatePath(facade, phantom_nodes, unpacked_nodes, unpacked_edges, unpacked_path);
+    if (!unpacked_nodes.empty())
+    {
+        for (auto node_iter = unpacked_nodes.begin(); node_iter != std::prev(unpacked_nodes.end()); node_iter++)
+        {
+            distance += computeEdgeDistance(facade, *node_iter);
+        }
+    }
 
-    return getPathDistance(facade, unpacked_path, source_phantom, target_phantom);
+    adjustPathDistanceToPhantomNodes(
+        unpacked_nodes, phantom_nodes.source_phantom, phantom_nodes.target_phantom, distance);
+
+    return distance / 10.;
 }
 
 } // namespace mld

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -471,11 +471,7 @@ double getNetworkDistance(SearchEngineData<Algorithm> &engine_working_data,
                           const PhantomNode &target_phantom,
                           EdgeWeight weight_upper_bound = INVALID_EDGE_WEIGHT)
 {
-    forward_heap.Clear();
-    reverse_heap.Clear();
-
     const PhantomNodes phantom_nodes{source_phantom, target_phantom};
-    insertNodesInHeaps(forward_heap, reverse_heap, phantom_nodes);
 
     EdgeWeight weight = INVALID_EDGE_WEIGHT;
     std::vector<NodeID> unpacked_nodes;

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -23,9 +23,6 @@ namespace detail
 {
 const constexpr double DEGREE_TO_RAD = 0.017453292519943295769236907684886;
 const constexpr double RAD_TO_DEGREE = 1. / DEGREE_TO_RAD;
-// earth radius varies between 6,356.750-6,378.135 km (3,949.901-3,963.189mi)
-// The IUGG value for the equatorial radius is 6378.137 km (3963.19 miles)
-const constexpr long double EARTH_RADIUS = 6372797.560856;
 
 inline double degToRad(const double degree)
 {

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -227,6 +227,9 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
                 {
                     continue;
                 }
+                forward_heap.Clear();
+                const auto& source_phantom = prev_unbroken_timestamps_list[s].phantom_node;
+                insertSourceInHeap(forward_heap, source_phantom);
 
                 for (const auto s_prime : util::irange<std::size_t>(0UL, current_viterbi.size()))
                 {
@@ -237,13 +240,17 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
                         continue;
                     }
 
+                    reverse_heap.Clear();
+                    const auto &target_phantom = current_timestamps_list[s_prime].phantom_node;
+                    insertTargetInHeap(reverse_heap, target_phantom);
+
                     double network_distance =
                         getNetworkDistance(engine_working_data,
                                            facade,
                                            forward_heap,
                                            reverse_heap,
-                                           prev_unbroken_timestamps_list[s].phantom_node,
-                                           current_timestamps_list[s_prime].phantom_node,
+                                           source_phantom,
+                                           target_phantom,
                                            weight_upper_bound);
 
                     // get distance diff between loc1/2 and locs/s_prime

--- a/src/engine/routing_algorithms/routing_base.cpp
+++ b/src/engine/routing_algorithms/routing_base.cpp
@@ -33,6 +33,72 @@ bool needsLoopBackwards(const PhantomNodes &phantoms)
     return needsLoopBackwards(phantoms.source_phantom, phantoms.target_phantom);
 }
 
+void adjustPathDistanceToPhantomNodes(const std::vector<NodeID> &path,
+                                      const PhantomNode &source_phantom,
+                                      const PhantomNode &target_phantom,
+                                      EdgeDistance &distance)
+{
+    if (!path.empty())
+    {
+
+        // check the direction of travel to figure out how to calculate the offset to/from
+        // the source/target
+        if (source_phantom.forward_segment_id.id == path.front())
+        {
+            //       ............       <-- calculateEGBAnnotation returns distance from 0 to 3
+            //       -->s               <-- subtract offset to start at source
+            //          .........       <-- want this distance as result
+            // entry 0---1---2---3---   <-- 3 is exit node
+            distance -= source_phantom.GetForwardDistance();
+        }
+        else if (source_phantom.reverse_segment_id.id == path.front())
+        {
+            //       ............    <-- calculateEGBAnnotation returns distance from 0 to 3
+            //          s<-------    <-- subtract offset to start at source
+            //       ...             <-- want this distance
+            // entry 0---1---2---3   <-- 3 is exit node
+            distance -= source_phantom.GetReverseDistance();
+        }
+        if (target_phantom.forward_segment_id.id == path.back())
+        {
+            //       ............       <-- calculateEGBAnnotation returns distance from 0 to 3
+            //                   ++>t   <-- add offset to get to target
+            //       ................   <-- want this distance as result
+            // entry 0---1---2---3---   <-- 3 is exit node
+            distance += target_phantom.GetForwardDistance();
+        }
+        else if (target_phantom.reverse_segment_id.id == path.back())
+        {
+            //       ............       <-- calculateEGBAnnotation returns distance from 0 to 3
+            //                   <++t   <-- add offset to get from target
+            //       ................   <-- want this distance as result
+            // entry 0---1---2---3---   <-- 3 is exit node
+            distance += target_phantom.GetReverseDistance();
+        }
+    }
+    else
+    {
+        // there is no shortcut to unpack. source and target are on the same EBG Node.
+        // if the offset of the target is greater than the offset of the source, subtract it
+        if (target_phantom.GetForwardDistance() > source_phantom.GetForwardDistance())
+        {
+            //       --------->t        <-- offsets
+            //       ->s                <-- subtract source offset from target offset
+            //         .........        <-- want this distance as result
+            // entry 0---1---2---3---   <-- 3 is exit node
+            distance = target_phantom.GetForwardDistance() - source_phantom.GetForwardDistance();
+        }
+        else
+        {
+            //               s<---      <-- offsets
+            //         t<---------      <-- subtract source offset from target offset
+            //         ......           <-- want this distance as result
+            // entry 0---1---2---3---   <-- 3 is exit node
+            distance = target_phantom.GetReverseDistance() - source_phantom.GetReverseDistance();
+        }
+    }
+}
+
 } // namespace routing_algorithms
 } // namespace engine
 } // namespace osrm

--- a/src/engine/routing_algorithms/routing_base_ch.cpp
+++ b/src/engine/routing_algorithms/routing_base_ch.cpp
@@ -176,11 +176,6 @@ double getNetworkDistance(SearchEngineData<Algorithm> &engine_working_data,
                           const PhantomNode &target_phantom,
                           EdgeWeight weight_upper_bound)
 {
-    forward_heap.Clear();
-    reverse_heap.Clear();
-
-    insertNodesInHeaps(forward_heap, reverse_heap, {source_phantom, target_phantom});
-
     EdgeWeight weight = INVALID_EDGE_WEIGHT;
     std::vector<NodeID> packed_path;
     search(engine_working_data,

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -22,6 +22,11 @@ namespace coordinate_calculation
 
 namespace
 {
+
+// earth radius varies between 6,356.750-6,378.135 km (3,949.901-3,963.189mi)
+// The IUGG value for the equatorial radius is 6378.137 km (3963.19 miles)
+const constexpr long double EARTH_RADIUS = 6372797.560856;
+
 class CheapRulerContainer
 {
   public:
@@ -112,7 +117,7 @@ double haversineDistance(const Coordinate coordinate_1, const Coordinate coordin
     const double aharv = std::pow(std::sin(dlat / 2.0), 2.0) +
                          std::cos(dlat1) * std::cos(dlat2) * std::pow(std::sin(dlong / 2.), 2);
     const double charv = 2. * std::atan2(std::sqrt(aharv), std::sqrt(1.0 - aharv));
-    return detail::EARTH_RADIUS * charv;
+    return EARTH_RADIUS * charv;
 }
 
 double greatCircleDistance(const Coordinate coordinate_1, const Coordinate coordinate_2)
@@ -133,7 +138,7 @@ double greatCircleDistance(const Coordinate coordinate_1, const Coordinate coord
 
     const double x_value = (float_lon2 - float_lon1) * std::cos((float_lat1 + float_lat2) / 2.0);
     const double y_value = float_lat2 - float_lat1;
-    return std::hypot(x_value, y_value) * detail::EARTH_RADIUS;
+    return std::hypot(x_value, y_value) * EARTH_RADIUS;
 }
 
 double perpendicularDistance(const Coordinate segment_source,


### PR DESCRIPTION
# Issue

This PR optimizes the map matching plugin for speed. It uses two things to do that:
- The distance annotation work and improved distance calculation speed
- Caching the forward search space for every state transition.

For my test trace this yielded a speedup of 50%.

## Tasklist

 - [ ] run benchmark on real traces with bigger dataset 
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
