### PR TITLE
Upgrade Boost to 1.70, fix inefficient connection handling

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -21,13 +21,13 @@ env:
 
 jobs:
   format-taginfo-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 10
+        node-version: 12
     - name: Enable Node.js cache
       uses: actions/cache@v2
       with:
@@ -54,33 +54,33 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: gcc-7-debug-cov
+          - name: gcc-9-debug-cov
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
-            CCOMPILER: gcc-7
+            CCOMPILER: gcc-9
             CUCUMBER_TIMEOUT: 20000
-            CXXCOMPILER: g++-7
+            CXXCOMPILER: g++-9
             ENABLE_COVERAGE: ON
 
-          - name: gcc-7-debug-asan
+          - name: gcc-9-debug-asan
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
-            CCOMPILER: gcc-7
+            CCOMPILER: gcc-9
             CUCUMBER_TIMEOUT: 20000
-            CXXCOMPILER: g++-7
+            CXXCOMPILER: g++-9
             ENABLE_SANITIZER: ON
             TARGET_ARCH: x86_64-asan
 
           - name: clang-5.0-debug
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
@@ -88,8 +88,8 @@ jobs:
 
           - name: mason-linux-debug-asan
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
@@ -98,27 +98,57 @@ jobs:
 
           - name: mason-linux-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_MASON: ON
 
+          - name: gcc-11-release
+            continue-on-error: false
+            node: 12
+            runs-on: ubuntu-20.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-11
+            CXXCOMPILER: g++-11
+
+          - name: gcc-10-release
+            continue-on-error: false
+            node: 12
+            runs-on: ubuntu-20.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-10
+            CXXCOMPILER: g++-10
+
           - name: gcc-9-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: gcc-9
             CXXCOMPILER: g++-9
             CXXFLAGS: -Wno-cast-function-type
 
+          - name: gcc-9-release-i686
+            continue-on-error: false
+            node: 12
+            runs-on: ubuntu-20.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-9
+            CFLAGS: "-m32 -msse2 -mfpmath=sse"
+            CXXCOMPILER: g++-9
+            CXXFLAGS: "-m32 -msse2 -mfpmath=sse"
+            TARGET_ARCH: i686
+
           - name: gcc-8-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: gcc-8
@@ -127,55 +157,12 @@ jobs:
 
           - name: gcc-7-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: gcc-7
             CXXCOMPILER: g++-7
-
-          - name: gcc-7-release-i686
-            continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-7
-            CFLAGS: "-m32 -msse2 -mfpmath=sse"
-            CXXCOMPILER: g++-7
-            CXXFLAGS: "-m32 -msse2 -mfpmath=sse"
-            TARGET_ARCH: i686
-
-          - name: gcc-5-release
-            continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-5
-            CXXCOMPILER: g++-5
-
-          - name: gcc-6-release
-            continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-6
-            CXXCOMPILER: g++-6
-
-          - name: mason-osx-release-node-10
-            build_node_package: true
-            continue-on-error: false
-            node: 10
-            runs-on: macos-10.15
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang
-            CXXCOMPILER: clang++
-            CUCUMBER_TIMEOUT: 60000
-            ENABLE_ASSERTIONS: ON
-            ENABLE_MASON: ON
 
           - name: mason-osx-release-node-12
             build_node_package: true
@@ -203,43 +190,34 @@ jobs:
             ENABLE_ASSERTIONS: ON
             ENABLE_MASON: ON
 
+          - name: mason-osx-release-node-16
+            build_node_package: true
+            continue-on-error: false
+            node: 16
+            runs-on: macos-10.15
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang
+            CXXCOMPILER: clang++
+            CUCUMBER_TIMEOUT: 60000
+            ENABLE_ASSERTIONS: ON
+            ENABLE_MASON: ON
+
           - name: gcc-7-release-shared
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             BUILD_SHARED_LIBS: ON
             CCOMPILER: gcc-7
             CXXCOMPILER: g++-7
 
-          - name: node-14-mason-linux-release
-            build_node_package: true
-            continue-on-error: false
-            node: 14
-            runs-on: ubuntu-18.04
-            BUILD_TYPE: Release
-            CLANG_VERSION: 5.0.0
-            ENABLE_GLIBC_WORKAROUND: ON
-            ENABLE_MASON: ON
-            NODE_PACKAGE_TESTS_ONLY: ON
-
-          - name: node-14-mason-linux-debug
-            build_node_package: true
-            continue-on-error: false
-            node: 14
-            runs-on: ubuntu-18.04
-            BUILD_TYPE: Debug
-            CLANG_VERSION: 5.0.0
-            ENABLE_GLIBC_WORKAROUND: ON
-            ENABLE_MASON: ON
-            NODE_PACKAGE_TESTS_ONLY: ON
-
           - name: node-12-mason-linux-release
             build_node_package: true
             continue-on-error: false
             node: 12
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -250,29 +228,52 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 12
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
             ENABLE_MASON: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
