### PR TITLE
Configurable snapping behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - Features:
       - ADDED: new waypoints parameter to the `route` plugin, enabling silent waypoints [#5345](https://github.com/Project-OSRM/osrm-backend/pull/5345)
       - ADDED: data timestamp information in the response (saved in new file `.osrm.timestamp`). [#5115](https://github.com/Project-OSRM/osrm-backend/issues/5115)
+      - ADDED: new API parameter - `snapping=any|default` to allow snapping to previously unsnappable edges [#5361](https://github.com/Project-OSRM/osrm-backend/pull/5361)
     - Routing:
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -32,6 +32,7 @@ To pass parameters to each location some options support an array like encoding:
 |hints           |`{hint};{hint}[;{hint} ...]`                            |Hint from previous request to derive position in street network.                                       |
 |approaches      |`{approach};{approach}[;{approach} ...]`                |Keep waypoints on curb side.                                                                           |
 |exclude         |`{class}[,{class}]`                                     |Additive list of classes to avoid, order does not matter.                                              |
+|snapping        |`default` (default), `any`                              |Default snapping avoids is_startpoint (see profile) edges, `any` will snap to any edge in the graph    |
 
 Where the elements follow the following format:
 

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -59,6 +59,7 @@ Returns the fastest route between two or more coordinates while visiting the way
     -   `options.approaches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Keep waypoints on curb side. Can be `null` (unrestricted, default) or `curb`.
     -   `options.waypoints` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Indices to coordinates to treat as waypoints.  If not supplied, all coordinates are waypoints.  Must include first and last coordinate index.
                          `null`/`true`/`false`
+    -   `options.snapping` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Which edges can be snapped to, either `default`, or `any`.  `default` only snaps to edges marked by the profile as `is_startpoint`, `any` will allow snapping to any edge in the routing graph.
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)**
 
 **Examples**
@@ -91,6 +92,7 @@ Note: `coordinates` in the general options only supports a single `{longitude},{
     -   `options.number` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Number of nearest segments that should be returned.
         Must be an integer greater than or equal to `1`. (optional, default `1`)
     -   `options.approaches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Keep waypoints on curb side. Can be `null` (unrestricted, default) or `curb`.
+    -   `options.snapping` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Which edges can be snapped to, either `default`, or `any`.  `default` only snaps to edges marked by the profile as `is_startpoint`, `any` will allow snapping to any edge in the routing graph.
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)**
 
 **Examples**
@@ -133,6 +135,7 @@ tables. Optionally returns distance table.
     -   `options.fallback_speed` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Replace `null` responses in result with as-the-crow-flies estimates based on `fallback_speed`.  Value is in metres/second.
     -   `options.fallback_coordinate` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Either `input` (default) or `snapped`.  If using a `fallback_speed`, use either the user-supplied coordinate (`input`), or the snapped coordinate (`snapped`) for calculating the as-the-crow-flies diestance between two points.
     -   `options.scale_factor` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Multiply the table duration values in the table by this number for more controlled input into a route optimization solver.
+    -   `options.snapping` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Which edges can be snapped to, either `default`, or `any`.  `default` only snaps to edges marked by the profile as `is_startpoint`, `any` will allow snapping to any edge in the routing graph.
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)**
 
 **Examples**
@@ -212,6 +215,7 @@ if they can not be matched successfully.
     -   `options.gaps` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Allows the input track splitting based on huge timestamp gaps between points. Either `split` or `ignore` (optional, default `split`).
     -   `options.tidy` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Allows the input track modification to obtain better matching quality for noisy tracks (optional, default `false`).
     -   `options.waypoints` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Indices to coordinates to treat as waypoints.  If not supplied, all coordinates are waypoints.  Must include first and last coordinate index.
+    -   `options.snapping` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Which edges can be snapped to, either `default`, or `any`.  `default` only snaps to edges marked by the profile as `is_startpoint`, `any` will allow snapping to any edge in the routing graph.
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)**
 
 **Examples**
@@ -276,6 +280,7 @@ Right now, the following combinations are possible:
     -   `options.source` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Return route starts at `any` or `first` coordinate. (optional, default `any`)
     -   `options.destination` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Return route ends at `any` or `last` coordinate. (optional, default `any`)
     -   `options.approaches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Keep waypoints on curb side. Can be `null` (unrestricted, default) or `curb`.
+    -   `options.snapping` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Which edges can be snapped to, either `default`, or `any`.  `default` only snaps to edges marked by the profile as `is_startpoint`, `any` will allow snapping to any edge in the routing graph.
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)**
 
 **Examples**

--- a/features/car/startpoint.feature
+++ b/features/car/startpoint.feature
@@ -35,3 +35,28 @@ Feature: Car - Allowed start/end modes
             | from | to | route | modes           |
             | 1    | 2  | ab,ab | driving,driving |
             | 2    | 1  | ab,ab | driving,driving |
+
+    Scenario: Car - URL override of non-startpoints
+        Given the node map
+            """
+            a 1 b   c 2 d
+            """
+
+        Given the query options
+            | snapping  | any          |
+
+        And the ways
+            | nodes | highway | access  |
+            | ab    | service | private |
+            | bc    | primary |         |
+            | cd    | service | private |
+
+        When I request a travel time matrix I should get
+            |   | 2    | c    |
+            | 1 | 59.1 | 35.1 |
+            | b | 35.1 | 11.1 |
+
+        When I route I should get
+            | from | to | route    |
+            | 1    | 2  | ab,bc,cd |
+            | 2    | 1  | cd,bc,ab |

--- a/include/engine/api/base_parameters.hpp
+++ b/include/engine/api/base_parameters.hpp
@@ -63,6 +63,13 @@ namespace api
  */
 struct BaseParameters
 {
+
+    enum class SnappingType
+    {
+        Default,
+        Any
+    };
+
     std::vector<util::Coordinate> coordinates;
     std::vector<boost::optional<Hint>> hints;
     std::vector<boost::optional<double>> radiuses;
@@ -73,15 +80,19 @@ struct BaseParameters
     // Adds hints to response which can be included in subsequent requests, see `hints` above.
     bool generate_hints = true;
 
+    SnappingType snapping = SnappingType::Default;
+
     BaseParameters(const std::vector<util::Coordinate> coordinates_ = {},
                    const std::vector<boost::optional<Hint>> hints_ = {},
                    std::vector<boost::optional<double>> radiuses_ = {},
                    std::vector<boost::optional<Bearing>> bearings_ = {},
                    std::vector<boost::optional<Approach>> approaches_ = {},
                    bool generate_hints_ = true,
-                   std::vector<std::string> exclude = {})
+                   std::vector<std::string> exclude = {},
+                   const SnappingType snapping_ = SnappingType::Default)
         : coordinates(coordinates_), hints(hints_), radiuses(radiuses_), bearings(bearings_),
-          approaches(approaches_), exclude(std::move(exclude)), generate_hints(generate_hints_)
+          approaches(approaches_), exclude(std::move(exclude)), generate_hints(generate_hints_),
+          snapping(snapping_)
     {
     }
 

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -389,23 +389,25 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const Approach approach) const override final
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
         return m_geospatial_query->NearestPhantomNodeWithAlternativeFromBigComponent(
-            input_coordinate, approach);
+            input_coordinate, approach, use_all_edges);
     }
 
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
-                                                      const Approach approach) const override final
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
         return m_geospatial_query->NearestPhantomNodeWithAlternativeFromBigComponent(
-            input_coordinate, max_distance, approach);
+            input_coordinate, max_distance, approach, use_all_edges);
     }
 
     std::pair<PhantomNode, PhantomNode>
