### PR TITLE
Improve map matching benchmark

### DIFF
--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -12,12 +12,14 @@
 
 #include <boost/assert.hpp>
 
+#include <boost/optional/optional.hpp>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
-
-#include <cstdlib>
 
 int main(int argc, const char *argv[])
 try
@@ -213,25 +215,54 @@ try
         FloatCoordinate{FloatLongitude{7.415513992309569}, FloatLatitude{43.73347615145474}});
     params.coordinates.push_back(
         FloatCoordinate{FloatLongitude{7.415342330932617}, FloatLatitude{43.733251335381205}});
-
-    TIMER_START(routes);
-    auto NUM = 100;
-    for (int i = 0; i < NUM; ++i)
+    for (size_t index = 0; index < params.coordinates.size(); ++index)
     {
-        engine::api::ResultT result = json::Object();
-        const auto rc = osrm.Match(params, result);
-        auto &json_result = result.get<json::Object>();
-        if (rc != Status::Ok ||
-            json_result.values.at("matchings").get<json::Array>().values.size() != 1)
-        {
-            return EXIT_FAILURE;
-        }
+        params.radiuses.emplace_back();
     }
-    TIMER_STOP(routes);
-    std::cout << (TIMER_MSEC(routes) / NUM) << "ms/req at " << params.coordinates.size()
-              << " coordinate" << std::endl;
-    std::cout << (TIMER_MSEC(routes) / NUM / params.coordinates.size()) << "ms/coordinate"
-              << std::endl;
+
+    auto run_benchmark = [&](std::optional<double> radiusInMeters)
+    {
+        if (radiusInMeters)
+        {
+            for (auto &radius : params.radiuses)
+            {
+                radius = *radiusInMeters;
+            }
+        }
+
+        TIMER_START(routes);
+        auto NUM = 100;
+        for (int i = 0; i < NUM; ++i)
+        {
+            engine::api::ResultT result = json::Object();
+            const auto rc = osrm.Match(params, result);
+            auto &json_result = result.get<json::Object>();
+            if (rc != Status::Ok ||
+                json_result.values.at("matchings").get<json::Array>().values.size() != 1)
+            {
+                throw std::runtime_error{"Couldn't match"};
+            }
+        }
+        TIMER_STOP(routes);
+        if (radiusInMeters)
+        {
+            std::cout << "Radius " << *radiusInMeters << "m: " << std::endl;
+        }
+        else
+        {
+            std::cout << "Default radius: " << std::endl;
+        }
+        std::cout << (TIMER_MSEC(routes) / NUM) << "ms/req at " << params.coordinates.size()
+                  << " coordinate" << std::endl;
+        std::cout << (TIMER_MSEC(routes) / NUM / params.coordinates.size()) << "ms/coordinate"
+                  << std::endl;
+    };
+
+    run_benchmark(std::nullopt);
+    run_benchmark(5.0);
+    run_benchmark(10.0);
+    run_benchmark(15.0);
+    run_benchmark(30.0);
 
     return EXIT_SUCCESS;
 }

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -11,8 +11,6 @@
 #include "osrm/status.hpp"
 
 #include <boost/assert.hpp>
-
-#include <boost/optional/optional.hpp>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -255,11 +253,10 @@ try
                   << std::endl;
     };
 
-    run_benchmark(std::nullopt);
-    run_benchmark(5.0);
-    run_benchmark(10.0);
-    run_benchmark(15.0);
-    run_benchmark(30.0);
+    for (auto radius : std::vector<std::optional<double>>{std::nullopt, 5.0, 10.0, 15.0, 30.0})
+    {
+        run_benchmark(radius);
+    }
 
     return EXIT_SUCCESS;
 }

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -215,18 +215,15 @@ try
         FloatCoordinate{FloatLongitude{7.415513992309569}, FloatLatitude{43.73347615145474}});
     params.coordinates.push_back(
         FloatCoordinate{FloatLongitude{7.415342330932617}, FloatLatitude{43.733251335381205}});
-    for (size_t index = 0; index < params.coordinates.size(); ++index)
-    {
-        params.radiuses.emplace_back();
-    }
 
     auto run_benchmark = [&](std::optional<double> radiusInMeters)
     {
+        params.radiuses = {};
         if (radiusInMeters)
         {
-            for (auto &radius : params.radiuses)
+            for (size_t index = 0; index < params.coordinates.size(); ++index)
             {
-                radius = *radiusInMeters;
+                params.radiuses.emplace_back(*radiusInMeters);
             }
         }
 


### PR DESCRIPTION
# Issue

Search radius impacts map matching a lot, so it worth benchmarking it with different search radiuses. This change is extracted from https://github.com/Project-OSRM/osrm-backend/pull/6881 - I want to merge it separately to see results of this benchmark for master branch as well before merging other PRs related to map matching.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?


<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1088.02<br/>plain u32: 1096.49<br/>aliased double: 960.197<br/>plain double: 959.21 | aliased u32: 1088.03<br/>plain u32: 1099.89<br/>aliased double: 957.808<br/>plain double: 969.223 |
| json-render | String: 8.46777ms<br/>Stringstream: 11.55ms<br/>Vector: 7.60681ms | String: 8.47694ms<br/>Stringstream: 11.7215ms<br/>Vector: 7.63128ms |
| match_ch | 8.25151ms/req at 82 coordinate<br/>0.100628ms/coordinate | Default radius: <br/>8.18099ms/req at 82 coordinate<br/>0.0997682ms/coordinate<br/>Radius 5m: <br/>8.23441ms/req at 82 coordinate<br/>0.10042ms/coordinate<br/>Radius 10m: <br/>19.285ms/req at 82 coordinate<br/>0.235183ms/coordinate<br/>Radius 15m: <br/>41.4395ms/req at 82 coordinate<br/>0.50536ms/coordinate<br/>Radius 30m: <br/>319.343ms/req at 82 coordinate<br/>3.89443ms/coordinate |
| match_mld | 7.52004ms/req at 82 coordinate<br/>0.0917078ms/coordinate | Default radius: <br/>7.16231ms/req at 82 coordinate<br/>0.0873452ms/coordinate<br/>Radius 5m: <br/>7.13249ms/req at 82 coordinate<br/>0.0869816ms/coordinate<br/>Radius 10m: <br/>16.5194ms/req at 82 coordinate<br/>0.201457ms/coordinate<br/>Radius 15m: <br/>36.4576ms/req at 82 coordinate<br/>0.444605ms/coordinate<br/>Radius 30m: <br/>357.755ms/req at 82 coordinate<br/>4.36286ms/coordinate |
| packedvector | random write:<br/>std::vector 9814.47 ms<br/>util::packed_vector 82157.9 ms<br/>slowdown: 8.3711<br/>random read:<br/>std::vector 8508.21 ms<br/>util::packed_vector 33175.6 ms<br/>slowdown: 3.89924 | random write:<br/>std::vector 9793.71 ms<br/>util::packed_vector 73861.9 ms<br/>slowdown: 7.54177<br/>random read:<br/>std::vector 8541.27 ms<br/>util::packed_vector 30449.3 ms<br/>slowdown: 3.56497 |
| rtree | 1 result:<br/>206.353ms ->  0.0206353 ms/query<br/>10 results:<br/>242.143ms ->  0.0242143 ms/query | 1 result:<br/>207.206ms ->  0.0207206 ms/query<br/>10 results:<br/>242.502ms ->  0.0242502 ms/query |
<!-- BENCHMARK_RESULTS_END -->