### PR TITLE
Add Acceleration Profiles to Tune Route Duration (especially for short trips)

### DIFF
--- a/features/testbot/stoppage.feature
+++ b/features/testbot/stoppage.feature
@@ -1,0 +1,168 @@
+@routing @maxspeed @testbot
+Feature: Testbot - Acceleration profiles
+
+    Background: Use specific speeds
+        Given the profile "testbot"
+
+    Scenario: Testbot - No stoppage penalties
+        Given a grid size of 10 meters
+        Given the node map
+            """
+            a 1 2 3 4 5 b
+            """
+
+        And the ways
+            | nodes | highway | maxspeed:forward    | maxspeed:backward |
+            | ab    | trunk   | 60                  | 45                |
+
+        When I route I should get
+            | from | to | route | time   | distance |
+            | a    | b  | ab,ab | 3.6s   | 59.9m    |
+            | a    | 1  | ab,ab | 0.6s   | 10m      |
+            | a    | 2  | ab,ab | 1.2s   | 20m      |
+            | a    | 3  | ab,ab | 1.8s   | 30m      |
+            | a    | 4  | ab,ab | 2.4s   | 40m      |
+            | a    | 5  | ab,ab | 3s     | 50m      |
+            | 5    | b  | ab,ab | 0.6s   | 9.9m     |
+            | 4    | b  | ab,ab | 1.2s   | 19.9m    |
+            | 3    | b  | ab,ab | 1.8s   | 29.9m    |
+            | 2    | b  | ab,ab | 2.4s   | 39.9m    |
+            | 1    | b  | ab,ab | 3s     | 49.9m    |
+            | 1    | 2  | ab,ab | 0.6s   | 10m      |
+            | 1    | 3  | ab,ab | 1.2s   | 20m      |
+            | 1    | 4  | ab,ab | 1.8s   | 30m      |
+            | 1    | 5  | ab,ab | 2.4s   | 40m      |
+
+        When I request a travel time matrix I should get
+            |   | a     | 1     | 2   | 3   | 4   | 5   | b   |
+            | a | 0     | 0.6   | 1.2 | 1.8 | 2.4 | 3   | 3.6 |
+            | 1 | 0.8   | 0     | 0.6 | 1.2 | 1.8 | 2.4 | 3   |
+            | 2 | 1.6   | 0.8   | 0   | 0.6 | 1.2 | 1.8 | 2.4 |
+            | 3 | 2.4   | 1.6   | 0.8 | 0   | 0.6 | 1.2 | 1.8 |
+            | 4 | 3.2   | 2.4   | 1.6 | 0.8 | 0   | 0.6 | 1.2 |
+            | 5 | 4     | 3.2   | 2.4 | 1.6 | 0.8 | 0   | 0.6 |
+            | b | 4.8   | 4     | 3.2 | 2.4 | 1.6 | 0.8 | 0   |
+
+   Scenario: Testbot - No stoppage points, tiny grid size
+        Given a grid size of 1 meters
+        Given the node map
+            """
+            a 1 2 3 4 5 6 7 8 9 b
+            """
+
+        And the ways
+            | nodes | highway | maxspeed:forward    | maxspeed:backward |
+            | ab    | trunk   | 60                  | 45                |
+
+        When I request a travel time matrix I should get
+            |   |  a    |  1    |  2   |  3   |  4   |  5    |  6    |  7   |  8   |  9   |  b   |
+            | a |  0    |  0    |  0.1 |  0.1 |  0.2 |  0.3  |  0.3  |  0.4 |  0.4 |  0.5 |  0.6 |
+            | 1 |  0    |  0    |  0.1 |  0.1 |  0.2 |  0.3  |  0.3  |  0.4 |  0.4 |  0.5 |  0.6 |
+            | 2 |  0.1  |  0.1  |  0   |  0   |  0.1 |  0.2  |  0.2  |  0.3 |  0.3 |  0.4 |  0.5 |
+            | 3 |  0.2  |  0.2  |  0.1 |  0   |  0.1 |  0.2  |  0.2  |  0.3 |  0.3 |  0.4 |  0.5 |
+            | 4 |  0.3  |  0.3  |  0.2 |  0.1 |  0   |  0.1  |  0.1  |  0.2 |  0.2 |  0.3 |  0.4 |
+            | 5 |  0.4  |  0.4  |  0.3 |  0.2 |  0.1 |  0    |  0    |  0.1 |  0.1 |  0.2 |  0.3 |
+            | 6 |  0.4  |  0.4  |  0.3 |  0.2 |  0.1 |  0    |  0    |  0.1 |  0.1 |  0.2 |  0.3 |
+            | 7 |  0.5  |  0.5  |  0.4 |  0.3 |  0.2 |  0.1  |  0.1  |  0   |  0   |  0.1 |  0.2 |
+            | 8 |  0.6  |  0.6  |  0.5 |  0.4 |  0.3 |  0.2  |  0.2  |  0.1 |  0   |  0.1 |  0.2 |
+            | 9 |  0.7  |  0.7  |  0.6 |  0.5 |  0.4 |  0.3  |  0.3  |  0.2 |  0.1 |  0   |  0.1 |
+            | b |  0.8  |  0.8  |  0.7 |  0.6 |  0.5 |  0.4  |  0.4  |  0.3 |  0.2 |  0.1 |  0   |
+
+   Scenario: Testbot - With stoppage points, tiny grid size
+        Given a grid size of 1 meters
+        Given the node map
+            """
+            a 1 2 3 4 5 6 7 8 9 b
+            """
+
+        And the ways
+            | nodes | highway | maxspeed:forward    | maxspeed:backward |
+            | ab    | trunk   | 60                  | 45                |
+
+        And the query options
+            | acceleration_profile | car |
+
+        When I request a travel time matrix I should get
+            |   | a   | 1   | 2   | 3   | 4   | 5   | 6   | 7   | 8   | 9   | b   |
+            | a | 0   | 1.1 | 1.7 | 2.1 | 2.4 | 2.6 | 2.9 | 3.1 | 3.4 | 3.5 | 3.7 |
+            | 1 | 1.1 | 0   | 1.1 | 1.7 | 2   | 2.3 | 2.6 | 2.8 | 3.1 | 3.3 | 3.5 |
+            | 2 | 1.7 | 1.1 | 0   | 1.1 | 1.7 | 2   | 2.4 | 2.6 | 2.9 | 3.1 | 3.3 |
+            | 3 | 2   | 1.5 | 1.1 | 0   | 1.1 | 1.5 | 2   | 2.3 | 2.6 | 2.8 | 3   |
+            | 4 | 2.3 | 1.9 | 1.5 | 1.1 | 0   | 1.1 | 1.7 | 2   | 2.4 | 2.6 | 2.8 |
+            | 5 | 2.5 | 2.2 | 1.9 | 1.5 | 1.1 | 0   | 1.1 | 1.7 | 2.1 | 2.4 | 2.6 |
+            | 6 | 2.8 | 2.5 | 2.3 | 2   | 1.7 | 1.1 | 0   | 1.1 | 1.7 | 2   | 2.3 |
+            | 7 | 3   | 2.8 | 2.5 | 2.3 | 2   | 1.7 | 1.1 | 0   | 1.1 | 1.7 | 2   |
+            | 8 | 3.2 | 3   | 2.8 | 2.5 | 2.3 | 2   | 1.5 | 1.1 | 0   | 1.1 | 1.5 |
+            | 9 | 3.4 | 3.2 | 3   | 2.8 | 2.5 | 2.3 | 1.9 | 1.5 | 1.1 | 0   | 1.1 |
+            | b | 3.6 | 3.4 | 3.2 | 3   | 2.8 | 2.5 | 2.2 | 1.9 | 1.5 | 1.1 | 0   |
+
+
+    Scenario: Testbot - Use stoppage penalty at waypoints
+        Given a grid size of 10 meters
+        Given the node map
+            """
+            a 1 2 3 4 5 b
+            """
+
+        And the ways
+            | nodes | highway | maxspeed:forward    | maxspeed:backward |
+            | ab    | trunk   | 60                  | 45                |
+
+        And the query options
+            | acceleration_profile | car |
+
+        When I request a travel time matrix I should get
+            |   | a   | 1   | 2   | 3   | 4   | 5   | b   |
+            | a | 0   | 3.7 | 5.3 | 6.5 | 7.5 | 8.4 | 9.1 |
+            | 1 | 3.6 | 0   | 3.7 | 5.3 | 6.5 | 7.5 | 8.3 |
+            | 2 | 5.1 | 3.6 | 0   | 3.7 | 5.3 | 6.5 | 7.5 |
+            | 3 | 6.3 | 5.1 | 3.6 | 0   | 3.7 | 5.3 | 6.4 |
+            | 4 | 7.2 | 6.3 | 5.1 | 3.6 | 0   | 3.7 | 5.2 |
+            | 5 | 8.1 | 7.2 | 6.3 | 5.1 | 3.6 | 0   | 3.7 |
+            | b | 8.9 | 8.1 | 7.2 | 6.2 | 5.1 | 3.6 | 0   |
+
+
+    Scenario: Long distance grid with no penalty
+        Given a grid size of 1000 meters
+        Given the node map
+            """
+            a 1 2 3 4 5 b
+            """
+
+        And the ways
+            | nodes | highway | maxspeed:forward    | maxspeed:backward |
+            | ab    | trunk   | 60                  | 45                |
+
+        When I request a travel time matrix I should get
+            |   | a     | 1    | 2     | 3     | 4     | 5     | b     |
+            | a | 0     | 59.9 | 119.9 | 179.9 | 239.9 | 299.9 | 359.9 |
+            | 1 | 79.9  | 0    | 60    | 120   | 180   | 240   | 300   |
+            | 2 | 159.9 | 80   | 0     | 60    | 120   | 180   | 240   |
+            | 3 | 239.9 | 160  | 80    | 0     | 60    | 120   | 180   |
+            | 4 | 319.9 | 240  | 160   | 80    | 0     | 60    | 120   |
+            | 5 | 399.9 | 320  | 240   | 160   | 80    | 0     | 60    |
+            | b | 479.9 | 400  | 320   | 240   | 160   | 80    | 0     |
+
+    Scenario: Long distance grid
+        Given a grid size of 1000 meters
+        Given the node map
+            """
+            a 1 2 3 4 5 b
+            """
+
+        And the ways
+            | nodes | highway | maxspeed:forward    | maxspeed:backward |
+            | ab    | trunk   | 60                  | 45                |
+
+        And the query options
+            | acceleration_profile | car |
+
+        When I request a travel time matrix I should get
+            |   | a     | 1     | 2     | 3     | 4     | 5     | b     |
+            | a | 0     | 65.1  | 125.1 | 185.1 | 245.1 | 305.1 | 365.1 |
+            | 1 | 83.7  | 0     | 65.2  | 125.2 | 185.2 | 245.2 | 305.2 |
+            | 2 | 163.7 | 83.8  | 0     | 65.2  | 125.2 | 185.2 | 245.2 |
+            | 3 | 243.7 | 163.8 | 83.8  | 0     | 65.2  | 125.2 | 185.2 |
+            | 4 | 323.7 | 243.8 | 163.8 | 83.8  | 0     | 65.2  | 125.2 |
+            | 5 | 403.7 | 323.8 | 243.8 | 163.8 | 83.8  | 0     | 65.2  |
+            | b | 483.7 | 403.8 | 323.8 | 243.8 | 163.8 | 83.8  | 0     |