@@ -413,24 +415,26 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
                                                       const double max_distance,
                                                       const int bearing,
                                                       const int bearing_range,
-                                                      const Approach approach) const override final
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
         return m_geospatial_query->NearestPhantomNodeWithAlternativeFromBigComponent(
-            input_coordinate, max_distance, bearing, bearing_range, approach);
+            input_coordinate, max_distance, bearing, bearing_range, approach, use_all_edges);
     }
 
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const int bearing,
                                                       const int bearing_range,
-                                                      const Approach approach) const override final
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const override final
     {
         BOOST_ASSERT(m_geospatial_query.get());
 
         return m_geospatial_query->NearestPhantomNodeWithAlternativeFromBigComponent(
-            input_coordinate, bearing, bearing_range, approach);
+            input_coordinate, bearing, bearing_range, approach, use_all_edges);
     }
 
     std::uint32_t GetCheckSum() const override final { return m_check_sum; }

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -161,22 +161,26 @@ class BaseDataFacade
 
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const Approach approach) const = 0;
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const = 0;
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
-                                                      const Approach approach) const = 0;
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const = 0;
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
                                                       const int bearing,
                                                       const int bearing_range,
-                                                      const Approach approach) const = 0;
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const = 0;
     virtual std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const int bearing,
                                                       const int bearing_range,
