### PR TITLE
Undo libosrm API break by overloading method response types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+    - API:
+      - FIXED: Undo libosrm API break by overloading method response types [#5860](https://github.com/Project-OSRM/osrm-backend/pull/5860)
 
 # 5.23.0
   - Changes from 5.22.0

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -52,15 +52,14 @@ int main(int argc, const char *argv[])
     params.coordinates.push_back({util::FloatLongitude{7.419505}, util::FloatLatitude{43.736825}});
 
     // Response is in JSON format
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     // Execute routing request, this does the heavy lifting
     const auto status = osrm.Route(params, result);
 
-    auto &json_result = result.get<json::Object>();
     if (status == Status::Ok)
     {
-        auto &routes = json_result.values["routes"].get<json::Array>();
+        auto &routes = result.values["routes"].get<json::Array>();
 
         // Let's just use the first route
         auto &route = routes.values.at(0).get<json::Object>();
@@ -80,8 +79,8 @@ int main(int argc, const char *argv[])
     }
     else if (status == Status::Error)
     {
-        const auto code = json_result.values["code"].get<json::String>().value;
-        const auto message = json_result.values["message"].get<json::String>().value;
+        const auto code = result.values["code"].get<json::String>().value;
+        const auto message = result.values["message"].get<json::String>().value;
 
         std::cout << "Code: " << code << "\n";
         std::cout << "Message: " << code << "\n";

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -32,7 +32,7 @@ class MatchPlugin : public BasePlugin
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::MatchParameters &parameters,
-                         osrm::engine::api::ResultT &json_result) const;
+                         osrm::engine::api::ResultT &result) const;
 
   private:
     const int max_locations_map_matching;

--- a/include/engine/plugins/tile.hpp
+++ b/include/engine/plugins/tile.hpp
@@ -28,7 +28,7 @@ class TilePlugin final : public BasePlugin
   public:
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TileParameters &parameters,
-                         osrm::engine::api::ResultT &pbf_buffer) const;
+                         osrm::engine::api::ResultT &result) const;
 };
 }
 }

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -40,7 +40,7 @@ class TripPlugin final : public BasePlugin
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TripParameters &parameters,
-                         osrm::engine::api::ResultT &json_result) const;
+                         osrm::engine::api::ResultT &result) const;
 };
 }
 }

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -33,7 +33,7 @@ class ViaRoutePlugin final : public BasePlugin
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::RouteParameters &route_parameters,
-                         osrm::engine::api::ResultT &json_result) const;
+                         osrm::engine::api::ResultT &result) const;
 };
 }
 }

--- a/include/osrm/osrm.hpp
+++ b/include/osrm/osrm.hpp
@@ -84,7 +84,8 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, RouteParameters and json::Object
      */
-    Status Route(const RouteParameters &parameters, osrm::engine::api::ResultT &result) const;
+    Status Route(const RouteParameters &parameters, json::Object &result) const;
+    Status Route(const RouteParameters &parameters, flatbuffers::FlatBufferBuilder &result) const;
 
     /**
      * Distance tables for coordinates.
@@ -93,7 +94,8 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, TableParameters and json::Object
      */
-    Status Table(const TableParameters &parameters, osrm::engine::api::ResultT &result) const;
+    Status Table(const TableParameters &parameters, json::Object &result) const;
+    Status Table(const TableParameters &parameters, flatbuffers::FlatBufferBuilder &result) const;
 
     /**
      * Nearest street segment for coordinate.
@@ -102,7 +104,9 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, NearestParameters and json::Object
      */
-    Status Nearest(const NearestParameters &parameters, osrm::engine::api::ResultT &result) const;
+    Status Nearest(const NearestParameters &parameters, json::Object &result) const;
+    Status Nearest(const NearestParameters &parameters,
+                   flatbuffers::FlatBufferBuilder &result) const;
 
     /**
      * Trip: shortest round trip between coordinates.
@@ -111,7 +115,8 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, TripParameters and json::Object
      */
-    Status Trip(const TripParameters &parameters, osrm::engine::api::ResultT &result) const;
+    Status Trip(const TripParameters &parameters, json::Object &result) const;
+    Status Trip(const TripParameters &parameters, flatbuffers::FlatBufferBuilder &result) const;
 
     /**
      * Match: snaps noisy coordinate traces to the road network
@@ -120,7 +125,8 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, MatchParameters and json::Object
      */
-    Status Match(const MatchParameters &parameters, osrm::engine::api::ResultT &result) const;
+    Status Match(const MatchParameters &parameters, json::Object &result) const;
+    Status Match(const MatchParameters &parameters, flatbuffers::FlatBufferBuilder &result) const;
 
     /**
      * Tile: vector tiles with internal graph representation
@@ -129,7 +135,7 @@ class OSRM final
      * \return Status indicating success for the query or failure
      * \see Status, TileParameters and json::Object
      */
