### PR TITLE
Osrm-datastore stability fixes, extra logging

### DIFF
--- a/include/updater/source.hpp
+++ b/include/updater/source.hpp
@@ -6,6 +6,7 @@
 #include <boost/optional.hpp>
 
 #include <vector>
+#include <sstream>
 
 namespace osrm
 {
@@ -45,6 +46,11 @@ struct Segment final
     {
         return std::tie(from, to) == std::tie(rhs.from, rhs.to);
     }
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{from: " << from << ", to: " << to << "}";
+        return oss.str();
+    }
 };
 
 struct SpeedSource final
@@ -53,6 +59,12 @@ struct SpeedSource final
     unsigned speed;
     boost::optional<double> rate;
     std::uint8_t source;
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{speed: " << speed << ", source: " << (int)source << "}";
+        return oss.str();
+    }
+
 };
 
 struct Turn final
@@ -76,6 +88,11 @@ struct Turn final
     {
         return std::tie(from, via, to) == std::tie(rhs.from, rhs.via, rhs.to);
     }
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{from: " << from << ", via: " << via << ", to: " << to << "}";
+        return oss.str();
+    }
 };
 
 struct PenaltySource final
@@ -84,6 +101,11 @@ struct PenaltySource final
     double duration;
     double weight;
     std::uint8_t source;
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{duration: " << duration << ", weight: " << weight << ", source: " << source << "}";
+        return oss.str();
+    }
 };
 
 using SegmentLookupTable = LookupTable<Segment, SpeedSource>;

--- a/include/util/log.hpp
+++ b/include/util/log.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <mutex>
 #include <sstream>
+#include <map>
 
 enum LogLevel
 {
@@ -101,6 +102,42 @@ class UnbufferedLog : public Log
   public:
     UnbufferedLog(LogLevel level_ = logINFO);
 };
+
+template<typename CONTAINER>
+std::string ToStringArray(const CONTAINER& arr) {
+  std::ostringstream oss;
+  oss << "#" << arr.size() << "{";
+  bool first = true;
+  for (const auto& e : arr) {
+    if (not first) {
+      oss << ", ";
+    }
+    first = false;
+    oss << e;
+  }
+  oss << "}";
+  return oss.str();
+}
+
+template<typename K, typename V>
+std::string ToStringMap(const std::map<K, V>& m) {
+  std::ostringstream oss;
+  oss << "#" << m.size() << "{";
+  bool first = true;
+  for (const auto& p : m) {
+    if (not first) {
+      oss << ", ";
+    }
+    first = false;
+    oss << p.first << ": " << p.second;
+  }
+  oss << "}";
+  return oss.str();
+}
+
+std::string toHexString(int a);
+std::string shmKeyToString(std::uint16_t shm_key);
+
 } // namespace util
 } // namespace osrm
 

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -22,6 +22,7 @@ SharedMemoryAllocator::SharedMemoryAllocator(
     {
         util::Log(logDEBUG) << "Loading new data for region " << (int)shm_key;
         BOOST_ASSERT(storage::SharedMemory::RegionExists(shm_key));
+        util::Log(logWARNING) << "CTudorache SharedMemoryAllocator, shm_key: " << shm_key;
         auto mem = storage::makeSharedMemory(shm_key);
 
         storage::io::BufferReader reader(reinterpret_cast<char *>(mem->Ptr()), mem->Size());

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -49,7 +49,13 @@ struct RegionHandle
     std::unique_ptr<SharedMemory> memory;
     char *data_ptr;
     std::uint16_t shm_key;
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{shm_key: " << shm_key << "}";
+        return oss.str();
+    }
 };
+inline std::ostream& operator<<(std::ostream& os, const RegionHandle& r) { return os << r.ToString(); }
 
 RegionHandle setupRegion(SharedRegionRegister &shared_register,
                          const storage::BaseDataLayout &layout)
