### PR TITLE
Fix fallback_speed vector access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - CHANGED: switch to pre-calculated distances for table responses for large speedup and 10% memory increase. [#5251](https://github.com/Project-OSRM/osrm-backend/pull/5251)
       - ADDED: new parameter `fallback_speed` which will fill `null` cells with estimated value [#5257](https://github.com/Project-OSRM/osrm-backend/pull/5257)
       - CHANGED: Remove API check for matrix sources/destination length to be less than or equal to coordinates length. [#5298](https://github.com/Project-OSRM/osrm-backend/pull/5289)
+      - FIXED: Fix crashing bug when using fallback_speed parameter with more sources than destinations. [#5291](https://github.com/Project-OSRM/osrm-backend/pull/5291)
     - Features:
       - ADDED: direct mmapping of datafiles is now supported via the `--mmap` switch. [#5242](https://github.com/Project-OSRM/osrm-backend/pull/5242)
       - REMOVED: the previous `--memory_file` switch is now deprecated and will fallback to `--mmap` [#5242](https://github.com/Project-OSRM/osrm-backend/pull/5242)

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -667,3 +667,28 @@ Feature: Basic Distance Matrix
             | b | 300.2  | 0     | 600.5 | 900.7  |
             | f | 900.7  | 600.5 | 0     | 302.2  |
             | 1 | 1200.9 | 900.7 | 300.2 | 0      |
+
+    Scenario: Testbot - Filling in noroutes with estimates - use snapped coordinate - asymetric
+        Given a grid size of 300 meters
+        Given the extract extra arguments "--small-component-size 4"
+        Given the query options
+            | fallback_speed | 5 |
+            | fallback_coordinate | snapped |
+        Given the node map
+            """
+            a b   f h 1
+            d e   g i
+            """
+
+        And the ways
+            | nodes |
+            | abeda |
+            | fhigf |
+
+        When I request a travel distance matrix I should get
+            |   | a      |
+            | a | 0      |
+            | b | 300.2  |
+            | f | 900.7  |
+            | 1 | 1200.9 |
+            

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -668,7 +668,7 @@ Feature: Basic Distance Matrix
             | f | 900.7  | 600.5 | 0     | 302.2  |
             | 1 | 1200.9 | 900.7 | 300.2 | 0      |
 
-    Scenario: Testbot - Filling in noroutes with estimates - use snapped coordinate - asymetric
+    Scenario: Testbot - Asymetric fallback_speed - more sources than destinations
         Given a grid size of 300 meters
         Given the extract extra arguments "--small-component-size 4"
         Given the query options
@@ -691,4 +691,24 @@ Feature: Basic Distance Matrix
             | b | 300.2  |
             | f | 900.7  |
             | 1 | 1200.9 |
-            
+
+ Scenario: Testbot - Asymetric fallback_speed - more destinations than sources
+        Given a grid size of 300 meters
+        Given the extract extra arguments "--small-component-size 4"
+        Given the query options
+            | fallback_speed | 5 |
+            | fallback_coordinate | snapped |
+        Given the node map
+            """
+            a b   f h 1
+            d e   g i
+            """
+
+        And the ways
+            | nodes |
+            | abeda |
+            | fhigf |
+
+        When I request a travel distance matrix I should get
+            |   | a      | b     | f     | 1      |
+            | a | 0      | 300.2 | 900.7 | 1200.9 |

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -102,7 +102,7 @@ Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
         {
             for (std::size_t column = 0; column < num_destinations; column++)
             {
-                const auto &table_index = row * num_sources + column;
+                const auto &table_index = row * num_destinations + column;
                 BOOST_ASSERT(table_index < result_tables_pair.first.size());
                 if (result_tables_pair.first[table_index] == MAXIMAL_EDGE_DURATION)
                 {

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -103,6 +103,7 @@ Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
             for (std::size_t column = 0; column < num_destinations; column++)
             {
                 const auto &table_index = row * num_sources + column;
+                BOOST_ASSERT(table_index < result_tables_pair.first.size());
                 if (result_tables_pair.first[table_index] == MAXIMAL_EDGE_DURATION)
                 {
                     const auto &source =


### PR DESCRIPTION
# Issue

If there is an assymetric (more sources than destinations) matrix request and fallback_speed is used, garbage is returned, or it segfaults. This PR fixes this issue.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
