### PR TITLE
Remove superflous iostreams include from header files

### DIFF
--- a/include/nodejs/node_osrm_support.hpp
+++ b/include/nodejs/node_osrm_support.hpp
@@ -24,7 +24,6 @@
 #include <boost/optional.hpp>
 
 #include <algorithm>
-#include <iostream>
 #include <iterator>
 #include <sstream>
 #include <stdexcept>

--- a/include/storage/io.hpp
+++ b/include/storage/io.hpp
@@ -18,6 +18,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <iostream>
 #include <tuple>
 #include <type_traits>
 

--- a/include/util/debug.hpp
+++ b/include/util/debug.hpp
@@ -12,7 +12,7 @@
 #include "util/typedefs.hpp"
 
 #include <iomanip>
-#include <iostream>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/include/util/exception.hpp
+++ b/include/util/exception.hpp
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <array>
 #include <exception>
-#include <iostream>
 #include <string>
 #include <utility>
 

--- a/include/util/exception_utils.hpp
+++ b/include/util/exception_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef SOURCE_MACROS_HPP
 #define SOURCE_MACROS_HPP
-#include <cstring>
+
+#include <string>
 
 // Helper macros, don't use these ones
 // STRIP the OSRM_PROJECT_DIR from the front of a filename.  Expected to come

--- a/include/util/exception_utils.hpp
+++ b/include/util/exception_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef SOURCE_MACROS_HPP
 #define SOURCE_MACROS_HPP
 
+#include <cstring>
 #include <string>
 
 // Helper macros, don't use these ones

--- a/include/util/exception_utils.hpp
+++ b/include/util/exception_utils.hpp
@@ -1,5 +1,5 @@
-#ifndef SOURCE_MACROS_HPP
-#define SOURCE_MACROS_HPP
+#ifndef EXCEPTION_UTILS_HPP
+#define EXCEPTION_UTILS_HPP
 
 #include <cstring>
 #include <string>
@@ -14,4 +14,4 @@
 // This is the macro to use
 #define SOURCE_REF (OSRM_SOURCE_FILE_ + ":" + std::to_string(__LINE__))
 
-#endif // SOURCE_MACROS_HPP
+#endif // EXCEPTION_UTILS_HPP

--- a/include/util/lua_util.hpp
+++ b/include/util/lua_util.hpp
@@ -10,7 +10,6 @@ extern "C"
 
 #include <boost/filesystem.hpp>
 
-#include <iostream>
 #include <string>
 
 namespace osrm::util

--- a/include/util/node_based_graph.hpp
+++ b/include/util/node_based_graph.hpp
@@ -9,7 +9,6 @@
 
 #include <tbb/parallel_sort.h>
 
-#include <iostream>
 #include <memory>
 #include <utility>
 

--- a/src/benchmarks/packed_vector.cpp
+++ b/src/benchmarks/packed_vector.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <iostream>
 #include <numeric>
 #include <random>
 #include <string>

--- a/src/extractor/compressed_edge_container.cpp
+++ b/src/extractor/compressed_edge_container.cpp
@@ -9,8 +9,6 @@
 #include <limits>
 #include <string>
 
