### PR TITLE
Ensure u-turn exists in intersection view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
       - ADDED: Support snapping to multiple ways at an input location. [#5953](https://github.com/Project-OSRM/osrm-backend/pull/5953)
       - FIXED: Fix snapping target locations to ways used in turn restrictions. [#6339](https://github.com/Project-OSRM/osrm-backend/pull/6339)
       - ADDED: Support OSM traffic signal directions. [#6153](https://github.com/Project-OSRM/osrm-backend/pull/6153)
+      - FIXED: Ensure u-turn exists in intersection view. [#6376](https://github.com/Project-OSRM/osrm-backend/pull/6376)
     - Profile:
       - CHANGED: Bicycle surface speeds [#6212](https://github.com/Project-OSRM/osrm-backend/pull/6212)
 

--- a/features/foot/intersection.feature
+++ b/features/foot/intersection.feature
@@ -1,0 +1,31 @@
+@routing @foot
+Feature: Foot - Intersections
+
+    Background:
+        Given the profile "foot"
+        Given a grid size of 2 meters
+
+    # https://github.com/Project-OSRM/osrm-backend/issues/6218
+    Scenario: Foot - Handles non-planar intersections
+        Given the node map
+
+            """
+                f
+                |
+                a
+                |
+            b---c---d
+                |
+                e
+            """
+
+        And the ways
+            | nodes | highway | foot | layer |
+            | ac    | footway | yes  | 0     |
+            | bc    | footway | yes  | 0     |
+            | cd    | footway | yes  | 0     |
+            | cef   | footway | yes  | 1     |
+
+        When I route I should get
+            | from | to | route    |
+            | a    | d  | ac,cd,cd |


### PR DESCRIPTION
# Context

The full graphic details are in #6218

The motivation for this PR is to unblock the debug build on very large (i.e. global) datasets. Currently they will fail on this assertion, so we are unable to reach issues further down the processing chain.

# Issue
Due to some rather complex logic that tries to calculate intersection angles by looking further up the road, it's possible to return an intersection view that is missing a u-turn - something which is assumed to exist in later guidance calculations.

We apply a fix here by ensuring the u-turn is always included in the returned view.

Ideally we would refactor what looks like some quite brittle intersection code, but that requires:
- better understanding of the guidance code
- a large and complicated change

so this appears to be the better alternative in the short-term.



## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #6218
