### PR TITLE
Use Lemire's fast check whether to escape a JSON string

### DIFF
--- a/include/util/string_util.hpp
+++ b/include/util/string_util.hpp
@@ -16,11 +16,11 @@ namespace osrm::util
 inline static constexpr std::array<uint8_t, 256> json_quotable_character = []() constexpr
 {
     std::array<uint8_t, 256> result{};
-    for (size_t i = 0; i < 32; i++)
+    for (auto i = 0; i < 32; i++)
     {
         result[i] = 1;
     }
-    for (size_t i : {'"', '\\'})
+    for (auto i : {'"', '\\'})
     {
         result[i] = 1;
     }

--- a/include/util/string_util.hpp
+++ b/include/util/string_util.hpp
@@ -1,8 +1,9 @@
 #ifndef STRING_UTIL_HPP
 #define STRING_UTIL_HPP
 
+#include <array>
 #include <cctype>
-
+#include <cstddef>
 #include <random>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Lemire explains the method in his recent [blog post](https://lemire.me/blog/2024/05/31/quickly-checking-whether-a-string-needs-escaping/). Bottom line, it is faster.

<!-- BENCHMARK_RESULTS_START -->
## Benchmark Results
| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1082.07<br/>plain u32: 1082.28<br/>aliased double: 952.881<br/>plain double: 954.315 | aliased u32: 1088.98<br/>plain u32: 1156.68<br/>aliased double: 948.964<br/>plain double: 951.851 |
| json-render | String: 6.65077ms<br/>Stringstream: 9.38816ms<br/>Vector: 6.83465ms | String: 6.62298ms<br/>Stringstream: 9.41552ms<br/>Vector: 6.93634ms |
| match_ch | Default radius: <br/>4.41722ms/req at 82 coordinate<br/>0.0538685ms/coordinate<br/>Radius 5m: <br/>4.38879ms/req at 82 coordinate<br/>0.0535219ms/coordinate<br/>Radius 10m: <br/>14.9413ms/req at 82 coordinate<br/>0.182211ms/coordinate<br/>Radius 15m: <br/>36.589ms/req at 82 coordinate<br/>0.446208ms/coordinate<br/>Radius 30m: <br/>312.676ms/req at 82 coordinate<br/>3.81312ms/coordinate | Default radius: <br/>4.40638ms/req at 82 coordinate<br/>0.0537364ms/coordinate<br/>Radius 5m: <br/>4.39026ms/req at 82 coordinate<br/>0.0535398ms/coordinate<br/>Radius 10m: <br/>15.0229ms/req at 82 coordinate<br/>0.183206ms/coordinate<br/>Radius 15m: <br/>36.6518ms/req at 82 coordinate<br/>0.446973ms/coordinate<br/>Radius 30m: <br/>312.225ms/req at 82 coordinate<br/>3.80763ms/coordinate |
| match_mld | Default radius: <br/>2.77057ms/req at 82 coordinate<br/>0.0337874ms/coordinate<br/>Radius 5m: <br/>2.8208ms/req at 82 coordinate<br/>0.0344ms/coordinate<br/>Radius 10m: <br/>10.0691ms/req at 82 coordinate<br/>0.122794ms/coordinate<br/>Radius 15m: <br/>25.7561ms/req at 82 coordinate<br/>0.314099ms/coordinate<br/>Radius 30m: <br/>302.227ms/req at 82 coordinate<br/>3.6857ms/coordinate | Default radius: <br/>2.7439ms/req at 82 coordinate<br/>0.0334622ms/coordinate<br/>Radius 5m: <br/>2.73356ms/req at 82 coordinate<br/>0.0333361ms/coordinate<br/>Radius 10m: <br/>10.0565ms/req at 82 coordinate<br/>0.12264ms/coordinate<br/>Radius 15m: <br/>25.6863ms/req at 82 coordinate<br/>0.313247ms/coordinate<br/>Radius 30m: <br/>302.331ms/req at 82 coordinate<br/>3.68697ms/coordinate |
| packedvector | random write:<br/>std::vector 9770.72 ms<br/>util::packed_vector 81846 ms<br/>slowdown: 8.37666<br/>random read:<br/>std::vector 8409.35 ms<br/>util::packed_vector 33338.8 ms<br/>slowdown: 3.96449 | random write:<br/>std::vector 9833.76 ms<br/>util::packed_vector 81878.2 ms<br/>slowdown: 8.32624<br/>random read:<br/>std::vector 8461.8 ms<br/>util::packed_vector 33322.9 ms<br/>slowdown: 3.93804 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>510.386ms<br/>0.510386ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>351.149ms<br/>0.351149ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>627.407ms<br/>0.627407ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.105ms<br/>0.151105ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.3492ms<br/>0.0973492ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>146.415ms<br/>0.146415ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.311ms<br/>0.150311ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.8538ms<br/>0.0968538ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.538ms<br/>0.132538ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>511.762ms<br/>0.511762ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>349.853ms<br/>0.349853ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>643.417ms<br/>0.643417ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>150.425ms<br/>0.150425ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>96.5273ms<br/>0.0965273ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>131.715ms<br/>0.131715ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.649ms<br/>0.150649ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.6212ms<br/>0.0966212ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.529ms<br/>0.131529ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>635.801ms<br/>0.635801ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>435.188ms<br/>0.435188ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>809.095ms<br/>0.809095ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>266.64ms<br/>0.26664ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>161.2ms<br/>0.1612ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>287.36ms<br/>0.28736ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>264.154ms<br/>0.264154ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>160.813ms<br/>0.160813ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>286.529ms<br/>0.286529ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>638.876ms<br/>0.638876ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>435.419ms<br/>0.435419ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>810.814ms<br/>0.810814ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>262.779ms<br/>0.262779ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>161.743ms<br/>0.161743ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>286.937ms<br/>0.286937ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>255.757ms<br/>0.255757ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.964ms<br/>0.159964ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>284.179ms<br/>0.284179ms/req |
| rtree | 1 result:<br/>206.318ms ->  0.0206318 ms/query<br/>10 results:<br/>241.795ms ->  0.0241795 ms/query | 1 result:<br/>208.932ms ->  0.0208932 ms/query<br/>10 results:<br/>245.349ms ->  0.0245349 ms/query |
<!-- BENCHMARK_RESULTS_END -->