### PR TITLE
Fix snapping target locations to ways used in turn restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
       - ADDED: Add support for non-round-trips with a single fixed endpoint. [#6050](https://github.com/Project-OSRM/osrm-backend/pull/6050)
       - FIXED: Improvements to maneuver override processing [#6125](https://github.com/Project-OSRM/osrm-backend/pull/6125)
       - ADDED: Support snapping to multiple ways at an input location. [#5953](https://github.com/Project-OSRM/osrm-backend/pull/5953)
+      - FIXED: Fix snapping target locations to ways used in turn restrictions. [#6339](https://github.com/Project-OSRM/osrm-backend/pull/6339)
 
 # 5.26.0
   - Changes from 5.25.0

--- a/features/car/multi_via_restrictions.feature
+++ b/features/car/multi_via_restrictions.feature
@@ -1031,3 +1031,61 @@ Feature: Car - Multiple Via Turn restrictions
             | from | to | route             | locations   |
 	    | a    | f  | ab,bc,cd,de,ef,ef | a,b,c,d,e,f |
 
+
+    @restriction-way
+    Scenario: Snap source/target to via restriction way
+        Given the node map
+            """
+            a-1-b-2-c-3-d
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | cd    |
+
+        And the relations
+            | type        | way:from | way:via | way:to  | restriction    |
+            | restriction | ab       | bc      | cd      | no_straight_on |
+
+        When I route I should get
+            | from | to | route    |
+            | 1    | 2  | ab,bc,bc |
+            | 2    | 3  | bc,cd,cd |
+
+
+    @restriction-way
+    Scenario: Car - Snap source/target to multi-via restriction way
+    # Example: https://www.openstreetmap.org/relation/11787041
+        Given the node map
+            """
+            |--g---f---e
+            a      |   1
+            |--b---c---d
+
+            """
+
+       And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+
+        And the ways
+            | nodes | oneway | name  |
+            | ab    | yes    | enter |
+            | bc    | yes    | enter |
+            | cd    | yes    | right |
+            | de    | yes    | up    |
+            | ef    | yes    | left  |
+            | fc    | yes    | down  |
+            | fg    | yes    | exit  |
+            | ga    | yes    | exit  |
+
+        And the relations
+            | type        | way:from | way:via    | way:to | restriction  |
+            | restriction | bc       | cd,de,ef   | fg     | no_u_turn    |
+
+        When I route I should get
+            | from | to | route              | locations           |
+            | a    | 1  | enter,right,up,up  | a,c,d,_             |
+            | 1    | a  | up,left,exit,exit  | _,e,f,a             |


### PR DESCRIPTION
# Issue
![before_after_via_end_1](https://user-images.githubusercontent.com/1063186/187031528-d50c4a15-72b4-4d4a-b64c-c9270f8eb813.png)

[link](https://map.project-osrm.org/?z=18&center=50.778949%2C6.093239&loc=50.777613%2C6.094687&loc=50.778243%2C6.094258&hl=en&alt=0&srv=0)

Currently there is an edge-case in the turn restriction implementation, such that routes can not be found if the target input location snaps to a way used in a (multi) via restriction.

With the addition of snapping input locations to multiple ways, we can now also snap to the "duplicate" edges created for the restriction graph, thereby fixing the problem.
This is achieved by adding the duplicate restriction edges to the geospatial search RTree.

This does open up the possibility of multiple paths representing exactly the same route - one using the original edge as a source, the other using the duplicate restriction graph edge as source.
This is fine, as both edges are represented by the same geometry, so will generate the same result.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #6069
Fixes https://github.com/Project-OSRM/osrm-backend/pull/5907#issuecomment-797430372
