### PR TITLE
Avoid copy of std::function-based callback in path unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Avoid copy of std::function-based callback in path unpacking [#6895](https://github.com/Project-OSRM/osrm-backend/pull/6895)
       - CHANGED: Partial fix migration from boost::optional to std::optional [#6551](https://github.com/Project-OSRM/osrm-backend/issues/6551)
       - CHANGED: Update Conan Boost version to 1.85.0. [#6868](https://github.com/Project-OSRM/osrm-backend/pull/6868)
       - FIXED: Fix an error in a RouteParameters AnnotationsType operator overload. [#6646](https://github.com/Project-OSRM/osrm-backend/pull/6646)

--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -55,7 +55,7 @@ template <> class AlgorithmDataFacade<CH>
 
     virtual EdgeID FindSmallestEdge(const NodeID edge_based_node_from,
                                     const NodeID edge_based_node_to,
-                                    const std::function<bool(const EdgeData&)> &filter) const = 0;
+                                    const std::function<bool(const EdgeData &)> &filter) const = 0;
 };
 
 template <> class AlgorithmDataFacade<MLD>

--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -55,7 +55,7 @@ template <> class AlgorithmDataFacade<CH>
 
     virtual EdgeID FindSmallestEdge(const NodeID edge_based_node_from,
                                     const NodeID edge_based_node_to,
-                                    const std::function<bool(EdgeData)> filter) const = 0;
+                                    const std::function<bool(const EdgeData&)> &filter) const = 0;
 };
 
 template <> class AlgorithmDataFacade<MLD>

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -130,9 +130,10 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
             edge_based_node_from, edge_based_node_to, result);
     }
 
-    EdgeID FindSmallestEdge(const NodeID edge_based_node_from,
-                            const NodeID edge_based_node_to,
-                            const std::function<bool(const EdgeData&)> &filter) const override final
+    EdgeID
+    FindSmallestEdge(const NodeID edge_based_node_from,
+                     const NodeID edge_based_node_to,
+                     const std::function<bool(const EdgeData &)> &filter) const override final
     {
         return m_query_graph.FindSmallestEdge(edge_based_node_from, edge_based_node_to, filter);
     }

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -132,7 +132,7 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
 
     EdgeID FindSmallestEdge(const NodeID edge_based_node_from,
                             const NodeID edge_based_node_to,
-                            std::function<bool(EdgeData)> filter) const override final
+                            const std::function<bool(const EdgeData&)> &filter) const override final
     {
         return m_query_graph.FindSmallestEdge(edge_based_node_from, edge_based_node_to, filter);
     }

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -238,9 +238,10 @@ class MockAlgorithmDataFacade<engine::datafacade::CH>
         return SPECIAL_EDGEID;
     }
 
-    EdgeID FindSmallestEdge(const NodeID /* from */,
-                            const NodeID /* to */,
-                            const std::function<bool(const EdgeData&)> &/* filter */) const override
+    EdgeID
+    FindSmallestEdge(const NodeID /* from */,
+                     const NodeID /* to */,
+                     const std::function<bool(const EdgeData &)> & /* filter */) const override
     {
         return SPECIAL_EDGEID;
     }

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -240,7 +240,7 @@ class MockAlgorithmDataFacade<engine::datafacade::CH>
 
     EdgeID FindSmallestEdge(const NodeID /* from */,
                             const NodeID /* to */,
-                            std::function<bool(EdgeData)> /* filter */) const override
+                            const std::function<bool(const EdgeData&)> &/* filter */) const override
     {
         return SPECIAL_EDGEID;
     }


### PR DESCRIPTION
# Issue

A callback based on std::function is passed by copy. Consistently passing the path unpacking filter by const ref should avoid temporaries.

