### PR TITLE
Add support for a default_bearing_radius flag

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -395,7 +395,7 @@ jobs:
         if [[ "${RUNNER_OS}" == "Linux" ]]; then
           echo "JOBS=$((`nproc` + 1))" >>  $GITHUB_ENV
         elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-          echo "JOBS=$((`ulimit -n 1024 && sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
+          echo "JOBS=$((`sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
         fi
 
     - name: Install dev dependencies

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -395,7 +395,7 @@ jobs:
         if [[ "${RUNNER_OS}" == "Linux" ]]; then
           echo "JOBS=$((`nproc` + 1))" >>  $GITHUB_ENV
         elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-          echo "JOBS=$((`sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
+          echo "JOBS=$((`ulimit -n 1024 && sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
         fi
 
     - name: Install dev dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
   - Changes from 5.27.1
+    - Features
+      - ADDED: Added support for a default_bearing_radius flag. [#]()
     - Build:
       - ADDED: Add CI job which builds OSRM with gcc 12. [#6455](https://github.com/Project-OSRM/osrm-backend/pull/6455)
       - CHANGED: Upgrade to clang-tidy 15. [#6439](https://github.com/Project-OSRM/osrm-backend/pull/6439)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
   - Changes from 5.27.1
     - Features
-      - ADDED: Added support for a default_bearing_radius flag. [#]()
+      - ADDED: Added support for a default_bearing_radius flag. [#6575](https://github.com/Project-OSRM/osrm-backend/pull/6575)
     - Build:
       - ADDED: Add CI job which builds OSRM with gcc 12. [#6455](https://github.com/Project-OSRM/osrm-backend/pull/6455)
       - CHANGED: Upgrade to clang-tidy 15. [#6439](https://github.com/Project-OSRM/osrm-backend/pull/6439)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
   - Changes from 5.27.1
     - Features
-      - ADDED: Added support for a default_bearing_radius flag. [#6575](https://github.com/Project-OSRM/osrm-backend/pull/6575)
+      - ADDED: Add support for a default_radius flag. [#6575](https://github.com/Project-OSRM/osrm-backend/pull/6575)
     - Build:
       - ADDED: Add CI job which builds OSRM with gcc 12. [#6455](https://github.com/Project-OSRM/osrm-backend/pull/6455)
       - CHANGED: Upgrade to clang-tidy 15. [#6439](https://github.com/Project-OSRM/osrm-backend/pull/6439)

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -38,6 +38,7 @@ var osrm = new OSRM('network.osrm');
     -   `options.max_radius_map_matching` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. radius size supported in map matching query (default: 5).
     -   `options.max_results_nearest` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. results supported in nearest query (default: unlimited).
     -   `options.max_alternatives` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. number of alternatives supported in alternative routes query (default: 3).
+    -   `options.default_bearing_radius` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Default radius for queries containing a bearings parameter (default: unlimited).
 
 ### route
 

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -38,7 +38,7 @@ var osrm = new OSRM('network.osrm');
     -   `options.max_radius_map_matching` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. radius size supported in map matching query (default: 5).
     -   `options.max_results_nearest` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. results supported in nearest query (default: unlimited).
     -   `options.max_alternatives` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. number of alternatives supported in alternative routes query (default: 3).
-    -   `options.default_bearing_radius` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Default radius for queries containing a bearings parameter (default: unlimited).
+    -   `options.default_radius` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Default radius for queries (default: unlimited).
 
 ### route
 

--- a/features/options/routed/help.feature
+++ b/features/options/routed/help.feature
@@ -22,6 +22,7 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--max-trip-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
+        And stdout should contain "--default-bearings-radius"
         And it should exit successfully
 
     Scenario: osrm-routed - Help, short
@@ -42,6 +43,7 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--max-trip-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
+        And stdout should contain "--default-bearings-radius"
         And it should exit successfully
 
     Scenario: osrm-routed - Help, long
@@ -62,4 +64,5 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
+        And stdout should contain "--default-bearings-radius"
         And it should exit successfully

--- a/features/options/routed/help.feature
+++ b/features/options/routed/help.feature
@@ -22,7 +22,7 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--max-trip-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
-        And stdout should contain "--default-bearings-radius"
+        And stdout should contain "--default-radius"
         And it should exit successfully
 
     Scenario: osrm-routed - Help, short
@@ -43,7 +43,7 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--max-trip-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
-        And stdout should contain "--default-bearings-radius"
+        And stdout should contain "--default-radius"
         And it should exit successfully
 
     Scenario: osrm-routed - Help, long
@@ -64,5 +64,5 @@ Feature: osrm-routed command line options: help
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-table-size"
         And stdout should contain "--max-matching-size"
-        And stdout should contain "--default-bearings-radius"
+        And stdout should contain "--default-radius"
         And it should exit successfully

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -43,11 +43,11 @@ template <typename Algorithm> class Engine final : public EngineInterface
 {
   public:
     explicit Engine(const EngineConfig &config)
-        : route_plugin(config.max_locations_viaroute, config.max_alternatives),            //
-          table_plugin(config.max_locations_distance_table),                               //
-          nearest_plugin(config.max_results_nearest),                                      //
-          trip_plugin(config.max_locations_trip),                                          //
-          match_plugin(config.max_locations_map_matching, config.max_radius_map_matching), //
+        : route_plugin(config.max_locations_viaroute, config.max_alternatives, config.default_bearing_radius),            //
+          table_plugin(config.max_locations_distance_table, config.default_bearing_radius),                               //
+          nearest_plugin(config.max_results_nearest, config.default_bearing_radius),                                      //
+          trip_plugin(config.max_locations_trip, config.default_bearing_radius),                                          //
+          match_plugin(config.max_locations_map_matching, config.max_radius_map_matching, config.default_bearing_radius), //
           tile_plugin()                                                                    //
 
     {

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -45,13 +45,13 @@ template <typename Algorithm> class Engine final : public EngineInterface
     explicit Engine(const EngineConfig &config)
         : route_plugin(config.max_locations_viaroute,
                        config.max_alternatives,
-                       config.default_bearing_radius),                                      //
-          table_plugin(config.max_locations_distance_table, config.default_bearing_radius), //
-          nearest_plugin(config.max_results_nearest, config.default_bearing_radius),        //
-          trip_plugin(config.max_locations_trip, config.default_bearing_radius),            //
+                       config.default_radius),                                      //
+          table_plugin(config.max_locations_distance_table, config.default_radius), //
+          nearest_plugin(config.max_results_nearest, config.default_radius),        //
+          trip_plugin(config.max_locations_trip, config.default_radius),            //
           match_plugin(config.max_locations_map_matching,
                        config.max_radius_map_matching,
-                       config.default_bearing_radius), //
+                       config.default_radius), //
           tile_plugin()                                //
 
     {

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -43,12 +43,16 @@ template <typename Algorithm> class Engine final : public EngineInterface
 {
   public:
     explicit Engine(const EngineConfig &config)
-        : route_plugin(config.max_locations_viaroute, config.max_alternatives, config.default_bearing_radius),            //
-          table_plugin(config.max_locations_distance_table, config.default_bearing_radius),                               //
-          nearest_plugin(config.max_results_nearest, config.default_bearing_radius),                                      //
-          trip_plugin(config.max_locations_trip, config.default_bearing_radius),                                          //
-          match_plugin(config.max_locations_map_matching, config.max_radius_map_matching, config.default_bearing_radius), //
-          tile_plugin()                                                                    //
+        : route_plugin(config.max_locations_viaroute,
+                       config.max_alternatives,
+                       config.default_bearing_radius),                                      //
+          table_plugin(config.max_locations_distance_table, config.default_bearing_radius), //
+          nearest_plugin(config.max_results_nearest, config.default_bearing_radius),        //
+          trip_plugin(config.max_locations_trip, config.default_bearing_radius),            //
+          match_plugin(config.max_locations_map_matching,
+                       config.max_radius_map_matching,
+                       config.default_bearing_radius), //
+          tile_plugin()                                //
 
     {
         if (config.use_shared_memory)

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -52,7 +52,7 @@ template <typename Algorithm> class Engine final : public EngineInterface
           match_plugin(config.max_locations_map_matching,
                        config.max_radius_map_matching,
                        config.default_radius), //
-          tile_plugin()                                //
+          tile_plugin()                        //
 
     {
         if (config.use_shared_memory)

--- a/include/engine/engine_config.hpp
+++ b/include/engine/engine_config.hpp
@@ -83,7 +83,7 @@ struct EngineConfig final
     int max_locations_map_matching = -1;
     double max_radius_map_matching = -1.0;
     int max_results_nearest = -1;
-    boost::optional<double> default_bearing_radius;
+    boost::optional<double> default_radius;
     int max_alternatives = 3; // set an arbitrary upper bound; can be adjusted by user
     bool use_shared_memory = true;
     boost::filesystem::path memory_file;

--- a/include/engine/engine_config.hpp
+++ b/include/engine/engine_config.hpp
@@ -83,6 +83,7 @@ struct EngineConfig final
     int max_locations_map_matching = -1;
     double max_radius_map_matching = -1.0;
     int max_results_nearest = -1;
+    boost::optional<double> default_bearing_radius;
     int max_alternatives = 3; // set an arbitrary upper bound; can be adjusted by user
     bool use_shared_memory = true;
     boost::filesystem::path memory_file;

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -23,8 +23,8 @@ class MatchPlugin : public BasePlugin
     MatchPlugin(const int max_locations_map_matching,
                 const double max_radius_map_matching,
                 boost::optional<double> default_radius)
-        : BasePlugin(std::move(default_radius))
-        , max_locations_map_matching(max_locations_map_matching),
+        : BasePlugin(std::move(default_radius)),
+          max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {
     }

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -20,11 +20,13 @@ class MatchPlugin : public BasePlugin
     using CandidateLists = routing_algorithms::CandidateLists;
     static const constexpr double RADIUS_MULTIPLIER = 3;
 
-    MatchPlugin(const int max_locations_map_matching, const double max_radius_map_matching, const boost::optional<double> default_bearing_radius)
+    MatchPlugin(const int max_locations_map_matching,
+                const double max_radius_map_matching,
+                const boost::optional<double> default_bearing_radius)
         : max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {
-      this->default_bearing_radius = default_bearing_radius;
+        this->default_bearing_radius = default_bearing_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -22,11 +22,11 @@ class MatchPlugin : public BasePlugin
 
     MatchPlugin(const int max_locations_map_matching,
                 const double max_radius_map_matching,
-                const boost::optional<double> default_bearing_radius)
+                const boost::optional<double> default_radius)
         : max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {
-        this->default_bearing_radius = default_bearing_radius;
+        this->default_radius = default_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -23,8 +23,7 @@ class MatchPlugin : public BasePlugin
     MatchPlugin(const int max_locations_map_matching,
                 const double max_radius_map_matching,
                 const boost::optional<double> default_radius)
-        : BasePlugin(default_radius),
-          max_locations_map_matching(max_locations_map_matching),
+        : BasePlugin(default_radius), max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {
     }

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -22,11 +22,11 @@ class MatchPlugin : public BasePlugin
 
     MatchPlugin(const int max_locations_map_matching,
                 const double max_radius_map_matching,
-                const boost::optional<double> default_radius)
-        : max_locations_map_matching(max_locations_map_matching),
+                boost::optional<double> default_radius)
+        : BasePlugin(std::move(default_radius))
+        , max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {
-        this->default_radius = default_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -22,8 +22,8 @@ class MatchPlugin : public BasePlugin
 
     MatchPlugin(const int max_locations_map_matching,
                 const double max_radius_map_matching,
-                boost::optional<double> default_radius)
-        : BasePlugin(std::move(default_radius)),
+                const boost::optional<double> default_radius)
+        : BasePlugin(default_radius),
           max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {

--- a/include/engine/plugins/match.hpp
+++ b/include/engine/plugins/match.hpp
@@ -20,10 +20,11 @@ class MatchPlugin : public BasePlugin
     using CandidateLists = routing_algorithms::CandidateLists;
     static const constexpr double RADIUS_MULTIPLIER = 3;
 
-    MatchPlugin(const int max_locations_map_matching, const double max_radius_map_matching)
+    MatchPlugin(const int max_locations_map_matching, const double max_radius_map_matching, const boost::optional<double> default_bearing_radius)
         : max_locations_map_matching(max_locations_map_matching),
           max_radius_map_matching(max_radius_map_matching)
     {
+      this->default_bearing_radius = default_bearing_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -13,7 +13,7 @@ namespace osrm::engine::plugins
 class NearestPlugin final : public BasePlugin
 {
   public:
-    explicit NearestPlugin(const int max_results, const boost::optional<double> default_radius);
+    explicit NearestPlugin(const int max_results, boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -13,8 +13,7 @@ namespace osrm::engine::plugins
 class NearestPlugin final : public BasePlugin
 {
   public:
-    explicit NearestPlugin(const int max_results,
-                           const boost::optional<double> default_radius);
+    explicit NearestPlugin(const int max_results, const boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -13,7 +13,7 @@ namespace osrm::engine::plugins
 class NearestPlugin final : public BasePlugin
 {
   public:
-    explicit NearestPlugin(const int max_results);
+    explicit NearestPlugin(const int max_results, const boost::optional<double> default_bearing_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -13,7 +13,7 @@ namespace osrm::engine::plugins
 class NearestPlugin final : public BasePlugin
 {
   public:
-    explicit NearestPlugin(const int max_results, boost::optional<double> default_radius);
+    explicit NearestPlugin(const int max_results, const boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -14,7 +14,7 @@ class NearestPlugin final : public BasePlugin
 {
   public:
     explicit NearestPlugin(const int max_results,
-                           const boost::optional<double> default_bearing_radius);
+                           const boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,

--- a/include/engine/plugins/nearest.hpp
+++ b/include/engine/plugins/nearest.hpp
@@ -13,7 +13,8 @@ namespace osrm::engine::plugins
 class NearestPlugin final : public BasePlugin
 {
   public:
-    explicit NearestPlugin(const int max_results, const boost::optional<double> default_bearing_radius);
+    explicit NearestPlugin(const int max_results,
+                           const boost::optional<double> default_bearing_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::NearestParameters &params,

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -28,9 +28,8 @@ class BasePlugin
 {
   protected:
     BasePlugin() = default;
-    
-    BasePlugin(boost::optional<double> default_radius_) 
-        : default_radius(std::move(default_radius_))
+
+    BasePlugin(boost::optional<double> default_radius_) : default_radius(std::move(default_radius_))
     {
     }
 

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -237,7 +237,7 @@ class BasePlugin
             phantom_nodes[i] = facade.NearestPhantomNodes(
                 parameters.coordinates[i],
                 number_of_results,
-                use_radiuses ? parameters.radiuses[i] : boost::none,
+                use_radiuses ? parameters.radiuses[i] : default_bearing_radius,
                 use_bearings ? parameters.bearings[i] : boost::none,
                 use_approaches && parameters.approaches[i] ? parameters.approaches[i].get()
                                                            : engine::Approach::UNRESTRICTED);
@@ -279,7 +279,7 @@ class BasePlugin
 
             alternatives[i] = facade.NearestCandidatesWithAlternativeFromBigComponent(
                 parameters.coordinates[i],
-                use_radiuses ? parameters.radiuses[i] : boost::none,
+                use_radiuses ? parameters.radiuses[i] : default_bearing_radius,
                 use_bearings ? parameters.bearings[i] : boost::none,
                 use_approaches && parameters.approaches[i] ? parameters.approaches[i].get()
                                                            : engine::Approach::UNRESTRICTED,
@@ -320,6 +320,8 @@ class BasePlugin
         return std::string("Could not find a matching segment for coordinate ") +
                std::to_string(missing_index);
     }
+
+    boost::optional<double> default_bearing_radius;
 };
 } // namespace osrm::engine::plugins
 

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -29,9 +29,7 @@ class BasePlugin
   protected:
     BasePlugin() = default;
 
-    BasePlugin(const boost::optional<double> default_radius_) : default_radius(default_radius_)
-    {
-    }
+    BasePlugin(const boost::optional<double> default_radius_) : default_radius(default_radius_) {}
 
     bool CheckAllCoordinates(const std::vector<util::Coordinate> &coordinates) const
     {

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -237,7 +237,7 @@ class BasePlugin
             phantom_nodes[i] = facade.NearestPhantomNodes(
                 parameters.coordinates[i],
                 number_of_results,
-                use_radiuses ? parameters.radiuses[i] : default_bearing_radius,
+                use_radiuses ? parameters.radiuses[i] : default_radius,
                 use_bearings ? parameters.bearings[i] : boost::none,
                 use_approaches && parameters.approaches[i] ? parameters.approaches[i].get()
                                                            : engine::Approach::UNRESTRICTED);
@@ -279,7 +279,7 @@ class BasePlugin
 
             alternatives[i] = facade.NearestCandidatesWithAlternativeFromBigComponent(
                 parameters.coordinates[i],
-                use_radiuses ? parameters.radiuses[i] : default_bearing_radius,
+                use_radiuses ? parameters.radiuses[i] : default_radius,
                 use_bearings ? parameters.bearings[i] : boost::none,
                 use_approaches && parameters.approaches[i] ? parameters.approaches[i].get()
                                                            : engine::Approach::UNRESTRICTED,
@@ -321,7 +321,7 @@ class BasePlugin
                std::to_string(missing_index);
     }
 
-    boost::optional<double> default_bearing_radius;
+    boost::optional<double> default_radius;
 };
 } // namespace osrm::engine::plugins
 

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -29,7 +29,7 @@ class BasePlugin
   protected:
     BasePlugin() = default;
 
-    BasePlugin(boost::optional<double> default_radius_) : default_radius(std::move(default_radius_))
+    BasePlugin(const boost::optional<double> default_radius_) : default_radius(default_radius_)
     {
     }
 

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -27,6 +27,13 @@ namespace osrm::engine::plugins
 class BasePlugin
 {
   protected:
+    BasePlugin() = default;
+    
+    BasePlugin(boost::optional<double> default_radius_) 
+        : default_radius(std::move(default_radius_))
+    {
+    }
+
     bool CheckAllCoordinates(const std::vector<util::Coordinate> &coordinates) const
     {
         return !std::any_of(
@@ -321,7 +328,7 @@ class BasePlugin
                std::to_string(missing_index);
     }
 
-    boost::optional<double> default_radius;
+    const boost::optional<double> default_radius;
 };
 } // namespace osrm::engine::plugins
 

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -15,7 +15,7 @@ class TablePlugin final : public BasePlugin
 {
   public:
     explicit TablePlugin(const int max_locations_distance_table,
-                         const boost::optional<double> default_radius);
+                         boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TableParameters &params,

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -15,7 +15,7 @@ class TablePlugin final : public BasePlugin
 {
   public:
     explicit TablePlugin(const int max_locations_distance_table,
-                         boost::optional<double> default_radius);
+                         const boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TableParameters &params,

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -14,7 +14,7 @@ namespace osrm::engine::plugins
 class TablePlugin final : public BasePlugin
 {
   public:
-    explicit TablePlugin(const int max_locations_distance_table);
+    explicit TablePlugin(const int max_locations_distance_table, const boost::optional<double> default_bearing_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TableParameters &params,

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -15,7 +15,7 @@ class TablePlugin final : public BasePlugin
 {
   public:
     explicit TablePlugin(const int max_locations_distance_table,
-                         const boost::optional<double> default_bearing_radius);
+                         const boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TableParameters &params,

--- a/include/engine/plugins/table.hpp
+++ b/include/engine/plugins/table.hpp
@@ -14,7 +14,8 @@ namespace osrm::engine::plugins
 class TablePlugin final : public BasePlugin
 {
   public:
-    explicit TablePlugin(const int max_locations_distance_table, const boost::optional<double> default_bearing_radius);
+    explicit TablePlugin(const int max_locations_distance_table,
+                         const boost::optional<double> default_bearing_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TableParameters &params,

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -32,7 +32,9 @@ class TripPlugin final : public BasePlugin
                                      const bool roundtrip) const;
 
   public:
-    explicit TripPlugin(const int max_locations_trip_) : max_locations_trip(max_locations_trip_) {}
+    explicit TripPlugin(const int max_locations_trip_, const boost::optional<double> default_bearing_radius) : max_locations_trip(max_locations_trip_) {
+      this->default_bearing_radius = default_bearing_radius;
+    }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::TripParameters &parameters,

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -33,7 +33,7 @@ class TripPlugin final : public BasePlugin
 
   public:
     explicit TripPlugin(const int max_locations_trip_, boost::optional<double> default_radius)
-        : BasePlugin(std::move(default_radius)), max_locations_trip(max_locations_trip_)
+        : BasePlugin(default_radius), max_locations_trip(max_locations_trip_)
     {
     }
 

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -32,8 +32,11 @@ class TripPlugin final : public BasePlugin
                                      const bool roundtrip) const;
 
   public:
-    explicit TripPlugin(const int max_locations_trip_, const boost::optional<double> default_bearing_radius) : max_locations_trip(max_locations_trip_) {
-      this->default_bearing_radius = default_bearing_radius;
+    explicit TripPlugin(const int max_locations_trip_,
+                        const boost::optional<double> default_bearing_radius)
+        : max_locations_trip(max_locations_trip_)
+    {
+        this->default_bearing_radius = default_bearing_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -33,10 +33,10 @@ class TripPlugin final : public BasePlugin
 
   public:
     explicit TripPlugin(const int max_locations_trip_,
-                        const boost::optional<double> default_bearing_radius)
+                        const boost::optional<double> default_radius)
         : max_locations_trip(max_locations_trip_)
     {
-        this->default_bearing_radius = default_bearing_radius;
+        this->default_radius = default_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -33,8 +33,7 @@ class TripPlugin final : public BasePlugin
 
   public:
     explicit TripPlugin(const int max_locations_trip_, boost::optional<double> default_radius)
-        : BasePlugin(std::move(default_radius))
-        , max_locations_trip(max_locations_trip_)
+        : BasePlugin(std::move(default_radius)), max_locations_trip(max_locations_trip_)
     {
     }
 

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -32,8 +32,7 @@ class TripPlugin final : public BasePlugin
                                      const bool roundtrip) const;
 
   public:
-    explicit TripPlugin(const int max_locations_trip_,
-                        const boost::optional<double> default_radius)
+    explicit TripPlugin(const int max_locations_trip_, const boost::optional<double> default_radius)
         : max_locations_trip(max_locations_trip_)
     {
         this->default_radius = default_radius;

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -32,10 +32,10 @@ class TripPlugin final : public BasePlugin
                                      const bool roundtrip) const;
 
   public:
-    explicit TripPlugin(const int max_locations_trip_, const boost::optional<double> default_radius)
-        : max_locations_trip(max_locations_trip_)
+    explicit TripPlugin(const int max_locations_trip_, boost::optional<double> default_radius)
+        : BasePlugin(std::move(default_radius))
+        , max_locations_trip(max_locations_trip_)
     {
-        this->default_radius = default_radius;
     }
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -27,7 +27,7 @@ class ViaRoutePlugin final : public BasePlugin
   public:
     explicit ViaRoutePlugin(int max_locations_viaroute,
                             int max_alternatives,
-                            const boost::optional<double> default_radius);
+                            boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::RouteParameters &route_parameters,

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -27,7 +27,7 @@ class ViaRoutePlugin final : public BasePlugin
   public:
     explicit ViaRoutePlugin(int max_locations_viaroute,
                             int max_alternatives,
-                            const boost::optional<double> default_bearing_radius);
+                            const boost::optional<double> default_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::RouteParameters &route_parameters,

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -25,7 +25,9 @@ class ViaRoutePlugin final : public BasePlugin
     const int max_alternatives;
 
   public:
-    explicit ViaRoutePlugin(int max_locations_viaroute, int max_alternatives, const boost::optional<double> default_bearing_radius);
+    explicit ViaRoutePlugin(int max_locations_viaroute,
+                            int max_alternatives,
+                            const boost::optional<double> default_bearing_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::RouteParameters &route_parameters,

--- a/include/engine/plugins/viaroute.hpp
+++ b/include/engine/plugins/viaroute.hpp
@@ -25,7 +25,7 @@ class ViaRoutePlugin final : public BasePlugin
     const int max_alternatives;
 
   public:
-    explicit ViaRoutePlugin(int max_locations_viaroute, int max_alternatives);
+    explicit ViaRoutePlugin(int max_locations_viaroute, int max_alternatives, const boost::optional<double> default_bearing_radius);
 
     Status HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                          const api::RouteParameters &route_parameters,

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -285,7 +285,7 @@ inline engine_config_ptr argumentsToEngineConfig(const Napi::CallbackInfo &args)
     auto max_results_nearest = params.Get("max_results_nearest");
     auto max_alternatives = params.Get("max_alternatives");
     auto max_radius_map_matching = params.Get("max_radius_map_matching");
-    auto default_bearing_radius = params.Get("default_bearing_radius");
+    auto default_radius = params.Get("default_radius");
 
     if (!max_locations_trip.IsUndefined() && !max_locations_trip.IsNumber())
     {
@@ -317,9 +317,9 @@ inline engine_config_ptr argumentsToEngineConfig(const Napi::CallbackInfo &args)
         ThrowError(args.Env(), "max_alternatives must be an integral number");
         return engine_config_ptr();
     }
-    if (!default_bearing_radius.IsUndefined() && !default_bearing_radius.IsNumber())
+    if (!default_radius.IsUndefined() && !default_radius.IsNumber())
     {
-        ThrowError(args.Env(), "default_bearing_radius must be an integral number");
+        ThrowError(args.Env(), "default_radius must be an integral number");
         return engine_config_ptr();
     }
 
@@ -339,8 +339,8 @@ inline engine_config_ptr argumentsToEngineConfig(const Napi::CallbackInfo &args)
         engine_config->max_alternatives = max_alternatives.ToNumber().Int32Value();
     if (max_radius_map_matching.IsNumber())
         engine_config->max_radius_map_matching = max_radius_map_matching.ToNumber().DoubleValue();
-    if (default_bearing_radius.IsNumber())
-        engine_config->default_bearing_radius = default_bearing_radius.ToNumber().DoubleValue();
+    if (default_radius.IsNumber())
+        engine_config->default_radius = default_radius.ToNumber().DoubleValue();
 
     return engine_config;
 }

--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -285,6 +285,7 @@ inline engine_config_ptr argumentsToEngineConfig(const Napi::CallbackInfo &args)
     auto max_results_nearest = params.Get("max_results_nearest");
     auto max_alternatives = params.Get("max_alternatives");
     auto max_radius_map_matching = params.Get("max_radius_map_matching");
+    auto default_bearing_radius = params.Get("default_bearing_radius");
 
     if (!max_locations_trip.IsUndefined() && !max_locations_trip.IsNumber())
     {
@@ -316,6 +317,11 @@ inline engine_config_ptr argumentsToEngineConfig(const Napi::CallbackInfo &args)
         ThrowError(args.Env(), "max_alternatives must be an integral number");
         return engine_config_ptr();
     }
+    if (!default_bearing_radius.IsUndefined() && !default_bearing_radius.IsNumber())
+    {
+        ThrowError(args.Env(), "default_bearing_radius must be an integral number");
+        return engine_config_ptr();
+    }
 
     if (max_locations_trip.IsNumber())
         engine_config->max_locations_trip = max_locations_trip.ToNumber().Int32Value();
@@ -333,6 +339,8 @@ inline engine_config_ptr argumentsToEngineConfig(const Napi::CallbackInfo &args)
         engine_config->max_alternatives = max_alternatives.ToNumber().Int32Value();
     if (max_radius_map_matching.IsNumber())
         engine_config->max_radius_map_matching = max_radius_map_matching.ToNumber().DoubleValue();
+    if (default_bearing_radius.IsNumber())
+        engine_config->default_bearing_radius = default_bearing_radius.ToNumber().DoubleValue();
 
     return engine_config;
 }

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -181,25 +181,29 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
     if (tidied.parameters.radiuses.empty())
     {
         search_radiuses.resize(tidied.parameters.coordinates.size(),
-                               default_radius.has_value() ? *default_radius :
-                               routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER);
+                               default_radius.has_value()
+                                   ? *default_radius
+                                   : routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER);
     }
     else
     {
         search_radiuses.resize(tidied.parameters.coordinates.size());
-        std::transform(tidied.parameters.radiuses.begin(),
-                       tidied.parameters.radiuses.end(),
-                       search_radiuses.begin(),
-                       [default_radius = this->default_radius](const boost::optional<double> &maybe_radius) {
-                           if (maybe_radius)
-                           {
-                               return *maybe_radius * RADIUS_MULTIPLIER;
-                           }
-                           else
-                           {
-                               return default_radius.has_value() ? *default_radius : routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER;
-                           }
-                       });
+        std::transform(
+            tidied.parameters.radiuses.begin(),
+            tidied.parameters.radiuses.end(),
+            search_radiuses.begin(),
+            [default_radius = this->default_radius](const boost::optional<double> &maybe_radius) {
+                if (maybe_radius)
+                {
+                    return *maybe_radius * RADIUS_MULTIPLIER;
+                }
+                else
+                {
+                    return default_radius.has_value()
+                               ? *default_radius
+                               : routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER;
+                }
+            });
     }
 
     auto candidates_lists =

--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -181,6 +181,7 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
     if (tidied.parameters.radiuses.empty())
     {
         search_radiuses.resize(tidied.parameters.coordinates.size(),
+                               default_radius.has_value() ? *default_radius :
                                routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER);
     }
     else
@@ -189,14 +190,14 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
         std::transform(tidied.parameters.radiuses.begin(),
                        tidied.parameters.radiuses.end(),
                        search_radiuses.begin(),
-                       [](const boost::optional<double> &maybe_radius) {
+                       [default_radius = this->default_radius](const boost::optional<double> &maybe_radius) {
                            if (maybe_radius)
                            {
                                return *maybe_radius * RADIUS_MULTIPLIER;
                            }
                            else
                            {
-                               return routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER;
+                               return default_radius.has_value() ? *default_radius : routing_algorithms::DEFAULT_GPS_PRECISION * RADIUS_MULTIPLIER;
                            }
                        });
     }

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -10,7 +10,10 @@
 namespace osrm::engine::plugins
 {
 
-NearestPlugin::NearestPlugin(const int max_results_, const boost::optional<double> default_bearing_radius_) : max_results{max_results_} {
+NearestPlugin::NearestPlugin(const int max_results_,
+                             const boost::optional<double> default_bearing_radius_)
+    : max_results{max_results_}
+{
     this->default_bearing_radius = default_bearing_radius_;
 }
 

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -10,10 +10,10 @@
 namespace osrm::engine::plugins
 {
 
-NearestPlugin::NearestPlugin(const int max_results_, const boost::optional<double> default_radius_)
-    : max_results{max_results_}
+NearestPlugin::NearestPlugin(const int max_results_, boost::optional<double> default_radius_)
+    : BasePlugin(std::move(default_radius_))
+    , max_results{max_results_}
 {
-    this->default_radius = default_radius_;
 }
 
 Status NearestPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -11,10 +11,10 @@ namespace osrm::engine::plugins
 {
 
 NearestPlugin::NearestPlugin(const int max_results_,
-                             const boost::optional<double> default_bearing_radius_)
+                             const boost::optional<double> default_radius_)
     : max_results{max_results_}
 {
-    this->default_bearing_radius = default_bearing_radius_;
+    this->default_radius = default_radius_;
 }
 
 Status NearestPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -11,8 +11,7 @@ namespace osrm::engine::plugins
 {
 
 NearestPlugin::NearestPlugin(const int max_results_, boost::optional<double> default_radius_)
-    : BasePlugin(std::move(default_radius_))
-    , max_results{max_results_}
+    : BasePlugin(std::move(default_radius_)), max_results{max_results_}
 {
 }
 

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -10,8 +10,7 @@
 namespace osrm::engine::plugins
 {
 
-NearestPlugin::NearestPlugin(const int max_results_,
-                             const boost::optional<double> default_radius_)
+NearestPlugin::NearestPlugin(const int max_results_, const boost::optional<double> default_radius_)
     : max_results{max_results_}
 {
     this->default_radius = default_radius_;

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -10,7 +10,9 @@
 namespace osrm::engine::plugins
 {
 
-NearestPlugin::NearestPlugin(const int max_results_) : max_results{max_results_} {}
+NearestPlugin::NearestPlugin(const int max_results_, const boost::optional<double> default_bearing_radius_) : max_results{max_results_} {
+    this->default_bearing_radius = default_bearing_radius_;
+}
 
 Status NearestPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                                     const api::NearestParameters &params,

--- a/src/engine/plugins/nearest.cpp
+++ b/src/engine/plugins/nearest.cpp
@@ -10,8 +10,8 @@
 namespace osrm::engine::plugins
 {
 
-NearestPlugin::NearestPlugin(const int max_results_, boost::optional<double> default_radius_)
-    : BasePlugin(std::move(default_radius_)), max_results{max_results_}
+NearestPlugin::NearestPlugin(const int max_results_, const boost::optional<double> default_radius_)
+    : BasePlugin(default_radius_), max_results{max_results_}
 {
 }
 

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -16,8 +16,8 @@ namespace osrm::engine::plugins
 
 TablePlugin::TablePlugin(const int max_locations_distance_table,
                          boost::optional<double> default_radius)
-    : BasePlugin(std::move(default_radius))
-    , max_locations_distance_table(max_locations_distance_table)
+    : BasePlugin(std::move(default_radius)),
+      max_locations_distance_table(max_locations_distance_table)
 {
 }
 

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -15,10 +15,10 @@ namespace osrm::engine::plugins
 {
 
 TablePlugin::TablePlugin(const int max_locations_distance_table,
-                         const boost::optional<double> default_radius)
-    : max_locations_distance_table(max_locations_distance_table)
+                         boost::optional<double> default_radius)
+    : BasePlugin(std::move(default_radius))
+    , max_locations_distance_table(max_locations_distance_table)
 {
-    this->default_radius = default_radius;
 }
 
 Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -16,8 +16,7 @@ namespace osrm::engine::plugins
 
 TablePlugin::TablePlugin(const int max_locations_distance_table,
                          const boost::optional<double> default_radius)
-    : BasePlugin(default_radius),
-      max_locations_distance_table(max_locations_distance_table)
+    : BasePlugin(default_radius), max_locations_distance_table(max_locations_distance_table)
 {
 }
 

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -14,7 +14,8 @@
 namespace osrm::engine::plugins
 {
 
-TablePlugin::TablePlugin(const int max_locations_distance_table, const boost::optional<double> default_bearing_radius)
+TablePlugin::TablePlugin(const int max_locations_distance_table,
+                         const boost::optional<double> default_bearing_radius)
     : max_locations_distance_table(max_locations_distance_table)
 {
     this->default_bearing_radius = default_bearing_radius;

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -14,9 +14,10 @@
 namespace osrm::engine::plugins
 {
 
-TablePlugin::TablePlugin(const int max_locations_distance_table)
+TablePlugin::TablePlugin(const int max_locations_distance_table, const boost::optional<double> default_bearing_radius)
     : max_locations_distance_table(max_locations_distance_table)
 {
+    this->default_bearing_radius = default_bearing_radius;
 }
 
 Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -15,10 +15,10 @@ namespace osrm::engine::plugins
 {
 
 TablePlugin::TablePlugin(const int max_locations_distance_table,
-                         const boost::optional<double> default_bearing_radius)
+                         const boost::optional<double> default_radius)
     : max_locations_distance_table(max_locations_distance_table)
 {
-    this->default_bearing_radius = default_bearing_radius;
+    this->default_radius = default_radius;
 }
 
 Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -15,8 +15,8 @@ namespace osrm::engine::plugins
 {
 
 TablePlugin::TablePlugin(const int max_locations_distance_table,
-                         boost::optional<double> default_radius)
-    : BasePlugin(std::move(default_radius)),
+                         const boost::optional<double> default_radius)
+    : BasePlugin(default_radius),
       max_locations_distance_table(max_locations_distance_table)
 {
 }

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -18,8 +18,8 @@ namespace osrm::engine::plugins
 ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute,
                                int max_alternatives,
                                boost::optional<double> default_radius)
-    : BasePlugin(std::move(default_radius))
-    , max_locations_viaroute(max_locations_viaroute), max_alternatives(max_alternatives) 
+    : BasePlugin(std::move(default_radius)), max_locations_viaroute(max_locations_viaroute),
+      max_alternatives(max_alternatives)
 {
 }
 

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -17,10 +17,10 @@ namespace osrm::engine::plugins
 
 ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute,
                                int max_alternatives,
-                               const boost::optional<double> default_bearing_radius)
+                               const boost::optional<double> default_radius)
     : max_locations_viaroute(max_locations_viaroute), max_alternatives(max_alternatives)
 {
-    this->default_bearing_radius = default_bearing_radius;
+    this->default_radius = default_radius;
 }
 
 Status ViaRoutePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -15,9 +15,10 @@
 namespace osrm::engine::plugins
 {
 
-ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute, int max_alternatives)
+ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute, int max_alternatives, const boost::optional<double> default_bearing_radius)
     : max_locations_viaroute(max_locations_viaroute), max_alternatives(max_alternatives)
 {
+    this->default_bearing_radius = default_bearing_radius;
 }
 
 Status ViaRoutePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -18,7 +18,7 @@ namespace osrm::engine::plugins
 ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute,
                                int max_alternatives,
                                boost::optional<double> default_radius)
-    : BasePlugin(std::move(default_radius)), max_locations_viaroute(max_locations_viaroute),
+    : BasePlugin(default_radius), max_locations_viaroute(max_locations_viaroute),
       max_alternatives(max_alternatives)
 {
 }

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -15,7 +15,9 @@
 namespace osrm::engine::plugins
 {
 
-ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute, int max_alternatives, const boost::optional<double> default_bearing_radius)
+ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute,
+                               int max_alternatives,
+                               const boost::optional<double> default_bearing_radius)
     : max_locations_viaroute(max_locations_viaroute), max_alternatives(max_alternatives)
 {
     this->default_bearing_radius = default_bearing_radius;

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -17,10 +17,10 @@ namespace osrm::engine::plugins
 
 ViaRoutePlugin::ViaRoutePlugin(int max_locations_viaroute,
                                int max_alternatives,
-                               const boost::optional<double> default_radius)
-    : max_locations_viaroute(max_locations_viaroute), max_alternatives(max_alternatives)
+                               boost::optional<double> default_radius)
+    : BasePlugin(std::move(default_radius))
+    , max_locations_viaroute(max_locations_viaroute), max_alternatives(max_alternatives) 
 {
-    this->default_radius = default_radius;
 }
 
 Status ViaRoutePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -81,7 +81,7 @@ Napi::Object Engine::Init(Napi::Env env, Napi::Object exports)
  * @param {Number} [options.max_radius_map_matching] Max. radius size supported in map matching query (default: 5).
  * @param {Number} [options.max_results_nearest] Max. results supported in nearest query (default: unlimited).
  * @param {Number} [options.max_alternatives] Max. number of alternatives supported in alternative routes query (default: 3).
- * @param {Number} [options.default_bearing_radius] Default radius for queries containing a bearings parameter (default: unlimited).
+ * @param {Number} [options.default_radius] Default radius for queries (default: unlimited).
  *
  * @class OSRM
  *

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -81,6 +81,7 @@ Napi::Object Engine::Init(Napi::Env env, Napi::Object exports)
  * @param {Number} [options.max_radius_map_matching] Max. radius size supported in map matching query (default: 5).
  * @param {Number} [options.max_results_nearest] Max. results supported in nearest query (default: unlimited).
  * @param {Number} [options.max_alternatives] Max. number of alternatives supported in alternative routes query (default: 3).
+ * @param {Number} [options.default_bearing_radius] Default radius for queries containing a bearings parameter (default: unlimited).
  *
  * @class OSRM
  *

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -148,9 +148,9 @@ inline unsigned generateServerProgramOptions(const int argc,
         ("max-matching-radius",
          value<double>(&config.max_radius_map_matching)->default_value(-1.0),
          "Max. radius size supported in map matching query. Default: unlimited.") //
-        ("default-bearings-radius",
-         value<boost::optional<double>>(&config.default_bearing_radius),
-         "Default radius size for queries with bearings. Default: unlimited.");
+        ("default-radius",
+         value<boost::optional<double>>(&config.default_radius),
+         "Default radius size for queries. Default: unlimited.");
 
     // hidden options, will be allowed on command line, but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");

--- a/src/tools/routed.cpp
+++ b/src/tools/routed.cpp
@@ -147,7 +147,10 @@ inline unsigned generateServerProgramOptions(const int argc,
          "Max. number of alternatives supported in the MLD route query") //
         ("max-matching-radius",
          value<double>(&config.max_radius_map_matching)->default_value(-1.0),
-         "Max. radius size supported in map matching query. Default: unlimited.");
+         "Max. radius size supported in map matching query. Default: unlimited.") //
+        ("default-bearings-radius",
+         value<boost::optional<double>>(&config.default_bearing_radius),
+         "Default radius size for queries with bearings. Default: unlimited.");
 
     // hidden options, will be allowed on command line, but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -112,17 +112,17 @@ test('constructor: throws if dataset_name is not a string', function(assert) {
     assert.throws(function() { new OSRM({dataset_name: "unsued_name___", shared_memory: true}); }, /Could not find shared memory region/, 'Does not accept wrong name');
 });
 
-test('constructor: takes a default_bearing_radius argument', function(assert) {
-    assert.plan(1);
-    var osrm = new OSRM({default_bearing_radius: 1});
-    assert.ok(osrm);
-});
+// test('constructor: takes a default_bearing_radius argument', function(assert) {
+//     assert.plan(1);
+//     var osrm = new OSRM({default_bearing_radius: 1});
+//     assert.ok(osrm);
+// });
 
-test('constructor: throws if default_bearing_radius is not a number', function(assert) {
-    assert.plan(2);
-    assert.throws(function() { new OSRM({default_bearing_radius: 'abc'}); }, /default_bearing_radius must be an integral number/, 'Does not accept string');
-    assert.ok(new OSRM({default_bearing_radius: 1}), 'Does accept number');
-});
+// test('constructor: throws if default_bearing_radius is not a number', function(assert) {
+//     assert.plan(2);
+//     assert.throws(function() { new OSRM({default_bearing_radius: 'abc'}); }, /default_bearing_radius must be an integral number/, 'Does not accept string');
+//     assert.ok(new OSRM({default_bearing_radius: 1}), 'Does accept number');
+// });
 
 test('constructor: parses custom limits', function(assert) {
     assert.plan(1);

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -114,14 +114,14 @@ test('constructor: throws if dataset_name is not a string', function(assert) {
 
 test('constructor: takes a default_radius argument', function(assert) {
     assert.plan(1);
-    var osrm = new OSRM({default_radius: 1});
+    var osrm = new OSRM({algorithm: 'MLD', path: monaco_mld_path, default_radius: 1});
     assert.ok(osrm);
 });
 
 test('constructor: throws if default_radius is not a number', function(assert) {
     assert.plan(2);
-    assert.throws(function() { new OSRM({default_radius: 'abc'}); }, /default_radius must be an integral number/, 'Does not accept string');
-    assert.ok(new OSRM({default_radius: 1}), 'Does accept number');
+    assert.throws(function() { new OSRM({algorithm: 'MLD', path: monaco_mld_path, default_radius: 'abc'}); }, /default_radius must be an integral number/, 'Does not accept string');
+    assert.ok(new OSRM({algorithm: 'MLD', path: monaco_mld_path, default_radius: 1}), 'Does accept number');
 });
 
 test('constructor: parses custom limits', function(assert) {

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -112,6 +112,12 @@ test('constructor: throws if dataset_name is not a string', function(assert) {
     assert.throws(function() { new OSRM({dataset_name: "unsued_name___", shared_memory: true}); }, /Could not find shared memory region/, 'Does not accept wrong name');
 });
 
+test('constructor: takes a default_bearing_radius argument', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({default_bearing_radius: 1});
+    assert.ok(osrm);
+});
+
 test('constructor: parses custom limits', function(assert) {
     assert.plan(1);
     var osrm = new OSRM({

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -112,16 +112,16 @@ test('constructor: throws if dataset_name is not a string', function(assert) {
     assert.throws(function() { new OSRM({dataset_name: "unsued_name___", shared_memory: true}); }, /Could not find shared memory region/, 'Does not accept wrong name');
 });
 
-// test('constructor: takes a default_bearing_radius argument', function(assert) {
+// test('constructor: takes a default_radius argument', function(assert) {
 //     assert.plan(1);
-//     var osrm = new OSRM({default_bearing_radius: 1});
+//     var osrm = new OSRM({default_radius: 1});
 //     assert.ok(osrm);
 // });
 
-// test('constructor: throws if default_bearing_radius is not a number', function(assert) {
+// test('constructor: throws if default_radius is not a number', function(assert) {
 //     assert.plan(2);
-//     assert.throws(function() { new OSRM({default_bearing_radius: 'abc'}); }, /default_bearing_radius must be an integral number/, 'Does not accept string');
-//     assert.ok(new OSRM({default_bearing_radius: 1}), 'Does accept number');
+//     assert.throws(function() { new OSRM({default_radius: 'abc'}); }, /default_radius must be an integral number/, 'Does not accept string');
+//     assert.ok(new OSRM({default_radius: 1}), 'Does accept number');
 // });
 
 test('constructor: parses custom limits', function(assert) {

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -112,17 +112,17 @@ test('constructor: throws if dataset_name is not a string', function(assert) {
     assert.throws(function() { new OSRM({dataset_name: "unsued_name___", shared_memory: true}); }, /Could not find shared memory region/, 'Does not accept wrong name');
 });
 
-// test('constructor: takes a default_radius argument', function(assert) {
-//     assert.plan(1);
-//     var osrm = new OSRM({default_radius: 1});
-//     assert.ok(osrm);
-// });
+test('constructor: takes a default_radius argument', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({default_radius: 1});
+    assert.ok(osrm);
+});
 
-// test('constructor: throws if default_radius is not a number', function(assert) {
-//     assert.plan(2);
-//     assert.throws(function() { new OSRM({default_radius: 'abc'}); }, /default_radius must be an integral number/, 'Does not accept string');
-//     assert.ok(new OSRM({default_radius: 1}), 'Does accept number');
-// });
+test('constructor: throws if default_radius is not a number', function(assert) {
+    assert.plan(2);
+    assert.throws(function() { new OSRM({default_radius: 'abc'}); }, /default_radius must be an integral number/, 'Does not accept string');
+    assert.ok(new OSRM({default_radius: 1}), 'Does accept number');
+});
 
 test('constructor: parses custom limits', function(assert) {
     assert.plan(1);

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -118,6 +118,12 @@ test('constructor: takes a default_bearing_radius argument', function(assert) {
     assert.ok(osrm);
 });
 
+test('constructor: throws if default_bearing_radius is not a number', function(assert) {
+    assert.plan(2);
+    assert.throws(function() { new OSRM({default_bearing_radius: 'abc'}); }, /default_bearing_radius must be an integral number/, 'Does not accept string');
+    assert.ok(new OSRM({default_bearing_radius: 1}), 'Does accept number');
+});
+
 test('constructor: parses custom limits', function(assert) {
     assert.plan(1);
     var osrm = new OSRM({


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Relevant to:
> https://github.com/Project-OSRM/osrm-backend/issues/2983 Require a radius parameter other than unlimited when using bearings

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?

> Relevant to PR #6572: Require a radius parameter when using bearings (GSoC)