### PR TITLE
Gracefully handle no-turn intersections in guidance processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
       - FIXED: Fix snapping target locations to ways used in turn restrictions. [#6339](https://github.com/Project-OSRM/osrm-backend/pull/6339)
       - ADDED: Support OSM traffic signal directions. [#6153](https://github.com/Project-OSRM/osrm-backend/pull/6153)
       - FIXED: Ensure u-turn exists in intersection view. [#6376](https://github.com/Project-OSRM/osrm-backend/pull/6376)
+      - FIXED: Gracefully handle no-turn intersections in guidance processing. [#6382](https://github.com/Project-OSRM/osrm-backend/issues/6382)
     - Profile:
       - CHANGED: Bicycle surface speeds [#6212](https://github.com/Project-OSRM/osrm-backend/pull/6212)
     - Tools:

--- a/features/guidance/bugs.feature
+++ b/features/guidance/bugs.feature
@@ -67,3 +67,37 @@ Feature: Features related to bugs
         When I route I should get
             | waypoints | route | intersections  |
             | a,c       | Pear to Merrit,Merritt to Apricot,Merritt to Apricot | true:0;true:0 false:180;true:180  |
+
+
+    # https://github.com/Project-OSRM/osrm-backend/issues/6373
+    Scenario: Segregated intersection with no second intersection turns
+        Given the node map
+            """
+                a  b
+                |  |
+             c--d--e--f
+                |  |
+             g--h--i--j
+
+            """
+
+        And the ways
+            | nodes | oneway | lanes | turn:lanes                         |
+            | dc    | yes    |  4    |                                    |
+            | ed    | yes    |  4    |                                    |
+            | fe    | yes    |  3    |                                    |
+            | gh    | yes    |  4    | left\|left\|through\|through;right |
+            | hi    | yes    |  2    |                                    |
+            | ij    | yes    |  3    |                                    |
+            | ie    | yes    |  4    |                                    |
+            | eb    | yes    |  2    |                                    |
+            | ad    | yes    |  4    | reverse\|right\|right\|right       |
+            | dh    | yes    |       |                                    |
+
+        And the relations
+            | type        | way:from | way:to | node:via | restriction  |
+            | restriction | dh       | hi     | h        | no_left_turn |
+
+        And the data has been saved to disk
+        When I try to run "osrm-extract {osm_file} --profile {profile_file}"
+        Then it should exit successfully

--- a/src/guidance/turn_lane_handler.cpp
+++ b/src/guidance/turn_lane_handler.cpp
@@ -329,7 +329,7 @@ TurnLaneScenario TurnLaneHandler::deduceScenario(const NodeID at,
                                           intersection)
                             .first;
 
-            // check if we were successfull in trimming
+            // check if we were successful in trimming
             if (lane_data.size() == possible_entries &&
                 isSimpleIntersection(lane_data, intersection))
                 return TurnLaneScenario::PARTITION_LOCAL;
@@ -556,7 +556,7 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
      * into two parts, one for the first and one for the second intersection.
      */
 
-    // Try and maitch lanes to available turns. For Turns that are not directly matchable, check
+    // Try and match lanes to available turns. For Turns that are not directly matchable, check
     // whether we can match them at the upcoming intersection.
 
     const auto straightmost = intersection.findClosestTurn(STRAIGHT_ANGLE);
@@ -675,10 +675,11 @@ std::pair<LaneDataVector, LaneDataVector> TurnLaneHandler::partitionLaneData(
             first.push_back(turn_lane_data[lane]);
     }
 
-    if (straightmost_tag_index == turn_lane_data.size() &&
+    std::size_t num_next_intersection_turns = getNumberOfTurns(next_intersection);
+    if (straightmost_tag_index == turn_lane_data.size() && num_next_intersection_turns > 0 &&
         static_cast<std::size_t>(
             std::count(matched_at_second.begin(), matched_at_second.end(), true)) ==
-            getNumberOfTurns(next_intersection))
+            num_next_intersection_turns)
     {
         TurnLaneData data = {TurnLaneType::straight, 255, 0};
         augmentEntry(data);


### PR DESCRIPTION
# Issue

Badly constructed OSM intersections can create OSRM intersection views that have no valid turns ([example](https://github.com/Project-OSRM/osrm-backend/issues/6373#issuecomment-1261510227)).

The guidance code for segregated intersections tries to look ahead to the second intersection to ensure lanes are  announced intuitively.

Currently, OSRM assumes there are always turns at the second intersection that we should consider. This commit corrects this assumption so that it can now handle badly constructed OSM intersections with no turns.

Tested this works on the Armenia extract from the issue, and on Great Britain as a general confidence check.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Fixes #6373 
