### PR TITLE
Use Github Releases for hosting node binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,7 +171,7 @@ matrix:
       # we use the xcode provides clang and don't install our own
       env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="10"
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: osx
       osx_image: xcode9.2
@@ -179,7 +179,7 @@ matrix:
       # we use the xcode provides clang and don't install our own
       env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="12"
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: osx
       osx_image: xcode9.2
@@ -187,7 +187,7 @@ matrix:
       # we use the xcode provides clang and don't install our own
       env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="14"
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     # Shared Library
     - os: linux
@@ -221,7 +221,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -245,7 +245,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -269,7 +269,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -293,7 +293,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -317,7 +317,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -341,7 +341,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: osx
       stage: optional
@@ -350,7 +350,7 @@ matrix:
       # we use the xcode provides clang and don't install our own
       env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="node"
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -374,7 +374,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -398,7 +398,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: osx
       osx_image: xcode9.2
@@ -406,7 +406,7 @@ matrix:
       # we use the xcode provides clang and don't install our own
       env: ENABLE_MASON=ON BUILD_TYPE='Release' CUCUMBER_TIMEOUT=60000 CCOMPILER='clang' CXXCOMPILER='clang++' ENABLE_ASSERTIONS=ON ENABLE_LTO=ON NODE="--lts"
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -430,7 +430,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
     - os: linux
       sudo: false
@@ -454,7 +454,7 @@ matrix:
       script:
         - npm run nodejs-tests
       after_success:
-        - ./scripts/travis/publish.sh
+        - ./scripts/travis/node_package.sh
 
   allow_failures:
     - compiler: "mason-osx-release-node-latest"
@@ -572,3 +572,14 @@ script:
   - |
   - popd
   - npm test
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "bSMTxzqgbAcOEszxOvv5FIBmv+BW70IobEHvxe0ShM+ekhLKwKTb5KQRj55ZjpmSEOwqvDr3S1vuqcgXegQvOcLy3HNhxg3aWisexKsbF2oGZdKyjMnyC6jURkXGQUoUoZyCbaOxV1ThJgpcWLjt5qVSR165Az7LxvCrdBer66E="
+  skip_cleanup: true
+  file_glob: true
+  file: build/stage/**/*.tar.gz
+  on:
+    tags: true
+    condition: "$PUBLISH = 'On'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -576,7 +576,7 @@ script:
 deploy:
   provider: releases
   api_key:
-    secure: "bSMTxzqgbAcOEszxOvv5FIBmv+BW70IobEHvxe0ShM+ekhLKwKTb5KQRj55ZjpmSEOwqvDr3S1vuqcgXegQvOcLy3HNhxg3aWisexKsbF2oGZdKyjMnyC6jURkXGQUoUoZyCbaOxV1ThJgpcWLjt5qVSR165Az7LxvCrdBer66E="
+    secure: "Ej7tPd+XhAlBvA0SnYghYakO6QUwUI+oOtjlkPmy0UfKtIQ4bIzoIm1BDbPwrmNiCSKB7lLZYZpKz68PBRtblfqvTjhzXSzlvFk36pyywgkuNY13N3VQZo2c5CShLCy41nx4+uLkjhLfKYOALSE3OivdJJHLZEsSwx60Csx7owU="
   skip_cleanup: true
   file_glob: true
   file: build/stage/**/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
   - Changes from 5.24.0
+    - Build:
+      - CHANGED: Node binaries now use Github Releases for hosting [#6030](https://github.com/Project-OSRM/osrm-backend/pull/6030)
     - Misc:
       - FIXED: Upgrade to @mapbox/node-pre-gyp fix various bugs with Node 12/14 [#5991](https://github.com/Project-OSRM/osrm-backend/pull/5991)
       - FIXED: `valid` type in documentation examples [#5990](https://github.com/Project-OSRM/osrm-backend/issues/5990)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -50,7 +50,8 @@ We may introduce forward-compatible changes: query parameters and response prope
 7. Push tags and commits: `git push; git push --tags`
 8. On https://github.com/Project-OSRM/osrm-backend/releases press `Draft a new release`,
    write the release tag `vx.y.z` in the `Tag version` field, write the changelog entries in the `Describe this release` field
-   and press `Publish release`.
+   and press `Publish release`. Note that Travis deployments will create a release when publishing node binaries, so the release
+   may already exist. In which case the description should be updated with the changelog entries.
 9. If not a release-candidate: Write a mailing-list post to osrm-talk@openstreetmap.org to announce the release
 10. Wait until the travis build has been completed and check if the node binaries were published by doing:
     `rm -rf node_modules && npm install` locally.

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "binary": {
     "module_name": "node_osrm",
     "module_path": "./lib/binding/",
-    "host": "https://mapbox-node-binary.s3.amazonaws.com",
-    "remote_path": "./{name}/v{version}/{configuration}/",
-    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+    "host": "https://github.com",
+    "remote_path": "./Project-OSRM/osrm-backend/releases/download/v{version}/",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}-{configuration}.tar.gz"
   }
 }

--- a/scripts/travis/node_package.sh
+++ b/scripts/travis/node_package.sh
@@ -31,7 +31,7 @@ if [[ ${PUBLISH} == 'On' ]]; then
         fi
     fi
 
-    ./node_modules/.bin/node-pre-gyp package publish info $NPM_FLAGS
+    ./node_modules/.bin/node-pre-gyp package testpackage $NPM_FLAGS
 else
     echo "PUBLISH is set to '${PUBLISH}', skipping."
 fi


### PR DESCRIPTION
# Issue
Replaces S3 hosting of node binaries with Github Releases.
`node-pre-gyp publish` works exclusively with S3, so upload step is now performed by the Travis deployment provider.
    
The behaviour for the package user should not change.
When building a new version tag, Travis will create a release for the tag if it does not already exist.

The secure token is my own personal token that has the `public_repo` Github OAuth permission. 
This is not ideal - Travis recommends to create a [machine user](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users) for deployments. Someone with owner or admin permissions for Project-OSRM would need to do this.

## Testing
I tested this on my own fork (see the [test release](https://github.com/mjjbell/osrm-backend/releases/tag/v9.9.19) from [this branch](https://github.com/mjjbell/osrm-backend/tree/travis) as an example).

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
Fixes #6013 
