### PR TITLE
Add support for lua5.4 in FindLua.cmake

### DIFF
--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -44,7 +44,7 @@ unset(_lua_append_versions)
 
 # this is a function only to have all the variables inside go away automatically
 function(_lua_set_version_vars)
-    set(LUA_VERSIONS5 5.3 5.2 5.1 5.0)
+    set(LUA_VERSIONS5 5.4 5.3 5.2 5.1 5.0)
 
     if (Lua_FIND_VERSION_EXACT)
         if (Lua_FIND_VERSION_COUNT GREATER 1)


### PR DESCRIPTION
# Issue

https://github.com/Project-OSRM/osrm-backend/issues/5980

This PR resolves the problem that cmake fails to find lua5.4.

```
$ cmake ..
(...)
-- Using Lua 5.4.2
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Using ccache to speed up incremental builds
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/user/maps/osrm-ijleesw/cmake-build-debug
```

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
