### PR TITLE
refactor match service response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
   - Changes from 5.18.0:
+    - API:
+      - CHANGED: refactor property `matchings_index` to `matching_index` in `tracepoints` object of `match` service response
+      - CHANGED: refactor property `waypoint_index` to `leg_index` in `tracepoints` object of `match` service response
     - Bugfixes:
       - FIXED: collapsing of ExitRoundabout instructions [#5114](https://github.com/Project-OSRM/osrm-backend/issues/5114)
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -428,8 +428,8 @@ The area to search is chosen such that the correct candidate should be considere
 - `tracepoints`: Array of `Waypoint` objects representing all points of the trace in order.
   If the trace point was ommited by map matching because it is an outlier, the entry will be `null`.
   Each `Waypoint` object has the following additional properties:
-  - `matchings_index`: Index to the `Route` object in `matchings` the sub-trace was matched to.
-  - `waypoint_index`: Index of the waypoint inside the matched route.
+  - `matching_index`: Index to the `Route` object in `matchings` the sub-trace was matched to.
+  - `leg_index`: Index to the `Leg` object inside the matched route.
   - `alternatives_count`: Number of probable alternative matchings for this trace point. A value of zero indicate that this point was matched unambiguously. Split the trace at these points for incremental map matching.
 - `matchings`: An array of `Route` objects that assemble the trace. Each `Route` object has the following additional properties:
   - `confidence`: Confidence of the matching. `float` value between 0 and 1. 1 is very confident that the matching is correct.

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -224,9 +224,9 @@ osrm.match(options, function(err, response) {
 Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** containing `tracepoints` and `matchings`.
 **`tracepoints`** Array of [`Ẁaypoint`](#waypoint) objects representing all points of the trace in order.
                   If the trace point was ommited by map matching because it is an outlier, the entry will be null.
-                  Each `Waypoint` object includes two additional properties, 1) `matchings_index`: Index to the
-                  [`Route`](#route) object in matchings the sub-trace was matched to, 2) `waypoint_index`: Index of
-                  the waypoint inside the matched route.
+                  Each `Waypoint` object includes two additional properties, 1) `matching_index`: Index to the
+                  [`Route`](#route) object in matchings the sub-trace was matched to, 2) `leg_index`: Index to the
+                  [`Leg`](#leg) object inside the matched route.
 **`matchings`** is an array of [`Route`](#route) objects that assemble the trace. Each `Route` object has an additional `confidence` property,
                 which is the confidence of the matching. float value between `0` and `1`. `1` is very confident that the matching is correct.
 

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -59,7 +59,7 @@ module.exports = function () {
                             for(var i = start_index; i < json.tracepoints.length; i++){
                                 if (json.tracepoints[i] === null) continue;
 
-                                let current_index = json.tracepoints[i].matchings_index;
+                                let current_index = json.tracepoints[i].matching_index;
 
                                 if(prev_index !== current_index) {
                                     if (sub.length > 0) subMatchings.push(sub);
@@ -191,7 +191,7 @@ module.exports = function () {
                         var got_loc = [];
                         for (let i = 0; i < json.tracepoints.length; i++) {
                             if (!json.tracepoints[i]) continue;
-                            if (json.tracepoints[i].waypoint_index != null)
+                            if (json.tracepoints[i].leg_index != null)
                                 got_loc.push(json.tracepoints[i].location);
                         }
 

--- a/include/engine/api/match_api.hpp
+++ b/include/engine/api/match_api.hpp
@@ -116,8 +116,8 @@ class MatchAPI final : public RouteAPI
             const auto &phantom =
                 sub_matchings[matching_index.sub_matching_index].nodes[matching_index.point_index];
             auto waypoint = BaseAPI::MakeWaypoint(phantom);
-            waypoint.values["matchings_index"] = matching_index.sub_matching_index;
-            waypoint.values["waypoint_index"] = matching_index.point_index;
+            waypoint.values["matching_index"] = matching_index.sub_matching_index;
+            waypoint.values["leg_index"] = matching_index.point_index;
             waypoint.values["alternatives_count"] =
                 sub_matchings[matching_index.sub_matching_index]
                     .alternatives_count[matching_index.point_index];
@@ -127,12 +127,12 @@ class MatchAPI final : public RouteAPI
             {
                 if (tidy_result.was_waypoint[trace_index])
                 {
-                    waypoint.values["waypoint_index"] = was_waypoint_idx;
+                    waypoint.values["leg_index"] = was_waypoint_idx;
                     was_waypoint_idx++;
                 }
                 else
                 {
-                    waypoint.values["waypoint_index"] = util::json::Null();
+                    waypoint.values["leg_index"] = util::json::Null();
                 }
             }
             waypoints.values.push_back(std::move(waypoint));

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -373,9 +373,9 @@ NAN_METHOD(Engine::tile)
  * @returns {Object} containing `tracepoints` and `matchings`.
  * **`tracepoints`** Array of [`Ẁaypoint`](#waypoint) objects representing all points of the trace in order.
  *                   If the trace point was ommited by map matching because it is an outlier, the entry will be null.
- *                   Each `Waypoint` object includes two additional properties, 1) `matchings_index`: Index to the
- *                   [`Route`](#route) object in matchings the sub-trace was matched to, 2) `waypoint_index`: Index of
- *                   the waypoint inside the matched route.
+ *                   Each `Waypoint` object includes two additional properties, 1) `matching_index`: Index to the
+ *                   [`Route`](#route) object in matchings the sub-trace was matched to, 2) `leg_index`: Index to the
+ *                   [`Leg`](#leg) object inside the matched route.
  * **`matchings`** is an array of [`Route`](#route) objects that assemble the trace. Each `Route` object has an additional `confidence` property,
  *                 which is the confidence of the matching. float value between `0` and `1`. `1` is very confident that the matching is correct.
  *

--- a/test/nodejs/match.js
+++ b/test/nodejs/match.js
@@ -20,7 +20,7 @@ test('match: match in Monaco', function(assert) {
         }))
         assert.equal(response.tracepoints.length, 3);
         assert.ok(response.tracepoints.every(function(t) {
-            return !!t.hint && !isNaN(t.matchings_index) && !isNaN(t.waypoint_index) && !!t.name;
+            return !!t.hint && !isNaN(t.matching_index) && !isNaN(t.leg_index) && !!t.name;
         }));
     });
 });
@@ -320,7 +320,7 @@ test('match: match in Monaco with waypoints', function(assert) {
         }))
         assert.equal(response.tracepoints.length, 3);
         assert.ok(response.tracepoints.every(function(t) {
-            return !!t.hint && !isNaN(t.matchings_index) && !isNaN(t.waypoint_index) && !!t.name;
+            return !!t.hint && !isNaN(t.matching_index) && !isNaN(t.leg_index) && !!t.name;
         }));
     });
 });

--- a/unit_tests/library/match.cpp
+++ b/unit_tests/library/match.cpp
@@ -45,17 +45,17 @@ BOOST_AUTO_TEST_CASE(test_match)
         {
             BOOST_CHECK(waypoint_check(waypoint));
             const auto &waypoint_object = waypoint.get<json::Object>();
-            const auto matchings_index =
-                waypoint_object.values.at("matchings_index").get<json::Number>().value;
-            const auto waypoint_index =
-                waypoint_object.values.at("waypoint_index").get<json::Number>().value;
-            const auto &route_legs = matchings[matchings_index]
+            const auto matching_index =
+                waypoint_object.values.at("matching_index").get<json::Number>().value;
+            const auto leg_index =
+                waypoint_object.values.at("leg_index").get<json::Number>().value;
+            const auto &route_legs = matchings[matching_index]
                                          .get<json::Object>()
                                          .values.at("legs")
                                          .get<json::Array>()
                                          .values;
-            BOOST_CHECK_LT(waypoint_index, route_legs.size() + 1);
-            BOOST_CHECK_LT(matchings_index, number_of_matchings);
+            BOOST_CHECK_LT(leg_index, route_legs.size() + 1);
+            BOOST_CHECK_LT(matching_index, number_of_matchings);
         }
         else
         {
@@ -95,18 +95,18 @@ BOOST_AUTO_TEST_CASE(test_match_split)
         {
             BOOST_CHECK(waypoint_check(waypoint));
             const auto &waypoint_object = waypoint.get<json::Object>();
-            const auto matchings_index =
-                waypoint_object.values.at("matchings_index").get<json::Number>().value;
-            const auto waypoint_index =
-                waypoint_object.values.at("waypoint_index").get<json::Number>().value;
+            const auto matching_index =
+                waypoint_object.values.at("matching_index").get<json::Number>().value;
+            const auto leg_index =
+                waypoint_object.values.at("leg_index").get<json::Number>().value;
 
-            BOOST_CHECK_LT(matchings_index, number_of_matchings);
+            BOOST_CHECK_LT(matching_index, number_of_matchings);
 
             expected_waypoint_index =
-                (current_matchings_index != matchings_index) ? 0 : expected_waypoint_index;
-            BOOST_CHECK_EQUAL(waypoint_index, expected_waypoint_index);
+                (current_matchings_index != matching_index) ? 0 : expected_waypoint_index;
+            BOOST_CHECK_EQUAL(leg_index, expected_waypoint_index);
 
-            current_matchings_index = matchings_index;
+            current_matchings_index = matching_index;
             ++expected_waypoint_index;
         }
         else


### PR DESCRIPTION
# Issue

The `matchings_index` and `waypoint_index` attributes in the `tracepoints` array of the `match` service response are not well named in my opinion. It is difficult to know what `waypoint_index` is referring.

## Tasklist

 - [x] update CHANGELOG.md
 - [x] update relevant Wiki pages
 - [x] add tests
 - [ ] cherry pick to release branch
