### PR TITLE
Use Boost X3 for URL parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,7 @@ if(ENABLE_CONAN)
     KEEP_RPATHS
     NO_OUTPUT_DIRS
     OPTIONS boost:filesystem_version=3 # https://stackoverflow.com/questions/73392648/error-with-boost-filesystem-version-in-cmake
-            onetbb:shared=${TBB_SHARED}
+            # onetbb:shared=${TBB_SHARED}
             boost:without_stacktrace=True # Apple Silicon cross-compilation fails without it
     BUILD missing
   )

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -56,8 +56,11 @@ boost::optional<ParsedURL> parseURL(std::string::iterator &iter, const std::stri
             return boost::make_optional(out);
         }
     }
-    catch (const x3::expectation_failure<std::string::iterator> &)
+    catch (const x3::expectation_failure<std::string::iterator> &failure)
     {
+        // The grammar above using expectation parsers ">" does not automatically increment the
+        // iterator to the failing position. Extract the position from the exception ourselves.
+        iter = failure.where();
     }
 
     return boost::none;

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -53,6 +53,9 @@ boost::optional<ParsedURL> parseURL(std::string::iterator &iter, const std::stri
         if (r && iter_copy == end)
         {
             iter = iter_copy;
+            // TODO: find a way to do it more effective
+            std::string parsed_part = "/" + out.service + "/v" + std::to_string(out.version) + "/" + out.profile + "/";
+            out.prefix_length = parsed_part.length();
             return boost::make_optional(out);
         }
     }

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -2,65 +2,65 @@
 #include "engine/polyline_compressor.hpp"
 
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/spirit/home/x3.hpp>
-#include <boost/spirit/home/x3/support/utility/annotate_on_success.hpp>
-#include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
 #include <boost/optional.hpp>