-          - name: node-10-mason-linux-release
+          - name: node-14-mason-linux-release
             build_node_package: true
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 14
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
             ENABLE_MASON: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
-          - name: node-10-mason-linux-debug
+          - name: node-14-mason-linux-debug
             build_node_package: true
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 14
+            runs-on: ubuntu-20.04
+            BUILD_TYPE: Debug
+            CLANG_VERSION: 5.0.0
+            ENABLE_GLIBC_WORKAROUND: ON
+            ENABLE_MASON: ON
+            NODE_PACKAGE_TESTS_ONLY: ON
+
+
+          - name: node-16-mason-linux-release
+            build_node_package: true
+            continue-on-error: false
+            node: 16
+            runs-on: ubuntu-20.04
+            BUILD_TYPE: Release
+            CLANG_VERSION: 5.0.0
+            ENABLE_GLIBC_WORKAROUND: ON
+            ENABLE_MASON: ON
+            NODE_PACKAGE_TESTS_ONLY: ON
+
+          - name: node-16-mason-linux-debug
+            build_node_package: true
+            continue-on-error: false
+            node: 16
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -297,7 +298,7 @@ jobs:
             continue-on-error: true
             # TODO: Use node 'latest' once supported: https://github.com/actions/setup-node/issues/257
             node: 16
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -309,7 +310,7 @@ jobs:
             continue-on-error: true
             # TODO: Use node 'latest' once supported: https://github.com/actions/setup-node/issues/257
             node: 16
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -332,7 +333,7 @@ jobs:
             build_node_package: true
             continue-on-error: true
             node: "lts/*"
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -343,7 +344,7 @@ jobs:
             build_node_package: true
             continue-on-error: true
             node: "lts/*"
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -410,7 +411,7 @@ jobs:
 
         if [[ "$ENABLE_SANITIZER" == 'ON' ]]; then
           # We can only set this after checkout once we know the workspace directory
-          echo "LSAN_OPTIONS=suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
+          echo "LSAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
         fi
 
         if [[ "${RUNNER_OS}" == "Linux" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
   - Changes from 5.26.0
+    - API:
+      - FIXED: Fix inefficient osrm-routed connection handling [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
     - Build:
       - CHANGED: Use Github Actions for building container images [#6138](https://github.com/Project-OSRM/osrm-backend/pull/6138)
+      - CHANGED: Upgrade Boost dependency to 1.70 [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - Build:
       - CHANGED: Use Github Actions for building container images [#6138](https://github.com/Project-OSRM/osrm-backend/pull/6138)
       - CHANGED: Upgrade Boost dependency to 1.70 [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
+      - CHANGED: Upgrade Ubuntu CI builds to 20.04  [#6119](https://github.com/Project-OSRM/osrm-backend/pull/6119)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 if(ENABLE_MASON)
   # versions in use
-  set(MASON_BOOST_VERSION "1.65.1")
+  set(MASON_BOOST_VERSION "1.73.0")
   set(MASON_EXPAT_VERSION "2.2.0")
   set(MASON_LUA_VERSION "5.2.4")
   set(MASON_BZIP2_VERSION "1.0.6")
@@ -521,7 +521,7 @@ if(ENABLE_MASON)
   include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include)
 else()
 
-  find_package(Boost 1.54 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+  find_package(Boost 1.70 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
   add_dependency_includes(${Boost_INCLUDE_DIRS})
 
   find_package(TBB REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -697,7 +697,7 @@ install(TARGETS osrm-components DESTINATION bin)
 if(BUILD_TOOLS)
   message(STATUS "Activating OSRM internal tools")
   add_executable(osrm-io-benchmark src/tools/io-benchmark.cpp $<TARGET_OBJECTS:UTIL>)
-  target_link_libraries(osrm-io-benchmark ${BOOST_BASE_LIBRARIES})
+  target_link_libraries(osrm-io-benchmark ${BOOST_BASE_LIBRARIES} ${TBB_LIBRARIES})
 
   install(TARGETS osrm-io-benchmark DESTINATION bin)
 endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim as builder
+FROM debian:bullseye-slim as builder
 ARG DOCKER_TAG
 ARG BUILD_CONCURRENCY
 RUN mkdir -p /src  && mkdir -p /opt
@@ -8,7 +8,7 @@ WORKDIR /src
 RUN NPROC=${BUILD_CONCURRENCY:-$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1)} && \
     apt-get update && \
     apt-get -y --no-install-recommends install cmake make git gcc g++ libbz2-dev libxml2-dev \
-    libzip-dev libboost1.62-all-dev lua5.2 liblua5.2-dev libtbb-dev -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 && \
+    libzip-dev libboost1.74-all-dev lua5.2 liblua5.2-dev libtbb-dev -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
@@ -30,12 +30,13 @@ RUN NPROC=${BUILD_CONCURRENCY:-$(grep -c ^processor /proc/cpuinfo 2>/dev/null ||
 
 # Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
-FROM debian:stretch-slim as runstage
+FROM debian:bullseye-slim as runstage
 RUN mkdir -p /src  && mkdir -p /opt
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libboost-program-options1.62.0 libboost-regex1.62.0 \
-        libboost-date-time1.62.0 libboost-chrono1.62.0 libboost-filesystem1.62.0 \
-        libboost-iostreams1.62.0 libboost-thread1.62.0 expat liblua5.2-0 libtbb2 &&\
+    apt-get install -y --no-install-recommends libboost-program-options1.74.0 libboost-regex1.74.0 \
+        libboost-date-time1.74.0 libboost-chrono1.74.0 libboost-filesystem1.74.0 \
+        libboost-iostreams1.74.0 libboost-system1.74.0 libboost-thread1.74.0 \
+        expat liblua5.2-0 libtbb2 &&\
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt /opt

--- a/include/server/connection.hpp
+++ b/include/server/connection.hpp
@@ -37,7 +37,7 @@ class RequestHandler;
 class Connection : public std::enable_shared_from_this<Connection>
 {
   public:
-    explicit Connection(boost::asio::io_service &io_service, RequestHandler &handler);
+    explicit Connection(boost::asio::io_context &io_context, RequestHandler &handler);
     Connection(const Connection &) = delete;
     Connection &operator=(const Connection &) = delete;
 
@@ -60,7 +60,7 @@ class Connection : public std::enable_shared_from_this<Connection>
     std::vector<char> compress_buffers(const std::vector<char> &uncompressed_data,
                                        const http::compression_type compression_type);
 
-    boost::asio::io_service::strand strand;
+    boost::asio::strand<boost::asio::io_context::executor_type> strand;
     boost::asio::ip::tcp::socket TCP_socket;
     boost::asio::deadline_timer timer;
     RequestHandler &request_handler;

--- a/scripts/ci/before_install.i686.sh
+++ b/scripts/ci/before_install.i686.sh
@@ -3,4 +3,4 @@
 sudo dpkg --add-architecture i386
 sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test && ( sudo apt-get update -qq --yes || true )
 
-sudo apt-get install -qq --yes --force-yes g++-7-multilib libxml2-dev:i386 libexpat1-dev:i386 libzip-dev:i386 libbz2-dev:i386 libtbb-dev:i386 lua5.2:i386 liblua5.2-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-iostreams-dev:i386 libboost-program-options-dev:i386 libboost-regex-dev:i386 libboost-system-dev:i386 libboost-thread-dev:i386 libboost-test-dev:i386
+sudo apt-get install -qq --yes --force-yes g++-9-multilib libxml2-dev:i386 libexpat1-dev:i386 libzip-dev:i386 libbz2-dev:i386 libtbb-dev:i386 lua5.2:i386 liblua5.2-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-iostreams-dev:i386 libboost-program-options-dev:i386 libboost-regex-dev:i386 libboost-system-dev:i386 libboost-thread-dev:i386 libboost-test-dev:i386


### PR DESCRIPTION
# Issue

A request to `osrm-routed` can be assigned to a thread which is currently busy processing another request, even when there
are other threads/cores available. This unnecessarily delays the response, and can make requests appear to hang when awaiting CPU intensive requests to finish.

See #6039 for details of how to reproduce the issue.

`osrm-routed` server implementation is heavily influenced by the [HTTP server 3 example](https://www.boost.org/doc/libs/1_65_0/doc/html/boost_asio/examples/cpp03_examples.html) in the
Boost.Asio docs. By upgrading to Boost 1.70 and updating the server connections to match the [example](https://www.boost.org/doc/libs/1_70_0/doc/html/boost_asio/example/cpp03/http/server3/connection.cpp) provided in the 1.70
release, the problem is resolved.

The diff of the changes to the Boost.Asio stack are [vast](https://github.com/boostorg/asio/commit/59066d80b26e1d5b83b60d127ee17948d9ae9702), so it's difficult to identify the exact cause. However
the implementation change is to push the `strand` of execution into the socket (and timer) objects, which suggests it's
fixing the type of threading issue we are observing.

This PR therefore also bumps the Boost dependency to >= 1.70. Given this was released over two years ago and many people will have already been using this version as a dependency when building OSRM, I see this as low risk.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #6039 
