### PR TITLE
Fix 32 bit CI builds

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -471,6 +471,7 @@ jobs:
           fi
         elif [[ $TARGET_ARCH == "i686" ]]; then
           source ./scripts/ci/before_install.${TARGET_ARCH}.sh
+          echo "PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
         fi
 
     - name: Prepare build

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -16,7 +16,7 @@ env:
   CCACHE_COMPRESS: 1
   CASHER_TIME_OUT: 599 # one second less than 10m to avoid 10m timeout error: https://github.com/Project-OSRM/osrm-backend/issues/2742
   CCACHE_VERSION: 3.3.1
-  CMAKE_VERSION: 3.7.2
+  CMAKE_VERSION: 3.21.2
   ENABLE_NODE_BINDINGS: "ON"
 
 jobs:
@@ -425,7 +425,7 @@ jobs:
 
         echo "MASON=${GITHUB_WORKSPACE}/scripts/mason.sh" >> $GITHUB_ENV
         echo "CMAKE_URL=https://mason-binaries.s3.amazonaws.com/${MASON_OS}-x86_64/cmake/${CMAKE_VERSION}.tar.gz" >> $GITHUB_ENV
-        echo "CMAKE_DIR=mason_packages/${MASON_OS}-x86_64/cmake/${CMAKE_VERSION}}" >> $GITHUB_ENV
+        echo "CMAKE_DIR=mason_packages/${MASON_OS}-x86_64/cmake/${CMAKE_VERSION}" >> $GITHUB_ENV
 
 
     - name: Install dev dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
       - CHANGED: Upgrade Ubuntu CI builds to 20.04  [#6119](https://github.com/Project-OSRM/osrm-backend/pull/6119)
       - CHANGED: Make building osrm-routed optional [#6144](https://github.com/Project-OSRM/osrm-backend/pull/6144)
       - FIXED: Run all unit tests in CI [#5248](https://github.com/Project-OSRM/osrm-backend/pull/5248)
+      - FIXED: Fix installation of Mason CMake [#6170](https://github.com/Project-OSRM/osrm-backend/pull/6170)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
       - CHANGED: Upgrade Ubuntu CI builds to 20.04  [#6119](https://github.com/Project-OSRM/osrm-backend/pull/6119)
       - CHANGED: Make building osrm-routed optional [#6144](https://github.com/Project-OSRM/osrm-backend/pull/6144)
       - FIXED: Run all unit tests in CI [#5248](https://github.com/Project-OSRM/osrm-backend/pull/5248)
-      - FIXED: Fix installation of Mason CMake [#6170](https://github.com/Project-OSRM/osrm-backend/pull/6170)
+      - FIXED: Fix installation of Mason CMake and 32 bit CI build [#6170](https://github.com/Project-OSRM/osrm-backend/pull/6170)
 
 # 5.26.0
   - Changes from 5.25.0


### PR DESCRIPTION
# Issue

This PR fixes two issues

1. Mason CMake was not being installed correctly due to a typo in the Github Actions script.
Once fixed, it also uncovers another problem. The version of Mason CMake requires libssl 1.0 as a dependency, whilst the Ubuntu Focal runners are on the newer libssl 1.1. Therefore, we also bump the version to `3.21.2` on CI.

2. A recent change to the Ubuntu Focal CI worker - possibly due to libexpat-dev being installed by default - leads to the 32-bit expat library to not be found by CMake ([example](https://github.com/Project-OSRM/osrm-backend/runs/4360200799?check_suite_focus=true)). `FindPackage(EXPAT)` finds the library via `pkg-config`, so the fix is to explicitly include the i386 pkgconfig directory in the `PKG_CONFIG_PATH` environment variable list.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #6165