-#include <iostream>
-
 namespace osrm::extractor
 {
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -50,7 +50,6 @@
 #include <atomic>
 #include <bitset>
 #include <chrono>
-#include <iostream>
 #include <memory>
 #include <thread>
 #include <tuple>

--- a/src/partitioner/bisection_graph_view.cpp
+++ b/src/partitioner/bisection_graph_view.cpp
@@ -1,6 +1,5 @@
 #include "partitioner/bisection_graph_view.hpp"
 
-#include <iostream>
 #include <iterator>
 
 #include <boost/assert.hpp>

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -31,7 +31,6 @@
 #include <cstdint>
 
 #include <fstream>
-#include <iostream>
 #include <iterator>
 #include <new>
 #include <string>

--- a/src/storage/storage_config.cpp
+++ b/src/storage/storage_config.cpp
@@ -3,6 +3,9 @@
 #include "util/exception_utils.hpp"
 #include <boost/algorithm/string/case_conv.hpp>
 
+#include <istream>
+#include <string>
+
 namespace osrm::storage
 {
 std::istream &operator>>(std::istream &in, FeatureDataset &datasets)

--- a/src/tools/extract.cpp
+++ b/src/tools/extract.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdlib>
 #include <exception>
+#include <iostream>
 #include <new>
 #include <thread>
 

--- a/src/util/coordinate.cpp
+++ b/src/util/coordinate.cpp
@@ -1,16 +1,8 @@
-#include "util/coordinate_calculation.hpp"
-
-#ifndef NDEBUG
-#include "util/log.hpp"
-#endif
 #include "osrm/coordinate.hpp"
 
-#ifndef NDEBUG
-#include <bitset>
-#endif
-#include <iomanip>
-#include <iostream>
-#include <limits>
+#include "util/coordinate_calculation.hpp"
+
+#include <cstdint>
 
 namespace osrm::util
 {

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -1,7 +1,5 @@
 #include "util/exception.hpp"
 
-#include <utility>
-
 // This function exists to 'anchor' the class, and stop the compiler from
 // copying vtable and RTTI info into every object file that includes
 // this header. (Caught by -Wweak-vtables under Clang.)

--- a/src/util/guidance/turn_lanes.cpp
+++ b/src/util/guidance/turn_lanes.cpp
@@ -1,10 +1,6 @@
 #include "util/guidance/turn_lanes.hpp"
 
-#include <algorithm>
-#include <iostream>
 #include <tuple>
-
-#include <boost/assert.hpp>
 
 namespace osrm::util::guidance
 {


### PR DESCRIPTION
# Issue

including iostream is a code smell :grin: 

<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1149.5<br/>plain u32: 1152.92<br/>aliased double: 1192.73<br/>plain double: 1226.24 | aliased u32: 1140.04<br/>plain u32: 1135.96<br/>aliased double: 1191.97<br/>plain double: 1179.31 |
| json-render | String: 8.65366ms<br/>Stringstream: 11.9421ms<br/>Vector: 7.72664ms | String: 8.3811ms<br/>Stringstream: 11.5928ms<br/>Vector: 7.48348ms |
| match_ch | Default radius: <br/>4.45105ms/req at 82 coordinate<br/>0.0542811ms/coordinate<br/>Radius 5m: <br/>4.44301ms/req at 82 coordinate<br/>0.0541831ms/coordinate<br/>Radius 10m: <br/>15.1047ms/req at 82 coordinate<br/>0.184203ms/coordinate<br/>Radius 15m: <br/>36.8425ms/req at 82 coordinate<br/>0.449299ms/coordinate<br/>Radius 30m: <br/>313.75ms/req at 82 coordinate<br/>3.82622ms/coordinate | Default radius: <br/>4.45681ms/req at 82 coordinate<br/>0.0543513ms/coordinate<br/>Radius 5m: <br/>4.42715ms/req at 82 coordinate<br/>0.0539896ms/coordinate<br/>Radius 10m: <br/>15.0754ms/req at 82 coordinate<br/>0.183846ms/coordinate<br/>Radius 15m: <br/>36.7688ms/req at 82 coordinate<br/>0.4484ms/coordinate<br/>Radius 30m: <br/>313.635ms/req at 82 coordinate<br/>3.82482ms/coordinate |
| match_mld | Default radius: <br/>2.83922ms/req at 82 coordinate<br/>0.0346246ms/coordinate<br/>Radius 5m: <br/>3.46332ms/req at 82 coordinate<br/>0.0422356ms/coordinate<br/>Radius 10m: <br/>10.2364ms/req at 82 coordinate<br/>0.124835ms/coordinate<br/>Radius 15m: <br/>25.959ms/req at 82 coordinate<br/>0.316573ms/coordinate<br/>Radius 30m: <br/>302.505ms/req at 82 coordinate<br/>3.68909ms/coordinate | Default radius: <br/>2.82378ms/req at 82 coordinate<br/>0.0344363ms/coordinate<br/>Radius 5m: <br/>2.7982ms/req at 82 coordinate<br/>0.0341244ms/coordinate<br/>Radius 10m: <br/>10.1089ms/req at 82 coordinate<br/>0.123279ms/coordinate<br/>Radius 15m: <br/>25.6753ms/req at 82 coordinate<br/>0.313113ms/coordinate<br/>Radius 30m: <br/>298.037ms/req at 82 coordinate<br/>3.6346ms/coordinate |
| packedvector | random write:<br/>std::vector 11533.7 ms<br/>util::packed_vector 78341.3 ms<br/>slowdown: 6.79238<br/>random read:<br/>std::vector 11336.6 ms<br/>util::packed_vector 33666.9 ms<br/>slowdown: 2.96975 | random write:<br/>std::vector 11276.1 ms<br/>util::packed_vector 76592.5 ms<br/>slowdown: 6.79247<br/>random read:<br/>std::vector 11239.4 ms<br/>util::packed_vector 32473.2 ms<br/>slowdown: 2.88923 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>592.398ms<br/>0.592398ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>374.506ms<br/>0.374506ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>758.339ms<br/>0.758339ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>160.27ms<br/>0.16027ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>102.934ms<br/>0.102934ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>143.359ms<br/>0.143359ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>160.865ms<br/>0.160865ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>102.698ms<br/>0.102698ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>142.837ms<br/>0.142837ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>596.461ms<br/>0.596461ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>379.358ms<br/>0.379358ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>768.937ms<br/>0.768937ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>161.377ms<br/>0.161377ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>103.603ms<br/>0.103603ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>144.056ms<br/>0.144056ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.623ms<br/>0.159623ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>103.457ms<br/>0.103457ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>144.124ms<br/>0.144124ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>725.171ms<br/>0.725171ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>465.519ms<br/>0.465519ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>956.377ms<br/>0.956377ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>283.12ms<br/>0.28312ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>169.24ms<br/>0.16924ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>307.464ms<br/>0.307464ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>279.266ms<br/>0.279266ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>169.58ms<br/>0.16958ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>308.413ms<br/>0.308413ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>725.453ms<br/>0.725453ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>466.925ms<br/>0.466925ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>952.26ms<br/>0.95226ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>282.626ms<br/>0.282626ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>167.719ms<br/>0.167719ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>303.848ms<br/>0.303848ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>281.084ms<br/>0.281084ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>168.693ms<br/>0.168693ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>303.77ms<br/>0.30377ms/req |
| rtree | 1 result:<br/>208.76ms ->  0.020876 ms/query<br/>10 results:<br/>243.918ms ->  0.0243918 ms/query | 1 result:<br/>209.796ms ->  0.0209796 ms/query<br/>10 results:<br/>246.411ms ->  0.0246411 ms/query |
<!-- BENCHMARK_RESULTS_END -->