### PR TITLE
Don't route on proposed ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
       - CHANGED: Replace boost::string_ref with std::string_view [#6433](https://github.com/Project-OSRM/osrm-backend/pull/6433)
       - ADDED: Print tracebacks for Lua runtime errors [#6564](https://github.com/Project-OSRM/osrm-backend/pull/6564)
       - FIXED: Added a variable to preprocessor guard in file osrm-backend/include/util/range_table.hpp to solve build error. [#6596](https://github.com/Project-OSRM/osrm-backend/pull/6596)
+    - Profiles:
+      - FIXED: Bicycle and foot profiles now don't route on proposed ways [#6615](https://github.com/Project-OSRM/osrm-backend/pull/6615)
     - Routing:
       - FIXED: Fix adding traffic signal penalties during compression [#6419](https://github.com/Project-OSRM/osrm-backend/pull/6419)
 # 5.27.1

--- a/features/bicycle/pushing.feature
+++ b/features/bicycle/pushing.feature
@@ -78,6 +78,15 @@ Feature: Bike - Accessability of different way types
             | construction | yes  |         |       |
             | construction |      | yes     |       |
 
+    @proposed
+    Scenario: Bike - Don't allow routing on ways still being proposed
+        Then routability should be
+            | highway  | foot | bicycle | proposed | bothw |
+            | primary  |      |         |          | x     |
+            | proposed |      |         |          |       |
+            | proposed | yes  |         | yes      |       |
+            | proposed |      | yes     | yes      |       |
+
     @roundabout
     Scenario: Bike - Don't push bikes against oneway flow on roundabouts
         Then routability should be

--- a/features/foot/way.feature
+++ b/features/foot/way.feature
@@ -36,3 +36,9 @@ Feature: Foot - Accessability of different way types
             | highway | leisure  | forw |
             | (nil)   | track    |   x  |
 
+    Scenario: Foot - Proposed ways
+        Then routability should be
+            | highway  | foot  | proposed | forw |
+            | footway  |       |          | x    |
+            | proposed |       |          |      |
+            | proposed | yes   | yes      |      |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -216,7 +216,8 @@ function setup()
 
     avoid = Set {
       'impassable',
-      'construction'
+      'construction',
+      'proposed'
     }
   }
 end

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -69,7 +69,8 @@ function setup()
     },
 
     avoid = Set {
-      'impassable'
+      'impassable',
+      'proposed'
     },
 
     speeds = Sequence {


### PR DESCRIPTION
# Issue

Please see detailed explanation on issue https://github.com/Project-OSRM/osrm-backend/issues/6614.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki) – No editing needed related to this pull request as far as I could see. [FAQ](https://github.com/Project-OSRM/osrm-backend/wiki/Frequently-Asked-Questions#why-doesnt-osrm-route-over-certain-roads) already tells "OSRM will by default avoid roads marked as proposed or under construction", which will be closer to truth after this fix has been merged. There is a separate issue https://github.com/Project-OSRM/osrm-backend/issues/4541 for ways under construction for foot profile.
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

None as far as I know.