### PR TITLE
Fix performance-type-promotion-in-math-fn clang-tidy warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,7 +54,6 @@ Checks: >
     performance-*,
     -performance-noexcept-move-constructor,
     -performance-no-int-to-ptr,
-    -performance-type-promotion-in-math-fn,
     readability-*,
     -readability-avoid-const-params-in-decls,
     -readability-braces-around-statements,

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -443,23 +443,22 @@ class RouteAPI : public BaseAPI
         if (requested_annotations & RouteParameters::AnnotationsType::Speed)
         {
             double prev_speed = 0;
-            speed =
-                GetAnnotations<float>(fb_result,
-                                      leg_geometry,
-                                      [&prev_speed](const guidance::LegGeometry::Annotation &anno)
-                                      {
-                                          if (anno.duration < std::numeric_limits<float>::min())
-                                          {
-                                              return prev_speed;
-                                          }
-                                          else
-                                          {
-                                              auto speed =
-                                                  round(anno.distance / anno.duration * 10.) / 10.;
-                                              prev_speed = speed;
-                                              return util::json::clamp_float(speed);
-                                          }
-                                      });
+            speed = GetAnnotations<float>(
+                fb_result,
+                leg_geometry,
+                [&prev_speed](const guidance::LegGeometry::Annotation &anno)
+                {
+                    if (anno.duration < std::numeric_limits<float>::min())
+                    {
+                        return prev_speed;
+                    }
+                    else
+                    {
+                        auto speed = std::round(anno.distance / anno.duration * 10.) / 10.;
+                        prev_speed = speed;
+                        return util::json::clamp_float(speed);
+                    }
+                });
         }
 
         flatbuffers::Offset<flatbuffers::Vector<uint32_t>> duration;

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -497,13 +497,13 @@ void encodeVectorTile(const DataFacadeBase &facade,
                     {
                         // Calculate the speed for this line
                         std::uint32_t speed_kmh_idx = static_cast<std::uint32_t>(
-                            round(length / from_alias<double>(forward_duration) * 10 * 3.6));
+                            std::round(length / from_alias<double>(forward_duration) * 10 * 3.6));
 
                         // Rate values are in meters per weight-unit - and similar to speeds, we
                         // present 1 decimal place of precision (these values are added as
                         // double/10) lower down
                         std::uint32_t forward_rate = static_cast<std::uint32_t>(
-                            round(length / from_alias<double>(forward_weight) * 10.));
+                            std::round(length / from_alias<double>(forward_weight) * 10.));
 
                         auto tile_line = coordinatesToTileLine(a, b, tile_bbox);
                         if (!tile_line.empty())
@@ -531,13 +531,13 @@ void encodeVectorTile(const DataFacadeBase &facade,
                     {
                         // Calculate the speed for this line
                         std::uint32_t speed_kmh_idx = static_cast<std::uint32_t>(
-                            round(length / from_alias<double>(reverse_duration) * 10 * 3.6));
+                            std::round(length / from_alias<double>(reverse_duration) * 10 * 3.6));
 
                         // Rate values are in meters per weight-unit - and similar to speeds, we
                         // present 1 decimal place of precision (these values are added as
                         // double/10) lower down
                         std::uint32_t reverse_rate = static_cast<std::uint32_t>(
-                            round(length / from_alias<double>(reverse_weight) * 10.));
+                            std::round(length / from_alias<double>(reverse_weight) * 10.));
 
                         auto tile_line = coordinatesToTileLine(b, a, tile_bbox);
                         if (!tile_line.empty())

--- a/src/extractor/raster_source.cpp
+++ b/src/extractor/raster_source.cpp
@@ -40,8 +40,8 @@ RasterDatum RasterSource::GetRasterData(const int lon, const int lat) const
         return {};
     }
 
-    const std::size_t xth = static_cast<std::size_t>(round((lon - xmin) / xstep));
-    const std::size_t yth = static_cast<std::size_t>(round((ymax - lat) / ystep));
+    const std::size_t xth = static_cast<std::size_t>(std::round((lon - xmin) / xstep));
+    const std::size_t yth = static_cast<std::size_t>(std::round((ymax - lat) / ystep));
 
     return {raster_data(xth, yth)};
 }

--- a/unit_tests/library/route.cpp
+++ b/unit_tests/library/route.cpp
@@ -54,8 +54,8 @@ void test_route_same_coordinates_fixture(bool use_json_only_api)
         itr.get<json::Object>().values["hint"] = "";
 
         // Round value to 6 decimal places for double comparison later
-        itr.get<json::Object>().values["distance"] =
-            round(itr.get<json::Object>().values["distance"].get<json::Number>().value * 1000000);
+        itr.get<json::Object>().values["distance"] = std::round(
+            itr.get<json::Object>().values["distance"].get<json::Number>().value * 1000000);
     }
 
     const auto location = json::Array{{{7.437070}, {43.749248}}};
