### PR TITLE
Install data directory (geojson files) like the profiles directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,6 +792,10 @@ install(TARGETS osrm_guidance DESTINATION lib)
 set(DefaultProfilesDir profiles)
 install(DIRECTORY ${DefaultProfilesDir} DESTINATION share/osrm)
 
+# Install data geojson files to /usr/local/share/osrm/data by default
+set(DefaultProfilesDir data)
+install(DIRECTORY ${DefaultProfilesDir} DESTINATION share/osrm)
+
 # Setup exporting variables for pkgconfig and subproject
 #
 


### PR DESCRIPTION
The `data` directory is not installed in the system like the `profiles` is.

The data directory contain useful, but optional geojson. But once OSRM installed in the system the data files are missing.