--- a/include/engine/api/base_parameters.hpp
+++ b/include/engine/api/base_parameters.hpp
@@ -81,6 +81,8 @@ struct BaseParameters
     bool generate_hints = true;
 
     SnappingType snapping = SnappingType::Default;
+    // Whether or not to add acceleration/decelleration penalties at waypoints
+    double waypoint_acceleration_factor = 0.;
 
     BaseParameters(const std::vector<util::Coordinate> coordinates_ = {},
                    const std::vector<boost::optional<Hint>> hints_ = {},
@@ -89,10 +91,11 @@ struct BaseParameters
                    std::vector<boost::optional<Approach>> approaches_ = {},
                    bool generate_hints_ = true,
                    std::vector<std::string> exclude = {},
-                   const SnappingType snapping_ = SnappingType::Default)
+                   const SnappingType snapping_ = SnappingType::Default,
+                   bool waypoint_acceleration_factor_ = 0.)
         : coordinates(coordinates_), hints(hints_), radiuses(radiuses_), bearings(bearings_),
           approaches(approaches_), exclude(std::move(exclude)), generate_hints(generate_hints_),
-          snapping(snapping_)
+          snapping(snapping_), waypoint_acceleration_factor(waypoint_acceleration_factor_)
     {
     }
 

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -692,6 +692,48 @@ inline bool argumentsToParameter(const Nan::FunctionCallbackInfo<v8::Value> &arg
         }
     }
 
