### PR TITLE
Return 'distance' in all waypoints for all APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Features:
       - ADDED: direct mmapping of datafiles is now supported via the `--mmap` switch. [#5242](https://github.com/Project-OSRM/osrm-backend/pull/5242)
       - REMOVED: the previous `--memory_file` switch is now deprecated and will fallback to `--mmap` [#5242](https://github.com/Project-OSRM/osrm-backend/pull/5242)
+      - ADDED: all waypoints in responses now contain a `distance` property between the original coordinate and the snapped location. [#5255](https://github.com/Project-OSRM/osrm-backend/pull/5255)
     - Windows:
       - FIXED: Windows builds again. [#5249](https://github.com/Project-OSRM/osrm-backend/pull/5249)
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -119,7 +119,6 @@ In addition to the [general options](#general-options) the following options are
 
 - `code` if the request was successful `Ok` otherwise see the service dependent and general status codes.
 - `waypoints` array of `Waypoint` objects sorted by distance to the input coordinate. Each object has at least the following additional properties:
-  - `distance`: Distance in meters to the supplied input coordinate.
   - `nodes`: Array of OpenStreetMap node ids.
 
 #### Example Requests
@@ -906,6 +905,7 @@ Object used to describe waypoint on a route.
 
 - `name` Name of the street the coordinate snapped to
 - `location` Array that contains the `[longitude, latitude]` pair of the snapped coordinate
+- `distance` The distance, in metres, from the input coordinate to the snapped coordinate
 - `hint` Unique internal identifier of the segment (ephemeral, not constant over data updates)
    This can be used on subsequent request to significantly speed up the query and to connect multiple services.
    E.g. you can use the `hint` value obtained by the `nearest` query as `hint` values for `route` inputs.

--- a/include/engine/api/base_api.hpp
+++ b/include/engine/api/base_api.hpp
@@ -6,6 +6,7 @@
 
 #include "engine/api/json_factory.hpp"
 #include "engine/hint.hpp"
+#include "util/coordinate_calculation.hpp"
 
 #include <boost/assert.hpp>
 #include <boost/range/algorithm/transform.hpp>
@@ -53,6 +54,8 @@ class BaseAPI
             // TODO: check forward/reverse
             return json::makeWaypoint(
                 phantom.location,
+                util::coordinate_calculation::fccApproximateDistance(phantom.location,
+                                                                     phantom.input_location),
                 facade.GetNameForID(facade.GetNameIndex(phantom.forward_segment_id.id)).to_string(),
                 Hint{phantom, facade.GetCheckSum()});
         }
@@ -61,6 +64,8 @@ class BaseAPI
             // TODO: check forward/reverse
             return json::makeWaypoint(
                 phantom.location,
+                util::coordinate_calculation::fccApproximateDistance(phantom.location,
+                                                                     phantom.input_location),
                 facade.GetNameForID(facade.GetNameIndex(phantom.forward_segment_id.id))
                     .to_string());
         }

--- a/include/engine/api/json_factory.hpp
+++ b/include/engine/api/json_factory.hpp
@@ -33,7 +33,7 @@ namespace json
 namespace detail
 {
 
-util::json::Array coordinateToLonLat(const util::Coordinate coordinate);
+util::json::Array coordinateToLonLat(const util::Coordinate &coordinate);
 
 /**
  * Ensures that a bearing value is a whole number, and clamped to the range 0-359
@@ -86,11 +86,14 @@ util::json::Object makeRoute(const guidance::Route &route,
                              const char *weight_name);
 
 // Creates a Waypoint without Hint, see the Hint overload below
-util::json::Object makeWaypoint(const util::Coordinate location, std::string name);
+util::json::Object
+makeWaypoint(const util::Coordinate &location, const double &distance, std::string name);
 
 // Creates a Waypoint with Hint, see the overload above when Hint is not needed
-util::json::Object
-makeWaypoint(const util::Coordinate location, std::string name, const Hint &hint);
+util::json::Object makeWaypoint(const util::Coordinate &location,
+                                const double &distance,
+                                std::string name,
+                                const Hint &hint);
 
 util::json::Object makeRouteLeg(guidance::RouteLeg leg, util::json::Array steps);
 

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -41,7 +41,6 @@ class NearestAPI final : public BaseAPI
             [this](const PhantomNodeWithDistance &phantom_with_distance) {
                 auto &phantom_node = phantom_with_distance.phantom_node;
                 auto waypoint = MakeWaypoint(phantom_node);
-                waypoint.values["distance"] = phantom_with_distance.distance;
 
                 util::json::Array nodes;
 

--- a/src/engine/api/json_factory.cpp
+++ b/src/engine/api/json_factory.cpp
@@ -94,7 +94,7 @@ std::string waypointTypeToString(const guidance::WaypointType waypoint_type)
     return waypoint_type_names[static_cast<std::size_t>(waypoint_type)];
 }
 
-util::json::Array coordinateToLonLat(const util::Coordinate coordinate)
+util::json::Array coordinateToLonLat(const util::Coordinate &coordinate)
 {
     util::json::Array array;
     array.values.push_back(static_cast<double>(util::toFloating(coordinate.lon)));
@@ -240,17 +240,22 @@ util::json::Object makeRoute(const guidance::Route &route,
     return json_route;
 }
 
-util::json::Object makeWaypoint(const util::Coordinate location, std::string name)
+util::json::Object
+makeWaypoint(const util::Coordinate &location, const double &distance, std::string name)
 {
     util::json::Object waypoint;
     waypoint.values["location"] = detail::coordinateToLonLat(location);
     waypoint.values["name"] = std::move(name);
+    waypoint.values["distance"] = distance;
     return waypoint;
 }
 
-util::json::Object makeWaypoint(const util::Coordinate location, std::string name, const Hint &hint)
+util::json::Object makeWaypoint(const util::Coordinate &location,
+                                const double &distance,
+                                std::string name,
+                                const Hint &hint)
 {
-    auto waypoint = makeWaypoint(location, name);
+    auto waypoint = makeWaypoint(location, distance, name);
     waypoint.values["hint"] = hint.ToBase64();
     return waypoint;
 }

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -153,7 +153,7 @@ double perpendicularDistance(const Coordinate segment_source,
                               web_mercator::fromWGS84(query_location));
     nearest_location = web_mercator::toWGS84(projected_nearest);
 
-    const double approximate_distance = greatCircleDistance(query_location, nearest_location);
+    const double approximate_distance = fccApproximateDistance(query_location, nearest_location);
     BOOST_ASSERT(0.0 <= approximate_distance);
     return approximate_distance;
 }

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -1,6 +1,8 @@
 #include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <cmath>
+
 #include "coordinates.hpp"
 #include "equal_json.hpp"
 #include "fixture.hpp"
@@ -32,18 +34,28 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
 
     // unset snapping dependent hint
     for (auto &itr : result.values["waypoints"].get<json::Array>().values)
+    {
+        // Hint values aren't stable, so blank it out
         itr.get<json::Object>().values["hint"] = "";
+
+        // Round value to 6 decimal places for double comparison later
+        itr.get<json::Object>().values["distance"] =
+            round(itr.get<json::Object>().values["distance"].get<json::Number>().value * 1000000);
+    }
 
     const auto location = json::Array{{{7.437070}, {43.749248}}};
 
     json::Object reference{
         {{"code", "Ok"},
          {"waypoints",
-          json::Array{
-              {json::Object{
-                   {{"name", "Boulevard du Larvotto"}, {"location", location}, {"hint", ""}}},
-               json::Object{
-                   {{"name", "Boulevard du Larvotto"}, {"location", location}, {"hint", ""}}}}}},
+          json::Array{{json::Object{{{"name", "Boulevard du Larvotto"},
+                                     {"location", location},
+                                     {"distance", round(0.137249 * 1000000)},
+                                     {"hint", ""}}},
+                       json::Object{{{"name", "Boulevard du Larvotto"},
+                                     {"location", location},
+                                     {"distance", round(0.137249 * 1000000)},
+                                     {"hint", ""}}}}}},
          {"routes",
           json::Array{{json::Object{
               {{"distance", 0.},


### PR DESCRIPTION
# Issue

This PR addresses https://github.com/Project-OSRM/osrm-backend/issues/5247 which notes that we're not returning `distance` for all `WayPoint` objects for all APIs.

Previously, the `nearest` API was doing this, but not others.

This PR makes all APIs return `distance` from the input coordinate to the actual snapped point.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch