### PR TITLE
Downgrade Docker images to debian:stretch-slim to ensure stable environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as builder
+FROM debian:stretch-slim as builder
 ARG DOCKER_TAG
 RUN mkdir -p /src  && mkdir -p /opt
 COPY . /src
@@ -6,9 +6,8 @@ WORKDIR /src
 
 RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
     apt-get update && \
-    apt-get -y --no-install-recommends install cmake make git gcc g++ libbz2-dev libstxxl-dev libstxxl1v5 libxml2-dev \
-    libzip-dev libboost1.67-all-dev lua5.2 liblua5.2-dev libtbb-dev -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 && \
-    NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
+    apt-get -y --no-install-recommends install cmake make git gcc g++ libbz2-dev libxml2-dev \
+    libzip-dev libboost1.62-all-dev lua5.2 liblua5.2-dev libtbb-dev -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
@@ -30,15 +29,20 @@ RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
 
 # Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
-FROM debian:buster-slim as runstage
+FROM debian:stretch-slim as runstage
 RUN mkdir -p /src  && mkdir -p /opt
 RUN apt-get update && \
-apt-get install -y --no-install-recommends libboost-program-options1.67.0 libboost-regex1.67.0 \
-libboost-date-time1.67.0 libboost-chrono1.67.0 libboost-filesystem1.67.0 \
-libboost-iostreams1.67.0 libboost-thread1.67.0 expat liblua5.2-0 libtbb2 &&\
-rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends libboost-program-options1.62.0 libboost-regex1.62.0 \
+        libboost-date-time1.62.0 libboost-chrono1.62.0 libboost-filesystem1.62.0 \
+        libboost-iostreams1.62.0 libboost-thread1.62.0 expat liblua5.2-0 libtbb2 &&\
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt /opt
+RUN /usr/local/bin/osrm-extract --help && \
+    /usr/local/bin/osrm-routed --help && \
+    /usr/local/bin/osrm-contract --help && \
+    /usr/local/bin/osrm-partition --help && \
+    /usr/local/bin/osrm-customize --help
 WORKDIR /opt
 
 EXPOSE 5000


### PR DESCRIPTION
With the switch to Debian base images for Docker (to use libc for some solid speedup over musl-c), we initially started using `debian:buster-slim` images.

Unfortunately, `buster` is still in an unstable state, which lead to https://github.com/Project-OSRM/osrm-backend/issues/5324

This problem does *not* occur if you re-build right now, but it shows that `buster` is still in a state of flux.

This PR downgrades the base image to `debian:stretch-slim` - AFAIK, there are no huge improvements in `buster` that OSRM is taking advantage of, so the effect here should be basically nothing, escept we get a much more stable base distribution that shouldn't change over time.

This PR deprecates https://github.com/Project-OSRM/osrm-backend/pull/5323, which provided a quick-fix for the `buster-slim` instability.

Once `buster` goes stable, we can consider upgrading the base image.