+    if (obj->Has(Nan::New("acceleration_profile").ToLocalChecked()))
+    {
+        v8::Local<v8::Value> acceleration_profile =
+            obj->Get(Nan::New("acceleration_profile").ToLocalChecked());
+        if (acceleration_profile.IsEmpty())
+            return false;
+
+        if (!acceleration_profile->IsNumber() && !acceleration_profile->IsString())
+        {
+            Nan::ThrowError("acceleration_profile must be a decimal number or one of 'car', 'fast_car', 'slow_car', 'truck', or 'tractor_trailer'");
+            return false;
+        }
+
+        if (acceleration_profile->IsString()) {
+                std::string ssaf = *v8::String::Utf8Value(acceleration_profile);
+                // If they say 'yes', they get the default
+                if (ssaf == "car") {
+                    params->waypoint_acceleration_factor = ACCELERATION_ALPHA_CAR;
+                } else if (ssaf == "fast_car") {
+                    params->waypoint_acceleration_factor = ACCELERATION_ALPHA_FAST_CAR;
+                } else if (ssaf == "slow_car") {
+                    params->waypoint_acceleration_factor = ACCELERATION_ALPHA_SLOW_CAR;
+                } else if (ssaf == "truck") {
+                    params->waypoint_acceleration_factor = ACCELERATION_ALPHA_TRUCK;
+                } else if (ssaf == "tractor_trailer") {
+                    params->waypoint_acceleration_factor = ACCELERATION_ALPHA_TRACTOR_TRAILER;
+                } else {
+                    Nan::ThrowError("acceleration_profile must be a decimal number or one of 'car', 'fast_car', 'slow_car', 'truck', or 'tractor_trailer'");
+                    return false;
+                }
+                return true;
+        }
+
+        const auto value = acceleration_profile->NumberValue();
+        if (value < 0) {
+            Nan::ThrowError("acceleration_profile cannot be negative");
+            return false;
+        }
+
+        params->waypoint_acceleration_factor = value;
+    }
+
     return true;
 }
 

