### PR TITLE
penalize toll roads instead of excluding them

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -416,6 +416,9 @@ function process_way(profile, way, result, relations)
     -- handle hov
     WayHandlers.hov,
 
+    -- apply high penalty for turns onto toll roads, starting on them still works
+    WayHandlers.penalize_toll_roads,
+
     -- compute speed taking into account way type, maxspeed tags, etc.
     WayHandlers.speed,
     WayHandlers.surface,

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -221,6 +221,26 @@ function WayHandlers.hov(profile,way,result,data)
   end
 end
 
+-- set restricted flags for toll roads; later on the profile can apply turn penalties
+function WayHandlers.penalize_toll_roads(profile,way,result,data)
+  -- if user tells us to avoid toll roads completely,
+  -- there is no need to set high penalties
+  if profile.avoid.toll then
+    return
+  end
+
+  local toll = way:get_value_by_key("toll")
+
+  if "yes" == toll then
+    result.forward_restricted = true
+    result.backward_restricted = true
+  end
+
+  -- Todo:
+  -- - forward/backward namespaces
+  -- - other tag values not only "yes"
+end
+
 
 -- set highway and access classification by user preference
 function WayHandlers.way_classification_for_turn(profile,way,result,data)


### PR DESCRIPTION
# Issue

In the [current behaviour ](https://github.com/Project-OSRM/osrm-backend/blob/master/profiles/car.lua#L123 )if you want to avoid toll roads you set the 'tolls' in the exclude set in the lua profile. This causes the router to completely remove all toll roads from the graph when creating the graph.

The problem with this behaviour is that if you happen to be on a toll road and request a route, then there is no road to snap you onto on the graph. 

This PR prevents stripping the toll roads completely from the graph, but rather penalizes making turns onto  toll roads.   

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
