### PR TITLE
Use clang-format from CI base image

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -88,9 +88,9 @@ jobs:
     - name: Prepare environment
       run: |
         npm ci --ignore-scripts
-        export MASON=${GITHUB_WORKSPACE}/scripts/mason.sh
-        ${MASON} install clang-format 10.0.0
-        echo "$(${MASON} prefix clang-format 10.0.0)/bin" >> $GITHUB_PATH
+        which clang-format
+        ls /usr/bin
+        clang-format-14 --version
     - name: Run checks
       run: |
         ./scripts/check_taginfo.py taginfo.json profiles/car.lua

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Prepare environment
       run: |
         npm ci --ignore-scripts
-        clang-format-11 --version
+        clang-format-10 --version
     - name: Run checks
       run: |
         ./scripts/check_taginfo.py taginfo.json profiles/car.lua

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -88,9 +88,7 @@ jobs:
     - name: Prepare environment
       run: |
         npm ci --ignore-scripts
-        which clang-format
-        ls /usr/bin
-        clang-format-14 --version
+        clang-format-11 --version
     - name: Run checks
       run: |
         ./scripts/check_taginfo.py taginfo.json profiles/car.lua

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ Thumbs.db
 /.vs*
 /*.local.bat
 /CMakeSettings.json
+/.cache
 
 # Jetbrains related files #
 ###########################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
       - FIXED: Bug in bicycle profile that caused exceptions if there is a highway=bicycle in the data. [#6296](https://github.com/Project-OSRM/osrm-backend/pull/6296)
       - FIXED: Internal refactoring of identifier types used in data facade [#6044](https://github.com/Project-OSRM/osrm-backend/pull/6044)
     - Build:
+      - CHANGED: Use clang-format from CI base image. [#6391](https://github.com/Project-OSRM/osrm-backend/pull/6391)
       - ADDED: Build Node bindings on Windows. [#6334](https://github.com/Project-OSRM/osrm-backend/pull/6334)
       - ADDED: Configure cross-compilation for Apple Silicon. [#6360](https://github.com/Project-OSRM/osrm-backend/pull/6360)
       - CHANGED: Use apt-get to install Clang on CI. [#6345](https://github.com/Project-OSRM/osrm-backend/pull/6345)

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -19,18 +19,18 @@ elif [[ ${OS} = "Darwin" ]] ; then
 fi
 
 # Discover clang-format
-if type clang-format-11 2> /dev/null ; then
-    CLANG_FORMAT=clang-format-11
+if type clang-format-10 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-10
 elif type clang-format 2> /dev/null ; then
     # Clang format found, but need to check version
     CLANG_FORMAT=clang-format
     V=$(clang-format --version)
-    if [[ $V != *11.0* ]] ; then
-        echo "clang-format is not 11.0 (returned ${V})"
+    if [[ $V != *10.0* ]] ; then
+        echo "clang-format is not 10.0 (returned ${V})"
         #exit 1
     fi
 else
-    echo "No appropriate clang-format found (expected clang-format-11, or clang-format)"
+    echo "No appropriate clang-format found (expected clang-format-10, or clang-format)"
     exit 1
 fi
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -19,18 +19,18 @@ elif [[ ${OS} = "Darwin" ]] ; then
 fi
 
 # Discover clang-format
-if type clang-format-14 2> /dev/null ; then
-    CLANG_FORMAT=clang-format-14
+if type clang-format-11 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-11
 elif type clang-format 2> /dev/null ; then
     # Clang format found, but need to check version
     CLANG_FORMAT=clang-format
     V=$(clang-format --version)
-    if [[ $V != *14.0* ]] ; then
-        echo "clang-format is not 14.0 (returned ${V})"
+    if [[ $V != *11.0* ]] ; then
+        echo "clang-format is not 11.0 (returned ${V})"
         #exit 1
     fi
 else
-    echo "No appropriate clang-format found (expected clang-format-14, or clang-format)"
+    echo "No appropriate clang-format found (expected clang-format-11, or clang-format)"
     exit 1
 fi
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -19,18 +19,18 @@ elif [[ ${OS} = "Darwin" ]] ; then
 fi
 
 # Discover clang-format
-if type clang-format-10.0.0 2> /dev/null ; then
-    CLANG_FORMAT=clang-format-10.0.0
+if type clang-format-14 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-14
 elif type clang-format 2> /dev/null ; then
     # Clang format found, but need to check version
     CLANG_FORMAT=clang-format
     V=$(clang-format --version)
-    if [[ $V != *10.0* ]] ; then
-        echo "clang-format is not 10.0 (returned ${V})"
+    if [[ $V != *14.0* ]] ; then
+        echo "clang-format is not 14.0 (returned ${V})"
         #exit 1
     fi
 else
-    echo "No appropriate clang-format found (expected clang-format-10.0.0, or clang-format)"
+    echo "No appropriate clang-format found (expected clang-format-14, or clang-format)"
     exit 1
 fi
 


### PR DESCRIPTION
# Issue

As we are [getting rid of Mason](https://github.com/Project-OSRM/osrm-backend/pull/6387) we need a way to use clang-format on CI(we download it from Mason at the moment). Possible options can be:
1. Download pre-built binary from somewhere else (currently implemented in https://github.com/Project-OSRM/osrm-backend/pull/6387 and downloads it from https://github.com/muttleyxd/clang-tools-static-binaries which doesn't seem very reliable solution on my taste)
2. Build own binary from source? It is quite complicated.
3. Use pre-installed binary from CI image. Currently available on our 20.04 image is:
```
Clang-format 10.0.0, 11.0.0, 12.0.0
```
Btw 11.0.0 is not available on modern 22.04 and we will have to update in the future.

I decided to go with option 3 and just update CI and source code to use clang-format from base image(but 1 is also way to go, don't have strong opinion, just think that using it from the base image feels more reliable). 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