<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1149.24<br/>plain u32: 1144.77<br/>aliased double: 1205.23<br/>plain double: 1185.16 | aliased u32: 1144.71<br/>plain u32: 1152.62<br/>aliased double: 1199.93<br/>plain double: 1197.95 |
| json-render | String: 8.52395ms<br/>Stringstream: 11.6021ms<br/>Vector: 7.59975ms | String: 8.41223ms<br/>Stringstream: 11.6769ms<br/>Vector: 7.66242ms |
| match_ch | Default radius: <br/>4.47431ms/req at 82 coordinate<br/>0.0545648ms/coordinate<br/>Radius 5m: <br/>4.47685ms/req at 82 coordinate<br/>0.0545957ms/coordinate<br/>Radius 10m: <br/>15.2145ms/req at 82 coordinate<br/>0.185543ms/coordinate<br/>Radius 15m: <br/>36.9994ms/req at 82 coordinate<br/>0.451213ms/coordinate<br/>Radius 30m: <br/>314.445ms/req at 82 coordinate<br/>3.8347ms/coordinate | Default radius: <br/>4.44708ms/req at 82 coordinate<br/>0.0542327ms/coordinate<br/>Radius 5m: <br/>4.45237ms/req at 82 coordinate<br/>0.0542972ms/coordinate<br/>Radius 10m: <br/>15.0919ms/req at 82 coordinate<br/>0.184047ms/coordinate<br/>Radius 15m: <br/>36.764ms/req at 82 coordinate<br/>0.448342ms/coordinate<br/>Radius 30m: <br/>312.878ms/req at 82 coordinate<br/>3.81559ms/coordinate |
| match_mld | Default radius: <br/>3.38798ms/req at 82 coordinate<br/>0.0413169ms/coordinate<br/>Radius 5m: <br/>3.37885ms/req at 82 coordinate<br/>0.0412054ms/coordinate<br/>Radius 10m: <br/>12.3656ms/req at 82 coordinate<br/>0.1508ms/coordinate<br/>Radius 15m: <br/>31.7576ms/req at 82 coordinate<br/>0.387288ms/coordinate<br/>Radius 30m: <br/>352.521ms/req at 82 coordinate<br/>4.29904ms/coordinate | Default radius: <br/>3.46569ms/req at 82 coordinate<br/>0.0422645ms/coordinate<br/>Radius 5m: <br/>3.46ms/req at 82 coordinate<br/>0.0421951ms/coordinate<br/>Radius 10m: <br/>12.746ms/req at 82 coordinate<br/>0.155439ms/coordinate<br/>Radius 15m: <br/>32.9919ms/req at 82 coordinate<br/>0.40234ms/coordinate<br/>Radius 30m: <br/>368.065ms/req at 82 coordinate<br/>4.4886ms/coordinate |
| packedvector | random write:<br/>std::vector 11241.5 ms<br/>util::packed_vector 82155.7 ms<br/>slowdown: 7.30827<br/>random read:<br/>std::vector 11124.6 ms<br/>util::packed_vector 33243.4 ms<br/>slowdown: 2.98828 | random write:<br/>std::vector 11352.4 ms<br/>util::packed_vector 76852.9 ms<br/>slowdown: 6.76973<br/>random read:<br/>std::vector 11150.7 ms<br/>util::packed_vector 31332.5 ms<br/>slowdown: 2.80993 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>596.362ms<br/>0.596362ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>373.348ms<br/>0.373348ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>756.679ms<br/>0.756679ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.33ms<br/>0.15133ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>96.6661ms<br/>0.0966661ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>133.455ms<br/>0.133455ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.343ms<br/>0.151343ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.8389ms<br/>0.0968389ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>133.683ms<br/>0.133683ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>596.552ms<br/>0.596552ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>375.754ms<br/>0.375754ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>759.868ms<br/>0.759868ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>153.283ms<br/>0.153283ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>98.7655ms<br/>0.0987655ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>134.414ms<br/>0.134414ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>181.608ms<br/>0.181608ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>102.409ms<br/>0.102409ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>135.261ms<br/>0.135261ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>718.881ms<br/>0.718881ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>461.798ms<br/>0.461798ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>946.874ms<br/>0.946874ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>268.491ms<br/>0.268491ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>161.703ms<br/>0.161703ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>287.299ms<br/>0.287299ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>266.971ms<br/>0.266971ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.844ms<br/>0.161844ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>287.01ms<br/>0.28701ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>716.917ms<br/>0.716917ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>460.221ms<br/>0.460221ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>933.096ms<br/>0.933096ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>267.557ms<br/>0.267557ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>159.567ms<br/>0.159567ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>283.92ms<br/>0.28392ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>259.649ms<br/>0.259649ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.987ms<br/>0.159987ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>294.389ms<br/>0.294389ms/req |
| rtree | 1 result:<br/>206.799ms ->  0.0206799 ms/query<br/>10 results:<br/>241.796ms ->  0.0241796 ms/query | 1 result:<br/>207.533ms ->  0.0207533 ms/query<br/>10 results:<br/>242.096ms ->  0.0242096 ms/query |
<!-- BENCHMARK_RESULTS_END -->