### PR TITLE
Fix bug in snapping=any when bearings are supplied.

### DIFF
--- a/features/car/startpoint.feature
+++ b/features/car/startpoint.feature
@@ -60,3 +60,66 @@ Feature: Car - Allowed start/end modes
             | from | to | route    |
             | 1    | 2  | ab,bc,cd |
             | 2    | 1  | cd,bc,ab |
+
+    Scenario: Car - URL override of non-startpoints
+        Given the node map
+            """
+            a 1 b   c 2 d
+            """
+
+        Given the query options
+            | snapping  | any          |
+            | bearings  | 90,180;      |
+
+        And the ways
+            | nodes | highway | access  |
+            | ab    | service | private |
+            | bc    | primary |         |
+            | cd    | service | private |
+
+        When I route I should get
+            | from | to | route    |
+            | 1    | 2  | ab,bc,cd |
+            | 2    | 1  | cd,bc,ab |
+
+    Scenario: Car - URL override of non-startpoints
+        Given the node map
+            """
+            a 1 b   c 2 d
+            """
+
+        Given the query options
+            | snapping  | any           |
+            | radiuses  | 100;unlimited |
+
+        And the ways
+            | nodes | highway | access  |
+            | ab    | service | private |
+            | bc    | primary |         |
+            | cd    | service | private |
+
+        When I route I should get
+            | from | to | route    |
+            | 1    | 2  | ab,bc,cd |
+            | 2    | 1  | cd,bc,ab |
+
+    Scenario: Car - URL override of non-startpoints
+        Given the node map
+            """
+            a 1 b   c 2 d
+            """
+
+        Given the query options
+            | snapping  | any            |
+            | bearings  | 90,180;0,180;; |
+
+        And the ways
+            | nodes | highway | access  |
+            | ab    | service | private |
+            | bc    | primary |         |
+            | cd    | service | private |
+
+        When I request a travel time matrix I should get
+            |   | 2    | c    |
+            | 1 | 59.1 | 35.1 |
+            | b | 35.1 | 11.1 |

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -327,13 +327,12 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                     (!has_small_component || (!has_big_component && !IsTinyComponent(segment)));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 const auto admissible_segments = CheckSegmentExclude(segment);
-                use_directions = boolPairAnd(use_directions, HasValidEdge(segment, use_all_edges));
 
                 if (use_segment)
                 {
                     use_directions =
                         boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
-                                    HasValidEdge(segment));
+                                    HasValidEdge(segment, use_all_edges));
                     use_directions = boolPairAnd(use_directions, admissible_segments);
                     use_directions = boolPairAnd(
                         use_directions, CheckApproach(input_coordinate, segment, approach));
@@ -387,13 +386,12 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                     (!has_small_component || (!has_big_component && !IsTinyComponent(segment)));
                 auto use_directions = std::make_pair(use_segment, use_segment);
                 const auto admissible_segments = CheckSegmentExclude(segment);
-                use_directions = boolPairAnd(use_directions, HasValidEdge(segment, use_all_edges));
 
                 if (use_segment)
                 {
                     use_directions =
                         boolPairAnd(CheckSegmentBearing(segment, bearing, bearing_range),
-                                    HasValidEdge(segment));
+                                    HasValidEdge(segment, use_all_edges));
                     use_directions = boolPairAnd(use_directions, admissible_segments);
                     use_directions = boolPairAnd(
                         use_directions, CheckApproach(input_coordinate, segment, approach));


### PR DESCRIPTION
# Issue


https://github.com/Project-OSRM/osrm-backend/pull/5361 missed 2 branches of logic - when radiuses and/or bearings are supplied, a different (but similar) function is called in `geospatial_query.hpp`.  This PR fixes the use of `use_all_edges` in those cases.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
