### PR TITLE
Fix bugprone-unused-return-value clang-tidy warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: >
     -bugprone-incorrect-enable-if,
     -bugprone-switch-missing-default-case,
     -bugprone-empty-catch,
-    -bugprone-unused-return-value,
     -clang-analyzer-*,
     -clang-diagnostic-deprecated-declarations,
     -clang-diagnostic-constant-conversion,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - FIXED: Fix bugprone-unused-return-value clang-tidy warning. [#6934](https://github.com/Project-OSRM/osrm-backend/pull/6934)
       - FIXED: Fix performance-noexcept-move-constructor clang-tidy warning. [#6931](https://github.com/Project-OSRM/osrm-backend/pull/6933)
       - FIXED: Fix performance-noexcept-swap clang-tidy warning. [#6931](https://github.com/Project-OSRM/osrm-backend/pull/6931)
       - CHANGED: Use custom struct instead of std::pair in QueryHeap. [#6921](https://github.com/Project-OSRM/osrm-backend/pull/6921)

--- a/src/server/connection.cpp
+++ b/src/server/connection.cpp
@@ -186,6 +186,7 @@ void Connection::handle_timeout(boost::system::error_code ec)
     if (ec != boost::asio::error::operation_aborted)
     {
         boost::system::error_code ignore_error;
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
         TCP_socket.cancel(ignore_error);
         handle_shutdown();
     }
@@ -197,6 +198,7 @@ void Connection::handle_shutdown()
     timer.cancel();
     // Initiate graceful connection closure.
     boost::system::error_code ignore_error;
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
     TCP_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignore_error);
 }
 


### PR DESCRIPTION

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1101.37<br/>plain u32: 1095.27<br/>aliased double: 968.342<br/>plain double: 985.91 | aliased u32: 1220.84<br/>plain u32: 1166.74<br/>aliased double: 1132.6<br/>plain double: 1003.04 |
| e2e_match_ch | requests: 374<br/>failures: 0<br/>req/s: 6.234req/s<br/>avg: 5.529ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 18ms<br/>98%: 33ms<br/>99%: 70ms   <br/>min: 1.501ms<br/>max: 96.334ms | requests: 359<br/>failures: 0<br/>req/s: 5.991req/s<br/>avg: 5.353ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 19ms<br/>98%: 33ms<br/>99%: 53ms   <br/>min: 1.147ms<br/>max: 106.222ms |
| e2e_match_mld | requests: 365<br/>failures: 0<br/>req/s: 6.084req/s<br/>avg: 4.503ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 10ms<br/>98%: 20ms<br/>99%: 40ms   <br/>min: 1.225ms<br/>max: 48.058ms | requests: 396<br/>failures: 0<br/>req/s: 6.609req/s<br/>avg: 4.700ms<br/>50%: 3ms<br/>75%: 4ms<br/>95%: 10ms<br/>98%: 32ms<br/>99%: 58ms   <br/>min: 1.294ms<br/>max: 100.437ms |
| e2e_nearest_ch | requests: 414<br/>failures: 0<br/>req/s: 6.900req/s<br/>avg: 1.644ms<br/>50%: 2ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 2ms   <br/>min: 1.199ms<br/>max: 4.045ms | requests: 413<br/>failures: 0<br/>req/s: 6.892req/s<br/>avg: 1.588ms<br/>50%: 2ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 2ms   <br/>min: 1.035ms<br/>max: 3.469ms |
| e2e_nearest_mld | requests: 444<br/>failures: 0<br/>req/s: 7.401req/s<br/>avg: 1.675ms<br/>50%: 2ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 3ms<br/>99%: 3ms   <br/>min: 1.140ms<br/>max: 7.449ms | requests: 405<br/>failures: 0<br/>req/s: 6.759req/s<br/>avg: 1.601ms<br/>50%: 2ms<br/>75%: 2ms<br/>95%: 2ms<br/>98%: 2ms<br/>99%: 2ms   <br/>min: 1.069ms<br/>max: 5.575ms |
| e2e_route_ch | requests: 409<br/>failures: 0<br/>req/s: 6.817req/s<br/>avg: 4.124ms<br/>50%: 4ms<br/>75%: 5ms<br/>95%: 6ms<br/>98%: 7ms<br/>99%: 9ms   <br/>min: 1.521ms<br/>max: 10.102ms | requests: 410<br/>failures: 0<br/>req/s: 6.842req/s<br/>avg: 4.176ms<br/>50%: 4ms<br/>75%: 5ms<br/>95%: 6ms<br/>98%: 8ms<br/>99%: 9ms   <br/>min: 1.366ms<br/>max: 10.710ms |
| e2e_route_mld | requests: 400<br/>failures: 0<br/>req/s: 6.668req/s<br/>avg: 4.646ms<br/>50%: 5ms<br/>75%: 5ms<br/>95%: 7ms<br/>98%: 8ms<br/>99%: 10ms   <br/>min: 1.496ms<br/>max: 10.717ms | requests: 412<br/>failures: 0<br/>req/s: 6.876req/s<br/>avg: 4.188ms<br/>50%: 4ms<br/>75%: 5ms<br/>95%: 6ms<br/>98%: 7ms<br/>99%: 10ms   <br/>min: 1.529ms<br/>max: 11.369ms |
| e2e_table_ch | requests: 365<br/>failures: 0<br/>req/s: 6.084req/s<br/>avg: 38.616ms<br/>50%: 26ms<br/>75%: 47ms<br/>95%: 120ms<br/>98%: 130ms<br/>99%: 140ms   <br/>min: 2.614ms<br/>max: 146.388ms | requests: 391<br/>failures: 0<br/>req/s: 6.525req/s<br/>avg: 45.511ms<br/>50%: 29ms<br/>75%: 76ms<br/>95%: 130ms<br/>98%: 140ms<br/>99%: 140ms   <br/>min: 2.458ms<br/>max: 160.769ms |
| e2e_table_mld | requests: 369<br/>failures: 0<br/>req/s: 6.151req/s<br/>avg: 75.592ms<br/>50%: 73ms<br/>75%: 110ms<br/>95%: 140ms<br/>98%: 150ms<br/>99%: 160ms   <br/>min: 4.671ms<br/>max: 171.151ms | requests: 384<br/>failures: 0<br/>req/s: 6.409req/s<br/>avg: 52.338ms<br/>50%: 35ms<br/>75%: 83ms<br/>95%: 130ms<br/>98%: 140ms<br/>99%: 140ms   <br/>min: 2.491ms<br/>max: 362.127ms |
| e2e_trip_ch | requests: 384<br/>failures: 0<br/>req/s: 6.400req/s<br/>avg: 15.739ms<br/>50%: 14ms<br/>75%: 20ms<br/>95%: 30ms<br/>98%: 33ms<br/>99%: 35ms   <br/>min: 2.164ms<br/>max: 42.537ms | requests: 365<br/>failures: 0<br/>req/s: 6.091req/s<br/>avg: 16.294ms<br/>50%: 15ms<br/>75%: 21ms<br/>95%: 31ms<br/>98%: 35ms<br/>99%: 35ms   <br/>min: 2.587ms<br/>max: 39.104ms |
| e2e_trip_mld | requests: 345<br/>failures: 0<br/>req/s: 5.751req/s<br/>avg: 21.842ms<br/>50%: 22ms<br/>75%: 28ms<br/>95%: 34ms<br/>98%: 38ms<br/>99%: 41ms   <br/>min: 4.124ms<br/>max: 49.008ms | requests: 342<br/>failures: 0<br/>req/s: 5.708req/s<br/>avg: 17.987ms<br/>50%: 17ms<br/>75%: 24ms<br/>95%: 33ms<br/>98%: 36ms<br/>99%: 39ms   <br/>min: 1.804ms<br/>max: 44.905ms |
| json-render | String: 6.64187ms<br/>Stringstream: 9.32875ms<br/>Vector: 6.89803ms | String: 6.62568ms<br/>Stringstream: 9.35627ms<br/>Vector: 6.92196ms |
| match_ch | Default radius: <br/>4.40558ms/req at 82 coordinate<br/>0.0537266ms/coordinate<br/>Radius 5m: <br/>4.39923ms/req at 82 coordinate<br/>0.0536492ms/coordinate<br/>Radius 10m: <br/>15.0154ms/req at 82 coordinate<br/>0.183114ms/coordinate<br/>Radius 15m: <br/>36.7744ms/req at 82 coordinate<br/>0.448469ms/coordinate<br/>Radius 30m: <br/>312.746ms/req at 82 coordinate<br/>3.81398ms/coordinate | Default radius: <br/>4.41805ms/req at 82 coordinate<br/>0.0538787ms/coordinate<br/>Radius 5m: <br/>4.38767ms/req at 82 coordinate<br/>0.0535082ms/coordinate<br/>Radius 10m: <br/>15.0246ms/req at 82 coordinate<br/>0.183227ms/coordinate<br/>Radius 15m: <br/>36.6784ms/req at 82 coordinate<br/>0.447298ms/coordinate<br/>Radius 30m: <br/>312.73ms/req at 82 coordinate<br/>3.81378ms/coordinate |
| match_mld | Default radius: <br/>2.79074ms/req at 82 coordinate<br/>0.0340334ms/coordinate<br/>Radius 5m: <br/>2.80465ms/req at 82 coordinate<br/>0.0342031ms/coordinate<br/>Radius 10m: <br/>10.1242ms/req at 82 coordinate<br/>0.123466ms/coordinate<br/>Radius 15m: <br/>25.9493ms/req at 82 coordinate<br/>0.316455ms/coordinate<br/>Radius 30m: <br/>304.064ms/req at 82 coordinate<br/>3.70809ms/coordinate | Default radius: <br/>2.76857ms/req at 82 coordinate<br/>0.0337631ms/coordinate<br/>Radius 5m: <br/>2.75576ms/req at 82 coordinate<br/>0.0336068ms/coordinate<br/>Radius 10m: <br/>10.1434ms/req at 82 coordinate<br/>0.1237ms/coordinate<br/>Radius 15m: <br/>25.9579ms/req at 82 coordinate<br/>0.31656ms/coordinate<br/>Radius 30m: <br/>303.413ms/req at 82 coordinate<br/>3.70016ms/coordinate |
| osrm_contract | Time: 96.00s Peak RAM: 185.49MB | Time: 96.01s Peak RAM: 185.61MB |
| osrm_customize | Time: 1.31s Peak RAM: 115.05MB | Time: 1.31s Peak RAM: 115.10MB |
| osrm_extract | Time: 12.35s Peak RAM: 412.14MB | Time: 12.41s Peak RAM: 409.42MB |
| osrm_partition | Time: 2.27s Peak RAM: 150.51MB | Time: 2.33s Peak RAM: 148.41MB |
| packedvector | random write:<br/>std::vector 9873.75 ms<br/>util::packed_vector 74900.2 ms<br/>slowdown: 7.58579<br/>random read:<br/>std::vector 8557.87 ms<br/>util::packed_vector 30682.3 ms<br/>slowdown: 3.58527 | random write:<br/>std::vector 10937.2 ms<br/>util::packed_vector 74663.4 ms<br/>slowdown: 6.82656<br/>random read:<br/>std::vector 9009.73 ms<br/>util::packed_vector 30940.3 ms<br/>slowdown: 3.4341 |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>513.002ms<br/>0.513002ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>353.934ms<br/>0.353934ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>630.357ms<br/>0.630357ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.311ms<br/>0.151311ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.5076ms<br/>0.0975076ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.297ms<br/>0.132297ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.692ms<br/>0.150692ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.1382ms<br/>0.0971382ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>133.127ms<br/>0.133127ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>512.267ms<br/>0.512267ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>353.505ms<br/>0.353505ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>645.919ms<br/>0.645919ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>150.704ms<br/>0.150704ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.761ms<br/>0.097761ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.082ms<br/>0.132082ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.081ms<br/>0.151081ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.4242ms<br/>0.0974242ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.53ms<br/>0.13253ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>644.141ms<br/>0.644141ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>442.442ms<br/>0.442442ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>815.308ms<br/>0.815308ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>270.488ms<br/>0.270488ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>164.212ms<br/>0.164212ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>288.699ms<br/>0.288699ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>260.024ms<br/>0.260024ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>162.393ms<br/>0.162393ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>285.866ms<br/>0.285866ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>642.001ms<br/>0.642001ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>442.046ms<br/>0.442046ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>811.902ms<br/>0.811902ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>266.708ms<br/>0.266708ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>162.038ms<br/>0.162038ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>290.747ms<br/>0.290747ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>257.978ms<br/>0.257978ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.88ms<br/>0.15988ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>287.324ms<br/>0.287324ms/req |
| rtree | 1 result:<br/>207.193ms ->  0.0207193 ms/query<br/>10 results:<br/>242.442ms ->  0.0242442 ms/query | 1 result:<br/>206.727ms ->  0.0206727 ms/query<br/>10 results:<br/>241.925ms ->  0.0241925 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
