### PR TITLE
Increase allowed shared memory regions to 512 from ~120.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     - Bugfixes:
       - FIXED: collapsing of ExitRoundabout instructions [#5114](https://github.com/Project-OSRM/osrm-backend/issues/5114)
       - FIXED: negative distances in table plugin annotation [#5106](https://github.com/Project-OSRM/osrm-backend/issues/5106)
+    - Misc:
+      - CHANGED: Support up to 512 named shared memory regions [#5185](https://github.com/Project-OSRM/osrm-backend/pull/5185)
 
 # 5.18.0
   - Changes from 5.17.0:

--- a/include/storage/shared_datatype.hpp
+++ b/include/storage/shared_datatype.hpp
@@ -26,7 +26,7 @@ namespace serialization
 inline void read(io::BufferReader &reader, DataLayout &layout);
 
 inline void write(io::BufferWriter &writer, const DataLayout &layout);
-}
+} // namespace serialization
 
 namespace detail
 {
@@ -52,7 +52,7 @@ inline std::string trimName(const std::string &name_prefix, const std::string &n
         return name;
     }
 }
-}
+} // namespace detail
 
 class DataLayout
 {
@@ -165,7 +165,7 @@ struct SharedRegion
     static constexpr const int MAX_NAME_LENGTH = 254;
 
     SharedRegion() : name{0}, timestamp{0} {}
-    SharedRegion(const std::string &name_, std::uint64_t timestamp, std::uint8_t shm_key)
+    SharedRegion(const std::string &name_, std::uint64_t timestamp, std::uint16_t shm_key)
         : name{0}, timestamp{timestamp}, shm_key{shm_key}
     {
         std::copy_n(name_.begin(), std::min<std::size_t>(MAX_NAME_LENGTH, name_.size()), name);
@@ -175,14 +175,14 @@ struct SharedRegion
 
     char name[MAX_NAME_LENGTH + 1];
     std::uint64_t timestamp;
-    std::uint8_t shm_key;
+    std::uint16_t shm_key;
 };
 
 // Keeps a list of all shared regions in a fixed-sized struct
 // for fast access and deserialization.
 struct SharedRegionRegister
 {
-    using RegionID = std::uint8_t;
+    using RegionID = std::uint16_t;
     static constexpr const RegionID INVALID_REGION_ID = std::numeric_limits<RegionID>::max();
     using ShmKey = decltype(SharedRegion::shm_key);
 
@@ -250,12 +250,11 @@ struct SharedRegionRegister
 
     void ReleaseKey(ShmKey key) { shm_key_in_use[key] = false; }
 
-    static constexpr const std::uint8_t MAX_SHARED_REGIONS =
-        std::numeric_limits<RegionID>::max() - 1;
+    static constexpr const std::size_t MAX_SHARED_REGIONS = 512;
     static_assert(MAX_SHARED_REGIONS < std::numeric_limits<RegionID>::max(),
                   "Number of shared memory regions needs to be less than the region id size.");
 
-    static constexpr const std::uint8_t MAX_SHM_KEYS = std::numeric_limits<std::uint8_t>::max() - 1;
+    static constexpr const std::size_t MAX_SHM_KEYS = MAX_SHARED_REGIONS * 2;
 
     static constexpr const char *name = "osrm-region";
 
@@ -263,7 +262,7 @@ struct SharedRegionRegister
     std::array<SharedRegion, MAX_SHARED_REGIONS> regions;
     std::array<bool, MAX_SHM_KEYS> shm_key_in_use;
 };
-}
-}
+} // namespace storage
+} // namespace osrm
 
 #endif /* SHARED_DATA_TYPE_HPP */

--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -33,7 +33,7 @@ template <class Lock> class InvertedLock
     InvertedLock(Lock &lock) : lock(lock) { lock.unlock(); }
     ~InvertedLock() { lock.lock(); }
 };
-}
+} // namespace
 
 // The shared monitor implementation based on a semaphore and mutex
 template <typename Data> struct SharedMonitor
@@ -146,7 +146,9 @@ template <typename Data> struct SharedMonitor
     // like two-turnstile reusable barrier or boost/interprocess/sync/spin/condition.hpp
     // fail if a waiter is killed.
 
-    static constexpr int buffer_size = 256;
+    // Buffer size needs to be large enough to hold all the semaphores for every
+    // listener you want to support.
+    static constexpr int buffer_size = 4096 * 4;
 
     struct InternalData
     {
@@ -232,8 +234,8 @@ template <typename Data> struct SharedMonitor
     bi::shared_memory_object shmem;
     bi::mapped_region region;
 };
-}
-}
+} // namespace storage
+} // namespace osrm
 
 #undef USE_BOOST_INTERPROCESS_CONDITION
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -66,7 +66,7 @@ struct RegionHandle
 {
     std::unique_ptr<SharedMemory> memory;
     char *data_ptr;
-    std::uint8_t shm_key;
+    std::uint16_t shm_key;
 };
 
 auto setupRegion(SharedRegionRegister &shared_register, const DataLayout &layout)

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -82,7 +82,8 @@ void springClean()
     }
     else
     {
-        for (auto key : util::irange<std::uint8_t>(0, storage::SharedRegionRegister::MAX_SHM_KEYS))
+        for (auto key : util::irange<storage::SharedRegionRegister::RegionID>(
+                 0, storage::SharedRegionRegister::MAX_SHM_KEYS))
         {
             deleteRegion(key);
         }


### PR DESCRIPTION
# Issue

Currently, if you try to create more than 128 named datasets, some `std::uint8_t` values will overflow, and you'll end up overwriting other datasets with different names, and/or crashing.

This change increases the limit to 512.  Achieving this requires a few steps:

  1. `::ftok()` only uses the lowest 8 bits from the `id` field, so we need to use more than one lockfile name to differentiate unique keys.
  2. Various variables need to be increased from `std::uint8_t` to `std::uint16_t` to hold the larger values.
  3. The ring buffer for swapping datasets needs to be increased so that it doesn't run out of space when lots of datasets are active.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