--- a/include/server/api/base_parameters_grammar.hpp
+++ b/include/server/api/base_parameters_grammar.hpp
@@ -135,6 +135,19 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                                            },
                                            qi::_1)];
 
+        acceleration_alpha_defaults_rule =
+            qi::lit("car")[qi::_val = ACCELERATION_ALPHA_CAR] |
+            qi::lit("fast_car")[qi::_val = ACCELERATION_ALPHA_FAST_CAR] |
+            qi::lit("slow_car")[qi::_val = ACCELERATION_ALPHA_SLOW_CAR] |
+            qi::lit("truck")[qi::_val = ACCELERATION_ALPHA_TRUCK] |
+            qi::lit("tractor_trailer")[qi::_val = ACCELERATION_ALPHA_TRACTOR_TRAILER];
+
+        acceleration_profile_rule =
+            qi::lit("acceleration_profile=") >
+            (qi::double_ | acceleration_alpha_defaults_rule)
+                [ph::bind(&engine::api::BaseParameters::waypoint_acceleration_factor, qi::_r1) =
+                     qi::_1];
+
         query_rule =
             ((location_rule % ';') | polyline_rule |
              polyline6_rule)[ph::bind(&engine::api::BaseParameters::coordinates, qi::_r1) = qi::_1];
@@ -179,7 +192,8 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                     | generate_hints_rule(qi::_r1) //
                     | approach_rule(qi::_r1)       //
                     | exclude_rule(qi::_r1)        //
-                    | snapping_rule(qi::_r1);
+                    | snapping_rule(qi::_r1)       //
+                    | acceleration_profile_rule(qi::_r1);//
     }
 
   protected:
@@ -196,6 +210,7 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
     qi::rule<Iterator, Signature> generate_hints_rule;
     qi::rule<Iterator, Signature> approach_rule;
     qi::rule<Iterator, Signature> exclude_rule;
+    qi::rule<Iterator, Signature> acceleration_profile_rule;
 
     qi::rule<Iterator, osrm::engine::Bearing()> bearing_rule;
     qi::rule<Iterator, osrm::util::Coordinate()> location_rule;
@@ -206,6 +221,8 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
     qi::rule<Iterator, std::string()> polyline_chars;
     qi::rule<Iterator, double()> unlimited_rule;
     qi::rule<Iterator, Signature> snapping_rule;
+
+    qi::rule<Iterator, double()> acceleration_alpha_defaults_rule;
 
     qi::symbols<char, engine::Approach> approach_type;
     qi::symbols<char, engine::api::BaseParameters::SnappingType> snapping_type;

