### PR TITLE
Avoid copy of intersection in totalTurnAngle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Avoid copy of intersection in totalTurnAngle. [#6938](https://github.com/Project-OSRM/osrm-backend/pull/6938)
       - FIXED: Fix bugprone-unused-return-value clang-tidy warning. [#6934](https://github.com/Project-OSRM/osrm-backend/pull/6934)
       - FIXED: Fix performance-noexcept-move-constructor clang-tidy warning. [#6931](https://github.com/Project-OSRM/osrm-backend/pull/6933)
       - FIXED: Fix performance-noexcept-swap clang-tidy warning. [#6931](https://github.com/Project-OSRM/osrm-backend/pull/6931)

--- a/include/engine/guidance/collapsing_utility.hpp
+++ b/include/engine/guidance/collapsing_utility.hpp
@@ -202,8 +202,8 @@ inline double totalTurnAngle(const RouteStep &entry_step, const RouteStep &exit_
     if (entry_step.geometry_begin > exit_step.geometry_begin)
         return totalTurnAngle(exit_step, entry_step);
 
-    const auto exit_intersection = exit_step.intersections.front();
-    const auto entry_intersection = entry_step.intersections.front();
+    const auto& exit_intersection = exit_step.intersections.front();
+    const auto& entry_intersection = entry_step.intersections.front();
     if ((exit_intersection.out >= exit_intersection.bearings.size()) ||
         (entry_intersection.in >= entry_intersection.bearings.size()))
         return entry_intersection.bearings[entry_intersection.out];

--- a/include/engine/guidance/collapsing_utility.hpp
+++ b/include/engine/guidance/collapsing_utility.hpp
@@ -202,8 +202,8 @@ inline double totalTurnAngle(const RouteStep &entry_step, const RouteStep &exit_
     if (entry_step.geometry_begin > exit_step.geometry_begin)
         return totalTurnAngle(exit_step, entry_step);
 
-    const auto& exit_intersection = exit_step.intersections.front();
-    const auto& entry_intersection = entry_step.intersections.front();
+    const auto &exit_intersection = exit_step.intersections.front();
+    const auto &entry_intersection = entry_step.intersections.front();
     if ((exit_intersection.out >= exit_intersection.bearings.size()) ||
         (entry_intersection.in >= entry_intersection.bearings.size()))
         return entry_intersection.bearings[entry_intersection.out];


### PR DESCRIPTION


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1159.52<br/>plain u32: 1156.91<br/>aliased double: 1286.96<br/>plain double: 1251.62 | aliased u32: 1111.95<br/>plain u32: 1110<br/>aliased double: 966.926<br/>plain double: 961.087 |
| e2e_match_ch | Total: 2798.346996307373ms<br/>Min time: 2.40325927734375ms<br/>Mean time: 21.361427452728037ms<br/>Median time: 16.7696475982666ms<br/>95th percentile: 67.46399402618408ms<br/>99th percentile: 81.91895484924312ms<br/>Max time: 94.60091590881348ms | Total: 2885.9128952026367ms<br/>Min time: 2.288818359375ms<br/>Mean time: 22.029869429027762ms<br/>Median time: 14.658927917480469ms<br/>95th percentile: 67.16310977935791ms<br/>99th percentile: 94.39878463745099ms<br/>Max time: 108.98184776306152ms |
| e2e_match_mld | Total: 2060.0523948669434ms<br/>Min time: 2.070903778076172ms<br/>Mean time: 15.725590800511018ms<br/>Median time: 9.062051773071289ms<br/>95th percentile: 50.34184455871582ms<br/>99th percentile: 57.715249061584416ms<br/>Max time: 67.50178337097168ms | Total: 2025.0144004821777ms<br/>Min time: 2.027750015258789ms<br/>Mean time: 15.458125194520441ms<br/>Median time: 8.671760559082031ms<br/>95th percentile: 49.40640926361084ms<br/>99th percentile: 59.287905693054135ms<br/>Max time: 67.18754768371582ms |
| e2e_nearest_ch | Total: 1366.3685321807861ms<br/>Min time: 1.1544227600097656ms<br/>Mean time: 1.3663685321807861ms<br/>Median time: 1.279592514038086ms<br/>95th percentile: 1.780533790588379ms<br/>99th percentile: 1.853954792022705ms<br/>Max time: 1.9097328186035156ms | Total: 1363.3761405944824ms<br/>Min time: 1.155853271484375ms<br/>Mean time: 1.3633761405944824ms<br/>Median time: 1.277923583984375ms<br/>95th percentile: 1.7789721488952634ms<br/>99th percentile: 1.8346834182739258ms<br/>Max time: 1.8990039825439453ms |
| e2e_nearest_mld | Total: 1360.8858585357666ms<br/>Min time: 1.1446475982666016ms<br/>Mean time: 1.3608858585357666ms<br/>Median time: 1.2742280960083008ms<br/>95th percentile: 1.7726659774780273ms<br/>99th percentile: 1.8253684043884277ms<br/>Max time: 2.020120620727539ms | Total: 1361.9441986083984ms<br/>Min time: 1.1448860168457031ms<br/>Mean time: 1.3619441986083984ms<br/>Median time: 1.2766122817993164ms<br/>95th percentile: 1.7836928367614746ms<br/>99th percentile: 1.8645024299621582ms<br/>Max time: 1.9466876983642578ms |
| e2e_route_ch | Total: 3184.1354370117188ms<br/>Min time: 1.386404037475586ms<br/>Mean time: 3.1841354370117188ms<br/>Median time: 3.218531608581543ms<br/>95th percentile: 4.197347164154052ms<br/>99th percentile: 4.674985408782959ms<br/>Max time: 5.453824996948242ms | Total: 3148.3311653137207ms<br/>Min time: 1.3935565948486328ms<br/>Mean time: 3.1483311653137207ms<br/>Median time: 3.1876564025878906ms<br/>95th percentile: 4.188573360443115ms<br/>99th percentile: 4.512832164764404ms<br/>Max time: 5.405664443969727ms |
| e2e_route_mld | Total: 3802.036762237549ms<br/>Min time: 1.382589340209961ms<br/>Mean time: 3.802036762237549ms<br/>Median time: 3.838658332824707ms<br/>95th percentile: 5.268204212188721ms<br/>99th percentile: 5.795438289642333ms<br/>Max time: 6.514310836791992ms | Total: 3763.4077072143555ms<br/>Min time: 1.3475418090820312ms<br/>Mean time: 3.7634077072143555ms<br/>Median time: 3.7935972213745117ms<br/>95th percentile: 5.216634273529053ms<br/>99th percentile: 5.700721740722656ms<br/>Max time: 6.341457366943359ms |
| e2e_table_ch | Total: 16474.595546722412ms<br/>Min time: 2.0563602447509766ms<br/>Mean time: 16.474595546722412ms<br/>Median time: 15.725135803222656ms<br/>95th percentile: 30.09549379348755ms<br/>99th percentile: 32.18545198440552ms<br/>Max time: 40.624141693115234ms | Total: 17119.64249610901ms<br/>Min time: 1.9855499267578125ms<br/>Mean time: 17.11964249610901ms<br/>Median time: 16.329169273376465ms<br/>95th percentile: 31.340980529785156ms<br/>99th percentile: 32.9705023765564ms<br/>Max time: 37.17041015625ms |
| e2e_table_mld | Total: 65245.715618133545ms<br/>Min time: 4.115581512451172ms<br/>Mean time: 65.24571561813354ms<br/>Median time: 61.40780448913574ms<br/>95th percentile: 125.98866224288939ms<br/>99th percentile: 132.78409242630005ms<br/>Max time: 136.85131072998047ms | Total: 64408.2396030426ms<br/>Min time: 4.248857498168945ms<br/>Mean time: 64.4082396030426ms<br/>Median time: 60.99140644073486ms<br/>95th percentile: 124.32955503463745ms<br/>99th percentile: 132.73844718933105ms<br/>Max time: 138.07368278503418ms |
| e2e_trip_ch | Total: 11223.434686660767ms<br/>Min time: 1.7361640930175781ms<br/>Mean time: 11.223434686660767ms<br/>Median time: 10.672688484191895ms<br/>95th percentile: 19.3577766418457ms<br/>99th percentile: 21.610889434814453ms<br/>Max time: 23.560285568237305ms | Total: 11295.657396316528ms<br/>Min time: 1.5666484832763672ms<br/>Mean time: 11.295657396316528ms<br/>Median time: 10.802626609802246ms<br/>95th percentile: 19.455862045288086ms<br/>99th percentile: 21.294007301330566ms<br/>Max time: 29.627084732055664ms |
| e2e_trip_mld | Total: 18430.936574935913ms<br/>Min time: 1.7638206481933594ms<br/>Mean time: 18.430936574935913ms<br/>Median time: 17.933249473571777ms<br/>95th percentile: 30.22942543029785ms<br/>99th percentile: 32.54720687866211ms<br/>Max time: 33.90002250671387ms | Total: 18600.618362426758ms<br/>Min time: 1.8186569213867188ms<br/>Mean time: 18.600618362426758ms<br/>Median time: 18.245458602905273ms<br/>95th percentile: 30.19547462463379ms<br/>99th percentile: 32.37475395202636ms<br/>Max time: 33.92624855041504ms |
| json-render | String: 6.657ms<br/>Stringstream: 9.35492ms<br/>Vector: 6.99336ms | String: 6.60984ms<br/>Stringstream: 9.43366ms<br/>Vector: 6.97093ms |
| match_ch | Default radius: <br/>4.48097ms/req at 82 coordinate<br/>0.054646ms/coordinate<br/>Radius 5m: <br/>4.40713ms/req at 82 coordinate<br/>0.0537455ms/coordinate<br/>Radius 10m: <br/>15.0431ms/req at 82 coordinate<br/>0.183452ms/coordinate<br/>Radius 15m: <br/>36.7635ms/req at 82 coordinate<br/>0.448336ms/coordinate<br/>Radius 30m: <br/>313.534ms/req at 82 coordinate<br/>3.82359ms/coordinate | Default radius: <br/>4.41745ms/req at 82 coordinate<br/>0.0538713ms/coordinate<br/>Radius 5m: <br/>4.41399ms/req at 82 coordinate<br/>0.0538292ms/coordinate<br/>Radius 10m: <br/>15.0612ms/req at 82 coordinate<br/>0.183673ms/coordinate<br/>Radius 15m: <br/>36.8286ms/req at 82 coordinate<br/>0.449129ms/coordinate<br/>Radius 30m: <br/>314.653ms/req at 82 coordinate<br/>3.83723ms/coordinate |
| match_mld | Default radius: <br/>2.82285ms/req at 82 coordinate<br/>0.034425ms/coordinate<br/>Radius 5m: <br/>2.78659ms/req at 82 coordinate<br/>0.0339829ms/coordinate<br/>Radius 10m: <br/>10.179ms/req at 82 coordinate<br/>0.124134ms/coordinate<br/>Radius 15m: <br/>26.0285ms/req at 82 coordinate<br/>0.31742ms/coordinate<br/>Radius 30m: <br/>305.018ms/req at 82 coordinate<br/>3.71973ms/coordinate | Default radius: <br/>2.80505ms/req at 82 coordinate<br/>0.0342079ms/coordinate<br/>Radius 5m: <br/>2.79642ms/req at 82 coordinate<br/>0.0341027ms/coordinate<br/>Radius 10m: <br/>10.2648ms/req at 82 coordinate<br/>0.12518ms/coordinate<br/>Radius 15m: <br/>26.312ms/req at 82 coordinate<br/>0.320879ms/coordinate<br/>Radius 30m: <br/>304.409ms/req at 82 coordinate<br/>3.71231ms/coordinate |
| osrm_contract | Time: 94.84s Peak RAM: 185.66MB | Time: 94.40s Peak RAM: 185.78MB |
| osrm_customize | Time: 1.35s Peak RAM: 114.91MB | Time: 1.30s Peak RAM: 114.93MB |
| osrm_extract | Time: 12.21s Peak RAM: 410.76MB | Time: 12.32s Peak RAM: 405.12MB |
| osrm_partition | Time: 2.23s Peak RAM: 150.61MB | Time: 2.20s Peak RAM: 148.36MB |
| packedvector | random write:<br/>std::vector 10681.5 ms<br/>util::packed_vector 74063.1 ms<br/>slowdown: 6.93379<br/>random read:<br/>std::vector 8899.21 ms<br/>util::packed_vector 30467.2 ms<br/>slowdown: 3.42359 | random write:<br/>std::vector 9877.51 ms<br/>util::packed_vector 82108.5 ms<br/>slowdown: 8.31267<br/>random read:<br/>std::vector 8785.17 ms<br/>util::packed_vector 33972.3 ms<br/>slowdown: 3.86701 |
| random_match_ch | 1000 matches, default radius<br/>total: 6940.79ms<br/>avg: 6.94ms<br/>min: 0.00ms<br/>max: 486.02ms<br/>p99: 106.59ms<br/><br/>1000 matches, radius=10<br/>total: 34646.57ms<br/>avg: 34.65ms<br/>min: 0.00ms<br/>max: 1882.04ms<br/>p99: 1855.69ms<br/><br/>1000 matches, radius=20<br/>total: 67404.05ms<br/>avg: 67.40ms<br/>min: 0.00ms<br/>max: 9238.75ms<br/>p99: 1148.37ms | 1000 matches, default radius<br/>total: 6785.15ms<br/>avg: 6.79ms<br/>min: 0.00ms<br/>max: 429.35ms<br/>p99: 103.02ms<br/><br/>1000 matches, radius=10<br/>total: 33375.90ms<br/>avg: 33.38ms<br/>min: 0.00ms<br/>max: 1728.93ms<br/>p99: 1692.13ms<br/><br/>1000 matches, radius=20<br/>total: 66141.85ms<br/>avg: 66.14ms<br/>min: 0.00ms<br/>max: 8423.22ms<br/>p99: 1113.43ms |
| random_match_mld | 1000 matches, default radius<br/>total: 5121.59ms<br/>avg: 5.12ms<br/>min: 0.00ms<br/>max: 382.01ms<br/>p99: 69.90ms<br/><br/>1000 matches, radius=10<br/>total: 26534.07ms<br/>avg: 26.53ms<br/>min: 0.00ms<br/>max: 1547.79ms<br/>p99: 1529.69ms<br/><br/>1000 matches, radius=20<br/>total: 52408.83ms<br/>avg: 52.41ms<br/>min: 0.00ms<br/>max: 6989.32ms<br/>p99: 798.21ms | 1000 matches, default radius<br/>total: 5142.66ms<br/>avg: 5.14ms<br/>min: 0.00ms<br/>max: 384.40ms<br/>p99: 69.47ms<br/><br/>1000 matches, radius=10<br/>total: 26606.80ms<br/>avg: 26.61ms<br/>min: 0.00ms<br/>max: 1552.42ms<br/>p99: 1535.96ms<br/><br/>1000 matches, radius=20<br/>total: 52503.05ms<br/>avg: 52.50ms<br/>min: 0.00ms<br/>max: 7004.05ms<br/>p99: 797.41ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>total: 480.40ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.28ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 619.20ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.20ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 771.99ms<br/>avg: 0.08ms<br/>min: 0.04ms<br/>max: 0.20ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 480.44ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.27ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 622.98ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.21ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 774.84ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.21ms<br/>p99: 0.14ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>total: 491.57ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.27ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 620.21ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.21ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 768.68ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.20ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 476.67ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.27ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 620.93ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.22ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 770.72ms<br/>avg: 0.08ms<br/>min: 0.04ms<br/>max: 0.20ms<br/>p99: 0.14ms |
| random_route_ch | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 22148.83ms<br/>avg: 2.21ms<br/>min: 0.15ms<br/>max: 5.41ms<br/>p99: 3.35ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 10331.43ms<br/>avg: 1.03ms<br/>min: 0.10ms<br/>max: 2.38ms<br/>p99: 1.71ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 18654.73ms<br/>avg: 1.87ms<br/>min: 0.09ms<br/>max: 5.63ms<br/>p99: 4.67ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 10461.39ms<br/>avg: 1.05ms<br/>min: 0.12ms<br/>max: 1.86ms<br/>p99: 1.50ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4357.94ms<br/>avg: 0.44ms<br/>min: 0.05ms<br/>max: 0.82ms<br/>p99: 0.68ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 9656.64ms<br/>avg: 0.97ms<br/>min: 0.06ms<br/>max: 4.02ms<br/>p99: 2.77ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 685.11ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 1.47ms<br/>p99: 0.72ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 716.22ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.61ms<br/>p99: 0.45ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 941.00ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.83ms<br/>p99: 1.18ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 22532.82ms<br/>avg: 2.25ms<br/>min: 0.14ms<br/>max: 4.30ms<br/>p99: 3.40ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 10721.45ms<br/>avg: 1.07ms<br/>min: 0.08ms<br/>max: 2.43ms<br/>p99: 1.78ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 19857.14ms<br/>avg: 1.99ms<br/>min: 0.10ms<br/>max: 5.81ms<br/>p99: 4.44ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 11688.60ms<br/>avg: 1.17ms<br/>min: 0.12ms<br/>max: 2.03ms<br/>p99: 1.70ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4905.15ms<br/>avg: 0.49ms<br/>min: 0.05ms<br/>max: 0.95ms<br/>p99: 0.78ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 10746.10ms<br/>avg: 1.07ms<br/>min: 0.07ms<br/>max: 5.22ms<br/>p99: 2.66ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 699.52ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 1.77ms<br/>p99: 0.75ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 736.73ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.64ms<br/>p99: 0.49ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1011.71ms<br/>avg: 0.10ms<br/>min: 0.01ms<br/>max: 2.37ms<br/>p99: 1.40ms |
| random_route_mld | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 43368.46ms<br/>avg: 4.34ms<br/>min: 0.16ms<br/>max: 10.32ms<br/>p99: 7.47ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 16002.25ms<br/>avg: 1.60ms<br/>min: 0.09ms<br/>max: 3.62ms<br/>p99: 2.90ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 44551.55ms<br/>avg: 4.46ms<br/>min: 0.08ms<br/>max: 11.32ms<br/>p99: 9.21ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 32434.32ms<br/>avg: 3.24ms<br/>min: 0.12ms<br/>max: 10.72ms<br/>p99: 5.88ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 10328.81ms<br/>avg: 1.03ms<br/>min: 0.05ms<br/>max: 2.54ms<br/>p99: 1.95ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 34813.79ms<br/>avg: 3.48ms<br/>min: 0.05ms<br/>max: 8.50ms<br/>p99: 7.15ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 881.47ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 4.55ms<br/>p99: 1.63ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 984.32ms<br/>avg: 0.10ms<br/>min: 0.01ms<br/>max: 1.52ms<br/>p99: 1.12ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1802.49ms<br/>avg: 0.18ms<br/>min: 0.01ms<br/>max: 5.50ms<br/>p99: 3.70ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 44006.30ms<br/>avg: 4.40ms<br/>min: 0.16ms<br/>max: 10.36ms<br/>p99: 7.63ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 16360.52ms<br/>avg: 1.64ms<br/>min: 0.09ms<br/>max: 3.43ms<br/>p99: 2.96ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 44631.46ms<br/>avg: 4.46ms<br/>min: 0.09ms<br/>max: 10.63ms<br/>p99: 9.25ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 32262.81ms<br/>avg: 3.23ms<br/>min: 0.12ms<br/>max: 10.12ms<br/>p99: 5.84ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 9669.35ms<br/>avg: 0.97ms<br/>min: 0.05ms<br/>max: 2.10ms<br/>p99: 1.80ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 35061.08ms<br/>avg: 3.51ms<br/>min: 0.05ms<br/>max: 8.61ms<br/>p99: 7.27ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 896.95ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 4.77ms<br/>p99: 1.74ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 995.97ms<br/>avg: 0.10ms<br/>min: 0.01ms<br/>max: 1.51ms<br/>p99: 1.17ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1817.01ms<br/>avg: 0.18ms<br/>min: 0.01ms<br/>max: 5.53ms<br/>p99: 3.73ms |
| random_table_ch | 250 tables, 3 coordinates<br/>total: 180.92ms<br/>avg: 0.72ms<br/>min: 0.52ms<br/>max: 1.87ms<br/>p99: 0.98ms<br/><br/>250 tables, 25 coordinates<br/>total: 1483.71ms<br/>avg: 5.93ms<br/>min: 5.31ms<br/>max: 6.53ms<br/>p99: 6.35ms<br/><br/>250 tables, 50 coordinates<br/>total: 3019.96ms<br/>avg: 12.08ms<br/>min: 11.13ms<br/>max: 13.03ms<br/>p99: 12.97ms<br/><br/>250 tables, 100 coordinates<br/>total: 6471.36ms<br/>avg: 25.89ms<br/>min: 24.34ms<br/>max: 27.88ms<br/>p99: 27.11ms | 250 tables, 3 coordinates<br/>total: 192.40ms<br/>avg: 0.77ms<br/>min: 0.55ms<br/>max: 1.78ms<br/>p99: 1.05ms<br/><br/>250 tables, 25 coordinates<br/>total: 1564.46ms<br/>avg: 6.26ms<br/>min: 5.78ms<br/>max: 6.90ms<br/>p99: 6.70ms<br/><br/>250 tables, 50 coordinates<br/>total: 3168.00ms<br/>avg: 12.67ms<br/>min: 11.55ms<br/>max: 13.53ms<br/>p99: 13.39ms<br/><br/>250 tables, 100 coordinates<br/>total: 6830.30ms<br/>avg: 27.32ms<br/>min: 25.97ms<br/>max: 32.11ms<br/>p99: 28.45ms |
| random_table_mld | 250 tables, 3 coordinates<br/>total: 758.71ms<br/>avg: 3.03ms<br/>min: 2.36ms<br/>max: 4.85ms<br/>p99: 4.27ms<br/><br/>250 tables, 25 coordinates<br/>total: 7022.28ms<br/>avg: 28.09ms<br/>min: 24.84ms<br/>max: 31.63ms<br/>p99: 31.08ms<br/><br/>250 tables, 50 coordinates<br/>total: 14911.70ms<br/>avg: 59.65ms<br/>min: 54.87ms<br/>max: 65.62ms<br/>p99: 64.45ms<br/><br/>250 tables, 100 coordinates<br/>total: 32233.18ms<br/>avg: 128.93ms<br/>min: 122.00ms<br/>max: 140.22ms<br/>p99: 137.78ms | 250 tables, 3 coordinates<br/>total: 751.09ms<br/>avg: 3.00ms<br/>min: 2.37ms<br/>max: 4.23ms<br/>p99: 3.92ms<br/><br/>250 tables, 25 coordinates<br/>total: 7021.50ms<br/>avg: 28.09ms<br/>min: 25.30ms<br/>max: 40.30ms<br/>p99: 36.97ms<br/><br/>250 tables, 50 coordinates<br/>total: 14974.84ms<br/>avg: 59.90ms<br/>min: 55.08ms<br/>max: 65.25ms<br/>p99: 64.66ms<br/><br/>250 tables, 100 coordinates<br/>total: 32713.14ms<br/>avg: 130.85ms<br/>min: 123.55ms<br/>max: 143.34ms<br/>p99: 140.31ms |
| random_trip_ch | 1000 trips, 3 coordinates<br/>total: 2227.69ms<br/>avg: 2.23ms<br/>min: 0.69ms<br/>max: 4.06ms<br/>p99: 2.97ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2780.04ms<br/>avg: 2.78ms<br/>min: 1.18ms<br/>max: 3.74ms<br/>p99: 3.55ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3365.32ms<br/>avg: 3.37ms<br/>min: 2.07ms<br/>max: 4.69ms<br/>p99: 4.23ms | 1000 trips, 3 coordinates<br/>total: 2239.94ms<br/>avg: 2.24ms<br/>min: 0.80ms<br/>max: 3.97ms<br/>p99: 2.91ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2838.80ms<br/>avg: 2.84ms<br/>min: 1.14ms<br/>max: 3.90ms<br/>p99: 3.65ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3371.13ms<br/>avg: 3.37ms<br/>min: 2.04ms<br/>max: 4.34ms<br/>p99: 4.14ms |
| random_trip_mld | 1000 trips, 3 coordinates<br/>total: 6254.24ms<br/>avg: 6.25ms<br/>min: 2.76ms<br/>max: 10.59ms<br/>p99: 8.60ms<br/><br/>1000 trips, 4 coordinates<br/>total: 8023.64ms<br/>avg: 8.02ms<br/>min: 3.89ms<br/>max: 11.25ms<br/>p99: 10.17ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9638.15ms<br/>avg: 9.64ms<br/>min: 5.80ms<br/>max: 12.87ms<br/>p99: 11.88ms | 1000 trips, 3 coordinates<br/>total: 6222.35ms<br/>avg: 6.22ms<br/>min: 2.76ms<br/>max: 9.01ms<br/>p99: 8.42ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7955.18ms<br/>avg: 7.96ms<br/>min: 3.86ms<br/>max: 10.83ms<br/>p99: 10.17ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9808.65ms<br/>avg: 9.81ms<br/>min: 5.81ms<br/>max: 12.79ms<br/>p99: 12.08ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>498.217ms<br/>0.498217ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>339.177ms<br/>0.339177ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>609.603ms<br/>0.609603ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.926ms<br/>0.151926ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>98.308ms<br/>0.098308ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>134.589ms<br/>0.134589ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>152.139ms<br/>0.152139ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>98.1049ms<br/>0.0981049ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>133.552ms<br/>0.133552ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>494.861ms<br/>0.494861ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>340.157ms<br/>0.340157ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>602.745ms<br/>0.602745ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.705ms<br/>0.151705ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.426ms<br/>0.097426ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>133.417ms<br/>0.133417ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>152.001ms<br/>0.152001ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.7806ms<br/>0.0977806ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.462ms<br/>0.132462ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>624.25ms<br/>0.62425ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>427.238ms<br/>0.427238ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>847.558ms<br/>0.847558ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>268.349ms<br/>0.268349ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>158.174ms<br/>0.158174ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>280.3ms<br/>0.2803ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>254.292ms<br/>0.254292ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>158.738ms<br/>0.158738ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>280.112ms<br/>0.280112ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>621.09ms<br/>0.62109ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>424.804ms<br/>0.424804ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>787.879ms<br/>0.787879ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>267.227ms<br/>0.267227ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>160.622ms<br/>0.160622ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>283.876ms<br/>0.283876ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>258.722ms<br/>0.258722ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.028ms<br/>0.159028ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>284.68ms<br/>0.28468ms/req |
| rtree | 1 result:<br/>207.307ms ->  0.0207307 ms/query<br/>10 results:<br/>242.715ms ->  0.0242715 ms/query | 1 result:<br/>207.838ms ->  0.0207838 ms/query<br/>10 results:<br/>243.045ms ->  0.0243045 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->

