### PR TITLE
Lazily generate optional route path data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
       - FIXED: Fixed Node docs generation check in CI. [#6058](https://github.com/Project-OSRM/osrm-backend/pull/6058)
       - CHANGED: Docker build, enabled arm64 build layer [#6172](https://github.com/Project-OSRM/osrm-backend/pull/6172)
       - CHANGED: Docker build, enabled apt-get update/install caching in separate layer for build phase [#6175](https://github.com/Project-OSRM/osrm-backend/pull/6175)
+    - Routing:
+      - CHANGED: Lazily generate optional route path data [#6045](https://github.com/Project-OSRM/osrm-backend/pull/6045)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -57,8 +57,7 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     const auto source_geometry_id = facade.GetGeometryIndex(source_node_id).id;
     const auto source_geometry = facade.GetUncompressedForwardGeometry(source_geometry_id);
 
-    geometry.osm_node_ids.push_back(
-        facade.GetOSMNodeIDOfNode(source_geometry(source_segment_start_coordinate)));
+    geometry.node_ids.push_back(source_geometry(source_segment_start_coordinate));
 
     auto cumulative_distance = 0.;
     auto current_distance = 0.;
@@ -71,7 +70,10 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         cumulative_distance += current_distance;
 
         // all changes to this check have to be matched with assemble_steps
-        if (path_point.turn_instruction.type != osrm::guidance::TurnType::NoTurn)
+        auto turn_instruction = path_point.turn_edge
+                                    ? facade.GetTurnInstructionForEdgeID(*path_point.turn_edge)
+                                    : osrm::guidance::TurnInstruction::NO_TURN();
+        if (turn_instruction.type != osrm::guidance::TurnType::NoTurn)
         {
             geometry.segment_distances.push_back(cumulative_distance);
             geometry.segment_offsets.push_back(geometry.locations.size());
@@ -79,11 +81,10 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
         }
 
         prev_coordinate = coordinate;
+        const auto node_id = path_point.turn_via_node;
 
-        const auto osm_node_id = facade.GetOSMNodeIDOfNode(path_point.turn_via_node);
-
-        if (osm_node_id != geometry.osm_node_ids.back() ||
-            path_point.turn_instruction.type != osrm::guidance::TurnType::NoTurn)
+        if (node_id != geometry.node_ids.back() ||
+            turn_instruction.type != osrm::guidance::TurnType::NoTurn)
         {
             geometry.annotations.emplace_back(LegGeometry::Annotation{
                 current_distance,
@@ -99,7 +100,7 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
                     facade.GetWeightMultiplier(),
                 path_point.datasource_id});
             geometry.locations.push_back(std::move(coordinate));
-            geometry.osm_node_ids.push_back(osm_node_id);
+            geometry.node_ids.push_back(node_id);
         }
     }
     current_distance =
@@ -158,8 +159,7 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
     const auto target_segment_end_coordinate =
         target_node.fwd_segment_position + (reversed_target ? 0 : 1);
     const auto target_geometry = facade.GetUncompressedForwardGeometry(target_geometry_id);
-    geometry.osm_node_ids.push_back(
-        facade.GetOSMNodeIDOfNode(target_geometry(target_segment_end_coordinate)));
+    geometry.node_ids.push_back(target_geometry(target_segment_end_coordinate));
 
     BOOST_ASSERT(geometry.segment_distances.size() == geometry.segment_offsets.size() - 1);
     BOOST_ASSERT(geometry.locations.size() > geometry.segment_distances.size());

--- a/include/engine/guidance/leg_geometry.hpp
+++ b/include/engine/guidance/leg_geometry.hpp
@@ -32,7 +32,7 @@ struct LegGeometry
     // length of the segment in meters
     std::vector<double> segment_distances;
     // original OSM node IDs for each coordinate
-    std::vector<OSMNodeID> osm_node_ids;
+    std::vector<NodeID> node_ids;
 
     // Per-coordinate metadata
     struct Annotation

--- a/include/engine/internal_route_result.hpp
+++ b/include/engine/internal_route_result.hpp
@@ -15,6 +15,7 @@
 #include "util/integer_range.hpp"
 #include "util/typedefs.hpp"
 
+#include <boost/optional.hpp>
 #include <vector>
 
 namespace osrm
@@ -28,43 +29,22 @@ struct PathData
     NodeID from_edge_based_node;
     // the internal OSRM id of the OSM node id that is the via node of the turn
     NodeID turn_via_node;
-    // name of the street that leads to the turn
-    unsigned name_id;
-    // segregated edge-based node that leads to the turn
-    bool is_segregated;
     // weight that is traveled on the segment until the turn is reached
     // including the turn weight, if one exists
     EdgeWeight weight_until_turn;
-    // If this segment immediately preceeds a turn, then duration_of_turn
+    // If this segment immediately precedes a turn, then duration_of_turn
     // will contain the weight of the turn.  Otherwise it will be 0.
     EdgeWeight weight_of_turn;
     // duration that is traveled on the segment until the turn is reached,
-    // including a turn if the segment preceeds one.
+    // including a turn if the segment precedes one.
     EdgeWeight duration_until_turn;
-    // If this segment immediately preceeds a turn, then duration_of_turn
+    // If this segment immediately precedes a turn, then duration_of_turn
     // will contain the duration of the turn.  Otherwise it will be 0.
     EdgeWeight duration_of_turn;
-    // instruction to execute at the turn
-    osrm::guidance::TurnInstruction turn_instruction;
-    // turn lane data
-    util::guidance::LaneTupleIdPair lane_data;
-    // travel mode of the street that leads to the turn
-    extractor::TravelMode travel_mode : 4;
-    // user defined classed of the street that leads to the turn
-    extractor::ClassData classes;
-    // entry class of the turn, indicating possibility of turns
-    util::guidance::EntryClass entry_class;
-
     // Source of the speed value on this road segment
     DatasourceID datasource_id;
-
-    // bearing (as seen from the intersection) pre-turn
-    osrm::guidance::TurnBearing pre_turn_bearing;
-    // bearing (as seen from the intersection) post-turn
-    osrm::guidance::TurnBearing post_turn_bearing;
-
-    // Driving side of the turn
-    bool is_left_hand_driving;
+    // If segment precedes a turn, ID of the turn itself
+    boost::optional<EdgeID> turn_edge;
 };
 
 struct InternalRouteResult

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -176,11 +176,6 @@ void annotatePath(const FacadeT &facade,
         const auto &edge_data = facade.GetEdgeData(*edge);
         const auto turn_id = edge_data.turn_id; // edge-based graph edge index
         const auto node_id = *node_from;        // edge-based graph node index
-        const auto name_index = facade.GetNameIndex(node_id);
-        const bool is_segregated = facade.IsSegregated(node_id);
-        const auto turn_instruction = facade.GetTurnInstructionForEdgeID(turn_id);
-        const extractor::TravelMode travel_mode = facade.GetTravelMode(node_id);
-        const auto classes = facade.GetClassData(node_id);
 
         const auto geometry_index = facade.GetGeometryIndex(node_id);
         get_segment_geometry(geometry_index);
@@ -206,45 +201,29 @@ void annotatePath(const FacadeT &facade,
         }
         const std::size_t end_index = weight_vector.size();
 
-        bool is_left_hand_driving = facade.IsLeftHandDriving(node_id);
-
         BOOST_ASSERT(start_index < end_index);
         for (std::size_t segment_idx = start_index; segment_idx < end_index; ++segment_idx)
         {
             unpacked_path.push_back(
-                PathData{*node_from,
+                PathData{node_id,
                          id_vector[segment_idx + 1],
-                         name_index,
-                         is_segregated,
                          static_cast<EdgeWeight>(weight_vector[segment_idx]),
                          0,
                          static_cast<EdgeDuration>(duration_vector[segment_idx]),
                          0,
-                         guidance::TurnInstruction::NO_TURN(),
-                         {{0, INVALID_LANEID}, INVALID_LANE_DESCRIPTIONID},
-                         travel_mode,
-                         classes,
-                         EMPTY_ENTRY_CLASS,
                          datasource_vector[segment_idx],
-                         osrm::guidance::TurnBearing(0),
-                         osrm::guidance::TurnBearing(0),
-                         is_left_hand_driving});
+                         boost::none});
         }
         BOOST_ASSERT(unpacked_path.size() > 0);
-        if (facade.HasLaneData(turn_id))
-            unpacked_path.back().lane_data = facade.GetLaneData(turn_id);
 
         const auto turn_duration = facade.GetDurationPenaltyForEdgeID(turn_id);
         const auto turn_weight = facade.GetWeightPenaltyForEdgeID(turn_id);
 
-        unpacked_path.back().entry_class = facade.GetEntryClass(turn_id);
-        unpacked_path.back().turn_instruction = turn_instruction;
         unpacked_path.back().duration_until_turn += turn_duration;
         unpacked_path.back().duration_of_turn = turn_duration;
         unpacked_path.back().weight_until_turn += turn_weight;
         unpacked_path.back().weight_of_turn = turn_weight;
-        unpacked_path.back().pre_turn_bearing = facade.PreTurnBearing(turn_id);
-        unpacked_path.back().post_turn_bearing = facade.PostTurnBearing(turn_id);
+        unpacked_path.back().turn_edge = turn_id;
     }
 
     std::size_t start_index = 0, end_index = 0;
@@ -280,33 +259,22 @@ void annotatePath(const FacadeT &facade,
     // t: fwd_segment 3
     // -> (U, v), (v, w), (w, x)
     // note that (x, t) is _not_ included but needs to be added later.
-    bool is_target_left_hand_driving = facade.IsLeftHandDriving(target_node_id);
     for (std::size_t segment_idx = start_index; segment_idx != end_index;
          (start_index < end_index ? ++segment_idx : --segment_idx))
     {
         BOOST_ASSERT(segment_idx < static_cast<std::size_t>(id_vector.size() - 1));
-        BOOST_ASSERT(facade.GetTravelMode(target_node_id) > 0);
         unpacked_path.push_back(
             PathData{target_node_id,
                      id_vector[start_index < end_index ? segment_idx + 1 : segment_idx - 1],
-                     facade.GetNameIndex(target_node_id),
-                     facade.IsSegregated(target_node_id),
                      static_cast<EdgeWeight>(weight_vector[segment_idx]),
                      0,
                      static_cast<EdgeDuration>(duration_vector[segment_idx]),
                      0,
-                     guidance::TurnInstruction::NO_TURN(),
-                     {{0, INVALID_LANEID}, INVALID_LANE_DESCRIPTIONID},
-                     facade.GetTravelMode(target_node_id),
-                     facade.GetClassData(target_node_id),
-                     EMPTY_ENTRY_CLASS,
                      datasource_vector[segment_idx],
-                     guidance::TurnBearing(0),
-                     guidance::TurnBearing(0),
-                     is_target_left_hand_driving});
+                     boost::none});
     }
 
