### PR TITLE
fix(json_render): json_render is not accurate enough for extremely sm…

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -376,9 +376,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{github.workspace}}/test/cache
-        key: v3-test-${{ matrix.name }}-${{ github.sha }}
+        key: v4-test-${{ matrix.name }}-${{ github.sha }}
         restore-keys: |
-          v3-test-${{ matrix.name }}-
+          v4-test-${{ matrix.name }}-
 
     - name: Prepare environment
       run: |

--- a/features/car/conditional_restrictions.feature
+++ b/features/car/conditional_restrictions.feature
@@ -538,9 +538,9 @@ Feature: Car - Turn restrictions
 
         When I route I should get
             | from | to | route                                      | turns                                       |
-            | a    | e  | cap south,florida ne,florida ne | depart,turn left,arrive     |
+            | a    | e  | cap south,florida nw,florida nw,florida ne | depart,turn right,continue uturn,arrive     |
             | f    | d  | cap north,florida nw,florida nw            | depart,turn left,arrive                     |
-            | e    | c  | florida ne,cap south,cap south  | depart,turn left,arrive     |
+            | e    | c  | florida ne,florida nw,cap south,cap south  | depart,continue uturn,turn right,arrive     |
 
     @no_turning @conditionals
     Scenario: Car - DC North capitol situation, one on two off

--- a/features/car/conditional_restrictions.feature
+++ b/features/car/conditional_restrictions.feature
@@ -538,9 +538,9 @@ Feature: Car - Turn restrictions
 
         When I route I should get
             | from | to | route                                      | turns                                       |
-            | a    | e  | cap south,florida nw,florida nw,florida ne | depart,turn right,continue uturn,arrive     |
+            | a    | e  | cap south,florida ne,florida ne | depart,turn left,arrive     |
             | f    | d  | cap north,florida nw,florida nw            | depart,turn left,arrive                     |
-            | e    | c  | florida ne,florida nw,cap south,cap south  | depart,continue uturn,turn right,arrive     |
+            | e    | c  | florida ne,cap south,cap south  | depart,turn left,arrive     |
 
     @no_turning @conditionals
     Scenario: Car - DC North capitol situation, one on two off
@@ -586,7 +586,7 @@ Feature: Car - Turn restrictions
         When I route I should get
             | from | to | route                                      | turns                                         |
             | a    | e  | cap south,florida ne,florida ne            | depart,turn left,arrive                       |
-            | f    | d  | cap north,florida ne,florida ne,florida nw | depart,turn sharp right,continue uturn,arrive |
+            | f    | d  | cap north,florida nw,florida nw | depart,turn left,arrive |
             | e    | c  | florida ne,cap south,cap south             | depart,turn left,arrive                       |
 
     @only_turning @conditionals

--- a/features/car/conditional_restrictions.feature
+++ b/features/car/conditional_restrictions.feature
@@ -586,7 +586,7 @@ Feature: Car - Turn restrictions
         When I route I should get
             | from | to | route                                      | turns                                         |
             | a    | e  | cap south,florida ne,florida ne            | depart,turn left,arrive                       |
-            | f    | d  | cap north,florida nw,florida nw | depart,turn left,arrive |
+            | f    | d  | cap north,florida ne,florida ne,florida nw | depart,turn sharp right,continue uturn,arrive |
             | e    | c  | florida ne,cap south,cap south             | depart,turn left,arrive                       |
 
     @only_turning @conditionals

--- a/features/testbot/annotations.feature
+++ b/features/testbot/annotations.feature
@@ -115,4 +115,4 @@ Feature: Annotations
 
         When I route I should get
             | from | to | route    | a:speed | a:distance            | a:duration | a:nodes |
-            | a    | c  | abc,abc  | 10:10   | 249.987618946:299.962882039 | 25:30      | 1:2:3   |
+            | a    | c  | abc,abc  | 10:10   | 249.9876189:299.962882 | 25:30      | 1:2:3   |

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -810,6 +810,6 @@ Feature: Basic Map Matching
         # These should have the same weights/duration in either direction
         When I match I should get
           | trace | geometry             | a:distance    | a:duration | a:weight | duration |
