### PR TITLE
Upgrade Ubuntu CI builds to use 20.04

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -21,13 +21,13 @@ env:
 
 jobs:
   format-taginfo-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 10
+        node-version: 12
     - name: Enable Node.js cache
       uses: actions/cache@v2
       with:
@@ -54,33 +54,33 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: gcc-7-debug-cov
+          - name: gcc-9-debug-cov
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
-            CCOMPILER: gcc-7
+            CCOMPILER: gcc-9
             CUCUMBER_TIMEOUT: 20000
-            CXXCOMPILER: g++-7
+            CXXCOMPILER: g++-9
             ENABLE_COVERAGE: ON
 
-          - name: gcc-7-debug-asan
+          - name: gcc-9-debug-asan
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
-            CCOMPILER: gcc-7
+            CCOMPILER: gcc-9
             CUCUMBER_TIMEOUT: 20000
-            CXXCOMPILER: g++-7
+            CXXCOMPILER: g++-9
             ENABLE_SANITIZER: ON
             TARGET_ARCH: x86_64-asan
 
           - name: clang-5.0-debug
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
@@ -88,8 +88,8 @@ jobs:
 
           - name: mason-linux-debug-asan
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
@@ -98,27 +98,57 @@ jobs:
 
           - name: mason-linux-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_MASON: ON
 
+          - name: gcc-11-release
+            continue-on-error: false
+            node: 12
+            runs-on: ubuntu-20.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-11
+            CXXCOMPILER: g++-11
+
+          - name: gcc-10-release
+            continue-on-error: false
+            node: 12
+            runs-on: ubuntu-20.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-10
+            CXXCOMPILER: g++-10
+
           - name: gcc-9-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: gcc-9
             CXXCOMPILER: g++-9
             CXXFLAGS: -Wno-cast-function-type
 
+          - name: gcc-9-release-i686
+            continue-on-error: false
+            node: 12
+            runs-on: ubuntu-20.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-9
+            CFLAGS: "-m32 -msse2 -mfpmath=sse"
+            CXXCOMPILER: g++-9
+            CXXFLAGS: "-m32 -msse2 -mfpmath=sse"
+            TARGET_ARCH: i686
+
           - name: gcc-8-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: gcc-8
@@ -127,55 +157,12 @@ jobs:
 
           - name: gcc-7-release
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: gcc-7
             CXXCOMPILER: g++-7
-
-          - name: gcc-7-release-i686
-            continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-7
-            CFLAGS: "-m32 -msse2 -mfpmath=sse"
-            CXXCOMPILER: g++-7
-            CXXFLAGS: "-m32 -msse2 -mfpmath=sse"
-            TARGET_ARCH: i686
-
-          - name: gcc-5-release
-            continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-5
-            CXXCOMPILER: g++-5
-
-          - name: gcc-6-release
-            continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-6
-            CXXCOMPILER: g++-6
-
-          - name: mason-osx-release-node-10
-            build_node_package: true
-            continue-on-error: false
-            node: 10
-            runs-on: macos-10.15
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang
-            CXXCOMPILER: clang++
-            CUCUMBER_TIMEOUT: 60000
-            ENABLE_ASSERTIONS: ON
-            ENABLE_MASON: ON
 
           - name: mason-osx-release-node-12
             build_node_package: true
@@ -203,43 +190,34 @@ jobs:
             ENABLE_ASSERTIONS: ON
             ENABLE_MASON: ON
 
+          - name: mason-osx-release-node-16
+            build_node_package: true
+            continue-on-error: false
+            node: 16
+            runs-on: macos-10.15
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang
+            CXXCOMPILER: clang++
+            CUCUMBER_TIMEOUT: 60000
+            ENABLE_ASSERTIONS: ON
+            ENABLE_MASON: ON
+
           - name: gcc-7-release-shared
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 12
+            runs-on: ubuntu-20.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             BUILD_SHARED_LIBS: ON
             CCOMPILER: gcc-7
             CXXCOMPILER: g++-7
 
-          - name: node-14-mason-linux-release
-            build_node_package: true
-            continue-on-error: false
-            node: 14
-            runs-on: ubuntu-18.04
-            BUILD_TYPE: Release
-            CLANG_VERSION: 5.0.0
-            ENABLE_GLIBC_WORKAROUND: ON
-            ENABLE_MASON: ON
-            NODE_PACKAGE_TESTS_ONLY: ON
-
-          - name: node-14-mason-linux-debug
-            build_node_package: true
-            continue-on-error: false
-            node: 14
-            runs-on: ubuntu-18.04
-            BUILD_TYPE: Debug
-            CLANG_VERSION: 5.0.0
-            ENABLE_GLIBC_WORKAROUND: ON
-            ENABLE_MASON: ON
-            NODE_PACKAGE_TESTS_ONLY: ON
-
           - name: node-12-mason-linux-release
             build_node_package: true
             continue-on-error: false
             node: 12
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -250,29 +228,52 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 12
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
             ENABLE_MASON: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
