### PR TITLE
Profile debug script which fetches a way from OSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
   - Changes from 5.23.0
     - Misc:
       - CHANGED: Unify `.osrm.turn_penalites_index` dump processing same with `.osrm.turn_weight_penalties` and `.osrm.turn_duration_penalties` [#5868](https://github.com/Project-OSRM/osrm-backend/pull/5868)
+    - Profile:
+      - ADDED: Profile debug script which fetches a way from OSM then outputs the result of the profile. [#5908](https://github.com/Project-OSRM/osrm-backend/pull/5908)
     - Infrastructure
       - CHANGED: Bundled protozero updated to v1.7.0. [#5858](https://github.com/Project-OSRM/osrm-backend/pull/5858)
     - Windows:

--- a/profiles/debug_way.lua
+++ b/profiles/debug_way.lua
@@ -1,0 +1,44 @@
+--
+-- Fetch a way from the OpenStreetMap API and run the given profile over it.
+--
+-- You'll need to install luasec and xml2lua first:
+--    > luarocks-5.1 install xml2lua
+--    > luarocks-5.1 install luasec
+-- [may require admin privileges]
+-- 
+-- Then to test way 2606296 using the foot profile:
+--    > lua5.1 debug_way.lua foot 2606296
+--
+
+-- initialise libraries
+local pprint = require('lib/pprint')
+local Debug = require('lib/profile_debugger')
+local xml2lua = require('xml2lua')
+local handler = require('xmlhandler.tree')
+local https = require('ssl.https')
+
+-- load the profile
+Debug.load_profile(arg[1])
+
+-- load way from the OSM API
+local url = 'https://www.openstreetmap.org/api/0.6/way/'..arg[2]
+local body, statusCode, headers, statusText = https.request(url)
+
+-- parse way tags
+local parser = xml2lua.parser(handler)
+parser:parse(body)
+
+-- convert XML-flavoured table to a simple k/v table
+local way = {}
+for i, p in pairs(handler.root.osm.way.tag) do
+  way[p._attr.k] = p._attr.v
+end
+
+-- call the way function
+local result = {}
+Debug.process_way(way,result)
+
+-- print input and output
+pprint(way)
+print("=>")
+pprint(result)

--- a/profiles/debug_way.lua
+++ b/profiles/debug_way.lua
@@ -1,13 +1,13 @@
 --
 -- Fetch a way from the OpenStreetMap API and run the given profile over it.
 --
--- You'll need to install luasec and xml2lua first:
---    > luarocks-5.1 install xml2lua
---    > luarocks-5.1 install luasec
--- [may require admin privileges]
--- 
+-- You'll need to install xml2lua first (may require admin privileges):
+--    > luarocks install xml2lua
+--
+-- You may also need to install luasec and luasocket if you don't have them already.
+--
 -- Then to test way 2606296 using the foot profile:
---    > lua5.1 debug_way.lua foot 2606296
+--    > lua debug_way.lua foot 2606296
 --
 
 -- initialise libraries

--- a/profiles/lib/profile_debugger.lua
+++ b/profiles/lib/profile_debugger.lua
@@ -52,7 +52,7 @@ end
 function canonicalizeStringList(str)
   return str
 end
- 
+
  
  
 -- debug helper
@@ -123,10 +123,13 @@ function Debug.process_way(way,result)
   result.forward_classes = {}
   result.backward_classes = {}
   
-  -- intercept tag function normally provided via C++
+  -- intercept tag functions normally provided via C++
   function way:get_value_by_key(k)
     Debug.register_tag_fetch(k)
     return self[k]
+  end
+  function way:get_location_tag(k)
+    return nil
   end
   
   -- reset tag counts


### PR DESCRIPTION
# Issue

When debugging profile issues (e.g. #5892), it's useful to be able to see instantly what the profile is calculating for a given way, without having to reprocess a whole OSM extract.

This short script fetches a way from the OSM API and runs the requested Lua profile over it, then prints the result:

````
$ lua5.1 debug_way.lua car 14672606
{ 
  highway = 'residential',
  maxspeed = '45 mph',
  name = 'E0770 Road',
  ['source:maxspeed'] = '45 in Blaine County unless otherwise posted.',
  ['tiger:cfcc'] = 'A41',
  ['tiger:county'] = 'Blaine, OK',
  ['tiger:name_base'] = 'E0770',
  ['tiger:name_type'] = 'Rd',
  ['tiger:reviewed'] = 'no' 
}
=>
{ 
  backward_classes = {},
  backward_mode = 1,
  backward_rate = 16.09,
  backward_speed = 57.924,
  duration = 0,
  forward_classes = {},
  forward_mode = 1,
  forward_rate = 16.09,
  forward_speed = 57.924,
  is_left_hand_driving = false,
  is_startpoint = true,
  name = 'E0770 Road',
  road_classification = { 
    may_be_ignored = false,
    road_priority_class = 10 
  } 
}
````

It uses the existing debug handler (tweaked to not error on the missing `get_location_tag` C++ method) and builds upon the example `profile_debugger.lua` script.

I use a similar script to this for cycle.travel and have found it enormously helpful in debugging profile issues.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Required Lua libraries are listed in the comments at the top of the script.