### PR TITLE
Use weight instead of duration for trip api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - Windows:
       - FIXED: Fix bit-shift overflow in MLD partition step. [#5878](https://github.com/Project-OSRM/osrm-backend/pull/5878)
       - FIXED: Fix vector bool permutation in graph contraction step [#5882](https://github.com/Project-OSRM/osrm-backend/pull/5882)
+      - FIXED: Fix trip api to use weight instead of duration internally [#5930](https://github.com/Project-OSRM/osrm-backend/pull/5930)
 
 
 # 5.23.0

--- a/include/engine/routing_algorithms.hpp
+++ b/include/engine/routing_algorithms.hpp
@@ -30,11 +30,12 @@ class RoutingAlgorithmsInterface
     virtual InternalRouteResult
     DirectShortestPathSearch(const PhantomNodes &phantom_node_pair) const = 0;
 
-    virtual std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
-    ManyToManySearch(const std::vector<PhantomNode> &phantom_nodes,
-                     const std::vector<std::size_t> &source_indices,
-                     const std::vector<std::size_t> &target_indices,
-                     const bool calculate_distance) const = 0;
+    virtual std::
+        tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+        ManyToManySearch(const std::vector<PhantomNode> &phantom_nodes,
+                         const std::vector<std::size_t> &source_indices,
+                         const std::vector<std::size_t> &target_indices,
+                         const bool calculate_distance) const = 0;
 
     virtual routing_algorithms::SubMatchingList
     MapMatching(const routing_algorithms::CandidateLists &candidates_list,
@@ -83,11 +84,12 @@ template <typename Algorithm> class RoutingAlgorithms final : public RoutingAlgo
     InternalRouteResult
     DirectShortestPathSearch(const PhantomNodes &phantom_nodes) const final override;
 
-    virtual std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
-    ManyToManySearch(const std::vector<PhantomNode> &phantom_nodes,
-                     const std::vector<std::size_t> &source_indices,
-                     const std::vector<std::size_t> &target_indices,
-                     const bool calculate_distance) const final override;
+    virtual std::
+        tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+        ManyToManySearch(const std::vector<PhantomNode> &phantom_nodes,
+                         const std::vector<std::size_t> &source_indices,
+                         const std::vector<std::size_t> &target_indices,
+                         const bool calculate_distance) const final override;
 
     routing_algorithms::SubMatchingList
     MapMatching(const routing_algorithms::CandidateLists &candidates_list,
@@ -192,7 +194,7 @@ inline routing_algorithms::SubMatchingList RoutingAlgorithms<Algorithm>::MapMatc
 }
 
 template <typename Algorithm>
-std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+std::tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
 RoutingAlgorithms<Algorithm>::ManyToManySearch(const std::vector<PhantomNode> &phantom_nodes,
                                                const std::vector<std::size_t> &_source_indices,
                                                const std::vector<std::size_t> &_target_indices,

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -91,7 +91,7 @@ struct NodeBucket
 } // namespace
 
 template <typename Algorithm>
-std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+std::tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
 manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                  const DataFacade<Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -217,7 +217,8 @@ Status TripPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
 
     // compute the duration table of all phantom nodes
     auto result_duration_table = util::DistTableWrapper<EdgeWeight>(
-        algorithms.ManyToManySearch(snapped_phantoms, {}, {}, /*requestDistance*/ false).first,
+        std::get<0>(
+            algorithms.ManyToManySearch(snapped_phantoms, {}, {}, /*requestDistance*/ false)),
         number_of_locations);
 
     if (result_duration_table.size() == 0)

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -178,7 +178,7 @@ void backwardRoutingStep(const DataFacade<Algorithm> &facade,
 } // namespace ch
 
 template <>
-std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+std::tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
 manyToManySearch(SearchEngineData<ch::Algorithm> &engine_working_data,
                  const DataFacade<ch::Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,
@@ -248,7 +248,8 @@ manyToManySearch(SearchEngineData<ch::Algorithm> &engine_working_data,
         }
     }
 
-    return std::make_pair(std::move(durations_table), std::move(distances_table));
+    return std::make_tuple(
+        std::move(weights_table), std::move(durations_table), std::move(distances_table));
 }
 
 } // namespace routing_algorithms

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -211,7 +211,7 @@ void relaxOutgoingEdges(
 // Unidirectional multi-layer Dijkstra search for 1-to-N and N-to-1 matrices
 //
 template <bool DIRECTION>
-std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+std::tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
 oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                 const DataFacade<Algorithm> &facade,
                 const std::vector<PhantomNode> &phantom_nodes,
@@ -392,7 +392,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
             facade, heapNode, query_heap, phantom_nodes, phantom_index, phantom_indices);
     }
 
-    return std::make_pair(std::move(durations_table), std::move(distances_table));
+    return std::make_tuple(
+        std::move(weights_table), std::move(durations_table), std::move(distances_table));
 }
 
 //
