### PR TITLE
Fix for_each_indexed util function

### DIFF
--- a/include/util/for_each_indexed.hpp
+++ b/include/util/for_each_indexed.hpp
@@ -20,7 +20,7 @@ void for_each_indexed(ForwardIterator first, ForwardIterator last, Function func
 }
 
 template <class ContainerT, typename Function>
-void for_each_pair(ContainerT &container, Function function)
+void for_each_indexed(ContainerT &container, Function function)
 {
     for_each_indexed(std::begin(container), std::end(container), function);
 }

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -747,7 +747,7 @@ ExtractionContainers::ReferencedWays ExtractionContainers::IdentifyManeuverOverr
 
     // Then, populate the values in that hashtable for only the ways
     // referenced
-    util::for_each_indexed(ways_list.cbegin(), ways_list.cend(), set_ids);
+    util::for_each_indexed(ways_list, set_ids);
 
     TIMER_STOP(identify_maneuver_override_ways);
     log << "ok, after " << TIMER_SEC(identify_maneuver_override_ways) << "s";
@@ -972,7 +972,7 @@ ExtractionContainers::ReferencedWays ExtractionContainers::IdentifyRestrictionWa
         }
     };
 
-    util::for_each_indexed(ways_list.cbegin(), ways_list.cend(), set_ids);
+    util::for_each_indexed(ways_list, set_ids);
     TIMER_STOP(identify_restriction_ways);
     log << "ok, after " << TIMER_SEC(identify_restriction_ways) << "s";
 

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -403,9 +403,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                                                   parsed_way.forward_travel_mode,
                                                                   parsed_way.is_left_hand_driving});
         util::for_each_pair(
-            nodes.cbegin(),
-            nodes.cend(),
-            [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
+            nodes, [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
                 NodeBasedEdgeWithOSM edge = {
                     OSMNodeID{static_cast<std::uint64_t>(first_node.ref())},
                     OSMNodeID{static_cast<std::uint64_t>(last_node.ref())},
@@ -439,9 +437,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
                                                                   parsed_way.backward_travel_mode,
                                                                   parsed_way.is_left_hand_driving});
         util::for_each_pair(
-            nodes.cbegin(),
-            nodes.cend(),
-            [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
+            nodes, [&](const osmium::NodeRef &first_node, const osmium::NodeRef &last_node) {
                 NodeBasedEdgeWithOSM edge = {
                     OSMNodeID{static_cast<std::uint64_t>(first_node.ref())},
                     OSMNodeID{static_cast<std::uint64_t>(last_node.ref())},

--- a/src/extractor/restriction_graph.cpp
+++ b/src/extractor/restriction_graph.cpp
@@ -215,8 +215,7 @@ void buildGraph(RestrictionGraph &rg, const std::vector<TurnRestriction> &restri
         if (restriction.Type() == RestrictionType::WAY_RESTRICTION)
         {
             const auto &way_restriction = restriction.AsWayRestriction();
-            util::for_each_pair(way_restriction.via.begin(),
-                                way_restriction.via.end(),
+            util::for_each_pair(way_restriction.via,
                                 [&](NodeID from, NodeID to) { builder.next(from, to); });
         }
         builder.end(restriction);

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -4,14 +4,11 @@
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/files.hpp"
-#include "extractor/node_based_edge.hpp"
 #include "extractor/packed_osm_ids.hpp"
 #include "extractor/restriction.hpp"
 #include "extractor/serialization.hpp"
 
 #include "guidance/files.hpp"
-
-#include "storage/io.hpp"
 
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
@@ -20,7 +17,6 @@
 #include "util/log.hpp"
 #include "util/mmap_tar.hpp"
 #include "util/opening_hours.hpp"
-#include "util/static_graph.hpp"
 #include "util/static_rtree.hpp"
 #include "util/string_util.hpp"
 #include "util/timezones.hpp"
@@ -29,10 +25,6 @@
 
 #include <boost/assert.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/index/rtree.hpp>
-#include <boost/interprocess/file_mapping.hpp>
-#include <boost/interprocess/mapped_region.hpp>
 
 #include <tbb/blocked_range.h>
 #include <tbb/concurrent_vector.h>
@@ -45,10 +37,8 @@
 #include <atomic>
 #include <bitset>
 #include <cstdint>
-#include <fstream>
 #include <iterator>
 #include <memory>
-#include <thread>
 #include <tuple>
 #include <vector>
 

--- a/unit_tests/partitioner/multi_level_partition.cpp
+++ b/unit_tests/partitioner/multi_level_partition.cpp
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(cell_64_bits)
         }
         levels_to_num_cells[level] = num_cells;
     };
-    util::for_each_indexed(level_cells.cbegin(), level_cells.cend(), set_level_cells);
+    util::for_each_indexed(level_cells, set_level_cells);
 
     MultiLevelPartition mlp{levels, levels_to_num_cells};
 
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(cell_overflow_bits)
         }
         levels_to_num_cells[level] = num_cells;
     };
-    util::for_each_indexed(level_cells.cbegin(), level_cells.cend(), set_level_cells);
+    util::for_each_indexed(level_cells, set_level_cells);
 
     BOOST_REQUIRE_EXCEPTION(MultiLevelPartition(levels, levels_to_num_cells),
                             util::exception,


### PR DESCRIPTION
# Issue
- Fix typo in util function name `for_each_indexed`.
- Use the overloaded functions `for_each_indexed` and `for_each_pair`
  with a container argument where possible to improve readability.