### PR TITLE
Fix generation of inefficient MLD partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
       - FIXED: Allow for special characters in the profile/method as part of the HTTP URL. [#6090](https://github.com/Project-OSRM/osrm-backend/pull/6090)
     - Build:
       - CHANGED: Replace Travis with Github Actions for CI builds [#6071](https://github.com/Project-OSRM/osrm-backend/pull/6071)
+    - Routing:
+      - FIXED: Fix generation of inefficient MLD partitions [#6084](https://github.com/Project-OSRM/osrm-backend/pull/6084)
 
 # 5.25.0
   - Changes from 5.24.0

--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -412,6 +412,13 @@ EdgeBasedGraphFactory::GenerateEdgeExpandedNodes(const WayRestrictionMap &way_re
             m_edge_based_node_distances.push_back(
                 m_edge_based_node_distances[nbe_to_ebn_mapping[eid]]);
 
+            // Include duplicate nodes in cnbg to ebg mapping. This means a
+            // compressed node pair (u,v) can appear multiple times in this list.
+            // This is needed by the MLD partition step to ensure duplicate nodes
+            // are also assigned to partitions (the MLD partitioner is currently
+            // the only consumer of this mapping).
+            mapping.push_back(NBGToEBG{node_u, node_v, edge_based_node_id, SPECIAL_NODEID});
+
             edge_based_node_id++;
             progress.PrintStatus(progress_counter++);
         }

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -118,6 +118,10 @@ int Partitioner::Run(const PartitionerConfig &config)
             edge_based_partition_ids[backward_node] = node_based_partition_ids[v];
     }
 
+    BOOST_ASSERT(std::none_of(edge_based_partition_ids.begin(),
+                              edge_based_partition_ids.end(),
+                              [](auto x) { return x == SPECIAL_NODEID; }));
+
     std::vector<Partition> partitions;
     std::vector<std::uint32_t> level_to_num_cells;
     std::tie(partitions, level_to_num_cells) =


### PR DESCRIPTION
# Issue

See #6084 for details

# Performance

This has measurable improvement on MLD routing.
Will include test results in comments below.
TL;DR
- `/table` is ~6% faster
- `/route` is ~3% faster
- `osrm-routed` uses 0.2% less memory 

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Closes #6084 
