### PR TITLE
Added motorway speed limits for Bulgaria (original fix by pl71)

### DIFF
--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -274,6 +274,7 @@ function setup()
       ["be-bru:rural"] = 70,
       ["be-bru:urban"] = 30,
       ["be-vlg:rural"] = 70,
+      ["bg:motorway"] = 140,
       ["by:urban"] = 60,
       ["by:motorway"] = 110,
       ["ca-on:rural"] = 80,

--- a/taginfo.json
+++ b/taginfo.json
@@ -150,6 +150,7 @@
         {"key": "maxspeed", "value": "AT:trunk"},
         {"key": "maxspeed", "value": "BE:motorway"},
         {"key": "maxspeed", "value": "BE-VLG:rural"},
+        {"key": "maxspeed", "value": "BG:motorway"},
         {"key": "maxspeed", "value": "BY:urban"},
         {"key": "maxspeed", "value": "BY:motorway"},
         {"key": "maxspeed", "value": "CA-ON:rural"},


### PR DESCRIPTION
Replace PR #6667

Add support of `BG:motorway=140` in car profile.
