### PR TITLE
Replace boost/function_output_iterator.hpp with boost/iterator/function_output_iterator.hpp

### DIFF
--- a/include/storage/serialization.hpp
+++ b/include/storage/serialization.hpp
@@ -10,7 +10,7 @@
 #include "storage/tar.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
 
 #include <cmath>

--- a/include/storage/shared_data_index.hpp
+++ b/include/storage/shared_data_index.hpp
@@ -3,7 +3,7 @@
 
 #include "storage/shared_datatype.hpp"
 
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <type_traits>
 #include <unordered_map>

--- a/include/util/indexed_data.hpp
+++ b/include/util/indexed_data.hpp
@@ -8,7 +8,7 @@
 #include "util/vector_view.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <array>
 #include <iterator>

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 namespace osrm
 {

--- a/src/extractor/location_dependent_data.cpp
+++ b/src/extractor/location_dependent_data.cpp
@@ -8,7 +8,7 @@
 #include <rapidjson/istreamwrapper.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 
 #include <fstream>

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -11,7 +11,7 @@
 #include "util/typedefs.hpp"
 
 #include <boost/filesystem.hpp>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <tbb/parallel_sort.h>
 

--- a/unit_tests/storage/tar.cpp
+++ b/unit_tests/storage/tar.cpp
@@ -3,7 +3,7 @@
 #include "../common/range_tools.hpp"
 #include "../common/temporary_file.hpp"
 
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
The former header is deprecated and causes a bunch of `#pragma message` to be issued during build.

The latter is present in at lease boost=1.67 which is at least 3 years old by now.
