### PR TITLE
Lock access to facade_factory in data_watchdog to avoid accessing destructed object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
       - CHANGED: default car weight was reduced to 2000 kg. [#5371](https://github.com/Project-OSRM/osrm-backend/pull/5371)
       - CHANGED: default car height was reduced to 2 meters. [#5389](https://github.com/Project-OSRM/osrm-backend/pull/5389)
       - FIXED: treat `bicycle=use_sidepath` as no access on the tagged way. [#5622](https://github.com/Project-OSRM/osrm-backend/pull/5622)
+      - FIXED: fix occasional segfault when swapping data with osrm-datastore and using `exclude=` [#5844](https://github.com/Project-OSRM/osrm-backend/pull/5844)
     - Misc:
       - CHANGED: Reduce memory usage for raster source handling. [#5572](https://github.com/Project-OSRM/osrm-backend/pull/5572)
       - CHANGED: Add cmake option `ENABLE_DEBUG_LOGGING` to control whether output debug logging. [#3427](https://github.com/Project-OSRM/osrm-backend/issues/3427)

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -56,11 +56,14 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
             static_region = *static_shared_region;
             updatable_region = *updatable_shared_region;
 
-            facade_factory =
-                DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
-                    std::make_shared<datafacade::SharedMemoryAllocator>(
-                        std::vector<storage::SharedRegionRegister::ShmKey>{
-                            static_region.shm_key, updatable_region.shm_key}));
+            {
+                boost::unique_lock<boost::shared_mutex> swap_lock(factory_mutex);
+                facade_factory =
+                    DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
+                        std::make_shared<datafacade::SharedMemoryAllocator>(
+                            std::vector<storage::SharedRegionRegister::ShmKey>{
+                                static_region.shm_key, updatable_region.shm_key}));
+            }
         }
 
         watcher = std::thread(&DataWatchdogImpl::Run, this);
@@ -75,10 +78,14 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
 
     std::shared_ptr<const Facade> Get(const api::BaseParameters &params) const
     {
+        // make sure facade_factory stays stable while we call Get()
+        boost::shared_lock<boost::shared_mutex> swap_lock(factory_mutex);
         return facade_factory.Get(params);
     }
     std::shared_ptr<const Facade> Get(const api::TileParameters &params) const
     {
+        // make sure facade_factory stays stable while we call Get()
+        boost::shared_lock<boost::shared_mutex> swap_lock(factory_mutex);
         return facade_factory.Get(params);
     }
 
@@ -111,16 +118,19 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
                         << (int)updatable_region.shm_key << " with timestamps "
                         << static_region.timestamp << " and " << updatable_region.timestamp;
 
-            facade_factory =
-                DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
-                    std::make_shared<datafacade::SharedMemoryAllocator>(
-                        std::vector<storage::SharedRegionRegister::ShmKey>{
-                            static_region.shm_key, updatable_region.shm_key}));
+            {
+                boost::unique_lock<boost::shared_mutex> swap_lock(factory_mutex);
+                facade_factory =DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
+                        std::make_shared<datafacade::SharedMemoryAllocator>(
+                            std::vector<storage::SharedRegionRegister::ShmKey>{
+                                static_region.shm_key, updatable_region.shm_key}));
+            }
         }
 
         util::Log() << "DataWatchdog thread stopped";
     }
 
+    mutable boost::shared_mutex factory_mutex;
     const std::string dataset_name;
     storage::SharedMonitor<storage::SharedRegionRegister> barrier;
     std::thread watcher;

--- a/include/engine/data_watchdog.hpp
+++ b/include/engine/data_watchdog.hpp
@@ -120,7 +120,8 @@ class DataWatchdogImpl<AlgorithmT, datafacade::ContiguousInternalMemoryDataFacad
 
             {
                 boost::unique_lock<boost::shared_mutex> swap_lock(factory_mutex);
-                facade_factory =DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
+                facade_factory =
+                    DataFacadeFactory<datafacade::ContiguousInternalMemoryDataFacade, AlgorithmT>(
                         std::make_shared<datafacade::SharedMemoryAllocator>(
                             std::vector<storage::SharedRegionRegister::ShmKey>{
                                 static_region.shm_key, updatable_region.shm_key}));


### PR DESCRIPTION
# Issue

We have a race condition in the `data_watchdog` where a request may still be accessing a `facade_factory` that has been destructed by the watchdog thread due to new traffic data arriving (loaded by `osrm-datastore`).

Performance before the lock:
```
$ wrk -c 8 -t 8 -d 20 "http://localhost:5000/route/v1/car/1,1;2,2?exclude=toll"
Running 20s test @ http://localhost:5000/route/v1/car/1,1;2,2?exclude=toll
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   706.66us  224.89us  10.92ms   94.13%
    Req/Sec     1.42k   193.42     1.68k    90.55%
  227791 requests in 20.10s, 207.90MB read
  Socket errors: connect 0, read 439, write 0, timeout 0
Requests/sec:  11332.57
Transfer/sec:     10.34MB
```

Performance after the lock:
```
$ wrk -c 8 -t 8 -d 20 "http://localhost:5000/route/v1/car/1,1;2,2?exclude=toll"
Running 20s test @ http://localhost:5000/route/v1/car/1,1;2,2?exclude=toll
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   761.02us    1.49ms  51.52ms   99.72%
    Req/Sec     1.43k   173.74     1.72k    86.07%
  229274 requests in 20.10s, 209.25MB read
  Socket errors: connect 0, read 443, write 0, timeout 0
Requests/sec:  11405.21
Transfer/sec:     10.41MB
```

My read on this is that the new shared lock has negligible impact on overall performance.

With the shared lock in place, I'm no longer able to reproduce the crash described in 

https://github.com/Project-OSRM/osrm-backend/issues/5841

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
