### PR TITLE
Remove at:urban maxspeed, partial revert

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -268,7 +268,6 @@ function setup()
 
     -- List only exceptions
     maxspeed_table = {
-      ["at:urban"] = 40,
       ["at:rural"] = 100,
       ["at:trunk"] = 100,
       ["be:motorway"] = 120,

--- a/taginfo.json
+++ b/taginfo.json
@@ -146,7 +146,6 @@
         {"key": "maxspeed", "value": "rural"},
         {"key": "maxspeed", "value": "trunk"},
         {"key": "maxspeed", "value": "motorway"},
-        {"key": "maxspeed", "value": "AT:urban"},
         {"key": "maxspeed", "value": "AT:rural"},
         {"key": "maxspeed", "value": "AT:trunk"},
         {"key": "maxspeed", "value": "BE:motorway"},


### PR DESCRIPTION
Sorry, this is a partial revert of my last PR #6448

The change to `at:urban=40` was report by OSM community as wrong https://github.com/osm-fr/osmose-backend/issues/1640.
And so also reverted in Osmose-QA.