### PR TITLE
Include information on estimates in table response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
   - Changes from 5.20.0
     - Features:
       - ADDED: all waypoints in responses now contain a distance property between the original coordinate and the snapped location. [#5255](https://github.com/Project-OSRM/osrm-backend/pull/5255)
-      - ADDED: if `fallback_speed` is used, a new structure `estimated_cells` will describe which cells contain estimated values [#5259](https://github.com/Project-OSRM/osrm-backend/pull/5259)
+      - ADDED: if `fallback_speed` is used, a new structure `fallback_speed_cells` will describe which cells contain estimated values [#5259](https://github.com/Project-OSRM/osrm-backend/pull/5259)
     - Table:
       - ADDED: new parameter `scale_factor` which will scale the cell `duration` values by this factor. [#5298](https://github.com/Project-OSRM/osrm-backend/pull/5298)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Changes from 5.20.0
     - Features:
       - ADDED: all waypoints in responses now contain a distance property between the original coordinate and the snapped location. [#5255](https://github.com/Project-OSRM/osrm-backend/pull/5255)
+      - ADDED: if `fallback_speed` is used, a new structure `estimated_cells` will describe which cells contain estimated values [#5259](https://github.com/Project-OSRM/osrm-backend/pull/5259)
     - Table:
       - ADDED: new parameter `scale_factor` which will scale the cell `duration` values by this factor. [#5298](https://github.com/Project-OSRM/osrm-backend/pull/5298)
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -284,6 +284,7 @@ curl 'http://router.project-osrm.org/table/v1/driving/13.388860,52.517037;13.397
   the i-th waypoint to the j-th waypoint. Values are given in meters. Can be `null` if no route between `i` and `j` can be found. Note that computing the `distances` table is currently only implemented for CH. If `annotations=distance` or `annotations=duration,distance` is requested when running a MLD router, a `NotImplemented` error will be returned.
 - `sources` array of `Waypoint` objects describing all sources in order
 - `destinations` array of `Waypoint` objects describing all destinations in order
+- `estimated_cells` (optional) array of arrays containing `i,j` pairs indicating which cells contain estimated values based on `fallback_speed`.  Will be absent if `fallback_speed` is not used.
 
 In case of error the following `code`s are supported in addition to the general ones:
 
@@ -384,6 +385,10 @@ All other properties might be undefined.
       2361.73,
       0
     ]
+  ],
+  "estimated_cells": [
+    [ 0, 1 ],
+    [ 1, 0 ]
   ]
 }
 ```

--- a/docs/http.md
+++ b/docs/http.md
@@ -284,7 +284,7 @@ curl 'http://router.project-osrm.org/table/v1/driving/13.388860,52.517037;13.397
   the i-th waypoint to the j-th waypoint. Values are given in meters. Can be `null` if no route between `i` and `j` can be found. Note that computing the `distances` table is currently only implemented for CH. If `annotations=distance` or `annotations=duration,distance` is requested when running a MLD router, a `NotImplemented` error will be returned.
 - `sources` array of `Waypoint` objects describing all sources in order
 - `destinations` array of `Waypoint` objects describing all destinations in order
-- `estimated_cells` (optional) array of arrays containing `i,j` pairs indicating which cells contain estimated values based on `fallback_speed`.  Will be absent if `fallback_speed` is not used.
+- `fallback_speed_cells` (optional) array of arrays containing `i,j` pairs indicating which cells contain estimated values based on `fallback_speed`.  Will be absent if `fallback_speed` is not used.
 
 In case of error the following `code`s are supported in addition to the general ones:
 
@@ -386,7 +386,7 @@ All other properties might be undefined.
       0
     ]
   ],
-  "estimated_cells": [
+  "fallback_speed_cells": [
     [ 0, 1 ],
     [ 1, 0 ]
   ]

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -157,7 +157,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
                  Values are given in seconds.
 **`sources`**: array of [`Ẁaypoint`](#waypoint) objects describing all sources in order.
 **`destinations`**: array of [`Ẁaypoint`](#waypoint) objects describing all destinations in order.
-**`estimated_cells`**: (optional) if `fallback_speed` is used, will be an array of arrays of `row,column` values, indicating which cells contain estimated values.
+**`fallback_speed_cells`**: (optional) if `fallback_speed` is used, will be an array of arrays of `row,column` values, indicating which cells contain estimated values.
 
 ### tile
 

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -157,6 +157,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
                  Values are given in seconds.
 **`sources`**: array of [`Ẁaypoint`](#waypoint) objects describing all sources in order.
 **`destinations`**: array of [`Ẁaypoint`](#waypoint) objects describing all destinations in order.
+**`estimated_cells`**: (optional) if `fallback_speed` is used, will be an array of arrays of `row,column` values, indicating which cells contain estimated values.
 
 ### tile
 

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -3,22 +3,25 @@ var util = require('util');
 module.exports = function () {
     const durationsRegex = new RegExp(/^I request a travel time matrix I should get$/);
     const distancesRegex = new RegExp(/^I request a travel distance matrix I should get$/);
+    const estimatesRegex = new RegExp(/^I request a travel time matrix I should get estimates for$/);
 
     const DURATIONS_NO_ROUTE = 2147483647;     // MAX_INT
     const DISTANCES_NO_ROUTE = 3.40282e+38;    // MAX_FLOAT
 
     this.When(durationsRegex, function(table, callback) {tableParse.call(this, table, DURATIONS_NO_ROUTE, 'durations', callback);}.bind(this));
     this.When(distancesRegex, function(table, callback) {tableParse.call(this, table, DISTANCES_NO_ROUTE, 'distances', callback);}.bind(this));
+    this.When(estimatesRegex, function(table, callback) {tableParse.call(this, table, DISTANCES_NO_ROUTE, 'estimated_cells', callback);}.bind(this));
 };
 
 const durationsParse = function(v) { return isNaN(parseInt(v)); };
 const distancesParse = function(v) { return isNaN(parseFloat(v)); };
+const estimatesParse = function(v) { return isNaN(parseFloat(v)); };
 
 function tableParse(table, noRoute, annotation, callback) {
 
-    const parse = annotation == 'distances' ? distancesParse : durationsParse;
+    const parse = annotation == 'distances' ? distancesParse : (annotation == 'durations' ? durationsParse : estimatesParse);
     const params = this.queryParams;
-    params.annotations = annotation == 'distances' ? 'distance' : 'duration';
+    params.annotations = ['durations','estimated_cells'].includes(annotation) ? 'duration' : 'distance';
 
     var tableRows = table.raw();
 
@@ -61,11 +64,26 @@ function tableParse(table, noRoute, annotation, callback) {
 
             var json = JSON.parse(response.body);
 
-            var result = json[annotation].map(row => {
-                var hashes = {};
-                row.forEach((v, i) => { hashes[tableRows[0][i+1]] = parse(v) ? '' : v; });
-                return hashes;
-            });
+            var result = {};
+            if (annotation === 'estimated_cells') {
+                result = table.raw().map(row => row.map(cell => ''));
+                json[annotation].forEach(pair => {
+                    result[pair[0]+1][pair[1]+1] = 'Y';
+                });
+                result = result.slice(1).map(row => {
+                    var hashes = {};
+                    row.slice(1).forEach((v,i) => {
+                        hashes[tableRows[0][i+1]] = v;
+                    });
+                    return hashes;
+                });
+            } else {
+                result = json[annotation].map(row => {
+                    var hashes = {};
+                     row.forEach((v, i) => { hashes[tableRows[0][i+1]] = parse(v) ? '' : v; });
+                    return hashes;
+                });
+            }
 
             var testRow = (row, ri, cb) => {
                 for (var k in result[ri]) {

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -66,7 +66,7 @@ function tableParse(table, noRoute, annotation, callback) {
 
             var result = {};
             if (annotation === 'estimated_cells') {
-                result = table.raw().map(row => row.map(cell => ''));
+                result = table.raw().map(row => row.map(() => ''));
                 json[annotation].forEach(pair => {
                     result[pair[0]+1][pair[1]+1] = 'Y';
                 });

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -21,7 +21,7 @@ function tableParse(table, noRoute, annotation, callback) {
 
     const parse = annotation == 'distances' ? distancesParse : (annotation == 'durations' ? durationsParse : estimatesParse);
     const params = this.queryParams;
-    params.annotations = ['durations','estimated_cells'].includes(annotation) ? 'duration' : 'distance';
+    params.annotations = ['durations','estimated_cells'].indexOf(annotation) !== -1 ? 'duration' : 'distance';
 
     var tableRows = table.raw();
 

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -80,7 +80,7 @@ function tableParse(table, noRoute, annotation, callback) {
             } else {
                 result = json[annotation].map(row => {
                     var hashes = {};
-                     row.forEach((v, i) => { hashes[tableRows[0][i+1]] = parse(v) ? '' : v; });
+                    row.forEach((v, i) => { hashes[tableRows[0][i+1]] = parse(v) ? '' : v; });
                     return hashes;
                 });
             }

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -10,7 +10,7 @@ module.exports = function () {
 
     this.When(durationsRegex, function(table, callback) {tableParse.call(this, table, DURATIONS_NO_ROUTE, 'durations', callback);}.bind(this));
     this.When(distancesRegex, function(table, callback) {tableParse.call(this, table, DISTANCES_NO_ROUTE, 'distances', callback);}.bind(this));
-    this.When(estimatesRegex, function(table, callback) {tableParse.call(this, table, DISTANCES_NO_ROUTE, 'estimated_cells', callback);}.bind(this));
+    this.When(estimatesRegex, function(table, callback) {tableParse.call(this, table, DISTANCES_NO_ROUTE, 'fallback_speed_cells', callback);}.bind(this));
 };
 
 const durationsParse = function(v) { return isNaN(parseInt(v)); };
@@ -21,7 +21,7 @@ function tableParse(table, noRoute, annotation, callback) {
 
     const parse = annotation == 'distances' ? distancesParse : (annotation == 'durations' ? durationsParse : estimatesParse);
     const params = this.queryParams;
-    params.annotations = ['durations','estimated_cells'].indexOf(annotation) !== -1 ? 'duration' : 'distance';
+    params.annotations = ['durations','fallback_speed_cells'].indexOf(annotation) !== -1 ? 'duration' : 'distance';
 
     var tableRows = table.raw();
 
@@ -65,7 +65,7 @@ function tableParse(table, noRoute, annotation, callback) {
             var json = JSON.parse(response.body);
 
             var result = {};
-            if (annotation === 'estimated_cells') {
+            if (annotation === 'fallback_speed_cells') {
                 result = table.raw().map(row => row.map(() => ''));
                 json[annotation].forEach(pair => {
                     result[pair[0]+1][pair[1]+1] = 'Y';

--- a/features/testbot/duration_matrix.feature
+++ b/features/testbot/duration_matrix.feature
@@ -552,6 +552,17 @@ Feature: Basic Duration Matrix
             | f | Y | Y |   |   |
             | 1 | Y | Y |   |   |
 
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a |
+            | a |   |
+            | b |   |
+            | f | Y |
+            | 1 | Y |
+
     Scenario: Testbot - Filling in noroutes with estimates - use input coordinate
         Given a grid size of 300 meters
         Given the extract extra arguments "--small-component-size 4"
@@ -586,6 +597,25 @@ Feature: Basic Duration Matrix
             | b | 30 |
             | f | 18 |
             | 1 | 30 |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+            | b |   |   | Y | Y |
+            | f | Y | Y |   |   |
+            | 1 | Y | Y |   |   |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a |
+            | a |   |
+            | b |   |
+            | f | Y |
+            | 1 | Y |
+
 
     Scenario: Testbot - Filling in noroutes with estimates - use snapped coordinate
         Given a grid size of 300 meters
@@ -622,18 +652,35 @@ Feature: Basic Duration Matrix
             | f | 18 |
             | 1 | 24 |
 
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+            | b |   |   | Y | Y |
+            | f | Y | Y |   |   |
+            | 1 | Y | Y |   |   |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a |
+            | a |   |
+            | b |   |
+            | f | Y |
+            | 1 | Y |
 
     Scenario: Testbot - Travel time matrix of minimal network with scale factor
-         Given the query options
+        Given the query options
             | scale_factor | 2 |
-         Given the node map
+        Given the node map
             """
             a b
             """
-         And the ways
+        And the ways
             | nodes |
             | ab    |
-         When I request a travel time matrix I should get
+        When I request a travel time matrix I should get
             |   | a  | b  |
             | a | 0  | 20 |
             | b | 20 | 0  |
@@ -645,67 +692,86 @@ Feature: Basic Duration Matrix
             | fallback_speed | 5 |
             | fallback_coordinate | snapped |
 
-         Given the node map
+        Given the node map
             """
             a b   f h 1
             d e   g i
             """
 
-         And the ways
+        And the ways
             | nodes |
             | abeda |
             | fhigf |
 
-         When I request a travel time matrix I should get
+        When I request a travel time matrix I should get
             |   | a  | b  | f  | 1  |
             | a | 0  | 60 | 36 | 48 |
             | b | 60 | 0  | 24 | 36 |
             | f | 36 | 24 | 0  | 60 |
             | 1 | 48 | 36 | 60 | 0  |
 
-         When I request a travel time matrix I should get
+        When I request a travel time matrix I should get
             |   | a  | b  | f  | 1  |
             | a | 0  | 60 | 36 | 48 |
 
-         When I request a travel time matrix I should get
+        When I request a travel time matrix I should get
             |   | a  |
             | a | 0  |
             | b | 60 |
             | f | 36 |
             | 1 | 48 |
 
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+            | b |   |   | Y | Y |
+            | f | Y | Y |   |   |
+            | 1 | Y | Y |   |   |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+
+        When I request a travel time matrix I should get estimates for
+            |   | a |
+            | a |   |
+            | b |   |
+            | f | Y |
+            | 1 | Y |
+
+
      Scenario: Testbot - Travel time matrix of minimal network with overflow scale factor
         Given the query options
             | scale_factor | 2147483647 |
 
-         Given the node map
+        Given the node map
             """
             a b
             """
 
-         And the ways
+        And the ways
             | nodes |
             | ab    |
 
-         When I request a travel time matrix I should get
+        When I request a travel time matrix I should get
             |   | a           | b           |
             | a | 0           | 214748364.6 |
             | b | 214748364.6 | 0           |
 
      Scenario: Testbot - Travel time matrix of minimal network with fraction scale factor
-         Given the query options
+        Given the query options
             | scale_factor | 0.5 |
 
-         Given the node map
+        Given the node map
             """
             a b
             """
 
-         And the ways
+        And the ways
             | nodes |
             | ab    |
 
-         When I request a travel time matrix I should get
+        When I request a travel time matrix I should get
             |   | a  | b  |
             | a | 0  | 5  |
             | b | 5  | 0  |

--- a/features/testbot/duration_matrix.feature
+++ b/features/testbot/duration_matrix.feature
@@ -545,6 +545,13 @@ Feature: Basic Duration Matrix
             | f | 18 |
             | 1 | 30 |
 
+        When I request a travel time matrix I should get estimates for
+            |   | a | b | f | 1 |
+            | a |   |   | Y | Y |
+            | b |   |   | Y | Y |
+            | f | Y | Y |   |   |
+            | 1 | Y | Y |   |   |
+
     Scenario: Testbot - Filling in noroutes with estimates - use input coordinate
         Given a grid size of 300 meters
         Given the extract extra arguments "--small-component-size 4"

--- a/include/engine/api/table_api.hpp
+++ b/include/engine/api/table_api.hpp
@@ -31,6 +31,15 @@ namespace api
 class TableAPI final : public BaseAPI
 {
   public:
+    struct TableCellRef
+    {
+        TableCellRef(const std::size_t &row, const std::size_t &column) : row{row}, column{column}
+        {
+        }
+        std::size_t row;
+        std::size_t column;
+    };
+
     TableAPI(const datafacade::BaseDataFacade &facade_, const TableParameters &parameters_)
         : BaseAPI(facade_, parameters_), parameters(parameters_)
     {
@@ -39,6 +48,7 @@ class TableAPI final : public BaseAPI
     virtual void
     MakeResponse(const std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>> &tables,
                  const std::vector<PhantomNode> &phantoms,
+                 const std::vector<TableCellRef> &estimated_cells,
                  util::json::Object &response) const
     {
         auto number_of_sources = parameters.sources.size();
@@ -75,6 +85,11 @@ class TableAPI final : public BaseAPI
         {
             response.values["distances"] =
                 MakeDistanceTable(tables.second, number_of_sources, number_of_destinations);
+        }
+
+        if (parameters.fallback_speed > 0)
+        {
+            response.values["estimated_cells"] = MakeEstimatesTable(estimated_cells);
         }
 
         response.values["code"] = "Ok";
@@ -160,6 +175,19 @@ class TableAPI final : public BaseAPI
                            });
             json_table.values.push_back(std::move(json_row));
         }
+        return json_table;
+    }
+
+    virtual util::json::Array
+    MakeEstimatesTable(const std::vector<TableCellRef> &estimated_cells) const
+    {
+        util::json::Array json_table;
+        std::for_each(estimated_cells.begin(), estimated_cells.end(), [&](const auto &cell) {
+            util::json::Array row;
+            row.values.push_back(util::json::Number(cell.row));
+            row.values.push_back(util::json::Number(cell.column));
+            json_table.values.push_back(std::move(row));
+        });
         return json_table;
     }
 

--- a/include/engine/api/table_api.hpp
+++ b/include/engine/api/table_api.hpp
@@ -182,12 +182,13 @@ class TableAPI final : public BaseAPI
     MakeEstimatesTable(const std::vector<TableCellRef> &fallback_speed_cells) const
     {
         util::json::Array json_table;
-        std::for_each(fallback_speed_cells.begin(), fallback_speed_cells.end(), [&](const auto &cell) {
-            util::json::Array row;
-            row.values.push_back(util::json::Number(cell.row));
-            row.values.push_back(util::json::Number(cell.column));
-            json_table.values.push_back(std::move(row));
-        });
+        std::for_each(
+            fallback_speed_cells.begin(), fallback_speed_cells.end(), [&](const auto &cell) {
+                util::json::Array row;
+                row.values.push_back(util::json::Number(cell.row));
+                row.values.push_back(util::json::Number(cell.column));
+                json_table.values.push_back(std::move(row));
+            });
         return json_table;
     }
 

--- a/include/engine/api/table_api.hpp
+++ b/include/engine/api/table_api.hpp
@@ -48,7 +48,7 @@ class TableAPI final : public BaseAPI
     virtual void
     MakeResponse(const std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>> &tables,
                  const std::vector<PhantomNode> &phantoms,
-                 const std::vector<TableCellRef> &estimated_cells,
+                 const std::vector<TableCellRef> &fallback_speed_cells,
                  util::json::Object &response) const
     {
         auto number_of_sources = parameters.sources.size();
@@ -89,7 +89,7 @@ class TableAPI final : public BaseAPI
 
         if (parameters.fallback_speed != INVALID_FALLBACK_SPEED && parameters.fallback_speed > 0)
         {
-            response.values["estimated_cells"] = MakeEstimatesTable(estimated_cells);
+            response.values["fallback_speed_cells"] = MakeEstimatesTable(fallback_speed_cells);
         }
 
         response.values["code"] = "Ok";
@@ -179,10 +179,10 @@ class TableAPI final : public BaseAPI
     }
 
     virtual util::json::Array
-    MakeEstimatesTable(const std::vector<TableCellRef> &estimated_cells) const
+    MakeEstimatesTable(const std::vector<TableCellRef> &fallback_speed_cells) const
     {
         util::json::Array json_table;
-        std::for_each(estimated_cells.begin(), estimated_cells.end(), [&](const auto &cell) {
+        std::for_each(fallback_speed_cells.begin(), fallback_speed_cells.end(), [&](const auto &cell) {
             util::json::Array row;
             row.values.push_back(util::json::Number(cell.row));
             row.values.push_back(util::json::Number(cell.column));

--- a/include/engine/api/table_api.hpp
+++ b/include/engine/api/table_api.hpp
@@ -87,7 +87,7 @@ class TableAPI final : public BaseAPI
                 MakeDistanceTable(tables.second, number_of_sources, number_of_destinations);
         }
 
-        if (parameters.fallback_speed > 0)
+        if (parameters.fallback_speed != INVALID_FALLBACK_SPEED && parameters.fallback_speed > 0)
         {
             response.values["estimated_cells"] = MakeEstimatesTable(estimated_cells);
         }

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -95,6 +95,8 @@ Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
         return Error("NoTable", "No table found", result);
     }
 
+    std::vector<api::TableAPI::TableCellRef> estimated_pairs;
+
     // Scan table for null results - if any exist, replace with distance estimates
     if (params.fallback_speed != INVALID_FALLBACK_SPEED || params.scale_factor > 0)
     {
@@ -127,6 +129,8 @@ Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                     {
                         result_tables_pair.second[table_index] = distance_estimate;
                     }
+
+                    estimated_pairs.emplace_back(row, column);
                 }
                 if (params.scale_factor > 0 && params.scale_factor != 1 &&
                     result_tables_pair.first[table_index] != MAXIMAL_EDGE_DURATION &&
@@ -150,7 +154,7 @@ Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
     }
 
     api::TableAPI table_api{facade, params};
-    table_api.MakeResponse(result_tables_pair, snapped_phantoms, result);
+    table_api.MakeResponse(result_tables_pair, snapped_phantoms, estimated_pairs, result);
 
     return Status::Ok;
 }

--- a/test/nodejs/table.js
+++ b/test/nodejs/table.js
@@ -234,7 +234,7 @@ tables.forEach(function(annotation) {
     });
 
     test('table: ' + annotation + ' table in Monaco without motorways', function(assert) {
-        assert.plan(1);
+        assert.plan(2);
         var osrm = new OSRM({path: mld_data_path, algorithm: 'MLD'});
         var options = {
             coordinates: two_test_coordinates,
@@ -243,11 +243,12 @@ tables.forEach(function(annotation) {
         };
         osrm.table(options, function(err, response) {
             assert.equal(response[annotation].length, 2);
+            assert.strictEqual(response.estimated_cells, undefined);
         });
     });
 
     test('table: ' + annotation + ' table in Monaco with fallback speeds', function(assert) {
-        assert.plan(1);
+        assert.plan(2);
         var osrm = new OSRM({path: mld_data_path, algorithm: 'MLD'});
         var options = {
             coordinates: two_test_coordinates,
@@ -257,6 +258,7 @@ tables.forEach(function(annotation) {
         };
         osrm.table(options, function(err, response) {
             assert.equal(response[annotation].length, 2);
+            assert.equal(response['estimated_cells'].length, 0);
         });
     });
 

--- a/test/nodejs/table.js
+++ b/test/nodejs/table.js
@@ -243,7 +243,7 @@ tables.forEach(function(annotation) {
         };
         osrm.table(options, function(err, response) {
             assert.equal(response[annotation].length, 2);
-            assert.strictEqual(response.estimated_cells, undefined);
+            assert.strictEqual(response.fallback_speed_cells, undefined);
         });
     });
 
@@ -258,7 +258,7 @@ tables.forEach(function(annotation) {
         };
         osrm.table(options, function(err, response) {
             assert.equal(response[annotation].length, 2);
-            assert.equal(response['estimated_cells'].length, 0);
+            assert.equal(response['fallback_speed_cells'].length, 0);
         });
     });
 


### PR DESCRIPTION
# Issue

If the `fallback_speed` option is used, it's useful to know *which* cells contain estimated information.

This PR adds a new data structure to the `table` API response that looks like this:

**UPDATED: param name to `fallback_speed_cells` from `estimated_cells`:**
```json
  fallback_speed_cells: [
    [1,0],
    [2,3]
  ]
```
which are the `row,column` references to cells that contain estimated data.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
