### PR TITLE
pass flags into process_segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
       - ADDED: Add support for a default_radius flag. [#6575](https://github.com/Project-OSRM/osrm-backend/pull/6575)
       - ADDED: Add support for disabling feature datasets. [#6666](https://github.com/Project-OSRM/osrm-backend/pull/6666)
       - ADDED: Add support for opposite approach request parameter. [#6842](https://github.com/Project-OSRM/osrm-backend/pull/6842)
+      - ADDED: Add support for accessing edge flags in `process_segment` [#6658](https://github.com/Project-OSRM/osrm-backend/pull/6658)
     - Build:
       - ADDED: Add CI job which builds OSRM with gcc 12. [#6455](https://github.com/Project-OSRM/osrm-backend/pull/6455)
       - CHANGED: Upgrade to clang-tidy 15. [#6439](https://github.com/Project-OSRM/osrm-backend/pull/6439)

--- a/features/options/extract/lua.feature
+++ b/features/options/extract/lua.feature
@@ -154,3 +154,27 @@ Feature: osrm-extract lua ways:get_nodes()
         Then it should exit successfully
         And stdout should contain "node 42"
         And stdout should contain "way 42"
+
+    Scenario: osrm-extract flags accessible in process_segment function
+        Given the profile file
+        """
+        functions = require('testbot')
+
+        functions.process_segment = function (profile, segment)
+            print('segment forward ' .. tostring(segment.flags.forward) .. ' backward ' .. tostring(segment.flags.backward))
+        end
+
+        return functions
+        """
+
+        And the node map
+            """
+            a b
+            """
+        And the ways
+            | nodes | oneway |
+            | ab    | yes    |
+        And the data has been saved to disk
+        When I run "osrm-extract --profile {profile_file} {osm_file}"
+        Then it should exit successfully
+        And stdout should contain "segment forward true backward false"

--- a/include/extractor/extraction_segment.hpp
+++ b/include/extractor/extraction_segment.hpp
@@ -12,9 +12,10 @@ struct ExtractionSegment
                       const osrm::util::Coordinate target_,
                       double distance_,
                       double weight_,
-                      double duration_)
+                      double duration_,
+                      const osrm::extractor::NodeBasedEdgeClassification flags_)
         : source(source_), target(target_), distance(distance_), weight(weight_),
-          duration(duration_)
+          duration(duration_), flags(flags_)
     {
     }
 
@@ -23,6 +24,7 @@ struct ExtractionSegment
     const double distance;
     double weight;
     double duration;
+    const osrm::extractor::NodeBasedEdgeClassification flags;
 };
 } // namespace osrm::extractor
 

--- a/include/extractor/extraction_segment.hpp
+++ b/include/extractor/extraction_segment.hpp
@@ -13,7 +13,7 @@ struct ExtractionSegment
                       double distance_,
                       double weight_,
                       double duration_,
-                      const osrm::extractor::NodeBasedEdgeClassification flags_)
+                      const NodeBasedEdgeClassification flags_)
         : source(source_), target(target_), distance(distance_), weight(weight_),
           duration(duration_), flags(flags_)
     {
@@ -24,7 +24,7 @@ struct ExtractionSegment
     const double distance;
     double weight;
     double duration;
-    const osrm::extractor::NodeBasedEdgeClassification flags;
+    const NodeBasedEdgeClassification flags;
 };
 } // namespace osrm::extractor
 

--- a/include/extractor/extraction_segment.hpp
+++ b/include/extractor/extraction_segment.hpp
@@ -1,6 +1,7 @@
 #ifndef OSRM_EXTRACTION_SEGMENT_HPP
 #define OSRM_EXTRACTION_SEGMENT_HPP
 
+#include <extractor/node_based_edge.hpp>
 #include <util/coordinate.hpp>
 
 namespace osrm::extractor

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -706,7 +706,7 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
             const auto accurate_distance =
                 util::coordinate_calculation::greatCircleDistance(source_coord, target_coord);
 
-            ExtractionSegment segment(source_coord, target_coord, distance, weight, duration);
+            ExtractionSegment segment(source_coord, target_coord, distance, weight, duration, edge_iterator->result.flags);
             scripting_environment.ProcessSegment(segment);
 
             auto &edge = edge_iterator->result;

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -706,7 +706,12 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
             const auto accurate_distance =
                 util::coordinate_calculation::greatCircleDistance(source_coord, target_coord);
 
