### PR TITLE
Annotations was missing as part of the table documentation

### DIFF
--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -141,6 +141,8 @@ tables. Optionally returns distance table.
     -   `options.fallback_coordinate` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Either `input` (default) or `snapped`.  If using a `fallback_speed`, use either the user-supplied coordinate (`input`), or the snapped coordinate (`snapped`) for calculating the as-the-crow-flies diestance between two points.
     -   `options.scale_factor` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Multiply the table duration values in the table by this number for more controlled input into a route optimization solver.
     -   `options.snapping` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Which edges can be snapped to, either `default`, or `any`.  `default` only snaps to edges marked by the profile as `is_startpoint`, `any` will allow snapping to any edge in the routing graph.
+    -   `options.annotations` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Return the requested table or tables in response. Can be `['duration']` (return the duration matrix, default) or `['duration', distance']` (return both the duration matrix and the distance matrix). 
+     
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)**
 
 **Examples**


### PR DESCRIPTION
# Issue
The nodejs api docs don't show that the table can take an `attributes` parameter. 

Related to [this issue](https://github.com/Project-OSRM/osrm-backend/issues/5823)

Using the docs available here as the basis for my change.

http://project-osrm.org/docs/v5.22.0/api/#table-service

## Tasklist

 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)

## Requirements / Relations

I've also opened up a [PR on the DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47389) to expose the same annotation field there. 

Trying to make sure docs are consistent with that. Let me know if there's anything else I should update!
