### PR TITLE
In Belgium the maximum speed in rural areas is 70 in the region Flanders

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -269,6 +269,7 @@ function setup()
       ["at:rural"] = 100,
       ["at:trunk"] = 100,
       ["be:motorway"] = 120,
+      ["be-vlg:rural"] = 70,
       ["by:urban"] = 60,
       ["by:motorway"] = 110,
       ["ch:rural"] = 80,

--- a/taginfo.json
+++ b/taginfo.json
@@ -148,6 +148,7 @@
         {"key": "maxspeed", "value": "AT:rural"},
         {"key": "maxspeed", "value": "AT:trunk"},
         {"key": "maxspeed", "value": "BE:motorway"},
+        {"key": "maxspeed", "value": "BE-VLG:rural"},
         {"key": "maxspeed", "value": "BY:urban"},
         {"key": "maxspeed", "value": "BY:motorway"},
         {"key": "maxspeed", "value": "CH:rural"},


### PR DESCRIPTION
In Belgium the maximum speed in rural areas is 70 in the region Flanders
(hint from https://github.com/osm-fr/osmose-backend/issues/334)