### PR TITLE
Use std::string_view::starts_with instead of boost::starts_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Use std::string_view::starts_with instead of boost::starts_with. [#6918](https://github.com/Project-OSRM/osrm-backend/pull/6918) 
       - CHANGED: Use std::variant instead of mapbox::util::variant. [#6903](https://github.com/Project-OSRM/osrm-backend/pull/6903)
       - CHANGED: Bump rapidjson to version f9d53419e912910fd8fa57d5705fa41425428c35 [#6906](https://github.com/Project-OSRM/osrm-backend/pull/6906)
       - CHANGED: Bump mapbox/variant to version 1.2.0 [#6898](https://github.com/Project-OSRM/osrm-backend/pull/6898)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
-      - CHANGED: Use std::string_view::starts_with instead of boost::starts_with. [#6918](https://github.com/Project-OSRM/osrm-backend/pull/6918) 
+      - CHANGED: Use std::string_view::starts_with instead of boost::starts_with. [#6918](https://github.com/Project-OSRM/osrm-backend/pull/6918)
       - CHANGED: Use std::variant instead of mapbox::util::variant. [#6903](https://github.com/Project-OSRM/osrm-backend/pull/6903)
       - CHANGED: Bump rapidjson to version f9d53419e912910fd8fa57d5705fa41425428c35 [#6906](https://github.com/Project-OSRM/osrm-backend/pull/6906)
       - CHANGED: Bump mapbox/variant to version 1.2.0 [#6898](https://github.com/Project-OSRM/osrm-backend/pull/6898)

--- a/include/util/guidance/name_announcements.hpp
+++ b/include/util/guidance/name_announcements.hpp
@@ -124,8 +124,7 @@ inline bool requiresNameAnnounced(const StringView &from_name,
 
     // check similarity of names
     const auto names_are_empty = from_name.empty() && to_name.empty();
-    const auto name_is_contained =
-        from_name.starts_with(to_name) || to_name.starts_with(from_name);
+    const auto name_is_contained = from_name.starts_with(to_name) || to_name.starts_with(from_name);
 
     const auto checkForPrefixOrSuffixChange = [](const std::string_view first,
                                                  const std::string_view second,

--- a/include/util/guidance/name_announcements.hpp
+++ b/include/util/guidance/name_announcements.hpp
@@ -8,8 +8,6 @@
 
 #include "util/typedefs.hpp"
 
-#include <boost/algorithm/string.hpp>
-
 #include <algorithm>
 #include <string>
 #include <tuple>
@@ -127,7 +125,7 @@ inline bool requiresNameAnnounced(const StringView &from_name,
     // check similarity of names
     const auto names_are_empty = from_name.empty() && to_name.empty();
     const auto name_is_contained =
-        boost::starts_with(from_name, to_name) || boost::starts_with(to_name, from_name);
+        from_name.starts_with(to_name) || to_name.starts_with(from_name);
 
     const auto checkForPrefixOrSuffixChange = [](const std::string_view first,
                                                  const std::string_view second,


### PR DESCRIPTION
<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1134.34<br/>plain u32: 1142.94<br/>aliased double: 1181.36<br/>plain double: 1204.1 | aliased u32: 1131.88<br/>plain u32: 1138.95<br/>aliased double: 1172.12<br/>plain double: 1169.76 |
| json-render | String: 6.54466ms<br/>Stringstream: 9.29745ms<br/>Vector: 6.87775ms | String: 6.54051ms<br/>Stringstream: 9.32552ms<br/>Vector: 6.89345ms |
| match_ch | Default radius: <br/>4.57155ms/req at 82 coordinate<br/>0.0557506ms/coordinate<br/>Radius 5m: <br/>4.55827ms/req at 82 coordinate<br/>0.0555887ms/coordinate<br/>Radius 10m: <br/>15.4237ms/req at 82 coordinate<br/>0.188094ms/coordinate<br/>Radius 15m: <br/>37.6846ms/req at 82 coordinate<br/>0.459569ms/coordinate<br/>Radius 30m: <br/>320.622ms/req at 82 coordinate<br/>3.91003ms/coordinate | Default radius: <br/>4.46443ms/req at 82 coordinate<br/>0.0544443ms/coordinate<br/>Radius 5m: <br/>4.44697ms/req at 82 coordinate<br/>0.0542313ms/coordinate<br/>Radius 10m: <br/>15.1336ms/req at 82 coordinate<br/>0.184556ms/coordinate<br/>Radius 15m: <br/>37.0512ms/req at 82 coordinate<br/>0.451844ms/coordinate<br/>Radius 30m: <br/>317.421ms/req at 82 coordinate<br/>3.87098ms/coordinate |
| match_mld | Default radius: <br/>2.84428ms/req at 82 coordinate<br/>0.0346864ms/coordinate<br/>Radius 5m: <br/>2.80042ms/req at 82 coordinate<br/>0.0341515ms/coordinate<br/>Radius 10m: <br/>10.3784ms/req at 82 coordinate<br/>0.126566ms/coordinate<br/>Radius 15m: <br/>26.5601ms/req at 82 coordinate<br/>0.323903ms/coordinate<br/>Radius 30m: <br/>310.031ms/req at 82 coordinate<br/>3.78087ms/coordinate | Default radius: <br/>2.80905ms/req at 82 coordinate<br/>0.0342567ms/coordinate<br/>Radius 5m: <br/>2.79896ms/req at 82 coordinate<br/>0.0341337ms/coordinate<br/>Radius 10m: <br/>10.3965ms/req at 82 coordinate<br/>0.126787ms/coordinate<br/>Radius 15m: <br/>26.7536ms/req at 82 coordinate<br/>0.326264ms/coordinate<br/>Radius 30m: <br/>312.492ms/req at 82 coordinate<br/>3.81088ms/coordinate |
| packedvector | random write:<br/>std::vector 11331.2 ms<br/>util::packed_vector 73550.7 ms<br/>slowdown: 6.49096<br/>random read:<br/>std::vector 11382.7 ms<br/>util::packed_vector 29370.4 ms<br/>slowdown: 2.58028 | random write:<br/>std::vector 11183.6 ms<br/>util::packed_vector 81468.2 ms<br/>slowdown: 7.2846<br/>random read:<br/>std::vector 11047.3 ms<br/>util::packed_vector 33396.3 ms<br/>slowdown: 3.02302 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>511.328ms<br/>0.511328ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>349.06ms<br/>0.34906ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>628.072ms<br/>0.628072ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>152.432ms<br/>0.152432ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.0099ms<br/>0.0970099ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.947ms<br/>0.132947ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.464ms<br/>0.150464ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.1997ms<br/>0.0971997ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.274ms<br/>0.132274ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>511.114ms<br/>0.511114ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>352.525ms<br/>0.352525ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>630.397ms<br/>0.630397ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>150.793ms<br/>0.150793ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.0945ms<br/>0.0970945ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.172ms<br/>0.132172ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.575ms<br/>0.151575ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.6632ms<br/>0.0966632ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.951ms<br/>0.131951ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>640.56ms<br/>0.64056ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>443.141ms<br/>0.443141ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>816.859ms<br/>0.816859ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>281.248ms<br/>0.281248ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>215.694ms<br/>0.215694ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>293.283ms<br/>0.293283ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>270.009ms<br/>0.270009ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.425ms<br/>0.161425ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>292.799ms<br/>0.292799ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>639.096ms<br/>0.639096ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>439.312ms<br/>0.439312ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>812.386ms<br/>0.812386ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>276.425ms<br/>0.276425ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>164.154ms<br/>0.164154ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>296.432ms<br/>0.296432ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>275.594ms<br/>0.275594ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>162.919ms<br/>0.162919ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>296.315ms<br/>0.296315ms/req |
| rtree | 1 result:<br/>207.502ms ->  0.0207502 ms/query<br/>10 results:<br/>242.292ms ->  0.0242292 ms/query | 1 result:<br/>207.224ms ->  0.0207224 ms/query<br/>10 results:<br/>242.412ms ->  0.0242412 ms/query |
<!-- BENCHMARK_RESULTS_END -->