-    Status Tile(const TileParameters &parameters, osrm::engine::api::ResultT &result) const;
+    Status Tile(const TileParameters &parameters, std::string &result) const;
 
   private:
     std::unique_ptr<engine::EngineInterface> engine_;

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -214,11 +214,9 @@ int main(int argc, const char *argv[]) try
     auto NUM = 100;
     for (int i = 0; i < NUM; ++i)
     {
-        engine::api::ResultT result = json::Object();
+        json::Object result;
         const auto rc = osrm.Match(params, result);
-        auto &json_result = result.get<json::Object>();
-        if (rc != Status::Ok ||
-            json_result.values.at("matchings").get<json::Array>().values.size() != 1)
+        if (rc != Status::Ok || result.values.at("matchings").get<json::Array>().values.size() != 1)
         {
             return EXIT_FAILURE;
         }

--- a/src/osrm/osrm.cpp
+++ b/src/osrm/osrm.cpp
@@ -56,40 +56,96 @@ OSRM &OSRM::operator=(OSRM &&) noexcept = default;
 
 // Forward to implementation
 
-engine::Status OSRM::Route(const engine::api::RouteParameters &params,
-                           osrm::engine::api::ResultT &result) const
+Status OSRM::Route(const engine::api::RouteParameters &params, json::Object &json_result) const
 {
-    return engine_->Route(params, result);
+    osrm::engine::api::ResultT result = json::Object();
+    auto status = engine_->Route(params, result);
+    json_result = std::move(result.get<json::Object>());
+    return status;
 }
 
-engine::Status OSRM::Table(const engine::api::TableParameters &params,
-                           osrm::engine::api::ResultT &result) const
+Status OSRM::Route(const RouteParameters &params, flatbuffers::FlatBufferBuilder &fb_result) const
 {
-    return engine_->Table(params, result);
+    osrm::engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    auto status = engine_->Route(params, result);
+    fb_result = std::move(result.get<flatbuffers::FlatBufferBuilder>());
+    return status;
 }
 
-engine::Status OSRM::Nearest(const engine::api::NearestParameters &params,
-                             osrm::engine::api::ResultT &result) const
+Status OSRM::Table(const engine::api::TableParameters &params, json::Object &json_result) const
 {
-    return engine_->Nearest(params, result);
+    osrm::engine::api::ResultT result = json::Object();
+    auto status = engine_->Table(params, result);
+    json_result = std::move(result.get<json::Object>());
+    return status;
+}
+
+Status OSRM::Table(const TableParameters &parameters,
+                   flatbuffers::FlatBufferBuilder &fb_result) const
+{
+    osrm::engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    auto status = engine_->Table(parameters, result);
+    fb_result = std::move(result.get<flatbuffers::FlatBufferBuilder>());
+    return status;
+}
+
+Status OSRM::Nearest(const engine::api::NearestParameters &params, json::Object &json_result) const
+{
+    osrm::engine::api::ResultT result = json::Object();
+    auto status = engine_->Nearest(params, result);
+    json_result = std::move(result.get<json::Object>());
+    return status;
+}
+
+Status OSRM::Nearest(const NearestParameters &parameters,
+                     flatbuffers::FlatBufferBuilder &fb_result) const
+{
+    osrm::engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    auto status = engine_->Nearest(parameters, result);
+    fb_result = std::move(result.get<flatbuffers::FlatBufferBuilder>());
+    return status;
+}
+
+Status OSRM::Trip(const engine::api::TripParameters &params, json::Object &json_result) const
+{
+    osrm::engine::api::ResultT result = json::Object();
+    auto status = engine_->Trip(params, result);
+    json_result = std::move(result.get<json::Object>());
+    return status;
 }
 
 engine::Status OSRM::Trip(const engine::api::TripParameters &params,
-                          osrm::engine::api::ResultT &result) const
+                          flatbuffers::FlatBufferBuilder &fb_result) const
 {
-    return engine_->Trip(params, result);
+    osrm::engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    auto status = engine_->Trip(params, result);
+    fb_result = std::move(result.get<flatbuffers::FlatBufferBuilder>());
+    return status;
 }
 
-engine::Status OSRM::Match(const engine::api::MatchParameters &params,
-                           osrm::engine::api::ResultT &result) const
+Status OSRM::Match(const engine::api::MatchParameters &params, json::Object &json_result) const
 {
-    return engine_->Match(params, result);
+    osrm::engine::api::ResultT result = json::Object();
+    auto status = engine_->Match(params, result);
+    json_result = std::move(result.get<json::Object>());
+    return status;
 }
 
-engine::Status OSRM::Tile(const engine::api::TileParameters &params,
-                          osrm::engine::api::ResultT &result) const
+Status OSRM::Match(const MatchParameters &parameters,
+                   flatbuffers::FlatBufferBuilder &fb_result) const
 {
-    return engine_->Tile(params, result);
+    osrm::engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    auto status = engine_->Match(parameters, result);
+    fb_result = std::move(result.get<flatbuffers::FlatBufferBuilder>());
+    return status;
+}
+
+Status OSRM::Tile(const engine::api::TileParameters &params, std::string &str_result) const
+{
+    osrm::engine::api::ResultT result = std::string();
+    auto status = engine_->Tile(params, result);
+    str_result = std::move(result.get<std::string>());
+    return status;
 }
 
 } // ns osrm

--- a/src/server/service/match_service.cpp
+++ b/src/server/service/match_service.cpp
@@ -74,9 +74,11 @@ engine::Status MatchService::RunQuery(std::size_t prefix_length,
         if (parameters->format == engine::api::BaseParameters::OutputFormatType::FLATBUFFERS)
         {
             result = flatbuffers::FlatBufferBuilder();
+            auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
+            return BaseService::routing_machine.Match(*parameters, fb_result);
         }
     }
