### PR TITLE
[WIP] add stoppage penalties to table_params and use to penalize table results

### DIFF
--- a/include/engine/api/table_parameters.hpp
+++ b/include/engine/api/table_parameters.hpp
@@ -60,6 +60,8 @@ struct TableParameters : public BaseParameters
     std::vector<std::size_t> sources;
     std::vector<std::size_t> destinations;
     double fallback_speed = INVALID_FALLBACK_SPEED;
+    double min_stoppage_penalty = INVALID_MINIMUM_STOPAGE_PENALTY;
+    double max_stoppage_penalty = INVALID_MAXIMUM_STOPAGE_PENALTY;
 
     enum class FallbackCoordinateType
     {
@@ -108,11 +110,14 @@ struct TableParameters : public BaseParameters
                     double fallback_speed_,
                     FallbackCoordinateType fallback_coordinate_type_,
                     double scale_factor_,
+                    double min_stoppage_penalty_,
+                    double max_stoppage_penalty_,
                     Args... args_)
         : BaseParameters{std::forward<Args>(args_)...}, sources{std::move(sources_)},
           destinations{std::move(destinations_)}, fallback_speed{fallback_speed_},
           fallback_coordinate_type{fallback_coordinate_type_}, annotations{annotations_},
-          scale_factor{scale_factor_}
+          scale_factor{scale_factor_}, min_stoppage_penalty{min_stoppage_penalty_},
+          max_stoppage_penalty{max_stoppage_penalty_}
 
     {
     }
@@ -141,6 +146,10 @@ struct TableParameters : public BaseParameters
             return false;
 
         if (scale_factor <= 0)
+            return false;
+
+        if (min_stoppage_penalty <= 0 || max_stoppage_penalty <= 0 ||
+                max_stoppage_penalty > min_stoppage_penalty)
             return false;
 
         return true;

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -48,7 +48,7 @@ struct osm_way_id
 struct duplicated_node
 {
 };
-}
+} // namespace tag
 using OSMNodeID = osrm::Alias<std::uint64_t, tag::osm_node_id>;
 static_assert(std::is_pod<OSMNodeID>(), "OSMNodeID is not a valid alias");
 using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
@@ -117,7 +117,13 @@ static const EdgeDuration MAXIMAL_EDGE_DURATION = std::numeric_limits<EdgeDurati
 static const EdgeDistance MAXIMAL_EDGE_DISTANCE = std::numeric_limits<EdgeDistance>::max();
 static const TurnPenalty INVALID_TURN_PENALTY = std::numeric_limits<TurnPenalty>::max();
 static const EdgeDistance INVALID_EDGE_DISTANCE = std::numeric_limits<EdgeDistance>::max();
-static const EdgeDistance INVALID_FALLBACK_SPEED = std::numeric_limits<double>::max();
+static const EdgeDistance INVALID_FALLBACK_SPEED = std::numeric_limits<EdgeDistance>::max();
+static const EdgeDuration INVALID_MINIMUM_STOPAGE_PENALTY =
+    std::numeric_limits<EdgeDuration>::max();
+static const EdgeDuration INVALID_MAXIMUM_STOPAGE_PENALTY =
+    std::numeric_limits<EdgeDuration>::max();
+constexpr double MINIMAL_ACCEL_DECEL_PENALIZABLE_SPEED = 10;
+constexpr double MAXIMAL_ACCEL_DECEL_PENALIZABLE_SPEED = 40;
 
 // FIXME the bitfields we use require a reduced maximal duration, this should be kept consistent
 // within the code base. For now we have to ensure that we don't case 30 bit to -1 and break any


### PR DESCRIPTION
# Issue

This PR is meant as a step toward addressing #5353 

The gist is that I've added a place for new table parameters that allow you to add a penalty (in terms of time/duration) to each table result (source/target pair) based on how acceleration at the beginning of that trip might happen and how deceleration at the end of the trip might happen.

The additional parameters are a minimum and maximum penalty in seconds. Basically an upper and lower bound. The penalty will vary with respect to the expected speed of travel on the edge where the source/target was correlated in the graph. The slower the speed of the edge, the lesser the penalty. The idea being that it takes you less time to get up to speed or come to a stop for edges with slower speeds. The inverse should hold true for edges with higher speeds.

For edge speeds lower than a certain cutoff, no penalty is applied. For edge speeds greater than a certain cutoff, the user provided maximum penalty is applied (this probably doesnt make sense for space travel, but should be ok for personal vehicle travel). Speeds in between the two extrema result in a penalty that is a linear combination of the upper and lower user-supplied penalties.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
