### PR TITLE
Fix build with GCC 13

### DIFF
--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/numeric/conversion/cast.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iosfwd> //for std::ostream
 #include <sstream>
 #include <string>

--- a/include/util/opening_hours.hpp
+++ b/include/util/opening_hours.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/date_time/gregorian/gregorian.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/util/query_heap.hpp
+++ b/include/util/query_heap.hpp
@@ -6,6 +6,7 @@
 #include <boost/optional.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <unordered_map>


### PR DESCRIPTION
# Issue

Building with GCC 13 failed because for example `std::int32_t` was not found. [Porting guide](https://gcc.gnu.org/gcc-13/porting_to.html) suggested to add explicit includes for `<cstdint>` if necessary, so did just that.

(Link to issue will appear here soon.)

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki) (nothing to be done)
 - [x] add tests (this is just a build fix)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

None