### PR TITLE
Make MMapMemoryAllocator map files in read-only (O_RDONLY) mode

### DIFF
--- a/include/engine/datafacade/mmap_memory_allocator.hpp
+++ b/include/engine/datafacade/mmap_memory_allocator.hpp
@@ -33,7 +33,7 @@ class MMapMemoryAllocator : public ContiguousBlockAllocator
 
   private:
     storage::SharedDataIndex index;
-    std::vector<boost::iostreams::mapped_file> mapped_memory_files;
+    std::vector<boost::iostreams::mapped_file_source> mapped_memory_files;
     std::string rtree_filename;
 };
 

--- a/src/engine/datafacade/mmap_memory_allocator.cpp
+++ b/src/engine/datafacade/mmap_memory_allocator.cpp
@@ -52,11 +52,11 @@ MMapMemoryAllocator::MMapMemoryAllocator(const storage::StorageConfig &config)
         {
             std::unique_ptr<storage::BaseDataLayout> layout =
                 std::make_unique<storage::TarDataLayout>();
-            boost::iostreams::mapped_file mapped_memory_file;
-            util::mmapFile<char>(file.second, mapped_memory_file);
+            boost::iostreams::mapped_file_source mapped_memory_file;
+            auto data = util::mmapFile<char>(file.second, mapped_memory_file).data();
             mapped_memory_files.push_back(std::move(mapped_memory_file));
             storage::populateLayoutFromFile(file.second, *layout);
-            allocated_regions.push_back({mapped_memory_file.data(), std::move(layout)});
+            allocated_regions.push_back({const_cast<char *>(data), std::move(layout)});
         }
     }
 


### PR DESCRIPTION
Mapping with O_RDWR will cause copy_up across Docker layers.

# Issue

https://github.com/Project-OSRM/osrm-backend/issues/5820

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))

## Requirements / Relations
