### PR TITLE
Replace deprecated std::is_pod

### DIFF
--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -72,12 +72,12 @@ using FloatLongitude = Alias<double, tag::longitude>;
 // range checks on these (toFixed/toFloat, etc)
 using UnsafeFloatLatitude = Alias<double, tag::unsafelatitude>;
 using UnsafeFloatLongitude = Alias<double, tag::unsafelongitude>;
-static_assert(std::is_pod<FixedLatitude>(), "FixedLatitude is not a valid alias");
-static_assert(std::is_pod<FixedLongitude>(), "FixedLongitude is not a valid alias");
-static_assert(std::is_pod<FloatLatitude>(), "FloatLatitude is not a valid alias");
-static_assert(std::is_pod<FloatLongitude>(), "FloatLongitude is not a valid alias");
-static_assert(std::is_pod<UnsafeFloatLatitude>(), "UnsafeFloatLatitude is not a valid alias");
-static_assert(std::is_pod<UnsafeFloatLongitude>(), "UnsafeFloatLongitude is not a valid alias");
+static_assert(std::is_standard_layout<FixedLatitude>() && std::is_trivial<FixedLatitude>(), "FixedLatitude is not a valid alias");
+static_assert(std::is_standard_layout<FixedLongitude>() && std::is_trivial<FixedLongitude>(), "FixedLongitude is not a valid alias");
+static_assert(std::is_standard_layout<FloatLatitude>() && std::is_trivial<FloatLatitude>(), "FloatLatitude is not a valid alias");
+static_assert(std::is_standard_layout<FloatLongitude>() && std::is_trivial<FloatLongitude>(), "FloatLongitude is not a valid alias");
+static_assert(std::is_standard_layout<UnsafeFloatLatitude>() && std::is_trivial<UnsafeFloatLatitude>(), "UnsafeFloatLatitude is not a valid alias");
+static_assert(std::is_standard_layout<UnsafeFloatLongitude>() && std::is_trivial<UnsafeFloatLongitude>(), "UnsafeFloatLongitude is not a valid alias");
 
 /**
  * Converts a typed latitude from floating to fixed representation.

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -72,12 +72,20 @@ using FloatLongitude = Alias<double, tag::longitude>;
 // range checks on these (toFixed/toFloat, etc)
 using UnsafeFloatLatitude = Alias<double, tag::unsafelatitude>;
 using UnsafeFloatLongitude = Alias<double, tag::unsafelongitude>;
-static_assert(std::is_standard_layout<FixedLatitude>() && std::is_trivial<FixedLatitude>(), "FixedLatitude is not a valid alias");
-static_assert(std::is_standard_layout<FixedLongitude>() && std::is_trivial<FixedLongitude>(), "FixedLongitude is not a valid alias");
-static_assert(std::is_standard_layout<FloatLatitude>() && std::is_trivial<FloatLatitude>(), "FloatLatitude is not a valid alias");
-static_assert(std::is_standard_layout<FloatLongitude>() && std::is_trivial<FloatLongitude>(), "FloatLongitude is not a valid alias");
-static_assert(std::is_standard_layout<UnsafeFloatLatitude>() && std::is_trivial<UnsafeFloatLatitude>(), "UnsafeFloatLatitude is not a valid alias");
-static_assert(std::is_standard_layout<UnsafeFloatLongitude>() && std::is_trivial<UnsafeFloatLongitude>(), "UnsafeFloatLongitude is not a valid alias");
+static_assert(std::is_standard_layout<FixedLatitude>() && std::is_trivial<FixedLatitude>(),
+              "FixedLatitude is not a valid alias");
+static_assert(std::is_standard_layout<FixedLongitude>() && std::is_trivial<FixedLongitude>(),
+              "FixedLongitude is not a valid alias");
+static_assert(std::is_standard_layout<FloatLatitude>() && std::is_trivial<FloatLatitude>(),
+              "FloatLatitude is not a valid alias");
+static_assert(std::is_standard_layout<FloatLongitude>() && std::is_trivial<FloatLongitude>(),
+              "FloatLongitude is not a valid alias");
+static_assert(std::is_standard_layout<UnsafeFloatLatitude>() &&
+                  std::is_trivial<UnsafeFloatLatitude>(),
+              "UnsafeFloatLatitude is not a valid alias");
+static_assert(std::is_standard_layout<UnsafeFloatLongitude>() &&
+                  std::is_trivial<UnsafeFloatLongitude>(),
+              "UnsafeFloatLongitude is not a valid alias");
 
 /**
  * Converts a typed latitude from floating to fixed representation.

--- a/include/util/fingerprint.hpp
+++ b/include/util/fingerprint.hpp
@@ -33,7 +33,7 @@ struct FingerPrint
 
 static_assert(sizeof(FingerPrint) == 8, "FingerPrint has unexpected size");
 static_assert(std::is_trivial<FingerPrint>::value, "FingerPrint needs to be trivial.");
-static_assert(std::is_pod<FingerPrint>::value, "FingerPrint needs to be a POD.");
+static_assert(std::is_standard_layout<FingerPrint>::value, "FingerPrint needs have a standard layout.");
 } // namespace osrm::util
 
 #endif /* FingerPrint_H */