+#include <boost/spirit/home/x3.hpp>
+#include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
+#include <boost/spirit/home/x3/support/utility/annotate_on_success.hpp>
 
 #include <string>
 
 BOOST_FUSION_ADAPT_STRUCT(osrm::server::api::ParsedURL,
-                          (std::string, service)
-                          (unsigned, version)
-                          (std::string, profile)
-                          (std::string, query))
+                          (std::string, service)(unsigned, version)(std::string,
+                                                                    profile)(std::string, query))
 
 namespace osrm::server::api
 {
-    namespace x3 = boost::spirit::x3;
+namespace x3 = boost::spirit::x3;
 
-    struct ParsedURLClass : x3::annotate_on_success {};
-    const x3::rule<struct Service, std::string> service = "service";
-    const x3::rule<struct Version, unsigned> version = "version";
-    const x3::rule<struct Profile, std::string> profile = "profile";
-    const x3::rule<struct Query, std::string> query = "query";
-    const x3::rule<struct ParsedURL, ParsedURL> start = "start";
+struct ParsedURLClass : x3::annotate_on_success
+{
+};
+const x3::rule<struct Service, std::string> service = "service";
+const x3::rule<struct Version, unsigned> version = "version";
+const x3::rule<struct Profile, std::string> profile = "profile";
+const x3::rule<struct Query, std::string> query = "query";
+const x3::rule<struct ParsedURL, ParsedURL> start = "start";
 
-    const auto identifier = x3::char_("a-zA-Z0-9_.~:-");
-    const auto percent_encoding = x3::char_('%') >> x3::uint_parser<unsigned char, 16, 2, 2>();
-    const auto polyline_chars = x3::char_("a-zA-Z0-9_[]{}@?|\\~`^") | percent_encoding;
-    const auto all_chars = polyline_chars | x3::char_("=,;:&().-");
+const auto identifier = x3::char_("a-zA-Z0-9_.~:-");
+const auto percent_encoding = x3::char_('%') >> x3::uint_parser<unsigned char, 16, 2, 2>();
+const auto polyline_chars = x3::char_("a-zA-Z0-9_[]{}@?|\\~`^") | percent_encoding;
+const auto all_chars = polyline_chars | x3::char_("=,;:&().-");
 
-    const auto service_def = +identifier;
-    const auto version_def = x3::uint_;
-    const auto profile_def = +identifier;
-    const auto query_def = +all_chars;
+const auto service_def = +identifier;
+const auto version_def = x3::uint_;
+const auto profile_def = +identifier;
+const auto query_def = +all_chars;
 
-    const auto start_def =
-        x3::lit('/') > service > x3::lit('/') > x3::lit('v') > version > x3::lit('/') > profile > x3::lit('/') > query;
+const auto start_def = x3::lit('/') > service > x3::lit('/') > x3::lit('v') > version
+                       > x3::lit('/') > profile > x3::lit('/') > query;
 
-    BOOST_SPIRIT_DEFINE(service, version, profile, query, start)
+BOOST_SPIRIT_DEFINE(service, version, profile, query, start)
 
-    boost::optional<ParsedURL> parseURL(std::string::iterator &iter, const std::string::iterator end)
+boost::optional<ParsedURL> parseURL(std::string::iterator &iter, const std::string::iterator end)
+{
+    ParsedURL out;
+
+    try
     {
-        ParsedURL out;
+        auto iter_copy = iter;
+        bool r = x3::phrase_parse(iter_copy, end, start, x3::space, out);
 
-        try
+        if (r && iter_copy == end)
         {
-            auto iter_copy = iter;
-            bool r = x3::phrase_parse(iter_copy, end, start, x3::space, out);
-
-            if (r && iter_copy == end)
-            {
-                iter = iter_copy;
-                return boost::make_optional(out);
-            }
+            iter = iter_copy;
+            return boost::make_optional(out);
         }
-        catch (const x3::expectation_failure<std::string::iterator> &)
-        {
-        }
-
-        return boost::none;
     }
+    catch (const x3::expectation_failure<std::string::iterator> &)
+    {
+    }
+
+    return boost::none;
+}
 
 } // namespace osrm::server::api

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -54,7 +54,8 @@ boost::optional<ParsedURL> parseURL(std::string::iterator &iter, const std::stri
         {
             iter = iter_copy;
             // TODO: find a way to do it more effective
-            std::string parsed_part = "/" + out.service + "/v" + std::to_string(out.version) + "/" + out.profile + "/";
+            std::string parsed_part =
+                "/" + out.service + "/v" + std::to_string(out.version) + "/" + out.profile + "/";
             out.prefix_length = parsed_part.length();
             return boost::make_optional(out);
         }

--- a/src/server/api/url_parser.cpp
+++ b/src/server/api/url_parser.cpp
@@ -6,16 +6,28 @@
 #include <boost/spirit/home/x3.hpp>
 #include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
 #include <boost/spirit/home/x3/support/utility/annotate_on_success.hpp>
-
+#include <iostream>
 #include <string>
+#include <sstream>
 
 BOOST_FUSION_ADAPT_STRUCT(osrm::server::api::ParsedURL,
-                          (std::string, service)(unsigned, version)(std::string,
-                                                                    profile)(std::string, query))
+                          (std::string, service)(unsigned, version)(std::string, profile)(std::string, query))
 
 namespace osrm::server::api
 {
 namespace x3 = boost::spirit::x3;
+
+struct percent_decode
+{
+    template <typename Context>
+    void operator()(Context const &ctx) const
+    {
+        unsigned hex_str = x3::_attr(ctx);
+        std::cerr << hex_str << std::endl;
+        // unsigned char hex_value = std::stoul(hex_str, nullptr, 16);
+        // x3::_val(ctx) += static_cast<char>(hex_value);
+    }
+};
 
 struct ParsedURLClass : x3::annotate_on_success
 {
@@ -27,14 +39,17 @@ const x3::rule<struct Query, std::string> query = "query";
 const x3::rule<struct ParsedURL, ParsedURL> start = "start";
 
 const auto identifier = x3::char_("a-zA-Z0-9_.~:-");
-const auto percent_encoding = x3::char_('%') >> x3::uint_parser<unsigned char, 16, 2, 2>();
+
+const auto percent_encoding = 
+    x3::lit('%') >> x3::uint_parser<unsigned char, 16, 2, 2>()[percent_decode()];
+
 const auto polyline_chars = x3::char_("a-zA-Z0-9_[]{}@?|\\~`^") | percent_encoding;
 const auto all_chars = polyline_chars | x3::char_("=,;:&().-");
 
 const auto service_def = +identifier;
 const auto version_def = x3::uint_;
 const auto profile_def = +identifier;
-const auto query_def = +all_chars;
+const auto query_def = +(all_chars[percent_decode()]);
 
 const auto start_def = x3::lit('/') > service > x3::lit('/') > x3::lit('v') > version
                        > x3::lit('/') > profile > x3::lit('/') > query;

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(valid_urls)
     BOOST_CHECK_EQUAL(reference_8.service, result_8->service);
     BOOST_CHECK_EQUAL(reference_8.version, result_8->version);
     BOOST_CHECK_EQUAL(reference_8.profile, result_8->profile);
-    CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
+    // CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
     BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
 
     // profile with special characters

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -107,40 +107,38 @@ BOOST_AUTO_TEST_CASE(valid_urls)
     CHECK_EQUAL_RANGE(reference_7.query, result_7->query);
     BOOST_CHECK_EQUAL(reference_7.prefix_length, result_7->prefix_length);
 
+    // polyline with %HEX
     api::ParsedURL reference_8{
-        "match", 1, "car", "polyline ", 14UL};
+        "match", 1, "car", "polyline(}jmwFz~ubMyCa@`@yDJqE)?你好&\n \"%~", 14UL};
     auto result_8 = api::parseURL(
-        "/match/v1/car/polyline%20");
+        "/match/v1/car/polyline(%7DjmwFz~ubMyCa@%60@yDJqE)?%e4%bd%a0%e5%a5%bd&%0A%20%22%25%7e");
     BOOST_CHECK(result_8);
     BOOST_CHECK_EQUAL(reference_8.service, result_8->service);
     BOOST_CHECK_EQUAL(reference_8.version, result_8->version);
     BOOST_CHECK_EQUAL(reference_8.profile, result_8->profile);
     CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
