### PR TITLE
Fixes signed/unsigned comparision spotted by gcc10.

### DIFF
--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -192,17 +192,22 @@ void annotatePath(const FacadeT &facade,
 
         const bool is_first_segment = unpacked_path.empty();
 
-        const std::size_t start_index =
-            (is_first_segment ? ((start_traversed_in_reverse)
-                                     ? weight_vector.size() -
-                                           phantom_node_pair.source_phantom.fwd_segment_position - 1
-                                     : phantom_node_pair.source_phantom.fwd_segment_position)
-                              : 0);
+        std::size_t start_index = 0;
+        if (is_first_segment)
+        {
+            unsigned short segment_position = phantom_node_pair.source_phantom.fwd_segment_position;
+            if (start_traversed_in_reverse)
+            {
+                segment_position = weight_vector.size() -
+                                   phantom_node_pair.source_phantom.fwd_segment_position - 1;
+            }
+            BOOST_ASSERT(segment_position >= 0);
+            start_index = static_cast<std::size_t>(segment_position);
+        }
         const std::size_t end_index = weight_vector.size();
 
         bool is_left_hand_driving = facade.IsLeftHandDriving(node_id);
 
-        BOOST_ASSERT(start_index >= 0);
         BOOST_ASSERT(start_index < end_index);
         for (std::size_t segment_idx = start_index; segment_idx < end_index; ++segment_idx)
         {


### PR DESCRIPTION
Fixed by moving assertion to the actual point where signed values are used.

# 5757
