### PR TITLE
Add benchmarks comparison job

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -658,10 +658,6 @@ jobs:
       - name: Run Benchmarks
         run: |
           ./pr/scripts/ci/run_benchmarks.sh base pr
-      - name: Compare Benchmarks
-        run: |
-          cat pr_results/match_mld.bench
-          cat base_results/match_mld.bench
       - name: Post Benchmark Results
         run: |
           python3 pr/scripts/ci/post_benchmark_results.py base_results pr_results

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -601,7 +601,6 @@ jobs:
           key: v1-ccache-benchmarks-${{ github.sha }}
           restore-keys: |
             v1-ccache-benchmarks-
-      - name: mkdir -p ~/.ccache
       - name: Enable Conan cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -631,7 +631,7 @@ jobs:
           ref: ${{ github.head_ref }}
           path: pr
       - run: python3 -m pip install "conan<2.0.0" "requests==2.31.0"
-      - name: Build
+      - name: Build PR Branch
         run: |
           mkdir -p pr/build
           cd pr/build
@@ -640,15 +640,12 @@ jobs:
           make -j$(nproc) benchmarks
           cd ..
           make -C test/data 
-      - name: Run Benchmark on Master Branch
-        run: |
-          ./pr/build/src/benchmarks/match-bench ./pr/test/data/mld/monaco.osrm mld > pr/match.bench
       - name: Checkout Master Branch
         uses: actions/checkout@v3
         with:
           ref: master
           path: master
-      - name: Build
+      - name: Build Master Branch
         run: |
           mkdir master/build
           cd master/build

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -610,6 +610,7 @@ jobs:
       - run: pip install "conan<2.0.0"
       - name: Build
         run: |
+          rm -rf build
           mkdir build
           cd build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
@@ -623,6 +624,7 @@ jobs:
           ref: master
       - name: Build
         run: |
+          rm -rf build
           mkdir build
           cd build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -609,6 +609,7 @@ jobs:
       CXX: clang++-13
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps: 
       - name: Checkout PR Branch
         uses: actions/checkout@v3

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -24,578 +24,612 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  windows-release-node:
-    needs: format-taginfo-docs
-    runs-on: windows-2022
-    continue-on-error: false
-    env:
-      BUILD_TYPE: Release
-    steps:
-    - uses: actions/checkout@v3
-    - run: pip install "conan<2.0.0"
-    - run: conan --version
-    - run: cmake --version
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - run: node --version
-    - run: npm --version
-    - name: Prepare environment
-      shell: bash
-      run: |
-        PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-        echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
-    - run: npm install --ignore-scripts
-    - run: npm link --ignore-scripts
-    - uses: microsoft/setup-msbuild@v1.1
-    - name: Build
-      run: |
-        .\scripts\ci\windows-build.bat
-    - name: Run node tests
-      shell: bash
-      run: |
-        ./lib/binding/osrm-datastore.exe test/data/ch/monaco.osrm
-        node test/nodejs/index.js
-    - name: Build Node package
-      shell: bash
-      run: ./scripts/ci/node_package.sh
-    - name: Publish Node package
-      if: ${{ env.PUBLISH == 'On' }}
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: true
-        artifactErrorsFailBuild: true
-        artifacts: build/stage/**/*.tar.gz
-        omitBody: true
-        omitBodyDuringUpdate: true
-        omitName: true
-        omitNameDuringUpdate: true
-        replacesArtifacts: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+  # windows-release-node:
+  #   needs: format-taginfo-docs
+  #   runs-on: windows-2022
+  #   continue-on-error: false
+  #   env:
+  #     BUILD_TYPE: Release
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - run: pip install "conan<2.0.0"
+  #   - run: conan --version
+  #   - run: cmake --version
+  #   - uses: actions/setup-node@v3
+  #     with:
+  #       node-version: 18
+  #   - run: node --version
+  #   - run: npm --version
+  #   - name: Prepare environment
+  #     shell: bash
+  #     run: |
+  #       PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+  #       echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
+  #   - run: npm install --ignore-scripts
+  #   - run: npm link --ignore-scripts
+  #   - uses: microsoft/setup-msbuild@v1.1
+  #   - name: Build
+  #     run: |
+  #       .\scripts\ci\windows-build.bat
+  #   - name: Run node tests
+  #     shell: bash
+  #     run: |
+  #       ./lib/binding/osrm-datastore.exe test/data/ch/monaco.osrm
+  #       node test/nodejs/index.js
+  #   - name: Build Node package
+  #     shell: bash
+  #     run: ./scripts/ci/node_package.sh
+  #   - name: Publish Node package
+  #     if: ${{ env.PUBLISH == 'On' }}
+  #     uses: ncipollo/release-action@v1
+  #     with:
+  #       allowUpdates: true
+  #       artifactErrorsFailBuild: true
+  #       artifacts: build/stage/**/*.tar.gz
+  #       omitBody: true
+  #       omitBodyDuringUpdate: true
+  #       omitName: true
+  #       omitNameDuringUpdate: true
+  #       replacesArtifacts: true
+  #       token: ${{ secrets.GITHUB_TOKEN }}
 
-  format-taginfo-docs:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - name: Enable Node.js cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - name: Prepare environment
-      run: |
-        npm ci --ignore-scripts
-        clang-format-15 --version
-    - name: Run checks
-      run: |
-        ./scripts/check_taginfo.py taginfo.json profiles/car.lua
-        ./scripts/format.sh && ./scripts/error_on_dirty.sh
-        node ./scripts/validate_changelog.js
-        npm run docs && ./scripts/error_on_dirty.sh
-        npm audit --production
+  # format-taginfo-docs:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Use Node.js
+  #     uses: actions/setup-node@v3
+  #     with:
+  #       node-version: 18
+  #   - name: Enable Node.js cache
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/.npm
+  #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+  #       restore-keys: |
+  #         ${{ runner.os }}-node-
+  #   - name: Prepare environment
+  #     run: |
+  #       npm ci --ignore-scripts
+  #       clang-format-15 --version
+  #   - name: Run checks
+  #     run: |
+  #       ./scripts/check_taginfo.py taginfo.json profiles/car.lua
+  #       ./scripts/format.sh && ./scripts/error_on_dirty.sh
+  #       node ./scripts/validate_changelog.js
+  #       npm run docs && ./scripts/error_on_dirty.sh
+  #       npm audit --production
 
-  docker-image:
-    needs: format-taginfo-docs
-    runs-on: ubuntu-22.04
-    continue-on-error: false
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-      - name: Enable osm.pbf cache
-        uses: actions/cache@v3
-        with:
-          path: berlin-latest.osm.pbf
-          key: v1-berlin-osm-pbf
-          restore-keys: |
-            v1-berlin-osm-pbf
-      - name: Docker build
-        run: |
-          docker build -t osrm-backend-local -f docker/Dockerfile .
-      - name: Test Docker image
-        run: |
-          if [ ! -f "${PWD}/berlin-latest.osm.pbf" ]; then
-            wget http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
-          fi
-          TAG=osrm-backend-local
-          # when `--memory-swap` value equals `--memory` it means container won't use swap
-          # see https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details
-          MEMORY_ARGS="--memory=1g --memory-swap=1g"
-          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-extract --dump-nbg-graph -p /opt/car.lua /data/berlin-latest.osm.pbf
-          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-components /data/berlin-latest.osrm.nbg /data/berlin-latest.geojson
-          if [ ! -s "${PWD}/berlin-latest.geojson" ]
-          then
-            >&2 echo "No berlin-latest.geojson found"
-            exit 1
-          fi
+  # docker-image:
+  #   needs: format-taginfo-docs
+  #   runs-on: ubuntu-22.04
+  #   continue-on-error: false
+  #   steps:
+  #     - name: Check out the repo
+  #       uses: actions/checkout@v3
+  #     - name: Enable osm.pbf cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: berlin-latest.osm.pbf
+  #         key: v1-berlin-osm-pbf
+  #         restore-keys: |
+  #           v1-berlin-osm-pbf
+  #     - name: Docker build
+  #       run: |
+  #         docker build -t osrm-backend-local -f docker/Dockerfile .
+  #     - name: Test Docker image
+  #       run: |
+  #         if [ ! -f "${PWD}/berlin-latest.osm.pbf" ]; then
+  #           wget http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
+  #         fi
+  #         TAG=osrm-backend-local
+  #         # when `--memory-swap` value equals `--memory` it means container won't use swap
+  #         # see https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details
+  #         MEMORY_ARGS="--memory=1g --memory-swap=1g"
+  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-extract --dump-nbg-graph -p /opt/car.lua /data/berlin-latest.osm.pbf
+  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-components /data/berlin-latest.osrm.nbg /data/berlin-latest.geojson
+  #         if [ ! -s "${PWD}/berlin-latest.geojson" ]
+  #         then
+  #           >&2 echo "No berlin-latest.geojson found"
+  #           exit 1
+  #         fi
 
-          # removing `.osrm.nbg` to check that whole pipeline works without it
-          rm -rf "${PWD}/berlin-latest.osrm.nbg"
+  #         # removing `.osrm.nbg` to check that whole pipeline works without it
+  #         rm -rf "${PWD}/berlin-latest.osrm.nbg"
 
-          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-partition /data/berlin-latest.osrm
-          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-customize /data/berlin-latest.osrm
-          docker run $MEMORY_ARGS --name=osrm-container -t -p 5000:5000 -v "${PWD}:/data" "${TAG}" osrm-routed --algorithm mld /data/berlin-latest.osrm &
-          curl --retry-delay 3 --retry 10 --retry-all-errors "http://127.0.0.1:5000/route/v1/driving/13.388860,52.517037;13.385983,52.496891?steps=true"
-          docker stop osrm-container
+  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-partition /data/berlin-latest.osrm
+  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-customize /data/berlin-latest.osrm
+  #         docker run $MEMORY_ARGS --name=osrm-container -t -p 5000:5000 -v "${PWD}:/data" "${TAG}" osrm-routed --algorithm mld /data/berlin-latest.osrm &
+  #         curl --retry-delay 3 --retry 10 --retry-all-errors "http://127.0.0.1:5000/route/v1/driving/13.388860,52.517037;13.385983,52.496891?steps=true"
+  #         docker stop osrm-container
 
-  build-test-publish:
-    needs: format-taginfo-docs
-    strategy:
-      matrix:
-        include:
-          - name: gcc-13-debug-cov
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Debug
-            CCOMPILER: gcc-13
-            CUCUMBER_TIMEOUT: 20000
-            CXXCOMPILER: g++-13
-            ENABLE_COVERAGE: ON
+  # build-test-publish:
+  #   needs: format-taginfo-docs
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - name: gcc-13-debug-cov
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Debug
+  #           CCOMPILER: gcc-13
+  #           CUCUMBER_TIMEOUT: 20000
+  #           CXXCOMPILER: g++-13
+  #           ENABLE_COVERAGE: ON
 
-          - name: clang-15-debug-asan-ubsan
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Debug
-            CCOMPILER: clang-15
-            CUCUMBER_TIMEOUT: 20000
-            CXXCOMPILER: clang++-15
-            ENABLE_SANITIZER: ON
-            TARGET_ARCH: x86_64-asan-ubsan
-            OSRM_CONNECTION_RETRIES: 10
-            OSRM_CONNECTION_EXP_BACKOFF_COEF: 1.5
+  #         - name: clang-15-debug-asan-ubsan
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Debug
+  #           CCOMPILER: clang-15
+  #           CUCUMBER_TIMEOUT: 20000
+  #           CXXCOMPILER: clang++-15
+  #           ENABLE_SANITIZER: ON
+  #           TARGET_ARCH: x86_64-asan-ubsan
+  #           OSRM_CONNECTION_RETRIES: 10
+  #           OSRM_CONNECTION_EXP_BACKOFF_COEF: 1.5
 
-          - name: clang-15-release
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang-15
-            CXXCOMPILER: clang++-15
-            CUCUMBER_TIMEOUT: 60000
+  #         - name: clang-15-release
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang-15
+  #           CXXCOMPILER: clang++-15
+  #           CUCUMBER_TIMEOUT: 60000
 
-          - name: clang-15-debug
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Debug
-            CCOMPILER: clang-15
-            CXXCOMPILER: clang++-15
-            CUCUMBER_TIMEOUT: 60000
+  #         - name: clang-15-debug
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Debug
+  #           CCOMPILER: clang-15
+  #           CXXCOMPILER: clang++-15
+  #           CUCUMBER_TIMEOUT: 60000
 
-          - name: clang-15-debug-clang-tidy
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Debug
-            CCOMPILER: clang-15
-            CXXCOMPILER: clang++-15
-            CUCUMBER_TIMEOUT: 60000
-            ENABLE_CLANG_TIDY: ON
+  #         - name: clang-15-debug-clang-tidy
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Debug
+  #           CCOMPILER: clang-15
+  #           CXXCOMPILER: clang++-15
+  #           CUCUMBER_TIMEOUT: 60000
+  #           ENABLE_CLANG_TIDY: ON
 
-          - name: clang-14-release
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang-14
-            CXXCOMPILER: clang++-14
-            CUCUMBER_TIMEOUT: 60000
+  #         - name: clang-14-release
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang-14
+  #           CXXCOMPILER: clang++-14
+  #           CUCUMBER_TIMEOUT: 60000
 
-          - name: clang-13-release
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang-13
-            CXXCOMPILER: clang++-13
-            CUCUMBER_TIMEOUT: 60000
+  #         - name: clang-13-release
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang-13
+  #           CXXCOMPILER: clang++-13
+  #           CUCUMBER_TIMEOUT: 60000
 
-          - name: conan-linux-debug-asan-ubsan
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang-15
-            CXXCOMPILER: clang++-15
-            ENABLE_CONAN: ON
-            ENABLE_SANITIZER: ON
+  #         - name: conan-linux-debug-asan-ubsan
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang-15
+  #           CXXCOMPILER: clang++-15
+  #           ENABLE_CONAN: ON
+  #           ENABLE_SANITIZER: ON
 
-          - name: conan-linux-release
-            continue-on-error: false
-            node: 18
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: clang-15
-            CXXCOMPILER: clang++-15
-            ENABLE_CONAN: ON
+  #         - name: conan-linux-release
+  #           continue-on-error: false
+  #           node: 18
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang-15
+  #           CXXCOMPILER: clang++-15
+  #           ENABLE_CONAN: ON
 
-          - name: gcc-13-release
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-13
-            CXXCOMPILER: g++-13
-            ENABLE_BENCHMARKS: ON
-            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
+  #         - name: gcc-13-release
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: gcc-13
+  #           CXXCOMPILER: g++-13
+  #           ENABLE_BENCHMARKS: ON
+  #           CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
 
-          - name: gcc-12-release
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-12
-            CXXCOMPILER: g++-12
-            ENABLE_BENCHMARKS: ON
-            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
+  #         - name: gcc-12-release
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: gcc-12
+  #           CXXCOMPILER: g++-12
+  #           ENABLE_BENCHMARKS: ON
+  #           CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
 
