### PR TITLE
Decrease default car weight to 2 tons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
       - ADDED: new API parameter - `snapping=any|default` to allow snapping to previously unsnappable edges [#5361](https://github.com/Project-OSRM/osrm-backend/pull/5361)
     - Routing:
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
+      - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)
 
 # 5.21.0
   - Changes from 5.20.0

--- a/features/car/physical_limitation.feature
+++ b/features/car/physical_limitation.feature
@@ -62,6 +62,7 @@ Feature: Car - Handle physical limitation
             | highway | maxweight | bothw |
             | primary |           | x     |
             | primary | 1         |       |
+            | primary | 2         | x     |
             | primary | 3.5       | x     |
             | primary | 35000 kg  | x     |
             | primary | 8.9t      | x     |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -44,7 +44,7 @@ function setup()
 
     -- Size of the vehicle, to be limited mostly by legal restriction of the way
     vehicle_length = 4.8, -- in meters, 4.8m is the length of large or familly car
-    vehicle_weight = 3500, -- in kilograms
+    vehicle_weight = 2000, -- in kilograms
 
     -- a list of suffixes to suppress in name change instructions. The suffixes also include common substrings of each other
     suffix_list = {


### PR DESCRIPTION
See issue #5370.

Googling shows that the average car weight is between 1.6 and 2 tons. The default 3.5 exceeds even the official limit for heavy cars in USA and Canada, which is 6000 lbs (2.7 tons). With most customer cars weighting under 1.5 tons, I consider 2 tons a good default.

Among other things, this would allow northbound passage through Brooklyn Bridge in New York, which is limited to 2.7 tons. People have not noticed this regression in OSRM 5.19, since most instances run on older versions: e.g. 5.14 for the FOSSGIS server.

References: [1](https://cars.lovetoknow.com/List_of_Car_Weights), [2](https://www.creditdonkey.com/average-weight-car.html), [3](https://www.quora.com/How-much-does-an-average-car-weigh), [4](https://en.wikipedia.org/wiki/Car#Weight).

## Tasklist

 - [x] CHANGELOG.md entry
 - [x] add tests
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch