### PR TITLE
Fix MSVC 19.28+ issue with ByEdgeOrByMeterValue::by_edge and ByEdgeOrByMeterValue::by_meter definitions

### DIFF
--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -25,6 +25,24 @@
 #include <string>
 #include <vector>
 
+#ifdef _MSC_VER
+#if (_MSC_VER>=1928)
+#ifdef _DEBUG
+namespace osrm
+{
+namespace extractor
+{
+namespace detail
+{
+    const ByEdgeOrByMeterValue::ValueByEdge     ByEdgeOrByMeterValue::by_edge;
+    const ByEdgeOrByMeterValue::ValueByMeter    ByEdgeOrByMeterValue::by_meter;
+}
+}
+}
+#endif
+#endif
+#endif
+
 namespace osrm
 {
 namespace extractor

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #ifdef _MSC_VER
-#if (_MSC_VER>=1928)
+#if (_MSC_VER >= 1928)
 #ifdef _DEBUG
 namespace osrm
 {
@@ -34,11 +34,11 @@ namespace extractor
 {
 namespace detail
 {
-    const ByEdgeOrByMeterValue::ValueByEdge     ByEdgeOrByMeterValue::by_edge;
-    const ByEdgeOrByMeterValue::ValueByMeter    ByEdgeOrByMeterValue::by_meter;
-}
-}
-}
+const ByEdgeOrByMeterValue::ValueByEdge ByEdgeOrByMeterValue::by_edge;
+const ByEdgeOrByMeterValue::ValueByMeter ByEdgeOrByMeterValue::by_meter;
+} // namespace detail
+} // namespace extractor
+} // namespace osrm
 #endif
 #endif
 #endif


### PR DESCRIPTION
# Issue

This is a workaround for discrepancy between MSVC 19.27 and 19.28
about static const member definition
https://developercommunity2.visualstudio.com/t/discrepancy-between-msvc-1927-vs-1928-about-static/1255338

Building Debug configuration with MSVC 19.28+ fails with:

```
osrm_extract.lib(extractor_callbacks.obj) : error LNK2001: unresolved external symbol
  "public: static struct osrm::extractor::detail::ByEdgeOrByMeterValue::ValueByEdge const osrm::extractor::detail::ByEdgeOrByMeterValue::by_edge"
osrm_extract.lib(extractor_callbacks.obj) : error LNK2001: unresolved external symbol
  "public: static struct osrm::extractor::detail::ByEdgeOrByMeterValue::ValueByMeter const osrm::extractor::detail::ByEdgeOrByMeterValue::by_meter"
```

We can not use C++17 inline variable as a workaround suggested
in the issue report linked above, because the sol2 does not
seem to compile in C++17 mode:

    third_party/sol2/sol2/sol.hpp: error C2039: 'object_type': is not a member of...

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch
