### PR TITLE
Remove redundant loading of .osrm.cell_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - Misc:
       - FIXED: Upgrade to @mapbox/node-pre-gyp fix various bugs with Node 12/14 [#5991](https://github.com/Project-OSRM/osrm-backend/pull/5991)
       - FIXED: `valid` type in documentation examples [#5990](https://github.com/Project-OSRM/osrm-backend/issues/5990)
+      - FIXED: Remove redundant loading of .osrm.cell_metrics [#6019](https://github.com/Project-OSRM/osrm-backend/issues/6019)
     - Profile:
       - FIXED: Add kerb barrier exception to default car profile. [#5999](https://github.com/Project-OSRM/osrm-backend/pull/5999)
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -489,15 +489,6 @@ void Storage::PopulateStaticData(const SharedDataIndex &index)
         partitioner::files::readCells(config.GetPath(".osrm.cells"), storage);
     }
 
-    if (boost::filesystem::exists(config.GetPath(".osrm.cell_metrics")))
-    {
-        auto exclude_metrics = make_cell_metric_view(index, "/mld/metrics/" + metric_name);
-        std::unordered_map<std::string, std::vector<customizer::CellMetricView>> metrics = {
-            {metric_name, std::move(exclude_metrics)},
-        };
-        customizer::files::readCellMetrics(config.GetPath(".osrm.cell_metrics"), metrics);
-    }
-
     // load maneuver overrides
     {
         auto views = make_maneuver_overrides_views(index, "/common/maneuver_overrides");


### PR DESCRIPTION
# Issue
When using process memory, MLD cell metrics are loaded twice from `.osrm.cell_metrics` - once when loading static data, and again when loading updatable data. The former appears to be the mistake, as `.osrm.cell_metrics` is only listed in `GetUpdatableFiles`.

## Impact
For `germany-latest.osm.pbf`, saves between 100-200ms when loading `osrm-routed`

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
