### PR TITLE
Pin Yarn to 1.11.1 so it works with Node4 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -296,7 +296,7 @@ before_install:
     fi
   - |
     if [[ ! -f $(which yarn) ]]; then
-      npm install -g yarn
+      npm install -g yarn@1.11.1
     fi
   - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
   - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")


### PR DESCRIPTION
Our node4 builds started failing suddnely.  Looks like it was caused by this PR:
(https://github.com/yarnpkg/yarn/pull/6409#issuecomment-429181371)

being merged into `yarn`, and we weren't pinned to a `yarn` version, so our Node4 build broke.

This Pr pins us to yarn@1.11.1 which works with node4