### PR TITLE
Bicycle: treat use_sidepath as no access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
       - CHANGED: allow routing past `barrier=arch` [#5352](https://github.com/Project-OSRM/osrm-backend/pull/5352)
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)
       - CHANGED: default car height was reduced to 2 meters. [#5389](https://github.com/Project-OSRM/osrm-backend/pull/5389)
+      - FIXED: treat `bicycle=use_sidepath` as no access on the tagged way. [#5622](https://github.com/Project-OSRM/osrm-backend/pull/5622)
     - Misc:
       - CHANGED: Reduce memory usage for raster source handling. [#5572](https://github.com/Project-OSRM/osrm-backend/pull/5572)
 

--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -127,6 +127,7 @@ Feature: Bike - Access tags on ways
             |              |              | agricultural |         |
             |              |              | forestry     |         |
             |              |              | delivery     |         |
+            |              |              | use_sidepath |         |
 
     Scenario: Bike - Access tags on both node and way
         Then routability should be

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -56,7 +56,13 @@ function setup()
       'private',
       'agricultural',
       'forestry',
-      'delivery'
+      'delivery',
+      -- When a way is tagged with `use_sidepath` a parallel way suitable for
+      -- cyclists is mapped and must be used instead (by law). This tag is
+      -- used on ways that normally may be used by cyclists, but not when
+      -- a signposted parallel cycleway is available. For purposes of routing
+      -- cyclists, this value should be treated as 'no access for bicycles'.
+      'use_sidepath'
     },
 
     restricted_access_tag_list = Set { },


### PR DESCRIPTION
# Issue

Fixes #5557; treat `bicycle=use_sidepath` as *no access* on the tagged way. When this tag is used, a parallel way that is legally suitable for bicycles will have been mapped, and the way marked with `use_sidepath` should be ignored.

Please see [the OSM Wiki](https://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath) for details on the tag.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
