### PR TITLE
Fix windows build due to missing header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
   - Changes from 5.19.0:
+    - Windows:
+      - FIXED: Windows builds again. [#5249](https://github.com/Project-OSRM/osrm-backend/pull/5249)
 
 # 5.19.0
   - Changes from 5.18.0:

--- a/include/util/ieee754.hpp
+++ b/include/util/ieee754.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include <math.h>
 
 #if defined(_MSC_VER)
-#include "msinttypes/stdint.h"
+#include "rapidjson/msinttypes/stdint.h"
 #include <intrin.h>
 #else
 #include <stdint.h>


### PR DESCRIPTION
A little while ago, I added a fast IEEE754 renderer to speed up JSON serialization, particularly for large `table` requests where lots of decimal numbers need to get written to a string.

That change broke the Windows builds - on Windows, the `msinttypes/stdlib.h` header was needed, but it wasn't in the search path.

This PR modifies the IEEE754 renderer to use the `msinttypes/stdlib.h` file that's already included with RapidJSON, so things compile on Windows again.