### PR TITLE
Do not use deprecated Callback::Call overload in Node bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - FIXED: Use Boost.Beast to parse HTTP request. [#6294](https://github.com/Project-OSRM/osrm-backend/pull/6294)
       - FIXED: Fix inefficient osrm-routed connection handling [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
     - Misc:
+      - CHANGED: Do not use deprecated Callback::Call overload in Node bindings. [#6318](https://github.com/Project-OSRM/osrm-backend/pull/6318)
       - FIXED: Fix distance calculation consistency. [#6315](https://github.com/Project-OSRM/osrm-backend/pull/6315)
       - FIXED: Fix performance issue after migration to sol2 3.3.0. [#6304](https://github.com/Project-OSRM/osrm-backend/pull/6304)
       - CHANGED: Pass osm_node_ids by reference in osrm::updater::Updater class. [#6298](https://github.com/Project-OSRM/osrm-backend/pull/6298)

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -148,7 +148,7 @@ inline void async(const Nan::FunctionCallbackInfo<v8::Value> &info,
                ServiceMemFn service,
                Nan::Callback *callback,
                PluginParameters pluginParams_)
-            : Base(callback), osrm{std::move(osrm_)}, service{std::move(service)},
+            : Base(callback, "osrm:async"), osrm{std::move(osrm_)}, service{std::move(service)},
               params{std::move(params_)}, pluginParams{std::move(pluginParams_)}
         {
         }
@@ -184,7 +184,7 @@ inline void async(const Nan::FunctionCallbackInfo<v8::Value> &info,
             const constexpr auto argc = 2u;
             v8::Local<v8::Value> argv[argc] = {Nan::Null(), render(result)};
 
-            callback->Call(argc, argv);
+            callback->Call(argc, argv, async_resource);
         }
 
         // Keeps the OSRM object alive even after shutdown until we're done with callback
@@ -230,7 +230,7 @@ inline void asyncForTiles(const Nan::FunctionCallbackInfo<v8::Value> &info,
                ServiceMemFn service,
                Nan::Callback *callback,
                PluginParameters pluginParams_)
-            : Base(callback), osrm{std::move(osrm_)}, service{std::move(service)},
+            : Base(callback, "osrm:asyncForTiles"), osrm{std::move(osrm_)}, service{std::move(service)},
               params{std::move(params_)}, pluginParams{std::move(pluginParams_)}
         {
         }
@@ -256,7 +256,7 @@ inline void asyncForTiles(const Nan::FunctionCallbackInfo<v8::Value> &info,
             auto str_result = result.get<std::string>();
             v8::Local<v8::Value> argv[argc] = {Nan::Null(), render(str_result)};
 
-            callback->Call(argc, argv);
+            callback->Call(argc, argv, async_resource);
         }
 
         // Keeps the OSRM object alive even after shutdown until we're done with callback

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -230,8 +230,9 @@ inline void asyncForTiles(const Nan::FunctionCallbackInfo<v8::Value> &info,
                ServiceMemFn service,
                Nan::Callback *callback,
                PluginParameters pluginParams_)
-            : Base(callback, "osrm:asyncForTiles"), osrm{std::move(osrm_)}, service{std::move(service)},
-              params{std::move(params_)}, pluginParams{std::move(pluginParams_)}
+            : Base(callback, "osrm:asyncForTiles"), osrm{std::move(osrm_)},
+              service{std::move(service)}, params{std::move(params_)}, pluginParams{
+                                                                           std::move(pluginParams_)}
         {
         }
 


### PR DESCRIPTION
# Issue

Noticed that we use deprecated overload of this method.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
