### PR TITLE
Optimise R-tree queries in the case of map matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
       - FIXED: Correctly check runtime search conditions for forcing routing steps [#6866](https://github.com/Project-OSRM/osrm-backend/pull/6866)
     - Map Matching:
       - CHANGED: Optimise path distance calculation in MLD map matching. [#6876](https://github.com/Project-OSRM/osrm-backend/pull/6876)
+      - CHANGED: Optimise R-tree queries in the case of map matching. [#6881](https://github.com/Project-OSRM/osrm-backend/pull/6876)
     - Debug tiles:
       - FIXED: Ensure speed layer features have unique ids. [#6726](https://github.com/Project-OSRM/osrm-backend/pull/6726)
 

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -375,7 +375,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         BOOST_ASSERT(m_geospatial_query.get());
 
         return m_geospatial_query->NearestPhantomNodes(
-            input_coordinate, approach, boost::none, max_distance, bearing, use_all_edges);
+            input_coordinate, approach, max_distance, bearing, use_all_edges);
     }
 
     std::vector<PhantomNodeWithDistance>

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -74,11 +74,6 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 {
                     return std::pair<bool, bool>{false, false};
                 }
-                (void)approach;
-                (void)use_all_edges;
-                (void)bearing_with_range;
-                (void)use_all_edges;
-
                 auto valid = CheckSegmentExclude(segment) &&
                              CheckApproach(input_coordinate, segment, approach) &&
                              (use_all_edges ? HasValidEdge(segment, *use_all_edges)

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -87,7 +87,15 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                                                  : std::make_pair(true, true));
                 return valid;
             });
-        return MakePhantomNodes(input_coordinate, results);
+        auto phantom_nodes = MakePhantomNodes(input_coordinate, results);
+        // there is no guarantee that `SearchInRange` will return results sorted by distance, 
+        // but we may rely on it somewhere
+        std::sort(phantom_nodes.begin(), phantom_nodes.end(), [](const auto &lhs,
+                                                                        const auto &rhs)
+            {
+                return lhs.distance < rhs.distance;
+            });
+        return phantom_nodes;
 #endif
     }
 
@@ -338,11 +346,6 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                        distance_and_phantoms.begin(),
                        [this, &input_coordinate](const CandidateSegment &segment)
                        { return MakePhantomNode(input_coordinate, segment.data); });
-        std::sort(distance_and_phantoms.begin(), distance_and_phantoms.end(), [](const auto &lhs,
-                                                                                const auto &rhs)
-                  {
-                      return lhs.distance < rhs.distance;
-                  });
         return distance_and_phantoms;
     }
 

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -88,13 +88,11 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                 return valid;
             });
         auto phantom_nodes = MakePhantomNodes(input_coordinate, results);
-        // there is no guarantee that `SearchInRange` will return results sorted by distance, 
+        // there is no guarantee that `SearchInRange` will return results sorted by distance,
         // but we may rely on it somewhere
-        std::sort(phantom_nodes.begin(), phantom_nodes.end(), [](const auto &lhs,
-                                                                        const auto &rhs)
-            {
-                return lhs.distance < rhs.distance;
-            });
+        std::sort(phantom_nodes.begin(),
+                  phantom_nodes.end(),
+                  [](const auto &lhs, const auto &rhs) { return lhs.distance < rhs.distance; });
         return phantom_nodes;
 #endif
     }

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -54,14 +54,6 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                         const boost::optional<Bearing> bearing_with_range,
                         const boost::optional<bool> use_all_edges) const
     {
-#if 0
-        return NearestPhantomNodes(input_coordinate,
-                                   approach,
-                                   boost::optional<size_t>{},
-                                   max_distance,
-                                   bearing_with_range,
-                                   use_all_edges);
-#else
         auto results = rtree.SearchInRange(
             input_coordinate,
             max_distance,
@@ -89,7 +81,6 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                   phantom_nodes.end(),
                   [](const auto &lhs, const auto &rhs) { return lhs.distance < rhs.distance; });
         return phantom_nodes;
-#endif
     }
 
     // Returns max_results nearest PhantomNodes that are valid within the provided parameters.

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -82,7 +82,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
     std::vector<PhantomNodeWithDistance>
     NearestPhantomNodes(const util::Coordinate input_coordinate,
                         const Approach approach,
-                        const boost::optional<size_t> max_results,
+                        const size_t max_results,
                         const boost::optional<double> max_distance,
                         const boost::optional<Bearing> bearing_with_range,
                         const boost::optional<bool> use_all_edges) const
