### PR TITLE
Remove highway=bicycle safety bonys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
       - FIXED: Fix inefficient osrm-routed connection handling [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
     - Misc:
       - FIXED: Fix bug with reading Set values from Lua scripts. [#6285](https://github.com/Project-OSRM/osrm-backend/pull/6285)
+      - FIXED: Bug in bicycle profile that caused exceptions if there is a highway=bicycle in the data. [#6296](https://github.com/Project-OSRM/osrm-backend/pull/6296)
     - Build:
       - CHANGED: Configure Undefined Behaviour Sanitizer. [#6290](https://github.com/Project-OSRM/osrm-backend/pull/6290)
       - CHANGED: Use Conan instead of Mason to install code dependencies. [#6284](https://github.com/Project-OSRM/osrm-backend/pull/6284)

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -543,21 +543,6 @@ function safety_handler(profile,way,result,data)
     if result.duration > 0 then
       result.weight = result.duration / forward_penalty
     end
-
-    if data.highway == "bicycle" then
-      safety_bonus = safety_bonus + 0.2
-      if result.forward_speed > 0 then
-        -- convert from km/h to m/s
-        result.forward_rate = result.forward_speed / 3.6 * safety_bonus
-      end
-      if result.backward_speed > 0 then
-        -- convert from km/h to m/s
-        result.backward_rate = result.backward_speed / 3.6 * safety_bonus
-      end
-      if result.duration > 0 then
-        result.weight = result.duration / safety_bonus
-      end
-    end
   end
 end
 


### PR DESCRIPTION
# Issue

This removes a bonus for a road class that doesn't exist (`cycleway` would be correct), but the code was buggy since `safety_bonus` is `nil` and caused an arithmetic exception. We only caught this 4 (!) years later since
recently a way was tagged with `highway=bicycle` and made it in our OSM data leading to preprocessing failures.

## Tasklist

 - [x] CHANGELOG.md entry
