### PR TITLE
Set Windows build to quiet

### DIFF
--- a/scripts/ci/windows-build.bat
+++ b/scripts/ci/windows-build.bat
@@ -21,7 +21,7 @@ msbuild OSRM.sln ^
 /p:BuildInParallel=true ^
 /m:%NUMBER_OF_PROCESSORS% ^
 /toolsversion:Current ^
-/clp:Verbosity=normal ^
+/clp:Verbosity=quiet ^
 /nologo
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 


### PR DESCRIPTION
The normal flag generates 290 megabytes of log output for a regular build. Setting it to quiet will reduce this and still print errors.

Update:
The change seems to have a net positive effect on log size, as well as build times:

| | before | after|
|-|---|--|
|build time | 37m16 | **28m35**|
|log size | 290MB | **138MB** |