### PR TITLE
Make node bindings optionally return pre-rendered JSON buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Optimizations:
       - CHANGED: Map matching is now almost twice as fast. [#5060](https://github.com/Project-OSRM/osrm-backend/pull/5060)
       - CHANGED: Use Grisu2 for serializing floating point numbers. [#5188](https://github.com/Project-OSRM/osrm-backend/pull/5188)
+      - ADDED: Node bindings can return pre-rendered JSON buffer. [#5189](https://github.com/Project-OSRM/osrm-backend/pull/5189)
     - Bugfixes:
       - FIXED: collapsing of ExitRoundabout instructions [#5114](https://github.com/Project-OSRM/osrm-backend/issues/5114)
       - FIXED: negative distances in table plugin annotation [#5106](https://github.com/Project-OSRM/osrm-backend/issues/5106)

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -297,6 +297,29 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
                  2) `waypoint_index`: index of the point in the trip.
 **`trips`**: an array of [`Route`](#route) objects that assemble the trace.
 
+## Plugin behaviour
+
+All plugins support a second additional object that is available to configure some NodeJS specific behaviours.
+
+-   `plugin_config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Object literal containing parameters for the trip query.
+    -   `plugin_config.format` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** The format of the result object to various API calls.  Valid options are `object` (default), which returns a standard Javascript object, as described above, and `json_buffer`, which will return a NodeJS **[Buffer](https://nodejs.org/api/buffer.html)** object, containing a JSON string.  The latter has the advantage that it can be immediately serialized to disk/sent over the network, and the generation of the string is performed outside the main NodeJS event loop.  This option is ignored by the `tile` plugin.
+
+**Examples**
+
+```javascript
+var osrm = new OSRM('network.osrm');
+var options = {
+  coordinates: [
+    [13.36761474609375, 52.51663871100423],
+    [13.374481201171875, 52.506191342034576]
+  ]
+};
+osrm.route(options, { format: "json_buffer" }, function(err, response) {
+  if (err) throw err;
+  console.log(response.toString("utf-8"));
+});
+```
+
 ## Responses
 
 Responses

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -9,11 +9,14 @@
 #include "osrm/trip_parameters.hpp"
 
 #include <exception>
+#include <sstream>
 #include <type_traits>
 #include <utility>
 
 #include "nodejs/node_osrm.hpp"
 #include "nodejs/node_osrm_support.hpp"
+
+#include "util/json_renderer.hpp"
 
 namespace node_osrm
 {
@@ -122,6 +125,8 @@ inline void async(const Nan::FunctionCallbackInfo<v8::Value> &info,
     if (!params)
         return;
 
+    auto pluginParams = argumentsToPluginParameters(info);
+
     BOOST_ASSERT(params->IsValid());
 
     if (!info[info.Length() - 1]->IsFunction())
@@ -137,9 +142,89 @@ inline void async(const Nan::FunctionCallbackInfo<v8::Value> &info,
         Worker(std::shared_ptr<osrm::OSRM> osrm_,
                ParamPtr params_,
                ServiceMemFn service,
-               Nan::Callback *callback)
+               Nan::Callback *callback,
+               PluginParameters pluginParams_)
             : Base(callback), osrm{std::move(osrm_)}, service{std::move(service)},
-              params{std::move(params_)}
+              params{std::move(params_)}, pluginParams{std::move(pluginParams_)}
+        {
+        }
+
+        void Execute() override try
+        {
+            osrm::json::Object r;
+            const auto status = ((*osrm).*(service))(*params, r);
+            ParseResult(status, r);
+            if (pluginParams.renderJSONToBuffer)
+            {
+                std::ostringstream buf;
+                osrm::util::json::render(buf, r);
+                result = buf.str();
+            }
+            else
+            {
+                result = r;
+            }
+        }
+        catch (const std::exception &e)
+        {
+            SetErrorMessage(e.what());
+        }
+
+        void HandleOKCallback() override
+        {
+            Nan::HandleScope scope;
+
+            const constexpr auto argc = 2u;
+            v8::Local<v8::Value> argv[argc] = {Nan::Null(), render(result)};
+
+            callback->Call(argc, argv);
+        }
+
+        // Keeps the OSRM object alive even after shutdown until we're done with callback
+        std::shared_ptr<osrm::OSRM> osrm;
+        ServiceMemFn service;
+        const ParamPtr params;
+        const PluginParameters pluginParams;
+
+        ObjectOrString result;
+    };
+
+    auto *callback = new Nan::Callback{info[info.Length() - 1].As<v8::Function>()};
+    Nan::AsyncQueueWorker(
+        new Worker{self->this_, std::move(params), service, callback, std::move(pluginParams)});
+}
+
+template <typename ParameterParser, typename ServiceMemFn>
+inline void asyncForTiles(const Nan::FunctionCallbackInfo<v8::Value> &info,
+                          ParameterParser argsToParams,
+                          ServiceMemFn service,
+                          bool requires_multiple_coordinates)
+{
+    auto params = argsToParams(info, requires_multiple_coordinates);
+    if (!params)
+        return;
+
+    auto pluginParams = argumentsToPluginParameters(info);
+
+    BOOST_ASSERT(params->IsValid());
+
+    if (!info[info.Length() - 1]->IsFunction())
+        return Nan::ThrowTypeError("last argument must be a callback function");
+
+    auto *const self = Nan::ObjectWrap::Unwrap<Engine>(info.Holder());
+    using ParamPtr = decltype(params);
+
+    struct Worker final : Nan::AsyncWorker
+    {
+        using Base = Nan::AsyncWorker;
+
+        Worker(std::shared_ptr<osrm::OSRM> osrm_,
+               ParamPtr params_,
+               ServiceMemFn service,
+               Nan::Callback *callback,
+               PluginParameters pluginParams_)
+            : Base(callback), osrm{std::move(osrm_)}, service{std::move(service)},
+              params{std::move(params_)}, pluginParams{std::move(pluginParams_)}
         {
         }
 
@@ -167,18 +252,14 @@ inline void async(const Nan::FunctionCallbackInfo<v8::Value> &info,
         std::shared_ptr<osrm::OSRM> osrm;
         ServiceMemFn service;
         const ParamPtr params;
+        const PluginParameters pluginParams;
 
-        // All services return json::Object .. except for Tile!
-        using ObjectOrString =
-            typename std::conditional<std::is_same<ParamPtr, tile_parameters_ptr>::value,
-                                      std::string,
-                                      osrm::json::Object>::type;
-
-        ObjectOrString result;
+        std::string result;
     };
 
     auto *callback = new Nan::Callback{info[info.Length() - 1].As<v8::Function>()};
-    Nan::AsyncQueueWorker(new Worker{self->this_, std::move(params), service, callback});
+    Nan::AsyncQueueWorker(
+        new Worker{self->this_, std::move(params), service, callback, std::move(pluginParams)});
 }
 
 // clang-format off
@@ -341,7 +422,7 @@ NAN_METHOD(Engine::table) //
 // clang-format on
 NAN_METHOD(Engine::tile)
 {
-    async(info, &argumentsToTileParameters, &osrm::OSRM::Tile, {/*unused*/});
+    asyncForTiles(info, &argumentsToTileParameters, &osrm::OSRM::Tile, {/*unused*/});
 }
 
 // clang-format off

--- a/test/nodejs/match.js
+++ b/test/nodejs/match.js
@@ -25,6 +25,28 @@ test('match: match in Monaco', function(assert) {
     });
 });
 
+test('match: match in Monaco returning a buffer', function(assert) {
+    assert.plan(6);
+    var osrm = new OSRM(data_path);
+    var options = {
+        coordinates: three_test_coordinates,
+        timestamps: [1424684612, 1424684616, 1424684620]
+    };
+    osrm.match(options, { format: 'json_buffer' }, function(err, response) {
+        assert.ifError(err);
+        assert.ok(response instanceof Buffer);
+        response = JSON.parse(response);
+        assert.equal(response.matchings.length, 1);
+        assert.ok(response.matchings.every(function(m) {
+            return !!m.distance && !!m.duration && Array.isArray(m.legs) && !!m.geometry && m.confidence > 0;
+        }))
+        assert.equal(response.tracepoints.length, 3);
+        assert.ok(response.tracepoints.every(function(t) {
+            return !!t.hint && !isNaN(t.matchings_index) && !isNaN(t.waypoint_index) && !!t.name;
+        }));
+    });
+});
+
 test('match: match in Monaco without timestamps', function(assert) {
     assert.plan(3);
     var osrm = new OSRM(data_path);
@@ -223,6 +245,16 @@ test('match: throws on invalid tidy param', function(assert) {
     };
     assert.throws(function() { osrm.match(options, function(err, response) {}) },
         /tidy must be of type Boolean/);
+});
+
+test('match: throws on invalid config param', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({path: mld_data_path, algorithm: 'MLD'});
+    var options = {
+        coordinates: three_test_coordinates,
+    };
+    assert.throws(function() { osrm.match(options, { format: 'invalid' }, function(err, response) {}) },
+        /format must be a string:/);
 });
 
 test('match: match in Monaco without motorways', function(assert) {

--- a/test/nodejs/nearest.js
+++ b/test/nodejs/nearest.js
@@ -19,6 +19,21 @@ test('nearest', function(assert) {
     });
 });
 
+test('nearest', function(assert) {
+    assert.plan(5);
+    var osrm = new OSRM(data_path);
+    osrm.nearest({
+        coordinates: [three_test_coordinates[0]]
+    }, { format: 'json_buffer' }, function(err, result) {
+        assert.ifError(err);
+        assert.ok(result instanceof Buffer);
+        result = JSON.parse(result);
+        assert.equal(result.waypoints.length, 1);
+        assert.equal(result.waypoints[0].location.length, 2);
+        assert.ok(result.waypoints[0].hasOwnProperty('name'));
+    });
+});
+
 test('nearest: can ask for multiple nearest pts', function(assert) {
     assert.plan(2);
     var osrm = new OSRM(data_path);
@@ -32,7 +47,7 @@ test('nearest: can ask for multiple nearest pts', function(assert) {
 });
 
 test('nearest: throws on invalid args', function(assert) {
-    assert.plan(6);
+    assert.plan(7);
     var osrm = new OSRM(data_path);
     var options = {};
     assert.throws(function() { osrm.nearest(options); },
@@ -52,6 +67,10 @@ test('nearest: throws on invalid args', function(assert) {
     options.number = 0;
     assert.throws(function() { osrm.nearest(options, function(err, res) {}); },
         /Number must be an integer greater than or equal to 1/);
+
+    options.number = 1;
+    assert.throws(function() { osrm.nearest(options, { format: 'invalid' }, function(err, res) {}); },
+        /format must be a string:/);
 });
 
 test('nearest: nearest in Monaco without motorways', function(assert) {

--- a/test/nodejs/route.js
+++ b/test/nodejs/route.js
@@ -43,8 +43,22 @@ test('route: routes Monaco on CoreCH', function(assert) {
     });
 });
 
+test('route: routes Monaco and returns a JSON buffer', function(assert) {
+    assert.plan(6);
+    var osrm = new OSRM({path: monaco_corech_path, algorithm: 'CoreCH'});
+    osrm.route({coordinates: [[13.43864,52.51993],[13.415852,52.513191]]}, { format: 'json_buffer'}, function(err, result) {
+        assert.ifError(err);
+        assert.ok(result instanceof Buffer);
+        const route = JSON.parse(result);
+        assert.ok(route.waypoints);
+        assert.ok(route.routes);
+        assert.ok(route.routes.length);
+        assert.ok(route.routes[0].geometry);
+    });
+});
+
 test('route: throws with too few or invalid args', function(assert) {
-    assert.plan(3);
+    assert.plan(4);
     var osrm = new OSRM(monaco_path);
     assert.throws(function() { osrm.route({coordinates: two_test_coordinates}) },
         /Two arguments required/);
@@ -52,6 +66,8 @@ test('route: throws with too few or invalid args', function(assert) {
         /First arg must be an object/);
     assert.throws(function() { osrm.route({coordinates: two_test_coordinates}, true)},
         /last argument must be a callback function/);
+    assert.throws(function() { osrm.route({coordinates: two_test_coordinates}, { format: 'invalid' }, function(err, route) {})},
+        /format must be a string:/);
 });
 
 test('route: provides no alternatives by default, but when requested it may (not guaranteed)', function(assert) {

--- a/test/nodejs/table.js
+++ b/test/nodejs/table.js
@@ -48,6 +48,20 @@ test('table: test annotations paramater combination', function(assert) {
     });
 });
 
+test('table: returns buffer', function(assert) {
+    assert.plan(3);
+    var osrm = new OSRM(data_path);
+    var options = {
+        coordinates: [three_test_coordinates[0], three_test_coordinates[1]],
+    };
+    osrm.table(options, { format: 'json_buffer' }, function(err, table) {
+        assert.ifError(err);
+        assert.ok(table instanceof Buffer);
+        table = JSON.parse(table);
+        assert.ok(table['durations'], 'distances table result should exist');
+    });
+});
+
 var tables = ['distances', 'durations'];
 
 tables.forEach(function(annotation) {
@@ -116,7 +130,7 @@ tables.forEach(function(annotation) {
     });
 
     test('table: ' + annotation + ' throws on invalid arguments', function(assert) {
-        assert.plan(14);
+        assert.plan(15);
         var osrm = new OSRM(data_path);
         var options = {annotations: [annotation.slice(0,-1)]};
         assert.throws(function() { osrm.table(options); },
@@ -135,6 +149,9 @@ tables.forEach(function(annotation) {
             /Coordinates must be an array of \(lon\/lat\) pairs/);
 
         options.coordinates = two_test_coordinates;
+        assert.throws(function() { osrm.table(options, { format: 'invalid' }, function(err, response) {}) },
+            /format must be a string:/);
+
         options.sources = true;
         assert.throws(function() { osrm.table(options, function(err, response) {}) },
             /Sources must be an array of indices \(or undefined\)/);

--- a/test/nodejs/trip.js
+++ b/test/nodejs/trip.js
@@ -17,6 +17,19 @@ test('trip: trip in Monaco', function(assert) {
     });
 });
 
+test('trip: trip in Monaco as a buffer', function(assert) {
+    assert.plan(3);
+    var osrm = new OSRM(data_path);
+    osrm.trip({coordinates: two_test_coordinates}, { format: 'json_buffer' }, function(err, trip) {
+        assert.ifError(err);
+        assert.ok(trip instanceof Buffer);
+        trip = JSON.parse(trip);
+        for (t = 0; t < trip.trips.length; t++) {
+            assert.ok(trip.trips[t].geometry);
+        }
+    });
+});
+
 test('trip: trip with many locations in Monaco', function(assert) {
     assert.plan(2);
 
@@ -33,12 +46,14 @@ test('trip: trip with many locations in Monaco', function(assert) {
 });
 
 test('trip: throws with too few or invalid args', function(assert) {
-    assert.plan(2);
+    assert.plan(3);
     var osrm = new OSRM(data_path);
     assert.throws(function() { osrm.trip({coordinates: two_test_coordinates}) },
         /Two arguments required/);
     assert.throws(function() { osrm.trip(null, function(err, trip) {}) },
         /First arg must be an object/);
+    assert.throws(function() { osrm.trip({coordinates: two_test_coordinates}, { format: 'invalid' }, function(err, trip) {}) },
+        /format must be a string:/);
 });
 
 test('trip: throws with bad params', function(assert) {


### PR DESCRIPTION
If you're using the NodeJS bindings with OSRM, and you're generating large responses, there can be significant overhead simply translating the OSRM JSON structure into a NodeJS object tree.

There are several use-cases where the next step you take is to simply render the NodeJS object into a JSON string, and send it over the network - using NodeJS as your OSRM HTTP server is one example of this.

This PR adds a new optional parameter to all the NodeJS API methods that allows you to configure the format of the response that OSRM returns.  It defaults to the current object tree, but if you supply `{format: 'json_buffer'}`, it will instead cause OSRM to pre-render the JSON tree on a worker thread, then return a NodeJS `Buffer` object containing the JSON response string.

In cases where you only wanted to return the result to a client over the network anyway, pre-rendering the JSON has a significant speedup.  It significantly unburdens the main NodeJS thread, allowing more concurrent work.

Timeline of a 5000x5000 `table` request and serialization over the network before this change:
<img width="718" alt="screen shot 2018-09-01 at 12 30 04 pm" src="https://user-images.githubusercontent.com/1892250/44968645-e531b880-aefd-11e8-8de1-12b133da92d9.png">

Timeline of a 5000x5000 `table` request and serialization over the network after this change:
<img width="519" alt="screen shot 2018-09-01 at 12 29 19 pm" src="https://user-images.githubusercontent.com/1892250/44968646-e7941280-aefd-11e8-851c-20055a4a433a.png">

The `Main Thread` here represents the primary NodeJS event loop - less work done here means the event loop stays clear to handle i/O.

The time spent in the `pthread_body` has increased slightly in the second image - this shows the additional time spent rendering the JSON outside the main thread.


## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
