### PR TITLE
Add support for disabling feature datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Changes from 5.27.1
     - Features
       - ADDED: Add support for a default_radius flag. [#6575](https://github.com/Project-OSRM/osrm-backend/pull/6575)
+      - ADDED: Add support for disabling feature datasets. [#6666](https://github.com/Project-OSRM/osrm-backend/pull/6666)
     - Build:
       - ADDED: Add CI job which builds OSRM with gcc 12. [#6455](https://github.com/Project-OSRM/osrm-backend/pull/6455)
       - CHANGED: Upgrade to clang-tidy 15. [#6439](https://github.com/Project-OSRM/osrm-backend/pull/6439)

--- a/docs/nodejs/api.md
+++ b/docs/nodejs/api.md
@@ -31,6 +31,7 @@ var osrm = new OSRM('network.osrm');
                Old behaviour: Path to a file on disk to store the memory using mmap.  Current behaviour: setting this value is the same as setting `mmap_memory: true`.
     -   `options.mmap_memory` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Map on-disk files to virtual memory addresses (mmap), rather than loading into RAM.
     -   `options.path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The path to the `.osrm` files. This is mutually exclusive with setting {options.shared_memory} to true.
+    -   `options.disable_feature_dataset` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Disables a feature dataset from being loaded into memory if not needed. Options: `ROUTE_STEPS`, `ROUTE_GEOMETRY`.
     -   `options.max_locations_trip` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. locations supported in trip query (default: unlimited).
     -   `options.max_locations_viaroute` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. locations supported in viaroute query (default: unlimited).
     -   `options.max_locations_distance_table` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Max. locations supported in distance table query (default: unlimited).

--- a/features/lib/osrm_loader.js
+++ b/features/lib/osrm_loader.js
@@ -68,8 +68,9 @@ class OSRMDirectLoader extends OSRMBaseLoader {
         super(scope);
     }
 
-    load (inputFile, callback) {
-        this.inputFile = inputFile;
+    load (ctx, callback) {
+        this.inputFile = ctx.inputFile;
+        this.loaderArgs = ctx.loaderArgs;
         this.shutdown(() => {
             this.launch(callback);
         });
@@ -78,7 +79,7 @@ class OSRMDirectLoader extends OSRMBaseLoader {
     osrmUp (callback) {
         if (this.osrmIsRunning()) return callback(new Error("osrm-routed already running!"));
 
-        const command_arguments = util.format('%s -p %d -i %s -a %s', this.inputFile, this.scope.OSRM_PORT, this.scope.OSRM_IP, this.scope.ROUTING_ALGORITHM);
+        const command_arguments = util.format('%s -p %d -i %s -a %s %s', this.inputFile, this.scope.OSRM_PORT, this.scope.OSRM_IP, this.scope.ROUTING_ALGORITHM, this.loaderArgs);
         this.child = this.scope.runBin('osrm-routed', command_arguments, this.scope.environment, (err) => {
             if (err && err.signal !== 'SIGINT') {
                 this.child = null;
@@ -101,8 +102,9 @@ class OSRMmmapLoader extends OSRMBaseLoader {
         super(scope);
     }
 
-    load (inputFile, callback) {
-        this.inputFile = inputFile;
+    load (ctx, callback) {
+        this.inputFile = ctx.inputFile;
+        this.loaderArgs = ctx.loaderArgs;
         this.shutdown(() => {
             this.launch(callback);
         });
@@ -111,7 +113,7 @@ class OSRMmmapLoader extends OSRMBaseLoader {
     osrmUp (callback) {
         if (this.osrmIsRunning()) return callback(new Error("osrm-routed already running!"));
 
-        const command_arguments = util.format('%s -p %d -i %s -a %s --mmap', this.inputFile, this.scope.OSRM_PORT, this.scope.OSRM_IP, this.scope.ROUTING_ALGORITHM);
+        const command_arguments = util.format('%s -p %d -i %s -a %s --mmap %s', this.inputFile, this.scope.OSRM_PORT, this.scope.OSRM_IP, this.scope.ROUTING_ALGORITHM, this.loaderArgs);
         this.child = this.scope.runBin('osrm-routed', command_arguments, this.scope.environment, (err) => {
             if (err && err.signal !== 'SIGINT') {
                 this.child = null;
@@ -134,8 +136,9 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
         super(scope);
     }
 
-    load (inputFile, callback) {
-        this.inputFile = inputFile;
+    load (ctx, callback) {
+        this.inputFile = ctx.inputFile;
+        this.loaderArgs = ctx.loaderArgs;
 
         this.loadData((err) => {
             if (err) return callback(err);
@@ -148,7 +151,7 @@ class OSRMDatastoreLoader extends OSRMBaseLoader {
     }
 
     loadData (callback) {
-        const command_arguments = util.format('--dataset-name=%s %s', this.scope.DATASET_NAME, this.inputFile);
+        const command_arguments = util.format('--dataset-name=%s %s %s', this.scope.DATASET_NAME, this.inputFile, this.loaderArgs);
         this.scope.runBin('osrm-datastore', command_arguments, this.scope.environment, (err) => {
             if (err) return callback(new Error('*** osrm-datastore exited with ' + err.code + ': ' + err));
             callback();

--- a/features/options/data/disabled_dataset.feature
+++ b/features/options/data/disabled_dataset.feature
@@ -1,0 +1,141 @@
+@routing @disable-feature-dataset
+Feature: disable-feature-dataset command line options
+    Background:
+        Given the profile "testbot"
+        And the node map
+            """
+            0
+            a b c
+            """
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+
+    Scenario: disable-feature-dataset - geometry disabled error
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_GEOMETRY"
+
+        # The default values
+        And the query options
+          | overview       | simplified |
+          | annotations    | false      |
+          | steps          | false      |
+          | skip_waypoints | false      |
+
+        When I route I should get
+            | from | to | code              |
+            | a    | c  | DisabledDataset  |
+
+        When I plan a trip I should get
+            | waypoints | code             |
+            | a,b,c     | DisabledDataset |
+
+        When I match I should get
+          | trace | code             |
+          | abc   | DisabledDataset |
+
+    Scenario: disable-feature-dataset - geometry disabled error table
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_GEOMETRY"
+
+        When I request nearest I should get
+            | in | code              |
+            | 0  | DisabledDataset  |
+
+        When I request a travel time matrix with these waypoints I should get the response code
+            | waypoints  | code             |
+            | a,b,c      | DisabledDataset |
+
+
+    Scenario: disable-feature-dataset - geometry disabled success
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_GEOMETRY"
+
+        # No geometry values returned
+        And the query options
+          | overview       | false |
+          | annotations    | false |
+          | steps          | false |
+          | skip_waypoints | true  |
+
+        When I route I should get
+            | from | to | code     |
+            | a    | c  | Ok       |
+
+        When I plan a trip I should get
+            | waypoints |  code |
+            | a,b,c     |  Ok   |
+
+        When I match I should get
+          | trace | code |
+          | abc   | Ok   |
+
+    Scenario: disable-feature-dataset - geometry disabled error table
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_GEOMETRY"
+
+        And the query options
+          | skip_waypoints | true  |
+
+        # You would never do this, but just to prove the point.
+        When I request nearest I should get
+            | in | code              |
+            | 0  | Ok                |
+
+        When I request a travel time matrix with these waypoints I should get the response code
+            | waypoints  | code  |
+            | a,b,c      | Ok    |
+
+
+    Scenario: disable-feature-dataset - steps disabled error
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_STEPS"
+
+        # Default + annotations, steps
+	And the query options
+          | overview       | simplified |
+          | annotations    | true       |
+          | steps          | true       |
+
+        When I route I should get
+            | from | to | code               |
+            | a    | c  | DisabledDataset   |
+
+        When I plan a trip I should get
+            | waypoints |  code            |
+            | a,b,c     | DisabledDataset |
+
+        When I match I should get
+          | trace | code             |
+          | abc   | DisabledDataset |
+
+
+    Scenario: disable-feature-dataset - geometry disabled error table
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_STEPS"
+
+        When I request nearest I should get
+            | in | code |
+            | 0  | Ok   |
+
+        When I request a travel time matrix with these waypoints I should get the response code
+            | waypoints  | code  |
+            | a,b,c      | Ok    |
+
+
+    Scenario: disable-feature-dataset - steps disabled success
+        Given the data load extra arguments "--disable-feature-dataset ROUTE_STEPS"
+
+        # Default + steps
+        And the query options
+          | overview       | simplified |
+          | annotations    | true       |
+          | steps          | false      |
+
+        When I route I should get
+            | from | to | code     |
+            | a    | c  | Ok       |
+
+        When I plan a trip I should get
+            | waypoints |  code |
+            | a,b,c     |  Ok   |
+
+        When I match I should get
+          | trace | code |
+          | abc   | Ok   |
+

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -33,6 +33,11 @@ module.exports = function () {
         callback();
     });
 
+    this.Given(/^the data load extra arguments "(.*?)"$/, (args, callback) => {
+        this.loaderArgs = this.expandOptions(args);
+        callback();
+    });
+
     this.Given(/^a grid size of ([0-9.]+) meters$/, (meters, callback) => {
         this.setGridSize(meters);
         callback();

--- a/features/step_definitions/trip.js
+++ b/features/step_definitions/trip.js
@@ -91,7 +91,7 @@ module.exports = function () {
 
                     var encodedResult = '';
 
-                    if (json.trips) row.trips.split(',').forEach((sub, si) => {
+                    if (json.trips && row.trips) row.trips.split(',').forEach((sub, si) => {
                         if (si >= subTrips.length) {
                             ok = false;
                         } else {
@@ -134,7 +134,6 @@ module.exports = function () {
                 } else {
                     var params = this.queryParams,
                         waypoints = [];
-                    params['steps'] = 'true';
                     if (row.from && row.to) {
                         var fromNode = this.findNodeByName(row.from);
                         if (!fromNode) throw new Error(util.format('*** unknown from-node "%s"', row.from));

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -280,10 +280,11 @@ module.exports = function () {
     };
 
     this.reprocessAndLoadData = (callback) => {
+        let p = {loaderArgs: this.loaderArgs, inputFile: this.processedCacheFile};
         let queue = d3.queue(1);
         queue.defer(this.writeAndLinkOSM.bind(this));
         queue.defer(this.extractContractPartitionAndCustomize.bind(this));
-        queue.defer(this.osrmLoader.load.bind(this.osrmLoader), this.processedCacheFile);
+        queue.defer(this.osrmLoader.load.bind(this.osrmLoader), p);
         queue.awaitAll(callback);
     };
 

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -37,6 +37,7 @@ module.exports = function () {
         this.contractArgs = '';
         this.partitionArgs = '';
         this.customizeArgs = '';
+        this.loaderArgs = '';
         this.environment = Object.assign(this.DEFAULT_ENVIRONMENT);
         this.resetOSM();
 

--- a/features/support/route.js
+++ b/features/support/route.js
@@ -101,7 +101,8 @@ module.exports = function () {
 
     this.requestTrip = (waypoints, userParams, callback) => {
         var defaults = {
-                output: 'json'
+                output: 'json',
+                steps: 'true'
             },
             params = this.overwriteParams(defaults, userParams);
 

--- a/include/engine/engine_config.hpp
+++ b/include/engine/engine_config.hpp
@@ -29,9 +29,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ENGINE_CONFIG_HPP
 
 #include "storage/storage_config.hpp"
+#include "osrm/datasets.hpp"
 
 #include <boost/filesystem/path.hpp>
 
+#include <set>
 #include <string>
 
 namespace osrm::engine
@@ -89,6 +91,7 @@ struct EngineConfig final
     boost::filesystem::path memory_file;
     bool use_mmap = true;
     Algorithm algorithm = Algorithm::CH;
+    std::vector<storage::FeatureDataset> disable_feature_dataset;
     std::string verbosity;
     std::string dataset_name;
 };

--- a/include/osrm/datasets.hpp
+++ b/include/osrm/datasets.hpp
@@ -1,0 +1,15 @@
+#ifndef DATASETS_HPP
+#define DATASETS_HPP
+
+namespace osrm::storage
+{
+
+enum class FeatureDataset
+{
+    ROUTE_STEPS,
+    ROUTE_GEOMETRY,
+};
+
+} // namespace osrm::storage
+
+#endif

--- a/include/osrm/error_codes.hpp
+++ b/include/osrm/error_codes.hpp
@@ -23,7 +23,8 @@ enum ErrorCode
     FileIOError,
     UnexpectedEndOfFile,
     IncompatibleDataset,
-    UnknownAlgorithm
+    UnknownAlgorithm,
+    UnknownFeatureDataset
 #ifndef NDEBUG
     // Leave this at the end.  In debug mode, we assert that the size of
     // this enum matches the number of messages we have documented, and __ENDMARKER__

--- a/include/storage/io_config.hpp
+++ b/include/storage/io_config.hpp
@@ -35,6 +35,11 @@ struct IOConfig
         return {base_path.string() + fileName};
     }
 
+    bool IsRequiredConfiguredInput(const std::string &fileName) const
+    {
+        return IsConfigured(fileName, required_input_files);
+    }
+
     boost::filesystem::path base_path;
 
   protected:

--- a/include/storage/storage_config.hpp
+++ b/include/storage/storage_config.hpp
@@ -31,9 +31,60 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/filesystem/path.hpp>
 
 #include "storage/io_config.hpp"
+#include "osrm/datasets.hpp"
+
+#include <set>
 
 namespace osrm::storage
 {
+
+std::istream &operator>>(std::istream &in, FeatureDataset &datasets);
+
+static std::vector<boost::filesystem::path>
+GetRequiredFiles(const std::vector<storage::FeatureDataset> &disabled_feature_dataset)
+{
+    std::set<boost::filesystem::path> required{
+        ".osrm.datasource_names",
+        ".osrm.ebg_nodes",
+        ".osrm.edges",
+        ".osrm.fileIndex",
+        ".osrm.geometry",
+        ".osrm.icd",
+        ".osrm.maneuver_overrides",
+        ".osrm.names",
+        ".osrm.nbg_nodes",
+        ".osrm.properties",
+        ".osrm.ramIndex",
+        ".osrm.timestamp",
+        ".osrm.tld",
+        ".osrm.tls",
+        ".osrm.turn_duration_penalties",
+        ".osrm.turn_weight_penalties",
+    };
+
+    for (const auto &to_disable : disabled_feature_dataset)
+    {
+        switch (to_disable)
+        {
+        case FeatureDataset::ROUTE_STEPS:
+            for (const auto &dataset : {".osrm.icd", ".osrm.tld", ".osrm.tls"})
+            {
+                required.erase(dataset);
+            }
+            break;
+        case FeatureDataset::ROUTE_GEOMETRY:
+            for (const auto &dataset :
+                 {".osrm.edges", ".osrm.icd", ".osrm.names", ".osrm.tld", ".osrm.tls"})
+            {
+                required.erase(dataset);
+            }
+            break;
+        }
+    }
+
+    return std::vector<boost::filesystem::path>(required.begin(), required.end());
+    ;
+}
 
 /**
  * Configures OSRM's file storage paths.
@@ -42,29 +93,17 @@ namespace osrm::storage
  */
 struct StorageConfig final : IOConfig
 {
-    StorageConfig(const boost::filesystem::path &base) : StorageConfig()
+
+    StorageConfig(const boost::filesystem::path &base,
+                  const std::vector<storage::FeatureDataset> &disabled_feature_datasets_ = {})
+        : StorageConfig(disabled_feature_datasets_)
     {
         IOConfig::UseDefaultOutputNames(base);
     }
 
-    StorageConfig()
+    StorageConfig(const std::vector<storage::FeatureDataset> &disabled_feature_datasets_ = {})
         : IOConfig(
-              {".osrm.ramIndex",
-               ".osrm.fileIndex",
-               ".osrm.edges",
-               ".osrm.geometry",
-               ".osrm.turn_weight_penalties",
-               ".osrm.turn_duration_penalties",
-               ".osrm.datasource_names",
-               ".osrm.ebg_nodes",
-               ".osrm.names",
-               ".osrm.nbg_nodes",
-               ".osrm.timestamp",
-               ".osrm.tls",
-               ".osrm.tld",
-               ".osrm.properties",
-               ".osrm.icd",
-               ".osrm.maneuver_overrides"},
+              GetRequiredFiles(disabled_feature_datasets_),
               {".osrm.hsgr", ".osrm.cells", ".osrm.cell_metrics", ".osrm.mldgr", ".osrm.partition"},
               {})
     {

--- a/include/util/exception.hpp
+++ b/include/util/exception.hpp
@@ -62,7 +62,7 @@ class exception : public std::exception
  * user supplied bad data, etc).
  */
 
-constexpr const std::array<const char *, 11> ErrorDescriptions = {{
+constexpr const std::array<const char *, 12> ErrorDescriptions = {{
     "",                                               // Dummy - ErrorCode values start at 2
     "",                                               // Dummy - ErrorCode values start at 2
     "Fingerprint did not match the expected value",   // InvalidFingerprint
@@ -75,7 +75,8 @@ constexpr const std::array<const char *, 11> ErrorDescriptions = {{
     // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
     "The dataset you are trying to load is not "              // IncompatibleDataset
     "compatible with the routing algorithm you want to use.", // ...continued...
-    "Incompatible algorithm"                                  // IncompatibleAlgorithm
+    "Incompatible algorithm",                                 // IncompatibleAlgorithm
+    "Unknown feature dataset"                                 // UnknownFeatureDataset
 }};
 
 #ifndef NDEBUG
@@ -83,6 +84,32 @@ constexpr const std::array<const char *, 11> ErrorDescriptions = {{
 static_assert(ErrorDescriptions.size() == ErrorCode::__ENDMARKER__,
               "ErrorCode list and ErrorDescription lists are different sizes");
 #endif
+
+class DisabledDatasetException : public exception
+{
+  public:
+    explicit DisabledDatasetException(const std::string &dataset_)
+        : exception(BuildMessage(dataset_)), dataset(dataset_)
+    {
+    }
+
+    const std::string &Dataset() const { return dataset; }
+
+  private:
+    // This function exists to 'anchor' the class, and stop the compiler from
+    // copying vtable and RTTI info into every object file that includes
+    // this header. (Caught by -Wweak-vtables under Clang.)
+    virtual void anchor() const override;
+    const std::string dataset;
+
+    static std::string BuildMessage(const std::string &dataset)
+    {
+        return "DisabledDatasetException: Your query tried to access the disabled dataset " +
+               dataset +
+               ". Please check your configuration: "
+               "https://github.com/Project-OSRM/osrm-backend/wiki/Disabled-Datasets";
+    }
+};
 
 class RuntimeError : public exception
 {

--- a/src/nodejs/node_osrm.cpp
+++ b/src/nodejs/node_osrm.cpp
@@ -74,6 +74,7 @@ Napi::Object Engine::Init(Napi::Env env, Napi::Object exports)
  *        Old behaviour: Path to a file on disk to store the memory using mmap.  Current behaviour: setting this value is the same as setting `mmap_memory: true`.
  * @param {Boolean} [options.mmap_memory] Map on-disk files to virtual memory addresses (mmap), rather than loading into RAM.
  * @param {String} [options.path] The path to the `.osrm` files. This is mutually exclusive with setting {options.shared_memory} to true.
+ * @param {Array}  [options.disable_feature_dataset] Disables a feature dataset from being loaded into memory if not needed. Options: `ROUTE_STEPS`, `ROUTE_GEOMETRY`.
  * @param {Number} [options.max_locations_trip] Max. locations supported in trip query (default: unlimited).
  * @param {Number} [options.max_locations_viaroute] Max. locations supported in viaroute query (default: unlimited).
  * @param {Number} [options.max_locations_distance_table] Max. locations supported in distance table query (default: unlimited).

--- a/src/storage/storage_config.cpp
+++ b/src/storage/storage_config.cpp
@@ -1,0 +1,23 @@
+#include "osrm/datasets.hpp"
+#include "osrm/exception.hpp"
+#include "util/exception_utils.hpp"
+#include <boost/algorithm/string/case_conv.hpp>
+
+namespace osrm::storage
+{
+std::istream &operator>>(std::istream &in, FeatureDataset &datasets)
+{
+    std::string token;
+    in >> token;
+    boost::to_lower(token);
+
+    if (token == "route_steps")
+        datasets = FeatureDataset::ROUTE_STEPS;
+    else if (token == "route_geometry")
+        datasets = FeatureDataset::ROUTE_GEOMETRY;
+    else
+        throw util::RuntimeError(token, ErrorCode::UnknownFeatureDataset, SOURCE_REF);
+    return in;
+}
+
+} // namespace osrm::storage

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -1,5 +1,7 @@
 #include "util/exception.hpp"
 
+#include <utility>
+
 // This function exists to 'anchor' the class, and stop the compiler from
 // copying vtable and RTTI info into every object file that includes
 // this header. (Caught by -Wweak-vtables under Clang.)
@@ -16,4 +18,5 @@ namespace osrm::util
 
 void exception::anchor() const {}
 void RuntimeError::anchor() const {}
+void DisabledDatasetException::anchor() const {}
 } // namespace osrm::util

--- a/test/nodejs/index.js
+++ b/test/nodejs/index.js
@@ -163,6 +163,43 @@ test('constructor: throws on invalid custom limits', function(assert) {
         })
     });
 });
+test('constructor: throws on invalid disable_feature_dataset option', function(assert) {
+    assert.plan(1);
+    assert.throws(function() {
+        var osrm = new OSRM({
+            path: monaco_path,
+            disable_feature_dataset: ['NOT_EXIST'],
+        })
+    });
+});
+
+test('constructor: throws on non-array disable_feature_dataset', function(assert) {
+    assert.plan(1);
+    assert.throws(function() {
+        var osrm = new OSRM({
+            path: monaco_path,
+            disable_feature_dataset: 'ROUTE_GEOMETRY',
+        })
+    });
+});
+
+test('constructor: ok on valid disable_feature_dataset option', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({
+        path: monaco_path,
+        disable_feature_dataset: ['ROUTE_GEOMETRY'],
+    });
+    assert.ok(osrm);
+});
+
+test('constructor: ok on multiple overlapping disable_feature_dataset options', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({
+        path: monaco_path,
+        disable_feature_dataset: ['ROUTE_GEOMETRY', 'ROUTE_STEPS'],
+    });
+    assert.ok(osrm);
+});
 
 require('./route.js');
 require('./trip.js');

--- a/test/nodejs/match.js
+++ b/test/nodejs/match.js
@@ -398,3 +398,65 @@ test('match: match in Monaco with waypoints', function(assert) {
         }));
     });
 });
+
+test('match: throws on disabled geometry', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.match(options, function(err, route) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+
+test('match: ok on disabled geometry', function (assert) {
+    assert.plan(2);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        steps: false,
+        overview: 'false',
+        annotations: false,
+        skip_waypoints: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.match(options, function(err, response) {
+        assert.ifError(err);
+        assert.equal(response.matchings.length, 1);
+    });
+});
+
+test('match: throws on disabled steps', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.match(options, function(err, route) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+
+test('match: ok on disabled steps', function (assert) {
+    assert.plan(8);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    var options = {
+        steps: false,
+        overview: 'simplified',
+        annotations: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.match(options, function(err, response) {
+        assert.ifError(err);
+        assert.ok(response.tracepoints);
+        assert.ok(response.matchings);
+        assert.equal(response.matchings.length, 1);
+        assert.ok(response.matchings[0].geometry, "the match has geometry");
+        assert.ok(response.matchings[0].legs, "the match has legs");
+        assert.notok(response.matchings[0].legs.every(l => { return l.steps.length > 0; }), 'every leg has steps');
+        assert.ok(response.matchings[0].legs.every(l => { return l.annotation;}), 'every leg has annotations');
+    });
+});

--- a/test/nodejs/nearest.js
+++ b/test/nodejs/nearest.js
@@ -103,3 +103,40 @@ test('nearest: nearest in Monaco without motorways', function(assert) {
         assert.equal(response.waypoints.length, 1);
     });
 });
+
+test('nearest: throws on disabled geometry', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({path: data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        coordinates: [two_test_coordinates[0]],
+    };
+    osrm.nearest(options, function(err, response) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+test('nearest: ok on disabled geometry', function(assert) {
+    assert.plan(2);
+    var osrm = new OSRM({path: data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        coordinates: [two_test_coordinates[0]],
+        skip_waypoints: true,
+    };
+    osrm.nearest(options, function(err, response) {
+        assert.ifError(err);
+        assert.notok(response.waypoints);
+
+    });
+});
+
+test('nearest: ok on disabled steps', function(assert) {
+    assert.plan(2);
+    var osrm = new OSRM({path: data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    var options = {
+        coordinates: [two_test_coordinates[0]],
+    };
+    osrm.nearest(options, function(err, response) {
+        assert.ifError(err);
+        assert.equal(response.waypoints.length, 1);
+    });
+});

--- a/test/nodejs/table.js
+++ b/test/nodejs/table.js
@@ -19,7 +19,7 @@ test('table: flatbuffer format', function(assert) {
         assert.ok(table instanceof Buffer);
         const fb = FBResult.getRootAsFBResult(new flatbuffers.ByteBuffer(table));
         assert.ok(fb.table());
-        
+
     });
 });
 
@@ -369,3 +369,43 @@ tables.forEach(function(annotation) {
     });
 });
 
+test('table: throws on disabled geometry', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        coordinates: [three_test_coordinates[0], three_test_coordinates[1]],
+    };
+    osrm.table(options, function(err, table) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+
+test('table: ok on disabled geometry', function (assert) {
+    assert.plan(4);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        coordinates: [three_test_coordinates[0], three_test_coordinates[1]],
+        skip_waypoints: true
+    };
+    osrm.table(options, function(err, table) {
+        assert.ifError(err);
+        assert.ok(table.durations, 'distances table result should exist');
+        assert.notok(table.sources)
+        assert.notok(table.destinations)
+    });
+});
+
+test('table: ok on disabled steps', function (assert) {
+    assert.plan(4);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    var options = {
+        coordinates: [three_test_coordinates[0], three_test_coordinates[1]],
+    };
+    osrm.table(options, function(err, table) {
+        assert.ifError(err);
+        assert.ok(table.durations, 'distances table result should exist');
+        assert.ok(table.sources.length, 2)
+        assert.ok(table.destinations.length, 2)
+    });
+});

--- a/test/nodejs/tile.js
+++ b/test/nodejs/tile.js
@@ -23,3 +23,20 @@ test.test('tile interface pre-conditions', function(assert) {
     assert.throws(function() { osrm.tile(17059, 11948, 15, function(err, result) {}) }, /must be an array \[x, y, z\]/);
     assert.throws(function() { osrm.tile([17059, 11948, -15], function(err, result) {}) }, /must be unsigned/);
 });
+
+test.test('tile fails to load with geometry disabled', function(assert) {
+    assert.plan(1);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    osrm.tile(tile.at, function(err, result) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+test.test('tile ok with steps disabled', function(assert) {
+    assert.plan(2);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    osrm.tile(tile.at, function(err, result) {
+        assert.ifError(err);
+        assert.equal(result.length, tile.size);
+    });
+});

--- a/test/nodejs/trip.js
+++ b/test/nodejs/trip.js
@@ -368,3 +368,65 @@ test('trip: trip in Monaco without motorways', function(assert) {
     });
 });
 
+
+test('trip: throws on disabled geometry', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.trip(options, function(err, route) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+
+test('trip: ok on disabled geometry', function (assert) {
+    assert.plan(2);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_GEOMETRY']});
+    var options = {
+        steps: false,
+        overview: 'false',
+        annotations: false,
+        skip_waypoints: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.trip(options, function(err, response) {
+        assert.ifError(err);
+        assert.equal(response.trips.length, 1);
+    });
+});
+
+test('trip: throws on disabled steps', function (assert) {
+    assert.plan(1);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    var options = {
+        steps: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.trip(options, function(err, route) {
+        console.log(err)
+        assert.match(err.message, /DisabledDatasetException/);
+    });
+});
+
+test('trip: ok on disabled steps', function (assert) {
+    assert.plan(8);
+    var osrm = new OSRM({'path': data_path, 'disable_feature_dataset': ['ROUTE_STEPS']});
+    var options = {
+        steps: false,
+        overview: 'simplified',
+        annotations: true,
+        coordinates: three_test_coordinates.concat(three_test_coordinates),
+    };
+    osrm.trip(options, function(err, response) {
+        assert.ifError(err);
+        assert.ok(response.waypoints);
+        assert.ok(response.trips);
+        assert.equal(response.trips.length, 1);
+        assert.ok(response.trips[0].geometry, "trip has geometry");
+        assert.ok(response.trips[0].legs, "trip has legs");
+        assert.notok(response.trips[0].legs.every(l => { return l.steps.length > 0; }), 'every leg has steps');
+        assert.ok(response.trips[0].legs.every(l => { return l.annotation;}), 'every leg has annotations');
+    });
+});


### PR DESCRIPTION
# Issue

This change adds support for disabling datasets, such that specific files are not loaded into memory when running OSRM. This enables users to not pay the memory cost for features they do not intend to use.

Initially, there are two options:
- `ROUTE_GEOMETRY`, for disabling overview, steps, annotations and waypoints.
- `ROUTE_STEPS`, for disabling steps only.

Attempts to query a feature for which the dataset is disabled will lead to a `DisabledDatasetException` being returned.

Full details are on a new wiki page: https://github.com/Project-OSRM/osrm-backend/wiki/Disabled-Datasets

## Design Choices
The implementation separates the "feature dataset" concept from the actual files loaded into memory. This gives some flexibility in how the data is stored, allowing for changes in the file structure without breaking the user facing API.

The feature datasets to disable are passed as an array argument to `osrm-routed`, `osrm-datastore` and the NodeJS engine configuration. Currently, you would only select at most one option (`ROUTE_GEOMETRY` is a superset of `ROUTE_STEPS`), but the array interface will allow us to add more options in the future whilst maintaining backwards compatibility.

On every data facade call to optional datasets, we check a boolean to see if its loaded. I attempted other solutions that don't perform a check on every call, such as virtual functions and lambdas. These didn't improve performance and were significantly more complicated, so I stuck with the simplest implementation.

## Performance
For a contraction hierarchy dataset, `--disable-feature-dataset ROUTE_GEOMETRY` reduces RAM usage by ~15%.

There appears to be no impact on query performance. This is likely due to the number of data facade calls affected being very small. Will add full query performance results in a subsequent post. 

## Future Direction
Some optional datasets are stored in files with required datasets. One such example is OSM node IDs being stored with coordinates. We could reduce memory usage further when disabling `ROUTE_GEOMETRY` by splitting such files, or refactoring how files are loaded into memory.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations
#5218
#5838
#6045