### PR TITLE
remove matrix api destination/sources length <= coordinates length check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Table:
       - CHANGED: switch to pre-calculated distances for table responses for large speedup and 10% memory increase. [#5251](https://github.com/Project-OSRM/osrm-backend/pull/5251)
       - ADDED: new parameter `fallback_speed` which will fill `null` cells with estimated value [#5257](https://github.com/Project-OSRM/osrm-backend/pull/5257)
+      - CHANGED: Remove API check for matrix sources/destination length to be less than or equal to coordinates length. [#5298](https://github.com/Project-OSRM/osrm-backend/pull/5289)
     - Features:
       - ADDED: direct mmapping of datafiles is now supported via the `--mmap` switch. [#5242](https://github.com/Project-OSRM/osrm-backend/pull/5242)
       - REMOVED: the previous `--memory_file` switch is now deprecated and will fallback to `--mmap` [#5242](https://github.com/Project-OSRM/osrm-backend/pull/5242)

--- a/include/engine/api/table_parameters.hpp
+++ b/include/engine/api/table_parameters.hpp
@@ -123,14 +123,7 @@ struct TableParameters : public BaseParameters
 
         // 1/ The user is able to specify duplicates in srcs and dsts, in that case it's their fault
 
-        // 2/ len(srcs) and len(dsts) smaller or equal to len(locations)
-        if (sources.size() > coordinates.size())
-            return false;
-
-        if (destinations.size() > coordinates.size())
-            return false;
-
-        // 3/ 0 <= index < len(locations)
+        // 2/ 0 <= index < len(locations)
         const auto not_in_range = [this](const std::size_t x) { return x >= coordinates.size(); };
 
         if (std::any_of(begin(sources), end(sources), not_in_range))


### PR DESCRIPTION
# Issue

We have a [table size check](https://github.com/Project-OSRM/osrm-backend/blob/82b5648c97edf1d2edec7aecebc35aa8a8033c82/src/engine/plugins/table.cpp#L63-L64) so there is no need to enforce this limit in the query parameters as well. 

This PR removes this additional limit enforcement.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
