### PR TITLE
Fix the URL parser for special chars in profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+  - Changes from 5.25.0
+    - API:
+      - FIXED: Allow for special characters in the profile/method as part of the HTTP URL.
 
 # 5.25.0
   - Changes from 5.24.0

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -26,10 +26,10 @@ struct URLParser final : qi::grammar<Iterator, Into>
     {
         using boost::spirit::repository::qi::iter_pos;
 
-        identifier = qi::char_("a-zA-Z0-9_..--~:");
+        identifier = qi::char_("a-zA-Z0-9_.~:-");
         percent_encoding =
             qi::char_('%') > qi::uint_parser<unsigned char, 16, 2, 2>()[qi::_val = qi::_1];
-        polyline_chars = qi::char_("a-zA-Z0-9_..--[]{}@?|\\~`^") | percent_encoding;
+        polyline_chars = qi::char_("a-zA-Z0-9_[]{}@?|\\~`^") | percent_encoding;
         all_chars = polyline_chars | qi::char_("=,;:&()..");
 
         service = +identifier;

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -26,15 +26,15 @@ struct URLParser final : qi::grammar<Iterator, Into>
     {
         using boost::spirit::repository::qi::iter_pos;
 
-        alpha_numeral = qi::char_("a-zA-Z0-9");
+        identifier = qi::char_("a-zA-Z0-9_..--~:");
         percent_encoding =
             qi::char_('%') > qi::uint_parser<unsigned char, 16, 2, 2>()[qi::_val = qi::_1];
-        polyline_chars = qi::char_("a-zA-Z0-9_.--[]{}@?|\\~`^") | percent_encoding;
-        all_chars = polyline_chars | qi::char_("=,;:&().");
+        polyline_chars = qi::char_("a-zA-Z0-9_..--[]{}@?|\\~`^") | percent_encoding;
+        all_chars = polyline_chars | qi::char_("=,;:&()..");
 
-        service = +alpha_numeral;
+        service = +identifier;
         version = qi::uint_;
-        profile = +alpha_numeral;
+        profile = +identifier;
         query = +all_chars;
 
         // Example input: /route/v1/driving/7.416351,43.731205;7.420363,43.736189
@@ -54,7 +54,7 @@ struct URLParser final : qi::grammar<Iterator, Into>
     qi::rule<Iterator, std::string()> profile;
     qi::rule<Iterator, std::string()> query;
 
-    qi::rule<Iterator, char()> alpha_numeral;
+    qi::rule<Iterator, char()> identifier;
     qi::rule<Iterator, char()> all_chars;
     qi::rule<Iterator, char()> polyline_chars;
     qi::rule<Iterator, char()> percent_encoding;

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -30,7 +30,7 @@ struct URLParser final : qi::grammar<Iterator, Into>
         percent_encoding =
             qi::char_('%') > qi::uint_parser<unsigned char, 16, 2, 2>()[qi::_val = qi::_1];
         polyline_chars = qi::char_("a-zA-Z0-9_[]{}@?|\\~`^") | percent_encoding;
-        all_chars = polyline_chars | qi::char_("=,;:&()..");
+        all_chars = polyline_chars | qi::char_("=,;:&().-");
 
         service = +identifier;
         version = qi::uint_;

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(invalid_urls)
     BOOST_CHECK_EQUAL(testInvalidURL("/route/"), 7UL);
     BOOST_CHECK_EQUAL(testInvalidURL("/route/bla"), 7UL);
     BOOST_CHECK_EQUAL(testInvalidURL("/route/1/1,2;3;4"), 7UL);
-    BOOST_CHECK_EQUAL(testInvalidURL("/route/v1/pro_file/1,2;3,4"), 13UL);
+    BOOST_CHECK_EQUAL(testInvalidURL("/route/v1/pro[]file/1,2;3,4"), 13UL);
     BOOST_CHECK_EQUAL(testInvalidURL("/route/v1/profile"), 17UL);
     BOOST_CHECK_EQUAL(testInvalidURL("/route/v1/profile/"), 18UL);
 }
@@ -124,6 +124,16 @@ BOOST_AUTO_TEST_CASE(valid_urls)
     BOOST_CHECK_EQUAL(reference_8.profile, result_8->profile);
     CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
     BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
+
+    // profile with special characters
+    api::ParsedURL reference_9{"route", 1, "foo-bar_baz.profile", "0,1;2,3;4,5?options=value&foo=bar", 30UL};
+    auto result_9 = api::parseURL("/route/v1/foo-bar_baz.profile/0,1;2,3;4,5?options=value&foo=bar");
+    BOOST_CHECK(result_9);
+    BOOST_CHECK_EQUAL(reference_9.service, result_9->service);
+    BOOST_CHECK_EQUAL(reference_9.version, result_9->version);
+    BOOST_CHECK_EQUAL(reference_9.profile, result_9->profile);
+    CHECK_EQUAL_RANGE(reference_9.query, result_9->query);
+    BOOST_CHECK_EQUAL(reference_9.prefix_length, result_9->prefix_length);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

The URLs used for `osrm-routed` have the form `{service}/{version}/{profile}/{params}?{options...}`. The boost spirit grammar for parsing the `profile` and `service` identifiers was artificially limited to only allow alpha-numerical characters, but any URL-safe character would be fine.

This PR additionally allows for `._-~`.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] add tests
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
