### PR TITLE
Introduce osm_nodes annotations for 64-bit OSM Node Ids

### DIFF
--- a/include/engine/api/flatbuffers/route.fbs
+++ b/include/engine/api/flatbuffers/route.fbs
@@ -10,6 +10,8 @@ table Annotation {
     duration: [uint];
     datasources: [uint];
     nodes: [uint];
+    osm_nodes: [ulong];
+    
     weight: [uint];
     speed: [float];
     metadata: Metadata;

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -7,6 +7,7 @@
 
 #include "engine/api/json_factory.hpp"
 #include "engine/phantom_node.hpp"
+#include "util/json_container.hpp"
 
 #include <boost/assert.hpp>
 
@@ -109,6 +110,11 @@ class NearestAPI final : public BaseAPI
                                nodes.values.push_back(node_values.first);
                                nodes.values.push_back(node_values.second);
                                waypoint.values["nodes"] = std::move(nodes);
+
+                               util::json::Array osm_nodes;
+                               osm_nodes.values.emplace_back(std::to_string(node_values.first));
+                               osm_nodes.values.emplace_back(std::to_string(node_values.second));
+                               waypoint.values["osm_nodes"] = std::move(osm_nodes);
 
                                return waypoint;
                            });

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -852,17 +852,6 @@ class RouteAPI : public BaseAPI
                         annotation.values["osmnodes"] = osm_nodes;
                     }
                 }
-                if (requested_annotations & RouteParameters::AnnotationsType::OSMNodes)
-                {
-                    util::json::Array nodes;
-                    nodes.values.reserve(leg_geometry.node_ids.size());
-                    for (const auto node_id : leg_geometry.node_ids)
-                    {
-                        nodes.values.push_back(std::to_string(
-                            static_cast<std::uint64_t>(facade.GetOSMNodeIDOfNode(node_id))));
-                    }
-                    annotation.values["nodes"] = std::move(nodes);
-                }
                 // Add any supporting metadata, if needed
                 if (requested_annotations & RouteParameters::AnnotationsType::Datasources)
                 {

--- a/include/engine/api/route_parameters.hpp
+++ b/include/engine/api/route_parameters.hpp
@@ -70,13 +70,14 @@ struct RouteParameters : public BaseParameters
     enum class AnnotationsType
     {
         None = 0,
-        Duration = 0x01,
-        Nodes = 0x02,
-        Distance = 0x04,
-        Weight = 0x08,
-        Datasources = 0x10,
-        Speed = 0x20,
-        All = Duration | Nodes | Distance | Weight | Datasources | Speed
+        Duration = 1 << 1,
+        Nodes = 1 << 2,
+        Distance = 1 << 3,
+        Weight = 1 << 4,
+        Datasources = 1 << 5,
+        Speed = 1 << 6,
+        OSMNodes = 1 << 7,
+        All = Duration | Nodes | Distance | Weight | Datasources | Speed | OSMNodes
     };
 
     RouteParameters() = default;

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -778,6 +778,11 @@ inline bool parseCommonParameters(const v8::Local<v8::Object> &obj, ParamType &p
                     params->annotations_type =
                         params->annotations_type | osrm::RouteParameters::AnnotationsType::Nodes;
                 }
+                else if (annotations_str == "osm_nodes")
+                {
+                    params->annotations_type =
+                        params->annotations_type | osrm::RouteParameters::AnnotationsType::OSMNodes;
+                }
                 else if (annotations_str == "distance")
                 {
                     params->annotations_type =

--- a/include/server/api/route_parameters_grammar.hpp
+++ b/include/server/api/route_parameters_grammar.hpp
@@ -73,8 +73,8 @@ struct RouteParametersGrammar : public BaseParametersGrammar<Iterator, Signature
             "full", engine::api::RouteParameters::OverviewType::Full)(
             "false", engine::api::RouteParameters::OverviewType::False);
 
-        annotations_type.add("duration", AnnotationsType::Duration)("nodes",
-                                                                    AnnotationsType::Nodes)(
+        annotations_type.add("duration", AnnotationsType::Duration)(
+            "nodes", AnnotationsType::Nodes)("osm_nodes", AnnotationsType::OSMNodes)(
             "distance", AnnotationsType::Distance)("weight", AnnotationsType::Weight)(
             "datasources", AnnotationsType::Datasources)("speed", AnnotationsType::Speed);
 


### PR DESCRIPTION
# Issue

potentially closes https://github.com/Project-OSRM/osrm-backend/issues/5970 and https://github.com/Project-OSRM/osrm-backend/issues/5716

The question here is how to preserve backward compatibility, that's why I want to discuss this before doing final "polishing".

What I am doing at the moment I add additional field `osm_nodes` which in some cases may be returned along with old `nodes` field which is kind of ugly and wasteful(but we cannot just remove this old `nodes` without breaking backward compatibility). Another option would be to add parameter(e.g. `use_64bit_node_ids=true`) and start returning node ids as strings in this case. 

Also worth noting that JSON itself seems to support 64-bit numbers and we could just fix our JSON serialization to not convert numbers to double before serialization, but JS itself safely supports only integers up to 53-bit(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) and 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
