### PR TITLE
Handle snapping parameter for all plugins in NodeJs bindings, but not for Route only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
   - Changes from 5.27.1
     - Misc:
+      - FIXED: Handle snapping parameter for all plugins in NodeJs bindings, but not for Route only. [#6417](https://github.com/Project-OSRM/osrm-backend/pull/6417)
       - FIXED: Fix bindings compilation issue on the latest Node. Update NAN to 2.17.0. [#6416](https://github.com/Project-OSRM/osrm-backend/pull/6416)
 # 5.27.1
   - Changes from 5.27.0

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -767,6 +767,37 @@ inline bool argumentsToParameter(const Nan::FunctionCallbackInfo<v8::Value> &arg
             return false;
         }
     }
+
+    if (Nan::Has(obj, Nan::New("snapping").ToLocalChecked()).FromJust())
+    {
+        v8::Local<v8::Value> snapping =
+            Nan::Get(obj, Nan::New("snapping").ToLocalChecked()).ToLocalChecked();
+        if (snapping.IsEmpty())
+            return false;
+
+        if (!snapping->IsString())
+        {
+            Nan::ThrowError("Snapping must be a string: [default, any]");
+            return false;
+        }
+        const Nan::Utf8String snapping_utf8str(snapping);
+        std::string snapping_str{*snapping_utf8str, *snapping_utf8str + snapping_utf8str.length()};
+
+        if (snapping_str == "default")
+        {
+            params->snapping = osrm::RouteParameters::SnappingType::Default;
+        }
+        else if (snapping_str == "any")
+        {
+            params->snapping = osrm::RouteParameters::SnappingType::Any;
+        }
+        else
+        {
+            Nan::ThrowError("'snapping' param must be one of [default, any]");
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -1106,36 +1137,6 @@ argumentsToRouteParameter(const Nan::FunctionCallbackInfo<v8::Value> &args,
                     return route_parameters_ptr();
                 }
             }
-        }
-    }
-
-    if (Nan::Has(obj, Nan::New("snapping").ToLocalChecked()).FromJust())
-    {
-        v8::Local<v8::Value> snapping =
-            Nan::Get(obj, Nan::New("snapping").ToLocalChecked()).ToLocalChecked();
-        if (snapping.IsEmpty())
-            return route_parameters_ptr();
-
-        if (!snapping->IsString())
-        {
-            Nan::ThrowError("Snapping must be a string: [default, any]");
-            return route_parameters_ptr();
-        }
-        const Nan::Utf8String snapping_utf8str(snapping);
-        std::string snapping_str{*snapping_utf8str, *snapping_utf8str + snapping_utf8str.length()};
-
-        if (snapping_str == "default")
-        {
-            params->snapping = osrm::RouteParameters::SnappingType::Default;
-        }
-        else if (snapping_str == "any")
-        {
-            params->snapping = osrm::RouteParameters::SnappingType::Any;
-        }
-        else
-        {
-            Nan::ThrowError("'snapping' param must be one of [default, any]");
-            return route_parameters_ptr();
         }
     }
 

--- a/test/nodejs/table.js
+++ b/test/nodejs/table.js
@@ -80,6 +80,30 @@ test('table: returns buffer', function(assert) {
     });
 });
 
+test('table: throws on invalid snapping values', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM(data_path);
+    var options = {
+        coordinates: [three_test_coordinates[0], three_test_coordinates[1]],
+        snapping: 'zing'
+    };
+    assert.throws(function () { osrm.table(options, function (err, response) { }); },
+        /'snapping' param must be one of \[default, any\]/);
+});
+
+test('table: snapping parameter passed through OK', function (assert) {
+    assert.plan(2);
+    var osrm = new OSRM(data_path);
+    var options = {
+        coordinates: [three_test_coordinates[0], three_test_coordinates[1]],
+        snapping: 'any'
+    };
+    osrm.table(options, function(err, table) {
+        assert.ifError(err);
+        assert.ok(table['durations'], 'distances table result should exist');
+    });
+});
+
 var tables = ['distances', 'durations'];
 
 tables.forEach(function(annotation) {


### PR DESCRIPTION
# Issue
One more thing I found while working on https://github.com/Project-OSRM/osrm-backend/pull/6411

According to our docs `snapping` is "general" option, i.e. should be supported by all services(and `osrm-routed` does so).

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