-    if (unpacked_path.size() > 0)
+    if (!unpacked_path.empty())
     {
         const auto source_weight = start_traversed_in_reverse
                                        ? phantom_node_pair.source_phantom.reverse_weight

--- a/src/engine/guidance/post_processing.cpp
+++ b/src/engine/guidance/post_processing.cpp
@@ -279,8 +279,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
                                      geometry.locations.begin() + offset);
             geometry.annotations.erase(geometry.annotations.begin(),
                                        geometry.annotations.begin() + offset);
-            geometry.osm_node_ids.erase(geometry.osm_node_ids.begin(),
-                                        geometry.osm_node_ids.begin() + offset);
+            geometry.node_ids.erase(geometry.node_ids.begin(), geometry.node_ids.begin() + offset);
         }
 
         auto const first_bearing = steps.front().maneuver.bearing_after;
@@ -377,7 +376,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
         // remove all the last coordinates from the geometry
         geometry.locations.resize(geometry.segment_offsets.back() + 1);
         geometry.annotations.resize(geometry.segment_offsets.back());
-        geometry.osm_node_ids.resize(geometry.segment_offsets.back() + 1);
+        geometry.node_ids.resize(geometry.segment_offsets.back() + 1);
 
         BOOST_ASSERT(geometry.segment_distances.back() <= 1);
         geometry.segment_distances.pop_back();