--- a/include/util/ieee754.hpp
+++ b/include/util/ieee754.hpp
@@ -488,8 +488,8 @@ inline void Prettify(char *buffer, int length, int k)
 inline void dtoa_milo(double value, char *buffer)
 {
     // Not handling NaN and inf
-    assert(!isnan(value));
-    assert(!isinf(value));
+    assert(!std::isnan(value));
+    assert(!std::isinf(value));
 
     if (value == 0)
     {

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -119,6 +119,14 @@ static const TurnPenalty INVALID_TURN_PENALTY = std::numeric_limits<TurnPenalty>
 static const EdgeDistance INVALID_EDGE_DISTANCE = std::numeric_limits<EdgeDistance>::max();
 static const EdgeDistance INVALID_FALLBACK_SPEED = std::numeric_limits<double>::max();
 
+// Recommended value for passenger vehicles from
+// https://fdotwww.blob.core.windows.net/sitefinity/docs/default-source/content/rail/publications/studies/safety/accelerationresearch.pdf?sfvrsn=716a4bb1_0
+static const double ACCELERATION_ALPHA_CAR = 6.0;
+static const double ACCELERATION_ALPHA_FAST_CAR = 18;
+static const double ACCELERATION_ALPHA_SLOW_CAR = 2;
+static const double ACCELERATION_ALPHA_TRUCK = 1.5;
+static const double ACCELERATION_ALPHA_TRACTOR_TRAILER = 0.5;
+
 // FIXME the bitfields we use require a reduced maximal duration, this should be kept consistent
 // within the code base. For now we have to ensure that we don't case 30 bit to -1 and break any
 // min() / operator< checks due to the invalid truncation. In addition, using signed and unsigned

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -143,7 +143,8 @@ void forwardRoutingStep(const DataFacade<Algorithm> &facade,
                 middle_nodes_table[row_index * number_of_targets + column_index] = node;
             }
         }
-        else if (std::tie(new_weight, new_duration) < std::tie(current_weight, current_duration))
+        else if (std::tie(new_weight, new_duration) < std::tie(current_weight, current_duration) &&
+                 new_distance >= 0)
         {
             current_weight = new_weight;
             current_duration = new_duration;

--- a/test/nodejs/table.js
+++ b/test/nodejs/table.js
@@ -303,5 +303,46 @@ tables.forEach(function(annotation) {
         assert.throws(()=>osrm.table(options, (err, res) => {}), /scale_factor must be > 0/, "should throw on invalid scale_factor value");
 
     });
+
+    test('table: ' + annotation + ' table in Monaco with acceleration_profile values', function(assert) {
+        assert.plan(12);
+        var osrm = new OSRM({path: mld_data_path, algorithm: 'MLD'});
+        var options = {
+            coordinates: two_test_coordinates,
+            annotations: [annotation.slice(0,-1)],
+            acceleration_profile: []
+        };
+
+        assert.throws(()=>osrm.table(options, (err, res) => {}), /acceleration_profile must be a decimal number or one of/, "should throw on empty array");
+
+        options.acceleration_profile = 'a';
+        assert.throws(()=>osrm.table(options, (err, res) => {}), /acceleration_profile must be a decimal number or one of/, "should throw on non-numeric value");
+
+        options.acceleration_profile = [1];
+        assert.throws(()=>osrm.table(options, (err, res) => {}), /acceleration_profile must be a decimal number or one of/, "should throw on non-numeric value");
+
+        options.acceleration_profile = -0.1;
+        assert.throws(()=>osrm.table(options, (err, res) => {}), /acceleration_profile cannot be negative/, "should throw on non-numeric value");
+
+        options.acceleration_profile = 0.;
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "should work with zero");
+
+        options.acceleration_profile = 2.0;
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "Should work with positive numeric values");
+        options.acceleration_profile = 'car';
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "Should work with car defaults");
+        options.acceleration_profile = 'fast_car';
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "Should work with fast car defaults");
+        options.acceleration_profile = 'slow_car';
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "Should work with slow car defaults");
+        options.acceleration_profile = 'truck';
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "Should work with truck defaults");
+        options.acceleration_profile = 'tractor_trailer';
+        assert.ok(()=>osrm.table(options, (err, res) => {}), "Should work with tractor trailer defaults");
+
+        options.acceleration_profile = 'yes';
+        assert.throws(()=>osrm.table(options, (err, res) => {}), /acceleration_profile must be a decimal number or one of/, "should throw on non-recognized string");
+
+    });
 });
 


### PR DESCRIPTION
# Issue

This PR is meant as a step toward addressing #5353

The gist is that we've added a new base parameter that allows you to select an acceleration profile. The idea being that this should increase the accuracy of the estimated duration of a trip by including some amount of penalty for starting/arriving from/at the given waypoints.

The additional parameter is the name of an acceleration profile which selects, at runtime, a profile appropriate for the vehicle being driven. Internally this essentially selects a coefficient of a larger set of equations used to estimate the time it takes to get up to or speed or come to a full stop. In the end this will add time to the routes duration. The penalty will vary with respect to the expected speed of travel on the edge where the waypoint was correlated in the graph. The slower the speed of the edge, the lesser the penalty. The idea being that it takes you less time to get up to speed or come to a stop for edges with slower speeds. The inverse should hold true for edges with higher speeds.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