-          | 2345  | 1.00018,1,1.000314,1 | 14.914666491  | 1.4        | 1.4      | 1.4      |
-          | 4321  | 1.00027,1,1.000135,1 | 15.025969972  | 1.5        | 1.5      | 1.5      |
+          | 2345  | 1.00018,1,1.000314,1 | 14.91466649  | 1.4        | 1.4      | 1.4      |
+          | 4321  | 1.00027,1,1.000135,1 | 15.02596997  | 1.5        | 1.5      | 1.5      |
 

--- a/features/testbot/snap_intersection.feature
+++ b/features/testbot/snap_intersection.feature
@@ -570,7 +570,7 @@ Feature: Snapping at intersections
             | a,f,k     | ac,cf,cf,fj,kj,kj     | 132.8s | 132.8  |
             | k,f       | ik,fi,fi              | 54.3s  | 54.3   |
             | f,a       | ef,ae,ae              | 66.6s  | 66.6   |
-            | k,f,a     | kj,fj,fj,ef,ae,ae     | 141.399999999s | 141.399999999  |
+            | k,f,a     | kj,fj,fj,ef,ae,ae     | 141.4s | 141.4  |
 
         When I request a travel time matrix I should get
             |   |  a    |   f  |     k |
@@ -626,4 +626,4 @@ Feature: Snapping at intersections
             | a,f,k     | ad,df,df,fj,kj,kj    | 105.6s | 105.6  |
             | k,f       | ik,fi,fi             | 54.3s  | 54.3   |
             | f,a       | ef,ae,ae             | 66.6s  | 66.6   |
-            | k,f,a     | ik,fi,fi,ef,ae,ae    | 120.899999999s | 120.899999999  |
+            | k,f,a     | ik,fi,fi,ef,ae,ae    | 120.9s | 120.9  |

--- a/features/testbot/weight.feature
+++ b/features/testbot/weight.feature
@@ -53,10 +53,10 @@ Feature: Weight tests
 
         When I route I should get
             | waypoints | route   | distances | weights | times   | a:distance                | a:duration | a:weight | a:speed |
-            | s,t       | abc,abc | 20m,0m    | 2,0     | 2s,0s   | 20.034626629              | 2          | 2        | 10      |
-            | t,s       | abc,abc | 20m,0m    | 2,0     | 2s,0s   | 20.034626629              | 2          | 2        | 10      |
-            | s,e       | abc,abc | 40m,0m    | 3.9,0   | 3.9s,0s | 29.940636463:10.017313314 | 3:0.9      | 3:0.9    | 10:11.1  |
-            | e,s       | abc,abc | 40m,0m    | 3.9,0   | 3.9s,0s | 10.017313314:29.940636463 | 0.9:3      | 0.9:3    | 11.1:10  |
+            | s,t       | abc,abc | 20m,0m    | 2,0     | 2s,0s   | 20.03462663              | 2          | 2        | 10      |
+            | t,s       | abc,abc | 20m,0m    | 2,0     | 2s,0s   | 20.03462663              | 2          | 2        | 10      |
+            | s,e       | abc,abc | 40m,0m    | 3.9,0   | 3.9s,0s | 29.94063646:10.01731331 | 3:0.9      | 3:0.9    | 10:11.1  |
+            | e,s       | abc,abc | 40m,0m    | 3.9,0   | 3.9s,0s | 10.01731331:29.94063646 | 0.9:3      | 0.9:3    | 11.1:10  |
 
 
     Scenario: Step weights -- way_function: fail if no weight or weight_per_meter property

--- a/include/util/json_renderer.hpp
+++ b/include/util/json_renderer.hpp
@@ -47,20 +47,12 @@ template <typename Out> struct Renderer
 
     void operator()(const Number &number)
     {
+        // we don't want to print NaN or Infinity
+        BOOST_ASSERT(std::isfinite(number.value));
         // `fmt::memory_buffer` stores first 500 bytes in the object itself(i.e. on stack in this
         // case) and then grows using heap if needed
         fmt::memory_buffer buffer;
-        fmt::format_to(std::back_inserter(buffer), FMT_COMPILE("{}"), number.value);
-
-        // Truncate to 10 decimal places
-        size_t decimalpos = std::find(buffer.begin(), buffer.end(), '.') - buffer.begin();
-        if (buffer.size() > (decimalpos + 10))
-        {
-            buffer.clear();
-            fmt::format_to(std::back_inserter(buffer), FMT_COMPILE("{0:.10f}"), number.value);
-
-            // buffer.resize(decimalpos + 10);
-        }
+        fmt::format_to(std::back_inserter(buffer), FMT_COMPILE("{:.10g}"), number.value);
 
         write(buffer.data(), buffer.size());
     }

