### PR TITLE
Partially fixes use of deprecated TBB features

### DIFF
--- a/include/updater/csv_file_parser.hpp
+++ b/include/updater/csv_file_parser.hpp
@@ -17,6 +17,8 @@
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 
+#include <exception>
+#include <stdexcept>
 #include <vector>
 
 namespace osrm
@@ -80,7 +82,9 @@ template <typename Key, typename Value> struct CSVFilesParser
 
             return LookupTable<Key, Value>{lookup};
         }
-        catch (const tbb::captured_exception &e)
+        catch (const std::exception &e)
+        // TBB should capture to std::exception_ptr and automatically rethrow in this thread.
+        // https://software.intel.com/en-us/node/506317
         {
             throw util::exception(e.what() + SOURCE_REF);
         }

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -36,7 +36,12 @@
 
 #include <boost/assert.hpp>
 
+#if TBB_VERSION_MAJOR == 2020
+#include <tbb/global_control.h>
+#else
 #include <tbb/task_scheduler_init.h>
+#endif
+
 namespace osrm
 {
 namespace contractor
@@ -44,8 +49,13 @@ namespace contractor
 
 int Contractor::Run()
 {
+#if TBB_VERSION_MAJOR == 2020
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism,
+                           config.requested_num_threads);
+#else
     tbb::task_scheduler_init init(config.requested_num_threads);
     BOOST_ASSERT(init.is_active());
+#endif
 
     if (config.core_factor != 1.0)
     {

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -21,7 +21,11 @@
 
 #include <boost/assert.hpp>
 
+#if TBB_VERSION_MAJOR == 2020
+#include <tbb/global_control.h>
+#else
 #include <tbb/task_scheduler_init.h>
+#endif
 
 namespace osrm
 {
@@ -118,8 +122,13 @@ std::vector<CellMetric> customizeFilteredMetrics(const partitioner::MultiLevelEd
 
 int Customizer::Run(const CustomizationConfig &config)
 {
+#if TBB_VERSION_MAJOR == 2020
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism,
+                           config.requested_num_threads);
+#else
     tbb::task_scheduler_init init(config.requested_num_threads);
     BOOST_ASSERT(init.is_active());
+#endif
 
     TIMER_START(loading_data);
 

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -31,13 +31,13 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <unordered_map>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <tbb/pipeline.h>
-#include <tbb/task_scheduler_init.h>
 
 namespace std
 {
@@ -1080,7 +1080,7 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
         // to be balanced with the GRAINSIZE above - ideally, the pipeline puts as much work
         // as possible in the `intersection_handler` step so that those parallel workers don't
         // get blocked too much by the slower (io-performing) `buffer_storage`
-        tbb::parallel_pipeline(tbb::task_scheduler_init::default_num_threads() * 5,
+        tbb::parallel_pipeline(std::thread::hardware_concurrency() * 5,
                                generator_stage & processor_stage & output_stage);
 
         // NOTE: buffer.delayed_data and buffer.delayed_turn_data have the same index

--- a/src/guidance/guidance_processing.cpp
+++ b/src/guidance/guidance_processing.cpp
@@ -10,7 +10,8 @@
 
 #include <tbb/blocked_range.h>
 #include <tbb/pipeline.h>
-#include <tbb/task_scheduler_init.h>
+
+#include <thread>
 
 namespace osrm
 {
@@ -324,7 +325,7 @@ void annotateTurns(const util::NodeBasedDynamicGraph &node_based_graph,
         // to be balanced with the GRAINSIZE above - ideally, the pipeline puts as much work
         // as possible in the `intersection_handler` step so that those parallel workers don't
         // get blocked too much by the slower (io-performing) `buffer_storage`
-        tbb::parallel_pipeline(tbb::task_scheduler_init::default_num_threads() * 5,
+        tbb::parallel_pipeline(std::thread::hardware_concurrency() * 5,
                                generator_stage & guidance_stage & guidance_output_stage);
 
         // NOTE: EBG edges delayed_data and turns delayed_turn_data have the same index

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -28,7 +28,11 @@
 #include <boost/assert.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#if TBB_VERSION_MAJOR == 2020
+#include <tbb/global_control.h>
+#else
 #include <tbb/task_scheduler_init.h>
+#endif
 
 #include "util/geojson_debug_logger.hpp"
 #include "util/geojson_debug_policies.hpp"
@@ -70,8 +74,13 @@ auto getGraphBisection(const PartitionerConfig &config)
 
 int Partitioner::Run(const PartitionerConfig &config)
 {
+#if TBB_VERSION_MAJOR == 2020
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism,
+                           config.requested_num_threads);
+#else
     tbb::task_scheduler_init init(config.requested_num_threads);
     BOOST_ASSERT(init.is_active());
+#endif
 
     const std::vector<BisectionID> &node_based_partition_ids = getGraphBisection(config);
 

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -10,12 +10,11 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/errors.hpp>
 
-#include <tbb/task_scheduler_init.h>
-
 #include <cstdlib>
 #include <exception>
 #include <new>
 #include <ostream>
+#include <thread>
 
 #include "util/meminfo.hpp"
 
@@ -45,7 +44,7 @@ return_code parseArguments(int argc,
     config_options.add_options()(
         "threads,t",
         boost::program_options::value<unsigned int>(&contractor_config.requested_num_threads)
-            ->default_value(tbb::task_scheduler_init::default_num_threads()),
+            ->default_value(std::thread::hardware_concurrency()),
         "Number of threads to use")(
         "core,k",
         boost::program_options::value<double>(&contractor_config.core_factor)->default_value(1.0),
@@ -171,7 +170,7 @@ int main(int argc, char *argv[]) try
         return EXIT_FAILURE;
     }
 
-    const unsigned recommended_num_threads = tbb::task_scheduler_init::default_num_threads();
+    const unsigned recommended_num_threads = std::thread::hardware_concurrency();
 
     if (recommended_num_threads != contractor_config.requested_num_threads)
     {

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -5,12 +5,11 @@
 #include "util/meminfo.hpp"
 #include "util/version.hpp"
 
-#include <tbb/task_scheduler_init.h>
-
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <iostream>
+#include <thread>
 
 using namespace osrm;
 
@@ -39,7 +38,7 @@ return_code parseArguments(int argc,
         //
         ("threads,t",
          boost::program_options::value<unsigned int>(&customization_config.requested_num_threads)
-             ->default_value(tbb::task_scheduler_init::default_num_threads()),
+             ->default_value(std::thread::hardware_concurrency()),
          "Number of threads to use")(
             "segment-speed-file",
             boost::program_options::value<std::vector<std::string>>(

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -4,14 +4,13 @@
 #include "util/log.hpp"
 #include "util/version.hpp"
 
-#include <tbb/task_scheduler_init.h>
-
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <cstdlib>
 #include <exception>
 #include <new>
+#include <thread>
 
 #include "util/meminfo.hpp"
 
@@ -49,7 +48,7 @@ return_code parseArguments(int argc,
         "Data version. Leave blank to avoid. osmosis - to get timestamp from file")(
         "threads,t",
         boost::program_options::value<unsigned int>(&extractor_config.requested_num_threads)
-            ->default_value(tbb::task_scheduler_init::default_num_threads()),
+            ->default_value(std::thread::hardware_concurrency()),
         "Number of threads to use")(
         "small-component-size",
         boost::program_options::value<unsigned int>(&extractor_config.small_component_size)

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -7,8 +7,6 @@
 #include "util/timing_util.hpp"
 #include "util/version.hpp"
 
-#include <tbb/task_scheduler_init.h>
-
 #include <boost/algorithm/string/join.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
@@ -17,6 +15,7 @@
 #include <iostream>
 #include <iterator>
 #include <regex>
+#include <thread>
 
 using namespace osrm;
 
@@ -86,7 +85,7 @@ return_code parseArguments(int argc,
         //
         ("threads,t",
          boost::program_options::value<unsigned int>(&config.requested_num_threads)
-             ->default_value(tbb::task_scheduler_init::default_num_threads()),
+             ->default_value(std::thread::hardware_concurrency()),
          "Number of threads to use")
         //
         ("balance",

--- a/unit_tests/contractor/graph_contractor.cpp
+++ b/unit_tests/contractor/graph_contractor.cpp
@@ -6,7 +6,12 @@
 #include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <tbb/tbb_stddef.h> // For version lookup
+#if TBB_VERSION_MAJOR == 2020
+#include <tbb/global_control.h>
+#else
 #include <tbb/task_scheduler_init.h>
+#endif
 
 using namespace osrm;
 using namespace osrm::contractor;
@@ -16,7 +21,11 @@ BOOST_AUTO_TEST_SUITE(graph_contractor)
 
 BOOST_AUTO_TEST_CASE(contract_graph)
 {
+#if TBB_VERSION_MAJOR == 2020
+    tbb::global_control scheduler(tbb::global_control::max_allowed_parallelism, 1);
+#else
     tbb::task_scheduler_init scheduler(1);
+#endif
     /*
      *                 <--1--<
      * (0) >--3--> (1) >--3--> (3)

--- a/unit_tests/library/contract.cpp
+++ b/unit_tests/library/contract.cpp
@@ -4,7 +4,7 @@
 #include "osrm/contractor.hpp"
 #include "osrm/contractor_config.hpp"
 
-#include <tbb/task_scheduler_init.h> // default_num_threads
+#include <thread>
 
 BOOST_AUTO_TEST_SUITE(library_contract)
 
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(test_contract_with_invalid_config)
     using namespace osrm;
 
     osrm::ContractorConfig config;
-    config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
+    config.requested_num_threads = std::thread::hardware_concurrency();
     BOOST_CHECK_THROW(osrm::contract(config),
                       std::exception); // including osrm::util::exception, etc.
 }

--- a/unit_tests/library/customize.cpp
+++ b/unit_tests/library/customize.cpp
@@ -4,7 +4,7 @@
 #include "osrm/customizer.hpp"
 #include "osrm/customizer_config.hpp"
 
-#include <tbb/task_scheduler_init.h> // default_num_threads
+#include <thread>
 
 BOOST_AUTO_TEST_SUITE(library_customize)
 
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(test_customize_with_invalid_config)
     using namespace osrm;
 
     osrm::CustomizationConfig config;
-    config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
+    config.requested_num_threads = std::thread::hardware_concurrency();
     BOOST_CHECK_THROW(osrm::customize(config),
                       std::exception); // including osrm::util::exception, etc.
 }

--- a/unit_tests/library/extract.cpp
+++ b/unit_tests/library/extract.cpp
@@ -4,14 +4,14 @@
 #include "osrm/extractor.hpp"
 #include "osrm/extractor_config.hpp"
 
-#include <tbb/task_scheduler_init.h> // default_num_threads
+#include <thread>
 
 BOOST_AUTO_TEST_SUITE(library_extract)
 
 BOOST_AUTO_TEST_CASE(test_extract_with_invalid_config)
 {
     osrm::ExtractorConfig config;
-    config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
+    config.requested_num_threads = std::thread::hardware_concurrency();
     BOOST_CHECK_THROW(osrm::extract(config),
                       std::exception); // including osrm::util::exception, osmium::io_error, etc.
 }
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(test_extract_with_valid_config)
     osrm::ExtractorConfig config;
     config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
     config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
-    config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
+    config.requested_num_threads = std::thread::hardware_concurrency();
     BOOST_CHECK_NO_THROW(osrm::extract(config));
 }
 

--- a/unit_tests/library/partition.cpp
+++ b/unit_tests/library/partition.cpp
@@ -4,7 +4,7 @@
 #include "osrm/partitioner.hpp"
 #include "osrm/partitioner_config.hpp"
 
-#include <tbb/task_scheduler_init.h> // default_num_threads
+#include <thread>
 
 BOOST_AUTO_TEST_SUITE(library_partition)
 
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(test_partition_with_invalid_config)
     using namespace osrm;
 
     osrm::PartitionerConfig config;
-    config.requested_num_threads = tbb::task_scheduler_init::default_num_threads();
+    config.requested_num_threads = std::thread::hardware_concurrency();
     BOOST_CHECK_THROW(osrm::partition(config),
                       std::exception); // including osrm::util::exception, etc.
 }

--- a/unit_tests/partitioner/recursive_bisection.cpp
+++ b/unit_tests/partitioner/recursive_bisection.cpp
@@ -9,8 +9,13 @@
 #include <boost/test/unit_test.hpp>
 
 // make sure not to leak in recursive bisection
+#if TBB_VERSION_MAJOR == 2020
+#include <tbb/global_control.h>
+tbb::global_control scheduler(tbb::global_control::max_allowed_parallelism, 2);
+#else
 #include <tbb/task_scheduler_init.h>
 tbb::task_scheduler_init init(2);
+#endif
 
 using namespace osrm::partitioner;
 using namespace osrm::util;

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -26,10 +26,14 @@
 #include <utility>
 #include <vector>
 
-#include <tbb/task_scheduler_init.h>
-
 // explicit TBB scheduler init to register resources cleanup at exit
+#if TBB_VERSION_MAJOR == 2020
+#include <tbb/global_control.h>
+tbb::global_control scheduler(tbb::global_control::max_allowed_parallelism, 2);
+#else
+#include <tbb/task_scheduler_init.h>
 tbb::task_scheduler_init init(2);
+#endif
 
 BOOST_AUTO_TEST_SUITE(static_rtree)
 


### PR DESCRIPTION
#5807

Fixes deprecation warning for `captured_exception` and `task_scheduler_init` by TBB, by replacing them with C++ native analogs.

Deprecation warning on `tbb\atomic.h` is not fixed yet, as it requires atomic_ref support, which requires either Boost version dump or C++20 or algorithm refactoring, so not yet.