### PR TITLE
Enable all unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -375,6 +375,14 @@ script:
   - ./unit_tests/util-tests
   - ./unit_tests/server-tests
   - ./unit_tests/partitioner-tests
+  - ./unit_tests/storage-tests
+  - ./unit_tests/customizer-tests
+  - ./unit_tests/library-contract-tests
+  - ./unit_tests/library-customize-tests
+  - ./unit_tests/library-extract-tests
+  - ./unit_tests/library-partition-tests
+  - ./unit_tests/storage-tests
+  - ./unit_tests/updater-tests
   - |
     if [ -z "${ENABLE_SANITIZER}" ] && [ "$TARGET_ARCH" != "i686" ]; then
       npm run nodejs-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -368,21 +368,7 @@ script:
   - ./example/build/osrm-example test/data/mld/monaco.osrm
   # All tests assume to be run from the build directory
   - pushd ${OSRM_BUILD_DIR}
-  - ./unit_tests/library-tests
-  - ./unit_tests/extractor-tests
-  - ./unit_tests/contractor-tests
-  - ./unit_tests/engine-tests
-  - ./unit_tests/util-tests
-  - ./unit_tests/server-tests
-  - ./unit_tests/partitioner-tests
-  - ./unit_tests/storage-tests
-  - ./unit_tests/customizer-tests
-  - ./unit_tests/library-contract-tests
-  - ./unit_tests/library-customize-tests
-  - ./unit_tests/library-extract-tests
-  - ./unit_tests/library-partition-tests
-  - ./unit_tests/storage-tests
-  - ./unit_tests/updater-tests
+  - for i in ./unit_tests/*-tests ; do echo Running $i ; $i ; done
   - |
     if [ -z "${ENABLE_SANITIZER}" ] && [ "$TARGET_ARCH" != "i686" ]; then
       npm run nodejs-tests

--- a/include/util/geojson_validation.hpp
+++ b/include/util/geojson_validation.hpp
@@ -48,6 +48,20 @@ inline void validateFeature(const rapidjson::Value &feature)
     {
         throw osrm::util::exception("Feature has non-object properties member.");
     }
+    if (feature["properties"].HasMember("tzid"))
+    {
+        if (!feature["properties"]["tzid"].IsString())
+            throw osrm::util::exception("Feature has non-string tzid property");
+    }
+    else if (feature["properties"].HasMember("TZID"))
+    {
+        if (!feature["properties"]["TZID"].IsString())
+            throw osrm::util::exception("Feature has non-string TZID property");
+    }
+    else
+    {
+        throw osrm::util::exception("Feature is missing tzid property.");
+    }
     if (!feature.HasMember("geometry"))
     {
         throw osrm::util::exception("Feature is missing geometry member.");
@@ -76,6 +90,14 @@ inline void validateFeature(const rapidjson::Value &feature)
     const auto coord_array = feature["geometry"].GetObject()["coordinates"].GetArray();
     if (coord_array.Empty())
         throw osrm::util::exception("Feature geometry coordinates member is empty.");
+
+    if (feature["geometry"]["type"] == "polygon" || feature["geometry"]["type"] == "Polygon")
+    {
+        if (!coord_array[0].IsArray() || !coord_array[0][0].IsArray())
+        {
+            throw osrm::util::exception("Polygon geometry missing outer ring");
+        }
+    }
 }
 }
 }

--- a/include/util/geojson_validation.hpp
+++ b/include/util/geojson_validation.hpp
@@ -48,20 +48,6 @@ inline void validateFeature(const rapidjson::Value &feature)
     {
         throw osrm::util::exception("Feature has non-object properties member.");
     }
-    if (feature["properties"].HasMember("tzid"))
-    {
-        if (!feature["properties"]["tzid"].IsString())
-            throw osrm::util::exception("Feature has non-string tzid property");
-    }
-    else if (feature["properties"].HasMember("TZID"))
-    {
-        if (!feature["properties"]["TZID"].IsString())
-            throw osrm::util::exception("Feature has non-string TZID property");
-    }
-    else
-    {
-        throw osrm::util::exception("Feature is missing tzid property.");
-    }
     if (!feature.HasMember("geometry"))
     {
         throw osrm::util::exception("Feature is missing geometry member.");

--- a/unit_tests/library/extract.cpp
+++ b/unit_tests/library/extract.cpp
@@ -21,6 +21,7 @@ BOOST_AUTO_TEST_CASE(test_extract_with_valid_config)
     osrm::ExtractorConfig config;
     config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
     config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
+    config.profile_path = OSRM_TEST_DATA_DIR "/../../profiles/car.lua";
     config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
     BOOST_CHECK_NO_THROW(osrm::extract(config));
 }

--- a/unit_tests/updater/timezoner.cpp
+++ b/unit_tests/updater/timezoner.cpp
@@ -53,5 +53,19 @@ BOOST_AUTO_TEST_CASE(timezoner_test)
         "48.88277], [8.57757, 49.07206], [8.28369, "
         "49.07206], [8.28369, 48.88277]]] }} ]}";
     BOOST_CHECK_THROW(Timezoner tz(missing_featc, now), util::exception);
+
+    char missing_tzid[] = "{ \"type\" : \"Feature\","
+                          "\"properties\" : { }, \"geometry\" : { \"type\": \"polygon\", "
+                          "\"coordinates\": [[[8.28369,48.88277], [8.57757, "
+                          "48.88277], [8.57757, 49.07206], [8.28369, "
+                          "49.07206], [8.28369, 48.88277]]] }}";
+    BOOST_CHECK_THROW(Timezoner tz(missing_tzid, now), util::exception);
+
+    char tzid_err[] = "{ \"type\" : \"Feature\","
+                      "\"properties\" : { \"TZID\" : []}, \"geometry\" : { \"type\": \"polygon\", "
+                      "\"coordinates\": [[[8.28369,48.88277], [8.57757, "
+                      "48.88277], [8.57757, 49.07206], [8.28369, "
+                      "49.07206], [8.28369, 48.88277]]] }}";
+    BOOST_CHECK_THROW(Timezoner tz(tzid_err, now), util::exception);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/updater/validation.cpp
+++ b/unit_tests/updater/validation.cpp
@@ -65,22 +65,6 @@ BOOST_AUTO_TEST_CASE(timezone_validation_test)
     doc.Parse(nonobj_props);
     BOOST_CHECK_THROW(util::validateFeature(doc), util::exception);
 
-    char missing_tzid[] = "{ \"type\" : \"Feature\","
-                          "\"properties\" : { }, \"geometry\" : { \"type\": \"polygon\", "
-                          "\"coordinates\": [[[8.28369,48.88277], [8.57757, "
-                          "48.88277], [8.57757, 49.07206], [8.28369, "
-                          "49.07206], [8.28369, 48.88277]]] }}";
-    doc.Parse(missing_tzid);
-    BOOST_CHECK_THROW(util::validateFeature(doc), util::exception);
-
-    char tzid_err[] = "{ \"type\" : \"Feature\","
-                      "\"properties\" : { \"TZID\" : []}, \"geometry\" : { \"type\": \"polygon\", "
-                      "\"coordinates\": [[[8.28369,48.88277], [8.57757, "
-                      "48.88277], [8.57757, 49.07206], [8.28369, "
-                      "49.07206], [8.28369, 48.88277]]] }}";
-    doc.Parse(tzid_err);
-    BOOST_CHECK_THROW(util::validateFeature(doc), util::exception);
-
     char missing_geom[] = "{ \"type\" : \"Feature\","
                           "\"properties\" : { \"TZID\" : \"Europe/Berlin\"}, \"geometries\" : { "
                           "\"type\": \"polygon\", "


### PR DESCRIPTION
We've got a few unit tests defined in `unit_tests/CMakeLists.txt` that aren't being run - the list in `.travis.yml` had a hard-coded list, and some that had been written weren't being run.

This PR enables all the tests during CI runs, and fixes the ones that are failing.

TODO:
  - Fix the customizer tests