### PR TITLE
Fix profiles/debug_example.lua cannot interprete by lua

### DIFF
--- a/profiles/debug_example.lua
+++ b/profiles/debug_example.lua
@@ -38,7 +38,7 @@ local way = {
 local result = {}
 
 -- call the way function
-Debug.way_function(way,result)
+Debug.process_way(way,result)
 
 -- print input and output
 pprint(way)


### PR DESCRIPTION
After run `lua5.1 profiles/debug_example.lua`, I got result:

```
lua5.1: debug_example.lua:41: attempt to call field 'way_function' (a nil value)
stack traceback:
        debug_example.lua:41: in main chunk
        [C]: ?
```

This is because Debug has not way_function in the module. This changes
change it to process_way and it's works!!

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
