### PR TITLE
Permit 'cycleway:both' way key to populate both left-and-right cycleway definitions

### DIFF
--- a/features/bicycle/cycleway.feature
+++ b/features/bicycle/cycleway.feature
@@ -9,16 +9,22 @@ Feature: Bike - Cycle tracks/lanes
         Then routability should be
             | highway     | cycleway     | forw | backw |
             | motorway    |              |      |       |
+            | motorway    | no           |      |       |
             | motorway    | track        | x    |       |
             | motorway    | lane         | x    |       |
             | motorway    | shared       | x    |       |
             | motorway    | share_busway | x    |       |
             | motorway    | sharrow      | x    |       |
+            | some_tag    |              |      |       |
+            | some_tag    | no           |      |       |
             | some_tag    | track        | x    | x     |
             | some_tag    | lane         | x    | x     |
             | some_tag    | shared       | x    | x     |
             | some_tag    | share_busway | x    | x     |
             | some_tag    | sharrow      | x    | x     |
+            # residential ways may not have cycleways present but they should be routable
+            | residential |              | x    | x     |
+            | residential | no           | x    | x     |
             | residential | track        | x    | x     |
             | residential | lane         | x    | x     |
             | residential | shared       | x    | x     |

--- a/features/bicycle/cycleway.feature
+++ b/features/bicycle/cycleway.feature
@@ -31,6 +31,16 @@ Feature: Bike - Cycle tracks/lanes
             | residential | share_busway | x    | x     |
             | residential | sharrow      | x    | x     |
 
+    Scenario: Bike - Bidirectional cycleways
+        Then routability should be
+            | highway  | cycleway:both | forw | backw |
+            | primary  |               | x    | x     |
+            | primary  | track         | x    | x     |
+            | primary  | opposite      | x    | x     |
+            | motorway |               |      |       |
+            | motorway | track         | x    | x     |
+            | motorway | opposite      | x    | x     |
+
     Scenario: Bike - Left/right side cycleways on implied bidirectionals
         Then routability should be
             | highway | cycleway | cycleway:left | cycleway:right | forw | backw |
@@ -103,3 +113,19 @@ Feature: Bike - Cycle tracks/lanes
             | residential | track    | yes    | 15 km/h | 4 km/h +-1 |
             | cycleway    | track    | yes    | 15 km/h | 4 km/h +-1 |
             | footway     | track    | yes    | 15 km/h | 4 km/h +-1 |
+
+    Scenario: Bike - Cycleway on twoways, modes
+        Then routability should be
+            | highway     | cycleway:both | forw    | backw   |
+            | motorway    | track         | cycling | cycling |
+            | residential | track         | cycling | cycling |
+            | cycleway    | track         | cycling | cycling |
+            | footway     | track         | cycling | cycling |
+
+    Scenario: Bike - Cycleway on twoways, speeds
+        Then routability should be
+            | highway     | cycleway:both | forw    | backw      |
+            | motorway    | track         | 15 km/h | 15 km/h    |
+            | residential | track         | 15 km/h | 15 km/h    |
+            | cycleway    | track         | 15 km/h | 15 km/h    |
+            | footway     | track         | 15 km/h | 15 km/h    |

--- a/features/bicycle/cycleway.feature
+++ b/features/bicycle/cycleway.feature
@@ -117,6 +117,7 @@ Feature: Bike - Cycle tracks/lanes
     Scenario: Bike - Cycleway on twoways, modes
         Then routability should be
             | highway     | cycleway:both | forw    | backw   |
+            | motorway    | no            |         |         |
             | motorway    | track         | cycling | cycling |
             | residential | track         | cycling | cycling |
             | cycleway    | track         | cycling | cycling |
@@ -125,6 +126,7 @@ Feature: Bike - Cycle tracks/lanes
     Scenario: Bike - Cycleway on twoways, speeds
         Then routability should be
             | highway     | cycleway:both | forw    | backw      |
+            | motorway    | no            |         |            |
             | motorway    | track         | 15 km/h | 15 km/h    |
             | residential | track         | 15 km/h | 15 km/h    |
             | cycleway    | track         | 15 km/h | 15 km/h    |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -276,8 +276,8 @@ function handle_bicycle_tags(profile,way,result,data)
   data.oneway = way:get_value_by_key("oneway")
   data.oneway_bicycle = way:get_value_by_key("oneway:bicycle")
   data.cycleway = way:get_value_by_key("cycleway")
-  data.cycleway_left = way:get_value_by_key("cycleway:left")
-  data.cycleway_right = way:get_value_by_key("cycleway:right")
+  data.cycleway_left = way:get_value_by_key("cycleway:left") or way:get_value_by_key("cycleway:both")
+  data.cycleway_right = way:get_value_by_key("cycleway:right") or way:get_value_by_key("cycleway:both")
   data.duration = way:get_value_by_key("duration")
   data.service = way:get_value_by_key("service")
   data.foot = way:get_value_by_key("foot")
@@ -370,6 +370,12 @@ function speed_handler(profile,way,result,data)
 end
 
 function oneway_handler(profile,way,result,data)
+  -- explicit twoway
+  local cycleway_both = way:get_value_by_key("cycleway:both")
+  if cycleway_both and profile.cycleway_tags[cycleway_both] then
+    return
+  end
+
   -- oneway
   data.implied_oneway = data.junction == "roundabout" or data.junction == "circular" or data.highway == "motorway"
   data.reverse = false


### PR DESCRIPTION
@Nate-Wessel @mjjbell I was taking a bit of a look at #6180 and the related test coverage question in the hope that it might be a quick fix / improvement.

A few hours later.. well, I'm not so sure it's a straightforward change, but thought I would offer what I've developed locally and some findings.

**Usage of `cycleway:both` tag**
I think that most of the increased usage of `cycleway:both` may be related to [StreetComplete](https://wiki.openstreetmap.org/wiki/StreetComplete), a map editing app, which asks users about the presence of bicycle routes when they're providing map information.

If no bicycle routes are indicated by the user, the app will add `cycleway:both=no` -- and my best guess is that those entries account for most of the uptick in the graph that @Nate-Wessel [referenced in the issue](https://github.com/Project-OSRM/osrm-backend/issues/6179#issue-1084148047).

**One-ways**
One tricky edge case to handle is 'implied one ways' -- typically traffic-controlled motorways, roundabouts and on/off-ramps - places where cycling contraflow may be dangerous (and/or illegal).  In those cases, the presence of `cycleway:both` as of f541885e6940a2d0f219f70fdfaa9aba1ca451c1 currently short-circuits the one-way handling; each affected way will be considered as routable.

:warning: This feels slightly unsafe, because those conditions could indicate a data entry or quality issue related to the implied one-way -- and marking them routable could cause real-world problems.  Because of that ambiguity/risk, I think I'll open this pull request in 'draft' status pending discussion and resolution.

When using [Overpass Turbo](https://overpass-turbo.eu/), an OSM query interface to try to find one-ways and motorways that have `cycleway:both`, I haven't yet found and confirmed any valid locations (after trying to compare against street photos -- and even then ground-truth checks would be a good follow-up).

Here's an example query I used, for reference:

```
way
  ["oneway"="yes"]
  ["cycleway:both"]
  ["cycleway:both"!="no"]
  ({{bbox}});
out;
```

**Test coverage**
This pull request offers some additional test coverage on various `cycleway` ... `=no` cases; these were partly to reassure me during experimentation and development, and partly because it feels worthwhile to reduce the chance that risky routing options could accidentally occur in future as the code evolves.

Resolves #6179 (alternate implementation to #6180).