-          - name: gcc-11-release
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TOOLS: ON
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-11
-            CXXCOMPILER: g++-11
-            ENABLE_BENCHMARKS: ON
+  #         - name: gcc-11-release
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TOOLS: ON
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: gcc-11
+  #           CXXCOMPILER: g++-11
+  #           ENABLE_BENCHMARKS: ON
 
-          - name: conan-linux-release-node
-            build_node_package: true
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TYPE: Release
-            CCOMPILER: clang-13
-            CXXCOMPILER: clang++-13
-            ENABLE_CONAN: ON
-            NODE_PACKAGE_TESTS_ONLY: ON
+  #         - name: conan-linux-release-node
+  #           build_node_package: true
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang-13
+  #           CXXCOMPILER: clang++-13
+  #           ENABLE_CONAN: ON
+  #           NODE_PACKAGE_TESTS_ONLY: ON
 
-          - name: conan-linux-debug-node
-            build_node_package: true
-            continue-on-error: false
-            node: 20
-            runs-on: ubuntu-22.04
-            BUILD_TYPE: Debug
-            CCOMPILER: clang-13
-            CXXCOMPILER: clang++-13
-            ENABLE_CONAN: ON
-            NODE_PACKAGE_TESTS_ONLY: ON
+  #         - name: conan-linux-debug-node
+  #           build_node_package: true
+  #           continue-on-error: false
+  #           node: 20
+  #           runs-on: ubuntu-22.04
+  #           BUILD_TYPE: Debug
+  #           CCOMPILER: clang-13
+  #           CXXCOMPILER: clang++-13
+  #           ENABLE_CONAN: ON
+  #           NODE_PACKAGE_TESTS_ONLY: ON
 
-          - name: conan-macos-x64-release-node
-            build_node_package: true
-            continue-on-error: true
-            node: 20
-            runs-on: macos-13 # x86_64
-            BUILD_TYPE: Release
-            CCOMPILER: clang
-            CXXCOMPILER: clang++
-            CUCUMBER_TIMEOUT: 60000
-            ENABLE_ASSERTIONS: ON
-            ENABLE_CONAN: ON
+  #         - name: conan-macos-x64-release-node
+  #           build_node_package: true
+  #           continue-on-error: true
+  #           node: 20
+  #           runs-on: macos-13 # x86_64
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang
+  #           CXXCOMPILER: clang++
+  #           CUCUMBER_TIMEOUT: 60000
+  #           ENABLE_ASSERTIONS: ON
+  #           ENABLE_CONAN: ON
 
-          - name: conan-macos-arm64-release-node
-            build_node_package: true
-            continue-on-error: true
-            node: 20
-            runs-on: macos-14 # arm64 
-            BUILD_TYPE: Release
-            CCOMPILER: clang
-            CXXCOMPILER: clang++
-            CUCUMBER_TIMEOUT: 60000
-            ENABLE_ASSERTIONS: ON
-            ENABLE_CONAN: ON
+  #         - name: conan-macos-arm64-release-node
+  #           build_node_package: true
+  #           continue-on-error: true
+  #           node: 20
+  #           runs-on: macos-14 # arm64 
+  #           BUILD_TYPE: Release
+  #           CCOMPILER: clang
+  #           CXXCOMPILER: clang++
+  #           CUCUMBER_TIMEOUT: 60000
+  #           ENABLE_ASSERTIONS: ON
+  #           ENABLE_CONAN: ON
 
-    name: ${{ matrix.name}}
-    continue-on-error: ${{ matrix.continue-on-error }}
-    runs-on: ${{ matrix.runs-on }}
-    env:
-      BUILD_TOOLS: ${{ matrix.BUILD_TOOLS }}
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
-      CCOMPILER: ${{ matrix.CCOMPILER }}
-      CFLAGS: ${{ matrix.CFLAGS }}
-      CUCUMBER_TIMEOUT: ${{ matrix.CUCUMBER_TIMEOUT }}
-      CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
-      CXXFLAGS: ${{ matrix.CXXFLAGS }}
-      ENABLE_ASSERTIONS: ${{ matrix.ENABLE_ASSERTIONS }}
-      ENABLE_CLANG_TIDY: ${{ matrix.ENABLE_CLANG_TIDY }}
-      ENABLE_COVERAGE: ${{ matrix.ENABLE_COVERAGE }}
-      ENABLE_CONAN: ${{ matrix.ENABLE_CONAN }}
-      ENABLE_SANITIZER: ${{ matrix.ENABLE_SANITIZER }}
-      NODE_PACKAGE_TESTS_ONLY: ${{ matrix.NODE_PACKAGE_TESTS_ONLY }}
-      TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
-      OSRM_CONNECTION_RETRIES: ${{ matrix.OSRM_CONNECTION_RETRIES }}
-      OSRM_CONNECTION_EXP_BACKOFF_COEF: ${{ matrix.OSRM_CONNECTION_EXP_BACKOFF_COEF }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build machine architecture
-      run: uname -m
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node }}
-    - name: Enable Node.js cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - name: Enable compiler cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: ccache-${{ matrix.name }}-${{ github.sha }}
-        restore-keys: |
-          ccache-${{ matrix.name }}-
-    - name: Enable Conan cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.conan
-        key: v9-conan-${{ matrix.name }}-${{ github.sha }}
-        restore-keys: |
-          v9-conan-${{ matrix.name }}-
-    - name: Enable test cache
-      uses: actions/cache@v3
-      with:
-        path: ${{github.workspace}}/test/cache
-        key: v4-test-${{ matrix.name }}-${{ github.sha }}
-        restore-keys: |
-          v4-test-${{ matrix.name }}-
+  #   name: ${{ matrix.name}}
+  #   continue-on-error: ${{ matrix.continue-on-error }}
+  #   runs-on: ${{ matrix.runs-on }}
+  #   env:
+  #     BUILD_TOOLS: ${{ matrix.BUILD_TOOLS }}
+  #     BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
+  #     BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
+  #     CCOMPILER: ${{ matrix.CCOMPILER }}
+  #     CFLAGS: ${{ matrix.CFLAGS }}
+  #     CUCUMBER_TIMEOUT: ${{ matrix.CUCUMBER_TIMEOUT }}
+  #     CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
+  #     CXXFLAGS: ${{ matrix.CXXFLAGS }}
+  #     ENABLE_ASSERTIONS: ${{ matrix.ENABLE_ASSERTIONS }}
+  #     ENABLE_CLANG_TIDY: ${{ matrix.ENABLE_CLANG_TIDY }}
+  #     ENABLE_COVERAGE: ${{ matrix.ENABLE_COVERAGE }}
+  #     ENABLE_CONAN: ${{ matrix.ENABLE_CONAN }}
+  #     ENABLE_SANITIZER: ${{ matrix.ENABLE_SANITIZER }}
+  #     NODE_PACKAGE_TESTS_ONLY: ${{ matrix.NODE_PACKAGE_TESTS_ONLY }}
+  #     TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
+  #     OSRM_CONNECTION_RETRIES: ${{ matrix.OSRM_CONNECTION_RETRIES }}
+  #     OSRM_CONNECTION_EXP_BACKOFF_COEF: ${{ matrix.OSRM_CONNECTION_EXP_BACKOFF_COEF }}
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Build machine architecture
+  #     run: uname -m
+  #   - name: Use Node.js
+  #     uses: actions/setup-node@v3
+  #     with:
+  #       node-version: ${{ matrix.node }}
+  #   - name: Enable Node.js cache
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/.npm
+  #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+  #       restore-keys: |
+  #         ${{ runner.os }}-node-
+  #   - name: Enable compiler cache
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/.ccache
+  #       key: ccache-${{ matrix.name }}-${{ github.sha }}
+  #       restore-keys: |
+  #         ccache-${{ matrix.name }}-
+  #   - name: Enable Conan cache
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/.conan
+  #       key: v9-conan-${{ matrix.name }}-${{ github.sha }}
+  #       restore-keys: |
+  #         v9-conan-${{ matrix.name }}-
+  #   - name: Enable test cache
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ${{github.workspace}}/test/cache
+  #       key: v4-test-${{ matrix.name }}-${{ github.sha }}
+  #       restore-keys: |
+  #         v4-test-${{ matrix.name }}-
 
-    - name: Prepare environment
-      run: |
-        PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-        echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
-        echo "OSRM_INSTALL_DIR=${GITHUB_WORKSPACE}/install-osrm" >> $GITHUB_ENV
-        echo "OSRM_BUILD_DIR=${GITHUB_WORKSPACE}/build-osrm" >> $GITHUB_ENV
-        if [[ "$ENABLE_SANITIZER" == 'ON' ]]; then
-          # We can only set this after checkout once we know the workspace directory
-          echo "LSAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
-          echo "UBSAN_OPTIONS=symbolize=1:halt_on_error=1:print_stacktrace=1:suppressions=${GITHUB_WORKSPACE}/scripts/ci/undefinedsanitizer.conf" >> $GITHUB_ENV
-          echo "ASAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/addresssanitizer.conf" >> $GITHUB_ENV
-        fi
+  #   - name: Prepare environment
+  #     run: |
+  #       PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+  #       echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
+  #       echo "OSRM_INSTALL_DIR=${GITHUB_WORKSPACE}/install-osrm" >> $GITHUB_ENV
+  #       echo "OSRM_BUILD_DIR=${GITHUB_WORKSPACE}/build-osrm" >> $GITHUB_ENV
+  #       if [[ "$ENABLE_SANITIZER" == 'ON' ]]; then
+  #         # We can only set this after checkout once we know the workspace directory
+  #         echo "LSAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
+  #         echo "UBSAN_OPTIONS=symbolize=1:halt_on_error=1:print_stacktrace=1:suppressions=${GITHUB_WORKSPACE}/scripts/ci/undefinedsanitizer.conf" >> $GITHUB_ENV
+  #         echo "ASAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/addresssanitizer.conf" >> $GITHUB_ENV
+  #       fi
 
-        if [[ "${RUNNER_OS}" == "Linux" ]]; then
-          echo "JOBS=$((`nproc` + 1))" >>  $GITHUB_ENV
-        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-          echo "JOBS=$((`sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
-        fi
+  #       if [[ "${RUNNER_OS}" == "Linux" ]]; then
+  #         echo "JOBS=$((`nproc` + 1))" >>  $GITHUB_ENV
+  #       elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+  #         echo "JOBS=$((`sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
+  #       fi
 
-    - name: Install dev dependencies
-      run: |
-        python3 -m pip install "conan<2.0.0" || python3 -m pip install "conan<2.0.0" --break-system-packages
+  #   - name: Install dev dependencies
+  #     run: |
+  #       python3 -m pip install "conan<2.0.0" || python3 -m pip install "conan<2.0.0" --break-system-packages
 
-        # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
-        # and that's why CI cannot find conan executable installed above
-        if [[ "${RUNNER_OS}" == "macOS" ]]; then
-          echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
-        fi
+  #       # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
+  #       # and that's why CI cannot find conan executable installed above
+  #       if [[ "${RUNNER_OS}" == "macOS" ]]; then
+  #         echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
+  #       fi
 
-        # ccache
-        if [[ "${RUNNER_OS}" == "Linux" ]]; then
-          sudo apt-get update -y && sudo apt-get install ccache
-        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-          brew install ccache
-        fi
+  #       # ccache
+  #       if [[ "${RUNNER_OS}" == "Linux" ]]; then
+  #         sudo apt-get update -y && sudo apt-get install ccache
+  #       elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+  #         brew install ccache
+  #       fi
 
-        # Linux dev packages
-        if [ "${ENABLE_CONAN}" != "ON" ]; then
-          sudo apt-get update -y
-          sudo apt-get install -y libbz2-dev libxml2-dev libzip-dev liblua5.2-dev libboost-all-dev
-          if [[ "${CCOMPILER}" != clang-* ]]; then
-            sudo apt-get install -y ${CXXCOMPILER}
-          fi
-          if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
-            sudo apt-get install -y lcov
-          fi
-        fi
+  #       # Linux dev packages
+  #       if [ "${ENABLE_CONAN}" != "ON" ]; then
+  #         sudo apt-get update -y
+  #         sudo apt-get install -y libbz2-dev libxml2-dev libzip-dev liblua5.2-dev libboost-all-dev
+  #         if [[ "${CCOMPILER}" != clang-* ]]; then
+  #           sudo apt-get install -y ${CXXCOMPILER}
+  #         fi
+  #         if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
+  #           sudo apt-get install -y lcov
+  #         fi
+  #       fi
 
-        # TBB
-        TBB_VERSION=2021.3.0
-        if [[ "${RUNNER_OS}" == "Linux" ]]; then
-          TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-lin.tgz"
-        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-          TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-mac.tgz"
-        fi
-        wget --tries 5 ${TBB_URL} -O onetbb.tgz
-        tar zxvf onetbb.tgz
-        sudo cp -a oneapi-tbb-${TBB_VERSION}/lib/. /usr/local/lib/
-        sudo cp -a oneapi-tbb-${TBB_VERSION}/include/. /usr/local/include/
-    - name: Prepare build
-      run: |
-        mkdir ${OSRM_BUILD_DIR}
-        ccache --max-size=256M
-        npm ci --ignore-scripts
-        if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
-          lcov --directory . --zerocounters # clean cached files
-        fi
-        echo "CC=${CCOMPILER}" >> $GITHUB_ENV
-        echo "CXX=${CXXCOMPILER}" >> $GITHUB_ENV
-        if [[ "${RUNNER_OS}" == "macOS" ]]; then
-          # missing from GCC path, needed for conan builds of libiconv, for example.
-          sudo xcode-select --switch /Library/Developer/CommandLineTools
-          echo "LIBRARY_PATH=${LIBRARY_PATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV
-          echo "CPATH=${CPATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" >> $GITHUB_ENV
-        fi
+  #       # TBB
+  #       TBB_VERSION=2021.3.0
+  #       if [[ "${RUNNER_OS}" == "Linux" ]]; then
+  #         TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-lin.tgz"
+  #       elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+  #         TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-mac.tgz"
+  #       fi
+  #       wget --tries 5 ${TBB_URL} -O onetbb.tgz
+  #       tar zxvf onetbb.tgz
+  #       sudo cp -a oneapi-tbb-${TBB_VERSION}/lib/. /usr/local/lib/
+  #       sudo cp -a oneapi-tbb-${TBB_VERSION}/include/. /usr/local/include/
+  #   - name: Prepare build
+  #     run: |
+  #       mkdir ${OSRM_BUILD_DIR}
+  #       ccache --max-size=256M
+  #       npm ci --ignore-scripts
+  #       if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
+  #         lcov --directory . --zerocounters # clean cached files
+  #       fi
+  #       echo "CC=${CCOMPILER}" >> $GITHUB_ENV
+  #       echo "CXX=${CXXCOMPILER}" >> $GITHUB_ENV
+  #       if [[ "${RUNNER_OS}" == "macOS" ]]; then
+  #         # missing from GCC path, needed for conan builds of libiconv, for example.
+  #         sudo xcode-select --switch /Library/Developer/CommandLineTools
+  #         echo "LIBRARY_PATH=${LIBRARY_PATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV
+  #         echo "CPATH=${CPATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" >> $GITHUB_ENV
+  #       fi
 
