### PR TITLE
Fixed edge_speed_in_km_h as Double in Traffic Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- Changes from 5.25.0
+    - API:
+      - FIXED: Allow for traffic updates to use edge_speed_in_km_h in decimals.
 
 # 5.25.0
   - Changes from 5.24.0

--- a/src/updater/csv_source.cpp
+++ b/src/updater/csv_source.cpp
@@ -37,7 +37,7 @@ SegmentLookupTable readSegmentValues(const std::vector<std::string> &paths)
     CSVFilesParser<Segment, SpeedSource> parser(
         1,
         qi::ulong_long >> ',' >> qi::ulong_long,
-        qi::uint_ >> -(',' >> (qi::double_ | qi::attr(value_if_blank))));
+        qi::double_ >> -(',' >> (qi::double_ | qi::attr(value_if_blank))));
 
     // Check consistency of keys in the result lookup table
     auto result = parser(paths);


### PR DESCRIPTION
# Issue
Fixed an issue that /src/updater/csv_source.cpp only took edge_speed_in_km_h as unit when processing traffic updates. 
Now edge_speed_in_km_h can be set as double type. 


## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
