### PR TITLE
Get rid of boost::math::constants::* and M_PI in favor of std::numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Get rid of boost::math::constants::* and M_PI in favor of std::numbers. [#6916](https://github.com/Project-OSRM/osrm-backend/pull/6916)
       - CHANGED: Use std::variant instead of mapbox::util::variant. [#6903](https://github.com/Project-OSRM/osrm-backend/pull/6903)
       - CHANGED: Bump rapidjson to version f9d53419e912910fd8fa57d5705fa41425428c35 [#6906](https://github.com/Project-OSRM/osrm-backend/pull/6906)
       - CHANGED: Bump mapbox/variant to version 1.2.0 [#6898](https://github.com/Project-OSRM/osrm-backend/pull/6898)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_dependency_defines(-DBOOST_LIB_DIAGNOSTIC)
   add_dependency_defines(-D_CRT_SECURE_NO_WARNINGS)
   add_dependency_defines(-DNOMINMAX) # avoid min and max macros that can break compilation
-  add_dependency_defines(-D_USE_MATH_DEFINES) #needed for M_PI with cmath.h
   add_dependency_defines(-D_WIN32_WINNT=0x0501)
   add_dependency_defines(-DXML_STATIC)
   find_library(ws2_32_LIBRARY_PATH ws2_32)
@@ -358,7 +357,7 @@ if(ENABLE_CONAN)
     KEEP_RPATHS
     NO_OUTPUT_DIRS
     OPTIONS boost:filesystem_version=3 # https://stackoverflow.com/questions/73392648/error-with-boost-filesystem-version-in-cmake
-            onetbb:shared=${TBB_SHARED}
+           #onetbb:shared=${TBB_SHARED}
             boost:without_stacktrace=True # Apple Silicon cross-compilation fails without it
     BUILD missing
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,7 @@ if(ENABLE_CONAN)
     KEEP_RPATHS
     NO_OUTPUT_DIRS
     OPTIONS boost:filesystem_version=3 # https://stackoverflow.com/questions/73392648/error-with-boost-filesystem-version-in-cmake
-           #onetbb:shared=${TBB_SHARED}
+            onetbb:shared=${TBB_SHARED}
             boost:without_stacktrace=True # Apple Silicon cross-compilation fails without it
     BUILD missing
   )

--- a/include/engine/map_matching/bayes_classifier.hpp
+++ b/include/engine/map_matching/bayes_classifier.hpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/math/constants/constants.hpp>
+#include <numbers>
 
 namespace osrm::engine::map_matching
 {
@@ -21,10 +21,8 @@ struct NormalDistribution
     // FIXME implement log-probability version since it's faster
     double Density(const double val) const
     {
-        using namespace boost::math::constants;
-
         const double x = val - mean;
-        return 1.0 / (std::sqrt(two_pi<double>()) * standard_deviation) *
+        return 1.0 / (std::sqrt(2 * std::numbers::pi) * standard_deviation) *
                std::exp(-x * x / (standard_deviation * standard_deviation));
     }
 

--- a/include/engine/map_matching/hidden_markov_model.hpp
+++ b/include/engine/map_matching/hidden_markov_model.hpp
@@ -4,7 +4,7 @@
 #include "util/integer_range.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/math/constants/constants.hpp>
+#include <numbers>
 
 #include <cmath>
 
@@ -14,7 +14,7 @@
 namespace osrm::engine::map_matching
 {
 
-static const double log_2_pi = std::log(2. * boost::math::constants::pi<double>());
+static const double log_2_pi = std::log(2. * std::numbers::pi);
 static const double IMPOSSIBLE_LOG_PROB = -std::numeric_limits<double>::infinity();
 static const double MINIMAL_LOG_PROB = std::numeric_limits<double>::lowest();
 static const std::size_t INVALID_STATE = std::numeric_limits<std::size_t>::max();

--- a/include/engine/map_matching/matching_confidence.hpp
+++ b/include/engine/map_matching/matching_confidence.hpp
@@ -2,7 +2,7 @@
 #define ENGINE_MAP_MATCHING_CONFIDENCE_HPP
 
 #include "engine/map_matching/bayes_classifier.hpp"
-
+#include <boost/assert.hpp>
 #include <cmath>
 
 namespace osrm::engine::map_matching

--- a/include/util/cheap_ruler.hpp
+++ b/include/util/cheap_ruler.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <tuple>
 #include <utility>
+#include <numbers>
 
 namespace mapbox
 {
@@ -37,7 +38,7 @@ class CheapRuler
     static constexpr double FE = 1.0 / 298.257223563; // flattening
 
     static constexpr double E2 = FE * (2 - FE);
-    static constexpr double RAD = M_PI / 180.0;
+    static constexpr double RAD = std::numbers::pi / 180.0;
 
   public:
     explicit CheapRuler(double latitude)

--- a/include/util/cheap_ruler.hpp
+++ b/include/util/cheap_ruler.hpp
@@ -4,9 +4,9 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <numbers>
 #include <tuple>
 #include <utility>
-#include <numbers>
 
 namespace mapbox
 {

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -3,7 +3,7 @@
 
 #include "util/coordinate.hpp"
 
-#include <boost/math/constants/constants.hpp>
+#include <numbers>
 
 #include <algorithm>
 #include <cmath>
@@ -23,17 +23,9 @@ const constexpr double RAD_TO_DEGREE = 1. / DEGREE_TO_RAD;
 // The IUGG value for the equatorial radius is 6378.137 km (3963.19 miles)
 const constexpr long double EARTH_RADIUS = 6372797.560856;
 
-inline double degToRad(const double degree)
-{
-    using namespace boost::math::constants;
-    return degree * (pi<double>() / 180.0);
-}
+inline double degToRad(const double degree) { return degree * (std::numbers::pi / 180.0); }
 
-inline double radToDeg(const double radian)
-{
-    using namespace boost::math::constants;
-    return radian * (180.0 * (1. / pi<double>()));
-}
+inline double radToDeg(const double radian) { return radian * (180.0 * (1. / std::numbers::pi)); }
 } // namespace detail
 
 const constexpr static double METERS_PER_DEGREE_LAT = 110567.0;

--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -25,7 +25,7 @@ const constexpr long double EARTH_RADIUS = 6372797.560856;
 
 inline double degToRad(const double degree) { return degree * (std::numbers::pi / 180.0); }
 
-inline double radToDeg(const double radian) { return radian * (180.0 * (1. / std::numbers::pi)); }
+inline double radToDeg(const double radian) { return radian * (180.0 * std::numbers::inv_pi); }
 } // namespace detail
 
 const constexpr static double METERS_PER_DEGREE_LAT = 110567.0;

--- a/include/util/trigonometry_table.hpp
+++ b/include/util/trigonometry_table.hpp
@@ -6,7 +6,7 @@
 
 #include <limits>
 
-#include <boost/math/constants/constants.hpp>
+#include <numbers>
 
 namespace osrm::util
 {
@@ -359,22 +359,22 @@ constexpr unsigned short atan_table[4096] = {
 #ifdef _MSC_VER // TODO: remove as soon as boost allows C++14 features with Visual Studio
 const constexpr double SCALING_FACTOR = 4. / M_PI * 0xFFFF;
 #else
-const constexpr double SCALING_FACTOR = 4. / boost::math::constants::pi<double>() * 0xFFFF;
+const constexpr double SCALING_FACTOR = 4. / std::numbers::pi * 0xFFFF;
 #endif
 
 inline double atan2_lookup(double y, double x)
 {
-    using namespace boost::math::constants;
+    static constexpr auto half_pi = std::numbers::pi * 0.5;
 
     if (std::abs(x) < std::numeric_limits<double>::epsilon())
     {
         if (y >= 0.)
         {
-            return half_pi<double>();
+            return half_pi;
         }
         else
         {
-            return -half_pi<double>();
+            return -half_pi;
         }
     }
 
@@ -405,25 +405,25 @@ inline double atan2_lookup(double y, double x)
     case 0:
         break;
     case 1:
-        angle = pi<double>() - angle;
+        angle = std::numbers::pi - angle;
         break;
     case 2:
         angle = -angle;
         break;
     case 3:
-        angle = -pi<double>() + angle;
+        angle = -std::numbers::pi + angle;
         break;
     case 4:
-        angle = half_pi<double>() - angle;
+        angle = half_pi - angle;
         break;
     case 5:
-        angle = half_pi<double>() + angle;
+        angle = half_pi + angle;
         break;
     case 6:
-        angle = -half_pi<double>() + angle;
+        angle = -half_pi + angle;
         break;
     case 7:
-        angle = -half_pi<double>() - angle;
+        angle = -half_pi - angle;
         break;
     }
     return angle;

--- a/include/util/trigonometry_table.hpp
+++ b/include/util/trigonometry_table.hpp
@@ -359,7 +359,7 @@ constexpr unsigned short atan_table[4096] = {
 #ifdef _MSC_VER // TODO: remove as soon as boost allows C++14 features with Visual Studio
 const constexpr double SCALING_FACTOR = 4. / M_PI * 0xFFFF;
 #else
-const constexpr double SCALING_FACTOR = 4. / std::numbers::pi * 0xFFFF;
+const constexpr double SCALING_FACTOR = 4. * std::numbers::inv_pi * 0xFFFF;
 #endif
 
 inline double atan2_lookup(double y, double x)

--- a/include/util/trigonometry_table.hpp
+++ b/include/util/trigonometry_table.hpp
@@ -356,11 +356,7 @@ constexpr unsigned short atan_table[4096] = {
     0xffe0, 0xffea, 0xfff4, 0xffff};
 
 // max value is pi/4
-#ifdef _MSC_VER // TODO: remove as soon as boost allows C++14 features with Visual Studio
-const constexpr double SCALING_FACTOR = 4. / M_PI * 0xFFFF;
-#else
 const constexpr double SCALING_FACTOR = 4. * std::numbers::inv_pi * 0xFFFF;
-#endif
 
 inline double atan2_lookup(double y, double x)
 {

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -103,8 +103,8 @@ inline void pixelToDegree(const double shift, double &x, double &y)
     const double b = shift / 2.0;
     x = (x - b) / shift * 360.0;
     // FIXME needs to be simplified
-    const double g = (y - b) / -(shift / (2 * M_PI)) / detail::DEGREE_TO_RAD;
-    static_assert(detail::DEGREE_TO_RAD / (2 * M_PI) - 1 / 360. < 0.0001, "");
+    const double g = (y - b) / -(shift * 0.5 * std::numbers::inv_pi) / detail::DEGREE_TO_RAD;
+    static_assert(detail::DEGREE_TO_RAD * 0.5 * std::numbers::inv_pi - 1 / 360. < 0.0001, "");
     y = static_cast<double>(yToLat(g));
 }
 

--- a/include/util/web_mercator.hpp
+++ b/include/util/web_mercator.hpp
@@ -3,7 +3,7 @@
 
 #include "util/coordinate.hpp"
 
-#include <boost/math/constants/constants.hpp>
+#include <numbers>
 
 namespace osrm::util::web_mercator
 {
@@ -14,7 +14,7 @@ const constexpr double RAD_TO_DEGREE = 1. / DEGREE_TO_RAD;
 // radius used by WGS84
 const constexpr double EARTH_RADIUS_WGS84 = 6378137.0;
 // earth circumference devided by 2
-const constexpr double MAXEXTENT = EARTH_RADIUS_WGS84 * boost::math::constants::pi<double>();
+const constexpr double MAXEXTENT = EARTH_RADIUS_WGS84 * std::numbers::pi;
 // ^ math functions are not constexpr since they have side-effects (setting errno) :(
 const constexpr double EPSG3857_MAX_LATITUDE = 85.051128779806592378; // 90(4*atan(exp(pi))/pi-1)
 const constexpr double MAX_LONGITUDE = 180.0;

--- a/src/extractor/intersection/intersection_analysis.cpp
+++ b/src/extractor/intersection/intersection_analysis.cpp
@@ -6,6 +6,7 @@
 #include "util/coordinate_calculation.hpp"
 
 #include <boost/optional/optional_io.hpp>
+#include <numbers>
 
 namespace osrm::extractor::intersection
 {
@@ -79,11 +80,11 @@ namespace
 {
 double findAngleBisector(double alpha, double beta)
 {
-    alpha *= M_PI / 180.;
-    beta *= M_PI / 180.;
+    alpha *= std::numbers::pi / 180.;
+    beta *= std::numbers::pi / 180.;
     const auto average =
-        180. * std::atan2(std::sin(alpha) + std::sin(beta), std::cos(alpha) + std::cos(beta)) /
-        M_PI;
+        180. * std::atan2(std::sin(alpha) + std::sin(beta), std::cos(alpha) + std::cos(beta)) *
+        std::numbers::inv_pi;
     return std::fmod(average + 360., 360.);
 }
 

--- a/src/extractor/intersection/mergable_road_detector.cpp
+++ b/src/extractor/intersection/mergable_road_detector.cpp
@@ -351,7 +351,7 @@ bool MergableRoadDetector::IsCircularShape(const NodeID intersection_node,
     //      ----         ----
     //          \       /
     //           -------
-    const auto constexpr CIRCULAR_POLYGON_ISOPERIMETRIC_LOWER_BOUND = 0.85 / (4 * M_PI);
+    const auto constexpr CIRCULAR_POLYGON_ISOPERIMETRIC_LOWER_BOUND = 0.85 / (4 * std::numbers::pi);
     if (connect_again && coordinates_to_the_left.front() == coordinates_to_the_left.back())
     { // if the left and right roads connect again and are closed polygons ...
         const auto area = util::coordinate_calculation::computeArea(coordinates_to_the_left);
@@ -359,7 +359,7 @@ bool MergableRoadDetector::IsCircularShape(const NodeID intersection_node,
         const auto area_to_squared_perimeter_ratio = std::abs(area) / (perimeter * perimeter);
 
         // then don't merge roads if A/L² is greater than the lower bound
-        BOOST_ASSERT(area_to_squared_perimeter_ratio <= 1. / (4 * M_PI));
+        BOOST_ASSERT(area_to_squared_perimeter_ratio <= 1. / (4 * std::numbers::pi));
         if (area_to_squared_perimeter_ratio >= CIRCULAR_POLYGON_ISOPERIMETRIC_LOWER_BOUND)
             return true;
     }

--- a/src/guidance/roundabout_handler.cpp
+++ b/src/guidance/roundabout_handler.cpp
@@ -337,7 +337,7 @@ RoundaboutType RoundaboutHandler::getRoundaboutType(const NodeID nid) const
         return RoundaboutType::RoundaboutIntersection;
     }
 
-    const double radius = roundabout_length / (2 * M_PI);
+    const double radius = roundabout_length * 0.5 * std::numbers::inv_pi;
 
     // Looks like a rotary: large roundabout with dedicated name
     // do we have a dedicated name for the rotary, if not its a roundabout

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -162,7 +162,7 @@ double computeAngle(const Coordinate first, const Coordinate second, const Coord
     const double v2y =
         web_mercator::latToY(toFloating(third.lat)) - web_mercator::latToY(toFloating(second.lat));
 
-    double angle = (atan2_lookup(v2y, v2x) - atan2_lookup(v1y, v1x)) * 180. / std::numbers::pi;
+    double angle = (atan2_lookup(v2y, v2x) - atan2_lookup(v1y, v1x)) * 180. * std::numbers::inv_pi;
 
     while (angle < 0.)
     {

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -146,7 +146,6 @@ double bearing(const Coordinate coordinate_1, const Coordinate coordinate_2)
 
 double computeAngle(const Coordinate first, const Coordinate second, const Coordinate third)
 {
-    using namespace boost::math::constants;
     using namespace coordinate_calculation;
 
     if (first == second || second == third)
@@ -163,7 +162,7 @@ double computeAngle(const Coordinate first, const Coordinate second, const Coord
     const double v2y =
         web_mercator::latToY(toFloating(third.lat)) - web_mercator::latToY(toFloating(second.lat));
 
-    double angle = (atan2_lookup(v2y, v2x) - atan2_lookup(v1y, v1x)) * 180. / pi<double>();
+    double angle = (atan2_lookup(v2y, v2x) - atan2_lookup(v1y, v1x)) * 180. / std::numbers::pi;
 
     while (angle < 0.)
     {


### PR DESCRIPTION
Let's prefer things from stdlib...

<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1105.94<br/>plain u32: 1098.95<br/>aliased double: 959.533<br/>plain double: 964.602 | aliased u32: 1097<br/>plain u32: 1101.59<br/>aliased double: 961.788<br/>plain double: 960.653 |
| json-render | String: 6.56501ms<br/>Stringstream: 9.29638ms<br/>Vector: 6.89917ms | String: 6.60594ms<br/>Stringstream: 9.31658ms<br/>Vector: 6.95441ms |
| match_ch | Default radius: <br/>4.44353ms/req at 82 coordinate<br/>0.0541894ms/coordinate<br/>Radius 5m: <br/>4.41448ms/req at 82 coordinate<br/>0.0538351ms/coordinate<br/>Radius 10m: <br/>15.1272ms/req at 82 coordinate<br/>0.184478ms/coordinate<br/>Radius 15m: <br/>37.1259ms/req at 82 coordinate<br/>0.452755ms/coordinate<br/>Radius 30m: <br/>315.501ms/req at 82 coordinate<br/>3.84757ms/coordinate | Default radius: <br/>4.74375ms/req at 82 coordinate<br/>0.0578506ms/coordinate<br/>Radius 5m: <br/>4.75225ms/req at 82 coordinate<br/>0.0579542ms/coordinate<br/>Radius 10m: <br/>16.3889ms/req at 82 coordinate<br/>0.199864ms/coordinate<br/>Radius 15m: <br/>40.2069ms/req at 82 coordinate<br/>0.490328ms/coordinate<br/>Radius 30m: <br/>343.263ms/req at 82 coordinate<br/>4.18613ms/coordinate |
| match_mld | Default radius: <br/>2.85775ms/req at 82 coordinate<br/>0.0348506ms/coordinate<br/>Radius 5m: <br/>2.99267ms/req at 82 coordinate<br/>0.036496ms/coordinate<br/>Radius 10m: <br/>10.532ms/req at 82 coordinate<br/>0.128439ms/coordinate<br/>Radius 15m: <br/>26.2624ms/req at 82 coordinate<br/>0.320274ms/coordinate<br/>Radius 30m: <br/>308.441ms/req at 82 coordinate<br/>3.76147ms/coordinate | Default radius: <br/>2.92088ms/req at 82 coordinate<br/>0.0356205ms/coordinate<br/>Radius 5m: <br/>2.91631ms/req at 82 coordinate<br/>0.0355647ms/coordinate<br/>Radius 10m: <br/>11.0469ms/req at 82 coordinate<br/>0.134718ms/coordinate<br/>Radius 15m: <br/>28.7166ms/req at 82 coordinate<br/>0.350202ms/coordinate<br/>Radius 30m: <br/>340.643ms/req at 82 coordinate<br/>4.15419ms/coordinate |
| packedvector | random write:<br/>std::vector 12113.6 ms<br/>util::packed_vector 82060.9 ms<br/>slowdown: 6.77429<br/>random read:<br/>std::vector 12158.6 ms<br/>util::packed_vector 33880.9 ms<br/>slowdown: 2.78659 | random write:<br/>std::vector 9872.18 ms<br/>util::packed_vector 81795.8 ms<br/>slowdown: 8.28549<br/>random read:<br/>std::vector 8576.45 ms<br/>util::packed_vector 33545 ms<br/>slowdown: 3.91129 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>506.633ms<br/>0.506633ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>347.475ms<br/>0.347475ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>625.175ms<br/>0.625175ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>152.014ms<br/>0.152014ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.3768ms<br/>0.0973768ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.47ms<br/>0.13247ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.173ms<br/>0.151173ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.3354ms<br/>0.0973354ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.317ms<br/>0.132317ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>510.971ms<br/>0.510971ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>351.5ms<br/>0.3515ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>630.938ms<br/>0.630938ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.031ms<br/>0.151031ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.1235ms<br/>0.0971235ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.182ms<br/>0.132182ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.397ms<br/>0.150397ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.1684ms<br/>0.0971684ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.916ms<br/>0.131916ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>642.159ms<br/>0.642159ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>438.686ms<br/>0.438686ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>808.316ms<br/>0.808316ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>286.203ms<br/>0.286203ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>163.405ms<br/>0.163405ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>299.09ms<br/>0.29909ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>277.855ms<br/>0.277855ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>162.643ms<br/>0.162643ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>294.36ms<br/>0.29436ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>655.219ms<br/>0.655219ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>446.499ms<br/>0.446499ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>834.273ms<br/>0.834273ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>298.316ms<br/>0.298316ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>164.838ms<br/>0.164838ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>316.454ms<br/>0.316454ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>297.283ms<br/>0.297283ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>164.39ms<br/>0.16439ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>310.592ms<br/>0.310592ms/req |
| rtree | 1 result:<br/>207.759ms ->  0.0207759 ms/query<br/>10 results:<br/>242.618ms ->  0.0242618 ms/query | 1 result:<br/>209.939ms ->  0.0209939 ms/query<br/>10 results:<br/>243.93ms ->  0.024393 ms/query |
<!-- BENCHMARK_RESULTS_END -->