### PR TITLE
Add issue templates for bug reporting, features, and questions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report issue with osrm-backend
+labels: Bug Report
+---
+
+# Issue
+
+Please describe the issue you are seeing with OSRM.
+Images are a good way to illustrate your problem.
+
+**Note**: If your issue relates to the demo site (https://map.project-osrm.org) or routing provided on openstreetmap.org, be aware that they use separate [profile settings](https://github.com/fossgis-routing-server/cbf-routing-profiles) from those provided by default in `osrm-backend`.
+If your issue relates to the demo site or openstreetmap.org behaviour, please check these profiles first to see if they explain the behaviour before creating an issue here.
+
+# Steps to reproduce
+
+Please provide the steps required to reproduce your problem.
+- `osrm-backend` version being used
+- OSM extract that was processed
+- Processing commands (e.g. CH vs MLD processing)
+- Server queries
+
+If you're reporting an issue with https://map.project-osrm.org, please provide a link to the problematic request.
+
+# Specifications
+
+Please provide details of your development environment.
+- Library/dependency versions
+- Operating system
+- Hardware

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,10 @@
+---
+name: Feature Request
+about: Request a new feature in osrm-backend
+labels: Feature Request
+---
+
+# Feature
+
+Please describe the feature you would like to see in OSRM.
+Images are often a good way to illustrate your requested feature.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,5 @@
+---
+name: Question
+about: Ask a question about OSRM
+labels: question
+---


### PR DESCRIPTION
# Issue

Primarily to educate bug reporters that demo site != default settings, but also to help organise and auto-assign new issues.
