### PR TITLE
Add simple benchmarks for osrm-* tools

### DIFF
--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -24,7 +24,7 @@ function run_benchmarks_for_folder {
 
     cp ~/data.osm.pbf $FOLDER
     $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf
-    $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm
+    time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm > "$RESULTS_FOLDER/osrm_partition.bench"
     $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm
     $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm
 

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -23,10 +23,10 @@ function run_benchmarks_for_folder {
     BINARIES_FOLDER="$FOLDER/build"
 
     cp ~/data.osm.pbf $FOLDER
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf | tail -n 1 2> "$RESULTS_FOLDER/osrm_extract.bench"
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm | tail -n 1 2> "$RESULTS_FOLDER/osrm_partition.bench"
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm | tail -n 1 2> "$RESULTS_FOLDER/osrm_customize.bench"
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm | tail -n 1 2> "$RESULTS_FOLDER/osrm_contract.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf 2>&1 | tail -n 1 > "$RESULTS_FOLDER/osrm_extract.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm 2>&1 | tail -n 1 > "$RESULTS_FOLDER/osrm_partition.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm 2>&1 | tail -n 1 > "$RESULTS_FOLDER/osrm_customize.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm 2>&1 | tail -n 1 > "$RESULTS_FOLDER/osrm_contract.bench"
 
     if [ -f "$FOLDER/scripts/ci/locustfile.py" ]; then
         for ALGORITHM in mld ch; do

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -24,7 +24,7 @@ function run_benchmarks_for_folder {
 
     cp ~/data.osm.pbf $FOLDER
     $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf
-    /usr/bin/time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm >2 "$RESULTS_FOLDER/osrm_partition.bench"
+    /usr/bin/time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_partition.bench"
     $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm
     $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm
 

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -5,7 +5,12 @@ function measure_peak_ram_and_time {
     COMMAND=$1
     OUTPUT_FILE=$2
 
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $COMMAND 2>&1 | tail -n 1 > $OUTPUT_FILE
+    OUTPUT=$(/usr/bin/time -f "%E %M" $COMMAND 2>&1 | tail -n 1)
+
+    TIME=$(echo $OUTPUT | awk '{print $1}')
+    PEAK_RAM_KB=$(echo $OUTPUT | awk '{print $2}')
+    PEAK_RAM_MB=$(echo "scale=2; $PEAK_RAM_KB / 1024" | bc)
+    echo "Time: $TIME Peak RAM: $PEAK_RAM_MB MB" > $OUTPUT_FILE
 }
 
 function run_benchmarks_for_folder {

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -23,10 +23,10 @@ function run_benchmarks_for_folder {
     BINARIES_FOLDER="$FOLDER/build"
 
     cp ~/data.osm.pbf $FOLDER
-    $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf
-    /usr/bin/time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_partition.bench"
-    $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm
-    $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf 2> "$RESULTS_FOLDER/osrm_extract.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_partition.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_customize.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_contract.bench"
 
     if [ -f "$FOLDER/scripts/ci/locustfile.py" ]; then
         for ALGORITHM in mld ch; do

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -24,7 +24,7 @@ function run_benchmarks_for_folder {
 
     cp ~/data.osm.pbf $FOLDER
     $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf
-    time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm > "$RESULTS_FOLDER/osrm_partition.bench"
+    /usr/bin/time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm > "$RESULTS_FOLDER/osrm_partition.bench"
     $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm
     $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm
 

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -5,12 +5,12 @@ function measure_peak_ram_and_time {
     COMMAND=$1
     OUTPUT_FILE=$2
 
-    OUTPUT=$(/usr/bin/time -f "%E %M" $COMMAND 2>&1 | tail -n 1)
+    OUTPUT=$(/usr/bin/time -f "%e %M" $COMMAND 2>&1 | tail -n 1)
 
     TIME=$(echo $OUTPUT | awk '{print $1}')
     PEAK_RAM_KB=$(echo $OUTPUT | awk '{print $2}')
     PEAK_RAM_MB=$(echo "scale=2; $PEAK_RAM_KB / 1024" | bc)
-    echo "Time: $TIME Peak RAM: $PEAK_RAM_MB MB" > $OUTPUT_FILE
+    echo "Time: ${TIME}s Peak RAM: ${PEAK_RAM_MB}MB" > $OUTPUT_FILE
 }
 
 function run_benchmarks_for_folder {

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -24,7 +24,7 @@ function run_benchmarks_for_folder {
 
     cp ~/data.osm.pbf $FOLDER
     $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf
-    /usr/bin/time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm > "$RESULTS_FOLDER/osrm_partition.bench"
+    /usr/bin/time -f "%M" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm >2 "$RESULTS_FOLDER/osrm_partition.bench"
     $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm
     $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm
 

--- a/scripts/ci/run_benchmarks.sh
+++ b/scripts/ci/run_benchmarks.sh
@@ -23,10 +23,10 @@ function run_benchmarks_for_folder {
     BINARIES_FOLDER="$FOLDER/build"
 
     cp ~/data.osm.pbf $FOLDER
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf 2> "$RESULTS_FOLDER/osrm_extract.bench"
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_partition.bench"
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_customize.bench"
-    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm 2> "$RESULTS_FOLDER/osrm_contract.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-extract -p $FOLDER/profiles/car.lua $FOLDER/data.osm.pbf | tail -n 1 2> "$RESULTS_FOLDER/osrm_extract.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-partition $FOLDER/data.osrm | tail -n 1 2> "$RESULTS_FOLDER/osrm_partition.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-customize $FOLDER/data.osrm | tail -n 1 2> "$RESULTS_FOLDER/osrm_customize.bench"
+    /usr/bin/time -f "Time: %E Peak RAM: %M Kb" $BINARIES_FOLDER/osrm-contract $FOLDER/data.osrm | tail -n 1 2> "$RESULTS_FOLDER/osrm_contract.bench"
 
     if [ -f "$FOLDER/scripts/ci/locustfile.py" ]; then
         for ALGORITHM in mld ch; do


### PR DESCRIPTION
It was low hanging fruit as we are running these tools for other benchmarks anyway.

<img width="1574" alt="Screenshot 2024-06-06 at 14 35 51" src="https://github.com/Project-OSRM/osrm-backend/assets/266271/e1e5fc34-710a-4fa3-86fc-a9cb177c227c">

Also I noticed that e2e tests I added recently are very "jumpy" :( I will probably address it in some separate PR...

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1133.92<br/>plain u32: 1133.8<br/>aliased double: 1167.26<br/>plain double: 1169.79 | aliased u32: 1097.71<br/>plain u32: 1138.42<br/>aliased double: 1172.87<br/>plain double: 1179.5 |
| e2e_match_ch | requests: 399<br/>failures: 0<br/>req/s: 6.650req/s<br/>avg: 5.575ms<br/>50%: 3ms<br/>75%: 3ms<br/>95%: 25ms<br/>98%: 49ms<br/>99%: 62ms   <br/>min: 1.157ms<br/>max: 96.289ms | requests: 385<br/>failures: 0<br/>req/s: 6.425req/s<br/>avg: 5.557ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 19ms<br/>98%: 46ms<br/>99%: 70ms   <br/>min: 1.464ms<br/>max: 91.964ms |
| e2e_match_mld | requests: 362<br/>failures: 0<br/>req/s: 6.034req/s<br/>avg: 4.496ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 11ms<br/>98%: 19ms<br/>99%: 53ms   <br/>min: 1.013ms<br/>max: 66.555ms | requests: 367<br/>failures: 0<br/>req/s: 6.116req/s<br/>avg: 5.576ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 18ms<br/>98%: 52ms<br/>99%: 75ms   <br/>min: 1.008ms<br/>max: 87.581ms |
| e2e_nearest_ch | requests: 428<br/>failures: 0<br/>req/s: 7.134req/s<br/>avg: 1.420ms<br/>50%: 1ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 2ms   <br/>min: 1.005ms<br/>max: 3.117ms | requests: 422<br/>failures: 0<br/>req/s: 7.042req/s<br/>avg: 1.571ms<br/>50%: 2ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 3ms   <br/>min: 1.068ms<br/>max: 2.761ms |
| e2e_nearest_mld | requests: 426<br/>failures: 0<br/>req/s: 7.100req/s<br/>avg: 1.458ms<br/>50%: 1ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 2ms   <br/>min: 1.039ms<br/>max: 6.775ms | requests: 425<br/>failures: 0<br/>req/s: 7.083req/s<br/>avg: 1.524ms<br/>50%: 1ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 2ms   <br/>min: 1.033ms<br/>max: 3.204ms |
| e2e_route_ch | requests: 414<br/>failures: 0<br/>req/s: 6.900req/s<br/>avg: 3.662ms<br/>50%: 4ms<br/>75%: 4ms<br/>95%: 5ms<br/>98%: 6ms<br/>99%: 8ms   <br/>min: 1.472ms<br/>max: 9.935ms | requests: 403<br/>failures: 0<br/>req/s: 6.725req/s<br/>avg: 4.276ms<br/>50%: 4ms<br/>75%: 5ms<br/>95%: 6ms<br/>98%: 7ms<br/>99%: 10ms   <br/>min: 1.470ms<br/>max: 99.512ms |
| e2e_route_mld | requests: 372<br/>failures: 0<br/>req/s: 6.200req/s<br/>avg: 4.636ms<br/>50%: 4ms<br/>75%: 5ms<br/>95%: 6ms<br/>98%: 7ms<br/>99%: 10ms   <br/>min: 1.373ms<br/>max: 141.264ms | requests: 419<br/>failures: 0<br/>req/s: 6.983req/s<br/>avg: 4.248ms<br/>50%: 4ms<br/>75%: 5ms<br/>95%: 6ms<br/>98%: 7ms<br/>99%: 9ms   <br/>min: 1.358ms<br/>max: 97.756ms |
| e2e_table_ch | requests: 388<br/>failures: 0<br/>req/s: 6.467req/s<br/>avg: 29.454ms<br/>50%: 22ms<br/>75%: 30ms<br/>95%: 110ms<br/>98%: 120ms<br/>99%: 130ms   <br/>min: 2.483ms<br/>max: 138.929ms | requests: 400<br/>failures: 0<br/>req/s: 6.675req/s<br/>avg: 35.443ms<br/>50%: 23ms<br/>75%: 34ms<br/>95%: 120ms<br/>98%: 130ms<br/>99%: 140ms   <br/>min: 2.451ms<br/>max: 151.331ms |
| e2e_table_mld | requests: 385<br/>failures: 0<br/>req/s: 6.417req/s<br/>avg: 73.161ms<br/>50%: 79ms<br/>75%: 110ms<br/>95%: 130ms<br/>98%: 140ms<br/>99%: 140ms   <br/>min: 4.356ms<br/>max: 165.649ms | requests: 390<br/>failures: 0<br/>req/s: 6.500req/s<br/>avg: 42.225ms<br/>50%: 27ms<br/>75%: 61ms<br/>95%: 130ms<br/>98%: 130ms<br/>99%: 140ms   <br/>min: 2.491ms<br/>max: 328.336ms |
| e2e_trip_ch | requests: 369<br/>failures: 0<br/>req/s: 6.150req/s<br/>avg: 13.448ms<br/>50%: 12ms<br/>75%: 17ms<br/>95%: 27ms<br/>98%: 31ms<br/>99%: 32ms   <br/>min: 1.994ms<br/>max: 106.068ms | requests: 352<br/>failures: 0<br/>req/s: 5.874req/s<br/>avg: 14.614ms<br/>50%: 13ms<br/>75%: 19ms<br/>95%: 29ms<br/>98%: 32ms<br/>99%: 34ms   <br/>min: 1.829ms<br/>max: 36.972ms |
| e2e_trip_mld | requests: 352<br/>failures: 0<br/>req/s: 5.867req/s<br/>avg: 20.310ms<br/>50%: 20ms<br/>75%: 26ms<br/>95%: 34ms<br/>98%: 37ms<br/>99%: 39ms   <br/>min: 3.991ms<br/>max: 44.437ms | requests: 351<br/>failures: 0<br/>req/s: 5.850req/s<br/>avg: 14.914ms<br/>50%: 13ms<br/>75%: 19ms<br/>95%: 28ms<br/>98%: 33ms<br/>99%: 36ms   <br/>min: 2.381ms<br/>max: 40.495ms |
| json-render | String: 6.56025ms<br/>Stringstream: 9.27548ms<br/>Vector: 6.8574ms | String: 6.66464ms<br/>Stringstream: 9.44745ms<br/>Vector: 7.01822ms |
| match_ch | Default radius: <br/>4.41197ms/req at 82 coordinate<br/>0.0538045ms/coordinate<br/>Radius 5m: <br/>4.39374ms/req at 82 coordinate<br/>0.0535822ms/coordinate<br/>Radius 10m: <br/>15.0527ms/req at 82 coordinate<br/>0.183569ms/coordinate<br/>Radius 15m: <br/>36.7583ms/req at 82 coordinate<br/>0.448272ms/coordinate<br/>Radius 30m: <br/>314.519ms/req at 82 coordinate<br/>3.8356ms/coordinate | Default radius: <br/>4.41337ms/req at 82 coordinate<br/>0.0538215ms/coordinate<br/>Radius 5m: <br/>4.40282ms/req at 82 coordinate<br/>0.053693ms/coordinate<br/>Radius 10m: <br/>15.0342ms/req at 82 coordinate<br/>0.183344ms/coordinate<br/>Radius 15m: <br/>36.9353ms/req at 82 coordinate<br/>0.45043ms/coordinate<br/>Radius 30m: <br/>313.907ms/req at 82 coordinate<br/>3.82813ms/coordinate |
| match_mld | Default radius: <br/>2.80752ms/req at 82 coordinate<br/>0.034238ms/coordinate<br/>Radius 5m: <br/>2.74811ms/req at 82 coordinate<br/>0.0335135ms/coordinate<br/>Radius 10m: <br/>10.1372ms/req at 82 coordinate<br/>0.123625ms/coordinate<br/>Radius 15m: <br/>25.9226ms/req at 82 coordinate<br/>0.31613ms/coordinate<br/>Radius 30m: <br/>305.832ms/req at 82 coordinate<br/>3.72966ms/coordinate | Default radius: <br/>2.77088ms/req at 82 coordinate<br/>0.0337912ms/coordinate<br/>Radius 5m: <br/>2.76309ms/req at 82 coordinate<br/>0.0336963ms/coordinate<br/>Radius 10m: <br/>10.1278ms/req at 82 coordinate<br/>0.12351ms/coordinate<br/>Radius 15m: <br/>26.0479ms/req at 82 coordinate<br/>0.317657ms/coordinate<br/>Radius 30m: <br/>302.263ms/req at 82 coordinate<br/>3.68613ms/coordinate |
| osrm_contract | Time: 93.18s Peak RAM: 185.41MB | Time: 94.27s Peak RAM: 185.70MB |
| osrm_customize | Time: 1.31s Peak RAM: 115.05MB | Time: 1.30s Peak RAM: 114.91MB |
| osrm_extract | Time: 12.18s Peak RAM: 415.62MB | Time: 12.31s Peak RAM: 425.00MB |
| osrm_partition | Time: 2.18s Peak RAM: 148.48MB | Time: 2.20s Peak RAM: 148.36MB |
| packedvector | random write:<br/>std::vector 11117.9 ms<br/>util::packed_vector 73460.3 ms<br/>slowdown: 6.60738<br/>random read:<br/>std::vector 11015.3 ms<br/>util::packed_vector 29535 ms<br/>slowdown: 2.68128 | random write:<br/>std::vector 9948.07 ms<br/>util::packed_vector 73306.6 ms<br/>slowdown: 7.36892<br/>random read:<br/>std::vector 8460.91 ms<br/>util::packed_vector 30177.8 ms<br/>slowdown: 3.56673 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>508.293ms<br/>0.508293ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>350.297ms<br/>0.350297ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>624.345ms<br/>0.624345ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>150.667ms<br/>0.150667ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.4145ms<br/>0.0974145ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>131.516ms<br/>0.131516ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>149.903ms<br/>0.149903ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.0547ms<br/>0.0970547ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.542ms<br/>0.131542ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>508.853ms<br/>0.508853ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>349.815ms<br/>0.349815ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>624.741ms<br/>0.624741ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.161ms<br/>0.151161ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>96.9316ms<br/>0.0969316ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.315ms<br/>0.132315ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>152.045ms<br/>0.152045ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.9038ms<br/>0.0969038ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.335ms<br/>0.132335ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>638.445ms<br/>0.638445ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>439.606ms<br/>0.439606ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>817.78ms<br/>0.81778ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>265.954ms<br/>0.265954ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>162.716ms<br/>0.162716ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>283.928ms<br/>0.283928ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>257.784ms<br/>0.257784ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.048ms<br/>0.161048ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>281.935ms<br/>0.281935ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>639.416ms<br/>0.639416ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>437.273ms<br/>0.437273ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>810.431ms<br/>0.810431ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>256.097ms<br/>0.256097ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>159.142ms<br/>0.159142ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>280.538ms<br/>0.280538ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>259.231ms<br/>0.259231ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.369ms<br/>0.159369ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>282.002ms<br/>0.282002ms/req |
| rtree | 1 result:<br/>202.806ms ->  0.0202806 ms/query<br/>10 results:<br/>237.224ms ->  0.0237224 ms/query | 1 result:<br/>209.887ms ->  0.0209887 ms/query<br/>10 results:<br/>246.082ms ->  0.0246082 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->