@@ -100,10 +100,10 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                                                  : std::make_pair(true, true));
                 return valid;
             },
-            [this, &max_distance, &max_results, input_coordinate](const std::size_t num_results,
-                                                                  const CandidateSegment &segment)
+            [this, &max_distance, max_results, input_coordinate](const std::size_t num_results,
+                                                                 const CandidateSegment &segment)
             {
-                return (max_results && num_results >= *max_results) ||
+                return (num_results >= max_results) ||
                        (max_distance && max_distance != -1.0 &&
                         CheckSegmentDistance(input_coordinate, segment, *max_distance));
             });

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -64,7 +64,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                     CheckSegmentDistance(input_coordinate, segment, max_distance);
                 if (invalidDistance)
                 {
-                    return std::pair<bool, bool>{false, false};
+                    return std::make_pair(false, false);
                 }
                 auto valid = CheckSegmentExclude(segment) &&
                              CheckApproach(input_coordinate, segment, approach) &&

--- a/include/engine/geospatial_query.hpp
+++ b/include/engine/geospatial_query.hpp
@@ -74,13 +74,7 @@ template <typename RTreeT, typename DataFacadeT> class GeospatialQuery
                                                  : std::make_pair(true, true));
                 return valid;
             });
-        auto phantom_nodes = MakePhantomNodes(input_coordinate, results);
-        // there is no guarantee that `SearchInRange` will return results sorted by distance,
-        // but we may rely on it somewhere
-        std::sort(phantom_nodes.begin(),
-                  phantom_nodes.end(),
-                  [](const auto &lhs, const auto &rhs) { return lhs.distance < rhs.distance; });
-        return phantom_nodes;
+        return MakePhantomNodes(input_coordinate, results);
     }
 
     // Returns max_results nearest PhantomNodes that are valid within the provided parameters.

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -36,6 +36,13 @@ inline double radToDeg(const double radian)
 }
 } // namespace detail
 
+const constexpr static double METERS_PER_DEGREE_LAT = 110567.0;
+
+inline double metersPerLngDegree(const FixedLatitude lat)
+{
+    return std::cos(detail::degToRad(static_cast<double>(toFloating(lat)))) * METERS_PER_DEGREE_LAT;
+}
+
 //! Takes the squared euclidean distance of the input coordinates. Does not return meters!
 std::uint64_t squaredEuclideanDistance(const Coordinate lhs, const Coordinate rhs);
 

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -4,8 +4,8 @@
 #include "coordinate.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
-
 #include <boost/assert.hpp>
+#include <boost/math/constants/constants.hpp>
 
 #include <limits>
 #include <utility>
@@ -170,19 +170,11 @@ struct RectangleInt2D
                max_lat != FixedLatitude{std::numeric_limits<std::int32_t>::min()};
     }
 
