### PR TITLE
print tracebacks and line numbers for Lua runtime errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
       - CHANGED: Make edge metrics strongly typed [#6420](https://github.com/Project-OSRM/osrm-backend/pull/6420)
       - FIXED: Typo in file name src/util/timed_historgram.cpp -> src/util/timed_histogram.cpp [#6428](https://github.com/Project-OSRM/osrm-backend/issues/6428)
       - CHANGED: Replace boost::string_ref with std::string_view [#6433](https://github.com/Project-OSRM/osrm-backend/pull/6433)
+      - ADDED: Print tracebacks for Lua runtime errors [#6564](https://github.com/Project-OSRM/osrm-backend/pull/6564)
     - Routing:
       - FIXED: Fix adding traffic signal penalties during compression [#6419](https://github.com/Project-OSRM/osrm-backend/pull/6419)
 # 5.27.1

--- a/include/extractor/scripting_environment_lua.hpp
+++ b/include/extractor/scripting_environment_lua.hpp
@@ -41,10 +41,10 @@ struct LuaScriptingContext final
     bool has_way_function = false;
     bool has_segment_function = false;
 
-    sol::function turn_function;
-    sol::function way_function;
-    sol::function node_function;
-    sol::function segment_function;
+    sol::protected_function turn_function;
+    sol::protected_function way_function;
+    sol::protected_function node_function;
+    sol::protected_function segment_function;
 
     int api_version = 4;
     sol::table profile_table;

--- a/scripts/ci/leaksanitizer.conf
+++ b/scripts/ci/leaksanitizer.conf
@@ -6,3 +6,12 @@
 #     #1 0x7f7ae595d13e  (/usr/lib/x86_64-linux-gnu/libtbb.so.2+0x2213e)
 
 leak:libtbb.so
+
+# The extract-tests leak some memory in the tests to confirm that
+# lua errors print tracebacks.
+# This appears to be because when these tests throw exceptions, the
+# osmium objects being processed are not freed. In production this doesn't
+# matter, as the exceptions bring down the entire osrm-extract process. In the
+# tests, we catch the error to make sure it occurs, which is why the
+# leaksanitizer flags it.
+leak:extract-tests

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -245,8 +245,7 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                  "valid",
                                                  &osmium::Location::valid);
 
-    auto get_location_tag = [](auto &context, const auto &location, const char *key)
-    {
+    auto get_location_tag = [](auto &context, const auto &location, const char *key) {
         if (context.location_dependent_data.empty())
             return sol::object(context.state);
 
@@ -273,8 +272,7 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "get_nodes",
         [](const osmium::Way &way) { return sol::as_table(&way.nodes()); },
         "get_location_tag",
-        [&context, &get_location_tag](const osmium::Way &way, const char *key)
-        {
+        [&context, &get_location_tag](const osmium::Way &way, const char *key) {
             // HEURISTIC: use a single node (last) of the way to localize the way
             // For more complicated scenarios a proper merging of multiple tags
             // at one or many locations must be provided
@@ -294,8 +292,9 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "version",
         &osmium::Node::version,
         "get_location_tag",
-        [&context, &get_location_tag](const osmium::Node &node, const char *key)
-        { return get_location_tag(context, node.location(), key); });
+        [&context, &get_location_tag](const osmium::Node &node, const char *key) {
+            return get_location_tag(context, node.location(), key);
+        });
 
     context.state.new_enum("traffic_lights",
                            "none",
@@ -311,8 +310,7 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "ResultNode",
         "traffic_lights",
         sol::property([](const ExtractionNode &node) { return node.traffic_lights; },
-                      [](ExtractionNode &node, const sol::object &obj)
-                      {
+                      [](ExtractionNode &node, const sol::object &obj) {
                           if (obj.is<bool>())
                           {
                               // The old approach of assigning a boolean traffic light
@@ -363,8 +361,7 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         sol::property(&ExtractionWay::GetName, &ExtractionWay::SetName),
         "ref", // backward compatibility
         sol::property(&ExtractionWay::GetForwardRef,
-                      [](ExtractionWay &way, const char *ref)
-                      {
+                      [](ExtractionWay &way, const char *ref) {
                           way.SetForwardRef(ref);
                           way.SetBackwardRef(ref);
                       }),
@@ -423,8 +420,7 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         sol::property([](const ExtractionWay &way) { return way.access_turn_classification; },
                       [](ExtractionWay &way, int flag) { way.access_turn_classification = flag; }));
 
-    auto getTypedRefBySol = [](const sol::object &obj) -> ExtractionRelation::OsmIDTyped
-    {
+    auto getTypedRefBySol = [](const sol::object &obj) -> ExtractionRelation::OsmIDTyped {
         if (obj.is<osmium::Way>())
         {
             osmium::Way *way = obj.as<osmium::Way *>();
@@ -460,19 +456,20 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         "get_value_by_key",
         [](ExtractionRelation &rel, const char *key) -> const char * { return rel.GetAttr(key); },
         "get_role",
-        [&getTypedRefBySol](ExtractionRelation &rel, const sol::object &obj) -> const char *
-        { return rel.GetRole(getTypedRefBySol(obj)); });
+        [&getTypedRefBySol](ExtractionRelation &rel, const sol::object &obj) -> const char * {
+            return rel.GetRole(getTypedRefBySol(obj));
+        });
 
     context.state.new_usertype<ExtractionRelationContainer>(
         "ExtractionRelationContainer",
         "get_relations",
         [&getTypedRefBySol](ExtractionRelationContainer &cont, const sol::object &obj)
-            -> const ExtractionRelationContainer::RelationIDList &
-        { return cont.GetRelations(getTypedRefBySol(obj)); },
+            -> const ExtractionRelationContainer::RelationIDList & {
+            return cont.GetRelations(getTypedRefBySol(obj));
+        },
         "relation",
-        [](ExtractionRelationContainer &cont,
-           const ExtractionRelation::OsmIDTyped &rel_id) -> const ExtractionRelation &
-        { return cont.GetRelationData(rel_id); });
+        [](ExtractionRelationContainer &cont, const ExtractionRelation::OsmIDTyped &rel_id)
+            -> const ExtractionRelation & { return cont.GetRelationData(rel_id); });
 
     context.state.new_usertype<ExtractionSegment>("ExtractionSegment",
                                                   "source",
@@ -488,12 +485,10 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
 
     // Keep in mind .location is available only if .pbf is preprocessed to set the location with the
     // ref using osmium command "osmium add-locations-to-ways"
-    context.state.new_usertype<osmium::NodeRef>("NodeRef",
-                                                "id",
-                                                &osmium::NodeRef::ref,
-                                                "location",
-                                                [](const osmium::NodeRef &nref)
-                                                { return nref.location(); });
+    context.state.new_usertype<osmium::NodeRef>(
+        "NodeRef", "id", &osmium::NodeRef::ref, "location", [](const osmium::NodeRef &nref) {
+            return nref.location();
+        });
 
     context.state.new_usertype<InternalExtractorEdge>("EdgeSource",
                                                       "source_coordinate",
@@ -549,8 +544,7 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
     util::Log() << "Using profile api version " << context.api_version;
 
     // version-dependent parts of the api
-    auto initV2Context = [&]()
-    {
+    auto initV2Context = [&]() {
         // clear global not used in v2
         context.state["properties"] = sol::nullopt;
 
@@ -641,31 +635,26 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         }
     };
 
-    auto initialize_V3_extraction_turn = [&]()
-    {
+    auto initialize_V3_extraction_turn = [&]() {
         context.state.new_usertype<ExtractionTurn>(
             "ExtractionTurn",
             "angle",
             &ExtractionTurn::angle,
             "turn_type",
-            sol::property(
-                [](const ExtractionTurn &turn)
-                {
-                    if (turn.number_of_roads > 2 || turn.source_mode != turn.target_mode ||
-                        turn.is_u_turn)
-                        return osrm::guidance::TurnType::Turn;
-                    else
-                        return osrm::guidance::TurnType::NoTurn;
-                }),
+            sol::property([](const ExtractionTurn &turn) {
+                if (turn.number_of_roads > 2 || turn.source_mode != turn.target_mode ||
+                    turn.is_u_turn)
+                    return osrm::guidance::TurnType::Turn;
+                else
+                    return osrm::guidance::TurnType::NoTurn;
+            }),
             "direction_modifier",
-            sol::property(
-                [](const ExtractionTurn &turn)
-                {
-                    if (turn.is_u_turn)
-                        return osrm::guidance::DirectionModifier::UTurn;
-                    else
-                        return osrm::guidance::DirectionModifier::Straight;
-                }),
+            sol::property([](const ExtractionTurn &turn) {
+                if (turn.is_u_turn)
+                    return osrm::guidance::DirectionModifier::UTurn;
+                else
+                    return osrm::guidance::DirectionModifier::Straight;
+            }),
             "has_traffic_light",
             &ExtractionTurn::has_traffic_light,
             "weight",

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -864,12 +864,10 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         BOOST_ASSERT(context.properties.GetTrafficSignalPenalty() == 0);
 
         // call source_function if present
-        sol::protected_function source_function = context.state["source_function"];
+        sol::function source_function = context.state["source_function"];
         if (source_function.valid())
         {
-            auto luares = source_function();
-            if (!luares.valid())
-                handle_lua_error(luares);
+            source_function();
         }
 
         break;
@@ -982,12 +980,10 @@ Sol2ScriptingEnvironment::GetStringListFromFunction(const std::string &function_
     auto &context = GetSol2Context();
     BOOST_ASSERT(context.state.lua_state());
     std::vector<std::string> strings;
-    sol::protected_function function = context.state[function_name];
+    sol::function function = context.state[function_name];
     if (function.valid())
     {
-        auto luares = function(strings);
-        if (!luares.valid())
-            handle_lua_error(luares);
+        function(strings);
     }
     return strings;
 }

--- a/test/data/profiles/bad_node.lua
+++ b/test/data/profiles/bad_node.lua
@@ -1,0 +1,140 @@
+-- copy of testbot with process_node throwing a runtime error
+
+api_version = 4
+
+function setup()
+  return {
+    properties = {
+      continue_straight_at_waypoint = true,
+      max_speed_for_map_matching    = 30/3.6, --km -> m/s
+      weight_name                   = 'duration',
+      process_call_tagless_node     = false,
+      u_turn_penalty                 = 20,
+      traffic_light_penalty         = 7,     -- seconds
+      use_turn_restrictions         = true
+    },
+
+    classes = {"motorway", "toll", "TooWords2"},
+
+    excludable = {
+        {["motorway"] = true},
+        {["toll"] = true},
+        {["motorway"] = true, ["toll"] = true}
+    },
+
+    default_speed  = 24,
+    speeds = {
+      primary = 36,
+      secondary = 18,
+      tertiary = 12,
+      steps = 6
+    }
+  }
+end
+
+function process_node (profile, node, result)
+  if (2 < nil) then
+    print("2 is less than nil")
+  end
+
+  -- check if node is a traffic light
+  -- TODO: a way to set the penalty value
+end
+
+function process_way (profile, way, result)
+  local highway = way:get_value_by_key("highway")
+  local toll = way:get_value_by_key("toll")
+  local name = way:get_value_by_key("name")
+  local oneway = way:get_value_by_key("oneway")
+  local route = way:get_value_by_key("route")
+  local duration = way:get_value_by_key("duration")
+  local maxspeed = tonumber(way:get_value_by_key ( "maxspeed"))
+  local maxspeed_forward = tonumber(way:get_value_by_key( "maxspeed:forward"))
+  local maxspeed_backward = tonumber(way:get_value_by_key( "maxspeed:backward"))
+  local junction = way:get_value_by_key("junction")
+
+  if name then
+    result.name = name
+  end
+
+  result.forward_mode = mode.driving
+  result.backward_mode = mode.driving
+
+  if duration and durationIsValid(duration) then
+    result.duration = math.max( 1, parseDuration(duration) )
+    result.forward_mode = mode.route
+    result.backward_mode = mode.route
+  else
+    local speed_forw = profile.speeds[highway] or profile.default_speed
+    local speed_back = speed_forw
+
+    if highway == "river" then
+      local temp_speed = speed_forw
+      result.forward_mode = mode.river_down
+      result.backward_mode = mode.river_up
+      speed_forw = temp_speed*1.5
+      speed_back = temp_speed/1.5
+    elseif highway == "steps" then
+      result.forward_mode = mode.steps_down
+      result.backward_mode = mode.steps_up
+    end
+
+    if maxspeed_forward ~= nil and maxspeed_forward > 0 then
+      speed_forw = maxspeed_forward
+    else
+      if maxspeed ~= nil and maxspeed > 0 and speed_forw > maxspeed then
+        speed_forw = maxspeed
+      end
+    end
+
+    if maxspeed_backward ~= nil and maxspeed_backward > 0 then
+      speed_back = maxspeed_backward
+    else
+      if maxspeed ~=nil and maxspeed > 0 and speed_back > maxspeed then
+        speed_back = maxspeed
+      end
+    end
+
+    result.forward_speed = speed_forw
+    result.backward_speed = speed_back
+  end
+
+  if oneway == "no" or oneway == "0" or oneway == "false" then
+    -- nothing to do
+  elseif oneway == "-1" then
+    result.forward_mode = mode.inaccessible
+  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" then
+    result.backward_mode = mode.inaccessible
+  end
+
+  if highway == 'motorway' then
+      result.forward_classes["motorway"] = true
+      result.backward_classes["motorway"] = true
+  end
+
+  if toll == "yes" then
+      result.forward_classes["toll"] = true
+      result.backward_classes["toll"] = true
+  end
+
+  if junction == 'roundabout' then
+    result.roundabout = true
+  end
+end
+
+function process_turn (profile, turn)
+  if turn.is_u_turn then
+    turn.duration = turn.duration + profile.properties.u_turn_penalty
+    turn.weight = turn.weight + profile.properties.u_turn_penalty
+  end
+  if turn.has_traffic_light then
+     turn.duration = turn.duration + profile.properties.traffic_light_penalty
+  end
+end
+
+return {
+  setup = setup,
+  process_way = process_way,
+  process_node = process_node,
+  process_turn = process_turn
+}

--- a/test/data/profiles/bad_segment.lua
+++ b/test/data/profiles/bad_segment.lua
@@ -1,0 +1,143 @@
+-- A copy of testbot with process_segment throwing a runtime error
+
+api_version = 4
+
+function setup()
+  return {
+    properties = {
+      continue_straight_at_waypoint = true,
+      max_speed_for_map_matching    = 30/3.6, --km -> m/s
+      weight_name                   = 'duration',
+      process_call_tagless_node     = false,
+      u_turn_penalty                 = 20,
+      traffic_light_penalty         = 7,     -- seconds
+      use_turn_restrictions         = true
+    },
+
+    classes = {"motorway", "toll", "TooWords2"},
+
+    excludable = {
+        {["motorway"] = true},
+        {["toll"] = true},
+        {["motorway"] = true, ["toll"] = true}
+    },
+
+    default_speed  = 24,
+    speeds = {
+      primary = 36,
+      secondary = 18,
+      tertiary = 12,
+      steps = 6
+    }
+  }
+end
+
+function process_node (profile, node, result)
+  -- check if node is a traffic light
+  -- TODO: a way to set the penalty value
+end
+
+function process_way (profile, way, result)
+  local highway = way:get_value_by_key("highway")
+  local toll = way:get_value_by_key("toll")
+  local name = way:get_value_by_key("name")
+  local oneway = way:get_value_by_key("oneway")
+  local route = way:get_value_by_key("route")
+  local duration = way:get_value_by_key("duration")
+  local maxspeed = tonumber(way:get_value_by_key ( "maxspeed"))
+  local maxspeed_forward = tonumber(way:get_value_by_key( "maxspeed:forward"))
+  local maxspeed_backward = tonumber(way:get_value_by_key( "maxspeed:backward"))
+  local junction = way:get_value_by_key("junction")
+
+  if name then
+    result.name = name
+  end
+
+  result.forward_mode = mode.driving
+  result.backward_mode = mode.driving
+
+  if duration and durationIsValid(duration) then
+    result.duration = math.max( 1, parseDuration(duration) )
+    result.forward_mode = mode.route
+    result.backward_mode = mode.route
+  else
+    local speed_forw = profile.speeds[highway] or profile.default_speed
+    local speed_back = speed_forw
+
+    if highway == "river" then
+      local temp_speed = speed_forw
+      result.forward_mode = mode.river_down
+      result.backward_mode = mode.river_up
+      speed_forw = temp_speed*1.5
+      speed_back = temp_speed/1.5
+    elseif highway == "steps" then
+      result.forward_mode = mode.steps_down
+      result.backward_mode = mode.steps_up
+    end
+
+    if maxspeed_forward ~= nil and maxspeed_forward > 0 then
+      speed_forw = maxspeed_forward
+    else
+      if maxspeed ~= nil and maxspeed > 0 and speed_forw > maxspeed then
+        speed_forw = maxspeed
+      end
+    end
+
+    if maxspeed_backward ~= nil and maxspeed_backward > 0 then
+      speed_back = maxspeed_backward
+    else
+      if maxspeed ~=nil and maxspeed > 0 and speed_back > maxspeed then
+        speed_back = maxspeed
+      end
+    end
+
+    result.forward_speed = speed_forw
+    result.backward_speed = speed_back
+  end
+
+  if oneway == "no" or oneway == "0" or oneway == "false" then
+    -- nothing to do
+  elseif oneway == "-1" then
+    result.forward_mode = mode.inaccessible
+  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" then
+    result.backward_mode = mode.inaccessible
+  end
+
+  if highway == 'motorway' then
+      result.forward_classes["motorway"] = true
+      result.backward_classes["motorway"] = true
+  end
+
+  if toll == "yes" then
+      result.forward_classes["toll"] = true
+      result.backward_classes["toll"] = true
+  end
+
+  if junction == 'roundabout' then
+    result.roundabout = true
+  end
+end
+
+function process_turn (profile, turn)
+  if turn.is_u_turn then
+    turn.duration = turn.duration + profile.properties.u_turn_penalty
+    turn.weight = turn.weight + profile.properties.u_turn_penalty
+  end
+  if turn.has_traffic_light then
+     turn.duration = turn.duration + profile.properties.traffic_light_penalty
+  end
+end
+
+function process_segment (profile, segment)
+  if (2 < nil) then
+    print("2 is less than nil")
+  end
+end
+
+return {
+  setup = setup,
+  process_way = process_way,
+  process_node = process_node,
+  process_turn = process_turn,
+  process_segment = process_segment
+}

--- a/test/data/profiles/bad_setup.lua
+++ b/test/data/profiles/bad_setup.lua
@@ -1,0 +1,140 @@
+-- Copy of testbot profile, with setup throwing a runtime error
+
+api_version = 4
+
+function setup()
+  if (2 < nil) then -- arithmetic with nil should error
+    return {}
+  end
+
+  return {
+    properties = {
+      continue_straight_at_waypoint = true,
+      max_speed_for_map_matching    = 30/3.6, --km -> m/s
+      weight_name                   = 'duration',
+      process_call_tagless_node     = false,
+      u_turn_penalty                 = 20,
+      traffic_light_penalty         = 7,     -- seconds
+      use_turn_restrictions         = true
+    },
+
+    classes = {"motorway", "toll", "TooWords2"},
+
+    excludable = {
+        {["motorway"] = true},
+        {["toll"] = true},
+        {["motorway"] = true, ["toll"] = true}
+    },
+
+    default_speed  = 24,
+    speeds = {
+      primary = 36,
+      secondary = 18,
+      tertiary = 12,
+      steps = 6
+    }
+  }
+end
+
+function process_node (profile, node, result)
+  -- check if node is a traffic light
+  -- TODO: a way to set the penalty value
+end
+
+function process_way (profile, way, result)
+  local highway = way:get_value_by_key("highway")
+  local toll = way:get_value_by_key("toll")
+  local name = way:get_value_by_key("name")
+  local oneway = way:get_value_by_key("oneway")
+  local route = way:get_value_by_key("route")
+  local duration = way:get_value_by_key("duration")
+  local maxspeed = tonumber(way:get_value_by_key ( "maxspeed"))
+  local maxspeed_forward = tonumber(way:get_value_by_key( "maxspeed:forward"))
+  local maxspeed_backward = tonumber(way:get_value_by_key( "maxspeed:backward"))
+  local junction = way:get_value_by_key("junction")
+
+  if name then
+    result.name = name
+  end
+
+  result.forward_mode = mode.driving
+  result.backward_mode = mode.driving
+
+  if duration and durationIsValid(duration) then
+    result.duration = math.max( 1, parseDuration(duration) )
+    result.forward_mode = mode.route
+    result.backward_mode = mode.route
+  else
+    local speed_forw = profile.speeds[highway] or profile.default_speed
+    local speed_back = speed_forw
+
+    if highway == "river" then
+      local temp_speed = speed_forw
+      result.forward_mode = mode.river_down
+      result.backward_mode = mode.river_up
+      speed_forw = temp_speed*1.5
+      speed_back = temp_speed/1.5
+    elseif highway == "steps" then
+      result.forward_mode = mode.steps_down
+      result.backward_mode = mode.steps_up
+    end
+
+    if maxspeed_forward ~= nil and maxspeed_forward > 0 then
+      speed_forw = maxspeed_forward
+    else
+      if maxspeed ~= nil and maxspeed > 0 and speed_forw > maxspeed then
+        speed_forw = maxspeed
+      end
+    end
+
+    if maxspeed_backward ~= nil and maxspeed_backward > 0 then
+      speed_back = maxspeed_backward
+    else
+      if maxspeed ~=nil and maxspeed > 0 and speed_back > maxspeed then
+        speed_back = maxspeed
+      end
+    end
+
+    result.forward_speed = speed_forw
+    result.backward_speed = speed_back
+  end
+
+  if oneway == "no" or oneway == "0" or oneway == "false" then
+    -- nothing to do
+  elseif oneway == "-1" then
+    result.forward_mode = mode.inaccessible
+  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" then
+    result.backward_mode = mode.inaccessible
+  end
+
+  if highway == 'motorway' then
+      result.forward_classes["motorway"] = true
+      result.backward_classes["motorway"] = true
+  end
+
+  if toll == "yes" then
+      result.forward_classes["toll"] = true
+      result.backward_classes["toll"] = true
+  end
+
+  if junction == 'roundabout' then
+    result.roundabout = true
+  end
+end
+
+function process_turn (profile, turn)
+  if turn.is_u_turn then
+    turn.duration = turn.duration + profile.properties.u_turn_penalty
+    turn.weight = turn.weight + profile.properties.u_turn_penalty
+  end
+  if turn.has_traffic_light then
+     turn.duration = turn.duration + profile.properties.traffic_light_penalty
+  end
+end
+
+return {
+  setup = setup,
+  process_way = process_way,
+  process_node = process_node,
+  process_turn = process_turn
+}

--- a/test/data/profiles/bad_turn.lua
+++ b/test/data/profiles/bad_turn.lua
@@ -1,0 +1,140 @@
+-- a copy of testbot with process_turn throwing an error
+
+api_version = 4
+
+function setup()
+  return {
+    properties = {
+      continue_straight_at_waypoint = true,
+      max_speed_for_map_matching    = 30/3.6, --km -> m/s
+      weight_name                   = 'duration',
+      process_call_tagless_node     = false,
+      u_turn_penalty                 = 20,
+      traffic_light_penalty         = 7,     -- seconds
+      use_turn_restrictions         = true
+    },
+
+    classes = {"motorway", "toll", "TooWords2"},
+
+    excludable = {
+        {["motorway"] = true},
+        {["toll"] = true},
+        {["motorway"] = true, ["toll"] = true}
+    },
+
+    default_speed  = 24,
+    speeds = {
+      primary = 36,
+      secondary = 18,
+      tertiary = 12,
+      steps = 6
+    }
+  }
+end
+
+function process_node (profile, node, result)
+  -- check if node is a traffic light
+  -- TODO: a way to set the penalty value
+end
+
+function process_way (profile, way, result)
+  local highway = way:get_value_by_key("highway")
+  local toll = way:get_value_by_key("toll")
+  local name = way:get_value_by_key("name")
+  local oneway = way:get_value_by_key("oneway")
+  local route = way:get_value_by_key("route")
+  local duration = way:get_value_by_key("duration")
+  local maxspeed = tonumber(way:get_value_by_key ( "maxspeed"))
+  local maxspeed_forward = tonumber(way:get_value_by_key( "maxspeed:forward"))
+  local maxspeed_backward = tonumber(way:get_value_by_key( "maxspeed:backward"))
+  local junction = way:get_value_by_key("junction")
+
+  if name then
+    result.name = name
+  end
+
+  result.forward_mode = mode.driving
+  result.backward_mode = mode.driving
+
+  if duration and durationIsValid(duration) then
+    result.duration = math.max( 1, parseDuration(duration) )
+    result.forward_mode = mode.route
+    result.backward_mode = mode.route
+  else
+    local speed_forw = profile.speeds[highway] or profile.default_speed
+    local speed_back = speed_forw
+
+    if highway == "river" then
+      local temp_speed = speed_forw
+      result.forward_mode = mode.river_down
+      result.backward_mode = mode.river_up
+      speed_forw = temp_speed*1.5
+      speed_back = temp_speed/1.5
+    elseif highway == "steps" then
+      result.forward_mode = mode.steps_down
+      result.backward_mode = mode.steps_up
+    end
+
+    if maxspeed_forward ~= nil and maxspeed_forward > 0 then
+      speed_forw = maxspeed_forward
+    else
+      if maxspeed ~= nil and maxspeed > 0 and speed_forw > maxspeed then
+        speed_forw = maxspeed
+      end
+    end
+
+    if maxspeed_backward ~= nil and maxspeed_backward > 0 then
+      speed_back = maxspeed_backward
+    else
+      if maxspeed ~=nil and maxspeed > 0 and speed_back > maxspeed then
+        speed_back = maxspeed
+      end
+    end
+
+    result.forward_speed = speed_forw
+    result.backward_speed = speed_back
+  end
+
+  if oneway == "no" or oneway == "0" or oneway == "false" then
+    -- nothing to do
+  elseif oneway == "-1" then
+    result.forward_mode = mode.inaccessible
+  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" then
+    result.backward_mode = mode.inaccessible
+  end
+
+  if highway == 'motorway' then
+      result.forward_classes["motorway"] = true
+      result.backward_classes["motorway"] = true
+  end
+
+  if toll == "yes" then
+      result.forward_classes["toll"] = true
+      result.backward_classes["toll"] = true
+  end
+
+  if junction == 'roundabout' then
+    result.roundabout = true
+  end
+end
+
+function process_turn (profile, turn)
+  if (2 < nil) then
+    print("2 is less than nil")
+  end
+
+  if turn.is_u_turn then
+    turn.duration = turn.duration + profile.properties.u_turn_penalty
+    turn.weight = turn.weight + profile.properties.u_turn_penalty
+  end
+  if turn.has_traffic_light then
+     turn.duration = turn.duration + profile.properties.traffic_light_penalty
+  end
+end
+
+return {
+  setup = setup,
+  process_way = process_way,
+  process_node = process_node,
+  process_turn = process_turn
+}

--- a/test/data/profiles/bad_way.lua
+++ b/test/data/profiles/bad_way.lua
@@ -1,0 +1,140 @@
+-- copy of testbot with process_way throwing a runtime error
+
+api_version = 4
+
+function setup()
+  return {
+    properties = {
+      continue_straight_at_waypoint = true,
+      max_speed_for_map_matching    = 30/3.6, --km -> m/s
+      weight_name                   = 'duration',
+      process_call_tagless_node     = false,
+      u_turn_penalty                 = 20,
+      traffic_light_penalty         = 7,     -- seconds
+      use_turn_restrictions         = true
+    },
+
+    classes = {"motorway", "toll", "TooWords2"},
+
+    excludable = {
+        {["motorway"] = true},
+        {["toll"] = true},
+        {["motorway"] = true, ["toll"] = true}
+    },
+
+    default_speed  = 24,
+    speeds = {
+      primary = 36,
+      secondary = 18,
+      tertiary = 12,
+      steps = 6
+    }
+  }
+end
+
+function process_node (profile, node, result)
+  -- check if node is a traffic light
+  -- TODO: a way to set the penalty value
+end
+
+function process_way (profile, way, result)
+  if (2 < nil) then
+    print("2 less than nil")
+  end
+
+  local highway = way:get_value_by_key("highway")
+  local toll = way:get_value_by_key("toll")
+  local name = way:get_value_by_key("name")
+  local oneway = way:get_value_by_key("oneway")
+  local route = way:get_value_by_key("route")
+  local duration = way:get_value_by_key("duration")
+  local maxspeed = tonumber(way:get_value_by_key ( "maxspeed"))
+  local maxspeed_forward = tonumber(way:get_value_by_key( "maxspeed:forward"))
+  local maxspeed_backward = tonumber(way:get_value_by_key( "maxspeed:backward"))
+  local junction = way:get_value_by_key("junction")
+
+  if name then
+    result.name = name
+  end
+
+  result.forward_mode = mode.driving
+  result.backward_mode = mode.driving
+
+  if duration and durationIsValid(duration) then
+    result.duration = math.max( 1, parseDuration(duration) )
+    result.forward_mode = mode.route
+    result.backward_mode = mode.route
+  else
+    local speed_forw = profile.speeds[highway] or profile.default_speed
+    local speed_back = speed_forw
+
+    if highway == "river" then
+      local temp_speed = speed_forw
+      result.forward_mode = mode.river_down
+      result.backward_mode = mode.river_up
+      speed_forw = temp_speed*1.5
+      speed_back = temp_speed/1.5
+    elseif highway == "steps" then
+      result.forward_mode = mode.steps_down
+      result.backward_mode = mode.steps_up
+    end
+
+    if maxspeed_forward ~= nil and maxspeed_forward > 0 then
+      speed_forw = maxspeed_forward
+    else
+      if maxspeed ~= nil and maxspeed > 0 and speed_forw > maxspeed then
+        speed_forw = maxspeed
+      end
+    end
+
+    if maxspeed_backward ~= nil and maxspeed_backward > 0 then
+      speed_back = maxspeed_backward
+    else
+      if maxspeed ~=nil and maxspeed > 0 and speed_back > maxspeed then
+        speed_back = maxspeed
+      end
+    end
+
+    result.forward_speed = speed_forw
+    result.backward_speed = speed_back
+  end
+
+  if oneway == "no" or oneway == "0" or oneway == "false" then
+    -- nothing to do
+  elseif oneway == "-1" then
+    result.forward_mode = mode.inaccessible
+  elseif oneway == "yes" or oneway == "1" or oneway == "true" or junction == "roundabout" then
+    result.backward_mode = mode.inaccessible
+  end
+
+  if highway == 'motorway' then
+      result.forward_classes["motorway"] = true
+      result.backward_classes["motorway"] = true
+  end
+
+  if toll == "yes" then
+      result.forward_classes["toll"] = true
+      result.backward_classes["toll"] = true
+  end
+
+  if junction == 'roundabout' then
+    result.roundabout = true
+  end
+end
+
+function process_turn (profile, turn)
+  if turn.is_u_turn then
+    turn.duration = turn.duration + profile.properties.u_turn_penalty
+    turn.weight = turn.weight + profile.properties.u_turn_penalty
+  end
+  if turn.has_traffic_light then
+     turn.duration = turn.duration + profile.properties.traffic_light_penalty
+  end
+end
+
+return {
+  setup = setup,
+  process_way = process_way,
+  process_node = process_node,
+  process_turn = process_turn
+}

--- a/unit_tests/library/extract.cpp
+++ b/unit_tests/library/extract.cpp
@@ -2,8 +2,42 @@
 
 #include "osrm/extractor.hpp"
 #include "osrm/extractor_config.hpp"
+#include "osrm/exception.hpp"
 
 #include <thread>
+#include <boost/algorithm/string.hpp>
+
+bool file_contains_string(std::string filename, std::string test) {
+    std::ifstream inp(filename);
+
+    if (inp.is_open()) {
+        std::string contents;
+        inp >> contents;
+
+        return(boost::algorithm::contains(contents, test));
+    } else {
+        return false; // just fail the boost assert (shouldn't happen)
+    }
+}
+
+// utility class to redirect stderr so we can test it
+// inspired by https://stackoverflow.com/questions/5405016
+class redirect_stderr {
+    // constructor: accept a pointer to a buffer where stderr will be redirected
+    public: redirect_stderr(std::streambuf * buf)
+        // store the original buffer for later (original buffer returned by rdbuf)
+        : old(std::cerr.rdbuf(buf))
+        { }
+
+    // destructor: restore the original cerr, regardless of how this class gets destroyed
+    ~redirect_stderr ()
+    {
+        std::cerr.rdbuf(old);
+    }
+
+    // place to store the buffer
+    private: std::streambuf * old;
+};
 
 BOOST_AUTO_TEST_SUITE(library_extract)
 
@@ -24,6 +58,111 @@ BOOST_AUTO_TEST_CASE(test_extract_with_valid_config)
     config.small_component_size = 1000;
     config.requested_num_threads = std::thread::hardware_concurrency();
     BOOST_CHECK_NO_THROW(osrm::extract(config));
+}
+
+BOOST_AUTO_TEST_CASE(test_setup_runtime_error)
+{
+    osrm::ExtractorConfig config;
+    config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
+    config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
+    config.profile_path = OSRM_TEST_DATA_DIR "/profiles/bad_setup.lua";
+    config.small_component_size = 1000;
+    config.requested_num_threads = std::thread::hardware_concurrency();
+
+    std::stringstream output;
+
+    {
+        redirect_stderr redir (output.rdbuf());
+        BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
+    }
+
+    // We just look for the line number, file name, and error message. This avoids portability issues
+    // since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_setup.lua:6: attempt to compare number with nil"));
+}
+
+BOOST_AUTO_TEST_CASE(test_way_runtime_error)
+{
+    osrm::ExtractorConfig config;
+    config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
+    config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
+    config.profile_path = OSRM_TEST_DATA_DIR "/profiles/bad_way.lua";
+    config.small_component_size = 1000;
+    config.requested_num_threads = std::thread::hardware_concurrency();
+
+    std::stringstream output;
+
+    {
+        redirect_stderr redir (output.rdbuf());
+        BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
+    }
+
+    // We just look for the line number, file name, and error message. This avoids portability issues
+    // since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_way.lua:41: attempt to compare number with nil"));
+}
+
+BOOST_AUTO_TEST_CASE(test_node_runtime_error)
+{
+    osrm::ExtractorConfig config;
+    config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
+    config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
+    config.profile_path = OSRM_TEST_DATA_DIR "/profiles/bad_node.lua";
+    config.small_component_size = 1000;
+    config.requested_num_threads = std::thread::hardware_concurrency();
+
+    std::stringstream output;
+
+    {
+        redirect_stderr redir (output.rdbuf());
+        BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
+    }
+
+    // We just look for the line number, file name, and error message. This avoids portability issues
+    // since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_node.lua:36: attempt to compare number with nil"));
+}
+
+BOOST_AUTO_TEST_CASE(test_segment_runtime_error)
+{
+    osrm::ExtractorConfig config;
+    config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
+    config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
+    config.profile_path = OSRM_TEST_DATA_DIR "/profiles/bad_segment.lua";
+    config.small_component_size = 1000;
+    config.requested_num_threads = std::thread::hardware_concurrency();
+
+    std::stringstream output;
+
+    {
+        redirect_stderr redir (output.rdbuf());
+        BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
+    }
+
+    // We just look for the line number, file name, and error message. This avoids portability issues
+    // since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_segment.lua:132: attempt to compare number with nil"));
+}
+
+BOOST_AUTO_TEST_CASE(test_turn_runtime_error)
+{
+    osrm::ExtractorConfig config;
+    config.input_path = OSRM_TEST_DATA_DIR "/monaco.osm.pbf";
+    config.UseDefaultOutputNames(OSRM_TEST_DATA_DIR "/monaco.osm.pbf");
+    config.profile_path = OSRM_TEST_DATA_DIR "/profiles/bad_turn.lua";
+    config.small_component_size = 1000;
+    config.requested_num_threads = std::thread::hardware_concurrency();
+
+    std::stringstream output;
+
+    {
+        redirect_stderr redir (output.rdbuf());
+        BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
+    }
+
+    // We just look for the line number, file name, and error message. This avoids portability issues
+    // since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_turn.lua:122: attempt to compare number with nil"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/library/extract.cpp
+++ b/unit_tests/library/extract.cpp
@@ -1,42 +1,47 @@
 #include <boost/test/unit_test.hpp>
 
+#include "osrm/exception.hpp"
 #include "osrm/extractor.hpp"
 #include "osrm/extractor_config.hpp"
-#include "osrm/exception.hpp"
 
-#include <thread>
 #include <boost/algorithm/string.hpp>
+#include <thread>
 
-bool file_contains_string(std::string filename, std::string test) {
+bool file_contains_string(std::string filename, std::string test)
+{
     std::ifstream inp(filename);
 
-    if (inp.is_open()) {
+    if (inp.is_open())
+    {
         std::string contents;
         inp >> contents;
 
-        return(boost::algorithm::contains(contents, test));
-    } else {
+        return (boost::algorithm::contains(contents, test));
+    }
+    else
+    {
         return false; // just fail the boost assert (shouldn't happen)
     }
 }
 
 // utility class to redirect stderr so we can test it
 // inspired by https://stackoverflow.com/questions/5405016
-class redirect_stderr {
+class redirect_stderr
+{
     // constructor: accept a pointer to a buffer where stderr will be redirected
-    public: redirect_stderr(std::streambuf * buf)
+  public:
+    redirect_stderr(std::streambuf *buf)
         // store the original buffer for later (original buffer returned by rdbuf)
         : old(std::cerr.rdbuf(buf))
-        { }
-
-    // destructor: restore the original cerr, regardless of how this class gets destroyed
-    ~redirect_stderr ()
     {
-        std::cerr.rdbuf(old);
     }
 
+    // destructor: restore the original cerr, regardless of how this class gets destroyed
+    ~redirect_stderr() { std::cerr.rdbuf(old); }
+
     // place to store the buffer
-    private: std::streambuf * old;
+  private:
+    std::streambuf *old;
 };
 
 BOOST_AUTO_TEST_SUITE(library_extract)
@@ -72,13 +77,14 @@ BOOST_AUTO_TEST_CASE(test_setup_runtime_error)
     std::stringstream output;
 
     {
-        redirect_stderr redir (output.rdbuf());
+        redirect_stderr redir(output.rdbuf());
         BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
     }
 
-    // We just look for the line number, file name, and error message. This avoids portability issues
-    // since the output contains the full path to the file, which may change between systems
-    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_setup.lua:6: attempt to compare number with nil"));
+    // We just look for the line number, file name, and error message. This avoids portability
+    // issues since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(),
+                                           "bad_setup.lua:6: attempt to compare number with nil"));
 }
 
 BOOST_AUTO_TEST_CASE(test_way_runtime_error)
@@ -93,13 +99,14 @@ BOOST_AUTO_TEST_CASE(test_way_runtime_error)
     std::stringstream output;
 
     {
-        redirect_stderr redir (output.rdbuf());
+        redirect_stderr redir(output.rdbuf());
         BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
     }
 
-    // We just look for the line number, file name, and error message. This avoids portability issues
-    // since the output contains the full path to the file, which may change between systems
-    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_way.lua:41: attempt to compare number with nil"));
+    // We just look for the line number, file name, and error message. This avoids portability
+    // issues since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(),
+                                           "bad_way.lua:41: attempt to compare number with nil"));
 }
 
 BOOST_AUTO_TEST_CASE(test_node_runtime_error)
@@ -114,13 +121,14 @@ BOOST_AUTO_TEST_CASE(test_node_runtime_error)
     std::stringstream output;
 
     {
-        redirect_stderr redir (output.rdbuf());
+        redirect_stderr redir(output.rdbuf());
         BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
     }
 
-    // We just look for the line number, file name, and error message. This avoids portability issues
-    // since the output contains the full path to the file, which may change between systems
-    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_node.lua:36: attempt to compare number with nil"));
+    // We just look for the line number, file name, and error message. This avoids portability
+    // issues since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(),
+                                           "bad_node.lua:36: attempt to compare number with nil"));
 }
 
 BOOST_AUTO_TEST_CASE(test_segment_runtime_error)
@@ -135,13 +143,14 @@ BOOST_AUTO_TEST_CASE(test_segment_runtime_error)
     std::stringstream output;
 
     {
-        redirect_stderr redir (output.rdbuf());
+        redirect_stderr redir(output.rdbuf());
         BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
     }
 
-    // We just look for the line number, file name, and error message. This avoids portability issues
-    // since the output contains the full path to the file, which may change between systems
-    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_segment.lua:132: attempt to compare number with nil"));
+    // We just look for the line number, file name, and error message. This avoids portability
+    // issues since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(
+        output.str(), "bad_segment.lua:132: attempt to compare number with nil"));
 }
 
 BOOST_AUTO_TEST_CASE(test_turn_runtime_error)
@@ -156,13 +165,14 @@ BOOST_AUTO_TEST_CASE(test_turn_runtime_error)
     std::stringstream output;
 
     {
-        redirect_stderr redir (output.rdbuf());
+        redirect_stderr redir(output.rdbuf());
         BOOST_CHECK_THROW(osrm::extract(config), osrm::util::exception);
     }
 
-    // We just look for the line number, file name, and error message. This avoids portability issues
-    // since the output contains the full path to the file, which may change between systems
-    BOOST_CHECK(boost::algorithm::contains(output.str(), "bad_turn.lua:122: attempt to compare number with nil"));
+    // We just look for the line number, file name, and error message. This avoids portability
+    // issues since the output contains the full path to the file, which may change between systems
+    BOOST_CHECK(boost::algorithm::contains(output.str(),
+                                           "bad_turn.lua:122: attempt to compare number with nil"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/library/extract.cpp
+++ b/unit_tests/library/extract.cpp
@@ -7,23 +7,6 @@
 #include <boost/algorithm/string.hpp>
 #include <thread>
 
-bool file_contains_string(std::string filename, std::string test)
-{
-    std::ifstream inp(filename);
-
-    if (inp.is_open())
-    {
-        std::string contents;
-        inp >> contents;
-
-        return (boost::algorithm::contains(contents, test));
-    }
-    else
-    {
-        return false; // just fail the boost assert (shouldn't happen)
-    }
-}
-
 // utility class to redirect stderr so we can test it
 // inspired by https://stackoverflow.com/questions/5405016
 class redirect_stderr


### PR DESCRIPTION
# Issue

This fixes #6563, and provides tracebacks and line number for Lua runtime errors. It does this by replacing all `sol::function`s with `sol::protected_function` and checking for errors after a Lua function is called. If one is detected, a traceback is printed to stderr, and an exception is thrown which causes OSRM to exit (as it did before when runtime errors were encountered).

Before:
```
$ osrm-extract -p ../profiles/bicycle_lts.lua bicycle_lts/bicycle_lts.osm.pbf
[lots of intermediate output]
libc++abi: terminating with uncaught exception of type sol::error: lua: error: attempt to compare two nil values
```

After:
```osrm-extract -p ../profiles/bicycle_lts.lua bicycle_lts/bicycle_lts.osm.pbf
[lots of intermediate output]
attempt to compare two nil values
stack traceback:
	[C]: in function 'math.max'
	...bc/git/vmt-mode-shift-study/src/routing/profiles/lts.lua:128: in function 'lts.lts_for_way'
	../profiles/bicycle_lts.lua:515: in function 'process_way'
attempt to compare two nil values
stack traceback:
	[C]: in function 'math.max'
	...bc/git/vmt-mode-shift-study/src/routing/profiles/lts.lua:128: in function 'lts.lts_for_way'
	../profiles/bicycle_lts.lua:515: in function 'process_way'
attempt to compare two nil values
stack traceback:
	[C]: in function 'math.max'
	...bc/git/vmt-mode-shift-study/src/routing/profiles/lts.lua:128: in function 'lts.lts_for_way'
	../profiles/bicycle_lts.lua:515: in function 'process_way'
attempt to compare two nil values
stack traceback:
	[C]: in function 'math.max'
	...bc/git/vmt-mode-shift-study/src/routing/profiles/lts.lua:128: in function 'lts.lts_for_way'
	../profiles/bicycle_lts.lua:515: in function 'process_way'
libc++abi: terminating with uncaught exception of type osrm::util::exception: Lua error (see stderr for traceback)
```

I believe the error message is printed multiple times because the error is getting hit in multiple threads before the exception kills the entire process. My understanding is that a single exception should kill the entire process, not just the thread, but I'm new to C++ so if that's incorrect changes will be required to ensure runtime errors actually terminate extraction.

Performance impact is negligible/nonexistent. With my small test PBF file, it took 3.511s to build and partition with this patch and 3.563 without.

~I ran the `format.sh` script as requested and it made some format changes elsewhere in the files. If this is an issue I can go back and manually revert those changes. It doesn't seem to pollute the diff too much.~ went ahead and reverted these for ease of review.

## Tasklist

I'm new to C++ and contributing to OSRM, so there's a few things I'm not completely sure of and would love feedback on.

 - [x] Make sure that errors in any Lua thread will bring the entire extraction process to a halt, not just that thread.
 - [x] I don't know what `source_function` and `GetStringListFromFunction` do. I changed these to have Lua error handling but it I'm not sure how to test them.
 - [x] Most places where profile functions are called there's a switch statement based on version; I define the result variable that I use to check for the error outside the statement. If the profile API version is increased, and the switch statements are not updated appropriately so that the lua function is always called, it's possible that the code would check for an error using an uninitialized result. I know C++ does weird things in this case - is it desirable to add an explicit check to each function to ensure the result has actually been initialized before checking if it is valid?
 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))


## Requirements / Relations

N/A