@@ -521,7 +522,7 @@ void retrievePackedPathFromSearchSpace(NodeID middle_node_id,
 }
 
 template <bool DIRECTION>
-std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+std::tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
 manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                  const DataFacade<Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,
@@ -601,7 +602,8 @@ manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
         }
     }
 
-    return std::make_pair(std::move(durations_table), std::move(distances_table));
+    return std::make_tuple(
+        std::move(weights_table), std::move(durations_table), std::move(distances_table));
 }
 
 } // namespace mld
@@ -619,7 +621,7 @@ manyToManySearch(SearchEngineData<Algorithm> &engine_working_data,
 //   then search is performed on a reversed graph with phantom nodes with flipped roles and
 //   returning a transposed matrix.
 template <>
-std::pair<std::vector<EdgeDuration>, std::vector<EdgeDistance>>
+std::tuple<std::vector<EdgeWeight>, std::vector<EdgeDuration>, std::vector<EdgeDistance>>
 manyToManySearch(SearchEngineData<mld::Algorithm> &engine_working_data,
                  const DataFacade<mld::Algorithm> &facade,
                  const std::vector<PhantomNode> &phantom_nodes,


### PR DESCRIPTION
# Issue

<img width="600" alt="img" src="https://user-images.githubusercontent.com/30719198/104398026-56370f80-5591-11eb-9913-67e8fb238c08.jpg">

In the above case, Trip API returns a clockwise route for a roundabout trip instead of a counter-clockwise route.
As rate(weight) should take priority over speed(duration), this looks like a bug.
Fixed this by changing `ManyToManySearch` to return a weight matrix along with duration/distance matrices and using the matrix in `TablePlugin::HandleRequest`.

Below is data I used to test my code.
```bash
$ cat rectangle.osm
<?xml version="1.0" encoding="UTF-8"?>
<osm version="0.6" generator="none">
  <bounds minlon="127.11664666" minlat="37.38013706" maxlon="127.12157070" maxlat="37.38390685" />
  <node id="1" lon="127.11967395" lat="37.38390685" />
  <node id="2" lon="127.12157070" lat="37.38217534" />
  <node id="3" lon="127.11851713" lat="37.38013706" />
  <node id="4" lon="127.11664666" lat="37.38172113" />
  <way id="101">
    <nd ref="1" />
    <nd ref="2" />
  </way>
  <way id="102">
    <nd ref="2" />
    <nd ref="3" />
  </way>
  <way id="103">
    <nd ref="3" />
    <nd ref="4" />
  </way>
  <way id="104">
    <nd ref="4" />
    <nd ref="1" />
  </way>
</osm>

$ cat trip.lua
api_version = 4

function setup()
    return {
        properties = {
            weight_name = 'test',
        }
    }
end

function process_way(profile, way, result, data)
    result.forward_mode = mode.driving
    result.forward_speed = 10
    result.forward_rate = 5

    result.backward_mode = mode.driving
    result.backward_speed = 5
    result.backward_rate = 10
end

return {
    setup = setup,
    process_way = process_way,
}

$ curl 'http://localhost:5000/trip/v1/driving/127.11967395,37.38390685;127.12157070,37.38217534;127.11851713,37.38013706;127.11664666,37.38172113?roundtrip=true&source=first'
```

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
