### PR TITLE
Fix table result when source and destination on same one-way segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)
       - CHANGED: default car height was reduced to 2 meters. [#5389](https://github.com/Project-OSRM/osrm-backend/pull/5389)
       - FIXED: treat `bicycle=use_sidepath` as no access on the tagged way. [#5622](https://github.com/Project-OSRM/osrm-backend/pull/5622)
+      - FIXED: fix table result when source and destination on same one-way segment. [#5828](https://github.com/Project-OSRM/osrm-backend/pull/5828)
     - Misc:
       - CHANGED: Reduce memory usage for raster source handling. [#5572](https://github.com/Project-OSRM/osrm-backend/pull/5572)
       - CHANGED: Add cmake option `ENABLE_DEBUG_LOGGING` to control whether output debug logging. [#3427](https://github.com/Project-OSRM/osrm-backend/issues/3427)

--- a/features/testbot/oneway_phantom.feature
+++ b/features/testbot/oneway_phantom.feature
@@ -1,0 +1,85 @@
+@routing @testbot @oneway
+Feature: Handle multiple phantom nodes in one-way segment
+
+# Check we handle routes where source and destination are
+# phantom nodes on the same one-way segment.
+# See: https://github.com/Project-OSRM/osrm-backend/issues/5788
+
+    Background:
+    Given the profile "testbot"
+
+    Scenario: One-way segment with adjacent phantom nodes
+    Given the node map
+        """
+        d  c
+
+        a12b
+        """
+
+    And the ways
+       | nodes | oneway |
+       | ab    | yes    |
+       | bc    | no     |
+       | cd    | no     |
+       | da    | no     |
+
+    When I route I should get
+       | from | to | route          | time      | distance |
+       | 1    | 2  | ab,ab          | 5s  +-0.1 | 50m  ~1% |
+       | 1    | c  | ab,bc,bc       | 30s +-0.1 | 300m ~1% |
+       | 2    | 1  | ab,bc,cd,da,ab | 65s +-0.1 | 650m ~1% |
+       | 2    | c  | ab,bc,bc       | 25s +-0.1 | 250m ~1% |
+       | c    | 1  | cd,da,ab       | 40s +-0.1 | 400m ~1% |
+       | c    | 2  | cd,da,ab       | 45s +-0.1 | 450m ~1% |
+
+    When I request a travel time matrix I should get
+       |   | 1        | 2        | c         |
+       | 1 | 0        | 5  +-0.1 | 30 +-0.1  |
+       | 2 | 65 +-0.1 | 0        | 25 +-0.1  |
+       | c | 40 +-0.1 | 45 +-0.1 | 0         |
+
+    When I request a travel time matrix I should get
+       |   | 1  | 2       | c        |
+       | 1 | 0  | 5 +-0.1 | 30 +-0.1 |
+
+    When I request a travel time matrix I should get
+       |   | 1        | 2  | c        |
+       | 2 | 65 +-0.1 | 0  | 25 +-0.1 |
+
+    When I request a travel time matrix I should get
+       |   | 1        |
+       | 1 | 0        |
+       | 2 | 65 +-0.1 |
+       | c | 40 +-0.1 |
+
+    When I request a travel time matrix I should get
+       |   | 2        |
+       | 1 | 5  +-0.1 |
+       | 2 | 0        |
+       | c | 45 +-0.1 |
+
+    When I request a travel distance matrix I should get
+       |   | 1       | 2       | c       |
+       | 1 | 0       | 50  ~1% | 300 ~1% |
+       | 2 | 650 ~1% | 0       | 250 ~1% |
+       | c | 400 ~1% | 450 ~1% | 0       |
+
+    When I request a travel distance matrix I should get
+       |   | 1   | 2      | c       |
+       | 1 | 0   | 50 ~1% | 300 ~1% |
+
+    When I request a travel distance matrix I should get
+       |   | 1       | 2   | c       |
+       | 2 | 650 ~1% | 0   | 250 ~1% |
+
+    When I request a travel distance matrix I should get
+       |   | 1       |
+       | 1 | 0       |
+       | 2 | 650 ~1% |
+       | c | 400 ~1% |
+
+    When I request a travel distance matrix I should get
+       |   | 2       |
+       | 1 | 50  ~1% |
+       | 2 | 0       |
+       | c | 450 ~1% |


### PR DESCRIPTION
# Issue

Fixes #5788 

Table queries where source and destination are phantom nodes on the same one-way segment can fail to find valid routes.

This is due to a bug in the MLD table generation for the special case where the query can be simplified to a
one-to-many search. If the destination is before the source on the one-way segment, it will fail to find a route.

We fix this case by not marking the node as visited at the start, so that valid paths to this node can be found later in the search.

We also remove redundant initialization for the source node as the same actions are performed by a search step.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [x] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