-    static double MetersPerLngDegree(const FixedLatitude lat)
-    {
-        constexpr static double kMetersPerDegreeLat = 110567.0f;
-
-        constexpr float kRadPerDeg = (3.14 /* TODO */ / 180.0f);
-
-        return std::cos(kRadPerDeg * static_cast<double>(toFloating(lat))) * kMetersPerDegreeLat;
-    }
     static RectangleInt2D ExpandMeters(const Coordinate &coordinate, const double meters)
     {
-        constexpr static double kMetersPerDegreeLat = 110567.0f;
-        const double lat_offset = meters / kMetersPerDegreeLat;
-        const double lon_offset = meters / MetersPerLngDegree(coordinate.lat);
+        const double lat_offset = meters / coordinate_calculation::METERS_PER_DEGREE_LAT;
+        const double lon_offset =
+            meters / coordinate_calculation::metersPerLngDegree(coordinate.lat);
 
         return RectangleInt2D{coordinate.lon - toFixed(FloatLongitude{lon_offset}),
                               coordinate.lon + toFixed(FloatLongitude{lon_offset}),

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -1,6 +1,7 @@
 #ifndef OSRM_UTIL_RECTANGLE_HPP
 #define OSRM_UTIL_RECTANGLE_HPP
 
+#include "coordinate.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
 
@@ -167,6 +168,26 @@ struct RectangleInt2D
                max_lon != FixedLongitude{std::numeric_limits<std::int32_t>::min()} &&
                min_lat != FixedLatitude{std::numeric_limits<std::int32_t>::max()} &&
                max_lat != FixedLatitude{std::numeric_limits<std::int32_t>::min()};
+    }
+
+    static double MetersPerLngDegree(const FixedLatitude lat)
+    {
+        constexpr static double kMetersPerDegreeLat = 110567.0f;
+
+        constexpr float kRadPerDeg = (3.14 /* TODO */ / 180.0f);
+
+        return std::cos(kRadPerDeg * static_cast<double>(toFloating(lat))) * kMetersPerDegreeLat;
+    }
+    static RectangleInt2D ExpandMeters(const Coordinate &coordinate, const double meters)
+    {
+        constexpr static double kMetersPerDegreeLat = 110567.0f;
+        const double lat_offset = meters / kMetersPerDegreeLat;
+        const double lon_offset = meters / MetersPerLngDegree(coordinate.lat);
+
+        return RectangleInt2D{coordinate.lon - toFixed(FloatLongitude{lon_offset}),
+                              coordinate.lon + toFixed(FloatLongitude{lon_offset}),
+                              coordinate.lat - toFixed(FloatLatitude{lat_offset}),
+                              coordinate.lat + toFixed(FloatLatitude{lat_offset})};
     }
 };
 } // namespace osrm::util

--- a/include/util/rectangle.hpp
+++ b/include/util/rectangle.hpp
@@ -1,11 +1,9 @@
 #ifndef OSRM_UTIL_RECTANGLE_HPP
 #define OSRM_UTIL_RECTANGLE_HPP
 
-#include "coordinate.hpp"
 #include "util/coordinate.hpp"
 #include "util/coordinate_calculation.hpp"
 #include <boost/assert.hpp>
-#include <boost/math/constants/constants.hpp>
 
 #include <limits>
 #include <utility>

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -565,21 +565,9 @@ class StaticRTree
             { return num_results >= max_results; });
     }
 
