### PR TITLE
Apply workaround for Conan installation issue on CI

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -508,7 +508,7 @@ jobs:
       run: |
         python3 -m pip install conan==1.53.0
         # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
-        # and that's CI cannot find conan executable installed above
+        # and that's why CI cannot find conan executable installed above
         if [[ "${RUNNER_OS}" == "macOS" ]]; then
           echo "/Library/Frameworks/Python.framework/Versions/3.11/bin" >> $GITHUB_PATH
         fi

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -506,6 +506,11 @@ jobs:
     - name: Install dev dependencies
       run: |
         python3 -m pip install conan==1.53.0
+        # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
+        # and that's CI cannot find conan executable installed above
+        if [[ "${RUNNER_OS}" == "macOS" ]]; then
+          echo "/Library/Frameworks/Python.framework/Versions/3.11/bin" >> $GITHUB_PATH
+        fi
 
         # ccache
         if [[ "${RUNNER_OS}" == "Linux" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - CHANGED: Update actions/cache to v3. [#6420](https://github.com/Project-OSRM/osrm-backend/pull/6420)
       - REMOVED: Drop support of Node 12 & 14. [#6431](https://github.com/Project-OSRM/osrm-backend/pull/6431)
     - Misc:
+      - FIXED: Apply workaround for Conan installation issue on CI. [#6442](https://github.com/Project-OSRM/osrm-backend/pull/6442)
       - FIXED: Handle snapping parameter for all plugins in NodeJs bindings, but not for Route only. [#6417](https://github.com/Project-OSRM/osrm-backend/pull/6417)
       - FIXED: Fix annotations=true handling in NodeJS bindings & libosrm. [#6415](https://github.com/Project-OSRM/osrm-backend/pull/6415/)
       - FIXED: Fix bindings compilation issue on the latest Node. Update NAN to 2.17.0. [#6416](https://github.com/Project-OSRM/osrm-backend/pull/6416)


### PR DESCRIPTION
# Issue

Seems to be related not to Conan itself, but this update of macOS image we are using https://github.com/actions/runner-images/pull/6499/files
<img width="1951" alt="Screenshot 2022-11-04 at 11 57 54" src="https://user-images.githubusercontent.com/266271/199958732-ab113e7a-c1eb-43cb-bf72-89c13082f40c.png">



## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
