### PR TITLE
Update macOS CI image to macos-11

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -177,7 +177,7 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 12
-            runs-on: macos-10.15
+            runs-on: macos-11
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: clang
@@ -190,7 +190,7 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 14
-            runs-on: macos-10.15
+            runs-on: macos-11
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: clang
@@ -203,7 +203,7 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 16
-            runs-on: macos-10.15
+            runs-on: macos-11
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
             CCOMPILER: clang
@@ -294,7 +294,7 @@ jobs:
             continue-on-error: true
             # TODO: Use node 'latest' once supported: https://github.com/actions/setup-node/issues/257
             node: 16
-            runs-on: macos-10.15
+            runs-on: macos-11
             BUILD_TYPE: Release
             CCOMPILER: clang
             CXXCOMPILER: clang++
@@ -330,7 +330,7 @@ jobs:
             build_node_package: true
             continue-on-error: true
             node: "lts/*"
-            runs-on: macos-10.15
+            runs-on: macos-11
             BUILD_TYPE: Release
             CCOMPILER: clang
             CXXCOMPILER: clang++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - API:
       - FIXED: Fix inefficient osrm-routed connection handling [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
     - Build:
+      - CHANGED: Update macOS CI image to macos-11. [#6286](https://github.com/Project-OSRM/osrm-backend/pull/6286)
       - CHANGED: Enable even more clang-tidy checks. [#6273](https://github.com/Project-OSRM/osrm-backend/pull/6273)
       - CHANGED: Configure CMake to not build flatbuffers tests and samples. [#6274](https://github.com/Project-OSRM/osrm-backend/pull/6274)
       - CHANGED: Enable more clang-tidy checks. [#6270](https://github.com/Project-OSRM/osrm-backend/pull/6270)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,7 +419,6 @@ endif()
 
 # Configuring other platform dependencies
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10")
   execute_process(COMMAND xcrun --sdk macosx --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT OUTPUT_STRIP_TRAILING_WHITESPACE)
   exec_program(uname ARGS -v  OUTPUT_VARIABLE DARWIN_VERSION)
   string(REGEX MATCH "[0-9]+" DARWIN_VERSION ${DARWIN_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ endif()
 
 # Configuring other platform dependencies
 if(APPLE)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10")
   execute_process(COMMAND xcrun --sdk macosx --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT OUTPUT_STRIP_TRAILING_WHITESPACE)
   exec_program(uname ARGS -v  OUTPUT_VARIABLE DARWIN_VERSION)
   string(REGEX MATCH "[0-9]+" DARWIN_VERSION ${DARWIN_VERSION})


### PR DESCRIPTION
# Issue

[In the end of August GitHub is going to stop support of macOS image we are using](https://github.com/actions/virtual-environments/issues/5583). This PR updates it to macos-11(I tried macos-12 which is newer, but faced issues and decided to not waste time on it).
<img width="2344" alt="Screenshot 2022-07-23 at 16 31 24" src="https://user-images.githubusercontent.com/266271/180609530-764607a8-8c29-455e-9a65-22bbe356da85.png">



## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
