### PR TITLE
Increase PackedOSMIDs size to 34 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - FIXED: Upgrade to @mapbox/node-pre-gyp fix various bugs with Node 12/14 [#5991](https://github.com/Project-OSRM/osrm-backend/pull/5991)
       - FIXED: `valid` type in documentation examples [#5990](https://github.com/Project-OSRM/osrm-backend/issues/5990)
       - FIXED: Remove redundant loading of .osrm.cell_metrics [#6019](https://github.com/Project-OSRM/osrm-backend/issues/6019)
+      - CHANGED: Increase PackedOSMIDs size to 34 bits. This breaks the **data format** [#6020](https://github.com/Project-OSRM/osrm-backend/issues/6020)
     - Profile:
       - FIXED: Add kerb barrier exception to default car profile. [#5999](https://github.com/Project-OSRM/osrm-backend/pull/5999)
 

--- a/include/extractor/packed_osm_ids.hpp
+++ b/include/extractor/packed_osm_ids.hpp
@@ -11,7 +11,7 @@ namespace extractor
 namespace detail
 {
 template <storage::Ownership Ownership>
-using PackedOSMIDs = util::detail::PackedVector<OSMNodeID, 33, Ownership>;
+using PackedOSMIDs = util::detail::PackedVector<OSMNodeID, 34, Ownership>;
 }
 
 using PackedOSMIDsView = detail::PackedOSMIDs<storage::Ownership::View>;


### PR DESCRIPTION
# Issue
OSM node [2^33](https://www.openstreetmap.org/node/8589934592) was created in early April 2021. This and all subsequently created IDs will be overflowing OSRM node storage which only supports 33 bit IDs.
Bump the number of bits to 34 to double node ID capacity. This is a breaking change to the data format as it alters the layout of `.osrm.nbg_nodes`.

# Impact
Increases size of file `.osrm.nbg_nodes` and its in-memory representation by ~1%
E.g. `germany-latest.osrm.nbg_nodes` increases from 379,732,480 to 383,647,232 bytes.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
Fixes #6016 
