### PR TITLE
Removed references to obsolete Boost.Test headers.

### DIFF
--- a/unit_tests/contractor/graph_contractor.cpp
+++ b/unit_tests/contractor/graph_contractor.cpp
@@ -3,7 +3,6 @@
 #include "../common/range_tools.hpp"
 #include "helper.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <tbb/task_scheduler_init.h>

--- a/unit_tests/engine/base64.cpp
+++ b/unit_tests/engine/base64.cpp
@@ -2,7 +2,6 @@
 #include "mocks/mock_datafacade.hpp"
 #include "engine/hint.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/engine/collapse_internal_route_result.cpp
+++ b/unit_tests/engine/collapse_internal_route_result.cpp
@@ -1,7 +1,6 @@
 #include "engine/internal_route_result.hpp"
 #include "engine/phantom_node.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/engine/douglas_peucker.cpp
+++ b/unit_tests/engine/douglas_peucker.cpp
@@ -2,7 +2,6 @@
 #include "util/coordinate_calculation.hpp"
 #include "util/debug.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <osrm/coordinate.hpp>

--- a/unit_tests/engine/guidance_assembly.cpp
+++ b/unit_tests/engine/guidance_assembly.cpp
@@ -7,7 +7,6 @@
 #include "engine/guidance/assemble_steps.hpp"
 #include "engine/guidance/post_processing.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(guidance_assembly)

--- a/unit_tests/engine/json_factory.cpp
+++ b/unit_tests/engine/json_factory.cpp
@@ -1,7 +1,6 @@
 #include "engine/api/json_factory.hpp"
 #include "guidance/turn_instruction.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(json_factory)

--- a/unit_tests/engine/polyline_compressor.cpp
+++ b/unit_tests/engine/polyline_compressor.cpp
@@ -1,7 +1,6 @@
 #include "engine/polyline_compressor.hpp"
 #include "util/coordinate.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <string>

--- a/unit_tests/engine/tidy.cpp
+++ b/unit_tests/engine/tidy.cpp
@@ -1,6 +1,5 @@
 #include "engine/api/match_parameters_tidy.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/extractor/compressed_edge_container.cpp
+++ b/unit_tests/extractor/compressed_edge_container.cpp
@@ -1,7 +1,6 @@
 #include "extractor/compressed_edge_container.hpp"
 #include "util/typedefs.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(compressed_edge_container)

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -7,7 +7,6 @@
 
 #include "../unit_tests/mocks/mock_scripting_environment.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <iostream>

--- a/unit_tests/extractor/intersection_analysis_tests.cpp
+++ b/unit_tests/extractor/intersection_analysis_tests.cpp
@@ -5,7 +5,6 @@
 #include "../common/range_tools.hpp"
 #include "../unit_tests/mocks/mock_scripting_environment.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(intersection_analysis_tests)

--- a/unit_tests/extractor/location_dependent_data_tests.cpp
+++ b/unit_tests/extractor/location_dependent_data_tests.cpp
@@ -3,7 +3,6 @@
 #include "../common/range_tools.hpp"
 
 #include <boost/filesystem.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>

--- a/unit_tests/extractor/name_table.cpp
+++ b/unit_tests/extractor/name_table.cpp
@@ -4,7 +4,6 @@
 #include "../common/temporary_file.hpp"
 
 #include <boost/filesystem.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <iomanip>

--- a/unit_tests/library/algorithm.cpp
+++ b/unit_tests/library/algorithm.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "fixture.hpp"

--- a/unit_tests/library/contract.cpp
+++ b/unit_tests/library/contract.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "osrm/contractor.hpp"

--- a/unit_tests/library/customize.cpp
+++ b/unit_tests/library/customize.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "osrm/customizer.hpp"

--- a/unit_tests/library/extract.cpp
+++ b/unit_tests/library/extract.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "osrm/extractor.hpp"

--- a/unit_tests/library/json.cpp
+++ b/unit_tests/library/json.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "coordinates.hpp"

--- a/unit_tests/library/limits.cpp
+++ b/unit_tests/library/limits.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "osrm/match_parameters.hpp"

--- a/unit_tests/library/match.cpp
+++ b/unit_tests/library/match.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "coordinates.hpp"

--- a/unit_tests/library/nearest.cpp
+++ b/unit_tests/library/nearest.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "coordinates.hpp"

--- a/unit_tests/library/options.cpp
+++ b/unit_tests/library/options.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "coordinates.hpp"

--- a/unit_tests/library/partition.cpp
+++ b/unit_tests/library/partition.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "osrm/partitioner.hpp"

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cmath>

--- a/unit_tests/library/table.cpp
+++ b/unit_tests/library/table.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "coordinates.hpp"

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "fixture.hpp"

--- a/unit_tests/library/trip.cpp
+++ b/unit_tests/library/trip.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "coordinates.hpp"

--- a/unit_tests/partitioner/bisection_graph.cpp
+++ b/unit_tests/partitioner/bisection_graph.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace osrm::partitioner;

--- a/unit_tests/partitioner/bisection_graph_view.cpp
+++ b/unit_tests/partitioner/bisection_graph_view.cpp
@@ -8,7 +8,6 @@
 #include <climits>
 #include <vector>
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace osrm::partitioner;

--- a/unit_tests/partitioner/dinic.cpp
+++ b/unit_tests/partitioner/dinic.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace osrm::partitioner;