-    return BaseService::routing_machine.Match(*parameters, result);
+    return BaseService::routing_machine.Match(*parameters, json_result);
 }
 }
 }

--- a/src/server/service/nearest_service.cpp
+++ b/src/server/service/nearest_service.cpp
@@ -68,9 +68,11 @@ engine::Status NearestService::RunQuery(std::size_t prefix_length,
         if (parameters->format == engine::api::BaseParameters::OutputFormatType::FLATBUFFERS)
         {
             result = flatbuffers::FlatBufferBuilder();
+            auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
+            return BaseService::routing_machine.Nearest(*parameters, fb_result);
         }
     }
-    return BaseService::routing_machine.Nearest(*parameters, result);
+    return BaseService::routing_machine.Nearest(*parameters, json_result);
 }
 }
 }

--- a/src/server/service/route_service.cpp
+++ b/src/server/service/route_service.cpp
@@ -72,9 +72,11 @@ engine::Status RouteService::RunQuery(std::size_t prefix_length,
         if (parameters->format == engine::api::BaseParameters::OutputFormatType::FLATBUFFERS)
         {
             result = flatbuffers::FlatBufferBuilder();
+            auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
+            return BaseService::routing_machine.Route(*parameters, fb_result);
         }
     }
-    return BaseService::routing_machine.Route(*parameters, result);
+    return BaseService::routing_machine.Route(*parameters, json_result);
 }
 }
 }

--- a/src/server/service/table_service.cpp
+++ b/src/server/service/table_service.cpp
@@ -103,9 +103,11 @@ engine::Status TableService::RunQuery(std::size_t prefix_length,
         if (parameters->format == engine::api::BaseParameters::OutputFormatType::FLATBUFFERS)
         {
             result = flatbuffers::FlatBufferBuilder();
+            auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
+            return BaseService::routing_machine.Table(*parameters, fb_result);
         }
     }
-    return BaseService::routing_machine.Table(*parameters, result);
+    return BaseService::routing_machine.Table(*parameters, json_result);
 }
 }
 }

--- a/src/server/service/tile_service.cpp
+++ b/src/server/service/tile_service.cpp
@@ -45,7 +45,8 @@ engine::Status TileService::RunQuery(std::size_t prefix_length,
     BOOST_ASSERT(parameters->IsValid());
 
     result = std::string();
-    return BaseService::routing_machine.Tile(*parameters, result);
+    auto &str_result = result.get<std::string>();
+    return BaseService::routing_machine.Tile(*parameters, str_result);
 }
 }
 }

--- a/src/server/service/trip_service.cpp
+++ b/src/server/service/trip_service.cpp
@@ -76,9 +76,11 @@ engine::Status TripService::RunQuery(std::size_t prefix_length,
         if (parameters->format == engine::api::BaseParameters::OutputFormatType::FLATBUFFERS)
         {
             result = flatbuffers::FlatBufferBuilder();
+            auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
+            return BaseService::routing_machine.Trip(*parameters, fb_result);
         }
     }
-    return BaseService::routing_machine.Trip(*parameters, result);
+    return BaseService::routing_machine.Trip(*parameters, json_result);
 }
 }
 }

--- a/unit_tests/library/limits.cpp
+++ b/unit_tests/library/limits.cpp
@@ -38,15 +38,14 @@ BOOST_AUTO_TEST_CASE(test_trip_limits)
     params.coordinates.emplace_back(getZeroCoordinate());
     params.coordinates.emplace_back(getZeroCoordinate());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Trip(params, result);
 
     BOOST_CHECK(rc == Status::Error);
 
     // Make sure we're not accidentally hitting a guard code path before
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values["code"].get<json::String>().value;
+    const auto code = result.values["code"].get<json::String>().value;
     BOOST_CHECK(code == "TooBig"); // per the New-Server API spec
 }
 
@@ -66,15 +65,14 @@ BOOST_AUTO_TEST_CASE(test_route_limits)
     params.coordinates.emplace_back(getZeroCoordinate());
     params.coordinates.emplace_back(getZeroCoordinate());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Route(params, result);
 
     BOOST_CHECK(rc == Status::Error);
 
     // Make sure we're not accidentally hitting a guard code path before
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values["code"].get<json::String>().value;
+    const auto code = result.values["code"].get<json::String>().value;
     BOOST_CHECK(code == "TooBig"); // per the New-Server API spec
 }
 
@@ -94,15 +92,14 @@ BOOST_AUTO_TEST_CASE(test_table_limits)
     params.coordinates.emplace_back(getZeroCoordinate());
     params.coordinates.emplace_back(getZeroCoordinate());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Table(params, result);
 
     BOOST_CHECK(rc == Status::Error);
 
     // Make sure we're not accidentally hitting a guard code path before
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values["code"].get<json::String>().value;
+    const auto code = result.values["code"].get<json::String>().value;
     BOOST_CHECK(code == "TooBig"); // per the New-Server API spec
 }
 
@@ -122,15 +119,14 @@ BOOST_AUTO_TEST_CASE(test_match_coordinate_limits)
     params.coordinates.emplace_back(getZeroCoordinate());
     params.coordinates.emplace_back(getZeroCoordinate());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Match(params, result);
 
     BOOST_CHECK(rc == Status::Error);
 
     // Make sure we're not accidentally hitting a guard code path before
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values["code"].get<json::String>().value;
+    const auto code = result.values["code"].get<json::String>().value;
     BOOST_CHECK(code == "TooBig"); // per the New-Server API spec
 }
 
@@ -155,15 +151,14 @@ BOOST_AUTO_TEST_CASE(test_match_radiuses_limits)
     params.radiuses.emplace_back(3.0);
     params.radiuses.emplace_back(2.0);
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Match(params, result);
 
     BOOST_CHECK(rc == Status::Error);
 
     // Make sure we're not accidentally hitting a guard code path before
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values["code"].get<json::String>().value;
+    const auto code = result.values["code"].get<json::String>().value;
     BOOST_CHECK(code == "TooBig"); // per the New-Server API spec
 }
 
@@ -182,15 +177,14 @@ BOOST_AUTO_TEST_CASE(test_nearest_limits)
     params.coordinates.emplace_back(getZeroCoordinate());
     params.number_of_results = 10000;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Nearest(params, result);
 
     BOOST_CHECK(rc == Status::Error);
 
     // Make sure we're not accidentally hitting a guard code path before
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values["code"].get<json::String>().value;
+    const auto code = result.values["code"].get<json::String>().value;
     BOOST_CHECK(code == "TooBig"); // per the New-Server API spec
 }
 

--- a/unit_tests/library/match.cpp
+++ b/unit_tests/library/match.cpp
@@ -25,19 +25,18 @@ BOOST_AUTO_TEST_CASE(test_match)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Match(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &tracepoints = json_result.values.at("tracepoints").get<json::Array>().values;
+    const auto &tracepoints = result.values.at("tracepoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(tracepoints.size(), params.coordinates.size());
 
-    const auto &matchings = json_result.values.at("matchings").get<json::Array>().values;
+    const auto &matchings = result.values.at("matchings").get<json::Array>().values;
     const auto &number_of_matchings = matchings.size();
     for (const auto &waypoint : tracepoints)
     {
@@ -76,16 +75,15 @@ BOOST_AUTO_TEST_CASE(test_match_skip_waypoints)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Match(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    BOOST_CHECK(json_result.values.find("tracepoints") == json_result.values.end());
+    BOOST_CHECK(result.values.find("tracepoints") == result.values.end());
 }
 
 BOOST_AUTO_TEST_CASE(test_match_split)
@@ -98,19 +96,18 @@ BOOST_AUTO_TEST_CASE(test_match_split)
     params.coordinates = get_split_trace_locations();
     params.timestamps = {1, 2, 1700, 1800};
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Match(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &tracepoints = json_result.values.at("tracepoints").get<json::Array>().values;
+    const auto &tracepoints = result.values.at("tracepoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(tracepoints.size(), params.coordinates.size());
 
-    const auto &matchings = json_result.values.at("matchings").get<json::Array>().values;
+    const auto &matchings = result.values.at("matchings").get<json::Array>().values;
     const auto &number_of_matchings = matchings.size();
     BOOST_CHECK_EQUAL(number_of_matchings, 2);
     std::size_t current_matchings_index = 0, expected_waypoint_index = 0;
@@ -152,13 +149,12 @@ BOOST_AUTO_TEST_CASE(test_match_fb_serialization)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
 
     const auto rc = osrm.Match(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
 
     BOOST_CHECK(!fb->error());
 
@@ -194,13 +190,12 @@ BOOST_AUTO_TEST_CASE(test_match_fb_serialization_skip_waypoints)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
 
     const auto rc = osrm.Match(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
 
     BOOST_CHECK(!fb->error());
 

--- a/unit_tests/library/nearest.cpp
+++ b/unit_tests/library/nearest.cpp
@@ -23,15 +23,14 @@ BOOST_AUTO_TEST_CASE(test_nearest_response)
     NearestParameters params;
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK(!waypoints.empty()); // the dataset has at least one nearest coordinate
 
     for (const auto &waypoint : waypoints)
@@ -52,15 +51,14 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_skip_waypoints)
     params.skip_waypoints = true;
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    BOOST_CHECK(json_result.values.find("waypoints") == json_result.values.end());
+    BOOST_CHECK(result.values.find("waypoints") == result.values.end());
 }
 
 BOOST_AUTO_TEST_CASE(test_nearest_response_no_coordinates)
@@ -71,12 +69,11 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_no_coordinates)
 
     NearestParameters params;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Error);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "InvalidOptions");
 }
 
@@ -90,12 +87,11 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_multiple_coordinates)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Error);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "InvalidOptions");
 }
 
@@ -111,15 +107,14 @@ BOOST_AUTO_TEST_CASE(test_nearest_response_for_location_in_small_component)
     params.coordinates.push_back(locations.at(0));
     params.number_of_results = 3;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK(!waypoints.empty());
 
     for (const auto &waypoint : waypoints)
@@ -147,12 +142,11 @@ BOOST_AUTO_TEST_CASE(test_nearest_fb_serialization)
     NearestParameters params;
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(!fb->error());
 
     BOOST_CHECK(fb->waypoints() != nullptr);
@@ -177,12 +171,11 @@ BOOST_AUTO_TEST_CASE(test_nearest_fb_serialization_skip_waypoints)
     params.skip_waypoints = true;
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(!fb->error());
 
     BOOST_CHECK(fb->waypoints() == nullptr);
@@ -196,12 +189,11 @@ BOOST_AUTO_TEST_CASE(test_nearest_fb_error)
 
     NearestParameters params;
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Nearest(params, result);
     BOOST_REQUIRE(rc == Status::Error);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(fb->error());
     BOOST_CHECK_EQUAL(fb->code()->code()->str(), "InvalidOptions");
 }

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -28,13 +28,12 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
     // unset snapping dependent hint
-    for (auto &itr : json_result.values["waypoints"].get<json::Array>().values)
+    for (auto &itr : result.values["waypoints"].get<json::Array>().values)
     {
         // Hint values aren't stable, so blank it out
         itr.get<json::Object>().values["hint"] = "";
@@ -113,7 +112,7 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_fixture)
 
                                    }}}}}}}}}}}}}}}}};
 
-    CHECK_EQUAL_JSON(reference, json_result);
+    CHECK_EQUAL_JSON(reference, result);
 }
 
 BOOST_AUTO_TEST_CASE(test_route_same_coordinates)
@@ -128,15 +127,14 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK(waypoints.size() == params.coordinates.size());
 
     for (const auto &waypoint : waypoints)
@@ -157,7 +155,7 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates)
         BOOST_CHECK(!hint.empty());
     }
 
-    const auto &routes = json_result.values.at("routes").get<json::Array>().values;
+    const auto &routes = result.values.at("routes").get<json::Array>().values;
     BOOST_REQUIRE_GT(routes.size(), 0);
 
     for (const auto &route : routes)
@@ -282,17 +280,16 @@ BOOST_AUTO_TEST_CASE(test_route_same_coordinates_no_waypoints)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    BOOST_CHECK(json_result.values.find("waypoints") == json_result.values.end());
+    BOOST_CHECK(result.values.find("waypoints") == result.values.end());
 
-    const auto &routes = json_result.values.at("routes").get<json::Array>().values;
+    const auto &routes = result.values.at("routes").get<json::Array>().values;
     BOOST_REQUIRE_GT(routes.size(), 0);
 
     for (const auto &route : routes)
@@ -329,15 +326,14 @@ BOOST_AUTO_TEST_CASE(test_route_response_for_locations_in_small_component)
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
     for (const auto &waypoint : waypoints)
@@ -365,15 +361,14 @@ BOOST_AUTO_TEST_CASE(test_route_response_for_locations_in_big_component)
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
     for (const auto &waypoint : waypoints)
@@ -403,15 +398,14 @@ BOOST_AUTO_TEST_CASE(test_route_response_for_locations_across_components)
     params.coordinates.push_back(small_component.at(1));
     params.coordinates.push_back(big_component.at(1));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
     for (const auto &waypoint : waypoints)
@@ -438,12 +432,11 @@ BOOST_AUTO_TEST_CASE(test_route_user_disables_generating_hints)
     params.coordinates.push_back(get_dummy_location());
     params.generate_hints = false;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    for (auto waypoint : json_result.values["waypoints"].get<json::Array>().values)
+    for (auto waypoint : result.values["waypoints"].get<json::Array>().values)
         BOOST_CHECK_EQUAL(waypoint.get<json::Object>().values.count("hint"), 0);
 }
 
@@ -460,12 +453,11 @@ BOOST_AUTO_TEST_CASE(speed_annotation_matches_duration_and_distance)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto &routes = json_result.values["routes"].get<json::Array>().values;
+    const auto &routes = result.values["routes"].get<json::Array>().values;
     const auto &legs = routes[0].get<json::Object>().values.at("legs").get<json::Array>().values;
     const auto &annotation =
         legs[0].get<json::Object>().values.at("annotation").get<json::Object>();
@@ -501,15 +493,14 @@ BOOST_AUTO_TEST_CASE(test_manual_setting_of_annotations_property)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    auto annotations = json_result.values["routes"]
+    auto annotations = result.values["routes"]
                            .get<json::Array>()
                            .values[0]
                            .get<json::Object>()
@@ -535,12 +526,11 @@ BOOST_AUTO_TEST_CASE(test_route_serialize_fb)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(!fb->error());
 
     BOOST_CHECK(fb->waypoints() != nullptr);
@@ -634,12 +624,11 @@ BOOST_AUTO_TEST_CASE(test_route_serialize_fb_skip_waypoints)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Route(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(!fb->error());
 
     BOOST_CHECK(fb->waypoints() == nullptr);

--- a/unit_tests/library/table.cpp
+++ b/unit_tests/library/table.cpp
@@ -28,18 +28,17 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_one_dest_matrix)
     params.destinations.push_back(2);
     params.annotations = TableParameters::AnnotationsType::All;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Table(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
     // check that returned durations error is expected size and proportions
     // this test expects a 1x1 matrix
-    const auto &durations_array = json_result.values.at("durations").get<json::Array>().values;
+    const auto &durations_array = result.values.at("durations").get<json::Array>().values;
     BOOST_CHECK_EQUAL(durations_array.size(), params.sources.size());
     for (unsigned int i = 0; i < durations_array.size(); i++)
     {
@@ -50,7 +49,7 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_one_dest_matrix)
 
     // check that returned distances error is expected size and proportions
     // this test expects a 1x1 matrix
-    const auto &distances_array = json_result.values.at("distances").get<json::Array>().values;
+    const auto &distances_array = result.values.at("distances").get<json::Array>().values;
     BOOST_CHECK_EQUAL(distances_array.size(), params.sources.size());
     for (unsigned int i = 0; i < distances_array.size(); i++)
     {
@@ -60,15 +59,14 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_one_dest_matrix)
     }
 
     // check destinations array of waypoint objects