-    - name: Build and install OSRM
-      run: |
-        echo "Using ${JOBS} jobs"
-        pushd ${OSRM_BUILD_DIR}
+  #   - name: Build and install OSRM
+  #     run: |
+  #       echo "Using ${JOBS} jobs"
+  #       pushd ${OSRM_BUILD_DIR}
 
 
-        cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-                 -DENABLE_CONAN=${ENABLE_CONAN:-OFF} \
-                 -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} \
-                 -DENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF} \
-                 -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} \
-                 -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} \
-                 -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
-                 -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} \
-                 -DBUILD_TOOLS=${BUILD_TOOLS:-OFF} \
-                 -DENABLE_CCACHE=ON \
-                 -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
-        make --jobs=${JOBS}
+  #       cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+  #                -DENABLE_CONAN=${ENABLE_CONAN:-OFF} \
+  #                -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} \
+  #                -DENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF} \
+  #                -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} \
+  #                -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} \
+  #                -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
+  #                -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} \
+  #                -DBUILD_TOOLS=${BUILD_TOOLS:-OFF} \
+  #                -DENABLE_CCACHE=ON \
+  #                -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+  #       make --jobs=${JOBS}
 
-        if [[ "${NODE_PACKAGE_TESTS_ONLY}" != "ON" ]]; then
-          make tests --jobs=${JOBS}
-          make benchmarks --jobs=${JOBS}
-          ccache -s
-          sudo make install
-          if [[ "${RUNNER_OS}" == "Linux" ]]; then
-            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OSRM_INSTALL_DIR}/lib" >> $GITHUB_ENV
-          fi
-          echo "PKG_CONFIG_PATH=${OSRM_INSTALL_DIR}/lib/pkgconfig" >> $GITHUB_ENV
-        fi
-        popd
-    - name: Build example
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
-      run: |
-        mkdir example/build && pushd example/build
-        cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-        make --jobs=${JOBS}
-        popd
-    - name: Run all tests
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
-      run: |
-        make -C test/data benchmark
+  #       if [[ "${NODE_PACKAGE_TESTS_ONLY}" != "ON" ]]; then
+  #         make tests --jobs=${JOBS}
+  #         make benchmarks --jobs=${JOBS}
+  #         ccache -s
+  #         sudo make install
+  #         if [[ "${RUNNER_OS}" == "Linux" ]]; then
+  #           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OSRM_INSTALL_DIR}/lib" >> $GITHUB_ENV
+  #         fi
+  #         echo "PKG_CONFIG_PATH=${OSRM_INSTALL_DIR}/lib/pkgconfig" >> $GITHUB_ENV
+  #       fi
+  #       popd
+  #   - name: Build example
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
+  #     run: |
+  #       mkdir example/build && pushd example/build
+  #       cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+  #       make --jobs=${JOBS}
+  #       popd
+  #   - name: Run all tests
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
+  #     run: |
+  #       make -C test/data benchmark
 
-        # macOS SIP strips the linker path. Reset this inside the running shell
-        export LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
-        ./example/build/osrm-example test/data/mld/monaco.osrm
+  #       # macOS SIP strips the linker path. Reset this inside the running shell
+  #       export LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
+  #       ./example/build/osrm-example test/data/mld/monaco.osrm
 
-        # All tests assume to be run from the build directory
-        pushd ${OSRM_BUILD_DIR}
-        for i in ./unit_tests/*-tests ; do echo Running $i ; $i ; done
-        if [ -z "${ENABLE_SANITIZER}" ]; then
-          npm run nodejs-tests
-        fi
-        popd
-        npm test
-    - name: Run benchmarks
-      if: ${{ matrix.ENABLE_BENCHMARKS == 'ON' }}
-      run: |
-        pushd ${OSRM_BUILD_DIR}
-        make --jobs=${JOBS} benchmarks
-        ./src/benchmarks/alias-bench
-        ./src/benchmarks/json-render-bench ../src/benchmarks/portugal_to_korea.json
-        ./src/benchmarks/match-bench ../test/data/ch/monaco.osrm
-        ./src/benchmarks/packedvector-bench
-        ./src/benchmarks/rtree-bench ../test/data/monaco.osrm.ramIndex ../test/data/monaco.osrm.fileIndex ../test/data/monaco.osrm.nbg_nodes
-        popd
+  #       # All tests assume to be run from the build directory
+  #       pushd ${OSRM_BUILD_DIR}
+  #       for i in ./unit_tests/*-tests ; do echo Running $i ; $i ; done
+  #       if [ -z "${ENABLE_SANITIZER}" ]; then
+  #         npm run nodejs-tests
+  #       fi
+  #       popd
+  #       npm test
+  #   - name: Run benchmarks
+  #     if: ${{ matrix.ENABLE_BENCHMARKS == 'ON' }}
+  #     run: |
+  #       pushd ${OSRM_BUILD_DIR}
+  #       make --jobs=${JOBS} benchmarks
+  #       ./src/benchmarks/alias-bench
+  #       ./src/benchmarks/json-render-bench ../src/benchmarks/portugal_to_korea.json
+  #       ./src/benchmarks/match-bench ../test/data/ch/monaco.osrm
+  #       ./src/benchmarks/packedvector-bench
+  #       ./src/benchmarks/rtree-bench ../test/data/monaco.osrm.ramIndex ../test/data/monaco.osrm.fileIndex ../test/data/monaco.osrm.nbg_nodes
+  #       popd
 
-    - name: Use Node 18
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - name: Run Node package tests on Node 18
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-      run: |
-        node --version
-        npm run nodejs-tests
-    - name: Use Node 20
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: 20
-    - name: Run Node package tests on Node 20
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-      run: |
-        node --version
-        npm run nodejs-tests
-    - name: Use Node latest
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: latest
-    - name: Run Node package tests on Node-latest
-      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-      run: |
-        node --version
-        npm run nodejs-tests
+  #   - name: Use Node 18
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+  #     uses: actions/setup-node@v3
+  #     with:
+  #       node-version: 18
+  #   - name: Run Node package tests on Node 18
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+  #     run: |
+  #       node --version
+  #       npm run nodejs-tests
+  #   - name: Use Node 20
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+  #     uses: actions/setup-node@v3
+  #     with:
+  #       node-version: 20
+  #   - name: Run Node package tests on Node 20
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+  #     run: |
+  #       node --version
+  #       npm run nodejs-tests
+  #   - name: Use Node latest
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+  #     uses: actions/setup-node@v3
+  #     with:
+  #       node-version: latest
+  #   - name: Run Node package tests on Node-latest
+  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+  #     run: |
+  #       node --version
+  #       npm run nodejs-tests
 
-    - name: Upload test logs
-      uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: logs
-        path: test/logs/
+  #   - name: Upload test logs
+  #     uses: actions/upload-artifact@v3
+  #     if: failure()
+  #     with:
+  #       name: logs
+  #       path: test/logs/
 
-    # - name: Generate code coverage
-    #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
-    #   run: |
-    #     lcov --directory . --capture --output-file coverage.info # capture coverage info
-    #     lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
-    #     lcov --list coverage.info #debug info
+  #   # - name: Generate code coverage
+  #   #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
+  #   #   run: |
+  #   #     lcov --directory . --capture --output-file coverage.info # capture coverage info
+  #   #     lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
+  #   #     lcov --list coverage.info #debug info
     
-    # # Uploading report to CodeCov
-    # - name: Upload code coverage
-    #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
-    #   uses: codecov/codecov-action@v1
-    #   with:
-    #     files: coverage.info
-    #     name: codecov-osrm-backend
-    #     fail_ci_if_error: true
-    #     verbose: true
-    - name: Build Node package
-      if: ${{ matrix.build_node_package }}
-      run: ./scripts/ci/node_package.sh
-    - name: Publish Node package
-      if: ${{ matrix.build_node_package && env.PUBLISH == 'On' }}
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: true
-        artifactErrorsFailBuild: true
-        artifacts: build/stage/**/*.tar.gz
-        omitBody: true
-        omitBodyDuringUpdate: true
-        omitName: true
-        omitNameDuringUpdate: true
-        replacesArtifacts: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+  #   # # Uploading report to CodeCov
+  #   # - name: Upload code coverage
+  #   #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
+  #   #   uses: codecov/codecov-action@v1
+  #   #   with:
+  #   #     files: coverage.info
+  #   #     name: codecov-osrm-backend
+  #   #     fail_ci_if_error: true
+  #   #     verbose: true
+  #   - name: Build Node package
+  #     if: ${{ matrix.build_node_package }}
+  #     run: ./scripts/ci/node_package.sh
+  #   - name: Publish Node package
+  #     if: ${{ matrix.build_node_package && env.PUBLISH == 'On' }}
+  #     uses: ncipollo/release-action@v1
+  #     with:
+  #       allowUpdates: true
+  #       artifactErrorsFailBuild: true
+  #       artifacts: build/stage/**/*.tar.gz
+  #       omitBody: true
+  #       omitBodyDuringUpdate: true
+  #       omitName: true
+  #       omitNameDuringUpdate: true
+  #       replacesArtifacts: true
+  #       token: ${{ secrets.GITHUB_TOKEN }}
 
-  ci-complete:
+  # ci-complete:
+  #   runs-on: ubuntu-22.04
+  #   needs: [build-test-publish, docker-image, windows-release-node]
+  #   steps:
+  #   - run: echo "CI complete"
+
+  benchmarks:
     runs-on: ubuntu-22.04
-    needs: [build-test-publish, docker-image, windows-release-node]
-    steps:
-    - run: echo "CI complete"
+    steps: 
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
+          make -j$(nproc) benchmarks
+      - name: Run Benchmark on Master Branch
+        run: |
+          ./build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > pr_bench.txt
+      - name: Checkout Master Branch
+        uses: actions/checkout@v3
+        with:
+          ref: master
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
+          make -j$(nproc) benchmarks
+      - name: Run Benchmark on Master Branch
+        run: |
+          ./build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > master_bench.txt
+      - name: Compare Benchmarks
+        run: |
+          cat pr_bench.txt
+          cat master_bench.txt

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -607,41 +607,49 @@ jobs:
       CXXCOMPILER: clang++-13
       CC: clang-13
       CXX: clang++-13
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps: 
       - name: Checkout PR Branch
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          path: pr
       - run: pip install "conan<2.0.0"
       - name: Build
         run: |
-          rm -rf build
-          mkdir build
-          cd build
+          mkdir -p pr/build
+          cd pr/build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
+          make -j$(nproc) 
           make -j$(nproc) benchmarks
           cd ..
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
-          ./build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > pr_bench.txt
+          ./pr/build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > pr_bench.txt
       - name: Checkout Master Branch
         uses: actions/checkout@v3
         with:
           ref: master
+          path: master
       - name: Build
         run: |
-          rm -rf build
-          mkdir build
-          cd build
+          mkdir master/build
+          cd master/build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
+          make -j$(nproc)
           make -j$(nproc) benchmarks
           cd ..
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
-          ./build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > master_bench.txt
+          ./master/build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > master_bench.txt
       - name: Compare Benchmarks
         run: |
           cat pr_bench.txt
           cat master_bench.txt
+            - name: Run benchmark and update PR
+      - name: Post Benchmark Results
+        run: |
+          python3 scripts/ci/post_benchmark_results.py

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -640,15 +640,15 @@ jobs:
           make -j$(nproc) benchmarks
           cd ..
           make -C test/data 
-      - name: Checkout Master Branch
+      - name: Checkout Base Branch
         uses: actions/checkout@v3
         with:
-          ref: master
-          path: master
-      - name: Build Master Branch
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base
+      - name: Build Base Branch
         run: |
-          mkdir master/build
-          cd master/build
+          mkdir base/build
+          cd base/build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
           make -j$(nproc)
           make -j$(nproc) benchmarks
@@ -656,11 +656,11 @@ jobs:
           make -C test/data 
       - name: Run Benchmarks
         run: |
-          ./scripts/ci/run_benchmarks.sh master pr
+          ./pr/scripts/ci/run_benchmarks.sh base pr
       - name: Compare Benchmarks
         run: |
           cat pr_results/match_mld.bench
-          cat master_results/match_mld.bench
+          cat base_results/match_mld.bench
       - name: Post Benchmark Results
         run: |
-          python3 pr/scripts/ci/post_benchmark_results.py master_results pr_results
+          python3 pr/scripts/ci/post_benchmark_results.py base_results pr_results

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -615,7 +615,7 @@ jobs:
       - name: Enable compiler cache
         uses: actions/cache@v3
         with:
-          path: ~/.ccache
+          paths: ["~/.ccache", "~/.cache/ccache"]
           key: v1-ccache-benchmarks-${{ github.sha }}
           restore-keys: |
             v1-ccache-benchmarks-

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -620,6 +620,7 @@ jobs:
           cd build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
           make -j$(nproc) benchmarks
+          cd ..
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
@@ -635,6 +636,7 @@ jobs:
           cd build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
           make -j$(nproc) benchmarks
+          cd ..
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -615,7 +615,7 @@ jobs:
       - name: Enable compiler cache
         uses: actions/cache@v3
         with:
-          paths: ["~/.ccache", "~/.cache/ccache"]
+          path: ~/.cache/ccache
           key: v1-ccache-benchmarks-${{ github.sha }}
           restore-keys: |
             v1-ccache-benchmarks-

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -644,7 +644,7 @@ jobs:
       - name: Checkout Base Branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.head_ref }} #${{ github.event.pull_request.base.ref }}
           path: base
       - name: Build Base Branch
         run: |

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -607,6 +607,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+      - run: pip install "conan<2.0.0"
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -611,20 +611,20 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps: 
-    - name: Enable compiler cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: v1-ccache-benchmarks-${{ github.sha }}
-        restore-keys: |
-          v1-ccache-benchmarks-
-    - name: Enable Conan cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.conan
-        key: v1-conan-benchmarks-${{ github.sha }}
-        restore-keys: |
-          v1-conan-benchmarks-
+      - name: Enable compiler cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: v1-ccache-benchmarks-${{ github.sha }}
+          restore-keys: |
+            v1-ccache-benchmarks-
+      - name: Enable Conan cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.conan
+          key: v1-conan-benchmarks-${{ github.sha }}
+          restore-keys: |
+            v1-conan-benchmarks-
       - name: Checkout PR Branch
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -359,20 +359,20 @@ jobs:
   #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
   #       restore-keys: |
   #         ${{ runner.os }}-node-
