### PR TITLE
Upgrade clang compiler in CI builds

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -170,14 +170,24 @@ jobs:
             OSRM_CONNECTION_RETRIES: 10
             OSRM_CONNECTION_EXP_BACKOFF_COEF: 1.5
 
-          - name: clang-6.0-debug
+          - name: clang-15.0-release
             continue-on-error: false
             node: 18
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-15.0
+            CXXCOMPILER: clang++-15.0
+            CUCUMBER_TIMEOUT: 60000
+
+          - name: clang-15.0-debug
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
-            CCOMPILER: clang-6.0
-            CXXCOMPILER: clang++-6.0
+            CCOMPILER: clang-15.0
+            CXXCOMPILER: clang++-15.0
             CUCUMBER_TIMEOUT: 60000
 
           - name: clang-15.0-debug-clang-tidy
@@ -191,25 +201,45 @@ jobs:
             CUCUMBER_TIMEOUT: 60000
             ENABLE_CLANG_TIDY: ON
 
+          - name: clang-14.0-release
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-14.0
+            CXXCOMPILER: clang++-14.0
+            CUCUMBER_TIMEOUT: 60000
+
+          - name: clang-13.0-release
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-13.0
+            CXXCOMPILER: clang++-13.0
+            CUCUMBER_TIMEOUT: 60000
+
           - name: conan-linux-debug-asan-ubsan
             continue-on-error: false
             node: 18
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
-            CCOMPILER: clang-11
-            CXXCOMPILER: clang++-11
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
             ENABLE_CONAN: ON
             ENABLE_SANITIZER: ON
 
           - name: conan-linux-release
             continue-on-error: false
             node: 18
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
-            CCOMPILER: clang-6.0
-            CXXCOMPILER: clang++-6.0
+            CCOMPILER: clang-15.0
+            CXXCOMPILER: clang++-15.0
             ENABLE_CONAN: ON
 
           - name: gcc-12-release
@@ -279,10 +309,10 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 20
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
             BUILD_TYPE: Release
-            CCOMPILER: clang-6.0
-            CXXCOMPILER: clang++-6.0
+            CCOMPILER: clang-13.0
+            CXXCOMPILER: clang++-13.0
             ENABLE_CONAN: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
@@ -290,10 +320,10 @@ jobs:
             build_node_package: true
             continue-on-error: false
             node: 20
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
             BUILD_TYPE: Debug
-            CCOMPILER: clang-6.0
-            CXXCOMPILER: clang++-6.0
+            CCOMPILER: clang-13.0
+            CXXCOMPILER: clang++-13.0
             ENABLE_CONAN: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
@@ -413,17 +443,6 @@ jobs:
           sudo apt-get update -y && sudo apt-get install ccache
         elif [[ "${RUNNER_OS}" == "macOS" ]]; then
           brew install ccache
-        fi
-
-        # clang
-        if [[ "${CCOMPILER}" == "clang-6.0" ]]; then
-          sudo apt-get update -y && sudo apt-get install clang++-6
-        elif [[ "${CCOMPILER}" == "clang-15" ]]; then
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-get update -y && sudo apt-get install software-properties-common
-          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
-          sudo apt-get update -y && sudo apt-get install clang++-15 clang-tidy-15
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100000
         fi
 
         # Linux dev packages

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -170,27 +170,27 @@ jobs:
             OSRM_CONNECTION_RETRIES: 10
             OSRM_CONNECTION_EXP_BACKOFF_COEF: 1.5
 
-          - name: clang-15.0-release
+          - name: clang-15-release
             continue-on-error: false
             node: 18
             runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
-            CCOMPILER: clang-15.0
-            CXXCOMPILER: clang++-15.0
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
             CUCUMBER_TIMEOUT: 60000
 
-          - name: clang-15.0-debug
+          - name: clang-15-debug
             continue-on-error: false
             node: 18
             runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Debug
-            CCOMPILER: clang-15.0
-            CXXCOMPILER: clang++-15.0
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
             CUCUMBER_TIMEOUT: 60000
 
-          - name: clang-15.0-debug-clang-tidy
+          - name: clang-15-debug-clang-tidy
             continue-on-error: false
             node: 18
             runs-on: ubuntu-22.04
@@ -201,24 +201,24 @@ jobs:
             CUCUMBER_TIMEOUT: 60000
             ENABLE_CLANG_TIDY: ON
 
-          - name: clang-14.0-release
+          - name: clang-14-release
             continue-on-error: false
             node: 18
             runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
-            CCOMPILER: clang-14.0
-            CXXCOMPILER: clang++-14.0
+            CCOMPILER: clang-14
+            CXXCOMPILER: clang++-14
             CUCUMBER_TIMEOUT: 60000
 
-          - name: clang-13.0-release
+          - name: clang-13-release
             continue-on-error: false
             node: 18
             runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
-            CCOMPILER: clang-13.0
-            CXXCOMPILER: clang++-13.0
+            CCOMPILER: clang-13
+            CXXCOMPILER: clang++-13
             CUCUMBER_TIMEOUT: 60000
 
           - name: conan-linux-debug-asan-ubsan
@@ -238,8 +238,8 @@ jobs:
             runs-on: ubuntu-22.04
             BUILD_TOOLS: ON
             BUILD_TYPE: Release
-            CCOMPILER: clang-15.0
-            CXXCOMPILER: clang++-15.0
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
             ENABLE_CONAN: ON
 
           - name: gcc-12-release
@@ -311,8 +311,8 @@ jobs:
             node: 20
             runs-on: ubuntu-22.04
             BUILD_TYPE: Release
-            CCOMPILER: clang-13.0
-            CXXCOMPILER: clang++-13.0
+            CCOMPILER: clang-13
+            CXXCOMPILER: clang++-13
             ENABLE_CONAN: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 
@@ -322,8 +322,8 @@ jobs:
             node: 20
             runs-on: ubuntu-22.04
             BUILD_TYPE: Debug
-            CCOMPILER: clang-13.0
-            CXXCOMPILER: clang++-13.0
+            CCOMPILER: clang-13
+            CXXCOMPILER: clang++-13
             ENABLE_CONAN: ON
             NODE_PACKAGE_TESTS_ONLY: ON
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if (ENABLE_CLANG_TIDY)
     message(FATAL_ERROR "ENABLE_CLANG_TIDY is ON but clang-tidy is not found!")
   else()
     message(STATUS "Found clang-tidy at ${CLANG_TIDY_COMMAND}")
-    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};--warnings-as-errors=*")
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};--warnings-as-errors=*;--header-filter=.*")
   endif()
 endif()
 

--- a/include/guidance/parsing_toolkit.hpp
+++ b/include/guidance/parsing_toolkit.hpp
@@ -71,7 +71,7 @@ trimLaneString(std::string lane_string, std::int32_t count_left, std::int32_t co
 OSRM_ATTR_WARN_UNUSED
 inline std::string applyAccessTokens(std::string lane_string, const std::string &access_tokens)
 {
-    typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+    using tokenizer = boost::tokenizer<boost::char_separator<char>>;
     boost::char_separator<char> sep("|", "", boost::keep_empty_tokens);
     tokenizer tokens(lane_string, sep);
     tokenizer access(access_tokens, sep);

--- a/src/extractor/extractor_callbacks.cpp
+++ b/src/extractor/extractor_callbacks.cpp
@@ -242,7 +242,7 @@ void ExtractorCallbacks::ProcessWay(const osmium::Way &input_way, const Extracti
 
         TurnLaneDescription lane_description;
 
-        typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+        using tokenizer = boost::tokenizer<boost::char_separator<char>>;
         boost::char_separator<char> sep("|", "", boost::keep_empty_tokens);
         boost::char_separator<char> inner_sep(";", "");
         tokenizer tokens(lane_string, sep);

--- a/src/guidance/turn_lane_data.cpp
+++ b/src/guidance/turn_lane_data.cpp
@@ -62,7 +62,7 @@ bool TurnLaneData::operator<(const TurnLaneData &other) const
 
 LaneDataVector laneDataFromDescription(const TurnLaneDescription &turn_lane_description)
 {
-    typedef std::unordered_map<TurnLaneType::Mask, std::pair<LaneID, LaneID>> LaneMap;
+    using LaneMap = std::unordered_map<TurnLaneType::Mask, std::pair<LaneID, LaneID>>;
     // TODO need to handle cases that have none-in between two identical values
     const auto num_lanes = boost::numeric_cast<LaneID>(turn_lane_description.size());
 


### PR DESCRIPTION
This PR sorts out the clang-based CI builds. It will do the following:

- Supported clang versions are raised to 13, 14, and 15 based on the ubuntu-22.04 image in Github actions.
- The node release build is done off the oldest clang version, i.e. 13.
- Custom script machinery to install clang-6 has been removed.

| build name | compiler | note  |
|------|---|---|
|clang-15.0-release|15.0| |
|clang-15.0-debug|15.0| most recent version also compiled in debug|
|clang-14.0-release|14.0| |
|clang-13.0-release|13.0| |
|conan-linux-debug-asan-ubsan| 15.0 | before: clang-11|
|conan-linux-release| 13.0 | before: clang-6 |
|conan-linux-release-node| 13.0 | before: clang-6 |
|conan-linux-debug-node| 13.0 | before: clang-6 |