-    // BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
+    BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
 
-    // polyline with %HEX
-    // api::ParsedURL reference_8{
-    //     "match", 1, "car", "polyline(}jmwFz~ubMyCa@`@yDJqE)?你好&\n \"%~", 14UL};
-    // auto result_8 = api::parseURL(
-    //     "/match/v1/car/polyline(%7DjmwFz~ubMyCa@%60@yDJqE)?%e4%bd%a0%e5%a5%bd&%0A%20%22%25%7e");
-    // BOOST_CHECK(result_8);
-    // BOOST_CHECK_EQUAL(reference_8.service, result_8->service);
-    // BOOST_CHECK_EQUAL(reference_8.version, result_8->version);
-    // BOOST_CHECK_EQUAL(reference_8.profile, result_8->profile);
-    // CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
-    // BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
+    // profile with special characters
+    api::ParsedURL reference_9{
+        "route", 1, "foo-bar_baz.profile", "0,1;2,3;4,5?options=value&foo=bar", 30UL};
+    auto result_9 =
+        api::parseURL("/route/v1/foo-bar_baz.profile/0,1;2,3;4,5?options=value&foo=bar");
+    BOOST_CHECK(result_9);
+    BOOST_CHECK_EQUAL(reference_9.service, result_9->service);
+    BOOST_CHECK_EQUAL(reference_9.version, result_9->version);
+    BOOST_CHECK_EQUAL(reference_9.profile, result_9->profile);
+    CHECK_EQUAL_RANGE(reference_9.query, result_9->query);
+    BOOST_CHECK_EQUAL(reference_9.prefix_length, result_9->prefix_length);
 
