### PR TITLE
Fix annotations=true handling in NodeJS bindings & libosrm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
   - Changes from 5.27.1
     - Misc:
-      - FIXED: Fix annotations=true handling in NodeJS bindings. [#6415](https://github.com/Project-OSRM/osrm-backend/pull/6415/)
+      - FIXED: Fix annotations=true handling in NodeJS bindings & libosrm. [#6415](https://github.com/Project-OSRM/osrm-backend/pull/6415/)
 # 5.27.1
   - Changes from 5.27.0
     - Misc:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
-
+  - Changes from 5.27.1
+    - Misc:
+      - FIXED: Fix annotations=true handling in NodeJS bindings. [#6415](https://github.com/Project-OSRM/osrm-backend/pull/6415/)
 # 5.27.1
   - Changes from 5.27.0
     - Misc:

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -778,7 +778,7 @@ class RouteAPI : public BaseAPI
                 util::json::Object annotation;
 
                 // AnnotationsType uses bit flags, & operator checks if a property is set
-                if (parameters.annotations_type & RouteParameters::AnnotationsType::Speed)
+                if (requested_annotations & RouteParameters::AnnotationsType::Speed)
                 {
                     double prev_speed = 0;
                     annotation.values["speed"] = GetAnnotations(

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -439,7 +439,7 @@ class RouteAPI : public BaseAPI
     {
         // AnnotationsType uses bit flags, & operator checks if a property is set
         flatbuffers::Offset<flatbuffers::Vector<float>> speed;
-        if (parameters.annotations_type & RouteParameters::AnnotationsType::Speed)
+        if (requested_annotations & RouteParameters::AnnotationsType::Speed)
         {
             double prev_speed = 0;
             speed =

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -799,6 +799,9 @@ inline bool parseCommonParameters(const v8::Local<v8::Object> &obj, ParamType &p
         if (annotations->IsBoolean())
         {
             params->annotations = Nan::To<bool>(annotations).FromJust();
+            params->annotations_type = params->annotations
+                        ? osrm::RouteParameters::AnnotationsType::All
+                        : osrm::RouteParameters::AnnotationsType::None;
         }
         else if (annotations->IsArray())
         {

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -848,6 +848,9 @@ inline bool parseCommonParameters(const v8::Local<v8::Object> &obj, ParamType &p
                     Nan::ThrowError("this 'annotations' param is not supported");
                     return false;
                 }
+
+                params->annotations =
+                    params->annotations_type != osrm::RouteParameters::AnnotationsType::None;
             }
         }
         else

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -800,8 +800,8 @@ inline bool parseCommonParameters(const v8::Local<v8::Object> &obj, ParamType &p
         {
             params->annotations = Nan::To<bool>(annotations).FromJust();
             params->annotations_type = params->annotations
-                        ? osrm::RouteParameters::AnnotationsType::All
-                        : osrm::RouteParameters::AnnotationsType::None;
+                                           ? osrm::RouteParameters::AnnotationsType::All
+                                           : osrm::RouteParameters::AnnotationsType::None;
         }
         else if (annotations->IsArray())
         {

--- a/test/nodejs/route.js
+++ b/test/nodejs/route.js
@@ -286,9 +286,9 @@ test('route: routes Monaco with several (duration, distance, nodes) annotations 
         assert.ok(first.routes[0].legs.every(l => { return l.annotation.distance;}), 'every leg has annotations for distance');
         assert.ok(first.routes[0].legs.every(l => { return l.annotation.duration;}), 'every leg has annotations for durations');
         assert.ok(first.routes[0].legs.every(l => { return l.annotation.nodes;}), 'every leg has annotations for nodes');
-        assert.notOk(first.routes[0].legs.every(l => { return l.annotation.weight; }), 'has no annotations for weight')
-        assert.notOk(first.routes[0].legs.every(l => { return l.annotation.datasources; }), 'has no annotations for datasources')
-        assert.notOk(first.routes[0].legs.every(l => { return l.annotation.speed; }), 'has no annotations for speed')
+        assert.notOk(first.routes[0].legs.every(l => { return l.annotation.weight; }), 'has no annotations for weight');
+        assert.notOk(first.routes[0].legs.every(l => { return l.annotation.datasources; }), 'has no annotations for datasources');
+        assert.notOk(first.routes[0].legs.every(l => { return l.annotation.speed; }), 'has no annotations for speed');
 
         options.overview = 'full';
         osrm.route(options, function(err, full) {
@@ -303,7 +303,7 @@ test('route: routes Monaco with several (duration, distance, nodes) annotations 
 });
 
 test('route: routes Monaco with options', function(assert) {
-    assert.plan(11);
+    assert.plan(17);
     var osrm = new OSRM(monaco_path);
     var options = {
         coordinates: two_test_coordinates,
@@ -322,6 +322,12 @@ test('route: routes Monaco with options', function(assert) {
         assert.ok(first.routes[0].legs[0]);
         assert.ok(first.routes[0].legs.every(l => { return l.steps.length > 0; }), 'every leg has steps');
         assert.ok(first.routes[0].legs.every(l => { return l.annotation;}), 'every leg has annotations');
+        assert.ok(first.routes[0].legs.every(l => { return l.annotation.distance;}), 'every leg has annotations for distance');
+        assert.ok(first.routes[0].legs.every(l => { return l.annotation.duration;}), 'every leg has annotations for durations');
+        assert.ok(first.routes[0].legs.every(l => { return l.annotation.nodes;}), 'every leg has annotations for nodes');
+        assert.ok(first.routes[0].legs.every(l => { return l.annotation.weight; }), 'every leg has annotations for weight');
+        assert.ok(first.routes[0].legs.every(l => { return l.annotation.datasources; }), 'every leg has annotations for datasources');
+        assert.ok(first.routes[0].legs.every(l => { return l.annotation.speed; }), 'every leg has annotations for speed');
 
         options.overview = 'full';
         osrm.route(options, function(err, full) {

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -584,7 +584,7 @@ void test_manual_setting_of_annotations_property(bool use_json_only_api)
                            .values["annotation"]
                            .get<json::Object>()
                            .values;
-    BOOST_CHECK_EQUAL(annotations.size(), 6);
+    BOOST_CHECK_EQUAL(annotations.size(), 7);
 }
 BOOST_AUTO_TEST_CASE(test_manual_setting_of_annotations_property_old_api)
 {


### PR DESCRIPTION
# Issue
Found this problem while working on https://github.com/Project-OSRM/osrm-backend/pull/6411 (it was actually caught by one of our tests when I started running them against NodeJS based server - one more reason to rewrite osrm-router in NodeJs :) ).

Now it works the same as in osrm-routed:
https://github.com/Project-OSRM/osrm-backend/blob/5e5f1f4add6d86b097569545b670de513ebc6b04/include/server/api/route_parameters_grammar.hpp#L94

Or in constructors of `RouteParameters`:
https://github.com/Project-OSRM/osrm-backend/blob/5e5f1f4add6d86b097569545b670de513ebc6b04/include/engine/api/route_parameters.hpp#L129

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