-                                                      const Approach approach) const = 0;
+                                                      const Approach approach,
+                                                      const bool use_all_edges = false) const = 0;
 
     virtual bool HasLaneData(const EdgeID id) const = 0;
     virtual util::guidance::LaneTupleIdPair GetLaneData(const EdgeID id) const = 0;

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -205,18 +205,23 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const double max_distance,
-                                                      const Approach approach) const
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
         auto results = rtree.Nearest(
             input_coordinate,
-            [this, approach, &input_coordinate, &has_big_component, &has_small_component](
-                const CandidateSegment &segment) {
+            [this,
+             approach,
+             &input_coordinate,
+             &has_big_component,
+             &has_small_component,
+             &use_all_edges](const CandidateSegment &segment) {
                 auto use_segment =
                     (!has_small_component || (!has_big_component && !IsTinyComponent(segment)));
                 auto use_directions = std::make_pair(use_segment, use_segment);
-                const auto valid_edges = HasValidEdge(segment);
+                const auto valid_edges = HasValidEdge(segment, use_all_edges);
                 const auto admissible_segments = CheckSegmentExclude(segment);
                 use_directions = boolPairAnd(use_directions, admissible_segments);
                 use_directions = boolPairAnd(use_directions, valid_edges);
@@ -251,19 +256,24 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     // a second phantom node is return that is the nearest coordinate in a big component.
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
-                                                      const Approach approach) const
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
         auto results = rtree.Nearest(
             input_coordinate,
-            [this, approach, &input_coordinate, &has_big_component, &has_small_component](
-                const CandidateSegment &segment) {
+            [this,
+             approach,
+             &input_coordinate,
+             &has_big_component,
+             &has_small_component,
+             &use_all_edges](const CandidateSegment &segment) {
                 auto use_segment =
                     (!has_small_component || (!has_big_component && !IsTinyComponent(segment)));
                 auto use_directions = std::make_pair(use_segment, use_segment);
 
-                const auto valid_edges = HasValidEdge(segment);
+                const auto valid_edges = HasValidEdge(segment, use_all_edges);
                 const auto admissible_segments = CheckSegmentExclude(segment);
                 use_directions = boolPairAnd(use_directions, admissible_segments);
                 use_directions = boolPairAnd(use_directions, valid_edges);
@@ -298,7 +308,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate input_coordinate,
                                                       const int bearing,
                                                       const int bearing_range,
-                                                      const Approach approach) const
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
@@ -310,12 +321,13 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
              bearing,
              bearing_range,
              &has_big_component,
-             &has_small_component](const CandidateSegment &segment) {
+             &has_small_component,
+             &use_all_edges](const CandidateSegment &segment) {
                 auto use_segment =
                     (!has_small_component || (!has_big_component && !IsTinyComponent(segment)));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 const auto admissible_segments = CheckSegmentExclude(segment);
-                use_directions = boolPairAnd(use_directions, HasValidEdge(segment));
+                use_directions = boolPairAnd(use_directions, HasValidEdge(segment, use_all_edges));
 
                 if (use_segment)
                 {
@@ -356,7 +368,8 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                                                       const double max_distance,
                                                       const int bearing,
                                                       const int bearing_range,
-                                                      const Approach approach) const
+                                                      const Approach approach,
+                                                      const bool use_all_edges) const
     {
         bool has_small_component = false;
         bool has_big_component = false;
@@ -368,12 +381,13 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
              bearing,
              bearing_range,
              &has_big_component,
-             &has_small_component](const CandidateSegment &segment) {
+             &has_small_component,
+             &use_all_edges](const CandidateSegment &segment) {
                 auto use_segment =
                     (!has_small_component || (!has_big_component && !IsTinyComponent(segment)));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 const auto admissible_segments = CheckSegmentExclude(segment);
-                use_directions = boolPairAnd(use_directions, HasValidEdge(segment));
+                use_directions = boolPairAnd(use_directions, HasValidEdge(segment, use_all_edges));
 
                 if (use_segment)
                 {

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -270,6 +270,7 @@ class BasePlugin
         const bool use_bearings = !parameters.bearings.empty();
         const bool use_radiuses = !parameters.radiuses.empty();
         const bool use_approaches = !parameters.approaches.empty();
+        const bool use_all_edges = parameters.snapping == api::BaseParameters::SnappingType::Any;
 
         BOOST_ASSERT(parameters.IsValid());
         for (const auto i : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
@@ -296,7 +297,8 @@ class BasePlugin
                             *parameters.radiuses[i],
                             parameters.bearings[i]->bearing,
                             parameters.bearings[i]->range,
-                            approach);
+                            approach,
+                            use_all_edges);
                 }
                 else
                 {
@@ -305,7 +307,8 @@ class BasePlugin
                             parameters.coordinates[i],
                             parameters.bearings[i]->bearing,
                             parameters.bearings[i]->range,
-                            approach);
+                            approach,
+                            use_all_edges);
                 }
             }
             else