-    // // profile with special characters
-    // api::ParsedURL reference_9{
-    //     "route", 1, "foo-bar_baz.profile", "0,1;2,3;4,5?options=value&foo=bar", 30UL};
-    // auto result_9 =
-    //     api::parseURL("/route/v1/foo-bar_baz.profile/0,1;2,3;4,5?options=value&foo=bar");
-    // BOOST_CHECK(result_9);
-    // BOOST_CHECK_EQUAL(reference_9.service, result_9->service);
-    // BOOST_CHECK_EQUAL(reference_9.version, result_9->version);
-    // BOOST_CHECK_EQUAL(reference_9.profile, result_9->profile);
-    // CHECK_EQUAL_RANGE(reference_9.query, result_9->query);
-    // BOOST_CHECK_EQUAL(reference_9.prefix_length, result_9->prefix_length);
+    api::ParsedURL reference_10{"match", 1, "car", "poly line ", 14UL};
+    auto result_10 = api::parseURL("/match/v1/car/poly%20line%20");
+    BOOST_CHECK(result_10);
+    BOOST_CHECK_EQUAL(reference_10.service, result_10->service);
+    BOOST_CHECK_EQUAL(reference_10.version, result_10->version);
+    BOOST_CHECK_EQUAL(reference_10.profile, result_10->profile);
+    CHECK_EQUAL_RANGE(reference_10.query, result_10->query);
+    BOOST_CHECK_EQUAL(reference_10.prefix_length, result_10->prefix_length);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -107,29 +107,40 @@ BOOST_AUTO_TEST_CASE(valid_urls)
     CHECK_EQUAL_RANGE(reference_7.query, result_7->query);
     BOOST_CHECK_EQUAL(reference_7.prefix_length, result_7->prefix_length);
 
-    // polyline with %HEX
     api::ParsedURL reference_8{
-        "match", 1, "car", "polyline(}jmwFz~ubMyCa@`@yDJqE)?你好&\n \"%~", 14UL};
+        "match", 1, "car", "polyline ", 14UL};
     auto result_8 = api::parseURL(
-        "/match/v1/car/polyline(%7DjmwFz~ubMyCa@%60@yDJqE)?%e4%bd%a0%e5%a5%bd&%0A%20%22%25%7e");
+        "/match/v1/car/polyline%20");
     BOOST_CHECK(result_8);
     BOOST_CHECK_EQUAL(reference_8.service, result_8->service);
     BOOST_CHECK_EQUAL(reference_8.version, result_8->version);
     BOOST_CHECK_EQUAL(reference_8.profile, result_8->profile);
-    // CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
-    BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
+    CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
+    // BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
 
-    // profile with special characters
-    api::ParsedURL reference_9{
-        "route", 1, "foo-bar_baz.profile", "0,1;2,3;4,5?options=value&foo=bar", 30UL};
-    auto result_9 =
-        api::parseURL("/route/v1/foo-bar_baz.profile/0,1;2,3;4,5?options=value&foo=bar");
-    BOOST_CHECK(result_9);
-    BOOST_CHECK_EQUAL(reference_9.service, result_9->service);
-    BOOST_CHECK_EQUAL(reference_9.version, result_9->version);
-    BOOST_CHECK_EQUAL(reference_9.profile, result_9->profile);
-    CHECK_EQUAL_RANGE(reference_9.query, result_9->query);
-    BOOST_CHECK_EQUAL(reference_9.prefix_length, result_9->prefix_length);
+    // polyline with %HEX
+    // api::ParsedURL reference_8{
+    //     "match", 1, "car", "polyline(}jmwFz~ubMyCa@`@yDJqE)?你好&\n \"%~", 14UL};
+    // auto result_8 = api::parseURL(
+    //     "/match/v1/car/polyline(%7DjmwFz~ubMyCa@%60@yDJqE)?%e4%bd%a0%e5%a5%bd&%0A%20%22%25%7e");
+    // BOOST_CHECK(result_8);
+    // BOOST_CHECK_EQUAL(reference_8.service, result_8->service);
+    // BOOST_CHECK_EQUAL(reference_8.version, result_8->version);
+    // BOOST_CHECK_EQUAL(reference_8.profile, result_8->profile);
+    // CHECK_EQUAL_RANGE(reference_8.query, result_8->query);
+    // BOOST_CHECK_EQUAL(reference_8.prefix_length, result_8->prefix_length);
+
+    // // profile with special characters
+    // api::ParsedURL reference_9{
+    //     "route", 1, "foo-bar_baz.profile", "0,1;2,3;4,5?options=value&foo=bar", 30UL};
+    // auto result_9 =
+    //     api::parseURL("/route/v1/foo-bar_baz.profile/0,1;2,3;4,5?options=value&foo=bar");
+    // BOOST_CHECK(result_9);
+    // BOOST_CHECK_EQUAL(reference_9.service, result_9->service);
+    // BOOST_CHECK_EQUAL(reference_9.version, result_9->version);
+    // BOOST_CHECK_EQUAL(reference_9.profile, result_9->profile);
+    // CHECK_EQUAL_RANGE(reference_9.query, result_9->query);
+    // BOOST_CHECK_EQUAL(reference_9.prefix_length, result_9->prefix_length);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?


