### PR TITLE
Immediately close bad connections to prevent file exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Changes from 5.25.0
     - API:
       - FIXED: Allow for special characters in the profile/method as part of the HTTP URL. [#6090](https://github.com/Project-OSRM/osrm-backend/pull/6090)
+      - FIXED: Set osrm-routed to immediately close bad connections [#6112](https://github.com/Project-OSRM/osrm-backend/pull/6112)
     - Build:
       - CHANGED: Replace Travis with Github Actions for CI builds [#6071](https://github.com/Project-OSRM/osrm-backend/pull/6071)
       - FIXED: Fixed Boost link flags in pkg-config file. [#6083](https://github.com/Project-OSRM/osrm-backend/pull/6083)

--- a/include/server/server.hpp
+++ b/include/server/server.hpp
@@ -101,6 +101,10 @@ class Server
                 new_connection->socket(),
                 boost::bind(&Server::HandleAccept, this, boost::asio::placeholders::error));
         }
+        else
+        {
+            util::Log(logERROR) << "HandleAccept error: " << e.message();
+        }
     }
 
     unsigned thread_pool_size;


### PR DESCRIPTION
`osrm-routed` does not immediately clean up a keep-alive connection when the client closes it. Instead it waits for five seconds of inactivity before removing.

Given a setup with low file limits and clients opening and closing a lot of keep-alive connections, it's possible for
`osrm-routed` to run out of file descriptors whilst it waits for the clean-up to trigger.

Furthermore, this causes the connection acceptor loop to exit.
Even after the old connections are cleaned up, new ones will not be created. Any new requests will block until the
server is restarted.

You can replicate this by limiting the number of open files (e.g. on Linux `ulimit -n 100`) and running a script that makes a curl request to a server endpoint in a loop.
```
while true
do
  curl "http://localhost:5000/match/v1/car/2.320208,48.702049;2.320521,48.702363;2.320843,48.702727;2.320874,48.702761;2.320874,48.702761;2.319644,48.701588" &>/dev/null
done
```

This commit improves the situation by:

- Immediately closing connections on error. This includes EOF errors
indicating that the client has closed the connection. This releases
resources early (including the open file) and doesn't wait for the
timer.

- Log when the acceptor loop exits. Whilst this means the behaviour
can still occur for reasons other than too many open files,
we will at least have visibility of the cause and can investigate further.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #6040 