-          - name: node-10-mason-linux-release
+          - name: node-14-mason-linux-release
             build_node_package: true
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 14
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
             ENABLE_MASON: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
-          - name: node-10-mason-linux-debug
+          - name: node-14-mason-linux-debug
             build_node_package: true
             continue-on-error: false
-            node: 10
-            runs-on: ubuntu-18.04
+            node: 14
+            runs-on: ubuntu-20.04
+            BUILD_TYPE: Debug
+            CLANG_VERSION: 5.0.0
+            ENABLE_GLIBC_WORKAROUND: ON
+            ENABLE_MASON: ON
+            NODE_PACKAGE_TESTS_ONLY: ON
+
+
+          - name: node-16-mason-linux-release
+            build_node_package: true
+            continue-on-error: false
+            node: 16
+            runs-on: ubuntu-20.04
+            BUILD_TYPE: Release
+            CLANG_VERSION: 5.0.0
+            ENABLE_GLIBC_WORKAROUND: ON
+            ENABLE_MASON: ON
+            NODE_PACKAGE_TESTS_ONLY: ON
+
+          - name: node-16-mason-linux-debug
+            build_node_package: true
+            continue-on-error: false
+            node: 16
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -297,7 +298,7 @@ jobs:
             continue-on-error: true
             # TODO: Use node 'latest' once supported: https://github.com/actions/setup-node/issues/257
             node: 16
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -309,7 +310,7 @@ jobs:
             continue-on-error: true
             # TODO: Use node 'latest' once supported: https://github.com/actions/setup-node/issues/257
             node: 16
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -332,7 +333,7 @@ jobs:
             build_node_package: true
             continue-on-error: true
             node: "lts/*"
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Release
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -343,7 +344,7 @@ jobs:
             build_node_package: true
             continue-on-error: true
             node: "lts/*"
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
             BUILD_TYPE: Debug
             CLANG_VERSION: 5.0.0
             ENABLE_GLIBC_WORKAROUND: ON
@@ -410,7 +411,7 @@ jobs:
 
         if [[ "$ENABLE_SANITIZER" == 'ON' ]]; then
           # We can only set this after checkout once we know the workspace directory
-          echo "LSAN_OPTIONS=suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
+          echo "LSAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
         fi
 
         if [[ "${RUNNER_OS}" == "Linux" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Build:
       - CHANGED: Replace Travis with Github Actions for CI builds [#6071](https://github.com/Project-OSRM/osrm-backend/pull/6071)
       - FIXED: Fixed Boost link flags in pkg-config file. [#6083](https://github.com/Project-OSRM/osrm-backend/pull/6083)
+      - CHANGED: Upgrade Ubuntu CI builds to 20.04  [#6119](https://github.com/Project-OSRM/osrm-backend/pull/6119)
     - Routing:
       - FIXED: Fix generation of inefficient MLD partitions [#6084](https://github.com/Project-OSRM/osrm-backend/pull/6084)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -697,7 +697,7 @@ install(TARGETS osrm-components DESTINATION bin)
 if(BUILD_TOOLS)
   message(STATUS "Activating OSRM internal tools")
   add_executable(osrm-io-benchmark src/tools/io-benchmark.cpp $<TARGET_OBJECTS:UTIL>)
-  target_link_libraries(osrm-io-benchmark ${BOOST_BASE_LIBRARIES})
+  target_link_libraries(osrm-io-benchmark ${BOOST_BASE_LIBRARIES} ${TBB_LIBRARIES})
 
   install(TARGETS osrm-io-benchmark DESTINATION bin)
 endif()

--- a/scripts/ci/before_install.i686.sh
+++ b/scripts/ci/before_install.i686.sh
@@ -3,4 +3,4 @@
 sudo dpkg --add-architecture i386
 sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test && ( sudo apt-get update -qq --yes || true )
 
-sudo apt-get install -qq --yes --force-yes g++-7-multilib libxml2-dev:i386 libexpat1-dev:i386 libzip-dev:i386 libbz2-dev:i386 libtbb-dev:i386 lua5.2:i386 liblua5.2-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-iostreams-dev:i386 libboost-program-options-dev:i386 libboost-regex-dev:i386 libboost-system-dev:i386 libboost-thread-dev:i386 libboost-test-dev:i386
+sudo apt-get install -qq --yes --force-yes g++-9-multilib libxml2-dev:i386 libexpat1-dev:i386 libzip-dev:i386 libbz2-dev:i386 libtbb-dev:i386 lua5.2:i386 liblua5.2-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-iostreams-dev:i386 libboost-program-options-dev:i386 libboost-regex-dev:i386 libboost-system-dev:i386 libboost-thread-dev:i386 libboost-test-dev:i386


### PR DESCRIPTION
# Issue
Moves Linux CI builds to the latest Ubuntu LTS.
- Bumps the GCC matrix to versions {7,8,9,10,11}, making 9 the default
for testing non-standard builds.
- Bump Node matrix to {12,14,16,LTS,latest} now that 10 is EOL.
- Fixes to CI builds due to library changes on newer distro.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
