### PR TITLE
Enable arm docker build

### DIFF
--- a/.github/workflows/osrm-backend-docker.yml
+++ b/.github/workflows/osrm-backend-docker.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Docker meta
         id: meta
@@ -34,10 +39,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           flavor: |
             latest=true
-            suffix=-assertions,onlatest=true
-          
-
-
+            suffix=-assertions,onlatest=true        
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v1
@@ -46,16 +48,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-
-
-
-
-
-
       - name: Build container image - debug
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile
           tags: ${{ steps.metadebug.outputs.tags  }}
           build-args: |
@@ -66,6 +63,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile
           tags: ${{ steps.metaassertions.outputs.tags  }}
           build-args: |
@@ -76,6 +74,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile
           tags:  ${{ steps.meta.outputs.tags  }}
           build-args: |


### PR DESCRIPTION
# Issue

This issue enables dockerX for multi-arch docker image building. Resulting images can be run on x86 and arm processors (for example [aws graviton](https://aws.amazon.com/ec2/graviton/))


## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?

[Multi-arch build and images, the simple way - Docker Blog](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/)
