### PR TITLE
Fix adding traffic signal penalties during compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
       - FIXED: Handle snapping parameter for all plugins in NodeJs bindings, but not for Route only. [#6417](https://github.com/Project-OSRM/osrm-backend/pull/6417)
       - FIXED: Fix annotations=true handling in NodeJS bindings & libosrm. [#6415](https://github.com/Project-OSRM/osrm-backend/pull/6415/)
       - FIXED: Fix bindings compilation issue on the latest Node. Update NAN to 2.17.0. [#6416](https://github.com/Project-OSRM/osrm-backend/pull/6416)
+    - Routing:
+      - FIXED: Fix adding traffic signal penalties during compression [#6419](https://github.com/Project-OSRM/osrm-backend/pull/6419)
 # 5.27.1
   - Changes from 5.27.0
     - Misc:

--- a/features/car/traffic_light_penalties.feature
+++ b/features/car/traffic_light_penalties.feature
@@ -66,15 +66,50 @@ Feature: Car - Handle traffic lights
             | k    | traffic_signals | backward                  |
 
         When I route I should get
-            | from | to | time   | #                             |
-            | 1    | 2  |  11.1s | no turn with no traffic light |
-            | 2    | 1  |  11.1s | no turn with no traffic light |
-            | 3    | 4  |  13.1s | no turn with traffic light    |
-            | 4    | 3  |  13.1s | no turn with traffic light    |
-            | 5    | 6  |  13.1s | no turn with traffic light    |
-            | 6    | 5  |  11.1s | no turn with no traffic light |
-            | 7    | 8  |  11.1s | no turn with no traffic light |
-            | 8    | 7  |  13.1s | no turn with traffic light    |
+            | from | to | time   | weight | #                             |
+            | 1    | 2  |  11.1s | 11.1   | no turn with no traffic light |
+            | 2    | 1  |  11.1s | 11.1   | no turn with no traffic light |
+            | 3    | 4  |  13.1s | 13.1   | no turn with traffic light    |
+            | 4    | 3  |  13.1s | 13.1   | no turn with traffic light    |
+            | 5    | 6  |  13.1s | 13.1   | no turn with traffic light    |
+            | 6    | 5  |  11.1s | 11.1   | no turn with no traffic light |
+            | 7    | 8  |  11.1s | 11.1   | no turn with no traffic light |
+            | 8    | 7  |  13.1s | 13.1   | no turn with traffic light    |
+
+
+    Scenario: Car - Traffic signal direction with distance weight
+        Given the profile file "car" initialized with
+        """
+        profile.properties.weight_name = 'distance'
+        profile.properties.traffic_light_penalty = 100000
+        """
+
+        Given the node map
+            """
+            a---b---c
+            1       2
+            |       |
+            |       |
+            |       |
+            |       |
+            |       |
+            d-------f
+
+            """
+
+        And the ways
+            | nodes | highway |
+            | abc   | primary |
+            | adfc  | primary |
+
+        And the nodes
+            | node | highway         |
+            | b    | traffic_signals |
+
+        When I route I should get
+            | from | to | time      | distances | weight | #                                     |
+            | 1    | 2  | 100033.2s | 599.9m,0m | 599.8  | goes via the expensive traffic signal |
+
 
 
     Scenario: Car - Encounters a traffic light


### PR DESCRIPTION
# Issue
As detected by @GitBenjamin in https://github.com/Project-OSRM/osrm-backend/commit/b17cbb4c4723d2ecfb3f145734b3a0e1f2089405#r87212707

Weight and duration penalties are flipped in the lambda function that applies penalties from traffic signals.

Duration is in deciseconds, whilst weight is multiplied by `10^weight_precision`, with `weight_precision` being 1 by default.

Therefore, for default routability profile, the penalties end up being the same, hence why no tests picked this up.

If distance weight is used however, it will incorrectly apply an additional penalty to the weight, and not add the traffic signal delay to the duration in the routing graph.

To confuse things further, in some API responses the values are correct because they use geometry data instead, but it's still possible that a sub-optimal route was selected.

However, given the distance weight is in meters, and the additional penalty per traffic light would be 20, it's unlikely this would have changed the routing results.

In any case, we correct the function to apply the arguments correctly.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

I will make a follow-up PR that implements #3601 to stop these types of mistakes, any maybe even detect some others in the codebase.
