### PR TITLE
Fix bit-shift overflow in MLD partition step for Windows builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
   - Changes from 5.23.0
     - Infrastructure
       - CHANGED: Bundled protozero updated to v1.7.0. [#5858](https://github.com/Project-OSRM/osrm-backend/pull/5858)
+    - Windows:
+      - FIXED: Fix bit-shift overflow in MLD partition step. [#5878](https://github.com/Project-OSRM/osrm-backend/pull/5878)
+
 
 # 5.23.0
   - Changes from 5.22.0

--- a/include/partitioner/multi_level_partition.hpp
+++ b/include/partitioner/multi_level_partition.hpp
@@ -212,10 +212,10 @@ template <storage::Ownership Ownership> class MultiLevelPartitionImpl final
                                 // create mask that has `bits` ones at its LSBs.
                                 // 000011
                                 BOOST_ASSERT(offset < NUM_PARTITION_BITS);
-                                PartitionID mask = (1UL << offset) - 1UL;
+                                PartitionID mask = (1ULL << offset) - 1ULL;
                                 // 001111
                                 BOOST_ASSERT(next_offset < NUM_PARTITION_BITS);
-                                PartitionID next_mask = (1UL << next_offset) - 1UL;
+                                PartitionID next_mask = (1ULL << next_offset) - 1ULL;
                                 // 001100
                                 masks[lidx++] = next_mask ^ mask;
                             });


### PR DESCRIPTION
# Issue
For very large graphs, generation of MLD level masks fail on Windows due to bit shift overflow of unsigned long values. Correct by using unsigned long long literals, which are 64 bit on all major systems.

Difficult to add a test case given the size of graph required. The existing asserts should detect any future overflow issues.

Fixes #5872 
Fixes #5227 

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
