### PR TITLE
Fix cpack config by pointing to a correct LICENSE file

### DIFF
--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -11,7 +11,7 @@ SET(CPACK_INCLUDE_TOPLEVEL_DIRECTORY "FALSE")
 SET(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Open Source Routing Machine (OSRM) is a high-performance routing engine. It combines sophisticated routing algorithms with the open and free data of the OpenStreetMap.")
 SET(CPACK_PACKAGE_CONTACT "Project OSRM <info@project-osrm.org>")
-SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENCE.TXT")
+SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.TXT")
 
 SET(CPACK_STRIP_FILES "TRUE")
 file(GLOB_RECURSE ProfileGlob ${CMAKE_SOURCE_DIR}/profiles/*)


### PR DESCRIPTION
In `cmake/CPackConfig.cmake` we set `CPACK_RESOURCE_FILE_LICENSE` to be `LICENCE.TXT`, while this file is actually called `LICENSE.TXT`

* Fix `CPACK_RESOURCE_FILE_LICENSE` to point to a correct license file.