### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/profiles/debug_way.lua
+++ b/profiles/debug_way.lua
@@ -21,7 +21,7 @@ local https = require('ssl.https')
 Debug.load_profile(arg[1])
 
 -- load way from the OSM API
-local url = 'https://www.openstreetmap.org/api/0.6/way/'..arg[2]
+local url = 'https://api.openstreetmap.org/api/0.6/way/'..arg[2]
 local body, statusCode, headers, statusText = https.request(url)
 
 -- parse way tags


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

Does not seem to be used anywhere else than in the debug code, based on a GitHub search within this repo.

cc: @systemed 