### PR TITLE
Decrease max height to 2 meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
     - Routing:
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)
-      - CHANGED: default car height was reduced to 2 meters.
+      - CHANGED: default car height was reduced to 2 meters. [#5389](https://github.com/Project-OSRM/osrm-backend/pull/5389)
 
 # 5.21.0
   - Changes from 5.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Routing:
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)
+      - CHANGED: default car height was reduced to 2 meters.
 
 # 5.21.0
   - Changes from 5.20.0

--- a/features/car/physical_limitation.feature
+++ b/features/car/physical_limitation.feature
@@ -43,6 +43,7 @@ Feature: Car - Handle physical limitation
             | primary | 1                  |           |       |
             | primary | 3                  |           | x     |
             | primary |                    | 1         |       |
+            | primary |                    | 8'        | x     |
             | primary |                    | 3         | x     |
             | primary |                    | default   | x     |
             | primary |                    | none      | x     |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -39,7 +39,7 @@ function setup()
     cardinal_directions       = false,
 
     -- Size of the vehicle, to be limited by physical restriction of the way
-    vehicle_height = 2.5, -- in meters, 2.5m is the height of van
+    vehicle_height = 2.0, -- in meters, 2.5m is the height of van
     vehicle_width = 1.9, -- in meters, ways with narrow tag are considered narrower than 2.2m
 
     -- Size of the vehicle, to be limited mostly by legal restriction of the way

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -39,11 +39,11 @@ function setup()
     cardinal_directions       = false,
 
     -- Size of the vehicle, to be limited by physical restriction of the way
-    vehicle_height = 2.0, -- in meters, 2.5m is the height of van
+    vehicle_height = 2.0, -- in meters, 2.0m is the height slightly above biggest SUVs
     vehicle_width = 1.9, -- in meters, ways with narrow tag are considered narrower than 2.2m
 
     -- Size of the vehicle, to be limited mostly by legal restriction of the way
-    vehicle_length = 4.8, -- in meters, 4.8m is the length of large or familly car
+    vehicle_length = 4.8, -- in meters, 4.8m is the length of large or family car
     vehicle_weight = 2000, -- in kilograms
 
     -- a list of suffixes to suppress in name change instructions. The suffixes also include common substrings of each other


### PR DESCRIPTION
See issue #5388

We again stumbled upon a default value that prevents routing over a major highway — in this case, [Highway 15](https://www.openstreetmap.org/way/186846100) in Connecticut. I again did some research and found that while vans can indeed be very high, they are less common that regular sedans and even SUVs.

A little googling showed that even the biggest SUVs (like Ford Expedition EL and VW Caravelle LG) are under two meters. See [this table](https://www.automobiledimension.com/car-search-engine.php) for example. In this pull request I am submitting a lesser default value for the average vehicle high, reflecting this research.