### PR TITLE
[WIP] In lua, replace access to speed by functions

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -10,6 +10,7 @@ find_access_tag = require("lib/access").find_access_tag
 limit = require("lib/maxspeed").limit
 Utils = require("lib/utils")
 Measure = require("lib/measure")
+Tags = require('lib/tags')
 
 function setup()
   return {
@@ -30,11 +31,11 @@ function setup()
     },
 
     default_mode              = mode.driving,
-    default_speed             = 10,
+    default_speed             = function(way) return 10 end,
     oneway_handling           = true,
     side_road_multiplier      = 0.8,
     turn_penalty              = 7.5,
-    speed_reduction           = 0.8,
+    speed_reduction           = function(way, speed) return speed * 0.8 end,
     turn_bias                 = 1.075,
     cardinal_directions       = false,
 
@@ -136,24 +137,28 @@ function setup()
       'proposed'
     },
 
-    speeds = Sequence {
-      highway = {
-        motorway        = 90,
-        motorway_link   = 45,
-        trunk           = 85,
-        trunk_link      = 40,
-        primary         = 65,
-        primary_link    = 30,
-        secondary       = 55,
-        secondary_link  = 25,
-        tertiary        = 40,
-        tertiary_link   = 20,
-        unclassified    = 25,
-        residential     = 25,
-        living_street   = 10,
-        service         = 15
+    speeds = function(way)
+      local s = Sequence {
+        highway = {
+          motorway        = 90,
+          motorway_link   = 45,
+          trunk           = 85,
+          trunk_link      = 40,
+          primary         = 65,
+          primary_link    = 30,
+          secondary       = 55,
+          secondary_link  = 25,
+          tertiary        = 40,
+          tertiary_link   = 20,
+          unclassified    = 25,
+          residential     = 25,
+          living_street   = 10,
+          service         = 15
+        }
       }
-    },
+
+      return Tags.get_constant_by_key_value(way, s)
+    end,
 
     service_penalties = {
       alley             = 0.5,

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -6,6 +6,7 @@ Set = require('lib/set')
 Sequence = require('lib/sequence')
 Handlers = require("lib/way_handlers")
 find_access_tag = require("lib/access").find_access_tag
+Tags = require('lib/tags')
 
 function setup()
   local walking_speed = 5
@@ -21,7 +22,7 @@ function setup()
     },
 
     default_mode            = mode.walking,
-    default_speed           = walking_speed,
+    default_speed           = function(way) return walking_speed end,
     oneway_handling         = 'specific',     -- respect 'oneway:foot' but not 'oneway'
 
     barrier_blacklist = Set {
@@ -72,44 +73,49 @@ function setup()
       'impassable'
     },
 
-    speeds = Sequence {
-      highway = {
-        primary         = walking_speed,
-        primary_link    = walking_speed,
-        secondary       = walking_speed,
-        secondary_link  = walking_speed,
-        tertiary        = walking_speed,
-        tertiary_link   = walking_speed,
-        unclassified    = walking_speed,
-        residential     = walking_speed,
-        road            = walking_speed,
-        living_street   = walking_speed,
-        service         = walking_speed,
-        track           = walking_speed,
-        path            = walking_speed,
-        steps           = walking_speed,
-        pedestrian      = walking_speed,
-        footway         = walking_speed,
-        pier            = walking_speed,
-      },
+    speeds = function(way)
+      local s = Sequence {
+        highway = {
+          primary         = walking_speed,
+          primary_link    = walking_speed,
+          secondary       = walking_speed,
+          secondary_link  = walking_speed,
+          tertiary        = walking_speed,
+          tertiary_link   = walking_speed,
+          unclassified    = walking_speed,
+          residential     = walking_speed,
+          road            = walking_speed,
+          living_street   = walking_speed,
+          service         = walking_speed,
+          track           = walking_speed,
+          path            = walking_speed,
+          steps           = walking_speed,
+          pedestrian      = walking_speed,
+          footway         = walking_speed,
+          pier            = walking_speed,
+        },
 
-      railway = {
-        platform        = walking_speed
-      },
+        railway = {
+          platform        = walking_speed
+        },
 
-      amenity = {
-        parking         = walking_speed,
-        parking_entrance= walking_speed
-      },
+        amenity = {
+          parking         = walking_speed,
+          parking_entrance= walking_speed
+        },
 
-      man_made = {
-        pier            = walking_speed
-      },
+        man_made = {
+          pier            = walking_speed
+        },
 
-      leisure = {
-        track           = walking_speed
+        leisure = {
+          track           = walking_speed
+        }
       }
-    },
+
+      print(way:id(), Tags.get_constant_by_key_value(way, s))
+      return Tags.get_constant_by_key_value(way, s)
+    end,
 
     route_speeds = {
       ferry = 5

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -274,7 +274,7 @@ function WayHandlers.speed(profile,way,result,data)
     return        -- abort if already set, eg. by a route
   end
 
-  local key,value,speed = Tags.get_constant_by_key_value(way,profile.speeds)
+  local key,value,speed = profile.speeds(way)
 
   if speed then
     -- set speed by way type
@@ -283,17 +283,17 @@ function WayHandlers.speed(profile,way,result,data)
   else
     -- Set the avg speed on ways that are marked accessible
     if profile.access_tag_whitelist[data.forward_access] then
-      result.forward_speed = profile.default_speed
+      result.forward_speed = profile.default_speed(way)
     elseif data.forward_access and not profile.access_tag_blacklist[data.forward_access] then
-      result.forward_speed = profile.default_speed -- fallback to the avg speed if access tag is not blacklisted
+      result.forward_speed = profile.default_speed(way) -- fallback to the avg speed if access tag is not blacklisted
     elseif not data.forward_access and data.backward_access then
        result.forward_mode = mode.inaccessible
     end
 
     if profile.access_tag_whitelist[data.backward_access] then
-      result.backward_speed = profile.default_speed
+      result.backward_speed = profile.default_speed(way)
     elseif data.backward_access and not profile.access_tag_blacklist[data.backward_access] then
-      result.backward_speed = profile.default_speed -- fallback to the avg speed if access tag is not blacklisted
+      result.backward_speed = profile.default_speed(way) -- fallback to the avg speed if access tag is not blacklisted
     elseif not data.backward_access and data.forward_access then
        result.backward_mode = mode.inaccessible
     end
@@ -438,11 +438,11 @@ function WayHandlers.maxspeed(profile,way,result,data)
   backward = WayHandlers.parse_maxspeed(backward,profile)
 
   if forward and forward > 0 then
-    result.forward_speed = forward * profile.speed_reduction
+    result.forward_speed = profile.speed_reduction(way, forward)
   end
 
   if backward and backward > 0 then
-    result.backward_speed = backward * profile.speed_reduction
+    result.backward_speed = profile.speed_reduction(way, backward)
   end
 end
 


### PR DESCRIPTION
Replace the call to constant speed value by functions.
The idea is to allow more dynamic speed usage without the need to edit way_handlers.lua.
This patch originally come from the Uban Density contrib profile : https://github.com/Project-OSRM/osrm-profiles-contrib/tree/master/5/18/urban-density
But It should be applicable to other dynamic speeds setting like using DEM, raster or --location-dependent-data.
My goal is to use it as basses for Uban Density contrib profile, and make the speed table subject of --location-dependent-data based with countries.

After test, there is no noticeable overload of osrm-extraction.