### PR TITLE
made whitespace between Header-key and value otional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
       - ADDED: flatbuffers output format support [#5513](https://github.com/Project-OSRM/osrm-backend/pull/5513)
       - ADDED: Global 'skip_waypoints' option [#5556](https://github.com/Project-OSRM/osrm-backend/pull/5556)
       - FIXED: Install the libosrm_guidance library correctly [#5604](https://github.com/Project-OSRM/osrm-backend/pull/5604)
+      - FIXED: Http Handler can now deal witch optional whitespace between header-key and -value [#5606](https://github.com
     - Routing:
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
       - ADDED: flatbuffers output format support [#5513](https://github.com/Project-OSRM/osrm-backend/pull/5513)
       - ADDED: Global 'skip_waypoints' option [#5556](https://github.com/Project-OSRM/osrm-backend/pull/5556)
       - FIXED: Install the libosrm_guidance library correctly [#5604](https://github.com/Project-OSRM/osrm-backend/pull/5604)
-      - FIXED: Http Handler can now deal witch optional whitespace between header-key and -value [#5606](https://github.com
+      - FIXED: Http Handler can now deal witch optional whitespace between header-key and -value [#5606](https://github.com/Project-OSRM/osrm-backend/issues/5606)
     - Routing:
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)

--- a/include/server/request_parser.hpp
+++ b/include/server/request_parser.hpp
@@ -61,7 +61,6 @@ class RequestParser
         header_line_start,
         header_lws,
         header_name,
-        space_before_header_value,
         header_value,
         expecting_newline_2,
         expecting_newline_3

--- a/src/server/request_parser.cpp
+++ b/src/server/request_parser.cpp
@@ -217,7 +217,7 @@ RequestParser::RequestStatus RequestParser::consume(http::request &current_reque
     case internal_state::header_name:
         if (input == ':')
         {
-            state = internal_state::space_before_header_value;
+            state = internal_state::header_value;
             return RequestStatus::indeterminate;
         }
         if (!is_char(input) || is_CTL(input) || is_special(input))
@@ -226,14 +226,12 @@ RequestParser::RequestStatus RequestParser::consume(http::request &current_reque
         }
         current_header.name.push_back(input);
         return RequestStatus::indeterminate;
-    case internal_state::space_before_header_value:
+    case internal_state::header_value:
         if (input == ' ')
         {
             state = internal_state::header_value;
             return RequestStatus::indeterminate;
         }
-        return RequestStatus::invalid;
-    case internal_state::header_value:
         if (input == '\r')
         {
             state = internal_state::expecting_newline_2;


### PR DESCRIPTION
 # modified FSM so that the whitespace between header-key and value is optional

# Issue
Fix for issue #5606 .


## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