-            ExtractionSegment segment(source_coord, target_coord, distance, weight, duration, edge_iterator->result.flags);
+            ExtractionSegment segment(source_coord,
+                                      target_coord,
+                                      distance,
+                                      weight,
+                                      duration,
+                                      edge_iterator->result.flags);
             scripting_environment.ProcessSegment(segment);
 
             auto &edge = edge_iterator->result;

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -471,29 +471,35 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         [](ExtractionRelationContainer &cont, const ExtractionRelation::OsmIDTyped &rel_id)
             -> const ExtractionRelation & { return cont.GetRelationData(rel_id); });
 
-    context.state.new_usertype<NodeBasedEdgeClassification>("NodeBasedEdgeClassification",
-                                                            "forward",
-                                                            // can't just do &NodeBasedEdgeClassification::forward with bitfields
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.forward; }),
-                                                            "backward",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.backward; }),
-                                                            "is_split",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.is_split; }),
-                                                            "roundabout",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.roundabout; }),
-                                                            "circular",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.circular; }),
-                                                            "startpoint",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.startpoint; }),
-                                                            "restricted",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.restricted; }),
-                                                            "road_classification",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> RoadClassification { return c.road_classification; }),
-                                                            "highway_turn_classification",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> uint8_t { return c.highway_turn_classification; }),
-                                                            "access_turn_classification",
-                                                            sol::property([](NodeBasedEdgeClassification &c) -> uint8_t { return c.access_turn_classification; })
-    );
+    context.state.new_usertype<NodeBasedEdgeClassification>(
+        "NodeBasedEdgeClassification",
+        "forward",
+        // can't just do &NodeBasedEdgeClassification::forward with bitfields
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.forward; }),
+        "backward",
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.backward; }),
+        "is_split",
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.is_split; }),
+        "roundabout",
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.roundabout; }),
+        "circular",
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.circular; }),
+        "startpoint",
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.startpoint; }),
+        "restricted",
+        sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.restricted; }),
+        "road_classification",
+        sol::property([](NodeBasedEdgeClassification &c) -> RoadClassification {
+            return c.road_classification;
+        }),
+        "highway_turn_classification",
+        sol::property([](NodeBasedEdgeClassification &c) -> uint8_t {
+            return c.highway_turn_classification;
+        }),
+        "access_turn_classification",
+        sol::property([](NodeBasedEdgeClassification &c) -> uint8_t {
+            return c.access_turn_classification;
+        }));
 
     context.state.new_usertype<ExtractionSegment>("ExtractionSegment",
                                                   "source",
@@ -508,7 +514,6 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                   &ExtractionSegment::duration,
                                                   "flags",
                                                   &ExtractionSegment::flags);
-
 
     // Keep in mind .location is available only if .pbf is preprocessed to set the location with the
     // ref using osmium command "osmium add-locations-to-ways"

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -471,6 +471,30 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         [](ExtractionRelationContainer &cont, const ExtractionRelation::OsmIDTyped &rel_id)
             -> const ExtractionRelation & { return cont.GetRelationData(rel_id); });
 
+    context.state.new_usertype<NodeBasedEdgeClassification>("NodeBasedEdgeClassification",
+                                                            "forward",
+                                                            // can't just do &NodeBasedEdgeClassification::forward with bitfields
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.forward; }),
+                                                            "backward",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.backward; }),
+                                                            "is_split",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.is_split; }),
+                                                            "roundabout",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.roundabout; }),
+                                                            "circular",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.circular; }),
+                                                            "startpoint",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.startpoint; }),
+                                                            "restricted",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> bool { return c.restricted; }),
+                                                            "road_classification",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> RoadClassification { return c.road_classification; }),
+                                                            "highway_turn_classification",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> uint8_t { return c.highway_turn_classification; }),
+                                                            "access_turn_classification",
+                                                            sol::property([](NodeBasedEdgeClassification &c) -> uint8_t { return c.access_turn_classification; })
+    );
+
     context.state.new_usertype<ExtractionSegment>("ExtractionSegment",
                                                   "source",
                                                   &ExtractionSegment::source,
@@ -481,7 +505,10 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                   "weight",
                                                   &ExtractionSegment::weight,
                                                   "duration",
-                                                  &ExtractionSegment::duration);
+                                                  &ExtractionSegment::duration,
+                                                  "flags",
+                                                  &ExtractionSegment::flags);
+
 
     // Keep in mind .location is available only if .pbf is preprocessed to set the location with the
     // ref using osmium command "osmium add-locations-to-ways"


### PR DESCRIPTION
# Issue

This partially addresses #6145, by making the extractor edge flags available to `process_segment` as `segment.flags`. This allows accessing road classification, start point, etc. in `process_segment`. I'm using it by tagging bridges/tunnels as non-startpoints and then not applying elevation weighting to them since they are flat (ish) where I am but often cross deep valleys.

I'm not quite sure how to write an automated test for this. Maybe a profile that uses the flags information in a cucumber test?

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