@@ -414,7 +413,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
         // This can happen if the last coordinate snaps to a node in the unpacked geometry
         geometry.locations.pop_back();
         geometry.annotations.pop_back();
-        geometry.osm_node_ids.pop_back();
+        geometry.node_ids.pop_back();
         geometry.segment_offsets.back()--;
         // since the last geometry includes the location of arrival, the arrival instruction
         // geometry overlaps with the previous segment
@@ -436,7 +435,7 @@ void trimShortSegments(std::vector<RouteStep> &steps, LegGeometry &geometry)
     }
 
     BOOST_ASSERT(geometry.segment_offsets.back() + 1 == geometry.locations.size());
-    BOOST_ASSERT(geometry.segment_offsets.back() + 1 == geometry.osm_node_ids.size());
+    BOOST_ASSERT(geometry.segment_offsets.back() + 1 == geometry.node_ids.size());
     BOOST_ASSERT(geometry.segment_offsets.back() == geometry.annotations.size());
 
     BOOST_ASSERT(steps.back().geometry_end == geometry.locations.size());
@@ -541,7 +540,7 @@ std::vector<RouteStep> buildIntersections(std::vector<RouteStep> steps)
         {
 
             // End of road is a turn that helps to identify the location of a turn. If the turn does
-            // not pass by any oter intersections, the end-of-road characteristic does not improve
+            // not pass by any other intersections, the end-of-road characteristic does not improve
             // the instructions.
             // Here we reduce the verbosity of our output by reducing end-of-road emissions in cases
             // where no intersections have been passed in between.

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -71,7 +71,7 @@ EdgeBasedGraphFactory::EdgeBasedGraphFactory(
     const extractor::LaneDescriptionMap &lane_description_map)
     : m_edge_based_node_container(node_data_container), m_connectivity_checksum(0),
       m_number_of_edge_based_nodes(0), m_coordinates(coordinates),
-      m_node_based_graph(std::move(node_based_graph)), m_barrier_nodes(barrier_nodes),
+      m_node_based_graph(node_based_graph), m_barrier_nodes(barrier_nodes),
       m_traffic_lights(traffic_lights), m_compressed_edge_container(compressed_edge_container),
       name_table(name_table), segregated_edges(segregated_edges),
       lane_description_map(lane_description_map)

--- a/unit_tests/engine/collapse_internal_route_result.cpp
+++ b/unit_tests/engine/collapse_internal_route_result.cpp
@@ -19,8 +19,8 @@ BOOST_AUTO_TEST_CASE(unchanged_collapse_route_result)
     PhantomNode target;
     source.forward_segment_id = {1, true};
     target.forward_segment_id = {6, true};
-    PathData pathy{0, 2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
-    PathData kathy{0, 1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData pathy{0, 2, 2, 3, 4, 5, 2, boost::none};
+    PathData kathy{0, 1, 1, 2, 3, 4, 1, boost::none};
     InternalRouteResult one_leg_result;
     one_leg_result.unpacked_path_segments = {{pathy, kathy}};
     one_leg_result.segment_end_coordinates = {PhantomNodes{source, target}};
@@ -37,13 +37,11 @@ BOOST_AUTO_TEST_CASE(unchanged_collapse_route_result)
 
 BOOST_AUTO_TEST_CASE(two_legs_to_one_leg)
 {
-    // from_edge_based_node, turn_via_node, name_id, is_segregated, weight_until_turn,
-    // weight_of_turn,
-    // duration_until_turn, duration_of_turn, turn_instruction, lane_data, travel_mode, classes,
-    // entry_class, datasource_id, pre_turn_bearing, post_turn_bearing, left_hand
-    PathData pathy{0, 2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
-    PathData kathy{0, 1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
-    PathData cathy{0, 3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    // from_edge_based_node, turn_via_node, weight_until_turn, weight_of_turn,
+    // duration_until_turn, duration_of_turn, datasource_id, turn_edge
+    PathData pathy{0, 2, 2, 3, 4, 5, 2, boost::none};
+    PathData kathy{0, 1, 1, 2, 3, 4, 1, boost::none};
+    PathData cathy{0, 3, 1, 2, 3, 4, 1, boost::none};
     PhantomNode node_1;
     PhantomNode node_2;
     PhantomNode node_3;
@@ -73,11 +71,11 @@ BOOST_AUTO_TEST_CASE(two_legs_to_one_leg)
 
 BOOST_AUTO_TEST_CASE(three_legs_to_two_legs)
 {
-    PathData pathy{0, 2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
-    PathData kathy{0, 1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
-    PathData qathy{0, 5, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
-    PathData cathy{0, 3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
-    PathData mathy{0, 4, 18, false, 8, 9, 13, 4, 2, {}, 4, 2, {}, 2, {3.0}, {1.0}, false};
+    PathData pathy{0, 2, 2, 3, 4, 5, 2, boost::none};
+    PathData kathy{0, 1, 1, 2, 3, 4, 1, boost::none};
+    PathData qathy{0, 5, 1, 2, 3, 4, 1, boost::none};
+    PathData cathy{0, 3, 1, 2, 3, 4, 1, boost::none};
+    PathData mathy{0, 4, 8, 9, 13, 4, 2, boost::none};
     PhantomNode node_1;
     PhantomNode node_2;
     PhantomNode node_3;
@@ -117,9 +115,9 @@ BOOST_AUTO_TEST_CASE(three_legs_to_two_legs)
 
 BOOST_AUTO_TEST_CASE(two_legs_to_two_legs)
 {
-    PathData pathy{0, 2, 17, false, 2, 3, 4, 5, 0, {}, 4, 2, {}, 2, {1.0}, {1.0}, false};
-    PathData kathy{0, 1, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
-    PathData cathy{0, 3, 16, false, 1, 2, 3, 4, 1, {}, 3, 1, {}, 1, {2.0}, {3.0}, false};
+    PathData pathy{0, 2, 2, 3, 4, 5, 2, boost::none};
+    PathData kathy{0, 1, 1, 2, 3, 4, 1, boost::none};
+    PathData cathy{0, 3, 1, 2, 3, 4, 1, boost::none};
     PhantomNode node_1;
     PhantomNode node_2;
     PhantomNode node_3;

--- a/unit_tests/engine/guidance_assembly.cpp
+++ b/unit_tests/engine/guidance_assembly.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
                           {FloatLongitude{-73.981495}, FloatLatitude{40.768275}}};
     geometry.segment_offsets = {0, 2};
     geometry.segment_distances = {1.9076601161280742};
-    geometry.osm_node_ids = {OSMNodeID{0}, OSMNodeID{1}, OSMNodeID{2}};
+    geometry.node_ids = {NodeID{0}, NodeID{1}, NodeID{2}};
     geometry.annotations = {{1.9076601161280742, 0.2, 0.2, 0}, {0, 0, 0, 0}};
 
     trimShortSegments(steps, geometry);
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
     BOOST_CHECK_EQUAL(geometry.segment_offsets.back(), 1);
     BOOST_CHECK_EQUAL(geometry.annotations.size(), 1);
     BOOST_CHECK_EQUAL(geometry.locations.size(), 2);
-    BOOST_CHECK_EQUAL(geometry.osm_node_ids.size(), 2);
+    BOOST_CHECK_EQUAL(geometry.node_ids.size(), 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Currently route results are annotated with additional path information, such as geometries, turn-by-turn steps and other metadata.

These annotations are generated even if they are not requested or returned in the response. Datasets needed to generate these annotations are loaded and available to the OSRM process even when unused.

This PR is a first step towards making the loading of these datasets optional. We refactor the code so that route annotations are only generated if explicitly requested and needed in the response

Specifically, we change the following annotations to be lazily generated:
- Turn-by-turn steps
- Route overview geometry
- Route segment metadata 

For example. a `/route/v1` request with
`steps=false&overview=false&annotations=false`
would no longer call the following data facade methods:
- `GetOSMNodeIDOfNode`
- `GetTurnInstructionForEdgeID`
- `GetNameIndex`
- `GetNameForID`
- `GetRefForID`
- `GetTurnInstructionForEdgeID`
- `GetClassData`
- `IsLeftHandDriving`
- `GetTravelMode`
- `IsSegregated`
- `PreTurnBearing`
- `PostTurnBearing`
- `HasLaneData`
- `GetLaneData`
- `GetEntryClass`

Requests that include segment metadata and/or overview geometry but not turn-by-turn instructions will also benefit from this, although there is some interdependency with the step instructions - a call to `GetTurnInstructionForEdgeID` is still required.
Requests for OSM annotations will understandably still need to call `GetOSMNodeIDOfNode`.

Making these changes unlocks the optional loading of data contained in
the following OSRM files:
- `osrm.names`
- `osrm.icd`
- `osrm.nbg_nodes` (partial)
- `osrm.ebg_nodes` (partial)
- `osrm.edges`


## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
#5838 