-    inline double GetSegmentDistance(const Coordinate input_coordinate,
-                                     const CandidateSegment &segment) const
-    {
-        BOOST_ASSERT(segment.data.forward_segment_id.id != SPECIAL_SEGMENTID ||
-                     !segment.data.forward_segment_id.enabled);
-        BOOST_ASSERT(segment.data.reverse_segment_id.id != SPECIAL_SEGMENTID ||
-                     !segment.data.reverse_segment_id.enabled);
-
-        Coordinate wsg84_coordinate =
-            util::web_mercator::toWGS84(segment.fixed_projected_coordinate);
-
-        return util::coordinate_calculation::greatCircleDistance(input_coordinate,
-                                                                 wsg84_coordinate);
-    }
-
+    // NB 1: results are not guaranteed to be sorted by distance
+    // NB 2: maxDistanceMeters is not a hard limit, it's just a way to reduce the number of edges
+    // returned
     template <typename FilterT>
     std::vector<CandidateSegment> SearchInRange(const Coordinate input_coordinate,
                                                 double maxDistanceMeters,

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -487,70 +487,9 @@ class StaticRTree
        Rectangle needs to be projected!*/
     std::vector<EdgeDataT> SearchInBox(const Rectangle &search_rectangle) const
     {
-        const Rectangle projected_rectangle{
-            search_rectangle.min_lon,
-            search_rectangle.max_lon,
-            toFixed(FloatLatitude{
-                web_mercator::latToY(toFloating(FixedLatitude(search_rectangle.min_lat)))}),
-            toFixed(FloatLatitude{
-                web_mercator::latToY(toFloating(FixedLatitude(search_rectangle.max_lat)))})};
         std::vector<EdgeDataT> results;
-
-        std::queue<TreeIndex> traversal_queue;
-        traversal_queue.push(TreeIndex{});
-
-        while (!traversal_queue.empty())
-        {
-            auto const current_tree_index = traversal_queue.front();
-            traversal_queue.pop();
-
-            // If we're at the bottom of the tree, we need to explore the
-            // element array
-            if (is_leaf(current_tree_index))
-            {
-
-                // Note: irange is [start,finish), so we need to +1 to make sure we visit the
-                // last
-                for (const auto current_child_index : child_indexes(current_tree_index))
-                {
-                    const auto &current_edge = m_objects[current_child_index];
-
-                    // we don't need to project the coordinates here,
-                    // because we use the unprojected rectangle to test against
-                    const Rectangle bbox{std::min(m_coordinate_list[current_edge.u].lon,
-                                                  m_coordinate_list[current_edge.v].lon),
-                                         std::max(m_coordinate_list[current_edge.u].lon,
-                                                  m_coordinate_list[current_edge.v].lon),
-                                         std::min(m_coordinate_list[current_edge.u].lat,
-                                                  m_coordinate_list[current_edge.v].lat),
-                                         std::max(m_coordinate_list[current_edge.u].lat,
-                                                  m_coordinate_list[current_edge.v].lat)};
-
-                    // use the _unprojected_ input rectangle here
-                    if (bbox.Intersects(search_rectangle))
-                    {
-                        results.push_back(current_edge);
-                    }
-                }
-            }
-            else
-            {
-                BOOST_ASSERT(current_tree_index.level + 1 < m_tree_level_starts.size());
-
-                for (const auto child_index : child_indexes(current_tree_index))
-                {
-                    const auto &child_rectangle =
-                        m_search_tree[child_index].minimum_bounding_rectangle;
-
-                    if (child_rectangle.Intersects(projected_rectangle))
-                    {
-                        traversal_queue.push(TreeIndex(
-                            current_tree_index.level + 1,
-                            child_index - m_tree_level_starts[current_tree_index.level + 1]));
-                    }
-                }
-            }
-        }
+        SearchInBox(search_rectangle,
+                    [&results](const auto &edge_data) { results.push_back(edge_data); });
         return results;
     }
 
@@ -573,34 +512,34 @@ class StaticRTree
                                                 double maxDistanceMeters,
                                                 const FilterT filter) const
     {
-        (void)filter;
         auto projected_coordinate = web_mercator::fromWGS84(input_coordinate);
         Coordinate fixed_projected_coordinate{projected_coordinate};
 
         auto bbox = Rectangle::ExpandMeters(input_coordinate, maxDistanceMeters);
-        auto results_in_bbox = SearchInBox(bbox);
         std::vector<CandidateSegment> results;
-        for (const auto &current_edge : results_in_bbox)
-        {
-            const auto projected_u = web_mercator::fromWGS84(m_coordinate_list[current_edge.u]);
-            const auto projected_v = web_mercator::fromWGS84(m_coordinate_list[current_edge.v]);
 
-            FloatCoordinate projected_nearest;
-            std::tie(std::ignore, projected_nearest) =
-                coordinate_calculation::projectPointOnSegment(
+        SearchInBox(
+            bbox,
+            [&results, &filter, fixed_projected_coordinate, this](const EdgeDataT &current_edge)
+            {
+                const auto projected_u = web_mercator::fromWGS84(m_coordinate_list[current_edge.u]);
+                const auto projected_v = web_mercator::fromWGS84(m_coordinate_list[current_edge.v]);
+
+                auto [_, projected_nearest] = coordinate_calculation::projectPointOnSegment(
                     projected_u, projected_v, fixed_projected_coordinate);
 
-            CandidateSegment current_candidate{projected_nearest, current_edge};
-            auto use_segment = filter(current_candidate);
-            if (!use_segment.first && !use_segment.second)
-            {
-                continue;
-            }
-            current_candidate.data.forward_segment_id.enabled &= use_segment.first;
-            current_candidate.data.reverse_segment_id.enabled &= use_segment.second;
+                CandidateSegment current_candidate{projected_nearest, current_edge};
+                auto use_segment = filter(current_candidate);
+                if (!use_segment.first && !use_segment.second)
+                {
+                    return;
+                }
+                current_candidate.data.forward_segment_id.enabled &= use_segment.first;
+                current_candidate.data.reverse_segment_id.enabled &= use_segment.second;
 
-            results.push_back(std::move(current_candidate));
-        }
+                results.push_back(current_candidate);
+            });
+
         return results;
     }
 
@@ -672,6 +611,73 @@ class StaticRTree
     }
 
   private:
+    template <typename Callback>
+    void SearchInBox(const Rectangle &search_rectangle, Callback &&callback) const
+    {
+        const Rectangle projected_rectangle{
+            search_rectangle.min_lon,
+            search_rectangle.max_lon,
+            toFixed(FloatLatitude{
+                web_mercator::latToY(toFloating(FixedLatitude(search_rectangle.min_lat)))}),
+            toFixed(FloatLatitude{
+                web_mercator::latToY(toFloating(FixedLatitude(search_rectangle.max_lat)))})};
+        std::queue<TreeIndex> traversal_queue;
+        traversal_queue.push(TreeIndex{});
+
+        while (!traversal_queue.empty())
+        {
+            auto const current_tree_index = traversal_queue.front();
+            traversal_queue.pop();
+
+            // If we're at the bottom of the tree, we need to explore the
+            // element array
+            if (is_leaf(current_tree_index))
+            {
+
+                // Note: irange is [start,finish), so we need to +1 to make sure we visit the
+                // last
+                for (const auto current_child_index : child_indexes(current_tree_index))
+                {
+                    const auto &current_edge = m_objects[current_child_index];
+
+                    // we don't need to project the coordinates here,
+                    // because we use the unprojected rectangle to test against
+                    const Rectangle bbox{std::min(m_coordinate_list[current_edge.u].lon,
+                                                  m_coordinate_list[current_edge.v].lon),
+                                         std::max(m_coordinate_list[current_edge.u].lon,
+                                                  m_coordinate_list[current_edge.v].lon),
+                                         std::min(m_coordinate_list[current_edge.u].lat,
+                                                  m_coordinate_list[current_edge.v].lat),
+                                         std::max(m_coordinate_list[current_edge.u].lat,
+                                                  m_coordinate_list[current_edge.v].lat)};
+
+                    // use the _unprojected_ input rectangle here
+                    if (bbox.Intersects(search_rectangle))
+                    {
+                        callback(current_edge);
+                    }
+                }
+            }
+            else
+            {
+                BOOST_ASSERT(current_tree_index.level + 1 < m_tree_level_starts.size());
+
+                for (const auto child_index : child_indexes(current_tree_index))
+                {
+                    const auto &child_rectangle =
+                        m_search_tree[child_index].minimum_bounding_rectangle;
+
+                    if (child_rectangle.Intersects(projected_rectangle))
+                    {
+                        traversal_queue.push(TreeIndex(
+                            current_tree_index.level + 1,
+                            child_index - m_tree_level_starts[current_tree_index.level + 1]));
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Iterates over all the objects in a leaf node and inserts them into our
      * search priority queue.  The speed of this function is very much governed

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -224,6 +224,7 @@ try
         if (rc != Status::Ok ||
             json_result.values.at("matchings").get<json::Array>().values.size() != 1)
         {
+            std::cerr << "Failure\n";
             return EXIT_FAILURE;
         }
     }

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -13,13 +13,13 @@
 #include <boost/assert.hpp>
 
 #include <boost/optional/optional.hpp>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
-
-#include <cstdlib>
 
 int main(int argc, const char *argv[])
 try

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -220,11 +220,14 @@ try
         params.radiuses.emplace_back();
     }
 
-    auto run_benchmark = [&](double radiusInMeters)
+    auto run_benchmark = [&](std::optional<double> radiusInMeters)
     {
-        for (auto &radius : params.radiuses)
+        if (radiusInMeters)
         {
-            radius = radiusInMeters;
+            for (auto &radius : params.radiuses)
+            {
+                radius = *radiusInMeters;
+            }
         }
 
         TIMER_START(routes);
@@ -241,25 +244,25 @@ try
             }
         }
         TIMER_STOP(routes);
-        std::cout << "Radius " << radiusInMeters << "m: " << std::endl;
+        if (radiusInMeters)
+        {
+            std::cout << "Radius " << *radiusInMeters << "m: " << std::endl;
+        }
+        else
+        {
+            std::cout << "Default radius: " << std::endl;
+        }
         std::cout << (TIMER_MSEC(routes) / NUM) << "ms/req at " << params.coordinates.size()
                   << " coordinate" << std::endl;
         std::cout << (TIMER_MSEC(routes) / NUM / params.coordinates.size()) << "ms/coordinate"
                   << std::endl;
     };
 
-    try
-    {
-        run_benchmark(5.0);
-        run_benchmark(10.0);
-        run_benchmark(15.0);
-        run_benchmark(30.0);
-    }
-    catch (const std::exception &e)
-    {
-        std::cerr << "Error: " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
+    run_benchmark(std::nullopt);
+    run_benchmark(5.0);
+    run_benchmark(10.0);
+    run_benchmark(15.0);
+    run_benchmark(30.0);
 
     return EXIT_SUCCESS;
 }

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -348,7 +348,13 @@ BOOST_AUTO_TEST_CASE(radius_regression_test)
 
     {
         auto results = query.NearestPhantomNodes(
-            input, osrm::engine::Approach::UNRESTRICTED, boost::none, 0.01, boost::none, true);
+            input, osrm::engine::Approach::UNRESTRICTED, 0.01, boost::none, true);
+        BOOST_CHECK_EQUAL(results.size(), 0);
+    }
+
+    {
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 1, 0.01, boost::none, true);
         BOOST_CHECK_EQUAL(results.size(), 0);
     }
 }
