### PR TITLE
Add 'load directly' mode to default Cucumber test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
       - CHANGED: Upgrade to clang-tidy 15. [#6439](https://github.com/Project-OSRM/osrm-backend/pull/6439)
       - CHANGED: Update actions/cache to v3. [#6420](https://github.com/Project-OSRM/osrm-backend/pull/6420)
       - REMOVED: Drop support of Node 12 & 14. [#6431](https://github.com/Project-OSRM/osrm-backend/pull/6431)
+      - ADDED: Add 'load directly' mode to default Cucumber test suite. [#6663](https://github.com/Project-OSRM/osrm-backend/pull/6663)
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,6 +1,6 @@
 module.exports = {
-    default: '--strict --tags ~@stress --tags ~@todo --tags ~@mld-only --require features/support --require features/step_definitions',
-    verify: '--strict --tags ~@stress --tags ~@todo --tags ~@mld-only -f progress --require features/support --require features/step_definitions',
+    default: '--strict --tags ~@stress --tags ~@todo --tags ~@mld --require features/support --require features/step_definitions',
+    ch: '--strict --tags ~@stress --tags ~@todo --tags ~@mld -f progress --require features/support --require features/step_definitions',
     todo: '--strict --tags @todo --require features/support --require features/step_definitions',
     all: '--strict --require features/support --require features/step_definitions',
     mld: '--strict --tags ~@stress --tags ~@todo --tags ~@ch --require features/support --require features/step_definitions -f progress'

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -27,7 +27,8 @@ module.exports = function () {
         this.DEFAULT_ENVIRONMENT = process.env;
         this.DEFAULT_PROFILE = 'bicycle';
         this.DEFAULT_INPUT_FORMAT = 'osm';
-        this.DEFAULT_LOAD_METHOD = process.argv[process.argv.indexOf('-m') +1].match('mmap') ? 'mmap' : 'datastore';
+        let loadMethod = process.argv[process.argv.indexOf('-m') +1];
+        this.DEFAULT_LOAD_METHOD = loadMethod.match('mmap') ? 'mmap' : loadMethod.match('directly') ? 'directly' : 'datastore';
         this.DEFAULT_ORIGIN = [1,1];
         this.OSM_USER = 'osrm';
         this.OSM_UID = 1;
@@ -42,7 +43,7 @@ module.exports = function () {
         this.OSRM_IP = process.env.OSRM_IP || '127.0.0.1';
         this.OSRM_CONNECTION_RETRIES = process.env.OSRM_CONNECTION_RETRIES && parseInt(process.env.OSRM_CONNECTION_RETRIES) || 10;
         this.OSRM_CONNECTION_EXP_BACKOFF_COEF = process.env.OSRM_CONNECTION_EXP_BACKOFF_COEF && parseFloat(process.env.OSRM_CONNECTION_EXP_BACKOFF_COEF) || 1.0;
-        
+
         this.HOST = `http://${this.OSRM_IP}:${this.OSRM_PORT}`;
 
         this.OSRM_PROFILE = process.env.OSRM_PROFILE;

--- a/features/testbot/alternative_loop.feature
+++ b/features/testbot/alternative_loop.feature
@@ -40,7 +40,7 @@ Feature: Alternative route
             | 7    | 8  | ca,ab,bd,dc,ca,ca |             |
 
 
-    @mld-only
+    @mld
     Scenario: Alternative loop paths on a single node with an asymmetric circle
         # The test checks only MLD implementation, alternatives results are unpredictable for CH on windows (#4691, #4693)
         Given a grid size of 10 meters

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "lint": "node ./node_modules/eslint/bin/eslint.js -c ./.eslintrc features/step_definitions/ features/support/",
-    "test": "npm run lint && node ./node_modules/cucumber/bin/cucumber.js features/ -p verify && node ./node_modules/cucumber/bin/cucumber.js features/ -p verify -m mmap && node ./node_modules/cucumber/bin/cucumber.js features/ -p mld && node ./node_modules/cucumber/bin/cucumber.js features/ -p mld -m mmap",
+    "test": "npm run lint && ./scripts/cucumber_test_matrix.sh",
     "clean": "rm -rf test/cache",
     "docs": "./scripts/build_api_docs.sh",
     "install": "node-pre-gyp install --fallback-to-build=false || ./scripts/node_install.sh",

--- a/scripts/cucumber_test_matrix.sh
+++ b/scripts/cucumber_test_matrix.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+loadmethods=(datastore mmap directly)
+profiles=(ch mld)
+
+for profile in "${profiles[@]}"
+do
+  for loadmethod in "${loadmethods[@]}"
+  do
+    set -x
+    node ./node_modules/cucumber/bin/cucumber.js features/ -p $profile -m $loadmethod
+    { set +x; } 2>/dev/null
+  done
+done


### PR DESCRIPTION
# Issue
Currently, `npm test` runs the Cucumber suite with a configuration matrix for the algorithm (CH, MLD) and data loading (shared-memory, mmap) options.

However, there is a third data loading option, 'load directly', which is to directly load the datasets into the `osrm-routed` process memory.

The code paths for each data loading option are distinct:

- shared-memory - [Storage::Run](https://github.com/Project-OSRM/osrm-backend/blob/3bb82ce1e2fd2299712b96176e651e6f7e999aae/src/storage/storage.cpp#L188) + [SharedMemoryAllocator](https://github.com/Project-OSRM/osrm-backend/blob/3bb82ce1e2fd2299712b96176e651e6f7e999aae/src/engine/datafacade/shared_memory_allocator.cpp#L12)
- mmap - [MMapMemoryAllocator](https://github.com/Project-OSRM/osrm-backend/blob/3bb82ce1e2fd2299712b96176e651e6f7e999aae/src/engine/datafacade/mmap_memory_allocator.cpp#L16)
- load directly - [ProcessMemoryAllocator](https://github.com/Project-OSRM/osrm-backend/blob/3bb82ce1e2fd2299712b96176e651e6f7e999aae/src/engine/datafacade/process_memory_allocator.cpp#L9)

This change adds 'load directly' as part of the Cucumber matrix configuration.
This will ensure future changes to dataset loading can be made without any regressions.

### Impact
This increases the number of Cucumber tests run by 50%, but thanks to caching, the runtime increase is only 15%.

There is an opportunity to reduce the runtime. Some tests which are algorithm/data-loading agnostic now run six times, when once will suffice.

However, this requires tidying up the tags assigned to each test case, which feels like a bit of yak shaving I'd prefer to do after adding optional data loading.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

Closes  #6661
