### PR TITLE
Remove unused AWS SDK for JavaScript v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@babel/preset-react": "^7.18.6",
         "acorn": "^8.8.0",
         "ansi-escape-sequences": "^5.1.2",
-        "aws-sdk": "~2.0.31",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "babelify": "^10.0.0",
         "browserify": "^17.0.0",
@@ -2830,28 +2829,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/aws-sdk": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
-      "integrity": "sha512-rgmExM3/LjhI95PfjwDs1hks/RYrQ/V3qLybFCzBqr8Y3Hz9Qq3jp+WR1BaWhUckgoVJs/ZE4VSvMKZeNwuFoA==",
-      "dev": true,
-      "dependencies": {
-        "xml2js": "0.2.6",
-        "xmlbuilder": "0.4.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/xmlbuilder": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
-      "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
       }
     },
     "node_modules/aws-sign2": {
@@ -14604,12 +14581,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true
     },
-    "node_modules/sax": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
-      "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -18389,15 +18360,6 @@
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
     },
-    "node_modules/xml2js": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
-      "integrity": "sha512-h+Nzgo0eLwideldZGqSquNtrsuX5zcDREImBa1GSNw9QljlXiFcM3E1kWjLprRjJe2jRuvnVk0j3WgQo9Deoog==",
-      "dev": true,
-      "dependencies": {
-        "sax": "0.4.2"
-      }
-    },
     "node_modules/xmlbuilder": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
@@ -20477,24 +20439,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==",
       "dev": true
-    },
-    "aws-sdk": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
-      "integrity": "sha512-rgmExM3/LjhI95PfjwDs1hks/RYrQ/V3qLybFCzBqr8Y3Hz9Qq3jp+WR1BaWhUckgoVJs/ZE4VSvMKZeNwuFoA==",
-      "dev": true,
-      "requires": {
-        "xml2js": "0.2.6",
-        "xmlbuilder": "0.4.2"
-      },
-      "dependencies": {
-        "xmlbuilder": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
-          "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=",
-          "dev": true
-        }
-      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -30258,12 +30202,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true
     },
-    "sax": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
-      "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=",
-      "dev": true
-    },
     "semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -33324,15 +33262,6 @@
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
-      "integrity": "sha512-h+Nzgo0eLwideldZGqSquNtrsuX5zcDREImBa1GSNw9QljlXiFcM3E1kWjLprRjJe2jRuvnVk0j3WgQo9Deoog==",
-      "dev": true,
-      "requires": {
-        "sax": "0.4.2"
-      }
     },
     "xmlbuilder": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@babel/preset-react": "^7.18.6",
     "acorn": "^8.8.0",
     "ansi-escape-sequences": "^5.1.2",
-    "aws-sdk": "~2.0.31",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",


### PR DESCRIPTION
# Issue

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

I discovered osrm-backend while searching for popular projects on GitHub which use AWS SDK for JavaScript v2.
On quick look, it appears like the aws-sdk dependency is not needed. It was added in commit https://github.com/Project-OSRM/osrm-backend/commit/2351b5a0840c39e31f31d0069dda6f8a4605f9dc

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

N/A