### PR TITLE
Support OSM traffic signal directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
       - FIXED: Improvements to maneuver override processing [#6125](https://github.com/Project-OSRM/osrm-backend/pull/6125)
       - ADDED: Support snapping to multiple ways at an input location. [#5953](https://github.com/Project-OSRM/osrm-backend/pull/5953)
       - FIXED: Fix snapping target locations to ways used in turn restrictions. [#6339](https://github.com/Project-OSRM/osrm-backend/pull/6339)
+      - ADDED: Support OSM traffic signal directions. [#6153](https://github.com/Project-OSRM/osrm-backend/pull/6153)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/features/car/traffic_light_penalties.feature
+++ b/features/car/traffic_light_penalties.feature
@@ -39,7 +39,113 @@ Feature: Car - Handle traffic lights
             | k    | n  |  20.7s | turn with traffic light       |
 
 
-    Scenario: Tarrif Signal Geometry
+    Scenario: Car - Traffic signal direction
+        Given the node map
+            """
+            a-1-b-2-c
+
+            d-3-e-4-f
+
+            g-5-h-6-i
+
+            j-7-k-8-l
+
+            """
+
+        And the ways
+            | nodes | highway |
+            | abc   | primary |
+            | def   | primary |
+            | ghi   | primary |
+            | jkl   | primary |
+
+        And the nodes
+            | node | highway         | traffic_signals:direction |
+            | e    | traffic_signals |                           |
+            | h    | traffic_signals | forward                   |
+            | k    | traffic_signals | backward                  |
+
+        When I route I should get
+            | from | to | time   | #                             |
+            | 1    | 2  |  11.1s | no turn with no traffic light |
+            | 2    | 1  |  11.1s | no turn with no traffic light |
+            | 3    | 4  |  13.1s | no turn with traffic light    |
+            | 4    | 3  |  13.1s | no turn with traffic light    |
+            | 5    | 6  |  13.1s | no turn with traffic light    |
+            | 6    | 5  |  11.1s | no turn with no traffic light |
+            | 7    | 8  |  11.1s | no turn with no traffic light |
+            | 8    | 7  |  13.1s | no turn with traffic light    |
+
+
+    Scenario: Car - Encounters a traffic light
+        Given the node map
+            """
+              a      f      k
+              |      |      |
+            b-c-d  h-g-i  l-m-n
+              |      |      |
+              e      j      o
+
+            """
+
+        And the ways
+            | nodes | highway |
+            | bcd   | primary |
+            | ace   | primary |
+            | hgi   | primary |
+            | fgj   | primary |
+            | lmn   | primary |
+            | kmo   | primary |
+
+        And the nodes
+            | node | highway         | traffic_signals:direction |
+            | g    | traffic_signals | forward                   |
+            | m    | traffic_signals | backward                  |
+
+
+        When I route I should get
+            | from | to | time   | #                             |
+            | a    | d  | 21.9s  | no turn with no traffic light |
+            | a    | e  | 22.2s  | no turn with traffic light    |
+            | a    | b  | 18.7s  | turn with no traffic light    |
+            | e    | b  | 21.9s  | no turn with no traffic light |
+            | e    | a  | 22.2s  | no turn with traffic light    |
+            | e    | d  | 18.7s  | turn with no traffic light    |
+            | d    | e  | 21.9s  | no turn with no traffic light |
+            | d    | b  | 11s    | no turn with traffic light    |
+            | d    | a  | 18.7s  | turn with no traffic light    |
+            | b    | a  | 21.9s  | no turn with no traffic light |
+            | b    | d  | 11s    | no turn with traffic light    |
+            | b    | e  | 18.7s  | turn with no traffic light    |
+
+            | f    | i  | 23.9s  | no turn with no traffic light |
+            | f    | j  | 24.2s  | no turn with traffic light    |
+            | f    | h  | 20.7s  | turn with no traffic light    |
+            | j    | h  | 21.9s  | no turn with no traffic light |
+            | j    | f  | 22.2s  | no turn with traffic light    |
+            | j    | i  | 18.7s  | turn with no traffic light    |
+            | i    | j  | 21.9s  | no turn with no traffic light |
+            | i    | h  | 11s    | no turn with traffic light    |
+            | i    | f  | 18.7s  | turn with no traffic light    |
+            | h    | f  | 23.9s  | no turn with no traffic light |
+            | h    | i  | 13s    | no turn with traffic light    |
+            | h    | j  | 20.7s  | turn with no traffic light    |
+
+            | k    | n  | 21.9s  | no turn with no traffic light |
+            | k    | o  | 22.2s  | no turn with traffic light    |
+            | k    | l  | 18.7s  | turn with no traffic light    |
+            | o    | l  | 23.9s  | no turn with no traffic light |
+            | o    | k  | 24.2s  | no turn with traffic light    |
+            | o    | n  | 20.7s  | turn with no traffic light    |
+            | n    | o  | 23.9s  | no turn with no traffic light |
+            | n    | l  | 13s    | no turn with traffic light    |
+            | n    | k  | 20.7s  | turn with no traffic light    |
+            | l    | k  | 21.9s  | no turn with no traffic light |
+            | l    | n  | 11s    | no turn with traffic light    |
+            | l    | o  | 18.7s  | turn with no traffic light    |
+
+
+    Scenario: Traffic Signal Geometry
         Given the query options
             | overview   | full      |
             | geometries | polyline  |
@@ -60,6 +166,53 @@ Feature: Car - Handle traffic lights
         When I route I should get
             | from | to | route   | geometry       |
             | a    | c  | abc,abc | _ibE_ibE?gJ?eJ |
+
+
+    Scenario: Traffic Signal Geometry - forward signal
+        Given the query options
+            | overview   | full      |
+            | geometries | polyline  |
+
+        Given the node map
+            """
+            a - b - c
+            """
+
+        And the ways
+            | nodes | highway |
+            | abc   | primary |
+
+        And the nodes
+            | node | highway         | traffic_signals:direction |
+            | b    | traffic_signals | forward                   |
+
+        When I route I should get
+            | from | to | route   | geometry       |
+            | a    | c  | abc,abc | _ibE_ibE?gJ?eJ |
+
+
+    Scenario: Traffic Signal Geometry - reverse signal
+        Given the query options
+            | overview   | full      |
+            | geometries | polyline  |
+
+        Given the node map
+            """
+            a - b - c
+            """
+
+        And the ways
+            | nodes | highway |
+            | abc   | primary |
+
+        And the nodes
+            | node | highway         | traffic_signals:direction |
+            | b    | traffic_signals | reverse                   |
+
+        When I route I should get
+            | from | to | route   | geometry       |
+            | a    | c  | abc,abc | _ibE_ibE?gJ?eJ |
+
 
     @traffic
     Scenario: Traffic update on the edge with a traffic signal
@@ -90,4 +243,68 @@ Feature: Car - Handle traffic lights
         When I route I should get
           | from | to | route   | speed   | weights | time  | distances | a:datasources | a:nodes | a:speed | a:duration |  a:weight |
           | a    | c  | abc,abc | 60 km/h | 24.2,0  | 24.2s | 400m,0m   |           1:0 |  1:2:3  |   18:18 |  11.1:11.1 | 11.1:11.1 |
+          | c    | a  | abc,abc | 60 km/h | 24.2,0  | 24.2s | 400m,0m   |           0:1 |  3:2:1  |   18:18 |  11.1:11.1 | 11.1:11.1 |
+
+
+    @traffic
+    Scenario: Traffic update on the edge with a traffic signal - forward
+        Given the node map
+            """
+            a - b - c
+            """
+
+        And the ways
+          | nodes | highway |
+          | abc   | primary |
+
+
+        And the nodes
+            | node | highway         | traffic_signals:direction |
+            | b    | traffic_signals | forward                   |
+
+        And the contract extra arguments "--segment-speed-file {speeds_file}"
+        And the customize extra arguments "--segment-speed-file {speeds_file}"
+        And the speed file
+        """
+        1,2,65
+        2,1,65
+        """
+        And the query options
+          | annotations | datasources,nodes,speed,duration,weight |
+
+        When I route I should get
+          | from | to | route   | speed   | weights | time  | distances | a:datasources | a:nodes | a:speed | a:duration |  a:weight |
+          | a    | c  | abc,abc | 60 km/h | 24.2,0  | 24.2s | 400m,0m   |           1:0 |  1:2:3  |   18:18 |  11.1:11.1 | 11.1:11.1 |
+          | c    | a  | abc,abc | 65 km/h | 22.2,0  | 22.2s | 400m,0m   |           0:1 |  3:2:1  |   18:18 |  11.1:11.1 | 11.1:11.1 |
+
+
+    @traffic
+    Scenario: Traffic update on the edge with a traffic signal - backward
+        Given the node map
+            """
+            a - b - c
+            """
+
+        And the ways
+          | nodes | highway |
+          | abc   | primary |
+
+
+        And the nodes
+            | node | highway         | traffic_signals:direction |
+            | b    | traffic_signals | backward                  |
+
+        And the contract extra arguments "--segment-speed-file {speeds_file}"
+        And the customize extra arguments "--segment-speed-file {speeds_file}"
+        And the speed file
+        """
+        1,2,65
+        2,1,65
+        """
+        And the query options
+          | annotations | datasources,nodes,speed,duration,weight |
+
+        When I route I should get
+          | from | to | route   | speed   | weights | time  | distances | a:datasources | a:nodes | a:speed | a:duration |  a:weight |
+          | a    | c  | abc,abc | 65 km/h | 22.2,0  | 22.2s | 400m,0m   |           1:0 |  1:2:3  |   18:18 |  11.1:11.1 | 11.1:11.1 |
           | c    | a  | abc,abc | 60 km/h | 24.2,0  | 24.2s | 400m,0m   |           0:1 |  3:2:1  |   18:18 |  11.1:11.1 | 11.1:11.1 |

--- a/include/extractor/edge_based_graph_factory.hpp
+++ b/include/extractor/edge_based_graph_factory.hpp
@@ -23,6 +23,7 @@
 #include "util/typedefs.hpp"
 
 #include "storage/io.hpp"
+#include "traffic_signals.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -68,7 +69,7 @@ class EdgeBasedGraphFactory
                                    EdgeBasedNodeDataContainer &node_data_container,
                                    const CompressedEdgeContainer &compressed_edge_container,
                                    const std::unordered_set<NodeID> &barrier_nodes,
-                                   const std::unordered_set<NodeID> &traffic_lights,
+                                   const TrafficSignals &traffic_signals,
                                    const std::vector<util::Coordinate> &coordinates,
                                    const NameTable &name_table,
                                    const std::unordered_set<EdgeID> &segregated_edges,
@@ -134,7 +135,7 @@ class EdgeBasedGraphFactory
     const util::NodeBasedDynamicGraph &m_node_based_graph;
 
     const std::unordered_set<NodeID> &m_barrier_nodes;
-    const std::unordered_set<NodeID> &m_traffic_lights;
+    const TrafficSignals &m_traffic_signals;
     const CompressedEdgeContainer &m_compressed_edge_container;
 
     const NameTable &name_table;

--- a/include/extractor/extraction_node.hpp
+++ b/include/extractor/extraction_node.hpp
@@ -1,6 +1,8 @@
 #ifndef EXTRACTION_NODE_HPP
 #define EXTRACTION_NODE_HPP
 
+#include "traffic_lights.hpp"
+
 namespace osrm
 {
 namespace extractor
@@ -8,9 +10,13 @@ namespace extractor
 
 struct ExtractionNode
 {
-    ExtractionNode() : traffic_lights(false), barrier(false) {}
-    void clear() { traffic_lights = barrier = false; }
-    bool traffic_lights;
+    ExtractionNode() : traffic_lights(TrafficLightClass::NONE), barrier(false) {}
+    void clear()
+    {
+        traffic_lights = TrafficLightClass::NONE;
+        barrier = false;
+    }
+    TrafficLightClass::Direction traffic_lights;
     bool barrier;
 };
 } // namespace extractor

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -43,6 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "util/guidance/turn_lanes.hpp"
 
 #include "restriction_graph.hpp"
+#include "traffic_signals.hpp"
 #include "util/typedefs.hpp"
 
 namespace osrm
@@ -64,7 +65,8 @@ class Extractor
 
     std::tuple<LaneDescriptionMap,
                std::vector<TurnRestriction>,
-               std::vector<UnresolvedManeuverOverride>>
+               std::vector<UnresolvedManeuverOverride>,
+               TrafficSignals>
     ParseOSMData(ScriptingEnvironment &scripting_environment, const unsigned number_of_threads);
 
     EdgeID BuildEdgeExpandedGraph(
@@ -73,7 +75,7 @@ class Extractor
         const std::vector<util::Coordinate> &coordinates,
         const CompressedEdgeContainer &compressed_edge_container,
         const std::unordered_set<NodeID> &barrier_nodes,
-        const std::unordered_set<NodeID> &traffic_lights,
+        const TrafficSignals &traffic_signals,
         const RestrictionGraph &restriction_graph,
         const std::unordered_set<EdgeID> &segregated_edges,
         const NameTable &name_table,

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -444,10 +444,9 @@ inline void readConditionalRestrictions(const boost::filesystem::path &path,
 }
 
 // reads .osrm file which is a temporary file of osrm-extract
-template <typename BarrierOutIter, typename TrafficSignalsOutIter, typename PackedOSMIDsT>
+template <typename BarrierOutIter, typename PackedOSMIDsT>
 void readRawNBGraph(const boost::filesystem::path &path,
                     BarrierOutIter barriers,
-                    TrafficSignalsOutIter traffic_signals,
                     std::vector<util::Coordinate> &coordinates,
                     PackedOSMIDsT &osm_node_ids,
                     std::vector<extractor::NodeBasedEdge> &edge_list,
@@ -470,8 +469,6 @@ void readRawNBGraph(const boost::filesystem::path &path,
                                                boost::make_function_output_iterator(decode));
 
     reader.ReadStreaming<NodeID>("/extractor/barriers", barriers);
-
-    reader.ReadStreaming<NodeID>("/extractor/traffic_lights", traffic_signals);
 
     storage::serialization::read(reader, "/extractor/edges", edge_list);
     storage::serialization::read(reader, "/extractor/annotations", annotations);

--- a/include/extractor/graph_compressor.hpp
+++ b/include/extractor/graph_compressor.hpp
@@ -4,6 +4,7 @@
 #include "extractor/scripting_environment.hpp"
 #include "util/typedefs.hpp"
 
+#include "traffic_signals.hpp"
 #include "util/node_based_graph.hpp"
 
 #include <memory>
@@ -25,7 +26,7 @@ class GraphCompressor
 
   public:
     void Compress(const std::unordered_set<NodeID> &barrier_nodes,
-                  const std::unordered_set<NodeID> &traffic_lights,
+                  const TrafficSignals &traffic_signals,
                   ScriptingEnvironment &scripting_environment,
                   std::vector<TurnRestriction> &turn_restrictions,
                   std::vector<UnresolvedManeuverOverride> &maneuver_overrides,

--- a/include/extractor/node_based_graph_factory.hpp
+++ b/include/extractor/node_based_graph_factory.hpp
@@ -8,6 +8,7 @@
 #include "extractor/packed_osm_ids.hpp"
 #include "extractor/scripting_environment.hpp"
 
+#include "traffic_signals.hpp"
 #include "util/coordinate.hpp"
 #include "util/node_based_graph.hpp"
 
@@ -40,11 +41,11 @@ class NodeBasedGraphFactory
     NodeBasedGraphFactory(const boost::filesystem::path &input_file,
                           ScriptingEnvironment &scripting_environment,
                           std::vector<TurnRestriction> &turn_restrictions,
-                          std::vector<UnresolvedManeuverOverride> &maneuver_overrides);
+                          std::vector<UnresolvedManeuverOverride> &maneuver_overrides,
+                          const TrafficSignals &traffic_signals);
 
     auto const &GetGraph() const { return compressed_output_graph; }
     auto const &GetBarriers() const { return barriers; }
-    auto const &GetTrafficSignals() const { return traffic_signals; }
     auto const &GetCompressedEdges() const { return compressed_edge_container; }
     auto const &GetCoordinates() const { return coordinates; }
     auto const &GetAnnotationData() const { return annotation_data; }
@@ -68,7 +69,8 @@ class NodeBasedGraphFactory
     // edges into a single representative form
     void Compress(ScriptingEnvironment &scripting_environment,
                   std::vector<TurnRestriction> &turn_restrictions,
-                  std::vector<UnresolvedManeuverOverride> &maneuver_overrides);
+                  std::vector<UnresolvedManeuverOverride> &maneuver_overrides,
+                  const TrafficSignals &traffic_signals);
 
     // Most ways are bidirectional, making the geometry in forward and backward direction the same,
     // except for reversal. We make use of this fact by keeping only one representation of the
@@ -89,7 +91,6 @@ class NodeBasedGraphFactory
 
     // General Information about the graph, not used outside of extractor
     std::unordered_set<NodeID> barriers;
-    std::unordered_set<NodeID> traffic_signals;
 
     std::vector<util::Coordinate> coordinates;
 

--- a/include/extractor/traffic_lights.hpp
+++ b/include/extractor/traffic_lights.hpp
@@ -1,0 +1,25 @@
+#ifndef OSRM_EXTRACTOR_TRAFFIC_LIGHTS_DATA_HPP_
+#define OSRM_EXTRACTOR_TRAFFIC_LIGHTS_DATA_HPP_
+
+namespace osrm
+{
+namespace extractor
+{
+
+namespace TrafficLightClass
+{
+// The traffic light annotation is extracted from node tags.
+// The directions in which the traffic light applies are relative to the way containing the node.
+enum Direction
+{
+    NONE = 0,
+    DIRECTION_ALL = 1,
+    DIRECTION_FORWARD = 2,
+    DIRECTION_REVERSE = 3
+};
+} // namespace TrafficLightClass
+
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_TRAFFIC_LIGHTS_DATA_HPP_

--- a/include/extractor/traffic_signals.hpp
+++ b/include/extractor/traffic_signals.hpp
@@ -1,0 +1,28 @@
+#ifndef OSRM_EXTRACTOR_TRAFFIC_SIGNALS_HPP
+#define OSRM_EXTRACTOR_TRAFFIC_SIGNALS_HPP
+
+#include "util/typedefs.hpp"
+#include <unordered_set>
+
+#include <boost/unordered_set.hpp>
+
+namespace osrm
+{
+namespace extractor
+{
+
+struct TrafficSignals
+{
+    std::unordered_set<NodeID> bidirectional_nodes;
+    std::unordered_set<std::pair<NodeID, NodeID>, boost::hash<std::pair<NodeID, NodeID>>>
+        unidirectional_segments;
+
+    inline bool HasSignal(NodeID from, NodeID to) const
+    {
+        return bidirectional_nodes.count(to) > 0 || unidirectional_segments.count({from, to}) > 0;
+    }
+};
+} // namespace extractor
+} // namespace osrm
+
+#endif // OSRM_EXTRACTOR_TRAFFIC_SIGNALS_HPP

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -5,6 +5,7 @@ api_version = 4
 Set = require('lib/set')
 Sequence = require('lib/sequence')
 Handlers = require("lib/way_handlers")
+TrafficSignal = require("lib/traffic_signal")
 find_access_tag = require("lib/access").find_access_tag
 limit = require("lib/maxspeed").limit
 Measure = require("lib/measure")
@@ -235,10 +236,7 @@ function process_node(profile, node, result)
   end
 
   -- check if node is a traffic light
-  local tag = node:get_value_by_key("highway")
-  if tag and "traffic_signals" == tag then
-    result.traffic_lights = true
-  end
+  result.traffic_lights = TrafficSignal.get_value(node)
 end
 
 function handle_bicycle_tags(profile,way,result,data)

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -6,6 +6,7 @@ Set = require('lib/set')
 Sequence = require('lib/sequence')
 Handlers = require("lib/way_handlers")
 Relations = require("lib/relations")
+TrafficSignal = require("lib/traffic_signal")
 find_access_tag = require("lib/access").find_access_tag
 limit = require("lib/maxspeed").limit
 Utils = require("lib/utils")
@@ -360,10 +361,7 @@ function process_node(profile, node, result, relations)
   end
 
   -- check if node is a traffic light
-  local tag = node:get_value_by_key("highway")
-  if "traffic_signals" == tag then
-    result.traffic_lights = true
-  end
+  result.traffic_lights = TrafficSignal.get_value(node)
 end
 
 function process_way(profile, way, result, relations)

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -157,6 +157,7 @@ function process_node(profile, node, result)
   -- check if node is a traffic light
   local tag = node:get_value_by_key("highway")
   if "traffic_signals" == tag then
+    -- Direction should only apply to vehicles
     result.traffic_lights = true
   end
 end

--- a/profiles/lib/traffic_signal.lua
+++ b/profiles/lib/traffic_signal.lua
@@ -1,0 +1,26 @@
+-- Assigns traffic light value to node as defined by
+-- include/extractor/traffic_lights.hpp
+
+local TrafficSignal = {}
+
+function TrafficSignal.get_value(node)
+    local tag = node:get_value_by_key("highway")
+    if "traffic_signals" == tag then
+        local direction = node:get_value_by_key("traffic_signals:direction")
+        if direction then
+            if "forward" == direction then
+                return traffic_lights.direction_forward
+            end
+            if "backward" == direction then
+                return traffic_lights.direction_reverse
+            end
+        end
+        -- return traffic_lights.direction_all
+        return true
+    end
+    -- return traffic_lights.none
+    return false
+end
+
+return TrafficSignal
+

--- a/profiles/testbot.lua
+++ b/profiles/testbot.lua
@@ -4,6 +4,7 @@
 -- Primary road:  36km/h = 36000m/3600s = 100m/10s
 -- Secondary road:  18km/h = 18000m/3600s = 100m/20s
 -- Tertiary road:  12km/h = 12000m/3600s = 100m/30s
+TrafficSignal = require("lib/traffic_signal")
 
 api_version = 4
 
@@ -38,12 +39,9 @@ function setup()
 end
 
 function process_node (profile, node, result)
-  local traffic_signal = node:get_value_by_key("highway")
-
-  if traffic_signal and traffic_signal == "traffic_signals" then
-    result.traffic_lights = true
-    -- TODO: a way to set the penalty value
-  end
+  -- check if node is a traffic light
+  result.traffic_lights = TrafficSignal.get_value(node)
+  -- TODO: a way to set the penalty value
 end
 
 function process_way (profile, way, result)

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -11,6 +11,7 @@
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
 #include "util/for_each_indexed.hpp"
+#include "util/for_each_pair.hpp"
 #include "util/log.hpp"
 #include "util/timing_util.hpp"
 
@@ -413,6 +414,7 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
 
     const auto restriction_ways = IdentifyRestrictionWays();
     const auto maneuver_override_ways = IdentifyManeuverOverrideWays();
+    const auto traffic_signals = IdentifyTrafficSignals();
 
     PrepareNodes();
     WriteNodes(writer);
@@ -422,6 +424,7 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
     WriteEdges(writer);
     WriteMetadata(writer);
 
+    PrepareTrafficSignals(traffic_signals);
     PrepareManeuverOverrides(maneuver_override_ways);
     PrepareRestrictions(restriction_ways);
     WriteCharData(name_file_name);
@@ -911,25 +914,6 @@ void ExtractionContainers::WriteNodes(storage::tar::FileWriter &writer) const
         log << "ok, after " << TIMER_SEC(write_nodes) << "s";
     }
 
-    {
-        util::UnbufferedLog log;
-        log << "Writing traffic light nodes     ... ";
-        TIMER_START(write_nodes);
-        std::vector<NodeID> internal_traffic_signals;
-        for (const auto osm_id : traffic_signals)
-        {
-            const auto node_id = mapExternalToInternalNodeID(
-                used_node_id_list.begin(), used_node_id_list.end(), osm_id);
-            if (node_id != SPECIAL_NODEID)
-            {
-                internal_traffic_signals.push_back(node_id);
-            }
-        }
-        storage::serialization::write(
-            writer, "/extractor/traffic_lights", internal_traffic_signals);
-        log << "ok, after " << TIMER_SEC(write_nodes) << "s";
-    }
-
     util::Log() << "Processed " << max_internal_node_id << " nodes";
 }
 
@@ -981,6 +965,50 @@ ExtractionContainers::ReferencedWays ExtractionContainers::IdentifyManeuverOverr
     log << "ok, after " << TIMER_SEC(identify_maneuver_override_ways) << "s";
 
     return maneuver_override_ways;
+}
+
+void ExtractionContainers::PrepareTrafficSignals(
+    const ExtractionContainers::ReferencedTrafficSignals &referenced_traffic_signals)
+{
+    const auto &bidirectional_signal_nodes = referenced_traffic_signals.first;
+    const auto &unidirectional_signal_segments = referenced_traffic_signals.second;
+
+    util::UnbufferedLog log;
+    log << "Preparing traffic light signals for " << bidirectional_signal_nodes.size()
+        << " bidirectional, " << unidirectional_signal_segments.size()
+        << " unidirectional nodes ...";
+    TIMER_START(prepare_traffic_signals);
+
+    std::unordered_set<NodeID> bidirectional;
+    std::unordered_set<std::pair<NodeID, NodeID>, boost::hash<std::pair<NodeID, NodeID>>>
+        unidirectional;
+
+    for (const auto &osm_node : bidirectional_signal_nodes)
+    {
+        const auto node_id = mapExternalToInternalNodeID(
+            used_node_id_list.begin(), used_node_id_list.end(), osm_node);
+        if (node_id != SPECIAL_NODEID)
+        {
+            bidirectional.insert(node_id);
+        }
+    }
+    for (const auto &to_from : unidirectional_signal_segments)
+    {
+        const auto to_node_id = mapExternalToInternalNodeID(
+            used_node_id_list.begin(), used_node_id_list.end(), to_from.first);
+        const auto from_node_id = mapExternalToInternalNodeID(
+            used_node_id_list.begin(), used_node_id_list.end(), to_from.second);
+        if (from_node_id != SPECIAL_NODEID && to_node_id != SPECIAL_NODEID)
+        {
+            unidirectional.insert({from_node_id, to_node_id});
+        }
+    }
+
+    internal_traffic_signals.bidirectional_nodes = std::move(bidirectional);
+    internal_traffic_signals.unidirectional_segments = std::move(unidirectional);
+
+    TIMER_STOP(prepare_traffic_signals);
+    log << "ok, after " << TIMER_SEC(prepare_traffic_signals) << "s";
 }
 
 void ExtractionContainers::PrepareManeuverOverrides(const ReferencedWays &maneuver_override_ways)
@@ -1161,6 +1189,93 @@ ExtractionContainers::ReferencedWays ExtractionContainers::IdentifyRestrictionWa
     log << "ok, after " << TIMER_SEC(identify_restriction_ways) << "s";
 
     return restriction_ways;
+}
+
+ExtractionContainers::ReferencedTrafficSignals ExtractionContainers::IdentifyTrafficSignals()
+{
+    util::UnbufferedLog log;
+    log << "Collecting traffic signal information on " << external_traffic_signals.size()
+        << " signals...";
+    TIMER_START(identify_traffic_signals);
+
+    // Temporary store for nodes containing a unidirectional signal.
+    std::unordered_map<OSMNodeID, TrafficLightClass::Direction> unidirectional_signals;
+
+    // For each node that has a unidirectional traffic signal, we store the node(s)
+    // that lead up to the signal.
+    std::unordered_multimap<OSMNodeID, OSMNodeID> signal_segments;
+
+    std::unordered_set<OSMNodeID> bidirectional_signals;
+
+    const auto mark_signals = [&](auto const &traffic_signal) {
+        if (traffic_signal.second == TrafficLightClass::DIRECTION_FORWARD ||
+            traffic_signal.second == TrafficLightClass::DIRECTION_REVERSE)
+        {
+            unidirectional_signals.insert({traffic_signal.first, traffic_signal.second});
+        }
+        else
+        {
+            BOOST_ASSERT(traffic_signal.second == TrafficLightClass::DIRECTION_ALL);
+            bidirectional_signals.insert(traffic_signal.first);
+        }
+    };
+    std::for_each(external_traffic_signals.begin(), external_traffic_signals.end(), mark_signals);
+
+    // Extract all the segments that lead up to unidirectional traffic signals.
+    const auto set_segments = [&](const size_t way_list_idx, auto const & /*unused*/) {
+        const auto node_start_offset =
+            used_node_id_list.begin() + way_node_id_offsets[way_list_idx];
+        const auto node_end_offset =
+            used_node_id_list.begin() + way_node_id_offsets[way_list_idx + 1];
+
+        for (auto node_it = node_start_offset; node_it < node_end_offset; node_it++)
+        {
+            const auto sig = unidirectional_signals.find(*node_it);
+            if (sig != unidirectional_signals.end())
+            {
+                if (sig->second == TrafficLightClass::DIRECTION_FORWARD)
+                {
+                    if (node_it != node_start_offset)
+                    {
+                        // Previous node leads to signal
+                        signal_segments.insert({*node_it, *(node_it - 1)});
+                    }
+                }
+                else
+                {
+                    BOOST_ASSERT(sig->second == TrafficLightClass::DIRECTION_REVERSE);
+                    if (node_it + 1 != node_end_offset)
+                    {
+                        // Next node leads to signal
+                        signal_segments.insert({*node_it, *(node_it + 1)});
+                    }
+                }
+            }
+        }
+    };
+    util::for_each_indexed(ways_list.cbegin(), ways_list.cend(), set_segments);
+
+    util::for_each_pair(
+        signal_segments, [](const auto pair_a, const auto pair_b) {
+            if (pair_a.first == pair_b.first)
+            {
+                // If a node is appearing multiple times in this map, then it's ambiguous.
+                // The node is an intersection and the traffic direction is being use for multiple
+                // ways. We can't be certain of the original intent. See:
+                // https://wiki.openstreetmap.org/wiki/Key:traffic_signals:direction
+
+                // OSRM will include the signal for all intersecting ways in the specified
+                // direction, but let's flag this as a concern.
+                util::Log(logWARNING)
+                    << "OSM node " << pair_a.first
+                    << " has a unidirectional traffic signal ambiguously applied to multiple ways";
+            }
+        });
+
+    TIMER_STOP(identify_traffic_signals);
+    log << "ok, after " << TIMER_SEC(identify_traffic_signals) << "s";
+
+    return {std::move(bidirectional_signals), std::move(signal_segments)};
 }
 
 void ExtractionContainers::PrepareRestrictions(const ReferencedWays &restriction_ways)

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -78,9 +78,9 @@ void ExtractorCallbacks::ProcessNode(const osmium::Node &input_node,
     {
         external_memory.barrier_nodes.push_back(id);
     }
-    if (result_node.traffic_lights)
+    if (result_node.traffic_lights != TrafficLightClass::NONE)
     {
-        external_memory.traffic_signals.push_back(id);
+        external_memory.external_traffic_signals.push_back({id, result_node.traffic_lights});
     }
 }
 

--- a/src/extractor/node_based_graph_factory.cpp
+++ b/src/extractor/node_based_graph_factory.cpp
@@ -19,10 +19,11 @@ NodeBasedGraphFactory::NodeBasedGraphFactory(
     const boost::filesystem::path &input_file,
     ScriptingEnvironment &scripting_environment,
     std::vector<TurnRestriction> &turn_restrictions,
-    std::vector<UnresolvedManeuverOverride> &maneuver_overrides)
+    std::vector<UnresolvedManeuverOverride> &maneuver_overrides,
+    const TrafficSignals &traffic_signals)
 {
     LoadDataFromFile(input_file);
-    Compress(scripting_environment, turn_restrictions, maneuver_overrides);
+    Compress(scripting_environment, turn_restrictions, maneuver_overrides, traffic_signals);
     CompressGeometry();
     CompressAnnotationData();
 }
@@ -31,16 +32,10 @@ NodeBasedGraphFactory::NodeBasedGraphFactory(
 void NodeBasedGraphFactory::LoadDataFromFile(const boost::filesystem::path &input_file)
 {
     auto barriers_iter = inserter(barriers, end(barriers));
-    auto traffic_signals_iter = inserter(traffic_signals, end(traffic_signals));
     std::vector<NodeBasedEdge> edge_list;
 
-    files::readRawNBGraph(input_file,
-                          barriers_iter,
-                          traffic_signals_iter,
-                          coordinates,
-                          osm_node_ids,
-                          edge_list,
-                          annotation_data);
+    files::readRawNBGraph(
+        input_file, barriers_iter, coordinates, osm_node_ids, edge_list, annotation_data);
 
     const auto number_of_node_based_nodes = coordinates.size();
     if (edge_list.empty())
@@ -80,7 +75,8 @@ void NodeBasedGraphFactory::LoadDataFromFile(const boost::filesystem::path &inpu
 
 void NodeBasedGraphFactory::Compress(ScriptingEnvironment &scripting_environment,
                                      std::vector<TurnRestriction> &turn_restrictions,
-                                     std::vector<UnresolvedManeuverOverride> &maneuver_overrides)
+                                     std::vector<UnresolvedManeuverOverride> &maneuver_overrides,
+                                     const TrafficSignals &traffic_signals)
 {
     GraphCompressor graph_compressor;
     graph_compressor.Compress(barriers,

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -44,7 +44,7 @@ std::size_t loadGraph(const std::string &path,
     auto nop = boost::make_function_output_iterator([](auto) {});
 
     extractor::files::readRawNBGraph(
-        path, nop, nop, coordinate_list, osm_node_ids, edge_list, annotation_data);
+        path, nop, coordinate_list, osm_node_ids, edge_list, annotation_data);
 
     // Building a node-based graph
     for (const auto &input_edge : edge_list)

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <iostream>
 #include <unordered_set>
 #include <vector>
 
@@ -66,7 +65,7 @@ BOOST_AUTO_TEST_CASE(long_road_test)
     GraphCompressor compressor;
 
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<TurnRestriction> restrictions;
     std::vector<NodeBasedEdgeAnnotation> annotations(1);
     CompressedEdgeContainer container;
@@ -112,7 +111,7 @@ BOOST_AUTO_TEST_CASE(loop_test)
     GraphCompressor compressor;
 
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
     std::vector<NodeBasedEdgeAnnotation> annotations(1);
@@ -175,7 +174,7 @@ BOOST_AUTO_TEST_CASE(t_intersection)
     GraphCompressor compressor;
 
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<NodeBasedEdgeAnnotation> annotations(1);
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
@@ -218,7 +217,7 @@ BOOST_AUTO_TEST_CASE(street_name_changes)
     GraphCompressor compressor;
 
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<NodeBasedEdgeAnnotation> annotations(2);
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
@@ -256,7 +255,7 @@ BOOST_AUTO_TEST_CASE(direction_changes)
     GraphCompressor compressor;
 
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<NodeBasedEdgeAnnotation> annotations(1);
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;

--- a/unit_tests/extractor/intersection_analysis_tests.cpp
+++ b/unit_tests/extractor/intersection_analysis_tests.cpp
@@ -19,7 +19,7 @@ using Graph = util::NodeBasedDynamicGraph;
 BOOST_AUTO_TEST_CASE(simple_intersection_connectivity)
 {
     std::unordered_set<NodeID> barrier_nodes{6};
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<NodeBasedEdgeAnnotation> annotations{
         {EMPTY_NAMEID, 0, INAVLID_CLASS_DATA, TRAVEL_MODE_DRIVING, false},
         {EMPTY_NAMEID, 1, INAVLID_CLASS_DATA, TRAVEL_MODE_DRIVING, false}};
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(simple_intersection_connectivity)
 BOOST_AUTO_TEST_CASE(roundabout_intersection_connectivity)
 {
     std::unordered_set<NodeID> barrier_nodes;
-    std::unordered_set<NodeID> traffic_lights;
+    TrafficSignals traffic_lights;
     std::vector<NodeBasedEdgeAnnotation> annotations;
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(roundabout_intersection_connectivity)
 BOOST_AUTO_TEST_CASE(skip_degree_two_nodes)
 {
     std::unordered_set<NodeID> barrier_nodes{1};
-    std::unordered_set<NodeID> traffic_lights{2};
+    TrafficSignals traffic_lights = {{2}, {}};
     std::vector<NodeBasedEdgeAnnotation> annotations(1);
     std::vector<TurnRestriction> restrictions;
     CompressedEdgeContainer container;


### PR DESCRIPTION
# Issue
Currently OSRM parses traffic signal nodes without consideration for the direction in which the signal applies. 
This can lead to duplicated routing penalties, especially when a forward and backward signal are in close proximity on a way.
    
 This commit adds support for directed signals to the extraction and graph creation. Signal penalties are only applied in the direction specified by the OSM tag.
    
We add the assignment of traffic directions to the lua scripts, maintaining backwards compatibility with the existing boolean traffic states.
    
As part of the changes to the internal structures used for tracking traffic signals during extraction, we stop serialising/deserialising signals to the `.osrm` file. 

The traffic signals are only used by `osrm-extract` so whilst this is a data format change, it will not break any existing user processes.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #1317