--- a/include/util/fingerprint.hpp
+++ b/include/util/fingerprint.hpp
@@ -33,7 +33,8 @@ struct FingerPrint
 
 static_assert(sizeof(FingerPrint) == 8, "FingerPrint has unexpected size");
 static_assert(std::is_trivial<FingerPrint>::value, "FingerPrint needs to be trivial.");
-static_assert(std::is_standard_layout<FingerPrint>::value, "FingerPrint needs have a standard layout.");
+static_assert(std::is_standard_layout<FingerPrint>::value,
+              "FingerPrint needs have a standard layout.");
 } // namespace osrm::util
 
 #endif /* FingerPrint_H */

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -71,10 +71,12 @@ struct turn_penalty
 using OSMNodeID = osrm::Alias<std::uint64_t, tag::osm_node_id>;
 // clang-tidy fires `bugprone-throw-keyword-missing` here for unknown reason
 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-static_assert(std::is_standard_layout<OSMNodeID>() && std::is_trivial<OSMNodeID>(), "OSMNodeID is not a valid alias");
+static_assert(std::is_standard_layout<OSMNodeID>() && std::is_trivial<OSMNodeID>(),
+              "OSMNodeID is not a valid alias");
 using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-static_assert(std::is_standard_layout<OSMWayID>() && std::is_trivial<OSMWayID>(), "OSMWayID is not a valid alias");
+static_assert(std::is_standard_layout<OSMWayID>() && std::is_trivial<OSMWayID>(),
+              "OSMWayID is not a valid alias");
 
 using DuplicatedNodeID = std::uint64_t;
 using RestrictionID = std::uint64_t;

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -71,10 +71,10 @@ struct turn_penalty
 using OSMNodeID = osrm::Alias<std::uint64_t, tag::osm_node_id>;
 // clang-tidy fires `bugprone-throw-keyword-missing` here for unknown reason
 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-static_assert(std::is_pod<OSMNodeID>(), "OSMNodeID is not a valid alias");
+static_assert(std::is_standard_layout<OSMNodeID>() && std::is_trivial<OSMNodeID>(), "OSMNodeID is not a valid alias");
 using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-static_assert(std::is_pod<OSMWayID>(), "OSMWayID is not a valid alias");
+static_assert(std::is_standard_layout<OSMWayID>() && std::is_trivial<OSMWayID>(), "OSMWayID is not a valid alias");
 
 using DuplicatedNodeID = std::uint64_t;
 using RestrictionID = std::uint64_t;


### PR DESCRIPTION
# Issue

Fixing issue #6716 by replacing std::is_pod with std::is_standard_layout && std::is_trivial

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

