### PR TITLE
Docker work

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The flag `-v $(pwd):/data` creates the directory `/data` inside the docker conta
 
 Note that `berlin-latest.osrm` has a different file extension. 
 
-    docker run -t -i -p 5000:5000 -v $(pwd):/data osrm/osrm-backend osrm-routed --algorithm mld /data/berlin-latest.osrm
+    docker run -t -i -p 5000:5000 -v $(pwd):/data osrm/osrm-backend su-exec osrm osrm-routed --algorithm mld /data/berlin-latest.osrm
 
 Make requests against the HTTP server
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ FROM alpine:3.6 as runstage
 RUN mkdir -p /src  && mkdir -p /opt
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk update && \
-    apk add boost-filesystem boost-program_options boost-regex boost-iostreams boost-thread libgomp lua5.2 expat libtbb@testing
+    apk add boost-filesystem boost-program_options boost-regex boost-iostreams boost-thread libgomp lua5.2 expat libtbb@testing su-exec
+RUN adduser -D osrm
 COPY --from=buildstage /usr/local /usr/local
 COPY --from=buildstage /opt /opt
 WORKDIR /opt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6 as buildstage
+FROM alpine:3.8 as buildstage
 
 ARG DOCKER_TAG
 RUN mkdir -p /src  && mkdir -p /opt
@@ -33,7 +33,7 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
 
 # Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
-FROM alpine:3.6 as runstage
+FROM alpine:3.8 as runstage
 RUN mkdir -p /src  && mkdir -p /opt
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk update && \


### PR DESCRIPTION
# Issue  #5146

General security practices say you run with the least privileges required, network daemons are particularly at risk when running as root as a bug in the daemon will give a remote attacker root access in the container, it's easier then to break out and get root on the host. Docker says in https://docs.docker.com/engine/security/security/#conclusions

"Docker containers are, by default, quite secure; especially if you run your processes as non-privileged users inside the container."

add su-exec and osrm user, change README.md to use su-exec osrm in osrm-routed example
bump alpine version