### PR TITLE
Don't collapse segregated intersections at roundabout exits, #5114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # UNRELEASED
+  - Changes from 5.18.0:
+    - Bugfixes:
+      - FIXED: collapsing of ExitRoundabout instructions [#5114](https://github.com/Project-OSRM/osrm-backend/issues/5114)
+
+# 5.18.0
   - Changes from 5.17.0:
     - Features:
       - ADDED: `table` plugin now optionally returns `distance` matrix as part of response [#4990](https://github.com/Project-OSRM/osrm-backend/pull/4990)

--- a/src/engine/guidance/collapse_turns.cpp
+++ b/src/engine/guidance/collapse_turns.cpp
@@ -621,6 +621,7 @@ RouteSteps collapseSegregatedTurnInstructions(RouteSteps steps)
         // else if the current step is segregated and the next step is not segregated
         // and the next step is not a roundabout then combine with turn adjustment
         else if (curr_step->is_segregated && !next_step->is_segregated &&
+                 !hasRoundaboutType(curr_step->maneuver.instruction) &&
                  !hasRoundaboutType(next_step->maneuver.instruction))
         {
             // Determine if u-turn


### PR DESCRIPTION
# Issue

Fixes #5114: roundabout instructions must not be collapsed as for segregated intersections.

Local results:
![screenshot from 2018-06-21 14-06-02](https://user-images.githubusercontent.com/4421046/41718178-86002020-755c-11e8-871a-7806614f5334.png)



## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
