### PR TITLE
Process maxspeed tag before surface, smoothness, and tracktype tags

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -431,8 +431,8 @@ function process_way(profile, way, result, relations)
     WayHandlers.hov,
 
     -- compute speed taking into account way type, maxspeed tags, etc.
-    WayHandlers.maxspeed,
     WayHandlers.speed,
+    WayHandlers.maxspeed,
     WayHandlers.surface,
     WayHandlers.penalties,
 

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -431,9 +431,9 @@ function process_way(profile, way, result, relations)
     WayHandlers.hov,
 
     -- compute speed taking into account way type, maxspeed tags, etc.
+    WayHandlers.maxspeed,
     WayHandlers.speed,
     WayHandlers.surface,
-    WayHandlers.maxspeed,
     WayHandlers.penalties,
 
     -- compute class labels


### PR DESCRIPTION
Let's say we have a tertiary road with the following tags:

- `maxspeed=60`
- `surface=gravel`
- `smoothness=horrible`

The `maxspeed` tag tells us the legal speed limit, but the `surface` and `smoothness` tags have much more effect on the real-world speed of a car. In the default car profile, the [gravel surface sets a driving speed of 40kph](https://github.com/Project-OSRM/osrm-backend/blob/41dda32546399f1dc12af1de41668993de44c7dc/profiles/car.lua#L223), and the [horrible smoothness sets a driving speed of 10kph](https://github.com/Project-OSRM/osrm-backend/blob/41dda32546399f1dc12af1de41668993de44c7dc/profiles/car.lua#L255). It seems to me that the tags should be processed in this order:

1. `maxspeed`
2. `surface`
3. `smoothness`

That is, `maxspeed` can be overridden by the `surface` tag, which can in turn be overridden by the `smoothness` tag. In the case of our secondary road, it would start with a driving speed of 60kph (from `maxspeed`), which would be reduced to 40kph (from `surface`), and end at 10kph (from `smoothness`).

However, before this change, the `maxspeed` tag is processed *after* `surface` and `smoothness`: our road starts with a driving speed of 40kph (from `surface`), it's reduced to 10kph (from `smoothness`), and then *increased* to 60kph (from `maxspeed`).

This change alters the processing order so that `maxspeed` is processed first, giving it the lowest priority of these three tags.