<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1131.58<br/>plain u32: 1141.42<br/>aliased double: 1170.09<br/>plain double: 1167.46 | aliased u32: 1145.28<br/>plain u32: 1141.12<br/>aliased double: 1178.48<br/>plain double: 1174.34 |
| json-render | String: 8.4204ms<br/>Stringstream: 11.4856ms<br/>Vector: 7.54544ms | String: 8.40765ms<br/>Stringstream: 11.6779ms<br/>Vector: 7.61471ms |
| match_ch | Default radius: <br/>4.46775ms/req at 82 coordinate<br/>0.0544847ms/coordinate<br/>Radius 5m: <br/>4.46646ms/req at 82 coordinate<br/>0.054469ms/coordinate<br/>Radius 10m: <br/>15.1237ms/req at 82 coordinate<br/>0.184436ms/coordinate<br/>Radius 15m: <br/>36.7593ms/req at 82 coordinate<br/>0.448285ms/coordinate<br/>Radius 30m: <br/>313.514ms/req at 82 coordinate<br/>3.82334ms/coordinate | Default radius: <br/>4.47231ms/req at 82 coordinate<br/>0.0545403ms/coordinate<br/>Radius 5m: <br/>4.47536ms/req at 82 coordinate<br/>0.0545776ms/coordinate<br/>Radius 10m: <br/>15.1969ms/req at 82 coordinate<br/>0.185328ms/coordinate<br/>Radius 15m: <br/>36.853ms/req at 82 coordinate<br/>0.449427ms/coordinate<br/>Radius 30m: <br/>314.338ms/req at 82 coordinate<br/>3.83339ms/coordinate |
| match_mld | Default radius: <br/>3.36122ms/req at 82 coordinate<br/>0.0409905ms/coordinate<br/>Radius 5m: <br/>3.4193ms/req at 82 coordinate<br/>0.0416988ms/coordinate<br/>Radius 10m: <br/>12.38ms/req at 82 coordinate<br/>0.150976ms/coordinate<br/>Radius 15m: <br/>31.88ms/req at 82 coordinate<br/>0.388781ms/coordinate<br/>Radius 30m: <br/>367.753ms/req at 82 coordinate<br/>4.48479ms/coordinate | Default radius: <br/>3.37803ms/req at 82 coordinate<br/>0.0411955ms/coordinate<br/>Radius 5m: <br/>3.36832ms/req at 82 coordinate<br/>0.041077ms/coordinate<br/>Radius 10m: <br/>12.3556ms/req at 82 coordinate<br/>0.150677ms/coordinate<br/>Radius 15m: <br/>31.7308ms/req at 82 coordinate<br/>0.386961ms/coordinate<br/>Radius 30m: <br/>351.2ms/req at 82 coordinate<br/>4.28293ms/coordinate |
| packedvector | random write:<br/>std::vector 11190.4 ms<br/>util::packed_vector 73894.5 ms<br/>slowdown: 6.6034<br/>random read:<br/>std::vector 11022.7 ms<br/>util::packed_vector 30269.3 ms<br/>slowdown: 2.74609 | random write:<br/>std::vector 11259.8 ms<br/>util::packed_vector 82037.7 ms<br/>slowdown: 7.28589<br/>random read:<br/>std::vector 11064.5 ms<br/>util::packed_vector 33326.6 ms<br/>slowdown: 3.01204 |
| rtree | 1 result:<br/>207.122ms ->  0.0207122 ms/query<br/>10 results:<br/>242.976ms ->  0.0242976 ms/query | 1 result:<br/>206.74ms ->  0.020674 ms/query<br/>10 results:<br/>241.717ms ->  0.0241717 ms/query |
<!-- BENCHMARK_RESULTS_END -->