### PR TITLE
Update car.lua - new maxspeed default speed for Brussels, Belgium

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -270,6 +270,8 @@ function setup()
       ["at:rural"] = 100,
       ["at:trunk"] = 100,
       ["be:motorway"] = 120,
+      ["be-bru:rural"] = 70,
+      ["be-bru:urban"] = 30,
       ["be-vlg:rural"] = 70,
       ["by:urban"] = 60,
       ["by:motorway"] = 110,


### PR DESCRIPTION
Those new speeds apply by law as from Jan. 1, 2021 within the entire Brussels-Capital Region, one of the 3 regions of Belgium.

## Requirements / Relations
This table is used by Osmose for validation tests, see discussion here: https://github.com/osm-fr/osmose-backend/issues/1037