--- a/include/util/json_renderer.hpp
+++ b/include/util/json_renderer.hpp
@@ -56,7 +56,10 @@ template <typename Out> struct Renderer
         size_t decimalpos = std::find(buffer.begin(), buffer.end(), '.') - buffer.begin();
         if (buffer.size() > (decimalpos + 10))
         {
-            buffer.resize(decimalpos + 10);
+            buffer.clear();
+            fmt::format_to(std::back_inserter(buffer), FMT_COMPILE("{0:.10f}"), number.value);
+
+            // buffer.resize(decimalpos + 10);
         }
 
         write(buffer.data(), buffer.size());

--- a/unit_tests/util/json_render.cpp
+++ b/unit_tests/util/json_render.cpp
@@ -32,6 +32,62 @@ BOOST_AUTO_TEST_CASE(test_json_issue_6531) {
     osrm::util::json::Renderer<std::string> renderer(output);
     renderer(0.0000000000017114087924596788);
     BOOST_CHECK_EQUAL(output, "1.711408792e-12");
+
+    output.clear();
+    renderer(42.0);
+    BOOST_CHECK_EQUAL(output, "42");
+
+    output.clear();
+    renderer(42.1);
+    BOOST_CHECK_EQUAL(output, "42.1");
+
+    output.clear();
+    renderer(42.12);
+    BOOST_CHECK_EQUAL(output, "42.12");
+
+    output.clear();
+    renderer(42.123);
+    BOOST_CHECK_EQUAL(output, "42.123");
+
+    output.clear();
+    renderer(42.1234);
+    BOOST_CHECK_EQUAL(output, "42.1234");
+
+    output.clear();
+    renderer(42.12345);
+    BOOST_CHECK_EQUAL(output, "42.12345");
+
+    output.clear();
+    renderer(42.123456);
+    BOOST_CHECK_EQUAL(output, "42.123456");
+
+    output.clear();
+    renderer(42.1234567);
+    BOOST_CHECK_EQUAL(output, "42.1234567");
+
+    output.clear();
+    renderer(42.12345678);
+    BOOST_CHECK_EQUAL(output, "42.12345678");
+
+    output.clear();
+    renderer(42.123456789);
+    BOOST_CHECK_EQUAL(output, "42.12345679");
+
+    output.clear();
+    renderer(0.12345678912345);
+    BOOST_CHECK_EQUAL(output, "0.1234567891");
+
+    output.clear();
+    renderer(0.123456789);
+    BOOST_CHECK_EQUAL(output, "0.123456789");
+
+    output.clear();
+    renderer(0.12345678916);
+    BOOST_CHECK_EQUAL(output, "0.1234567892");
+
+    output.clear();
+    renderer(123456789123456789);
+    BOOST_CHECK_EQUAL(output, "1.234567891e+17");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/json_render.cpp
+++ b/unit_tests/util/json_render.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(number_truncating)
 
     // this number would have more than 10 decimals if not truncated
     renderer(Number{42.9995999594999399299});
-    BOOST_CHECK_EQUAL(str, "42.999599959");
+    BOOST_CHECK_EQUAL(str, "42.99959996");
 }
 
 BOOST_AUTO_TEST_CASE(integer)
@@ -25,6 +25,13 @@ BOOST_AUTO_TEST_CASE(integer)
     Renderer<std::string> renderer(str);
     renderer(Number{42.0});
     BOOST_CHECK_EQUAL(str, "42");
+}
+
+BOOST_AUTO_TEST_CASE(test_json_issue_6531) {
+    std::string output;
+    osrm::util::json::Renderer<std::string> renderer(output);
+    renderer(0.0000000000017114087924596788);
+    BOOST_CHECK_EQUAL(output, "1.711408792e-12");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
fix(json_render): json_render is not accurate enough for extremely small numbers. eg: fmt::format_to(std::back_inserter(buffer), FMT_COMPILE("{}"), double(0.0000000000017114087924596788)); you will get a result of 1.7114087924, this is a completely wrong result.

formatter params(width & precision chapter): https://en.cppreference.com/w/cpp/utility/format/formatter 

# Issue

#6513 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
