### PR TITLE
Fix profiles/debug_example.lua cannot interprete by lua

### DIFF
--- a/profiles/debug_example.lua
+++ b/profiles/debug_example.lua
@@ -38,7 +38,7 @@ local way = {
 local result = {}
 
 -- call the way function
-Debug.way_function(way,result)
+Debug.process_way(way,result)
 
 -- print input and output
 pprint(way)


### PR DESCRIPTION
After run `lua5.1 profiles/debug_example.lua`, I got result:

```
lua5.1: debug_example.lua:41: attempt to call field 'way_function' (a nil value)
stack traceback:
        debug_example.lua:41: in main chunk
        [C]: ?
```

This is because Debug has not way_function in the module. This changes
change it to process_way and it's works!!

Fixes #5710