### PR TITLE
Fix MLD level mask generation to support 64-bit masks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
       - FIXED: Fixed Boost link flags in pkg-config file. [#6083](https://github.com/Project-OSRM/osrm-backend/pull/6083)
     - Routing:
       - FIXED: Fix generation of inefficient MLD partitions [#6084](https://github.com/Project-OSRM/osrm-backend/pull/6084)
+      - FIXED: Fix MLD level mask generation to support 64-bit masks. [#6123](https://github.com/Project-OSRM/osrm-backend/pull/6123)
 
 # 5.25.0
   - Changes from 5.24.0


### PR DESCRIPTION
# Issue

As discovered in #6121

The generation of level masks for compactly storing partition cells supports sizes that can be stored in 64 bits.

The current implementation fails if the total bit sum is 64 bits exactly. A bit shift mechanism is used that is undefined when the
shift size is equal to the bit size of the underlying type. This generates an incorrect mask value.

We fix this by adding a special case for a 64 bit offset. Given this code is called at most |level| times, there will be no effect on
performance. We also update the assertions to reflect 64 bit masks are now supported.


## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