@@ -62,7 +68,9 @@ RegionHandle setupRegion(SharedRegionRegister &shared_register,
     // to detach at the end of the function
     if (storage::SharedMemory::RegionExists(shm_key))
     {
-        util::Log(logWARNING) << "Old shared memory region " << (int)shm_key << " still exists.";
+        util::Log(logWARNING) << "Old shared memory region " << ShmKeyToString(shm_key) << " still exists. Attempting open";
+        auto shm = osrm::storage::makeSharedMemory(shm_key);
+        util::Log(logWARNING) << "Old shared memory region " << ShmKeyToString(shm_key) << " still exists: " << shm->ToString();
         util::UnbufferedLog() << "Retrying removal... ";
         storage::SharedMemory::Remove(shm_key);
         util::UnbufferedLog() << "ok.";
@@ -74,15 +82,17 @@ RegionHandle setupRegion(SharedRegionRegister &shared_register,
 
     // Allocate shared memory block
     auto regions_size = encoded_static_layout.size() + layout.GetSizeOfLayout();
-    util::Log() << "Data layout has a size of " << encoded_static_layout.size() << " bytes";
-    util::Log() << "Allocating shared memory of " << regions_size << " bytes";
+    util::Log() << "Data layout has a size of " << encoded_static_layout.size() << " bytes, Allocating shared memory of " << regions_size << " bytes";
     auto memory = makeSharedMemory(shm_key, regions_size);
+    util::Log(logWARNING) << "CTudorache setupRegion, shm_key: " << shm_key << ", regions_size: " << regions_size << ", mem: " << memory->ToString();
 
     // Copy memory static_layout to shared memory and populate data
+    //util::Log(logWARNING) << "CTudorache setupRegion, copy data, size: " << encoded_static_layout.size();
     char *shared_memory_ptr = static_cast<char *>(memory->Ptr());
     auto data_ptr =
         std::copy_n(encoded_static_layout.data(), encoded_static_layout.size(), shared_memory_ptr);
 
+    //util::Log(logWARNING) << "CTudorache setupRegion, copy data DONE";
     return RegionHandle{std::move(memory), data_ptr, shm_key};
 }
 
@@ -91,6 +101,7 @@ bool swapData(Monitor &monitor,
               const std::map<std::string, RegionHandle> &handles,
               int max_wait)
 {
+    util::Log(logWARNING) << "CTudorache swapData, max_wait: " << max_wait << ", shared_register: " << shared_register.ToString() << ", handles: " << osrm::util::ToStringMap(handles);
     std::vector<RegionHandle> old_handles;
 
     { // Lock for write access shared region mutex
@@ -114,20 +125,41 @@ bool swapData(Monitor &monitor,
         }
         else
         {
+            util::Log(logWARNING) << "CTudorache swapData locking sharedMonitor mutex";
             lock.lock();
         }
 
         for (auto &pair : handles)
         {
             auto region_id = shared_register.Find(pair.first);
+            util::Log(logWARNING) << "CTudorache swapData name: " << pair.first
+                                  << ", old region_id: " << region_id << (region_id == SharedRegionRegister::INVALID_REGION_ID ? "(INVALID)" : "(VALID)")
+                                  << ", new shm_key: " << pair.second.shm_key;
+            if (region_id != SharedRegionRegister::INVALID_REGION_ID)
+            {
+                auto &shared_region = shared_register.GetRegion(region_id);
+                if (!storage::SharedMemory::RegionExists(shared_region.shm_key))
+                {
+                    util::Log(logERROR) << "CTudorache swapData old region shm_key does not exist: " << shared_region.ToString();
+                    shared_region.timestamp = 0;
+                    shared_register.ReleaseKey(shared_region.shm_key);
+                    OSRMLockFile lock_file;
+                    boost::filesystem::remove(lock_file(shared_region.shm_key));
+                    region_id = SharedRegionRegister::INVALID_REGION_ID;
+                }
+            }
+
             if (region_id == SharedRegionRegister::INVALID_REGION_ID)
             {
+                util::Log(logWARNING) << "CTudorache swapData register: " << pair.first << ", key: " << util::shmKeyToString(pair.second.shm_key);
                 region_id = shared_register.Register(pair.first, pair.second.shm_key);
             }
             else
             {
                 auto &shared_region = shared_register.GetRegion(region_id);
-
+                util::Log(logWARNING) << "CTudorache swapData replacing shared_region: "
+                                      << shared_region.ToString() << "(exists: " << storage::SharedMemory::RegionExists(shared_region.shm_key) <<")"
+                                      << ", with new shm_key: " << pair.second.shm_key;
                 old_handles.push_back(RegionHandle{
                     makeSharedMemory(shared_region.shm_key), nullptr, shared_region.shm_key});
 
@@ -262,6 +294,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
         Storage::PopulateLayoutWithRTree(*static_layout);
         std::vector<std::pair<bool, boost::filesystem::path>> files = Storage::GetStaticFiles();
         Storage::PopulateLayout(*static_layout, files);
+        util::Log(logWARNING) << "CTudorache Storage::Run setupRegion static";
         auto static_handle = setupRegion(shared_register, *static_layout);
         regions.push_back({static_handle.data_ptr, std::move(static_layout)});
         handles[dataset_name + "/static"] = std::move(static_handle);
@@ -271,6 +304,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
         std::make_unique<storage::ContiguousDataLayout>();
     std::vector<std::pair<bool, boost::filesystem::path>> files = Storage::GetUpdatableFiles();
     Storage::PopulateLayout(*updatable_layout, files);
+    util::Log(logWARNING) << "CTudorache Storage::Run setupRegion updatable";
     auto updatable_handle = setupRegion(shared_register, *updatable_layout);
     regions.push_back({updatable_handle.data_ptr, std::move(updatable_layout)});
     handles[dataset_name + "/updatable"] = std::move(updatable_handle);
@@ -279,12 +313,16 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
 
     if (!only_metric)
     {
+        util::Log(logWARNING) << "CTudorache Storage::Run PopulateStaticData";
         PopulateStaticData(index);
     }
+    util::Log(logWARNING) << "CTudorache Storage::Run PopulateUpdatableData";
     PopulateUpdatableData(index);
 
+    util::Log(logWARNING) << "CTudorache Storage::Run swapData";
     swapData(monitor, shared_register, handles, max_wait);
 
+    util::Log(logWARNING) << "CTudorache Storage::Run DONE. SharedRegister: " << monitor.data().ToString();
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
# Issue

Osrm-datastore stability fixes:
- test if old shm segment exists before swapping data
- on signal handler (SIGTERM, SIGABRT, ..):
-- avoid deleting the global shared object "osrm-region" 
-- release the global mutex 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
