### PR TITLE
support rtree preheat

### DIFF
--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -260,6 +260,7 @@ class StaticRTree
     boost::iostreams::mapped_file_source m_objects_region;
     // This is a view of the EdgeDataT data mmap'd from the .fileIndex file
     util::vector_view<const EdgeDataT> m_objects;
+    EdgeDataT tmp;
 
   public:
     StaticRTree() = default;
@@ -462,6 +463,7 @@ class StaticRTree
         : m_coordinate_list(coordinate_list.data(), coordinate_list.size()),
           m_objects(mmapFile<EdgeDataT>(on_disk_file_name, m_objects_region))
     {
+              preheat();
     }
 
     /**
@@ -480,6 +482,7 @@ class StaticRTree
     {
         BOOST_ASSERT(m_tree_level_starts.size() >= 2);
         m_objects = mmapFile<EdgeDataT>(on_disk_file_name, m_objects_region);
+        preheat();
     }
 
     /* Returns all features inside the bounding box.
@@ -759,6 +762,18 @@ class StaticRTree
     {
         BOOST_ASSERT(m_tree_level_starts.size() >= 2);
         return treeindex.level == m_tree_level_starts.size() - 2;
+    }
+
+    void preheat()
+    {
+        auto iter = m_objects.begin();
+        auto end = m_objects.end();
+        while (iter < end)
+        {
+            tmp = *(iter.get_ptr());
+            // because os's page is unit of 4K
+            iter += LEAF_NODE_SIZE;
+        }
     }
 
     friend void serialization::read<EdgeDataT, Ownership, BRANCHING_FACTOR, LEAF_PAGE_SIZE>(

--- a/include/util/vector_view.hpp
+++ b/include/util/vector_view.hpp
@@ -41,6 +41,7 @@ class VectorViewIterator : public boost::iterator_facade<VectorViewIterator<Data
 
     explicit VectorViewIterator() : m_value(nullptr) {}
     explicit VectorViewIterator(DataT *x) : m_value(x) {}
+    DataT * get_ptr(){return m_value;}
 
   private:
     void increment() { ++m_value; }


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.
we found a lot of requests timeout when osrm is starting, but after a while the rt decrease, so we want to resolve the problem, and we found the reason is the preheat of rtree, because the leaf node of rtree is stored in the .fileIndex file and 
it use mmap so it will produce disk I/O for preheat

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