@@ -314,13 +317,16 @@ class BasePlugin
                 {
                     phantom_node_pairs[i] =
                         facade.NearestPhantomNodeWithAlternativeFromBigComponent(
-                            parameters.coordinates[i], *parameters.radiuses[i], approach);
+                            parameters.coordinates[i],
+                            *parameters.radiuses[i],
+                            approach,
+                            use_all_edges);
                 }
                 else
                 {
                     phantom_node_pairs[i] =
                         facade.NearestPhantomNodeWithAlternativeFromBigComponent(
-                            parameters.coordinates[i], approach);
+                            parameters.coordinates[i], approach, use_all_edges);
                 }
             }
 

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -1010,6 +1010,35 @@ argumentsToRouteParameter(const Nan::FunctionCallbackInfo<v8::Value> &args,
         }
     }
 
+    if (obj->Has(Nan::New("snapping").ToLocalChecked()))
+    {
+        v8::Local<v8::Value> snapping = obj->Get(Nan::New("snapping").ToLocalChecked());
+        if (snapping.IsEmpty())
+            return route_parameters_ptr();
+
+        if (!snapping->IsString())
+        {
+            Nan::ThrowError("Snapping must be a string: [default, any]");
+            return route_parameters_ptr();
+        }
+        const Nan::Utf8String snapping_utf8str(snapping);
+        std::string snapping_str{*snapping_utf8str, *snapping_utf8str + snapping_utf8str.length()};
+
+        if (snapping_str == "default")
+        {
+            params->snapping = osrm::RouteParameters::SnappingType::Default;
+        }
+        else if (snapping_str == "any")
+        {
+            params->snapping = osrm::RouteParameters::SnappingType::Any;
+        }
+        else
+        {
+            Nan::ThrowError("'snapping' param must be one of [default, any]");
+            return route_parameters_ptr();
+        }
+    }
+
     bool parsedSuccessfully = parseCommonParameters(obj, params);
     if (!parsedSuccessfully)
     {

--- a/include/server/api/base_parameters_grammar.hpp
+++ b/include/server/api/base_parameters_grammar.hpp
@@ -162,6 +162,13 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                         (-approach_type %
                          ';')[ph::bind(&engine::api::BaseParameters::approaches, qi::_r1) = qi::_1];
 
+        snapping_type.add("default", engine::api::BaseParameters::SnappingType::Default)(
+            "any", engine::api::BaseParameters::SnappingType::Any);
+
+        snapping_rule =
+            qi::lit("snapping=") >
+            snapping_type[ph::bind(&engine::api::BaseParameters::snapping, qi::_r1) = qi::_1];
+
         exclude_rule = qi::lit("exclude=") >
                        (qi::as_string[+qi::char_("a-zA-Z0-9")] %
                         ',')[ph::bind(&engine::api::BaseParameters::exclude, qi::_r1) = qi::_1];
@@ -171,7 +178,8 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
                     | bearings_rule(qi::_r1)       //
                     | generate_hints_rule(qi::_r1) //
                     | approach_rule(qi::_r1)       //
-                    | exclude_rule(qi::_r1);
+                    | exclude_rule(qi::_r1)        //
+                    | snapping_rule(qi::_r1);
     }
 
   protected:
@@ -197,8 +205,10 @@ struct BaseParametersGrammar : boost::spirit::qi::grammar<Iterator, Signature>
     qi::rule<Iterator, unsigned char()> base64_char;
     qi::rule<Iterator, std::string()> polyline_chars;
     qi::rule<Iterator, double()> unlimited_rule;
+    qi::rule<Iterator, Signature> snapping_rule;
 
     qi::symbols<char, engine::Approach> approach_type;
+    qi::symbols<char, engine::api::BaseParameters::SnappingType> snapping_type;
 };
 }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osrm",
-  "version": "5.22.0-latest.1",
+  "version": "5.22.0-customsnapping.2",
   "private": false,
   "description": "The Open Source Routing Machine is a high performance routing engine written in C++14 designed to run on OpenStreetMap data.",
   "dependencies": {

--- a/test/nodejs/route.js
+++ b/test/nodejs/route.js
@@ -690,3 +690,24 @@ test('route: throws on invalid waypoints values, waypoints must be an array of i
     assert.throws(function () { osrm.route(options, function (err, response) { console.error(`response: ${response}`); console.error(`error: ${err}`); }); },
         /Waypoints must be supplied in increasing order/);
 });
+
+test('route: throws on invalid snapping values', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM(monaco_path);
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+        snapping: "zing"
+    };
+    assert.throws(function () { osrm.route(options, function (err, response) { console.error(`response: ${response}`); console.error(`error: ${err}`); }); },
+        /'snapping' param must be one of \[default, any\]/);
+});
+
+test('route: snapping parameter passed through OK', function(assert) {
+    assert.plan(2);
+    var osrm = new OSRM(monaco_path);
+    osrm.route({snapping: "any", coordinates: [[7.448205209414596,43.754001097311544],[7.447122039202185,43.75306156811368]]}, function(err, route) {
+        assert.ifError(err);
+        assert.equal(Math.round(route.routes[0].distance * 10), 1314); // Round it to nearest 0.1m to eliminate floating point comparison error
+    });
+});

--- a/unit_tests/engine/offline_facade.cpp
+++ b/unit_tests/engine/offline_facade.cpp
@@ -284,7 +284,8 @@ class ContiguousInternalMemoryDataFacade<routing_algorithms::offline::Algorithm>
 
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
-                                                      const Approach /*approach*/) const override
+                                                      const Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }
@@ -292,7 +293,8 @@ class ContiguousInternalMemoryDataFacade<routing_algorithms::offline::Algorithm>
     std::pair<PhantomNode, PhantomNode>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
                                                       const double /*max_distance*/,
-                                                      const Approach /*approach*/) const override
+                                                      const Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }
@@ -302,7 +304,8 @@ class ContiguousInternalMemoryDataFacade<routing_algorithms::offline::Algorithm>
                                                       const double /*max_distance*/,
                                                       const int /*bearing*/,
                                                       const int /*bearing_range*/,
-                                                      const Approach /*approach*/) const override
+                                                      const Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }
@@ -311,7 +314,8 @@ class ContiguousInternalMemoryDataFacade<routing_algorithms::offline::Algorithm>
     NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
                                                       const int /*bearing*/,
                                                       const int /*bearing_range*/,
-                                                      const Approach /*approach*/) const override
+                                                      const Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -167,39 +167,39 @@ class MockBaseDataFacade : public engine::datafacade::BaseDataFacade
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate /*input_coordinate*/,
-        const engine::Approach /*approach*/) const override
+    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
+                                                      const engine::Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate /*input_coordinate*/,
-        const double /*max_distance*/,
-        const engine::Approach /*approach*/) const override
+    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
+                                                      const double /*max_distance*/,
+                                                      const engine::Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate /*input_coordinate*/,
-        const double /*max_distance*/,
-        const int /*bearing*/,
-        const int /*bearing_range*/,
-        const engine::Approach /*approach*/) const override
+    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
+                                                      const double /*max_distance*/,
+                                                      const int /*bearing*/,
+                                                      const int /*bearing_range*/,
+                                                      const engine::Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }
 
     std::pair<engine::PhantomNode, engine::PhantomNode>
-    NearestPhantomNodeWithAlternativeFromBigComponent(
-        const util::Coordinate /*input_coordinate*/,
-        const int /*bearing*/,
-        const int /*bearing_range*/,
-        const engine::Approach /*approach*/) const override
+    NearestPhantomNodeWithAlternativeFromBigComponent(const util::Coordinate /*input_coordinate*/,
+                                                      const int /*bearing*/,
+                                                      const int /*bearing_range*/,
+                                                      const engine::Approach /*approach*/,
+                                                      const bool /* use_all_edges */) const override
     {
         return {};
     }


### PR DESCRIPTION
# Issue

This PR allows requests to modify how coordinates are snapped.  Currently, it only supports one option:

  - `snapping=default` - the default, and maintains the current OSRM behaviour of not snapping to edges marked as `is_startpoint`
  - `snapping=any` - will snap to whichever edge is nearby.

Note that this does not modify the small component selection behaviour.

I intend on extending this parameter with new options in future changes.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch