### PR TITLE
Unify .osrm.turn_penalties_index dump same with turn_weight_penalties/turn_duration_penalties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
   - Changes from 5.23.0
+    - Misc:
+      - CHANGED: Unify `.osrm.turn_penalites_index` dump processing same with `.osrm.turn_weight_penalties` and `.osrm.turn_duration_penalties` [#5868](https://github.com/Project-OSRM/osrm-backend/pull/5868)
     - Infrastructure
       - CHANGED: Bundled protozero updated to v1.7.0. [#5858](https://github.com/Project-OSRM/osrm-backend/pull/5858)
 

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -399,6 +399,27 @@ inline void readTurnDurationPenalty(const boost::filesystem::path &path, TurnPen
     storage::serialization::read(reader, "/common/turn_penalty/duration", turn_penalty);
 }
 
+// writes .osrm.turn_penalties_index
+template <typename TurnIndexT>
+inline void writeTurnPenaltiesIndex(const boost::filesystem::path &path,
+                                   const TurnIndexT &turn_penalties_index)
+{
+    const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
+    storage::tar::FileWriter writer{path, fingerprint};
+
+    storage::serialization::write(writer, "/extractor/turn_index", turn_penalties_index);
+}
+
+// read .osrm.turn_penalties_index
+template <typename TurnIndexT>
+inline void readTurnPenaltiesIndex(const boost::filesystem::path &path, TurnIndexT &turn_penalties_index)
+{
+    const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
+    storage::tar::FileReader reader{path, fingerprint};
+
+    storage::serialization::read(reader, "/extractor/turn_index", turn_penalties_index);
+}
+
 // writes .osrm.restrictions
 template <typename ConditionalRestrictionsT>
 inline void writeConditionalRestrictions(const boost::filesystem::path &path,

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -402,7 +402,7 @@ inline void readTurnDurationPenalty(const boost::filesystem::path &path, TurnPen
 // writes .osrm.turn_penalties_index
 template <typename TurnIndexT>
 inline void writeTurnPenaltiesIndex(const boost::filesystem::path &path,
-                                   const TurnIndexT &turn_penalties_index)
+                                    const TurnIndexT &turn_penalties_index)
 {
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
@@ -412,7 +412,8 @@ inline void writeTurnPenaltiesIndex(const boost::filesystem::path &path,
 
 // read .osrm.turn_penalties_index
 template <typename TurnIndexT>
-inline void readTurnPenaltiesIndex(const boost::filesystem::path &path, TurnIndexT &turn_penalties_index)
+inline void readTurnPenaltiesIndex(const boost::filesystem::path &path,
+                                   TurnIndexT &turn_penalties_index)
 {
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -1130,7 +1130,8 @@ void EdgeBasedGraphFactory::GenerateEdgeExpandedEdges(
                                                    indexed_conditionals);
 
     // write weight penalties per turn
-    BOOST_ASSERT(turn_weight_penalties.size() == turn_duration_penalties.size() && turn_weight_penalties.size() == turn_penalties_index.size());
+    BOOST_ASSERT(turn_weight_penalties.size() == turn_duration_penalties.size() &&
+                 turn_weight_penalties.size() == turn_penalties_index.size());
     files::writeTurnWeightPenalty(turn_weight_penalties_filename, turn_weight_penalties);
     files::writeTurnDurationPenalty(turn_duration_penalties_filename, turn_duration_penalties);
     files::writeTurnPenaltiesIndex(turn_penalties_index_filename, turn_penalties_index);

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -432,6 +432,9 @@ updateTurnPenalties(const UpdaterConfig &config,
 {
     const auto weight_multiplier = profile_properties.GetWeightMultiplier();
 
+    // [NOTE] turn_index_blocks could be simply loaded by `files::readTurnPenaltiesIndex()`, 
+    //      however, we leave the below mmap to keep compatiblity. 
+    //      Use `files::readTurnPenaltiesIndex()` instead once the compatiblity is not that important.         
     // Mapped file pointer for turn indices
     boost::iostreams::mapped_file_source turn_index_region;
     const extractor::lookup::TurnIndexBlock *turn_index_blocks;

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -432,9 +432,10 @@ updateTurnPenalties(const UpdaterConfig &config,
 {
     const auto weight_multiplier = profile_properties.GetWeightMultiplier();
 
-    // [NOTE] turn_index_blocks could be simply loaded by `files::readTurnPenaltiesIndex()`, 
-    //      however, we leave the below mmap to keep compatiblity. 
-    //      Use `files::readTurnPenaltiesIndex()` instead once the compatiblity is not that important.         
+    // [NOTE] turn_index_blocks could be simply loaded by `files::readTurnPenaltiesIndex()`,
+    //      however, we leave the below mmap to keep compatiblity.
+    //      Use `files::readTurnPenaltiesIndex()` instead once the compatiblity is not that
+    //      important.
     // Mapped file pointer for turn indices
     boost::iostreams::mapped_file_source turn_index_region;
     const extractor::lookup::TurnIndexBlock *turn_index_blocks;


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.
Closes https://github.com/Project-OSRM/osrm-backend/issues/5862

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [x] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
