### PR TITLE
Osrm datastore stability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ configure_file(
 )
 file(GLOB UtilGlob src/util/*.cpp src/util/*/*.cpp)
 file(GLOB ExtractorGlob src/extractor/*.cpp src/extractor/*/*.cpp)
+file(GLOB MergerGlob src/merger/*.cpp src/guidance/*.cpp src/extractor/*.cpp src/extractor/intersection/*.cpp)
 file(GLOB GuidanceGlob src/guidance/*.cpp src/extractor/intersection/*.cpp)
 file(GLOB PartitionerGlob src/partitioner/*.cpp)
 file(GLOB CustomizerGlob src/customize/*.cpp)
@@ -155,6 +156,7 @@ file(GLOB ErrorcodesGlob src/osrm/errorcodes.cpp)
 
 add_library(UTIL OBJECT ${UtilGlob})
 add_library(EXTRACTOR OBJECT ${ExtractorGlob})
+add_library(MERGER OBJECT ${MergerGlob})
 add_library(GUIDANCE OBJECT ${GuidanceGlob})
 add_library(PARTITIONER OBJECT ${PartitionerGlob})
 add_library(CUSTOMIZER OBJECT ${CustomizerGlob})
@@ -167,6 +169,7 @@ add_library(SERVER OBJECT ${ServerGlob})
 set_target_properties(UTIL PROPERTIES LINKER_LANGUAGE CXX)
 
 add_executable(osrm-extract src/tools/extract.cpp)
+add_executable(osrm-merge src/tools/merge.cpp)
 add_executable(osrm-partition src/tools/partition.cpp)
 add_executable(osrm-customize src/tools/customize.cpp)
 add_executable(osrm-contract src/tools/contract.cpp)
@@ -175,6 +178,7 @@ add_executable(osrm-datastore src/tools/store.cpp $<TARGET_OBJECTS:MICROTAR> $<T
 add_library(osrm src/osrm/osrm.cpp $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_contract src/osrm/contractor.cpp $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_extract src/osrm/extractor.cpp $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
+add_library(osrm_merge src/osrm/merger.cpp $<TARGET_OBJECTS:MERGER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_guidance $<TARGET_OBJECTS:GUIDANCE> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_partition src/osrm/partitioner.cpp $<TARGET_OBJECTS:PARTITIONER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
 add_library(osrm_customize src/osrm/customizer.cpp $<TARGET_OBJECTS:CUSTOMIZER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
@@ -405,8 +409,6 @@ endif()
 if(APPLE)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10")
   execute_process(COMMAND xcrun --sdk macosx --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(CMAKE_OSX_ARCHITECTURES "x86_64")
-  message(STATUS "Set Architecture to x64 on OS X")
   exec_program(uname ARGS -v  OUTPUT_VARIABLE DARWIN_VERSION)
   string(REGEX MATCH "[0-9]+" DARWIN_VERSION ${DARWIN_VERSION})
   if(OSXLIBSTD)
@@ -611,12 +613,24 @@ set(BOOST_ENGINE_LIBRARIES
 # Binaries
 target_link_libraries(osrm-datastore osrm_store ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-extract osrm_extract ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(osrm-merge osrm_merge ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-partition osrm_partition ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-customize osrm_customize ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-contract osrm_contract ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
 
 set(EXTRACTOR_LIBRARIES
+    ${BZIP2_LIBRARIES}
+    ${Boost_REGEX_LIBRARY}
+    ${BOOST_BASE_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${EXPAT_LIBRARIES}
+    ${USED_LUA_LIBRARIES}
+    ${OSMIUM_LIBRARIES}
+    ${TBB_LIBRARIES}
+    ${ZLIB_LIBRARY}
+    ${MAYBE_COVERAGE_LIBRARIES})
+set(MERGER_LIBRARIES
     ${BZIP2_LIBRARIES}
     ${Boost_REGEX_LIBRARY}
     ${BOOST_BASE_LIBRARIES}
@@ -685,6 +699,7 @@ target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_update ${UPDATER_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES} osrm_update osrm_store)
 target_link_libraries(osrm_extract osrm_guidance ${EXTRACTOR_LIBRARIES})
+target_link_libraries(osrm_merge ${MERGER_LIBRARIES})
 target_link_libraries(osrm_partition ${PARTITIONER_LIBRARIES})
 target_link_libraries(osrm_customize ${CUSTOMIZER_LIBRARIES} osrm_update osrm_store)
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})
@@ -716,6 +731,7 @@ endif()
 # (i.e., from /usr/local/bin/) the linker can find library dependencies. For
 # more info see http://www.cmake.org/Wiki/CMake_RPATH_handling
 set_property(TARGET osrm-extract PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
+set_property(TARGET osrm-merge PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_property(TARGET osrm-partition PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_property(TARGET osrm-contract PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_property(TARGET osrm-datastore PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -729,6 +745,7 @@ set(ApiHeader include/engine/api/base_result.hpp)
 set(EngineHeader include/engine/status.hpp include/engine/engine_config.hpp include/engine/hint.hpp include/engine/bearing.hpp include/engine/approach.hpp include/engine/phantom_node.hpp)
 set(UtilHeader include/util/coordinate.hpp include/util/json_container.hpp include/util/typedefs.hpp include/util/alias.hpp include/util/exception.hpp include/util/bearing.hpp)
 set(ExtractorHeader include/extractor/extractor.hpp include/storage/io_config.hpp include/extractor/extractor_config.hpp include/extractor/travel_mode.hpp)
+set(MergerHeader include/merger/merger.hpp)
 set(PartitionerHeader include/partitioner/partitioner.hpp include/partitioner/partitioner_config.hpp)
 set(ContractorHeader include/contractor/contractor.hpp include/contractor/contractor_config.hpp)
 set(StorageHeader include/storage/storage.hpp include/storage/io_config.hpp include/storage/storage_config.hpp)
@@ -736,6 +753,7 @@ install(FILES ${EngineHeader} DESTINATION include/osrm/engine)
 install(FILES ${UtilHeader} DESTINATION include/osrm/util)
 install(FILES ${StorageHeader} DESTINATION include/osrm/storage)
 install(FILES ${ExtractorHeader} DESTINATION include/osrm/extractor)
+install(FILES ${MergerHeader} DESTINATION include/osrm/merger)
 install(FILES ${PartitionerHeader} DESTINATION include/osrm/partitioner)
 install(FILES ${ContractorHeader} DESTINATION include/osrm/contractor)
 install(FILES ${LibraryGlob} DESTINATION include/osrm)
@@ -744,6 +762,7 @@ install(FILES ${ApiHeader} DESTINATION include/osrm/engine/api)
 install(FILES ${VariantGlob} DESTINATION include/mapbox)
 install(FILES ${FlatbuffersGlob} DESTINATION include/flatbuffers)
 install(TARGETS osrm-extract DESTINATION bin)
+install(TARGETS osrm-merge DESTINATION bin)
 install(TARGETS osrm-partition DESTINATION bin)
 install(TARGETS osrm-customize DESTINATION bin)
 install(TARGETS osrm-contract DESTINATION bin)
@@ -751,6 +770,7 @@ install(TARGETS osrm-datastore DESTINATION bin)
 install(TARGETS osrm-routed DESTINATION bin)
 install(TARGETS osrm DESTINATION lib)
 install(TARGETS osrm_extract DESTINATION lib)
+install(TARGETS osrm_merge DESTINATION lib)
 install(TARGETS osrm_partition DESTINATION lib)
 install(TARGETS osrm_customize DESTINATION lib)
 install(TARGETS osrm_update DESTINATION lib)

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -60,6 +60,9 @@ class Extractor
     int run(ScriptingEnvironment &scripting_environment);
 
   private:
+    using MapKey = std::tuple<std::string, std::string, std::string, std::string, std::string>;
+    using MapVal = unsigned;
+    using StringMap = std::unordered_map<MapKey, MapVal>;
     ExtractorConfig config;
 
     std::tuple<LaneDescriptionMap,

--- a/include/extractor/extractor_callbacks.hpp
+++ b/include/extractor/extractor_callbacks.hpp
@@ -65,7 +65,7 @@ class ExtractorCallbacks
     using MapKey = std::tuple<std::string, std::string, std::string, std::string, std::string>;
     using MapVal = unsigned;
     using StringMap = std::unordered_map<MapKey, MapVal>;
-    StringMap string_map;
+    StringMap &string_map;
     ExtractionContainers &external_memory;
     std::unordered_map<std::string, ClassData> &classes_map;
     LaneDescriptionMap &lane_description_map;
@@ -75,7 +75,8 @@ class ExtractorCallbacks
   public:
     using ClassesMap = std::unordered_map<std::string, ClassData>;
 
-    explicit ExtractorCallbacks(ExtractionContainers &extraction_containers,
+    explicit ExtractorCallbacks(StringMap &string_map,
+                                ExtractionContainers &extraction_containers,
                                 std::unordered_map<std::string, ClassData> &classes_map,
                                 LaneDescriptionMap &lane_description_map,
                                 const ProfileProperties &properties);

--- a/include/extractor/node_data_container.hpp
+++ b/include/extractor/node_data_container.hpp
@@ -118,7 +118,6 @@ template <storage::Ownership Ownership> class EdgeBasedNodeDataContainerImpl
         return annotation_data[annotation];
     }
 
-  private:
     Vector<EdgeBasedNode> nodes;
     Vector<NodeBasedEdgeAnnotation> annotation_data;
 };

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -71,6 +71,8 @@ class Sol2ScriptingEnvironment final : public ScriptingEnvironment
     static const constexpr int SUPPORTED_MAX_API_VERSION = 4;
 
     explicit Sol2ScriptingEnvironment(
+        const std::string &file_name);
+    explicit Sol2ScriptingEnvironment(
         const std::string &file_name,
         const std::vector<boost::filesystem::path> &location_dependent_data_paths);
     ~Sol2ScriptingEnvironment() override = default;

--- a/include/merger/merger.hpp
+++ b/include/merger/merger.hpp
@@ -1,0 +1,113 @@
+#include "extractor/edge_based_edge.hpp"
+#include "extractor/edge_based_graph_factory.hpp"
+#include "extractor/extractor_config.hpp"
+#include "extractor/extractor_callbacks.hpp"
+#include "extractor/extraction_containers.hpp"
+#include "extractor/graph_compressor.hpp"
+#include "extractor/maneuver_override.hpp"
+#include "extractor/packed_osm_ids.hpp"
+#include "extractor/restriction_graph.hpp"
+#include "extractor/scripting_environment_lua.hpp"
+
+#include "guidance/guidance_processing.hpp"
+#include "guidance/turn_data_container.hpp"
+
+#include "merger_config.hpp"
+
+#include "util/guidance/bearing_class.hpp"
+#include "util/guidance/entry_class.hpp"
+#include "util/guidance/turn_lanes.hpp"
+
+#include "util/typedefs.hpp"
+
+namespace osrm
+{
+namespace merger
+{
+class Merger
+{
+  public:
+    Merger(MergerConfig merger_config) : config(std::move(merger_config)) {}
+    int run();
+  private:
+    using MapKey = std::tuple<std::string, std::string, std::string, std::string, std::string>;
+    using MapVal = unsigned;
+    using StringMap = std::unordered_map<MapKey, MapVal>;
+    MergerConfig config;
+
+    void parseOSMFiles(
+        StringMap &string_map,
+        extractor::ExtractionContainers &extraction_containers,
+        extractor::ExtractorCallbacks::ClassesMap &classes_map,
+        extractor::LaneDescriptionMap &turn_lane_map,
+        extractor::ScriptingEnvironment &scripting_environment,
+        const boost::filesystem::path profile_path,
+        const unsigned number_of_threads,
+        std::vector<std::string> &class_names,
+        std::set<std::set<std::string>> &excludeable_classes_set);
+
+    void parseOSMData(
+        StringMap &string_map,
+        extractor::ExtractionContainers &extraction_containers,
+        extractor::ExtractorCallbacks::ClassesMap &classes_map,
+        extractor::LaneDescriptionMap &turn_lane_map,
+        extractor::ScriptingEnvironment &scripting_environment,
+        const boost::filesystem::path input_path,
+        const boost::filesystem::path profile_path,
+        const unsigned number_of_threads);
+
+    void writeTimestamp();
+
+    void writeOSMData(
+        extractor::ExtractionContainers &extraction_containers,
+        extractor::ExtractorCallbacks::ClassesMap &classes_map,
+        std::vector<std::string> &class_names,
+        std::vector<std::vector<std::string>> &excludable_classes,
+        extractor::ScriptingEnvironment &scripting_environment);
+
+    EdgeID BuildEdgeExpandedGraph(
+        // input data
+        const util::NodeBasedDynamicGraph &node_based_graph,
+        const std::vector<util::Coordinate> &coordinates,
+        const extractor::CompressedEdgeContainer &compressed_edge_container,
+        const std::unordered_set<NodeID> &barrier_nodes,
+        const std::unordered_set<NodeID> &traffic_lights,
+        const extractor::RestrictionGraph &restriction_graph,
+        const std::unordered_set<EdgeID> &segregated_edges,
+        const extractor::NameTable &name_table,
+        const std::vector<extractor::UnresolvedManeuverOverride> &maneuver_overrides,
+        const extractor::LaneDescriptionMap &turn_lane_map,
+        // for calculating turn penalties
+        extractor::ScriptingEnvironment &scripting_environment,
+        // output data
+        extractor::EdgeBasedNodeDataContainer &edge_based_nodes_container,
+        std::vector<extractor::EdgeBasedNodeSegment> &edge_based_node_segments,
+        std::vector<EdgeWeight> &edge_based_node_weights,
+        std::vector<EdgeDuration> &edge_based_node_durations,
+        std::vector<EdgeDistance> &edge_based_node_distances,
+        util::DeallocatingVector<extractor::EdgeBasedEdge> &edge_based_edge_list,
+        std::uint32_t &connectivity_checksum);
+
+    void FindComponents(
+        unsigned max_edge_id,
+        const util::DeallocatingVector<extractor::EdgeBasedEdge> &input_edge_list,
+        const std::vector<extractor::EdgeBasedNodeSegment> &input_node_segments,
+        extractor::EdgeBasedNodeDataContainer &nodes_container) const;
+    
+    void BuildRTree(
+        std::vector<extractor::EdgeBasedNodeSegment> edge_based_node_segments,
+        const std::vector<util::Coordinate> &coordinates);
+
+    void ProcessGuidanceTurns(
+        const util::NodeBasedDynamicGraph &node_based_graph,
+        const extractor::EdgeBasedNodeDataContainer &edge_based_node_container,
+        const std::vector<util::Coordinate> &node_coordinates,
+        const extractor::CompressedEdgeContainer &compressed_edge_container,
+        const std::unordered_set<NodeID> &barrier_nodes,
+        const extractor::RestrictionGraph &restriction_graph,
+        const extractor::NameTable &name_table,
+        extractor::LaneDescriptionMap lane_description_map,
+        extractor::ScriptingEnvironment &scripting_environment);
+};
+}
+}

--- a/include/merger/merger_config.hpp
+++ b/include/merger/merger_config.hpp
@@ -1,0 +1,69 @@
+#ifndef MERGER_CONFIG_HPP
+#define MERGER_CONFIG_HPP
+
+#include "storage/io_config.hpp"
+
+#include <boost/filesystem/path.hpp>
+
+#include <map>
+
+namespace osrm
+{
+namespace merger
+{
+
+struct MergerConfig final : storage::IOConfig
+{
+    MergerConfig() noexcept
+        : IOConfig(
+              {
+                  "",
+              },
+              {},
+              {".osrm",
+               ".osrm.restrictions",
+               ".osrm.names",
+               ".osrm.tls",
+               ".osrm.tld",
+               ".osrm.geometry",
+               ".osrm.nbg_nodes",
+               ".osrm.ebg_nodes",
+               ".osrm.timestamp",
+               ".osrm.edges",
+               ".osrm.ebg",
+               ".osrm.ramIndex",
+               ".osrm.fileIndex",
+               ".osrm.turn_duration_penalties",
+               ".osrm.turn_weight_penalties",
+               ".osrm.turn_penalties_index",
+               ".osrm.enw",
+               ".osrm.properties",
+               ".osrm.icd",
+               ".osrm.cnbg",
+               ".osrm.cnbg_to_ebg",
+               ".osrm.maneuver_overrides"})
+    {
+    }
+
+    void UseDefaultOutputNames(const boost::filesystem::path &base)
+    {
+        IOConfig::UseDefaultOutputNames(base);
+    }
+
+    std::map<boost::filesystem::path, std::vector<boost::filesystem::path>> profile_to_input;
+    boost::filesystem::path output_path;
+
+    std::string data_version = "";
+
+    unsigned requested_num_threads;
+    unsigned small_component_size = 1000;
+
+    bool use_metadata = false;
+    bool parse_conditionals = false;
+    bool use_locations_cache = true;
+};
+
+}
+}
+
+#endif

--- a/include/osrm/merger.hpp
+++ b/include/osrm/merger.hpp
@@ -1,0 +1,9 @@
+namespace osrm
+{
+namespace merger
+{
+struct MergerConfig;
+
+}
+    void merge(merger::MergerConfig merger_config);
+}

--- a/include/osrm/merger_config.hpp
+++ b/include/osrm/merger_config.hpp
@@ -1,0 +1,11 @@
+#ifndef GLOBAL_MERGER_CONFIG_HPP
+#define GLOBAL_MERGER_CONFIG_HPP
+
+#include "merger/merger_config.hpp"
+
+namespace osrm
+{
+using merger::MergerConfig;
+}
+
+#endif

--- a/include/storage/shared_memory.hpp
+++ b/include/storage/shared_memory.hpp
@@ -163,9 +163,7 @@ class SharedMemory
             }
             BOOST_ASSERT(ret >= 0);
 
-            //std::this_thread::sleep_for(std::chrono::microseconds(100));
-            util::Log(logWARNING) << "CTudorache WaitForDetach, nattach: " << xsi_ds.shm_nattch;
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
         } while (xsi_ds.shm_nattch > 1);
     }
 #else

--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -254,10 +254,6 @@ template <typename Data> struct SharedMonitor
     bi::shared_memory_object shmem;
     bi::mapped_region region;
 };
-
-// template < typename Data >
-// SharedMonitor<Data>* SharedMonitor<Data>::g_instance = nullptr;
-
 } // namespace storage
 } // namespace osrm
 

--- a/include/storage/shared_monitor.hpp
+++ b/include/storage/shared_monitor.hpp
@@ -40,24 +40,6 @@ template <typename Data> struct SharedMonitor
 {
     using mutex_type = bi::interprocess_mutex;
 
-// private:
-//     static SharedMonitor* g_instance;
-
-// public:
-//     static SharedMonitor& instance() {
-//         if (!g_instance) {
-//             g_instance = new SharedMonitor();
-//         }
-//         return *g_instance;
-//     }
-//     static SharedMonitor& instance(const Data &initial_data) {
-//         if (!g_instance) {
-//             g_instance = new SharedMonitor(initial_data);
-//         }
-//         return *g_instance;
-//     }
-// private:
-
     SharedMonitor(const Data &initial_data)
     {
         util::Log(logWARNING) << "CTudorache sharedMonitor OPEN or CREATE: " << (const char*)Data::name;
@@ -109,7 +91,6 @@ template <typename Data> struct SharedMonitor
         }
     }
 
-// public:
     Data &data() const
     {
         auto region_pointer = reinterpret_cast<char *>(region.get_address());

--- a/include/updater/source.hpp
+++ b/include/updater/source.hpp
@@ -6,6 +6,7 @@
 #include <boost/optional.hpp>
 
 #include <vector>
+#include <sstream>
 
 namespace osrm
 {
@@ -45,6 +46,11 @@ struct Segment final
     {
         return std::tie(from, to) == std::tie(rhs.from, rhs.to);
     }
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{from: " << from << ", to: " << to << "}";
+        return oss.str();
+    }
 };
 
 struct SpeedSource final
@@ -53,6 +59,12 @@ struct SpeedSource final
     unsigned speed;
     boost::optional<double> rate;
     std::uint8_t source;
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{speed: " << speed << ", source: " << (int)source << "}";
+        return oss.str();
+    }
+
 };
 
 struct Turn final
@@ -76,6 +88,11 @@ struct Turn final
     {
         return std::tie(from, via, to) == std::tie(rhs.from, rhs.via, rhs.to);
     }
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{from: " << from << ", via: " << via << ", to: " << to << "}";
+        return oss.str();
+    }
 };
 
 struct PenaltySource final
@@ -84,6 +101,11 @@ struct PenaltySource final
     double duration;
     double weight;
     std::uint8_t source;
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{duration: " << duration << ", weight: " << weight << ", source: " << source << "}";
+        return oss.str();
+    }
 };
 
 using SegmentLookupTable = LookupTable<Segment, SpeedSource>;

--- a/include/util/log.hpp
+++ b/include/util/log.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <mutex>
 #include <sstream>
+#include <map>
 
 enum LogLevel
 {
@@ -101,6 +102,42 @@ class UnbufferedLog : public Log
   public:
     UnbufferedLog(LogLevel level_ = logINFO);
 };
+
+template<typename CONTAINER>
+std::string ToStringArray(const CONTAINER& arr) {
+  std::ostringstream oss;
+  oss << "#" << arr.size() << "{";
+  bool first = true;
+  for (const auto& e : arr) {
+    if (not first) {
+      oss << ", ";
+    }
+    first = false;
+    oss << e;
+  }
+  oss << "}";
+  return oss.str();
+}
+
+template<typename K, typename V>
+std::string ToStringMap(const std::map<K, V>& m) {
+  std::ostringstream oss;
+  oss << "#" << m.size() << "{";
+  bool first = true;
+  for (const auto& p : m) {
+    if (not first) {
+      oss << ", ";
+    }
+    first = false;
+    oss << p.first << ": " << p.second;
+  }
+  oss << "}";
+  return oss.str();
+}
+
+std::string toHexString(int a);
+std::string shmKeyToString(std::uint16_t shm_key);
+
 } // namespace util
 } // namespace osrm
 

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -22,7 +22,6 @@ SharedMemoryAllocator::SharedMemoryAllocator(
     {
         util::Log(logDEBUG) << "Loading new data for region " << (int)shm_key;
         BOOST_ASSERT(storage::SharedMemory::RegionExists(shm_key));
-        util::Log(logWARNING) << "CTudorache SharedMemoryAllocator, shm_key: " << shm_key;
         auto mem = storage::makeSharedMemory(shm_key);
 
         storage::io::BufferReader reader(reinterpret_cast<char *>(mem->Ptr()), mem->Size());

--- a/src/engine/datafacade/shared_memory_allocator.cpp
+++ b/src/engine/datafacade/shared_memory_allocator.cpp
@@ -22,6 +22,7 @@ SharedMemoryAllocator::SharedMemoryAllocator(
     {
         util::Log(logDEBUG) << "Loading new data for region " << (int)shm_key;
         BOOST_ASSERT(storage::SharedMemory::RegionExists(shm_key));
+        util::Log(logWARNING) << "CTudorache SharedMemoryAllocator, shm_key: " << shm_key;
         auto mem = storage::makeSharedMemory(shm_key);
 
         storage::io::BufferReader reader(reinterpret_cast<char *>(mem->Ptr()), mem->Size());

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -26,11 +26,12 @@ namespace osrm
 {
 namespace extractor
 {
-ExtractorCallbacks::ExtractorCallbacks(ExtractionContainers &extraction_containers_,
+ExtractorCallbacks::ExtractorCallbacks(StringMap &string_map,
+                                       ExtractionContainers &extraction_containers_,
                                        std::unordered_map<std::string, ClassData> &classes_map,
                                        LaneDescriptionMap &lane_description_map,
                                        const ProfileProperties &properties)
-    : external_memory(extraction_containers_), classes_map(classes_map),
+    : string_map(string_map), external_memory(extraction_containers_), classes_map(classes_map),
       lane_description_map(lane_description_map),
       fallback_to_duration(properties.fallback_to_duration),
       force_split_edges(properties.force_split_edges)

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -94,6 +94,12 @@ struct to_lua_object : public boost::static_visitor<sol::object>
 } // namespace
 
 Sol2ScriptingEnvironment::Sol2ScriptingEnvironment(
+    const std::string &file_name) : Sol2ScriptingEnvironment(file_name, std::vector<boost::filesystem::path>())
+{
+    
+}
+
+Sol2ScriptingEnvironment::Sol2ScriptingEnvironment(
     const std::string &file_name,
     const std::vector<boost::filesystem::path> &location_dependent_data_paths)
     : file_name(file_name), location_dependent_data(location_dependent_data_paths)

--- a/src/osrm/merger.cpp
+++ b/src/osrm/merger.cpp
@@ -1,0 +1,11 @@
+#include "merger/merger.hpp"
+#include "merger/merger_config.hpp"
+#include "osrm/merger.hpp"
+
+namespace osrm
+{
+    void merge(const merger::MergerConfig merger_config)
+    {
+        merger::Merger(merger_config).run();
+    }
+}

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -87,12 +87,10 @@ RegionHandle setupRegion(SharedRegionRegister &shared_register,
     util::Log(logWARNING) << "CTudorache setupRegion, shm_key: " << shm_key << ", regions_size: " << regions_size << ", mem: " << memory->ToString();
 
     // Copy memory static_layout to shared memory and populate data
-    //util::Log(logWARNING) << "CTudorache setupRegion, copy data, size: " << encoded_static_layout.size();
     char *shared_memory_ptr = static_cast<char *>(memory->Ptr());
     auto data_ptr =
         std::copy_n(encoded_static_layout.data(), encoded_static_layout.size(), shared_memory_ptr);
 
-    //util::Log(logWARNING) << "CTudorache setupRegion, copy data DONE";
     return RegionHandle{std::move(memory), data_ptr, shm_key};
 }
 
@@ -101,7 +99,6 @@ bool swapData(Monitor &monitor,
               const std::map<std::string, RegionHandle> &handles,
               int max_wait)
 {
-    util::Log(logWARNING) << "CTudorache swapData, max_wait: " << max_wait << ", shared_register: " << shared_register.ToString() << ", handles: " << osrm::util::ToStringMap(handles);
     std::vector<RegionHandle> old_handles;
 
     { // Lock for write access shared region mutex

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -49,7 +49,13 @@ struct RegionHandle
     std::unique_ptr<SharedMemory> memory;
     char *data_ptr;
     std::uint16_t shm_key;
+    std::string ToString() const {
+        std::ostringstream oss;
+        oss << "{shm_key: " << shm_key << "}";
+        return oss.str();
+    }
 };
+inline std::ostream& operator<<(std::ostream& os, const RegionHandle& r) { return os << r.ToString(); }
 
 RegionHandle setupRegion(SharedRegionRegister &shared_register,
                          const storage::BaseDataLayout &layout)
@@ -62,7 +68,9 @@ RegionHandle setupRegion(SharedRegionRegister &shared_register,
     // to detach at the end of the function
     if (storage::SharedMemory::RegionExists(shm_key))
     {
-        util::Log(logWARNING) << "Old shared memory region " << (int)shm_key << " still exists.";
+        util::Log(logWARNING) << "Old shared memory region " << ShmKeyToString(shm_key) << " still exists. Attempting open";
+        auto shm = osrm::storage::makeSharedMemory(shm_key);
+        util::Log(logWARNING) << "Old shared memory region " << ShmKeyToString(shm_key) << " still exists: " << shm->ToString();
         util::UnbufferedLog() << "Retrying removal... ";
         storage::SharedMemory::Remove(shm_key);
         util::UnbufferedLog() << "ok.";
@@ -74,15 +82,17 @@ RegionHandle setupRegion(SharedRegionRegister &shared_register,
 
     // Allocate shared memory block
     auto regions_size = encoded_static_layout.size() + layout.GetSizeOfLayout();
-    util::Log() << "Data layout has a size of " << encoded_static_layout.size() << " bytes";
-    util::Log() << "Allocating shared memory of " << regions_size << " bytes";
+    util::Log() << "Data layout has a size of " << encoded_static_layout.size() << " bytes, Allocating shared memory of " << regions_size << " bytes";
     auto memory = makeSharedMemory(shm_key, regions_size);
+    util::Log(logWARNING) << "CTudorache setupRegion, shm_key: " << shm_key << ", regions_size: " << regions_size << ", mem: " << memory->ToString();
 
     // Copy memory static_layout to shared memory and populate data
+    //util::Log(logWARNING) << "CTudorache setupRegion, copy data, size: " << encoded_static_layout.size();
     char *shared_memory_ptr = static_cast<char *>(memory->Ptr());
     auto data_ptr =
         std::copy_n(encoded_static_layout.data(), encoded_static_layout.size(), shared_memory_ptr);
 
+    //util::Log(logWARNING) << "CTudorache setupRegion, copy data DONE";
     return RegionHandle{std::move(memory), data_ptr, shm_key};
 }
 
@@ -91,6 +101,7 @@ bool swapData(Monitor &monitor,
               const std::map<std::string, RegionHandle> &handles,
               int max_wait)
 {
+    util::Log(logWARNING) << "CTudorache swapData, max_wait: " << max_wait << ", shared_register: " << shared_register.ToString() << ", handles: " << osrm::util::ToStringMap(handles);
     std::vector<RegionHandle> old_handles;
 
     { // Lock for write access shared region mutex
@@ -114,20 +125,41 @@ bool swapData(Monitor &monitor,
         }
         else
         {
+            util::Log(logWARNING) << "CTudorache swapData locking sharedMonitor mutex";
             lock.lock();
         }
 
         for (auto &pair : handles)
         {
             auto region_id = shared_register.Find(pair.first);
+            util::Log(logWARNING) << "CTudorache swapData name: " << pair.first
+                                  << ", old region_id: " << region_id << (region_id == SharedRegionRegister::INVALID_REGION_ID ? "(INVALID)" : "(VALID)")
+                                  << ", new shm_key: " << pair.second.shm_key;
+            if (region_id != SharedRegionRegister::INVALID_REGION_ID)
+            {
+                auto &shared_region = shared_register.GetRegion(region_id);
+                if (!storage::SharedMemory::RegionExists(shared_region.shm_key))
+                {
+                    util::Log(logERROR) << "CTudorache swapData old region shm_key does not exist: " << shared_region.ToString();
+                    shared_region.timestamp = 0;
+                    shared_register.ReleaseKey(shared_region.shm_key);
+                    OSRMLockFile lock_file;
+                    boost::filesystem::remove(lock_file(shared_region.shm_key));
+                    region_id = SharedRegionRegister::INVALID_REGION_ID;
+                }
+            }
+
             if (region_id == SharedRegionRegister::INVALID_REGION_ID)
             {
+                util::Log(logWARNING) << "CTudorache swapData register: " << pair.first << ", key: " << util::shmKeyToString(pair.second.shm_key);
                 region_id = shared_register.Register(pair.first, pair.second.shm_key);
             }
             else
             {
                 auto &shared_region = shared_register.GetRegion(region_id);
-
+                util::Log(logWARNING) << "CTudorache swapData replacing shared_region: "
+                                      << shared_region.ToString() << "(exists: " << storage::SharedMemory::RegionExists(shared_region.shm_key) <<")"
+                                      << ", with new shm_key: " << pair.second.shm_key;
                 old_handles.push_back(RegionHandle{
                     makeSharedMemory(shared_region.shm_key), nullptr, shared_region.shm_key});
 
@@ -262,6 +294,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
         Storage::PopulateLayoutWithRTree(*static_layout);
         std::vector<std::pair<bool, boost::filesystem::path>> files = Storage::GetStaticFiles();
         Storage::PopulateLayout(*static_layout, files);
+        util::Log(logWARNING) << "CTudorache Storage::Run setupRegion static";
         auto static_handle = setupRegion(shared_register, *static_layout);
         regions.push_back({static_handle.data_ptr, std::move(static_layout)});
         handles[dataset_name + "/static"] = std::move(static_handle);
@@ -271,6 +304,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
         std::make_unique<storage::ContiguousDataLayout>();
     std::vector<std::pair<bool, boost::filesystem::path>> files = Storage::GetUpdatableFiles();
     Storage::PopulateLayout(*updatable_layout, files);
+    util::Log(logWARNING) << "CTudorache Storage::Run setupRegion updatable";
     auto updatable_handle = setupRegion(shared_register, *updatable_layout);
     regions.push_back({updatable_handle.data_ptr, std::move(updatable_layout)});
     handles[dataset_name + "/updatable"] = std::move(updatable_handle);
@@ -279,12 +313,16 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
 
     if (!only_metric)
     {
+        util::Log(logWARNING) << "CTudorache Storage::Run PopulateStaticData";
         PopulateStaticData(index);
     }
+    util::Log(logWARNING) << "CTudorache Storage::Run PopulateUpdatableData";
     PopulateUpdatableData(index);
 
+    util::Log(logWARNING) << "CTudorache Storage::Run swapData";
     swapData(monitor, shared_register, handles, max_wait);
 
+    util::Log(logWARNING) << "CTudorache Storage::Run DONE. SharedRegister: " << monitor.data().ToString();
     return EXIT_SUCCESS;
 }
 

--- a/src/tools/merge.cpp
+++ b/src/tools/merge.cpp
@@ -1,0 +1,160 @@
+#include "osrm/merger.hpp"
+#include "osrm/merger_config.hpp"
+#include "util/log.hpp"
+#include "util/version.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+#include <cstdlib>
+#include <thread>
+
+using namespace osrm;
+
+enum class return_code : unsigned
+{
+    ok,
+    fail,
+    exit
+};
+
+return_code parseArguments(int argc,
+                           char *argv[],
+                           merger::MergerConfig &merger_config)
+{
+    // declare a group of options that will be a allowed only on command line
+    boost::program_options::options_description generic_options("Options");
+    generic_options.add_options()("version,v", "Show version")("help,h", "Show this help message");
+
+    // declare a group of options that will be allowed both on command line
+    boost::program_options::options_description config_options("Configuration");
+    config_options.add_options()(
+        "threads,t",
+        boost::program_options::value<unsigned int>(&merger_config.requested_num_threads)
+            ->default_value(std::thread::hardware_concurrency()),
+        "Number of threads to use")(
+        "output,o",
+        boost::program_options::value<boost::filesystem::path>(&merger_config.output_path)
+            ->default_value(boost::filesystem::path("merged")),
+        "Prefix for the output files");
+
+    boost::program_options::options_description hidden_options("Hidden options");
+    hidden_options.add_options()(
+        "profiles_to_input_maps",
+        boost::program_options::value<std::vector<std::string>>()->multitoken(),
+        "list of pairs <profile_file>:<input_map1>,...<input_mapN>");
+
+    // positional option
+    boost::program_options::positional_options_description positional_options;
+    positional_options.add("profiles_to_input_maps", -1);
+
+    // combine above options for parsing
+    boost::program_options::options_description cmdline_options;
+    cmdline_options.add(generic_options).add(config_options).add(hidden_options);
+
+    const auto *executable = argv[0];
+    boost::program_options::options_description visible_options(
+        boost::filesystem::path(executable).filename().string() +
+        " <.lua>:[<.osm.pbf>,...] <.lua>:[<.osm.pbf>,...] ...");
+    visible_options.add(generic_options).add(config_options);
+
+    // parse command line options
+    boost::program_options::variables_map option_variables;
+    try
+    {
+        boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
+                                          .options(cmdline_options)
+                                          .positional(positional_options)
+                                          .run(),
+                                      option_variables);
+    }
+    catch (const boost::program_options::error &e)
+    {
+        util::Log(logERROR) << e.what();
+        return return_code::fail;
+    }
+
+    if (option_variables.count("version"))
+    {
+        std::cout << OSRM_VERSION << std::endl;
+        return return_code::exit;
+    }
+
+    if (option_variables.count("help"))
+    {
+        std::cout << visible_options;
+        return return_code::exit;
+    }
+
+    boost::program_options::notify(option_variables);
+
+    if (option_variables["profiles_to_input_maps"].empty()) {
+        std::cout << visible_options;
+        return return_code::exit;
+    }
+    std::vector<std::string> pairs = option_variables["profiles_to_input_maps"].as<std::vector<std::string>>();
+    for (const auto &pair : pairs)
+    {
+        std::vector<std::string> tokens, input_maps;
+        boost::split(tokens, pair, boost::is_any_of(":"));
+        if (tokens.size() != 2)
+        {
+            std::cout << visible_options;
+            return return_code::exit;
+        }
+
+        boost::filesystem::path profile_path(tokens[0]);
+        boost::split(input_maps, tokens[1], boost::is_any_of(","));
+        std::vector<boost::filesystem::path> input_maps_path;
+        for (const auto &map : input_maps)
+        {
+            input_maps_path.push_back(boost::filesystem::path(map));
+        }
+        merger_config.profile_to_input.insert({profile_path, input_maps_path});
+    }
+
+    return return_code::ok;
+}
+
+int main(int argc, char *argv[])
+{
+    util::LogPolicy::GetInstance().Unmute();
+    merger::MergerConfig merger_config;
+
+    const auto result = parseArguments(argc, argv, merger_config);
+
+    if (return_code::fail == result)
+    {
+        return EXIT_FAILURE;
+    }
+    if (return_code::exit == result)
+    {
+        return EXIT_SUCCESS;
+    }
+
+    merger_config.UseDefaultOutputNames(merger_config.output_path);
+
+    for (const auto &pair : merger_config.profile_to_input)
+    {
+        if (!boost::filesystem::is_regular_file(pair.first))
+        {
+            util::Log(logERROR) << "Profile " << pair.first.string()
+                                << " not found!";
+            return EXIT_FAILURE;
+        }
+        for (const auto &input_map : pair.second)
+        {
+            if (!boost::filesystem::is_regular_file(input_map))
+            {
+                util::Log(logERROR) << "Input file " << input_map.string()
+                                    << " not found!";
+                return EXIT_FAILURE;
+            }
+        }
+    }
+
+    util::Log(logINFO) << "Starting merge...";
+
+    osrm::merge(merger_config);
+}

--- a/src/tools/store.cpp
+++ b/src/tools/store.cpp
@@ -37,7 +37,7 @@ void deleteRegion(const storage::SharedRegionRegister::ShmKey key)
 
 void listRegions(bool show_blocks)
 {
-    osrm::util::Log() << "name\tshm key\ttimestamp\tsize\tkey\tshmid";
+    osrm::util::Log() << "name\tshm key\ttimestamp\tsize";
     if (!storage::SharedMonitor<storage::SharedRegionRegister>::exists())
     {
         util::Log(logWARNING) << "CTudorache sharedMonitor DOES NOT EXIST: " << (const char *)storage::SharedRegionRegister::name;


### PR DESCRIPTION
# Issue

Osrm-datastore stability fixes:
- test if old shm segment exists before swapping data
- on signal handler (SIGTERM, SIGABRT, ..):
-- avoid deleting the global shared object "osrm-region" 
-- release the global mutex 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
