### PR TITLE
Fix metric offset overflow for large MLD partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
       - FIXED: Fixed Boost link flags in pkg-config file. [#6083](https://github.com/Project-OSRM/osrm-backend/pull/6083)
     - Routing:
       - FIXED: Fix generation of inefficient MLD partitions [#6084](https://github.com/Project-OSRM/osrm-backend/pull/6084)
+      - FIXED: Fix metric offset overflow for large MLD partitions. This breaks the **data format** [#6124](https://github.com/Project-OSRM/osrm-backend/pull/6124)
 
 # 5.25.0
   - Changes from 5.24.0

--- a/include/partitioner/cell_storage.hpp
+++ b/include/partitioner/cell_storage.hpp
@@ -52,11 +52,9 @@ namespace detail
 template <storage::Ownership Ownership> class CellStorageImpl
 {
   public:
-    using ValueOffset = std::uint32_t;
-    using BoundaryOffset = std::uint32_t;
+    using ValueOffset = std::uint64_t;
+    using BoundaryOffset = std::uint64_t;
     using BoundarySize = std::uint32_t;
-    using SourceIndex = std::uint32_t;
-    using DestinationIndex = std::uint32_t;
 
     static constexpr auto INVALID_VALUE_OFFSET = std::numeric_limits<ValueOffset>::max();
     static constexpr auto INVALID_BOUNDARY_OFFSET = std::numeric_limits<BoundaryOffset>::max();


### PR DESCRIPTION
# Issue
As discovered in #6121

Each MLD cell has source and destination nodes. MLD is keeping a |source| x |destination| sized table
for various metrics (distances, durations, etc) from each source to all destinations in a cell.

It stores all of the values for a metric in one large array, with an offset for each cell to find its values. The offset is currently
limited to 32 bit values, which overflows on very large graphs (e.g. Planet OSM).

We fix this by changing the offsets to be uint64_t types.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