-    const auto &destinations_array =
-        json_result.values.at("destinations").get<json::Array>().values;
+    const auto &destinations_array = result.values.at("destinations").get<json::Array>().values;
     BOOST_CHECK_EQUAL(destinations_array.size(), params.destinations.size());
     for (const auto &destination : destinations_array)
     {
         BOOST_CHECK(waypoint_check(destination));
     }
     // check sources array of waypoint objects
-    const auto &sources_array = json_result.values.at("sources").get<json::Array>().values;
+    const auto &sources_array = result.values.at("sources").get<json::Array>().values;
     BOOST_CHECK_EQUAL(sources_array.size(), params.sources.size());
     for (const auto &source : sources_array)
     {
@@ -91,18 +89,17 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_one_dest_matrix_no_waypo
     params.destinations.push_back(2);
     params.annotations = TableParameters::AnnotationsType::All;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Table(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
     // check that returned durations error is expected size and proportions
     // this test expects a 1x1 matrix
-    const auto &durations_array = json_result.values.at("durations").get<json::Array>().values;
+    const auto &durations_array = result.values.at("durations").get<json::Array>().values;
     BOOST_CHECK_EQUAL(durations_array.size(), params.sources.size());
     for (unsigned int i = 0; i < durations_array.size(); i++)
     {
@@ -113,7 +110,7 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_one_dest_matrix_no_waypo
 
     // check that returned distances error is expected size and proportions
     // this test expects a 1x1 matrix
-    const auto &distances_array = json_result.values.at("distances").get<json::Array>().values;
+    const auto &distances_array = result.values.at("distances").get<json::Array>().values;
     BOOST_CHECK_EQUAL(distances_array.size(), params.sources.size());
     for (unsigned int i = 0; i < distances_array.size(); i++)
     {
@@ -123,8 +120,8 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_one_dest_matrix_no_waypo
     }
 
     // waypoint arrays should be missing
-    BOOST_CHECK(json_result.values.find("destinations") == json_result.values.end());
-    BOOST_CHECK(json_result.values.find("sources") == json_result.values.end());
+    BOOST_CHECK(result.values.find("destinations") == result.values.end());
+    BOOST_CHECK(result.values.find("sources") == result.values.end());
 }
 
 BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_matrix)
@@ -138,18 +135,17 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_matrix)
     params.coordinates.push_back(get_dummy_location());
     params.coordinates.push_back(get_dummy_location());
     params.sources.push_back(0);
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Table(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
     // check that returned durations error is expected size and proportions
     // this test expects a 1x3 matrix
-    const auto &durations_array = json_result.values.at("durations").get<json::Array>().values;
+    const auto &durations_array = result.values.at("durations").get<json::Array>().values;
     BOOST_CHECK_EQUAL(durations_array.size(), params.sources.size());
     for (unsigned int i = 0; i < durations_array.size(); i++)
     {
@@ -159,15 +155,14 @@ BOOST_AUTO_TEST_CASE(test_table_three_coords_one_source_matrix)
                           params.sources.size() * params.coordinates.size());
     }
     // check destinations array of waypoint objects
-    const auto &destinations_array =
-        json_result.values.at("destinations").get<json::Array>().values;
+    const auto &destinations_array = result.values.at("destinations").get<json::Array>().values;
     BOOST_CHECK_EQUAL(destinations_array.size(), params.coordinates.size());
     for (const auto &destination : destinations_array)
     {
         BOOST_CHECK(waypoint_check(destination));
     }
     // check sources array of waypoint objects
