### PR TITLE
Quote command line options which may contain special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ Download OpenStreetMap extracts for example from [Geofabrik](http://download.geo
 
 Pre-process the extract with the car profile and start a routing engine HTTP server on port 5000
 
-    docker run -t -v $(pwd):/data osrm/osrm-backend osrm-extract -p /opt/car.lua /data/berlin-latest.osm.pbf
+    docker run -t -v "$(pwd):/data" osrm/osrm-backend osrm-extract -p /opt/car.lua /data/berlin-latest.osm.pbf
 
-The flag `-v $(pwd):/data` creates the directory `/data` inside the docker container and makes the current working directory `$(pwd)` available there. The file `/data/berlin-latest.osm.pbf` inside the container is referring to `$(pwd)/berlin-latest.osm.pbf` on the host.
+The flag `-v "$(pwd):/data"` creates the directory `/data` inside the docker container and makes the current working directory `"$(pwd)"` available there. The file `/data/berlin-latest.osm.pbf` inside the container is referring to `"$(pwd)/berlin-latest.osm.pbf"` on the host.
 
-    docker run -t -v $(pwd):/data osrm/osrm-backend osrm-partition /data/berlin-latest.osrm
-    docker run -t -v $(pwd):/data osrm/osrm-backend osrm-customize /data/berlin-latest.osrm
+    docker run -t -v "$(pwd):/data" osrm/osrm-backend osrm-partition /data/berlin-latest.osrm
+    docker run -t -v "$(pwd):/data" osrm/osrm-backend osrm-customize /data/berlin-latest.osrm
 
 Note that `berlin-latest.osrm` has a different file extension. 
 
-    docker run -t -i -p 5000:5000 -v $(pwd):/data osrm/osrm-backend osrm-routed --algorithm mld /data/berlin-latest.osrm
+    docker run -t -i -p 5000:5000 -v "$(pwd):/data" osrm/osrm-backend osrm-routed --algorithm mld /data/berlin-latest.osrm
 
 Make requests against the HTTP server
 


### PR DESCRIPTION
I.e. the example commands fail if `$PWD` contains a space character.