-  #   - name: Enable compiler cache
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/.ccache
-  #       key: ccache-${{ matrix.name }}-${{ github.sha }}
-  #       restore-keys: |
-  #         ccache-${{ matrix.name }}-
-  #   - name: Enable Conan cache
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/.conan
-  #       key: v9-conan-${{ matrix.name }}-${{ github.sha }}
-  #       restore-keys: |
-  #         v9-conan-${{ matrix.name }}-
+    # - name: Enable compiler cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/.ccache
+    #     key: ccache-${{ matrix.name }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ccache-${{ matrix.name }}-
+    # - name: Enable Conan cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/.conan
+    #     key: v9-conan-${{ matrix.name }}-${{ github.sha }}
+    #     restore-keys: |
+    #       v9-conan-${{ matrix.name }}-
   #   - name: Enable test cache
   #     uses: actions/cache@v3
   #     with:
@@ -611,12 +611,26 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps: 
+    - name: Enable compiler cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: v1-ccache-benchmarks-${{ github.sha }}
+        restore-keys: |
+          v1-ccache-benchmarks-
+    - name: Enable Conan cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.conan
+        key: v1-conan-benchmarks-${{ github.sha }}
+        restore-keys: |
+          v1-conan-benchmarks-
       - name: Checkout PR Branch
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           path: pr
-      - run: pip install "conan<2.0.0"
+      - run: python3 -m pip install "conan<2.0.0" "requests==2.31.0"
       - name: Build
         run: |
           mkdir -p pr/build
@@ -628,7 +642,7 @@ jobs:
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
-          ./pr/build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > pr_bench.txt
+          ./pr/build/src/benchmarks/match-bench ./pr/test/data/mld/monaco.osrm mld > pr_bench.txt
       - name: Checkout Master Branch
         uses: actions/checkout@v3
         with:
@@ -645,7 +659,7 @@ jobs:
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
-          ./master/build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > master_bench.txt
+          ./master/build/src/benchmarks/match-bench ./master/test/data/mld/monaco.osrm mld > master_bench.txt
       - name: Compare Benchmarks
         run: |
           cat pr_bench.txt

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -601,6 +601,7 @@ jobs:
   #   - run: echo "CI complete"
 
   benchmarks:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     env:
       CCOMPILER: clang-13

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -602,6 +602,9 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-22.04
+    env:
+      CFLAGS: clang-13
+      CXXCOMPILER: clang++-13
     steps: 
       - name: Checkout PR Branch
         uses: actions/checkout@v3

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -24,584 +24,566 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # windows-release-node:
-  #   needs: format-taginfo-docs
-  #   runs-on: windows-2022
-  #   continue-on-error: false
-  #   env:
-  #     BUILD_TYPE: Release
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - run: pip install "conan<2.0.0"
-  #   - run: conan --version
-  #   - run: cmake --version
-  #   - uses: actions/setup-node@v3
-  #     with:
-  #       node-version: 18
-  #   - run: node --version
-  #   - run: npm --version
-  #   - name: Prepare environment
-  #     shell: bash
-  #     run: |
-  #       PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-  #       echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
-  #   - run: npm install --ignore-scripts
-  #   - run: npm link --ignore-scripts
-  #   - uses: microsoft/setup-msbuild@v1.1
-  #   - name: Build
-  #     run: |
-  #       .\scripts\ci\windows-build.bat
-  #   - name: Run node tests
-  #     shell: bash
-  #     run: |
-  #       ./lib/binding/osrm-datastore.exe test/data/ch/monaco.osrm
-  #       node test/nodejs/index.js
-  #   - name: Build Node package
-  #     shell: bash
-  #     run: ./scripts/ci/node_package.sh
-  #   - name: Publish Node package
-  #     if: ${{ env.PUBLISH == 'On' }}
-  #     uses: ncipollo/release-action@v1
-  #     with:
-  #       allowUpdates: true
-  #       artifactErrorsFailBuild: true
-  #       artifacts: build/stage/**/*.tar.gz
-  #       omitBody: true
-  #       omitBodyDuringUpdate: true
-  #       omitName: true
-  #       omitNameDuringUpdate: true
-  #       replacesArtifacts: true
-  #       token: ${{ secrets.GITHUB_TOKEN }}
+  windows-release-node:
+    needs: format-taginfo-docs
+    runs-on: windows-2022
+    continue-on-error: false
+    env:
+      BUILD_TYPE: Release
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install "conan<2.0.0"
+    - run: conan --version
+    - run: cmake --version
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - run: node --version
+    - run: npm --version
+    - name: Prepare environment
+      shell: bash
+      run: |
+        PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+        echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
+    - run: npm install --ignore-scripts
+    - run: npm link --ignore-scripts
+    - uses: microsoft/setup-msbuild@v1.1
+    - name: Build
+      run: |
+        .\scripts\ci\windows-build.bat
+    - name: Run node tests
+      shell: bash
+      run: |
+        ./lib/binding/osrm-datastore.exe test/data/ch/monaco.osrm
+        node test/nodejs/index.js
+    - name: Build Node package
+      shell: bash
+      run: ./scripts/ci/node_package.sh
+    - name: Publish Node package
+      if: ${{ env.PUBLISH == 'On' }}
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true
+        artifactErrorsFailBuild: true
+        artifacts: build/stage/**/*.tar.gz
+        omitBody: true
+        omitBodyDuringUpdate: true
+        omitName: true
+        omitNameDuringUpdate: true
+        replacesArtifacts: true
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-  # format-taginfo-docs:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Use Node.js
-  #     uses: actions/setup-node@v3
-  #     with:
-  #       node-version: 18
-  #   - name: Enable Node.js cache
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/.npm
-  #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-  #       restore-keys: |
-  #         ${{ runner.os }}-node-
-  #   - name: Prepare environment
-  #     run: |
-  #       npm ci --ignore-scripts
-  #       clang-format-15 --version
-  #   - name: Run checks
-  #     run: |
-  #       ./scripts/check_taginfo.py taginfo.json profiles/car.lua
-  #       ./scripts/format.sh && ./scripts/error_on_dirty.sh
-  #       node ./scripts/validate_changelog.js
-  #       npm run docs && ./scripts/error_on_dirty.sh
-  #       npm audit --production
+  format-taginfo-docs:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Enable Node.js cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Prepare environment
+      run: |
+        npm ci --ignore-scripts
+        clang-format-15 --version
+    - name: Run checks
+      run: |
+        ./scripts/check_taginfo.py taginfo.json profiles/car.lua
+        ./scripts/format.sh && ./scripts/error_on_dirty.sh
+        node ./scripts/validate_changelog.js
+        npm run docs && ./scripts/error_on_dirty.sh
+        npm audit --production
 
-  # docker-image:
-  #   needs: format-taginfo-docs
-  #   runs-on: ubuntu-22.04
-  #   continue-on-error: false
-  #   steps:
-  #     - name: Check out the repo
-  #       uses: actions/checkout@v3
-  #     - name: Enable osm.pbf cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: berlin-latest.osm.pbf
-  #         key: v1-berlin-osm-pbf
-  #         restore-keys: |
-  #           v1-berlin-osm-pbf
-  #     - name: Docker build
-  #       run: |
-  #         docker build -t osrm-backend-local -f docker/Dockerfile .
-  #     - name: Test Docker image
-  #       run: |
-  #         if [ ! -f "${PWD}/berlin-latest.osm.pbf" ]; then
-  #           wget http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
-  #         fi
-  #         TAG=osrm-backend-local
-  #         # when `--memory-swap` value equals `--memory` it means container won't use swap
-  #         # see https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details
-  #         MEMORY_ARGS="--memory=1g --memory-swap=1g"
-  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-extract --dump-nbg-graph -p /opt/car.lua /data/berlin-latest.osm.pbf
-  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-components /data/berlin-latest.osrm.nbg /data/berlin-latest.geojson
-  #         if [ ! -s "${PWD}/berlin-latest.geojson" ]
-  #         then
-  #           >&2 echo "No berlin-latest.geojson found"
-  #           exit 1
-  #         fi
+  docker-image:
+    needs: format-taginfo-docs
+    runs-on: ubuntu-22.04
+    continue-on-error: false
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Enable osm.pbf cache
+        uses: actions/cache@v3
+        with:
+          path: berlin-latest.osm.pbf
+          key: v1-berlin-osm-pbf
+          restore-keys: |
+            v1-berlin-osm-pbf
+      - name: Docker build
+        run: |
+          docker build -t osrm-backend-local -f docker/Dockerfile .
+      - name: Test Docker image
+        run: |
+          if [ ! -f "${PWD}/berlin-latest.osm.pbf" ]; then
+            wget http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
+          fi
+          TAG=osrm-backend-local
+          # when `--memory-swap` value equals `--memory` it means container won't use swap
+          # see https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details
+          MEMORY_ARGS="--memory=1g --memory-swap=1g"
+          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-extract --dump-nbg-graph -p /opt/car.lua /data/berlin-latest.osm.pbf
+          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-components /data/berlin-latest.osrm.nbg /data/berlin-latest.geojson
+          if [ ! -s "${PWD}/berlin-latest.geojson" ]
+          then
+            >&2 echo "No berlin-latest.geojson found"
+            exit 1
+          fi
 
-  #         # removing `.osrm.nbg` to check that whole pipeline works without it
-  #         rm -rf "${PWD}/berlin-latest.osrm.nbg"
+          # removing `.osrm.nbg` to check that whole pipeline works without it
+          rm -rf "${PWD}/berlin-latest.osrm.nbg"
 
-  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-partition /data/berlin-latest.osrm
-  #         docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-customize /data/berlin-latest.osrm
-  #         docker run $MEMORY_ARGS --name=osrm-container -t -p 5000:5000 -v "${PWD}:/data" "${TAG}" osrm-routed --algorithm mld /data/berlin-latest.osrm &
-  #         curl --retry-delay 3 --retry 10 --retry-all-errors "http://127.0.0.1:5000/route/v1/driving/13.388860,52.517037;13.385983,52.496891?steps=true"
-  #         docker stop osrm-container
+          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-partition /data/berlin-latest.osrm
+          docker run $MEMORY_ARGS -t -v "${PWD}:/data" "${TAG}" osrm-customize /data/berlin-latest.osrm
+          docker run $MEMORY_ARGS --name=osrm-container -t -p 5000:5000 -v "${PWD}:/data" "${TAG}" osrm-routed --algorithm mld /data/berlin-latest.osrm &
+          curl --retry-delay 3 --retry 10 --retry-all-errors "http://127.0.0.1:5000/route/v1/driving/13.388860,52.517037;13.385983,52.496891?steps=true"
+          docker stop osrm-container
 
-  # build-test-publish:
-  #   needs: format-taginfo-docs
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - name: gcc-13-debug-cov
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Debug
-  #           CCOMPILER: gcc-13
-  #           CUCUMBER_TIMEOUT: 20000
-  #           CXXCOMPILER: g++-13
-  #           ENABLE_COVERAGE: ON
+  build-test-publish:
+    needs: format-taginfo-docs
+    strategy:
+      matrix:
+        include:
+          - name: gcc-13-debug-cov
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Debug
+            CCOMPILER: gcc-13
+            CUCUMBER_TIMEOUT: 20000
+            CXXCOMPILER: g++-13
+            ENABLE_COVERAGE: ON
 
-  #         - name: clang-15-debug-asan-ubsan
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Debug
-  #           CCOMPILER: clang-15
-  #           CUCUMBER_TIMEOUT: 20000
-  #           CXXCOMPILER: clang++-15
-  #           ENABLE_SANITIZER: ON
-  #           TARGET_ARCH: x86_64-asan-ubsan
-  #           OSRM_CONNECTION_RETRIES: 10
-  #           OSRM_CONNECTION_EXP_BACKOFF_COEF: 1.5
+          - name: clang-15-debug-asan-ubsan
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Debug
+            CCOMPILER: clang-15
+            CUCUMBER_TIMEOUT: 20000
+            CXXCOMPILER: clang++-15
+            ENABLE_SANITIZER: ON
+            TARGET_ARCH: x86_64-asan-ubsan
+            OSRM_CONNECTION_RETRIES: 10
+            OSRM_CONNECTION_EXP_BACKOFF_COEF: 1.5
 
-  #         - name: clang-15-release
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang-15
-  #           CXXCOMPILER: clang++-15
-  #           CUCUMBER_TIMEOUT: 60000
+          - name: clang-15-release
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
+            CUCUMBER_TIMEOUT: 60000
 
-  #         - name: clang-15-debug
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Debug
-  #           CCOMPILER: clang-15
-  #           CXXCOMPILER: clang++-15
-  #           CUCUMBER_TIMEOUT: 60000
+          - name: clang-15-debug
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Debug
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
+            CUCUMBER_TIMEOUT: 60000
 
-  #         - name: clang-15-debug-clang-tidy
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Debug
-  #           CCOMPILER: clang-15
-  #           CXXCOMPILER: clang++-15
-  #           CUCUMBER_TIMEOUT: 60000
-  #           ENABLE_CLANG_TIDY: ON
+          - name: clang-15-debug-clang-tidy
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Debug
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
+            CUCUMBER_TIMEOUT: 60000
+            ENABLE_CLANG_TIDY: ON
 
-  #         - name: clang-14-release
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang-14
-  #           CXXCOMPILER: clang++-14
-  #           CUCUMBER_TIMEOUT: 60000
+          - name: clang-14-release
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-14
+            CXXCOMPILER: clang++-14
+            CUCUMBER_TIMEOUT: 60000
 
-  #         - name: clang-13-release
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang-13
-  #           CXXCOMPILER: clang++-13
-  #           CUCUMBER_TIMEOUT: 60000
+          - name: clang-13-release
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-13
+            CXXCOMPILER: clang++-13
+            CUCUMBER_TIMEOUT: 60000
 
-  #         - name: conan-linux-debug-asan-ubsan
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang-15
-  #           CXXCOMPILER: clang++-15
-  #           ENABLE_CONAN: ON
-  #           ENABLE_SANITIZER: ON
+          - name: conan-linux-debug-asan-ubsan
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
+            ENABLE_CONAN: ON
+            ENABLE_SANITIZER: ON
 
-  #         - name: conan-linux-release
-  #           continue-on-error: false
-  #           node: 18
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang-15
-  #           CXXCOMPILER: clang++-15
-  #           ENABLE_CONAN: ON
+          - name: conan-linux-release
+            continue-on-error: false
+            node: 18
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: clang-15
+            CXXCOMPILER: clang++-15
+            ENABLE_CONAN: ON
 
-  #         - name: gcc-13-release
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: gcc-13
-  #           CXXCOMPILER: g++-13
-  #           ENABLE_BENCHMARKS: ON
-  #           CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
+          - name: gcc-13-release
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-13
+            CXXCOMPILER: g++-13
+            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
 
-  #         - name: gcc-12-release
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: gcc-12
-  #           CXXCOMPILER: g++-12
-  #           ENABLE_BENCHMARKS: ON
-  #           CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
+          - name: gcc-12-release
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-12
+            CXXCOMPILER: g++-12
+            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
 
-  #         - name: gcc-11-release
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TOOLS: ON
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: gcc-11
-  #           CXXCOMPILER: g++-11
-  #           ENABLE_BENCHMARKS: ON
+          - name: gcc-11-release
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TOOLS: ON
+            BUILD_TYPE: Release
+            CCOMPILER: gcc-11
+            CXXCOMPILER: g++-11
 
-  #         - name: conan-linux-release-node
-  #           build_node_package: true
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang-13
-  #           CXXCOMPILER: clang++-13
-  #           ENABLE_CONAN: ON
-  #           NODE_PACKAGE_TESTS_ONLY: ON
+          - name: conan-linux-release-node
+            build_node_package: true
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TYPE: Release
+            CCOMPILER: clang-13
+            CXXCOMPILER: clang++-13
+            ENABLE_CONAN: ON
+            NODE_PACKAGE_TESTS_ONLY: ON
 
-  #         - name: conan-linux-debug-node
-  #           build_node_package: true
-  #           continue-on-error: false
-  #           node: 20
-  #           runs-on: ubuntu-22.04
-  #           BUILD_TYPE: Debug
-  #           CCOMPILER: clang-13
-  #           CXXCOMPILER: clang++-13
-  #           ENABLE_CONAN: ON
-  #           NODE_PACKAGE_TESTS_ONLY: ON
+          - name: conan-linux-debug-node
+            build_node_package: true
+            continue-on-error: false
+            node: 20
+            runs-on: ubuntu-22.04
+            BUILD_TYPE: Debug
+            CCOMPILER: clang-13
+            CXXCOMPILER: clang++-13
+            ENABLE_CONAN: ON
+            NODE_PACKAGE_TESTS_ONLY: ON
 
-  #         - name: conan-macos-x64-release-node
-  #           build_node_package: true
-  #           continue-on-error: true
-  #           node: 20
-  #           runs-on: macos-13 # x86_64
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang
-  #           CXXCOMPILER: clang++
-  #           CUCUMBER_TIMEOUT: 60000
-  #           ENABLE_ASSERTIONS: ON
-  #           ENABLE_CONAN: ON
+          - name: conan-macos-x64-release-node
+            build_node_package: true
+            continue-on-error: true
+            node: 20
+            runs-on: macos-13 # x86_64
+            BUILD_TYPE: Release
+            CCOMPILER: clang
+            CXXCOMPILER: clang++
+            CUCUMBER_TIMEOUT: 60000
+            ENABLE_ASSERTIONS: ON
+            ENABLE_CONAN: ON
 
-  #         - name: conan-macos-arm64-release-node
-  #           build_node_package: true
-  #           continue-on-error: true
-  #           node: 20
-  #           runs-on: macos-14 # arm64 
-  #           BUILD_TYPE: Release
-  #           CCOMPILER: clang
-  #           CXXCOMPILER: clang++
-  #           CUCUMBER_TIMEOUT: 60000
-  #           ENABLE_ASSERTIONS: ON
-  #           ENABLE_CONAN: ON
+          - name: conan-macos-arm64-release-node
+            build_node_package: true
+            continue-on-error: true
+            node: 20
+            runs-on: macos-14 # arm64 
+            BUILD_TYPE: Release
+            CCOMPILER: clang
+            CXXCOMPILER: clang++
+            CUCUMBER_TIMEOUT: 60000
+            ENABLE_ASSERTIONS: ON
+            ENABLE_CONAN: ON
 
-  #   name: ${{ matrix.name}}
-  #   continue-on-error: ${{ matrix.continue-on-error }}
-  #   runs-on: ${{ matrix.runs-on }}
-  #   env:
-  #     BUILD_TOOLS: ${{ matrix.BUILD_TOOLS }}
-  #     BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-  #     BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
-  #     CCOMPILER: ${{ matrix.CCOMPILER }}
-  #     CFLAGS: ${{ matrix.CFLAGS }}
-  #     CUCUMBER_TIMEOUT: ${{ matrix.CUCUMBER_TIMEOUT }}
-  #     CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
-  #     CXXFLAGS: ${{ matrix.CXXFLAGS }}
-  #     ENABLE_ASSERTIONS: ${{ matrix.ENABLE_ASSERTIONS }}
-  #     ENABLE_CLANG_TIDY: ${{ matrix.ENABLE_CLANG_TIDY }}
-  #     ENABLE_COVERAGE: ${{ matrix.ENABLE_COVERAGE }}
-  #     ENABLE_CONAN: ${{ matrix.ENABLE_CONAN }}
-  #     ENABLE_SANITIZER: ${{ matrix.ENABLE_SANITIZER }}
-  #     NODE_PACKAGE_TESTS_ONLY: ${{ matrix.NODE_PACKAGE_TESTS_ONLY }}
-  #     TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
-  #     OSRM_CONNECTION_RETRIES: ${{ matrix.OSRM_CONNECTION_RETRIES }}
-  #     OSRM_CONNECTION_EXP_BACKOFF_COEF: ${{ matrix.OSRM_CONNECTION_EXP_BACKOFF_COEF }}
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Build machine architecture
-  #     run: uname -m
-  #   - name: Use Node.js
-  #     uses: actions/setup-node@v3
-  #     with:
-  #       node-version: ${{ matrix.node }}
-  #   - name: Enable Node.js cache
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/.npm
-  #       key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-  #       restore-keys: |
-  #         ${{ runner.os }}-node-
-    # - name: Enable compiler cache
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: ~/.ccache
-    #     key: ccache-${{ matrix.name }}-${{ github.sha }}
-    #     restore-keys: |
-    #       ccache-${{ matrix.name }}-
-    # - name: Enable Conan cache
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: ~/.conan
-    #     key: v9-conan-${{ matrix.name }}-${{ github.sha }}
-    #     restore-keys: |
-    #       v9-conan-${{ matrix.name }}-
-  #   - name: Enable test cache
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ${{github.workspace}}/test/cache
-  #       key: v4-test-${{ matrix.name }}-${{ github.sha }}
-  #       restore-keys: |
-  #         v4-test-${{ matrix.name }}-
+    name: ${{ matrix.name}}
+    continue-on-error: ${{ matrix.continue-on-error }}
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      BUILD_TOOLS: ${{ matrix.BUILD_TOOLS }}
+      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
+      BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
+      CCOMPILER: ${{ matrix.CCOMPILER }}
+      CFLAGS: ${{ matrix.CFLAGS }}
+      CUCUMBER_TIMEOUT: ${{ matrix.CUCUMBER_TIMEOUT }}
+      CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
+      CXXFLAGS: ${{ matrix.CXXFLAGS }}
+      ENABLE_ASSERTIONS: ${{ matrix.ENABLE_ASSERTIONS }}
+      ENABLE_CLANG_TIDY: ${{ matrix.ENABLE_CLANG_TIDY }}
+      ENABLE_COVERAGE: ${{ matrix.ENABLE_COVERAGE }}
+      ENABLE_CONAN: ${{ matrix.ENABLE_CONAN }}
+      ENABLE_SANITIZER: ${{ matrix.ENABLE_SANITIZER }}
+      NODE_PACKAGE_TESTS_ONLY: ${{ matrix.NODE_PACKAGE_TESTS_ONLY }}
+      TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
+      OSRM_CONNECTION_RETRIES: ${{ matrix.OSRM_CONNECTION_RETRIES }}
+      OSRM_CONNECTION_EXP_BACKOFF_COEF: ${{ matrix.OSRM_CONNECTION_EXP_BACKOFF_COEF }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build machine architecture
+      run: uname -m
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Enable Node.js cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Enable compiler cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: ccache-${{ matrix.name }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ matrix.name }}-
+    - name: Enable Conan cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.conan
+        key: v9-conan-${{ matrix.name }}-${{ github.sha }}
+        restore-keys: |
+          v9-conan-${{ matrix.name }}-
+    - name: Enable test cache
+      uses: actions/cache@v3
+      with:
+        path: ${{github.workspace}}/test/cache
+        key: v4-test-${{ matrix.name }}-${{ github.sha }}
+        restore-keys: |
+          v4-test-${{ matrix.name }}-
 
-  #   - name: Prepare environment
-  #     run: |
-  #       PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-  #       echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
-  #       echo "OSRM_INSTALL_DIR=${GITHUB_WORKSPACE}/install-osrm" >> $GITHUB_ENV
-  #       echo "OSRM_BUILD_DIR=${GITHUB_WORKSPACE}/build-osrm" >> $GITHUB_ENV
-  #       if [[ "$ENABLE_SANITIZER" == 'ON' ]]; then
-  #         # We can only set this after checkout once we know the workspace directory
-  #         echo "LSAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
-  #         echo "UBSAN_OPTIONS=symbolize=1:halt_on_error=1:print_stacktrace=1:suppressions=${GITHUB_WORKSPACE}/scripts/ci/undefinedsanitizer.conf" >> $GITHUB_ENV
-  #         echo "ASAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/addresssanitizer.conf" >> $GITHUB_ENV
-  #       fi
+    - name: Prepare environment
+      run: |
+        PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+        echo PUBLISH=$([[ "${GITHUB_REF:-}" == "refs/tags/v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off") >> $GITHUB_ENV
+        echo "OSRM_INSTALL_DIR=${GITHUB_WORKSPACE}/install-osrm" >> $GITHUB_ENV
+        echo "OSRM_BUILD_DIR=${GITHUB_WORKSPACE}/build-osrm" >> $GITHUB_ENV
+        if [[ "$ENABLE_SANITIZER" == 'ON' ]]; then
+          # We can only set this after checkout once we know the workspace directory
+          echo "LSAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/leaksanitizer.conf" >> $GITHUB_ENV
+          echo "UBSAN_OPTIONS=symbolize=1:halt_on_error=1:print_stacktrace=1:suppressions=${GITHUB_WORKSPACE}/scripts/ci/undefinedsanitizer.conf" >> $GITHUB_ENV
+          echo "ASAN_OPTIONS=print_suppressions=0:suppressions=${GITHUB_WORKSPACE}/scripts/ci/addresssanitizer.conf" >> $GITHUB_ENV
+        fi
 
-  #       if [[ "${RUNNER_OS}" == "Linux" ]]; then
-  #         echo "JOBS=$((`nproc` + 1))" >>  $GITHUB_ENV
-  #       elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-  #         echo "JOBS=$((`sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
-  #       fi
+        if [[ "${RUNNER_OS}" == "Linux" ]]; then
+          echo "JOBS=$((`nproc` + 1))" >>  $GITHUB_ENV
+        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+          echo "JOBS=$((`sysctl -n hw.ncpu` + 1))" >>  $GITHUB_ENV
+        fi
 
-  #   - name: Install dev dependencies
-  #     run: |
-  #       python3 -m pip install "conan<2.0.0" || python3 -m pip install "conan<2.0.0" --break-system-packages
+    - name: Install dev dependencies
+      run: |
+        python3 -m pip install "conan<2.0.0" || python3 -m pip install "conan<2.0.0" --break-system-packages
 
-  #       # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
-  #       # and that's why CI cannot find conan executable installed above
-  #       if [[ "${RUNNER_OS}" == "macOS" ]]; then
-  #         echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
-  #       fi
+        # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
+        # and that's why CI cannot find conan executable installed above
+        if [[ "${RUNNER_OS}" == "macOS" ]]; then
+          echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
+        fi
 
-  #       # ccache
-  #       if [[ "${RUNNER_OS}" == "Linux" ]]; then
-  #         sudo apt-get update -y && sudo apt-get install ccache
-  #       elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-  #         brew install ccache
-  #       fi
+        # ccache
+        if [[ "${RUNNER_OS}" == "Linux" ]]; then
+          sudo apt-get update -y && sudo apt-get install ccache
+        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+          brew install ccache
+        fi
 
-  #       # Linux dev packages
-  #       if [ "${ENABLE_CONAN}" != "ON" ]; then
-  #         sudo apt-get update -y
-  #         sudo apt-get install -y libbz2-dev libxml2-dev libzip-dev liblua5.2-dev libboost-all-dev
-  #         if [[ "${CCOMPILER}" != clang-* ]]; then
-  #           sudo apt-get install -y ${CXXCOMPILER}
-  #         fi
-  #         if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
-  #           sudo apt-get install -y lcov
-  #         fi
-  #       fi
+        # Linux dev packages
+        if [ "${ENABLE_CONAN}" != "ON" ]; then
+          sudo apt-get update -y
+          sudo apt-get install -y libbz2-dev libxml2-dev libzip-dev liblua5.2-dev libboost-all-dev
+          if [[ "${CCOMPILER}" != clang-* ]]; then
+            sudo apt-get install -y ${CXXCOMPILER}
+          fi
+          if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
+            sudo apt-get install -y lcov
+          fi
+        fi
 
-  #       # TBB
-  #       TBB_VERSION=2021.3.0
-  #       if [[ "${RUNNER_OS}" == "Linux" ]]; then
-  #         TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-lin.tgz"
-  #       elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-  #         TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-mac.tgz"
-  #       fi
-  #       wget --tries 5 ${TBB_URL} -O onetbb.tgz
-  #       tar zxvf onetbb.tgz
-  #       sudo cp -a oneapi-tbb-${TBB_VERSION}/lib/. /usr/local/lib/
-  #       sudo cp -a oneapi-tbb-${TBB_VERSION}/include/. /usr/local/include/
-  #   - name: Prepare build
-  #     run: |
-  #       mkdir ${OSRM_BUILD_DIR}
-  #       ccache --max-size=256M
-  #       npm ci --ignore-scripts
-  #       if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
-  #         lcov --directory . --zerocounters # clean cached files
-  #       fi
-  #       echo "CC=${CCOMPILER}" >> $GITHUB_ENV
-  #       echo "CXX=${CXXCOMPILER}" >> $GITHUB_ENV
-  #       if [[ "${RUNNER_OS}" == "macOS" ]]; then
-  #         # missing from GCC path, needed for conan builds of libiconv, for example.
-  #         sudo xcode-select --switch /Library/Developer/CommandLineTools
-  #         echo "LIBRARY_PATH=${LIBRARY_PATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV
-  #         echo "CPATH=${CPATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" >> $GITHUB_ENV
-  #       fi
+        # TBB
+        TBB_VERSION=2021.3.0
+        if [[ "${RUNNER_OS}" == "Linux" ]]; then
+          TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-lin.tgz"
+        elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+          TBB_URL="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-mac.tgz"
+        fi
+        wget --tries 5 ${TBB_URL} -O onetbb.tgz
+        tar zxvf onetbb.tgz
+        sudo cp -a oneapi-tbb-${TBB_VERSION}/lib/. /usr/local/lib/
+        sudo cp -a oneapi-tbb-${TBB_VERSION}/include/. /usr/local/include/
+    - name: Prepare build
+      run: |
+        mkdir ${OSRM_BUILD_DIR}
+        ccache --max-size=256M
+        npm ci --ignore-scripts
+        if [[ "${ENABLE_COVERAGE}" == "ON" ]]; then
+          lcov --directory . --zerocounters # clean cached files
+        fi
+        echo "CC=${CCOMPILER}" >> $GITHUB_ENV
+        echo "CXX=${CXXCOMPILER}" >> $GITHUB_ENV
+        if [[ "${RUNNER_OS}" == "macOS" ]]; then
+          # missing from GCC path, needed for conan builds of libiconv, for example.
+          sudo xcode-select --switch /Library/Developer/CommandLineTools
+          echo "LIBRARY_PATH=${LIBRARY_PATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV
+          echo "CPATH=${CPATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" >> $GITHUB_ENV
+        fi
 
-  #   - name: Build and install OSRM
-  #     run: |
-  #       echo "Using ${JOBS} jobs"
-  #       pushd ${OSRM_BUILD_DIR}
+    - name: Build and install OSRM
+      run: |
+        echo "Using ${JOBS} jobs"
+        pushd ${OSRM_BUILD_DIR}
 
 
-  #       cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-  #                -DENABLE_CONAN=${ENABLE_CONAN:-OFF} \
-  #                -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} \
-  #                -DENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF} \
-  #                -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} \
-  #                -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} \
-  #                -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
-  #                -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} \
-  #                -DBUILD_TOOLS=${BUILD_TOOLS:-OFF} \
-  #                -DENABLE_CCACHE=ON \
-  #                -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
-  #       make --jobs=${JOBS}
+        cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+                 -DENABLE_CONAN=${ENABLE_CONAN:-OFF} \
+                 -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} \
+                 -DENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF} \
+                 -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF} \
+                 -DENABLE_COVERAGE=${ENABLE_COVERAGE:-OFF} \
+                 -DENABLE_NODE_BINDINGS=${ENABLE_NODE_BINDINGS:-OFF} \
+                 -DENABLE_SANITIZER=${ENABLE_SANITIZER:-OFF} \
+                 -DBUILD_TOOLS=${BUILD_TOOLS:-OFF} \
+                 -DENABLE_CCACHE=ON \
+                 -DCMAKE_INSTALL_PREFIX=${OSRM_INSTALL_DIR}
+        make --jobs=${JOBS}
 
-  #       if [[ "${NODE_PACKAGE_TESTS_ONLY}" != "ON" ]]; then
-  #         make tests --jobs=${JOBS}
-  #         make benchmarks --jobs=${JOBS}
-  #         ccache -s
-  #         sudo make install
-  #         if [[ "${RUNNER_OS}" == "Linux" ]]; then
-  #           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OSRM_INSTALL_DIR}/lib" >> $GITHUB_ENV
-  #         fi
-  #         echo "PKG_CONFIG_PATH=${OSRM_INSTALL_DIR}/lib/pkgconfig" >> $GITHUB_ENV
-  #       fi
-  #       popd
-  #   - name: Build example
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
-  #     run: |
-  #       mkdir example/build && pushd example/build
-  #       cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-  #       make --jobs=${JOBS}
-  #       popd
-  #   - name: Run all tests
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
-  #     run: |
-  #       make -C test/data benchmark
+        if [[ "${NODE_PACKAGE_TESTS_ONLY}" != "ON" ]]; then
+          make tests --jobs=${JOBS}
+          make benchmarks --jobs=${JOBS}
+          ccache -s
+          sudo make install
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OSRM_INSTALL_DIR}/lib" >> $GITHUB_ENV
+          fi
+          echo "PKG_CONFIG_PATH=${OSRM_INSTALL_DIR}/lib/pkgconfig" >> $GITHUB_ENV
+        fi
+        popd
+    - name: Build example
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
+      run: |
+        mkdir example/build && pushd example/build
+        cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        make --jobs=${JOBS}
+        popd
+    - name: Run all tests
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY != 'ON' }}
+      run: |
+        make -C test/data benchmark
 
-  #       # macOS SIP strips the linker path. Reset this inside the running shell
-  #       export LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
-  #       ./example/build/osrm-example test/data/mld/monaco.osrm
+        # macOS SIP strips the linker path. Reset this inside the running shell
+        export LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
+        ./example/build/osrm-example test/data/mld/monaco.osrm
 
-  #       # All tests assume to be run from the build directory
-  #       pushd ${OSRM_BUILD_DIR}
-  #       for i in ./unit_tests/*-tests ; do echo Running $i ; $i ; done
-  #       if [ -z "${ENABLE_SANITIZER}" ]; then
-  #         npm run nodejs-tests
-  #       fi
-  #       popd
-  #       npm test
-  #   - name: Run benchmarks
-  #     if: ${{ matrix.ENABLE_BENCHMARKS == 'ON' }}
-  #     run: |
-  #       pushd ${OSRM_BUILD_DIR}
-  #       make --jobs=${JOBS} benchmarks
-  #       ./src/benchmarks/alias-bench
-  #       ./src/benchmarks/json-render-bench ../src/benchmarks/portugal_to_korea.json
-  #       ./src/benchmarks/match-bench ../test/data/ch/monaco.osrm
-  #       ./src/benchmarks/packedvector-bench
-  #       ./src/benchmarks/rtree-bench ../test/data/monaco.osrm.ramIndex ../test/data/monaco.osrm.fileIndex ../test/data/monaco.osrm.nbg_nodes
-  #       popd
+        # All tests assume to be run from the build directory
+        pushd ${OSRM_BUILD_DIR}
+        for i in ./unit_tests/*-tests ; do echo Running $i ; $i ; done
+        if [ -z "${ENABLE_SANITIZER}" ]; then
+          npm run nodejs-tests
+        fi
+        popd
+        npm test
 
-  #   - name: Use Node 18
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-  #     uses: actions/setup-node@v3
-  #     with:
-  #       node-version: 18
-  #   - name: Run Node package tests on Node 18
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-  #     run: |
-  #       node --version
-  #       npm run nodejs-tests
-  #   - name: Use Node 20
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-  #     uses: actions/setup-node@v3
-  #     with:
-  #       node-version: 20
-  #   - name: Run Node package tests on Node 20
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-  #     run: |
-  #       node --version
-  #       npm run nodejs-tests
-  #   - name: Use Node latest
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-  #     uses: actions/setup-node@v3
-  #     with:
-  #       node-version: latest
-  #   - name: Run Node package tests on Node-latest
-  #     if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
-  #     run: |
-  #       node --version
-  #       npm run nodejs-tests
+    - name: Use Node 18
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Run Node package tests on Node 18
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+      run: |
+        node --version
+        npm run nodejs-tests
+    - name: Use Node 20
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - name: Run Node package tests on Node 20
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+      run: |
+        node --version
+        npm run nodejs-tests
+    - name: Use Node latest
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: latest
+    - name: Run Node package tests on Node-latest
+      if: ${{ matrix.NODE_PACKAGE_TESTS_ONLY == 'ON' }}
+      run: |
+        node --version
+        npm run nodejs-tests
 
-  #   - name: Upload test logs
-  #     uses: actions/upload-artifact@v3
-  #     if: failure()
-  #     with:
-  #       name: logs
-  #       path: test/logs/
+    - name: Upload test logs
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: logs
+        path: test/logs/
 
-  #   # - name: Generate code coverage
-  #   #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
-  #   #   run: |
-  #   #     lcov --directory . --capture --output-file coverage.info # capture coverage info
-  #   #     lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
-  #   #     lcov --list coverage.info #debug info
+    # - name: Generate code coverage
+    #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
+    #   run: |
+    #     lcov --directory . --capture --output-file coverage.info # capture coverage info
+    #     lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
+    #     lcov --list coverage.info #debug info
     
-  #   # # Uploading report to CodeCov
-  #   # - name: Upload code coverage
-  #   #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
-  #   #   uses: codecov/codecov-action@v1
-  #   #   with:
-  #   #     files: coverage.info
-  #   #     name: codecov-osrm-backend
-  #   #     fail_ci_if_error: true
-  #   #     verbose: true
-  #   - name: Build Node package
-  #     if: ${{ matrix.build_node_package }}
-  #     run: ./scripts/ci/node_package.sh
-  #   - name: Publish Node package
-  #     if: ${{ matrix.build_node_package && env.PUBLISH == 'On' }}
-  #     uses: ncipollo/release-action@v1
-  #     with:
-  #       allowUpdates: true
-  #       artifactErrorsFailBuild: true
-  #       artifacts: build/stage/**/*.tar.gz
-  #       omitBody: true
-  #       omitBodyDuringUpdate: true
-  #       omitName: true
-  #       omitNameDuringUpdate: true
-  #       replacesArtifacts: true
-  #       token: ${{ secrets.GITHUB_TOKEN }}
+    # # Uploading report to CodeCov
+    # - name: Upload code coverage
+    #   if: ${{ matrix.ENABLE_COVERAGE == 'ON' }}
+    #   uses: codecov/codecov-action@v1
+    #   with:
+    #     files: coverage.info
+    #     name: codecov-osrm-backend
+    #     fail_ci_if_error: true
+    #     verbose: true
+    - name: Build Node package
+      if: ${{ matrix.build_node_package }}
+      run: ./scripts/ci/node_package.sh
+    - name: Publish Node package
+      if: ${{ matrix.build_node_package && env.PUBLISH == 'On' }}
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true
+        artifactErrorsFailBuild: true
+        artifacts: build/stage/**/*.tar.gz
+        omitBody: true
+        omitBodyDuringUpdate: true
+        omitName: true
+        omitNameDuringUpdate: true
+        replacesArtifacts: true
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-  # ci-complete:
-  #   runs-on: ubuntu-22.04
-  #   needs: [build-test-publish, docker-image, windows-release-node]
-  #   steps:
-  #   - run: echo "CI complete"
 
   benchmarks:
     if: github.event_name == 'pull_request'
+    needs: [format-taginfo-docs]
     runs-on: ubuntu-22.04
     env:
       CCOMPILER: clang-13
@@ -615,10 +597,11 @@ jobs:
       - name: Enable compiler cache
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ~/.ccache
           key: v1-ccache-benchmarks-${{ github.sha }}
           restore-keys: |
             v1-ccache-benchmarks-
+      - name: mkdir -p ~/.ccache
       - name: Enable Conan cache
         uses: actions/cache@v3
         with:
@@ -644,7 +627,7 @@ jobs:
       - name: Checkout Base Branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }} #${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.ref }}
           path: base
       - name: Build Base Branch
         run: |
@@ -661,3 +644,9 @@ jobs:
       - name: Post Benchmark Results
         run: |
           python3 pr/scripts/ci/post_benchmark_results.py base_results pr_results
+
+  ci-complete:
+    runs-on: ubuntu-22.04
+    needs: [build-test-publish, docker-image, windows-release-node, benchmarks]
+    steps:
+    - run: echo "CI complete"

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -642,7 +642,7 @@ jobs:
           make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
-          ./pr/build/src/benchmarks/match-bench ./pr/test/data/mld/monaco.osrm mld > pr_bench.txt
+          ./pr/build/src/benchmarks/match-bench ./pr/test/data/mld/monaco.osrm mld > pr/match.bench
       - name: Checkout Master Branch
         uses: actions/checkout@v3
         with:
@@ -657,14 +657,13 @@ jobs:
           make -j$(nproc) benchmarks
           cd ..
           make -C test/data 
-      - name: Run Benchmark on Master Branch
+      - name: Run Benchmarks
         run: |
-          ./master/build/src/benchmarks/match-bench ./master/test/data/mld/monaco.osrm mld > master_bench.txt
+          ./scripts/ci/run_benchmarks.sh master pr
       - name: Compare Benchmarks
         run: |
-          cat pr_bench.txt
-          cat master_bench.txt
-            - name: Run benchmark and update PR
+          cat pr_results/match.bench
+          cat master_results/match.bench
       - name: Post Benchmark Results
         run: |
-          python3 scripts/ci/post_benchmark_results.py
+          python3 pr/scripts/ci/post_benchmark_results.py master_results pr_results

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -659,8 +659,8 @@ jobs:
           ./scripts/ci/run_benchmarks.sh master pr
       - name: Compare Benchmarks
         run: |
-          cat pr_results/match.bench
-          cat master_results/match.bench
+          cat pr_results/match_mld.bench
+          cat master_results/match_mld.bench
       - name: Post Benchmark Results
         run: |
           python3 pr/scripts/ci/post_benchmark_results.py master_results pr_results

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -603,8 +603,10 @@ jobs:
   benchmarks:
     runs-on: ubuntu-22.04
     env:
-      CFLAGS: clang-13
+      CCOMPILER: clang-13
       CXXCOMPILER: clang++-13
+      CC: clang-13
+      CXX: clang++-13
     steps: 
       - name: Checkout PR Branch
         uses: actions/checkout@v3

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -620,6 +620,7 @@ jobs:
           cd build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
           make -j$(nproc) benchmarks
+          make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
           ./build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > pr_bench.txt
@@ -634,6 +635,7 @@ jobs:
           cd build
           cmake -DENABLE_CONAN=ON -DCMAKE_BUILD_TYPE=Release ..
           make -j$(nproc) benchmarks
+          make -C test/data 
       - name: Run Benchmark on Master Branch
         run: |
           ./build/src/benchmarks/match-bench ../test/data/mld/monaco.osrm mld > master_bench.txt

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -36,6 +36,7 @@ def collect_benchmark_results(base_folder, pr_folder):
     results_index = {}
 
     for file in os.listdir(base_folder):
+        print('base file:', file)
         if not file.endswith('.bench'): continue
         with open(f"{base_folder}/{file}") as f:
             result = f.read().strip()
@@ -43,6 +44,7 @@ def collect_benchmark_results(base_folder, pr_folder):
             results_index[file] = len(results) - 1
 
     for file in os.listdir(pr_folder):
+        print('pr file:', file)
         if not file.endswith('.bench'): continue
         with open(f"{pr_folder}/{file}") as f:
             result = f.read().strip()
@@ -50,6 +52,8 @@ def collect_benchmark_results(base_folder, pr_folder):
                 results[results_index[file]]['pr'] = result
             else:
                 results.append({'base': None, 'pr': result, 'name': os.path.splitext(file)[0]})
+
+    return results
 
 def main():
     if len(sys.argv) != 3:

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -2,6 +2,7 @@ import requests
 import os
 import re
 import sys
+import json
 
 GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
 REPO = os.getenv('GITHUB_REPOSITORY')  
@@ -14,15 +15,15 @@ def create_markdown_table(results):
     rows = [f"| {result['name']} | {result['base']} | {result['pr']} |" for result in results]
     return f"{header}\n" + "\n".join(rows)
 
-def get_pr_comments(repo_owner, repo_name, pr_number):
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
+def get_pr_details(repo_owner, repo_name, pr_number):
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
     headers = {'Authorization': f'token {GITHUB_TOKEN}'}
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     return response.json()
 
-def update_comment(comment_id, repo_owner, repo_name, body):
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/comments/{comment_id}"
+def update_pr_description(repo_owner, repo_name, pr_number, body):
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
     headers = {'Authorization': f'token {GITHUB_TOKEN}'}
     data = {'body': body}
     response = requests.patch(url, headers=headers, json=data)
@@ -60,27 +61,27 @@ def main():
 
     benchmark_results = collect_benchmark_results(base_folder, pr_folder)
 
-    comments = get_pr_comments(REPO_OWNER, REPO_NAME, PR_NUMBER)
-    if not comments or len(comments) > 0:
-        print("No comments found on this PR.")
-        exit(1)
+    print(json.dumps(benchmark_results, indent=2))
+
+    pr_details = get_pr_details(REPO_OWNER, REPO_NAME, PR_NUMBER)
+    pr_body = pr_details.get('body', '')
+
     
-    first_comment = comments[0]
     markdown_table = create_markdown_table(benchmark_results)
     new_benchmark_section = f"<!-- BENCHMARK_RESULTS_START -->\n## Benchmark Results\n{markdown_table}\n<!-- BENCHMARK_RESULTS_END -->"
 
-    if re.search(r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->', first_comment['body'], re.DOTALL):
+    if re.search(r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->', pr_body, re.DOTALL):
         updated_body = re.sub(
             r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->',
             new_benchmark_section,
-            first_comment['body'],
+            pr_body,
             flags=re.DOTALL
         )
     else:
-        updated_body = f"{first_comment['body']}\n\n{new_benchmark_section}"
+        updated_body = f"{pr_body}\n\n{new_benchmark_section}"
     
-    update_comment(first_comment['id'], REPO_OWNER, REPO_NAME, updated_body)
-    print("PR comment updated successfully.")
+    update_pr_description(REPO_OWNER, REPO_NAME, PR_NUMBER, updated_body)
+    print("PR description updated successfully.")
 
         
 

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -11,12 +11,14 @@ PR_NUMBER = os.getenv('PR_NUMBER')
 REPO_OWNER, REPO_NAME = REPO.split('/')
 
 def create_markdown_table(results):
+    results = sorted(results, key=lambda x: x['name'])
     header = "| Benchmark | Base | PR |\n|-----------|------|----|"
     rows = []
     for result in results:
+        name = result['name']
         base = result['base'].replace('\n', '<br/>')
         pr = result['pr'].replace('\n', '<br/>')
-        row = f"| {result['name']} | <pre>{base}</pre> | <pre>{pr}</pre> |"
+        row = f"| `{name}` | <pre>{base}</pre> | <pre>{pr}</pre> |"
         rows.append(row)
     return f"{header}\n" + "\n".join(rows)
 

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -18,7 +18,7 @@ def create_markdown_table(results):
         name = result['name']
         base = result['base'].replace('\n', '<br/>')
         pr = result['pr'].replace('\n', '<br/>')
-        row = f"| `{name}` | <pre>{base}</pre> | <pre>{pr}</pre> |"
+        row = f"| {name} | {base} | {pr} |"
         rows.append(row)
     return f"{header}\n" + "\n".join(rows)
 

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -14,9 +14,9 @@ def create_markdown_table(results):
     header = "| Benchmark | Base | PR |\n|-----------|------|----|"
     rows = []
     for result in results:
-        base = result['base'].replace('\n', '<br>')
-        pr = result['pr'].replace('\n', '<br>')
-        row = f"| {result['name']} | ```{base}``` | ```{pr}``` |"
+        base = result['base']
+        pr = result['pr']
+        row = f"| {result['name']} | ```\n{base}\n``` | ```\n{pr}\n``` |"
         rows.append(row)
     return f"{header}\n" + "\n".join(rows)
 

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -11,8 +11,13 @@ PR_NUMBER = os.getenv('PR_NUMBER')
 REPO_OWNER, REPO_NAME = REPO.split('/')
 
 def create_markdown_table(results):
-    header = "| Benchmark | Base | PR |\n|--------|----|"
-    rows = [f"| {result['name']} | {result['base']} | {result['pr']} |" for result in results]
+    header = "| Benchmark | Base | PR |\n|-----------|------|----|"
+    rows = []
+    for result in results:
+        base = result['base'].replace('\n', '<br>')
+        pr = result['pr'].replace('\n', '<br>')
+        row = f"| {result['name']} | ```{base}``` | ```{pr}``` |"
+        rows.append(row)
     return f"{header}\n" + "\n".join(rows)
 
 def get_pr_details(repo_owner, repo_name, pr_number):

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -43,7 +43,6 @@ def collect_benchmark_results(base_folder, pr_folder):
     results_index = {}
 
     for file in os.listdir(base_folder):
-        print('base file:', file)
         if not file.endswith('.bench'): continue
         with open(f"{base_folder}/{file}") as f:
             result = f.read().strip()
@@ -51,7 +50,6 @@ def collect_benchmark_results(base_folder, pr_folder):
             results_index[file] = len(results) - 1
 
     for file in os.listdir(pr_folder):
-        print('pr file:', file)
         if not file.endswith('.bench'): continue
         with open(f"{pr_folder}/{file}") as f:
             result = f.read().strip()
@@ -71,8 +69,6 @@ def main():
     pr_folder = sys.argv[2]
 
     benchmark_results = collect_benchmark_results(base_folder, pr_folder)
-
-    print(json.dumps(benchmark_results, indent=2))
 
     pr_details = get_pr_details(REPO_OWNER, REPO_NAME, PR_NUMBER)
     pr_body = pr_details.get('body', '')

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -10,8 +10,8 @@ PR_NUMBER = os.getenv('PR_NUMBER')
 REPO_OWNER, REPO_NAME = REPO.split('/')
 
 def create_markdown_table(results):
-    header = "| Benchmark | Master | PR |\n|--------|----|"
-    rows = [f"| {result['name']} | {result['master']} | {result['pr']} |" for result in results]
+    header = "| Benchmark | Base | PR |\n|--------|----|"
+    rows = [f"| {result['name']} | {result['base']} | {result['pr']} |" for result in results]
     return f"{header}\n" + "\n".join(rows)
 
 def get_pr_comments(repo_owner, repo_name, pr_number):
@@ -30,15 +30,15 @@ def update_comment(comment_id, repo_owner, repo_name, body):
     return response.json()
 
 
-def collect_benchmark_results(master_folder, pr_folder):
+def collect_benchmark_results(base_folder, pr_folder):
     results = []
     results_index = {}
 
-    for file in os.listdir(master_folder):
+    for file in os.listdir(base_folder):
         if not file.endswith('.bench'): continue
-        with open(f"{master_folder}/{file}") as f:
+        with open(f"{base_folder}/{file}") as f:
             result = f.read().strip()
-            results.append({'master': result, 'pr': None, 'name': os.path.splitext(file)[0]})
+            results.append({'base': result, 'pr': None, 'name': os.path.splitext(file)[0]})
             results_index[file] = len(results) - 1
 
     for file in os.listdir(pr_folder):
@@ -48,39 +48,41 @@ def collect_benchmark_results(master_folder, pr_folder):
             if file in results_index:
                 results[results_index[file]]['pr'] = result
             else:
-                results.append({'master': None, 'pr': result, 'name': os.path.splitext(file)[0]})
+                results.append({'base': None, 'pr': result, 'name': os.path.splitext(file)[0]})
 
 def main():
     if len(sys.argv) != 3:
-        print("Usage: python post_benchmark_results.py <master_folder> <pr_folder>")
+        print("Usage: python post_benchmark_results.py <base_folder> <pr_folder>")
         exit(1)
 
-    master_folder = sys.argv[1]
+    base_folder = sys.argv[1]
     pr_folder = sys.argv[2]
 
-    benchmark_results = collect_benchmark_results(master_folder, pr_folder)
+    benchmark_results = collect_benchmark_results(base_folder, pr_folder)
 
     comments = get_pr_comments(REPO_OWNER, REPO_NAME, PR_NUMBER)
-    if comments and len(comments) > 0:
-        first_comment = comments[0]
-        markdown_table = create_markdown_table(benchmark_results)
-        new_benchmark_section = f"<!-- BENCHMARK_RESULTS_START -->\n## Benchmark Results\n{markdown_table}\n<!-- BENCHMARK_RESULTS_END -->"
-
-        if re.search(r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->', first_comment['body'], re.DOTALL):
-            updated_body = re.sub(
-                r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->',
-                new_benchmark_section,
-                first_comment['body'],
-                flags=re.DOTALL
-            )
-        else:
-            updated_body = f"{first_comment['body']}\n\n{new_benchmark_section}"
-        
-        update_comment(first_comment['id'], REPO_OWNER, REPO_NAME, updated_body)
-        print("PR comment updated successfully.")
-    else:
+    if not comments or len(comments) > 0:
         print("No comments found on this PR.")
         exit(1)
+    
+    first_comment = comments[0]
+    markdown_table = create_markdown_table(benchmark_results)
+    new_benchmark_section = f"<!-- BENCHMARK_RESULTS_START -->\n## Benchmark Results\n{markdown_table}\n<!-- BENCHMARK_RESULTS_END -->"
+
+    if re.search(r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->', first_comment['body'], re.DOTALL):
+        updated_body = re.sub(
+            r'<!-- BENCHMARK_RESULTS_START -->.*<!-- BENCHMARK_RESULTS_END -->',
+            new_benchmark_section,
+            first_comment['body'],
+            flags=re.DOTALL
+        )
+    else:
+        updated_body = f"{first_comment['body']}\n\n{new_benchmark_section}"
+    
+    update_comment(first_comment['id'], REPO_OWNER, REPO_NAME, updated_body)
+    print("PR comment updated successfully.")
+
+        
 
 if __name__ == "__main__":
     main()

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -1,0 +1,50 @@
+import requests
+import os
+
+# GitHub token and repository details
+GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')  # Ensure this token has repo and workflow permissions
+REPO = os.getenv('GITHUB_REPOSITORY')
+PR_NUMBER = os.getenv('PR_NUMBER')  # Ensure this is set in the GitHub Actions environment
+
+REPO_OWNER, REPO_NAME = REPO.split('/')
+
+benchmark_results = [
+  {'master': '0.002s', 'pr': '0.0018s'},
+  {'master': '0.003s', 'pr': '0.0025s'},
+  {'master': '0.004s', 'pr': '0.0038s'}
+]
+
+def create_markdown_table(results):
+    header = "| Master | PR |\n|--------|----|"
+    rows = [f"| {result['master']} | {result['pr']} |" for result in results]
+    return f"{header}\n" + "\n".join(rows)
+
+def get_pr_comments(repo_owner, repo_name, pr_number):
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
+    headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+def update_comment(comment_id, repo_owner, repo_name, body):
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/comments/{comment_id}"
+    headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+    data = {'body': body}
+    response = requests.patch(url, headers=headers, json=data)
+    response.raise_for_status()
+    return response.json()
+
+def main():
+    comments = get_pr_comments(REPO_OWNER, REPO_NAME, PR_NUMBER)
+    if comments:
+        first_comment = comments[0]
+        markdown_table = create_markdown_table(benchmark_results)
+        new_body = f"{first_comment['body']}\n\n### Benchmark Results\n{markdown_table}"
+        update_comment(first_comment['id'], REPO_OWNER, REPO_NAME, new_body)
+        print("PR comment updated successfully.")
+    else:
+        print("No comments found on this PR.")
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/post_benchmark_results.py
+++ b/scripts/ci/post_benchmark_results.py
@@ -14,9 +14,9 @@ def create_markdown_table(results):
     header = "| Benchmark | Base | PR |\n|-----------|------|----|"
     rows = []
     for result in results:
-        base = result['base']
-        pr = result['pr']
-        row = f"| {result['name']} | ```\n{base}\n``` | ```\n{pr}\n``` |"
+        base = result['base'].replace('\n', '<br/>')
+        pr = result['pr'].replace('\n', '<br/>')
+        row = f"| {result['name']} | <pre>{base}</pre> | <pre>{pr}</pre> |"
         rows.append(row)
     return f"{header}\n" + "\n".join(rows)
 

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -9,12 +9,14 @@ function run_benchmarks_for_folder {
 
     mkdir -p $RESULTS_FOLDER
 
-    ./$FOLDER/build/src/benchmarks/match-bench "./$FOLDER/test/data/mld/monaco.osrm" mld > "$RESULTS_FOLDER/match_mld.bench"
-    ./$FOLDER/build/src/benchmarks/match-bench "./$FOLDER/test/data/ch/monaco.osrm" > "$RESULTS_FOLDER/match_ch.bench"
-    ./$FOLDER/build/src/benchmarks/alias-bench > "$RESULTS_FOLDER/alias.bench"
-    ./$FOLDER/build/src/benchmarks/json-render-bench  "./$FOLDER/src/benchmarks/portugal_to_korea.json" > "$RESULTS_FOLDER/json-render.bench"
-    ./$FOLDER/build/src/benchmarks/packedvector-bench > "$RESULTS_FOLDER/packedvector.bench"
-    ./$FOLDER/build/src/benchmarks/rtree-bench "./$FOLDER/test/data/monaco.osrm.ramIndex" "./$FOLDER/test/data/monaco.osrm.fileIndex" "./$FOLDER/test/data/monaco.osrm.nbg_nodes" > "$RESULTS_FOLDER/rtree.bench"
+    BENCHMARKS_FOLDER="$FOLDER/build/src/benchmarks"
+
+    ./$BENCHMARKS_FOLDER/match-bench "./$FOLDER/test/data/mld/monaco.osrm" mld > "$RESULTS_FOLDER/match_mld.bench"
+    ./$BENCHMARKS_FOLDER/match-bench "./$FOLDER/test/data/ch/monaco.osrm" > "$RESULTS_FOLDER/match_ch.bench"
+    ./$BENCHMARKS_FOLDER/alias-bench > "$RESULTS_FOLDER/alias.bench"
+    ./$BENCHMARKS_FOLDER/json-render-bench  "./$FOLDER/src/benchmarks/portugal_to_korea.json" > "$RESULTS_FOLDER/json-render.bench"
+    ./$BENCHMARKS_FOLDER/packedvector-bench > "$RESULTS_FOLDER/packedvector.bench"
+    ./$BENCHMARKS_FOLDER/rtree-bench "./$FOLDER/test/data/monaco.osrm.ramIndex" "./$FOLDER/test/data/monaco.osrm.fileIndex" "./$FOLDER/test/data/monaco.osrm.nbg_nodes" > "$RESULTS_FOLDER/rtree.bench"
 }
 
 run_benchmarks_for_folder $1 "${1}_results"

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e pipefail
+
+function run_benchmarks_for_folder {
+    echo "Running benchmarks for $1"
+
+    FOLDER=$1
+    RESULTS_FOLDER=$2
+
+    mkdir -p $RESULTS_FOLDER
+
+    ./$FOLDER/build/src/benchmarks/match-bench "./$FOLDER/test/data/mld/monaco.osrm" mld > "$RESULTS_FOLDER/match_mld.bench"
+    ./$FOLDER/build/src/benchmarks/match-bench "./$FOLDER/test/data/ch/monaco.osrm" > "$RESULTS_FOLDER/match_ch.bench"
+    ./$FOLDER/build/src/benchmarks/alias-bench > "$RESULTS_FOLDER/alias.bench"
+    ./$FOLDER/build/src/benchmarks/json-render-bench  "./$FOLDER/src/benchmarks/portugal_to_korea.json" > "$RESULTS_FOLDER/json-render.bench"
+    ./$FOLDER/build/src/benchmarks/packedvector-bench > "$RESULTS_FOLDER/packedvector.bench"
+    ./$FOLDER/build/src/benchmarks/rtree-bench "./$FOLDER/test/data/monaco.osrm.ramIndex" "./$FOLDER/test/data/monaco.osrm.fileIndex" "./$FOLDER/test/data/monaco.osrm.nbg_nodes" > "$RESULTS_FOLDER/rtree.bench"
+}
+
+run_benchmarks_for_folder $1 "${1}_results"
+run_benchmarks_for_folder $2 "${2}_results"
+

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e pipefail
+set -eou pipefail
 
 function run_benchmarks_for_folder {
     echo "Running benchmarks for $1"

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e pipefail
 
 function run_benchmarks_for_folder {

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -12,7 +12,7 @@ function run_benchmarks_for_folder {
     BENCHMARKS_FOLDER="$FOLDER/build/src/benchmarks"
 
     ./$BENCHMARKS_FOLDER/match-bench "./$FOLDER/test/data/mld/monaco.osrm" mld > "$RESULTS_FOLDER/match_mld.bench"
-    ./$BENCHMARKS_FOLDER/match-bench "./$FOLDER/test/data/ch/monaco.osrm" > "$RESULTS_FOLDER/match_ch.bench"
+    ./$BENCHMARKS_FOLDER/match-bench "./$FOLDER/test/data/ch/monaco.osrm" ch > "$RESULTS_FOLDER/match_ch.bench"
     ./$BENCHMARKS_FOLDER/alias-bench > "$RESULTS_FOLDER/alias.bench"
     ./$BENCHMARKS_FOLDER/json-render-bench  "./$FOLDER/src/benchmarks/portugal_to_korea.json" > "$RESULTS_FOLDER/json-render.bench"
     ./$BENCHMARKS_FOLDER/packedvector-bench > "$RESULTS_FOLDER/packedvector.bench"

--- a/src/benchmarks/alias.cpp
+++ b/src/benchmarks/alias.cpp
@@ -64,7 +64,7 @@ int main(int, char **)
             return EXIT_FAILURE;
     }
     TIMER_STOP(aliased_u32);
-    util::Log() << "aliased u32: " << TIMER_MSEC(aliased_u32);
+    std::cout << "aliased u32: " << TIMER_MSEC(aliased_u32) << std::endl;
 
     TIMER_START(plain_u32);
     for (auto round : util::irange(0, num_rounds))
@@ -83,7 +83,7 @@ int main(int, char **)
             return EXIT_FAILURE;
     }
     TIMER_STOP(plain_u32);
-    util::Log() << "plain u32: " << TIMER_MSEC(plain_u32);
+    std::cout << "plain u32: " << TIMER_MSEC(plain_u32) << std::endl;
 
     TIMER_START(aliased_double);
     for (auto round : util::irange(0, num_rounds))
@@ -103,7 +103,7 @@ int main(int, char **)
             return EXIT_FAILURE;
     }
     TIMER_STOP(aliased_double);
-    util::Log() << "aliased double: " << TIMER_MSEC(aliased_double);
+    std::cout << "aliased double: " << TIMER_MSEC(aliased_double) << std::endl;
 
     TIMER_START(plain_double);
     for (auto round : util::irange(0, num_rounds))
@@ -123,5 +123,5 @@ int main(int, char **)
             return EXIT_FAILURE;
     }
     TIMER_STOP(plain_double);
-    util::Log() << "plain double: " << TIMER_MSEC(plain_double);
+    std::cout << "plain double: " << TIMER_MSEC(plain_double) << std::endl;
 }

--- a/src/benchmarks/packed_vector.cpp
+++ b/src/benchmarks/packed_vector.cpp
@@ -72,10 +72,10 @@ int main(int, char **)
 
     auto write_slowdown = result_packed.random_write_ms / result_plain.random_write_ms;
     auto read_slowdown = result_packed.random_read_ms / result_plain.random_read_ms;
-    std::cout << "random write: std::vector " << result_plain.random_write_ms
-                << " ms, util::packed_vector " << result_packed.random_write_ms << " ms. "
-                << write_slowdown << std::endl;
-    std::cout << "random read: std::vector " << result_plain.random_read_ms
-                << " ms, util::packed_vector " << result_packed.random_read_ms << " ms. "
-                << read_slowdown << std::endl;
+    std::cout << "random write:\n std::vector " << result_plain.random_write_ms
+                << " ms\n util::packed_vector " << result_packed.random_write_ms << " ms\n"
+                << "slowdown: " << write_slowdown << std::endl;
+    std::cout << "random read:\n std::vector " << result_plain.random_read_ms
+                << " ms\n util::packed_vector " << result_packed.random_read_ms << " ms\n"
+                << "slowdown: " << read_slowdown << std::endl;
 }

--- a/src/benchmarks/packed_vector.cpp
+++ b/src/benchmarks/packed_vector.cpp
@@ -72,10 +72,10 @@ int main(int, char **)
 
     auto write_slowdown = result_packed.random_write_ms / result_plain.random_write_ms;
     auto read_slowdown = result_packed.random_read_ms / result_plain.random_read_ms;
-    util::Log() << "random write: std::vector " << result_plain.random_write_ms
+    std::cout << "random write: std::vector " << result_plain.random_write_ms
                 << " ms, util::packed_vector " << result_packed.random_write_ms << " ms. "
-                << write_slowdown;
-    util::Log() << "random read: std::vector " << result_plain.random_read_ms
+                << write_slowdown << std::endl;
+    std::cout << "random read: std::vector " << result_plain.random_read_ms
                 << " ms, util::packed_vector " << result_packed.random_read_ms << " ms. "
-                << read_slowdown;
+                << read_slowdown << std::endl;
 }

