### PR TITLE
Avoid dereferencing iterators over empty indexed data values

### DIFF
--- a/include/util/indexed_data.hpp
+++ b/include/util/indexed_data.hpp
@@ -331,6 +331,9 @@ template <typename GroupBlockPolicy, storage::Ownership Ownership> struct Indexe
     // Return value at the given index
     ResultType at(std::uint32_t index) const
     {
+        if (values.empty())
+            return ResultType();
+
         // Get block external ad internal indices
         const BlocksNumberType block_idx = index / (BLOCK_SIZE + 1);
         const std::uint32_t internal_idx = index % (BLOCK_SIZE + 1);


### PR DESCRIPTION
# Issue

It seems the values can be empty even if size of blocks is non-zero (e.g. `blocks.size()==1`).

## Question

Perhaps, a validation of `values_` (i.e. set `blocks` to empty if `values_` is empty) should be added to this constructor

https://github.com/Project-OSRM/osrm-backend/blob/96acdaf0d59185d9ae1233748d3fa27f5ab89a01/include/util/indexed_data.hpp#L276-L279

to align it with the setting of the number of blocks and elements in the other constructor:

https://github.com/Project-OSRM/osrm-backend/blob/96acdaf0d59185d9ae1233748d3fa27f5ab89a01/include/util/indexed_data.hpp#L294-L296

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
