### PR TITLE
Use custom struct instead of std::pair in QueryHeap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Use custom struct instead of std::pair in QueryHeap. [#6921](https://github.com/Project-OSRM/osrm-backend/pull/6921)
       - CHANGED: Make constants in PackedVector constexpr. [#6917](https://github.com/Project-OSRM/osrm-backend/pull/6917)
       - CHANGED: Use std::variant instead of mapbox::util::variant. [#6903](https://github.com/Project-OSRM/osrm-backend/pull/6903)
       - CHANGED: Bump rapidjson to version f9d53419e912910fd8fa57d5705fa41425428c35 [#6906](https://github.com/Project-OSRM/osrm-backend/pull/6906)

--- a/include/util/query_heap.hpp
+++ b/include/util/query_heap.hpp
@@ -370,7 +370,7 @@ class QueryHeap
         const auto index = node_index.peek_index(node);
         auto &reference = inserted_nodes[index];
         reference.weight = weight;
-        heap.increase(reference.handle, HeapData{weight, index});
+        heap.increase(reference.handle, HeapData{weight, static_cast<Key>(index)});
     }
 
     void DecreaseKey(const HeapNode &heapNode)

--- a/include/util/query_heap.hpp
+++ b/include/util/query_heap.hpp
@@ -193,7 +193,20 @@ template <typename NodeID,
 class QueryHeap
 {
   private:
-    using HeapData = std::pair<Weight, Key>;
+    struct HeapData
+    {
+        Weight weight;
+        Key index;
+
+        bool operator>(const HeapData &other) const
+        {
+            if (weight == other.weight)
+            {
+                return index > other.index;
+            }
+            return weight > other.weight;
+        }
+    };
     using HeapContainer = boost::heap::d_ary_heap<HeapData,
                                                   boost::heap::arity<4>,
                                                   boost::heap::mutable_<true>,
@@ -232,7 +245,7 @@ class QueryHeap
     {
         BOOST_ASSERT(node < std::numeric_limits<NodeID>::max());
         const auto index = static_cast<Key>(inserted_nodes.size());
-        const auto handle = heap.push(std::make_pair(weight, index));
+        const auto handle = heap.emplace(HeapData{weight, index});
         inserted_nodes.emplace_back(HeapNode{handle, node, weight, data});
         node_index[node] = index;
     }
@@ -315,19 +328,19 @@ class QueryHeap
     NodeID Min() const
     {
         BOOST_ASSERT(!heap.empty());
-        return inserted_nodes[heap.top().second].node;
+        return inserted_nodes[heap.top().index].node;
     }
 
     Weight MinKey() const
     {
         BOOST_ASSERT(!heap.empty());
-        return heap.top().first;
+        return heap.top().weight;
     }
 
     NodeID DeleteMin()
     {
         BOOST_ASSERT(!heap.empty());
-        const Key removedIndex = heap.top().second;
+        const Key removedIndex = heap.top().index;
         heap.pop();
         inserted_nodes[removedIndex].handle = heap.s_handle_from_iterator(heap.end());
         return inserted_nodes[removedIndex].node;
@@ -336,7 +349,7 @@ class QueryHeap
     HeapNode &DeleteMinGetHeapNode()
     {
         BOOST_ASSERT(!heap.empty());
-        const Key removedIndex = heap.top().second;
+        const Key removedIndex = heap.top().index;
         heap.pop();
         inserted_nodes[removedIndex].handle = heap.s_handle_from_iterator(heap.end());
         return inserted_nodes[removedIndex];
@@ -357,13 +370,13 @@ class QueryHeap
         const auto index = node_index.peek_index(node);
         auto &reference = inserted_nodes[index];
         reference.weight = weight;
-        heap.increase(reference.handle, std::make_pair(weight, index));
+        heap.increase(reference.handle, HeapData{weight, index});
     }
 
     void DecreaseKey(const HeapNode &heapNode)
     {
         BOOST_ASSERT(!WasRemoved(heapNode.node));
-        heap.increase(heapNode.handle, std::make_pair(heapNode.weight, (*heapNode.handle).second));
+        heap.increase(heapNode.handle, HeapData{heapNode.weight, (*heapNode.handle).index});
     }
 
   private:


### PR DESCRIPTION
- improves readability
- seems to be a microoptimisation


<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1087.89<br/>plain u32: 1085.74<br/>aliased double: 957.784<br/>plain double: 954.912 | aliased u32: 1094.16<br/>plain u32: 1143.48<br/>aliased double: 1181.03<br/>plain double: 1173.1 |
| json-render | String: 6.5949ms<br/>Stringstream: 9.33359ms<br/>Vector: 6.8915ms | String: 6.56282ms<br/>Stringstream: 9.17836ms<br/>Vector: 6.80801ms |
| match_ch | Default radius: <br/>4.46775ms/req at 82 coordinate<br/>0.0544847ms/coordinate<br/>Radius 5m: <br/>4.4405ms/req at 82 coordinate<br/>0.0541524ms/coordinate<br/>Radius 10m: <br/>15.1805ms/req at 82 coordinate<br/>0.185128ms/coordinate<br/>Radius 15m: <br/>37.1138ms/req at 82 coordinate<br/>0.452607ms/coordinate<br/>Radius 30m: <br/>317.423ms/req at 82 coordinate<br/>3.87101ms/coordinate | Default radius: <br/>4.42469ms/req at 82 coordinate<br/>0.0539597ms/coordinate<br/>Radius 5m: <br/>4.38681ms/req at 82 coordinate<br/>0.0534976ms/coordinate<br/>Radius 10m: <br/>15.0091ms/req at 82 coordinate<br/>0.183038ms/coordinate<br/>Radius 15m: <br/>36.6437ms/req at 82 coordinate<br/>0.446875ms/coordinate<br/>Radius 30m: <br/>312.646ms/req at 82 coordinate<br/>3.81276ms/coordinate |
| match_mld | Default radius: <br/>3.34427ms/req at 82 coordinate<br/>0.0407838ms/coordinate<br/>Radius 5m: <br/>2.79952ms/req at 82 coordinate<br/>0.0341405ms/coordinate<br/>Radius 10m: <br/>10.3098ms/req at 82 coordinate<br/>0.125729ms/coordinate<br/>Radius 15m: <br/>26.4945ms/req at 82 coordinate<br/>0.323104ms/coordinate<br/>Radius 30m: <br/>310.665ms/req at 82 coordinate<br/>3.7886ms/coordinate | Default radius: <br/>2.78484ms/req at 82 coordinate<br/>0.0339614ms/coordinate<br/>Radius 5m: <br/>2.7996ms/req at 82 coordinate<br/>0.0341415ms/coordinate<br/>Radius 10m: <br/>10.1723ms/req at 82 coordinate<br/>0.124052ms/coordinate<br/>Radius 15m: <br/>26.0148ms/req at 82 coordinate<br/>0.317254ms/coordinate<br/>Radius 30m: <br/>304.017ms/req at 82 coordinate<br/>3.70753ms/coordinate |
| packedvector | random write:<br/>std::vector 9858.82 ms<br/>util::packed_vector 82186.3 ms<br/>slowdown: 8.33632<br/>random read:<br/>std::vector 8513.61 ms<br/>util::packed_vector 33472.8 ms<br/>slowdown: 3.93168 | random write:<br/>std::vector 11236.2 ms<br/>util::packed_vector 73886.6 ms<br/>slowdown: 6.57575<br/>random read:<br/>std::vector 11103.5 ms<br/>util::packed_vector 30234 ms<br/>slowdown: 2.72293 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>509.659ms<br/>0.509659ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>351.646ms<br/>0.351646ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>628.2ms<br/>0.6282ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>152.53ms<br/>0.15253ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.4741ms<br/>0.0974741ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.57ms<br/>0.13257ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.428ms<br/>0.151428ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.0949ms<br/>0.0970949ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.039ms<br/>0.132039ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>511.645ms<br/>0.511645ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>353.033ms<br/>0.353033ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>630.633ms<br/>0.630633ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>149.976ms<br/>0.149976ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>96.5049ms<br/>0.0965049ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.923ms<br/>0.132923ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>149.583ms<br/>0.149583ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.4442ms<br/>0.0964442ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.794ms<br/>0.131794ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>643.621ms<br/>0.643621ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>441.984ms<br/>0.441984ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>818.912ms<br/>0.818912ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>280.732ms<br/>0.280732ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>164.269ms<br/>0.164269ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>300.394ms<br/>0.300394ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>272.22ms<br/>0.27222ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.836ms<br/>0.161836ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>293.598ms<br/>0.293598ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>640.204ms<br/>0.640204ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>436.477ms<br/>0.436477ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>815.515ms<br/>0.815515ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>268.377ms<br/>0.268377ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>159.875ms<br/>0.159875ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>287.392ms<br/>0.287392ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>261.197ms<br/>0.261197ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.217ms<br/>0.161217ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>287.302ms<br/>0.287302ms/req |
| rtree | 1 result:<br/>207.75ms ->  0.020775 ms/query<br/>10 results:<br/>243.355ms ->  0.0243355 ms/query | 1 result:<br/>207.172ms ->  0.0207172 ms/query<br/>10 results:<br/>243.418ms ->  0.0243418 ms/query |
<!-- BENCHMARK_RESULTS_END -->