### PR TITLE
Return early from alternative search if source or target are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
       - FIXED: treat `bicycle=use_sidepath` as no access on the tagged way. [#5622](https://github.com/Project-OSRM/osrm-backend/pull/5622)
       - FIXED: fix table result when source and destination on same one-way segment. [#5828](https://github.com/Project-OSRM/osrm-backend/pull/5828)
       - FIXED: fix occasional segfault when swapping data with osrm-datastore and using `exclude=` [#5844](https://github.com/Project-OSRM/osrm-backend/pull/5844)
+      - FIXED: fix crash in MLD alternative search if source or target are invalid [#5851](https://github.com/Project-OSRM/osrm-backend/pull/5851)
     - Misc:
       - CHANGED: Reduce memory usage for raster source handling. [#5572](https://github.com/Project-OSRM/osrm-backend/pull/5572)
       - CHANGED: Add cmake option `ENABLE_DEBUG_LOGGING` to control whether output debug logging. [#3427](https://github.com/Project-OSRM/osrm-backend/issues/3427)

--- a/features/testbot/zero-speed-updates.feature
+++ b/features/testbot/zero-speed-updates.feature
@@ -93,6 +93,31 @@ Feature: Check zero speed updates
           |    1 |  2 | NoRoute |
 
 
+    Scenario: Routing with alternatives on restricted way
+        Given the node map
+            """
+            a-1-b-2-c
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abc   | no     |
+        And the contract extra arguments "--segment-speed-file {speeds_file}"
+        And the customize extra arguments "--segment-speed-file {speeds_file}"
+        And the speed file
+            """
+            1,2,0
+            2,1,0
+            """
+        And the query options
+            | alternatives | true |
+
+
+        When I route I should get
+          | from | to | code    | alternative |
+          |    1 |  2 | NoRoute |             |
+
+
     Scenario: Routing on restricted oneway
         Given the node map
             """

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -663,6 +663,10 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
     Heap &reverse_heap = *search_engine_data.reverse_heap_1;
 
     insertNodesInHeaps(forward_heap, reverse_heap, phantom_node_pair);
+    if (forward_heap.Empty() || reverse_heap.Empty())
+    {
+        return {};
+    }
 
     // The single via node in the shortest paths s,via and via,t sub-paths and
     // the weight for the shortest path s,t we return and compare alternatives to.


### PR DESCRIPTION
# Issue
Fixes #5843 

In situations where there is not a valid source or target phantom
node (e.g. when snapping to an edge with a zero weight), a
heap assertion will fail in the MLD alternative search code.

We fix this by checking for empty heaps before proceeding with
the search.
## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [x] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch