### PR TITLE
Add BUILD_CONCURRENCY argument 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:stretch-slim as builder
 ARG DOCKER_TAG
+ARG BUILD_CONCURRENCY
 RUN mkdir -p /src  && mkdir -p /opt
 COPY . /src
 WORKDIR /src
 
-RUN NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
+RUN NPROC=${BUILD_CONCURRENCY:-$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1)} && \
     apt-get update && \
     apt-get -y --no-install-recommends install cmake make git gcc g++ libbz2-dev libxml2-dev \
     libzip-dev libboost1.62-all-dev lua5.2 liblua5.2-dev libtbb-dev -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 && \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -6,4 +6,4 @@
 # ensure that "COPY . /src" is referring to the repo root, not the directory
 # that contains the Dockerfile.
 # This script gets executed with a pwd of wherever the Dockerfile is.
-docker build --build-arg DOCKER_TAG=${DOCKER_TAG} -t $IMAGE_NAME -f Dockerfile ..
+docker build --build-arg BUILD_CONCURRENCY=${CONCURRENCY:-1} --build-arg DOCKER_TAG=${DOCKER_TAG} -t $IMAGE_NAME -f Dockerfile ..


### PR DESCRIPTION
so that we can limit concurrency on Docker Hub (and thus reduce peak memory need for build).

# Issue

Image builds on Docker Hub are often failing because we exceed the maximum allowed memory usage during the build.

This change allows us to pass in a `BUILD_CONCURRENCY` environment variable to limit the `make -j` concurrency to 1, reducing the peak memory need.

This should stop builds on Docker Hub failing so frequently.