### PR TITLE
Remove outdated/deprecated CMake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,6 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # be compatible with version handling before cmake 3.x
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 OLD)
-endif()
 if (POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()


### PR DESCRIPTION
# Issue

Fixes the following warning:

```
CMake Deprecation Warning at CMakeLists.txt:53 (cmake_policy):
  The OLD behavior for policy CMP0048 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```