### PR TITLE
Restrict test cache restoration

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -397,8 +397,6 @@ jobs:
       with:
         path: ${{github.workspace}}/test/cache
         key: test-${{ matrix.name }}-${{ github.sha }}
-        restore-keys: |
-          test-${{ matrix.name }}-
 
     - name: Prepare environment
       run: |


### PR DESCRIPTION
# Issue
There is currently no way to invalidate the cache (https://github.com/actions/cache/issues/2), so master won't pass CI if a breaking change has been made to the binary data formats.

Fix this by only restoring test cache from the same commit SHA.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
