### PR TITLE
Use <boost/iterator/function_output_iterator.hpp> instead of deprecated <boost/function_output_iterator.hpp>

### DIFF
--- a/include/storage/serialization.hpp
+++ b/include/storage/serialization.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <cmath>
 #include <cstdint>

--- a/include/storage/serialization.hpp
+++ b/include/storage/serialization.hpp
@@ -10,7 +10,6 @@
 #include "storage/tar.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/function_output_iterator.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
 
 #include <cmath>

--- a/include/storage/shared_data_index.hpp
+++ b/include/storage/shared_data_index.hpp
@@ -3,7 +3,7 @@
 
 #include "storage/shared_datatype.hpp"
 
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <type_traits>
 #include <unordered_map>

--- a/include/util/indexed_data.hpp
+++ b/include/util/indexed_data.hpp
@@ -7,7 +7,7 @@
 #include "util/vector_view.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <array>
 #include <iterator>

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 namespace osrm
 {

--- a/src/extractor/location_dependent_data.cpp
+++ b/src/extractor/location_dependent_data.cpp
@@ -8,8 +8,8 @@
 #include <rapidjson/istreamwrapper.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/function_output_iterator.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <fstream>
 #include <string>

--- a/src/tools/components.cpp
+++ b/src/tools/components.cpp
@@ -11,7 +11,7 @@
 #include "util/typedefs.hpp"
 
 #include <boost/filesystem.hpp>
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <tbb/parallel_sort.h>
 

--- a/unit_tests/storage/tar.cpp
+++ b/unit_tests/storage/tar.cpp
@@ -3,7 +3,6 @@
 #include "../common/range_tools.hpp"
 #include "../common/temporary_file.hpp"
 
-#include <boost/function_output_iterator.hpp>
 #include <boost/iterator/function_input_iterator.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/unit_tests/storage/tar.cpp
+++ b/unit_tests/storage/tar.cpp
@@ -4,6 +4,7 @@
 #include "../common/temporary_file.hpp"
 
 #include <boost/iterator/function_input_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(tar)


### PR DESCRIPTION
# Issue

It is deprecated since Boost 1.66.0 and causes deprecation warnings https://www.boost.org/doc/libs/1_66_0/boost/function_output_iterator.hpp

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
