### PR TITLE
Add support for non-round-trips with a single fixed endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
       - FIXED: Fixed Node docs generation check in CI. [#6058](https://github.com/Project-OSRM/osrm-backend/pull/6058)
       - CHANGED: Docker build, enabled arm64 build layer [#6172](https://github.com/Project-OSRM/osrm-backend/pull/6172)
       - CHANGED: Docker build, enabled apt-get update/install caching in separate layer for build phase [#6175](https://github.com/Project-OSRM/osrm-backend/pull/6175)
+    - Routing:
+      - ADDED: Add support for non-round-trips with a single fixed endpoint. [#6050](https://github.com/Project-OSRM/osrm-backend/pull/6050)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/docs/http.md
+++ b/docs/http.md
@@ -507,8 +507,8 @@ Right now, the following combinations are possible:
 | true | any | last | **yes** |
 | true | any | any | **yes** |
 | false | first | last | **yes** |
-| false | first | any | no |
-| false | any | last | no |
+| false | first | any | **yes** |
+| false | any | last | **yes** |
 | false | any | any | no |
 
 #### Example Requests

--- a/features/step_definitions/trip.js
+++ b/features/step_definitions/trip.js
@@ -61,7 +61,8 @@ module.exports = function () {
                     var subTrips;
                     var trip_durations;
                     var trip_distance;
-                    if (res.statusCode === 200) {
+                    var ok = res.statusCode === 200;
+                    if (ok) {
                         if (headers.has('trips')) {
                             subTrips = json.trips.filter(t => !!t).map(t => t.legs).map(tl => Array.prototype.concat.apply([], tl.map((sl, i) => {
                                 var toAdd = [];
@@ -84,8 +85,7 @@ module.exports = function () {
                         }
                     }
 
-                    var ok = true,
-                        encodedResult = '';
+                    var encodedResult = '';
 
                     if (json.trips) row.trips.split(',').forEach((sub, si) => {
                         if (si >= subTrips.length) {

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -5,7 +5,7 @@ Feature: Basic trip planning
         Given the profile "testbot"
         Given a grid size of 10 meters
 
-    Scenario: Testbot - Trip: Roundtrip with one waypoint
+    Scenario: Testbot - Trip: Roundtrip between same waypoint
         Given the node map
             """
             a b
@@ -21,7 +21,7 @@ Feature: Basic trip planning
 
         When I plan a trip I should get
             | waypoints | trips  |
-            | a         | aa     |
+            | a,a       | aa     |
 
     Scenario: Testbot - Trip: Roundtrip with waypoints (less than 10)
         Given the node map
@@ -69,36 +69,37 @@ Feature: Basic trip planning
             | waypoints               | trips         |
             | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba |
 
-    Scenario: Testbot - Trip: Roundtrip FS waypoints (more than 10)
-        Given the node map
-            """
-            a b c d
-            l     e
-            k     f
-            j i h g
-            """
-
-        And the ways
-            | nodes |
-            | ab    |
-            | bc    |
-            | de    |
-            | ef    |
-            | fg    |
-            | gh    |
-            | hi    |
-            | ij    |
-            | jk    |
-            | kl    |
-            | la    |
-
-        When I plan a trip I should get
-            | waypoints               | source | trips         |
-            | a,b,c,d,e,f,g,h,i,j,k,l | first  | alkjihgfedcba |
-
-    Scenario: Testbot - Trip: Roundtrip FE waypoints (more than 10)
+    Scenario: Testbot - Trip: FS waypoints (less than 10)
         Given the query options
-            | source | last  |
+            | source | first  |
+        Given the node map
+            """
+            a b c d
+            l     e
+
+            j i   g
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | de    |
+            | eg    |
+            | gi    |
+            | ij    |
+            | jl    |
+            | la    |
+
+        When I plan a trip I should get
+            | waypoints               | trips         | roundtrip | durations |
+            | a,b,c,d,e,g,i,j,l       | abcdegijla    | true      | 22        |
+            | a,b,c,d,e,g,i,j,l       | abcljiged     | false     | 13        |
+
+
+    Scenario: Testbot - Trip: FS waypoints (more than 10)
+        Given the query options
+            | source | first  |
         Given the node map
             """
             a b c d
@@ -122,8 +123,67 @@ Feature: Basic trip planning
             | la    |
 
         When I plan a trip I should get
-            | waypoints               | trips         |
-            | a,b,c,d,e,f,g,h,i,j,k,l | lkjihgfedcbal |
+            | waypoints               | trips         | roundtrip | durations |
+            | a,b,c,d,e,f,g,h,i,j,k,l | alkjihgfedcba | true      | 22        |
+            | a,b,c,d,e,f,g,h,i,j,k,l | acblkjihgfed  | false     | 13        |
+
+
+    Scenario: Testbot - Trip: FE waypoints (less than 10)
+        Given the query options
+            | destination | last  |
+        Given the node map
+            """
+            a b c d
+            l     e
+
+            j i   g
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | de    |
+            | eg    |
+            | gi    |
+            | ij    |
+            | jl    |
+            | la    |
+
+        When I plan a trip I should get
+            | waypoints             | trips        | roundtrip | durations |
+            | a,b,c,d,e,g,i,j,l     | labcdegijl   | true      | 22        |
+            | a,b,c,d,e,g,i,j,l     | degijabcl    | false     | 14        |
+
+    Scenario: Testbot - Trip: FE waypoints (more than 10)
+        Given the query options
+            | destination | last  |
+        Given the node map
+            """
+            a b c d
+            l     e
+            k     f
+            j i h g
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | de    |
+            | ef    |
+            | fg    |
+            | gh    |
+            | hi    |
+            | ij    |
+            | jk    |
+            | kl    |
+            | la    |
+
+        When I plan a trip I should get
+            | waypoints               | trips         | roundtrip | durations |
+            | a,b,c,d,e,f,g,h,i,j,k,l | lkjihgfedcbal | true      | 22        |
+            | a,b,c,d,e,f,g,h,i,j,k,l | cbakjihgfedl  | false     | 19        |
 
     Scenario: Testbot - Trip: Unroutable roundtrip with waypoints (less than 10)
         Given the node map
@@ -274,7 +334,7 @@ Feature: Basic trip planning
             |  a,b,d,e,c  | first  | last        | true      | abedca  |
 
 
-    Scenario: Testbot - Trip: midway points in isoldated roads should return no trips
+    Scenario: Testbot - Trip: midway points in isolated roads should return no trips
         Given the node map
             """
             a 1 b

--- a/features/testbot/zero-speed-updates.feature
+++ b/features/testbot/zero-speed-updates.feature
@@ -187,5 +187,5 @@ Feature: Check zero speed updates
 
         When I plan a trip I should get
             | waypoints | trips | code    |
-            | a,b,c,d   | abcda | NoTrips |
-            | d,b,c,a   | dbcad | NoTrips |
+            | a,b,c,d   |       | NoTrips |
+            | d,b,c,a   |       | NoTrips |

--- a/unit_tests/library/trip.cpp
+++ b/unit_tests/library/trip.cpp
@@ -362,7 +362,7 @@ void test_tfse_illegal_parameters(bool use_json_only_api)
     ResetParams(locations, params);
     params.source = TripParameters::SourceType::First;
     params.roundtrip = false;
-    CheckNotImplemented(osrm, params, use_json_only_api);
+    CheckOk(osrm, params, use_json_only_api);
 
     ResetParams(locations, params);
     params.destination = TripParameters::DestinationType::Any;
@@ -372,7 +372,7 @@ void test_tfse_illegal_parameters(bool use_json_only_api)
     ResetParams(locations, params);
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
-    CheckNotImplemented(osrm, params, use_json_only_api);
+    CheckOk(osrm, params, use_json_only_api);
 
     // three parameters set
     params.source = TripParameters::SourceType::Any;
@@ -383,12 +383,12 @@ void test_tfse_illegal_parameters(bool use_json_only_api)
     params.source = TripParameters::SourceType::Any;
     params.destination = TripParameters::DestinationType::Last;
     params.roundtrip = false;
-    CheckNotImplemented(osrm, params, use_json_only_api);
+    CheckOk(osrm, params, use_json_only_api);
 
     params.source = TripParameters::SourceType::First;
     params.destination = TripParameters::DestinationType::Any;
     params.roundtrip = false;
-    CheckNotImplemented(osrm, params, use_json_only_api);
+    CheckOk(osrm, params, use_json_only_api);
 }
 BOOST_AUTO_TEST_CASE(test_tfse_illegal_parameters_old_api) { test_tfse_illegal_parameters(true); }
 BOOST_AUTO_TEST_CASE(test_tfse_illegal_parameters_new_api) { test_tfse_illegal_parameters(false); }


### PR DESCRIPTION
# Issue

Currently `/trip` supports finding round-trip routes where only the start or end location is fixed. 
This PR extends this feature to non-round-trip requests.

We do this by a new table manipulation that simulates non-round-trip fixed endpoint requests as a round-trip request.

This PR also fixes a problem with the `trip` cucumber tests. If the response was not a `200` status code, the tests always passed. This corrects this and fixes the tests that were subsequently failing.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
Fixes #5647