--- a/unit_tests/partitioner/multi_level_graph.cpp
+++ b/unit_tests/partitioner/multi_level_graph.cpp
@@ -3,7 +3,6 @@
 
 #include "../common/range_tools.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/partitioner/recursive_bisection.cpp
+++ b/unit_tests/partitioner/recursive_bisection.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 // make sure not to leak in recursive bisection

--- a/unit_tests/partitioner/reorder_first_last.cpp
+++ b/unit_tests/partitioner/reorder_first_last.cpp
@@ -1,6 +1,5 @@
 #include "partitioner/reorder_first_last.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/partitioner/scc_integration.cpp
+++ b/unit_tests/partitioner/scc_integration.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace osrm::partitioner;

--- a/unit_tests/util/bearing.cpp
+++ b/unit_tests/util/bearing.cpp
@@ -2,7 +2,6 @@
 #include "util/typedefs.hpp"
 
 #include <boost/functional/hash.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(bearing_test)

--- a/unit_tests/util/bit_range.cpp
+++ b/unit_tests/util/bit_range.cpp
@@ -2,7 +2,6 @@
 
 #include "../common/range_tools.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(bit_range_test)

--- a/unit_tests/util/conditional_restrictions_parsing.cpp
+++ b/unit_tests/util/conditional_restrictions_parsing.cpp
@@ -1,6 +1,5 @@
 #include "util/conditional_restrictions.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(conditional_restrictions)

--- a/unit_tests/util/connectivity_checksum.cpp
+++ b/unit_tests/util/connectivity_checksum.cpp
@@ -1,6 +1,5 @@
 #include "util/connectivity_checksum.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(connectivity_checksum)

--- a/unit_tests/util/duration_parsing.cpp
+++ b/unit_tests/util/duration_parsing.cpp
@@ -1,6 +1,5 @@
 #include "extractor/extraction_helper_functions.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(durations_are_valid)

--- a/unit_tests/util/dynamic_graph.cpp
+++ b/unit_tests/util/dynamic_graph.cpp
@@ -3,7 +3,6 @@
 
 #include "../common/range_tools.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <vector>

--- a/unit_tests/util/filtered_integer_range.cpp
+++ b/unit_tests/util/filtered_integer_range.cpp
@@ -2,7 +2,6 @@
 
 #include "../common/range_tools.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(bit_range_test)

--- a/unit_tests/util/group_by.cpp
+++ b/unit_tests/util/group_by.cpp
@@ -1,6 +1,5 @@
 #include "util/group_by.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <iterator>

--- a/unit_tests/util/hilbert_values.cpp
+++ b/unit_tests/util/hilbert_values.cpp
@@ -1,6 +1,5 @@
 #include "util/hilbert_value.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(hilbert_values_test)

--- a/unit_tests/util/indexed_data.cpp
+++ b/unit_tests/util/indexed_data.cpp
@@ -2,7 +2,6 @@
 #include "common/temporary_file.hpp"
 #include "util/exception.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <iomanip>

--- a/unit_tests/util/io.cpp
+++ b/unit_tests/util/io.cpp
@@ -5,7 +5,6 @@
 #include "util/typedefs.hpp"
 #include "util/version.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <exception>

--- a/unit_tests/util/opening_hours_parsing.cpp
+++ b/unit_tests/util/opening_hours_parsing.cpp
@@ -1,7 +1,6 @@
 #include "util/opening_hours.hpp"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(opening_hours)

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -6,7 +6,6 @@
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/any_range.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/util/permutation.cpp
+++ b/unit_tests/util/permutation.cpp
@@ -2,7 +2,6 @@
 
 #include "util/permutation.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/util/query_heap.cpp
+++ b/unit_tests/util/query_heap.cpp
@@ -2,7 +2,6 @@
 #include "util/typedefs.hpp"
 
 #include <boost/mpl/list.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/util/range_table.cpp
+++ b/unit_tests/util/range_table.cpp
@@ -1,7 +1,6 @@
 #include "util/range_table.hpp"
 #include "util/typedefs.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <numeric>

--- a/unit_tests/util/rectangle.cpp
+++ b/unit_tests/util/rectangle.cpp
@@ -1,7 +1,6 @@
 #include "util/rectangle.hpp"
 #include "util/typedefs.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(rectangle_test)

--- a/unit_tests/util/static_graph.cpp
+++ b/unit_tests/util/static_graph.cpp
@@ -1,7 +1,6 @@
 #include "util/static_graph.hpp"
 #include "util/typedefs.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -11,8 +11,6 @@
 #include "mocks/mock_datafacade.hpp"
 
 #include <boost/functional/hash.hpp>
-#include <boost/test/auto_unit_test.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cmath>

--- a/unit_tests/util/string_util.cpp
+++ b/unit_tests/util/string_util.cpp
@@ -1,6 +1,5 @@
 #include "util/string_util.hpp"
 
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <iostream>

--- a/unit_tests/util/vector_view.cpp
+++ b/unit_tests/util/vector_view.cpp
@@ -3,7 +3,6 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/unit_tests/util/viewport.cpp
+++ b/unit_tests/util/viewport.cpp
@@ -3,7 +3,6 @@
 using namespace osrm::util;
 
 #include <boost/functional/hash.hpp>
-#include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <iostream>


### PR DESCRIPTION
#5807 

Removed usage of deprecated Boost.Test headers, which should decrease level of noise during build.