--- a/src/benchmarks/packed_vector.cpp
+++ b/src/benchmarks/packed_vector.cpp
@@ -73,9 +73,9 @@ int main(int, char **)
     auto write_slowdown = result_packed.random_write_ms / result_plain.random_write_ms;
     auto read_slowdown = result_packed.random_read_ms / result_plain.random_read_ms;
     std::cout << "random write:\nstd::vector " << result_plain.random_write_ms
-                << " ms\nutil::packed_vector " << result_packed.random_write_ms << " ms\n"
-                << "slowdown: " << write_slowdown << std::endl;
+              << " ms\nutil::packed_vector " << result_packed.random_write_ms << " ms\n"
+              << "slowdown: " << write_slowdown << std::endl;
     std::cout << "random read:\nstd::vector " << result_plain.random_read_ms
-                << " ms\nutil::packed_vector " << result_packed.random_read_ms << " ms\n"
-                << "slowdown: " << read_slowdown << std::endl;
+              << " ms\nutil::packed_vector " << result_packed.random_read_ms << " ms\n"
+              << "slowdown: " << read_slowdown << std::endl;
 }

--- a/src/benchmarks/packed_vector.cpp
+++ b/src/benchmarks/packed_vector.cpp
@@ -72,10 +72,10 @@ int main(int, char **)
 
     auto write_slowdown = result_packed.random_write_ms / result_plain.random_write_ms;
     auto read_slowdown = result_packed.random_read_ms / result_plain.random_read_ms;
-    std::cout << "random write:\n std::vector " << result_plain.random_write_ms
-                << " ms\n util::packed_vector " << result_packed.random_write_ms << " ms\n"
+    std::cout << "random write:\nstd::vector " << result_plain.random_write_ms
+                << " ms\nutil::packed_vector " << result_packed.random_write_ms << " ms\n"
                 << "slowdown: " << write_slowdown << std::endl;
-    std::cout << "random read:\n std::vector " << result_plain.random_read_ms
-                << " ms\n util::packed_vector " << result_packed.random_read_ms << " ms\n"
+    std::cout << "random read:\nstd::vector " << result_plain.random_read_ms
+                << " ms\nutil::packed_vector " << result_packed.random_read_ms << " ms\n"
                 << "slowdown: " << read_slowdown << std::endl;
 }

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -44,8 +44,8 @@ void benchmarkQuery(const std::vector<util::Coordinate> &queries,
     }
     TIMER_STOP(query);
 
-    std::cout << TIMER_MSEC(query) << "ms"
-              << "  ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
+    std::cout << name << " " << TIMER_MSEC(query) << "ms"
+              << ")  ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
               << "(" << TIMER_MSEC(query) << "ms"
               << ")" << std::endl;
 }

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -44,7 +44,8 @@ void benchmarkQuery(const std::vector<util::Coordinate> &queries,
     }
     TIMER_STOP(query);
 
-    std::cout << name << ":\n" << TIMER_MSEC(query) << "ms"
+    std::cout << name << ":\n"
+              << TIMER_MSEC(query) << "ms"
               << " ->  " << TIMER_MSEC(query) / queries.size() << " ms/query" << std::endl;
 }
 
@@ -60,9 +61,8 @@ void benchmark(BenchStaticRTree &rtree, unsigned num_queries)
                              util::FixedLatitude{lat_udist(mt_rand)});
     }
 
-    benchmarkQuery(queries,
-                   "1 result",
-                   [&rtree](const util::Coordinate &q) { return rtree.Nearest(q, 1); });
+    benchmarkQuery(
+        queries, "1 result", [&rtree](const util::Coordinate &q) { return rtree.Nearest(q, 1); });
     benchmarkQuery(queries,
                    "10 results",
                    [&rtree](const util::Coordinate &q) { return rtree.Nearest(q, 10); });

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -44,8 +44,8 @@ void benchmarkQuery(const std::vector<util::Coordinate> &queries,
     }
     TIMER_STOP(query);
 
-    std::cout << name << " " << TIMER_MSEC(query) << "ms"
-              << ")  ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
+    std::cout << name << ": " << TIMER_MSEC(query) << "ms"
+              << " ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
               << "(" << TIMER_MSEC(query) << "ms"
               << ")" << std::endl;
 }

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -44,10 +44,8 @@ void benchmarkQuery(const std::vector<util::Coordinate> &queries,
     }
     TIMER_STOP(query);
 
-    std::cout << name << ": " << TIMER_MSEC(query) << "ms"
-              << " ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
-              << "(" << TIMER_MSEC(query) << "ms"
-              << ")" << std::endl;
+    std::cout << name << ":\n" << TIMER_MSEC(query) << "ms"
+              << " ->  " << TIMER_MSEC(query) / queries.size() << " ms/query" << std::endl;
 }
 
 void benchmark(BenchStaticRTree &rtree, unsigned num_queries)

--- a/src/benchmarks/static_rtree.cpp
+++ b/src/benchmarks/static_rtree.cpp
@@ -36,8 +36,6 @@ void benchmarkQuery(const std::vector<util::Coordinate> &queries,
                     const std::string &name,
                     QueryT query)
 {
-    std::cout << "Running " << name << " with " << queries.size() << " coordinates: " << std::flush;
-
     TIMER_START(query);
     for (const auto &q : queries)
     {
@@ -46,9 +44,8 @@ void benchmarkQuery(const std::vector<util::Coordinate> &queries,
     }
     TIMER_STOP(query);
 
-    std::cout << "Took " << TIMER_SEC(query) << " seconds "
-              << "(" << TIMER_MSEC(query) << "ms"
-              << ")  ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
+    std::cout << TIMER_MSEC(query) << "ms"
+              << "  ->  " << TIMER_MSEC(query) / queries.size() << " ms/query "
               << "(" << TIMER_MSEC(query) << "ms"
               << ")" << std::endl;
 }
@@ -66,10 +63,10 @@ void benchmark(BenchStaticRTree &rtree, unsigned num_queries)
     }
 
     benchmarkQuery(queries,
-                   "raw RTree queries (1 result)",
+                   "1 result",
                    [&rtree](const util::Coordinate &q) { return rtree.Nearest(q, 1); });
     benchmarkQuery(queries,
-                   "raw RTree queries (10 results)",
+                   "10 results",
                    [&rtree](const util::Coordinate &q) { return rtree.Nearest(q, 10); });
 }
 } // namespace osrm::benchmarks


### PR DESCRIPTION
# Issue

This PR adds CI job which allows to compare results of benchmarks in base branch (i.e. usually `master`) and PR. Should allow us to detect regressions and prove improvements. 

Works in the following way:
- Checkout and build base branch
- Checkout and build PR branch
- Run benchmarks from both branches
- Gather report with stdout of benchmarks from both base and PR and post it as footer section to PR description (or update if it already exists)

Example can be seen even in this PR, but it looks really ugly, because benchmarks from base branch currently contain a lot of not really relevant text which makes output too long. Example how it will look like after merge(after merge base branch will contain changes I made in benchmarks):

<img width="1263" alt="Screenshot 2024-05-11 at 22 26 58" src="https://github.com/Project-OSRM/osrm-backend/assets/266271/c2e213a6-c93d-4bad-82b6-97c03176bee4">

Also benchmarks themselves could be really improved and, may be, somehow unified, but I keep it out of scope of this PR.


## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?


<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | [2024-05-11T20:45:52.697546907] [info] aliased u32: 1141.83<br/>[2024-05-11T20:45:53.831361105] [info] plain u32: 1133.64<br/>[2024-05-11T20:45:55.010312885] [info] aliased double: 1178.9<br/>[2024-05-11T20:45:56.187701530] [info] plain double: 1177.34 | aliased u32: 1134.61<br/>plain u32: 1124.43<br/>aliased double: 1165.93<br/>plain double: 1178.22 |
| json-render | String: 8.50562ms<br/>Stringstream: 11.4028ms<br/>Vector: 7.75605ms | String: 8.46138ms<br/>Stringstream: 11.3649ms<br/>Vector: 7.6425ms |
| match_ch | 8.21244ms/req at 82 coordinate<br/>0.100152ms/coordinate | 8.24465ms/req at 82 coordinate<br/>0.100544ms/coordinate |
| match_mld | 7.46581ms/req at 82 coordinate<br/>0.0910464ms/coordinate | 7.10228ms/req at 82 coordinate<br/>0.0866132ms/coordinate |
| packedvector | [2024-05-11T20:48:02.991000738] [info] random write: std::vector 11174 ms, util::packed_vector 73866.4 ms. 6.61055<br/>[2024-05-11T20:48:02.991129828] [info] random read: std::vector 11089.8 ms, util::packed_vector 30574.1 ms. 2.75696 | random write:<br/>std::vector 11179.6 ms<br/>util::packed_vector 81950.3 ms<br/>slowdown: 7.33033<br/>random read:<br/>std::vector 11004 ms<br/>util::packed_vector 33840 ms<br/>slowdown: 3.07525 |
| rtree | Running raw RTree queries (1 result) with 10000 coordinates: Took 0.206803 seconds (206.804ms)  ->  0.0206804 ms/query (206.804ms)<br/>Running raw RTree queries (10 results) with 10000 coordinates: Took 0.242288 seconds (242.288ms)  ->  0.0242288 ms/query (242.288ms) | 1 result:<br/>208.412ms ->  0.0208412 ms/query<br/>10 results:<br/>243.502ms ->  0.0243502 ms/query |
<!-- BENCHMARK_RESULTS_END -->