### PR TITLE
Count reverse offset from the back of the geometry, not the front.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Table:
       - ADDED: new parameter `scale_factor` which will scale the cell `duration` values by this factor. [#5298](https://github.com/Project-OSRM/osrm-backend/pull/5298)
       - FIXED: only trigger `scale_factor` code to scan matrix when necessary. [#5303](https://github.com/Project-OSRM/osrm-backend/pull/5303)
+      - FIXED: fix bug in reverse offset calculation that sometimes lead to negative (and other incorrect) values in distance table results [#5315](https://github.com/Project-OSRM/osrm-backend/pull/5315)
     - Docker:
       - FIXED: use consistent boost version between build and runtime [#5311](https://github.com/Project-OSRM/osrm-backend/pull/5311)
       - FIXED: don't override default permissions on /opt [#5311](https://github.com/Project-OSRM/osrm-backend/pull/5311)

--- a/features/testbot/distance_matrix.feature
+++ b/features/testbot/distance_matrix.feature
@@ -616,7 +616,7 @@ Feature: Basic Distance Matrix
             |   | a      | b      | f     | 1      |
             | a | 0      | 300.2  | 900.7 | 1501.1 |
             | b | 300.2  | 0      | 600.5 | 1200.9 |
-            | f | 900.7  | 600.5  | 0     | 302.2  |
+            | f | 900.7  | 600.5  | 0     | 300.2  |
             | 1 | 1501.1 | 1200.9 | 300.2 | 0      |
 
         When I request a travel distance matrix I should get
@@ -651,7 +651,7 @@ Feature: Basic Distance Matrix
             |   | a      | b      | f     | 1      |
             | a | 0      | 300.2  | 900.7 | 1501.1 |
             | b | 300.2  | 0      | 600.5 | 1200.9 |
-            | f | 900.7  | 600.5  | 0     | 302.2  |
+            | f | 900.7  | 600.5  | 0     | 300.2  |
             | 1 | 1501.1 | 1200.9 | 300.2 | 0      |
 
         When I request a travel distance matrix I should get
@@ -687,7 +687,7 @@ Feature: Basic Distance Matrix
             |   | a      | b     | f     | 1      |
             | a | 0      | 300.2 | 900.7 | 1200.9 |
             | b | 300.2  | 0     | 600.5 | 900.7  |
-            | f | 900.7  | 600.5 | 0     | 302.2  |
+            | f | 900.7  | 600.5 | 0     | 300.2  |
             | 1 | 1200.9 | 900.7 | 300.2 | 0      |
 
         When I request a travel distance matrix I should get
@@ -701,3 +701,25 @@ Feature: Basic Distance Matrix
             | f | 900.7  |
             | 1 | 1200.9 |
 
+    Scenario: Ensure consistency with route, and make sure offsets work in both directions
+        Given a grid size of 100 meters
+        Given the node map
+            """
+            a   b   c   d   e   f   g   h  i  j
+                  1                   2
+            """
+
+        And the ways
+            | nodes |
+            | abcdef  |
+            | fghij  |
+
+        When I route I should get
+            | from | to | route              | distance |
+            | 1    | 2  | abcdef,fghij,fghij | 999.9m  |
+
+        # TODO: this is "correct", but inconsistent with viaroute
+        When I request a travel distance matrix I should get
+            |   |   1    | 2      |
+            | 1 |   0    | 1000.7 |
+            | 2 | 1000.7 | 0      |

--- a/features/testbot/multi_level_routing.feature
+++ b/features/testbot/multi_level_routing.feature
@@ -111,9 +111,9 @@ Feature: Multi level routing
         When I request a travel distance matrix I should get
             |   | a      | f      | l      | o      |
             | a | 0      | 2383.7 | 1566.9 | 1366.8 |
-            | f | 2339.9 | 0      | 1198.1 | 1522.1 |
-            | l | 1618.3 | 1293.3 | 0      | 800.5  |
-            | o | 1418.2 | 1617.3 | 800.5  | 0      |
+            | f | 2383.7 | 0      | 1293.3 | 1617.3 |
+            | l | 1566.9 | 1293.3 | 0      | 800.5  |
+            | o | 1366.8 | 1617.3 | 800.5  | 0      |
 
         When I request a travel distance matrix I should get
             |   | a | f      | l      | o      |
@@ -122,21 +122,21 @@ Feature: Multi level routing
         When I request a travel distance matrix I should get
             |   | a      |
             | a | 0      |
-            | f | 2339.9 |
-            | l | 1618.3 |
-            | o | 1418.2 |
+            | f | 2383.7 |
+            | l | 1566.9 |
+            | o | 1366.8 |
 
         When I request a travel distance matrix I should get
             |   | a      | f      | l      | o      |
             | a | 0      | 2383.7 | 1566.9 | 1366.8 |
-            | f | 2339.9 | 0      | 1198.1 | 1522.1 |
+            | f | 2383.7 | 0      | 1293.3 | 1617.3 |
 
         When I request a travel distance matrix I should get
             |   | a      | o      |
             | a | 0      | 1366.8 |
-            | f | 2339.9 | 1522.1 |
-            | l | 1618.3 | 800.5  |
-            | o | 1418.2 | 0      |
+            | f | 2383.7 | 1617.3 |
+            | l | 1566.9 | 800.5  |
+            | o | 1366.8 | 0      |
 
     Scenario: Testbot - Multi level routing: horizontal road
         Given the node map

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -465,6 +465,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                             EdgeDuration{0});
 
         EdgeDistance forward_distance_offset = 0;
+        // Sum up the distance from the start to the fwd_segment_position
         for (auto current = forward_geometry.begin();
              current < forward_geometry.begin() + data.fwd_segment_position;
              ++current)
@@ -494,8 +495,9 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                             EdgeDuration{0});
 
         EdgeDistance reverse_distance_offset = 0;
-        for (auto current = forward_geometry.begin();
-             current < forward_geometry.end() - data.fwd_segment_position - 2;
+        // Sum up the distance from just after the fwd_segment_position to the end
+        for (auto current = forward_geometry.begin() + data.fwd_segment_position + 1;
+             current != std::prev(forward_geometry.end());
              ++current)
         {
             reverse_distance_offset += util::coordinate_calculation::fccApproximateDistance(


### PR DESCRIPTION
# Issue

Fixes a problem with distance calculations in `table` responses (reported in https://github.com/Project-OSRM/osrm-backend/issues/5306).

The reverse offset value in the PhantomNodes was being incorrectly calculated.  When this value was used, and the matrix covered only a small distance, it was possible for the incorrect offset to outweigh the distances added to it, and it would end up negative..

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