@@ -65,11 +65,11 @@ void test_route_same_coordinates_fixture(bool use_json_only_api)
          {"waypoints",
           json::Array{{json::Object{{{"name", "Boulevard du Larvotto"},
                                      {"location", location},
-                                     {"distance", round(0.137249 * 1000000)},
+                                     {"distance", std::round(0.137249 * 1000000)},
                                      {"hint", ""}}},
                        json::Object{{{"name", "Boulevard du Larvotto"},
                                      {"location", location},
-                                     {"distance", round(0.137249 * 1000000)},
+                                     {"distance", std::round(0.137249 * 1000000)},
                                      {"hint", ""}}}}}},
          {"routes",
           json::Array{{json::Object{


### PR DESCRIPTION
Related to https://github.com/Project-OSRM/osrm-backend/issues/6902

<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1154.93<br/>plain u32: 1154.56<br/>aliased double: 1197.49<br/>plain double: 1190.76 | aliased u32: 1140.36<br/>plain u32: 1142.91<br/>aliased double: 1191.35<br/>plain double: 1190.66 |
| json-render | String: 6.79129ms<br/>Stringstream: 10.6712ms<br/>Vector: 6.66896ms | String: 6.84238ms<br/>Stringstream: 10.8178ms<br/>Vector: 6.69384ms |
| match_ch | Default radius: <br/>4.51757ms/req at 82 coordinate<br/>0.0550923ms/coordinate<br/>Radius 5m: <br/>4.55657ms/req at 82 coordinate<br/>0.0555679ms/coordinate<br/>Radius 10m: <br/>15.2394ms/req at 82 coordinate<br/>0.185847ms/coordinate<br/>Radius 15m: <br/>37.2271ms/req at 82 coordinate<br/>0.45399ms/coordinate<br/>Radius 30m: <br/>317.726ms/req at 82 coordinate<br/>3.8747ms/coordinate | Default radius: <br/>4.49913ms/req at 82 coordinate<br/>0.0548674ms/coordinate<br/>Radius 5m: <br/>4.49297ms/req at 82 coordinate<br/>0.0547923ms/coordinate<br/>Radius 10m: <br/>15.2748ms/req at 82 coordinate<br/>0.186278ms/coordinate<br/>Radius 15m: <br/>37.3341ms/req at 82 coordinate<br/>0.455294ms/coordinate<br/>Radius 30m: <br/>319.143ms/req at 82 coordinate<br/>3.89199ms/coordinate |
| match_mld | Default radius: <br/>2.89112ms/req at 82 coordinate<br/>0.0352576ms/coordinate<br/>Radius 5m: <br/>2.94526ms/req at 82 coordinate<br/>0.0359178ms/coordinate<br/>Radius 10m: <br/>10.5547ms/req at 82 coordinate<br/>0.128716ms/coordinate<br/>Radius 15m: <br/>26.8133ms/req at 82 coordinate<br/>0.326992ms/coordinate<br/>Radius 30m: <br/>313.015ms/req at 82 coordinate<br/>3.81726ms/coordinate | Default radius: <br/>2.87658ms/req at 82 coordinate<br/>0.0350803ms/coordinate<br/>Radius 5m: <br/>2.86907ms/req at 82 coordinate<br/>0.0349887ms/coordinate<br/>Radius 10m: <br/>10.4353ms/req at 82 coordinate<br/>0.12726ms/coordinate<br/>Radius 15m: <br/>26.7162ms/req at 82 coordinate<br/>0.325808ms/coordinate<br/>Radius 30m: <br/>310.763ms/req at 82 coordinate<br/>3.78979ms/coordinate |
| packedvector | random write:<br/>std::vector 11450.8 ms<br/>util::packed_vector 78165.5 ms<br/>slowdown: 6.82621<br/>random read:<br/>std::vector 11292.2 ms<br/>util::packed_vector 33623.1 ms<br/>slowdown: 2.97754 | random write:<br/>std::vector 11417 ms<br/>util::packed_vector 77667.4 ms<br/>slowdown: 6.80278<br/>random read:<br/>std::vector 11287.5 ms<br/>util::packed_vector 33230.7 ms<br/>slowdown: 2.94403 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>599.604ms<br/>0.599604ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>382.334ms<br/>0.382334ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>767.69ms<br/>0.76769ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>161.915ms<br/>0.161915ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>103.68ms<br/>0.10368ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>145.003ms<br/>0.145003ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.808ms<br/>0.161808ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>103.379ms<br/>0.103379ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>145.001ms<br/>0.145001ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>599.391ms<br/>0.599391ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>377.378ms<br/>0.377378ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>764.628ms<br/>0.764628ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>161.696ms<br/>0.161696ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>103.66ms<br/>0.10366ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>145.265ms<br/>0.145265ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>160.223ms<br/>0.160223ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>103.586ms<br/>0.103586ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>144.89ms<br/>0.14489ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>731.488ms<br/>0.731488ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>487.761ms<br/>0.487761ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>959.513ms<br/>0.959513ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>283.698ms<br/>0.283698ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>171.11ms<br/>0.17111ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>310.768ms<br/>0.310768ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>279.454ms<br/>0.279454ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>170.053ms<br/>0.170053ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>306.901ms<br/>0.306901ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>728.084ms<br/>0.728084ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>469.701ms<br/>0.469701ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>956.26ms<br/>0.95626ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>291.752ms<br/>0.291752ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>173.47ms<br/>0.17347ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>313.42ms<br/>0.31342ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>283.377ms<br/>0.283377ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>171.271ms<br/>0.171271ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>312.578ms<br/>0.312578ms/req |
| rtree | 1 result:<br/>207.819ms ->  0.0207819 ms/query<br/>10 results:<br/>243.357ms ->  0.0243357 ms/query | 1 result:<br/>208.291ms ->  0.0208291 ms/query<br/>10 results:<br/>243.461ms ->  0.0243461 ms/query |
<!-- BENCHMARK_RESULTS_END -->