### PR TITLE
Bugfix TBB linking #5782

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,8 +530,8 @@ else()
 
   find_package(TBB REQUIRED)
   add_dependency_includes(${TBB_INCLUDE_DIR})
-  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES Debug)
-    set(TBB_LIBRARIES ${TBB_DEBUG_LIBRARIES})
+  if(WIN32)
+    set(TBB_LIBRARIES optimized ${TBB_LIBRARY} optimized ${TBB_MALLOC_LIBRARY} debug ${TBB_LIBRARY_DEBUG} debug ${TBB_MALLOC_LIBRARY_DEBUG})
   endif()
 
   find_package(EXPAT REQUIRED)


### PR DESCRIPTION
Issue #5782: The query if(WIN32 AND CMAKE_BUILD_TYPE MATCHES Debug) only works if you call CMake explicitly with the build configuration Debug. But if you generate Debug and Release all libraries are linked to the release version.