### PR TITLE
Always use original weights when handling --parse-conditionals-from-now

### DIFF
--- a/features/car/conditional_restrictions.feature
+++ b/features/car/conditional_restrictions.feature
@@ -353,6 +353,18 @@ Feature: Car - Turn restrictions
             | b    | a  | bj,jc,jc,aj,aj |
             | b    | d  | bj,jd,jd       |
 
+        # here we check that conditional restrictions can be updated via re-run of `contract`/`customize` with updated `--parse-conditionals-from-now`
+        # 10am utc, sat 
+        When I run "osrm-contract  {osm_file} --time-zone-file=test/data/tz/{timezone_names}/guinea.geojson --parse-conditionals-from-now=1494064800"
+        When I run "osrm-customize {osm_file} --time-zone-file=test/data/tz/{timezone_names}/guinea.geojson --parse-conditionals-from-now=1494064800"
+
+        When I route I should get
+            | from | to | route          |
+            | b    | c  | bj,jc,jc       |
+            | b    | a  | bj,aj,aj       |
+            | b    | d  | bj,jd,jd       |
+
+
     @no_turning @conditionals
     Scenario: Car - Conditional restriction with multiple time windows
         Given the extract extra arguments "--parse-conditional-restrictions"

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -583,8 +583,15 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
             [&] { extractor::files::readNodeData(config.GetPath(".osrm.ebg_nodes"), node_data); },
 
             [&] {
-                extractor::files::readTurnWeightPenalty(
-                    config.GetPath(".osrm.turn_weight_penalties"), turn_weight_penalties);
+                // we are going to overwrite this `.turn_weight_penalties` afterwards,
+                // so here we backup the original turn penalties if we didn't do that yet in order to
+                // guarantee that subsequent runs of this code will work on top of original weights
+                auto path = config.GetPath(".osrm.turn_weight_penalties").string() + ".original";
+                if (!boost::filesystem::exists(path))
+                {
+                    boost::filesystem::copy_file(config.GetPath(".osrm.turn_weight_penalties"), path);
+                }
+                extractor::files::readTurnWeightPenalty(path, turn_weight_penalties);
             },
             [&] {
                 extractor::files::readTurnDurationPenalty(


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
