### PR TITLE
Fix some compilation issues on modern macOS systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,6 +462,9 @@ add_dependency_defines(-DBOOST_SPIRIT_USE_PHOENIX_V3)
 add_dependency_defines(-DBOOST_RESULT_OF_USE_DECLTYPE)
 add_dependency_defines(-DBOOST_FILESYSTEM_NO_DEPRECATED)
 
+# Workaround for https://github.com/boostorg/phoenix/issues/111
+add_dependency_defines(-DBOOST_PHOENIX_STL_TUPLE_H_)
+
 add_definitions(${OSRM_DEFINES})
 include_directories(SYSTEM ${DEPENDENCIES_INCLUDE_DIRS})
 

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -184,7 +184,8 @@ double getLength(iterator_type begin, const iterator_type end, BinaryOperation o
         return false;
     };
     // side-effect find adding up distances
-    std::adjacent_find(begin, end, functor);
+    // Ignore return value, we are only interested in the side-effect
+    [[maybe_unused]] auto _ = std::adjacent_find(begin, end, functor);
 
     return result;
 }
@@ -202,7 +203,8 @@ findClosestDistance(const Coordinate coordinate, const iterator_type begin, cons
         return false;
     };
 
-    std::adjacent_find(begin, end, compute_minimum_distance);
+    // Ignore return value, we are only interested in the side-effect
+    [[maybe_unused]] auto _ = std::adjacent_find(begin, end, compute_minimum_distance);
     return current_min;
 }
 

--- a/src/extractor/intersection/coordinate_extractor.cpp
+++ b/src/extractor/intersection/coordinate_extractor.cpp
@@ -888,19 +888,20 @@ CoordinateExtractor::PrepareLengthCache(const std::vector<util::Coordinate> &coo
     // sentinel
     // NOLINTNEXTLINE(bugprone-unused-return-value)
     // We're only interested in the side effect of the lambda, not the return value
-    [[maybe_unused]] auto _ = std::find_if(std::next(std::begin(coordinates)),
-                 std::end(coordinates),
-                 [last_coordinate = coordinates.front(),
-                  limit,
-                  &segment_distances,
-                  accumulated_distance = 0.](const util::Coordinate current_coordinate) mutable {
-                     const auto distance = util::coordinate_calculation::greatCircleDistance(
-                         last_coordinate, current_coordinate);
-                     accumulated_distance += distance;
-                     last_coordinate = current_coordinate;
-                     segment_distances.push_back(distance);
-                     return accumulated_distance >= limit;
-                 });
+    [[maybe_unused]] auto _ = std::find_if(
+        std::next(std::begin(coordinates)),
+        std::end(coordinates),
+        [last_coordinate = coordinates.front(),
+         limit,
+         &segment_distances,
+         accumulated_distance = 0.](const util::Coordinate current_coordinate) mutable {
+            const auto distance = util::coordinate_calculation::greatCircleDistance(
+                last_coordinate, current_coordinate);
+            accumulated_distance += distance;
+            last_coordinate = current_coordinate;
+            segment_distances.push_back(distance);
+            return accumulated_distance >= limit;
+        });
     return segment_distances;
 }
 
@@ -1091,7 +1092,8 @@ CoordinateExtractor::SampleCoordinates(const std::vector<util::Coordinate> &coor
     };
 
     // misuse of adjacent_find. Loop over coordinates, until a total sample length is reached
-    [[maybe_unused]] auto _ = std::adjacent_find(coordinates.begin(), coordinates.end(), add_samples_until_length_limit);
+    [[maybe_unused]] auto _ =
+        std::adjacent_find(coordinates.begin(), coordinates.end(), add_samples_until_length_limit);
 
     return sampled_coordinates;
 }

--- a/src/extractor/intersection/coordinate_extractor.cpp
+++ b/src/extractor/intersection/coordinate_extractor.cpp
@@ -887,7 +887,8 @@ CoordinateExtractor::PrepareLengthCache(const std::vector<util::Coordinate> &coo
     segment_distances.push_back(0);
     // sentinel
     // NOLINTNEXTLINE(bugprone-unused-return-value)
-    std::find_if(std::next(std::begin(coordinates)),
+    // We're only interested in the side effect of the lambda, not the return value
+    [[maybe_unused]] auto _ = std::find_if(std::next(std::begin(coordinates)),
                  std::end(coordinates),
                  [last_coordinate = coordinates.front(),
                   limit,
@@ -1090,7 +1091,7 @@ CoordinateExtractor::SampleCoordinates(const std::vector<util::Coordinate> &coor
     };
 
     // misuse of adjacent_find. Loop over coordinates, until a total sample length is reached
-    std::adjacent_find(coordinates.begin(), coordinates.end(), add_samples_until_length_limit);
+    [[maybe_unused]] auto _ = std::adjacent_find(coordinates.begin(), coordinates.end(), add_samples_until_length_limit);
 
     return sampled_coordinates;
 }

--- a/src/partitioner/dinic_max_flow.cpp
+++ b/src/partitioner/dinic_max_flow.cpp
@@ -195,7 +195,9 @@ std::size_t DinicMaxFlow::BlockingFlow(FlowEdges &flow,
         };
 
         // augment all adjacent edges
-        std::adjacent_find(path.begin(), path.end(), augment_one);
+        // We're only interested in the side-effect of the augment_one function, the return
+        // value is ignored
+        [[maybe_unused]] auto _ = std::adjacent_find(path.begin(), path.end(), augment_one);
     };
 
     const auto augment_all_paths = [&](const NodeID sink_node_id) {

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -323,7 +323,7 @@ double findClosestDistance(const std::vector<Coordinate> &lhs, const std::vector
         return false;
     };
     // NOLINTNEXTLINE(bugprone-unused-return-value)
-    std::find_if(std::begin(lhs), std::end(lhs), compute_minimum_distance_in_rhs);
+    [[maybe_unused]] auto _ = std::find_if(std::begin(lhs), std::end(lhs), compute_minimum_distance_in_rhs);
     return current_min;
 }
 

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -323,7 +323,8 @@ double findClosestDistance(const std::vector<Coordinate> &lhs, const std::vector
         return false;
     };
     // NOLINTNEXTLINE(bugprone-unused-return-value)
-    [[maybe_unused]] auto _ = std::find_if(std::begin(lhs), std::end(lhs), compute_minimum_distance_in_rhs);
+    [[maybe_unused]] auto _ =
+        std::find_if(std::begin(lhs), std::end(lhs), compute_minimum_distance_in_rhs);
     return current_min;
 }
 


### PR DESCRIPTION
Apple clang 15 doesn't like some of our coding practices, notably some use of:

```
std::find_if
std::adjacent_find
```

where we're not interested in the return values, just the side-effects of the lambda functions.  This PR adds dummy variables to hold the results, and marks them as `[[maybe_unused]]`, which appeases the compiler.

I've also thrown in a workaround to https://github.com/boostorg/phoenix/issues/111 which is preventing things from building when compiled against Boost 1.8x, which is the current version available in Homebrew on macOS.

I haven't actually tested anything here, I just know it all compiles cleanly on my Apple M1 machine now.


Should address most of https://github.com/Project-OSRM/osrm-backend/issues/6707 - I didn't observe the issues with `std::unary_function` when using Boost 1.8x