### PR TITLE
Fix HTTP compression precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - CHANGED: Add `data_version` field to responses of all services. [#5387](https://github.com/Project-OSRM/osrm-backend/pull/5387)
       - FIXED: Use Boost.Beast to parse HTTP request. [#6294](https://github.com/Project-OSRM/osrm-backend/pull/6294)
       - FIXED: Fix inefficient osrm-routed connection handling [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
+      - FIXED: Fix HTTP compression precedence [#6113](https://github.com/Project-OSRM/osrm-backend/pull/6113)
     - NodeJS:
       - FIXED: Support `skip_waypoints` in Node bindings [#6060](https://github.com/Project-OSRM/osrm-backend/pull/6060)
     - Misc:

--- a/src/server/connection.cpp
+++ b/src/server/connection.cpp
@@ -27,13 +27,13 @@ http::compression_type select_compression(const boost::beast::http::fields &fiel
 {
     const auto header_value = fields[boost::beast::http::field::accept_encoding];
     /* giving gzip precedence over deflate */
-    if (boost::icontains(header_value, "deflate"))
-    {
-        return http::deflate_rfc1951;
-    }
     if (boost::icontains(header_value, "gzip"))
     {
         return http::gzip_rfc1952;
+    }
+    if (boost::icontains(header_value, "deflate"))
+    {
+        return http::deflate_rfc1951;
     }
     return http::no_compression;
 }


### PR DESCRIPTION
# Issue
There is a bug in the deflate compression. Therefore, we do not want
to select this in the default choice for HTTP response compression.
Instead we revert back to the previous precedence, selecting gzip as
the priority.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

#6330