@@ -374,13 +380,25 @@ BOOST_AUTO_TEST_CASE(permissive_edge_snapping)
 
     {
         auto results = query.NearestPhantomNodes(
-            input, osrm::engine::Approach::UNRESTRICTED, boost::none, 1000, boost::none, false);
+            input, osrm::engine::Approach::UNRESTRICTED, 1000, boost::none, false);
         BOOST_CHECK_EQUAL(results.size(), 1);
     }
 
     {
         auto results = query.NearestPhantomNodes(
-            input, osrm::engine::Approach::UNRESTRICTED, boost::none, 1000, boost::none, true);
+            input, osrm::engine::Approach::UNRESTRICTED, 1000, boost::none, true);
+        BOOST_CHECK_EQUAL(results.size(), 2);
+    }
+
+    {
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 10, 1000, boost::none, false);
+        BOOST_CHECK_EQUAL(results.size(), 1);
+    }
+
+    {
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 10, 1000, boost::none, true);
         BOOST_CHECK_EQUAL(results.size(), 2);
     }
 }
@@ -442,27 +460,45 @@ BOOST_AUTO_TEST_CASE(bearing_tests)
 
     {
         auto results = query.NearestPhantomNodes(
-            input, osrm::engine::Approach::UNRESTRICTED, boost::none, 11000, boost::none, true);
+            input, osrm::engine::Approach::UNRESTRICTED, 11000, boost::none, true);
         BOOST_CHECK_EQUAL(results.size(), 2);
     }
 
     {
-        auto results = query.NearestPhantomNodes(input,
-                                                 osrm::engine::Approach::UNRESTRICTED,
-                                                 boost::none,
-                                                 11000,
-                                                 engine::Bearing{270, 10},
-                                                 true);
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 10, 11000, boost::none, true);
+        BOOST_CHECK_EQUAL(results.size(), 2);
+    }
+
+    {
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 11000, engine::Bearing{270, 10}, true);
         BOOST_CHECK_EQUAL(results.size(), 0);
     }
 
     {
-        auto results = query.NearestPhantomNodes(input,
-                                                 osrm::engine::Approach::UNRESTRICTED,
-                                                 boost::none,
-                                                 11000,
-                                                 engine::Bearing{45, 10},
-                                                 true);
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 10, 11000, engine::Bearing{270, 10}, true);
+        BOOST_CHECK_EQUAL(results.size(), 0);
+    }
+
+    {
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 11000, engine::Bearing{45, 10}, true);
+        BOOST_CHECK_EQUAL(results.size(), 2);
+
+        BOOST_CHECK(results[0].phantom_node.forward_segment_id.enabled);
+        BOOST_CHECK(!results[0].phantom_node.reverse_segment_id.enabled);
+        BOOST_CHECK_EQUAL(results[0].phantom_node.forward_segment_id.id, 1);
+
+        BOOST_CHECK(!results[1].phantom_node.forward_segment_id.enabled);
+        BOOST_CHECK(results[1].phantom_node.reverse_segment_id.enabled);
+        BOOST_CHECK_EQUAL(results[1].phantom_node.reverse_segment_id.id, 1);
+    }
+
+    {
+        auto results = query.NearestPhantomNodes(
+            input, osrm::engine::Approach::UNRESTRICTED, 10, 11000, engine::Bearing{45, 10}, true);
         BOOST_CHECK_EQUAL(results.size(), 2);
 
         BOOST_CHECK(results[0].phantom_node.forward_segment_id.enabled);


### PR DESCRIPTION
# Issue

Since in map matching we don't need to find the N nearest projections, but simply all projections within a certain radius, instead of using a priority queue-based algorithm, we can simply find all edges intersecting the bounding box defined by this radius and then post-process the results to remove edges that are not within the required radius. According to our current simple map matching benchmark with a default search radius of 5m (which is effectively 15m in practice), this makes map matching up to 50% faster! However, with an increase in radius, this optimization becomes less noticeable since a larger radius increases the number of candidates, impacting the number of routes we need to compute in the map matching algorithm. But I have some ideas on how to optimize this as well in my future PRs.

Actual improvement can be seen below in the `match_ch` and `match_mld` benchmarks(the result in master corresponds to default/5m in this PR).



## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?


<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1101.99<br/>plain u32: 1093.37<br/>aliased double: 954.491<br/>plain double: 966.534 | aliased u32: 1098.31<br/>plain u32: 1101.72<br/>aliased double: 966.005<br/>plain double: 964.487 |
| json-render | String: 8.62683ms<br/>Stringstream: 11.6428ms<br/>Vector: 7.58827ms | String: 8.60096ms<br/>Stringstream: 11.7067ms<br/>Vector: 7.58147ms |
| match_ch | Default radius: <br/>8.23085ms/req at 82 coordinate<br/>0.100376ms/coordinate<br/>Radius 5m: <br/>8.19639ms/req at 82 coordinate<br/>0.099956ms/coordinate<br/>Radius 10m: <br/>19.3981ms/req at 82 coordinate<br/>0.236562ms/coordinate<br/>Radius 15m: <br/>41.5492ms/req at 82 coordinate<br/>0.506697ms/coordinate<br/>Radius 30m: <br/>320.866ms/req at 82 coordinate<br/>3.913ms/coordinate | Default radius: <br/>4.50758ms/req at 82 coordinate<br/>0.0549705ms/coordinate<br/>Radius 5m: <br/>4.48594ms/req at 82 coordinate<br/>0.0547065ms/coordinate<br/>Radius 10m: <br/>15.3305ms/req at 82 coordinate<br/>0.186957ms/coordinate<br/>Radius 15m: <br/>37.3413ms/req at 82 coordinate<br/>0.455381ms/coordinate<br/>Radius 30m: <br/>318.02ms/req at 82 coordinate<br/>3.87829ms/coordinate |
| match_mld | Default radius: <br/>7.43256ms/req at 82 coordinate<br/>0.090641ms/coordinate<br/>Radius 5m: <br/>7.12935ms/req at 82 coordinate<br/>0.0869433ms/coordinate<br/>Radius 10m: <br/>16.5298ms/req at 82 coordinate<br/>0.201583ms/coordinate<br/>Radius 15m: <br/>36.6781ms/req at 82 coordinate<br/>0.447294ms/coordinate<br/>Radius 30m: <br/>361.997ms/req at 82 coordinate<br/>4.4146ms/coordinate | Default radius: <br/>3.39512ms/req at 82 coordinate<br/>0.0414039ms/coordinate<br/>Radius 5m: <br/>3.37432ms/req at 82 coordinate<br/>0.0411503ms/coordinate<br/>Radius 10m: <br/>12.3558ms/req at 82 coordinate<br/>0.15068ms/coordinate<br/>Radius 15m: <br/>32.0192ms/req at 82 coordinate<br/>0.390477ms/coordinate<br/>Radius 30m: <br/>351.998ms/req at 82 coordinate<br/>4.29266ms/coordinate |
| packedvector | random write:<br/>std::vector 9792.03 ms<br/>util::packed_vector 82197.7 ms<br/>slowdown: 8.39435<br/>random read:<br/>std::vector 8512.14 ms<br/>util::packed_vector 33173.5 ms<br/>slowdown: 3.8972 | random write:<br/>std::vector 9835.57 ms<br/>util::packed_vector 74173.3 ms<br/>slowdown: 7.54133<br/>random read:<br/>std::vector 8557.96 ms<br/>util::packed_vector 29830.8 ms<br/>slowdown: 3.48573 |
| rtree | 1 result:<br/>208.575ms ->  0.0208575 ms/query<br/>10 results:<br/>243.318ms ->  0.0243318 ms/query | 1 result:<br/>220.757ms ->  0.0220757 ms/query<br/>10 results:<br/>242.402ms ->  0.0242402 ms/query |
<!-- BENCHMARK_RESULTS_END -->