-    const auto &sources_array = json_result.values.at("sources").get<json::Array>().values;
+    const auto &sources_array = result.values.at("sources").get<json::Array>().values;
     BOOST_CHECK_EQUAL(sources_array.size(), params.sources.size());
     for (const auto &source : sources_array)
     {
@@ -187,18 +182,17 @@ BOOST_AUTO_TEST_CASE(test_table_three_coordinates_matrix)
     params.coordinates.push_back(get_dummy_location());
     params.annotations = TableParameters::AnnotationsType::Duration;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Table(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
     // check that returned durations error is expected size and proportions
     // this test expects a 3x3 matrix
-    const auto &durations_array = json_result.values.at("durations").get<json::Array>().values;
+    const auto &durations_array = result.values.at("durations").get<json::Array>().values;
     BOOST_CHECK_EQUAL(durations_array.size(), params.coordinates.size());
     for (unsigned int i = 0; i < durations_array.size(); i++)
     {
@@ -206,13 +200,12 @@ BOOST_AUTO_TEST_CASE(test_table_three_coordinates_matrix)
         BOOST_CHECK_EQUAL(durations_matrix[i].get<json::Number>().value, 0);
         BOOST_CHECK_EQUAL(durations_matrix.size(), params.coordinates.size());
     }
-    const auto &destinations_array =
-        json_result.values.at("destinations").get<json::Array>().values;
+    const auto &destinations_array = result.values.at("destinations").get<json::Array>().values;
     for (const auto &destination : destinations_array)
     {
         BOOST_CHECK(waypoint_check(destination));
     }
-    const auto &sources_array = json_result.values.at("sources").get<json::Array>().values;
+    const auto &sources_array = result.values.at("sources").get<json::Array>().values;
     BOOST_CHECK_EQUAL(sources_array.size(), params.coordinates.size());
     for (const auto &source : sources_array)
     {
@@ -234,15 +227,14 @@ BOOST_AUTO_TEST_CASE(test_table_no_segment_for_some_coordinates)
     params.radiuses.push_back(boost::make_optional(0.));
     params.radiuses.push_back(boost::none);
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
 
     const auto rc = osrm.Table(params, result);
 
-    auto &json_result = result.get<json::Object>();
     BOOST_CHECK(rc == Status::Error);
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "NoSegment");
-    const auto message = json_result.values.at("message").get<json::String>().value;
+    const auto message = result.values.at("message").get<json::String>().value;
     BOOST_CHECK_EQUAL(message, "Could not find a matching segment for coordinate 0");
 }
 
@@ -260,14 +252,13 @@ BOOST_AUTO_TEST_CASE(test_table_serialiaze_fb)
     params.destinations.push_back(2);
     params.annotations = TableParameters::AnnotationsType::All;
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
 
     const auto rc = osrm.Table(params, result);
 
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(!fb->error());
     BOOST_CHECK(fb->table() != nullptr);
 
@@ -314,14 +305,13 @@ BOOST_AUTO_TEST_CASE(test_table_serialiaze_fb_no_waypoints)
     params.destinations.push_back(2);
     params.annotations = TableParameters::AnnotationsType::All;
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
 
     const auto rc = osrm.Table(params, result);
 
     BOOST_CHECK(rc == Status::Ok || rc == Status::Error);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
     BOOST_CHECK(!fb->error());
     BOOST_CHECK(fb->table() != nullptr);
 

--- a/unit_tests/library/tile.cpp
+++ b/unit_tests/library/tile.cpp
@@ -160,15 +160,14 @@ void validate_tile(const osrm::OSRM &osrm)
     // This tile should contain most of monaco
     TileParameters params{17059, 11948, 15};
 
-    engine::api::ResultT result = std::string();
+    std::string result;
 
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &str_result = result.get<std::string>();
-    BOOST_CHECK(str_result.size() > 114000);
+    BOOST_CHECK(result.size() > 114000);
 
-    vtzero::vector_tile tile{str_result};
+    vtzero::vector_tile tile{result};
 
     validate_feature_layer(tile.next_layer());
     validate_turn_layer(tile.next_layer());
@@ -207,14 +206,13 @@ void test_tile_turns(const osrm::OSRM &osrm)
     // Small tile where we can test all the values
     TileParameters params{272953, 191177, 19};
 
-    engine::api::ResultT result = std::string();
+    std::string result;
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &str_result = result.get<std::string>();
-    BOOST_CHECK_GT(str_result.size(), 128);
+    BOOST_CHECK_GT(result.size(), 128);
 
-    vtzero::vector_tile tile{str_result};
+    vtzero::vector_tile tile{result};
 
     tile.next_layer();
     auto layer = tile.next_layer();
@@ -349,14 +347,13 @@ void test_tile_speeds(const osrm::OSRM &osrm)
     // TileParameters params{272953, 191177, 19};
     TileParameters params{136477, 95580, 18};
 
-    engine::api::ResultT result = std::string();
+    std::string result;
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &str_result = result.get<std::string>();
-    BOOST_CHECK_GT(str_result.size(), 128);
+    BOOST_CHECK_GT(result.size(), 128);
 
-    vtzero::vector_tile tile{str_result};
+    vtzero::vector_tile tile{result};
 
     auto layer = tile.next_layer();
     BOOST_CHECK_EQUAL(to_string(layer.name()), "speeds");
@@ -430,14 +427,13 @@ void test_tile_nodes(const osrm::OSRM &osrm)
     // Small tile where we can test all the values
     TileParameters params{272953, 191177, 19};
 
-    engine::api::ResultT result = std::string();
+    std::string result;
     const auto rc = osrm.Tile(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &str_result = result.get<std::string>();
-    BOOST_CHECK_GT(str_result.size(), 128);
+    BOOST_CHECK_GT(result.size(), 128);
 
-    vtzero::vector_tile tile{str_result};
+    vtzero::vector_tile tile{result};
 
     tile.next_layer();
     tile.next_layer();

--- a/unit_tests/library/trip.cpp
+++ b/unit_tests/library/trip.cpp
@@ -26,18 +26,17 @@ BOOST_AUTO_TEST_CASE(test_roundtrip_response_for_locations_in_small_component)
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
-    const auto &trips = json_result.values.at("trips").get<json::Array>().values;
+    const auto &trips = result.values.at("trips").get<json::Array>().values;
     BOOST_CHECK_EQUAL(trips.size(), 1);
 
     for (const auto &waypoint : waypoints)
@@ -70,15 +69,14 @@ BOOST_AUTO_TEST_CASE(test_roundtrip_response_for_locations_in_small_component_sk
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    BOOST_CHECK(json_result.values.find("waypoints") == json_result.values.end());
+    BOOST_CHECK(result.values.find("waypoints") == result.values.end());
 }
 
 BOOST_AUTO_TEST_CASE(test_roundtrip_response_for_locations_in_big_component)
@@ -93,18 +91,17 @@ BOOST_AUTO_TEST_CASE(test_roundtrip_response_for_locations_in_big_component)
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
-    const auto &trips = json_result.values.at("trips").get<json::Array>().values;
+    const auto &trips = result.values.at("trips").get<json::Array>().values;
     BOOST_CHECK_EQUAL(trips.size(), 1);
 
     for (const auto &waypoint : waypoints)
@@ -138,18 +135,17 @@ BOOST_AUTO_TEST_CASE(test_roundtrip_response_for_locations_across_components)
     params.coordinates.push_back(small.at(1));
     params.coordinates.push_back(big.at(1));
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
-    const auto &trips = json_result.values.at("trips").get<json::Array>().values;
+    const auto &trips = result.values.at("trips").get<json::Array>().values;
     BOOST_CHECK_EQUAL(trips.size(), 1);
     // ^ First snapping, then SCC decomposition (see plugins/trip.cpp). Therefore only a single
     // trip.
@@ -187,18 +183,17 @@ BOOST_AUTO_TEST_CASE(test_tfse_1)
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
-    const auto &trips = json_result.values.at("trips").get<json::Array>().values;
+    const auto &trips = result.values.at("trips").get<json::Array>().values;
     BOOST_CHECK_EQUAL(trips.size(), 1);
 
     for (const auto &waypoint : waypoints)
@@ -234,18 +229,17 @@ BOOST_AUTO_TEST_CASE(test_tfse_2)
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
 
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &json_result = result.get<json::Object>();
-    const auto code = json_result.values.at("code").get<json::String>().value;
+    const auto code = result.values.at("code").get<json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 
-    const auto &waypoints = json_result.values.at("waypoints").get<json::Array>().values;
+    const auto &waypoints = result.values.at("waypoints").get<json::Array>().values;
     BOOST_CHECK_EQUAL(waypoints.size(), params.coordinates.size());
 
-    const auto &trips = json_result.values.at("trips").get<json::Array>().values;
+    const auto &trips = result.values.at("trips").get<json::Array>().values;
     BOOST_CHECK_EQUAL(trips.size(), 1);
 
     for (const auto &waypoint : waypoints)
@@ -275,22 +269,20 @@ void ResetParams(const Locations &locations, osrm::TripParameters &params)
 void CheckNotImplemented(const osrm::OSRM &osrm, osrm::TripParameters &params)
 {
     using namespace osrm;
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     auto rc = osrm.Trip(params, result);
     BOOST_REQUIRE(rc == osrm::Status::Error);
-    auto &json_result = result.get<json::Object>();
-    auto code = json_result.values.at("code").get<osrm::json::String>().value;
+    auto code = result.values.at("code").get<osrm::json::String>().value;
     BOOST_CHECK_EQUAL(code, "NotImplemented");
 }
 
 void CheckOk(const osrm::OSRM &osrm, osrm::TripParameters &params)
 {
     using namespace osrm;
-    engine::api::ResultT result = json::Object();
+    json::Object result;
     auto rc = osrm.Trip(params, result);
     BOOST_REQUIRE(rc == osrm::Status::Ok);
-    auto &json_result = result.get<json::Object>();
-    auto code = json_result.values.at("code").get<osrm::json::String>().value;
+    auto code = result.values.at("code").get<osrm::json::String>().value;
     BOOST_CHECK_EQUAL(code, "Ok");
 }
 
@@ -458,12 +450,11 @@ BOOST_AUTO_TEST_CASE(test_roundtrip_response_fb_serialization)
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
 
     BOOST_CHECK(!fb->error());
 
@@ -502,12 +493,11 @@ BOOST_AUTO_TEST_CASE(test_roundtrip_response_fb_serialization_skip_waypoints)
     params.coordinates.push_back(locations.at(1));
     params.coordinates.push_back(locations.at(2));
 
-    engine::api::ResultT result = flatbuffers::FlatBufferBuilder();
+    flatbuffers::FlatBufferBuilder result;
     const auto rc = osrm.Trip(params, result);
     BOOST_CHECK(rc == Status::Ok);
 
-    auto &fb_result = result.get<flatbuffers::FlatBufferBuilder>();
-    auto fb = engine::api::fbresult::GetFBResult(fb_result.GetBufferPointer());
+    auto fb = engine::api::fbresult::GetFBResult(result.GetBufferPointer());
 
     BOOST_CHECK(!fb->error());
 


### PR DESCRIPTION
# Issue
Removes the breaking libosrm API change by replacing the use of variant response type with method overloading.

This adds a bit of boilerplate to convert to/from the variant response used in plugin code. I avoided templating as I think this would have implications on the use of the pimpl pattern. Perhaps someone can correct me on this.

This also has the added benefit of being explicit about the supported response types for each libosrm API method.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
Closes #5741 
Closes #5548 
