### PR TITLE
Make constants in PackedVector constexpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Make constants in PackedVector constexpr. [#6917](https://github.com/Project-OSRM/osrm-backend/pull/6917)
       - CHANGED: Use std::variant instead of mapbox::util::variant. [#6903](https://github.com/Project-OSRM/osrm-backend/pull/6903)
       - CHANGED: Bump rapidjson to version f9d53419e912910fd8fa57d5705fa41425428c35 [#6906](https://github.com/Project-OSRM/osrm-backend/pull/6906)
       - CHANGED: Bump mapbox/variant to version 1.2.0 [#6898](https://github.com/Project-OSRM/osrm-backend/pull/6898)

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -153,8 +153,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
     // number of words per block
     static constexpr std::size_t BLOCK_WORDS = (Bits * BLOCK_ELEMENTS) / WORD_BITS;
 
-    // C++14 does not allow operator[] to be constexpr, this is fixed in C++17.
-    static /* constexpr */ std::array<WordT, BLOCK_ELEMENTS> initialize_lower_mask()
+    static constexpr std::array<WordT, BLOCK_ELEMENTS> initialize_lower_mask()
     {
         std::array<WordT, BLOCK_ELEMENTS> lower_mask;
 
@@ -170,7 +169,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         return lower_mask;
     }
 
-    static /* constexpr */ std::array<WordT, BLOCK_ELEMENTS> initialize_upper_mask()
+    static constexpr std::array<WordT, BLOCK_ELEMENTS> initialize_upper_mask()
     {
         std::array<WordT, BLOCK_ELEMENTS> upper_mask;
 
@@ -194,7 +193,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         return upper_mask;
     }
 
-    static /* constexpr */ std::array<std::uint8_t, BLOCK_ELEMENTS> initialize_lower_offset()
+    static constexpr std::array<std::uint8_t, BLOCK_ELEMENTS> initialize_lower_offset()
     {
         std::array<std::uint8_t, WORD_BITS> lower_offset;
 
@@ -209,7 +208,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         return lower_offset;
     }
 
-    static /* constexpr */ std::array<std::uint8_t, BLOCK_ELEMENTS> initialize_upper_offset()
+    static constexpr std::array<std::uint8_t, BLOCK_ELEMENTS> initialize_upper_offset()
     {
         std::array<std::uint8_t, BLOCK_ELEMENTS> upper_offset;
 
@@ -232,7 +231,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         return upper_offset;
     }
 
-    static /* constexpr */ std::array<std::uint8_t, BLOCK_ELEMENTS> initialize_word_offset()
+    static constexpr std::array<std::uint8_t, BLOCK_ELEMENTS> initialize_word_offset()
     {
         std::array<std::uint8_t, BLOCK_ELEMENTS> word_offset;
 
@@ -246,28 +245,15 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         return word_offset;
     }
 
-    // For now we need to call these on object creation
-    void initialize()
-    {
-        lower_mask = initialize_lower_mask();
-        upper_mask = initialize_upper_mask();
-        lower_offset = initialize_lower_offset();
-        upper_offset = initialize_upper_offset();
-        word_offset = initialize_word_offset();
-    }
-
     // mask for the lower/upper word of a record
-    // TODO: With C++17 these could be constexpr
-    /* static constexpr */ std::array<WordT, BLOCK_ELEMENTS>
-        lower_mask /* = initialize_lower_mask()*/;
-    /* static constexpr */ std::array<WordT, BLOCK_ELEMENTS>
-        upper_mask /* = initialize_upper_mask()*/;
-    /* static constexpr */ std::array<std::uint8_t, BLOCK_ELEMENTS>
-        lower_offset /* = initialize_lower_offset()*/;
-    /* static constexpr */ std::array<std::uint8_t, BLOCK_ELEMENTS>
-        upper_offset /* = initialize_upper_offset()*/;
+    static constexpr std::array<WordT, BLOCK_ELEMENTS> lower_mask = initialize_lower_mask();
+    static constexpr std::array<WordT, BLOCK_ELEMENTS> upper_mask = initialize_upper_mask();
+    static constexpr std::array<std::uint8_t, BLOCK_ELEMENTS> lower_offset =
+        initialize_lower_offset();
+    static constexpr std::array<std::uint8_t, BLOCK_ELEMENTS> upper_offset =
+        initialize_upper_offset();
     // in which word of the block is the element
-    /* static constexpr */ std::array<std::uint8_t, BLOCK_ELEMENTS> word_offset =
+    static constexpr std::array<std::uint8_t, BLOCK_ELEMENTS> word_offset =
         initialize_word_offset();
 
     struct InternalIndex
@@ -378,27 +364,21 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
     PackedVector(std::initializer_list<T> list)
     {
-        initialize();
         reserve(list.size());
         for (const auto value : list)
             push_back(value);
     }
 
-    PackedVector() { initialize(); };
+    PackedVector(){};
     PackedVector(const PackedVector &) = default;
     PackedVector(PackedVector &&) = default;
     PackedVector &operator=(const PackedVector &) = default;
     PackedVector &operator=(PackedVector &&) = default;
 
-    PackedVector(std::size_t size)
-    {
-        initialize();
-        resize(size);
-    }
+    PackedVector(std::size_t size) { resize(size); }
 
     PackedVector(std::size_t size, T initial_value)
     {
-        initialize();
         resize(size);
         fill(initial_value);
     }
@@ -406,7 +386,6 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
     PackedVector(util::ViewOrVector<WordT, Ownership> vec_, std::size_t num_elements)
         : vec(std::move(vec_)), num_elements(num_elements)
     {
-        initialize();
     }
 
     // forces the efficient read-only lookup


### PR DESCRIPTION
Fixes old TODO.

<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1091.83<br/>plain u32: 1103.7<br/>aliased double: 946.009<br/>plain double: 947.178 | aliased u32: 1094.02<br/>plain u32: 1086.57<br/>aliased double: 955.325<br/>plain double: 953.975 |
| json-render | String: 6.60321ms<br/>Stringstream: 9.26222ms<br/>Vector: 6.84999ms | String: 6.56698ms<br/>Stringstream: 9.28439ms<br/>Vector: 6.85995ms |
| match_ch | Default radius: <br/>4.47777ms/req at 82 coordinate<br/>0.054607ms/coordinate<br/>Radius 5m: <br/>4.47312ms/req at 82 coordinate<br/>0.0545503ms/coordinate<br/>Radius 10m: <br/>15.2705ms/req at 82 coordinate<br/>0.186226ms/coordinate<br/>Radius 15m: <br/>37.564ms/req at 82 coordinate<br/>0.458098ms/coordinate<br/>Radius 30m: <br/>318.241ms/req at 82 coordinate<br/>3.88099ms/coordinate | Default radius: <br/>4.43106ms/req at 82 coordinate<br/>0.0540373ms/coordinate<br/>Radius 5m: <br/>4.42271ms/req at 82 coordinate<br/>0.0539355ms/coordinate<br/>Radius 10m: <br/>15.0701ms/req at 82 coordinate<br/>0.183782ms/coordinate<br/>Radius 15m: <br/>36.8092ms/req at 82 coordinate<br/>0.448893ms/coordinate<br/>Radius 30m: <br/>314.393ms/req at 82 coordinate<br/>3.83406ms/coordinate |
| match_mld | Default radius: <br/>2.84118ms/req at 82 coordinate<br/>0.0346486ms/coordinate<br/>Radius 5m: <br/>2.81614ms/req at 82 coordinate<br/>0.0343431ms/coordinate<br/>Radius 10m: <br/>10.4999ms/req at 82 coordinate<br/>0.128047ms/coordinate<br/>Radius 15m: <br/>26.878ms/req at 82 coordinate<br/>0.327781ms/coordinate<br/>Radius 30m: <br/>316.391ms/req at 82 coordinate<br/>3.85843ms/coordinate | Default radius: <br/>2.80181ms/req at 82 coordinate<br/>0.0341684ms/coordinate<br/>Radius 5m: <br/>2.79596ms/req at 82 coordinate<br/>0.0340971ms/coordinate<br/>Radius 10m: <br/>10.2739ms/req at 82 coordinate<br/>0.125291ms/coordinate<br/>Radius 15m: <br/>26.3782ms/req at 82 coordinate<br/>0.321685ms/coordinate<br/>Radius 30m: <br/>308.975ms/req at 82 coordinate<br/>3.76798ms/coordinate |
| packedvector | random write:<br/>std::vector 10159.2 ms<br/>util::packed_vector 78449.2 ms<br/>slowdown: 7.72198<br/>random read:<br/>std::vector 10388 ms<br/>util::packed_vector 33958.5 ms<br/>slowdown: 3.26902 | random write:<br/>std::vector 10954.1 ms<br/>util::packed_vector 82178.4 ms<br/>slowdown: 7.50209<br/>random read:<br/>std::vector 11107.2 ms<br/>util::packed_vector 33510.9 ms<br/>slowdown: 3.01703 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>516.621ms<br/>0.516621ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>354.636ms<br/>0.354636ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>640.531ms<br/>0.640531ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>152.159ms<br/>0.152159ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.7101ms<br/>0.0977101ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.8ms<br/>0.1328ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>152.486ms<br/>0.152486ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>98.0277ms<br/>0.0980277ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>133.134ms<br/>0.133134ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>507.618ms<br/>0.507618ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>350.806ms<br/>0.350806ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>627.321ms<br/>0.627321ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.31ms<br/>0.15131ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.3628ms<br/>0.0973628ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.306ms<br/>0.132306ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.321ms<br/>0.150321ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.2103ms<br/>0.0972103ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>135.12ms<br/>0.13512ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>642.707ms<br/>0.642707ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>442.724ms<br/>0.442724ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>819.727ms<br/>0.819727ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>285.043ms<br/>0.285043ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>165.497ms<br/>0.165497ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>304.867ms<br/>0.304867ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>274.945ms<br/>0.274945ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>162.144ms<br/>0.162144ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>297.842ms<br/>0.297842ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>647.214ms<br/>0.647214ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>451.564ms<br/>0.451564ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>824.172ms<br/>0.824172ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>282.454ms<br/>0.282454ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>170.298ms<br/>0.170298ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>299.853ms<br/>0.299853ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>275.947ms<br/>0.275947ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>165.832ms<br/>0.165832ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>297.993ms<br/>0.297993ms/req |
| rtree | 1 result:<br/>207.122ms ->  0.0207122 ms/query<br/>10 results:<br/>242.587ms ->  0.0242587 ms/query | 1 result:<br/>206.96ms ->  0.020696 ms/query<br/>10 results:<br/>242.299ms ->  0.0242299 ms/query |
<!-- BENCHMARK_RESULTS_END -->