### PR TITLE
Avoid copy of vectors in MakeRoute function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Avoid copy of vectors in MakeRoute function. [#6939](https://github.com/Project-OSRM/osrm-backend/pull/6939)
       - FIXED: Fix bugprone-unused-return-value clang-tidy warning. [#6934](https://github.com/Project-OSRM/osrm-backend/pull/6934)
       - FIXED: Fix performance-noexcept-move-constructor clang-tidy warning. [#6931](https://github.com/Project-OSRM/osrm-backend/pull/6933)
       - FIXED: Fix performance-noexcept-swap clang-tidy warning. [#6931](https://github.com/Project-OSRM/osrm-backend/pull/6931)

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -340,8 +340,8 @@ class RouteAPI : public BaseAPI
                                   unpacked_path_segments,
                                   source_traversed_in_reverse,
                                   target_traversed_in_reverse);
-        std::vector<guidance::RouteLeg> legs = legs_info.first;
-        std::vector<guidance::LegGeometry> leg_geometries = legs_info.second;
+        std::vector<guidance::RouteLeg>& legs = legs_info.first;
+        std::vector<guidance::LegGeometry>& leg_geometries = legs_info.second;
         auto route = guidance::assembleRoute(legs);
 
         // Fill legs
@@ -716,8 +716,8 @@ class RouteAPI : public BaseAPI
                                   unpacked_path_segments,
                                   source_traversed_in_reverse,
                                   target_traversed_in_reverse);
-        std::vector<guidance::RouteLeg> legs = legs_info.first;
-        std::vector<guidance::LegGeometry> leg_geometries = legs_info.second;
+        std::vector<guidance::RouteLeg>& legs = legs_info.first;
+        std::vector<guidance::LegGeometry>& leg_geometries = legs_info.second;
 
         auto route = guidance::assembleRoute(legs);
         boost::optional<util::json::Value> json_overview =

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -340,8 +340,8 @@ class RouteAPI : public BaseAPI
                                   unpacked_path_segments,
                                   source_traversed_in_reverse,
                                   target_traversed_in_reverse);
-        std::vector<guidance::RouteLeg>& legs = legs_info.first;
-        std::vector<guidance::LegGeometry>& leg_geometries = legs_info.second;
+        std::vector<guidance::RouteLeg> &legs = legs_info.first;
+        std::vector<guidance::LegGeometry> &leg_geometries = legs_info.second;
         auto route = guidance::assembleRoute(legs);
 
         // Fill legs
@@ -716,8 +716,8 @@ class RouteAPI : public BaseAPI
                                   unpacked_path_segments,
                                   source_traversed_in_reverse,
                                   target_traversed_in_reverse);
-        std::vector<guidance::RouteLeg>& legs = legs_info.first;
-        std::vector<guidance::LegGeometry>& leg_geometries = legs_info.second;
+        std::vector<guidance::RouteLeg> &legs = legs_info.first;
+        std::vector<guidance::LegGeometry> &leg_geometries = legs_info.second;
 
         auto route = guidance::assembleRoute(legs);
         boost::optional<util::json::Value> json_overview =


### PR DESCRIPTION

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1084.52<br/>plain u32: 1092.16<br/>aliased double: 944.459<br/>plain double: 949.845 | aliased u32: 1085.86<br/>plain u32: 1090.26<br/>aliased double: 951.063<br/>plain double: 950.52 |
| e2e_match_ch | Total: 2897.4783420562744ms<br/>Min time: 2.3925304412841797ms<br/>Mean time: 22.118155282872323ms<br/>Median time: 17.45772361755371ms<br/>95th percentile: 69.76318359375ms<br/>99th percentile: 84.10015106201169ms<br/>Max time: 94.74039077758789ms | Total: 2764.0750408172607ms<br/>Min time: 2.2974014282226562ms<br/>Mean time: 21.099809471887486ms<br/>Median time: 16.847848892211914ms<br/>95th percentile: 66.67590141296387ms<br/>99th percentile: 84.41815376281728ms<br/>Max time: 94.00558471679688ms |
| e2e_match_mld | Total: 2025.0811576843262ms<br/>Min time: 2.1584033966064453ms<br/>Mean time: 15.458634791483405ms<br/>Median time: 8.678913116455078ms<br/>95th percentile: 50.0645637512207ms<br/>99th percentile: 57.61547088623042ms<br/>Max time: 67.85964965820312ms | Total: 2026.6757011413574ms<br/>Min time: 1.9257068634033203ms<br/>Mean time: 15.47080687894166ms<br/>Median time: 8.652448654174805ms<br/>95th percentile: 49.43287372589111ms<br/>99th percentile: 59.28809642791743ms<br/>Max time: 67.5663948059082ms |
| e2e_nearest_ch | Total: 1336.3399505615234ms<br/>Min time: 1.1339187622070312ms<br/>Mean time: 1.3363399505615234ms<br/>Median time: 1.2503862380981445ms<br/>95th percentile: 1.744520664215088ms<br/>99th percentile: 1.8091464042663574ms<br/>Max time: 2.0880699157714844ms | Total: 1340.5539989471436ms<br/>Min time: 1.1281967163085938ms<br/>Mean time: 1.3405539989471436ms<br/>Median time: 1.2562274932861328ms<br/>95th percentile: 1.7512321472167969ms<br/>99th percentile: 1.8029356002807617ms<br/>Max time: 1.8911361694335938ms |
| e2e_nearest_mld | Total: 1339.15376663208ms<br/>Min time: 1.1358261108398438ms<br/>Mean time: 1.33915376663208ms<br/>Median time: 1.2536048889160156ms<br/>95th percentile: 1.7461895942687988ms<br/>99th percentile: 1.7900848388671875ms<br/>Max time: 1.9543170928955078ms | Total: 1327.1679878234863ms<br/>Min time: 1.1415481567382812ms<br/>Mean time: 1.3271679878234863ms<br/>Median time: 1.244664192199707ms<br/>95th percentile: 1.7361760139465332ms<br/>99th percentile: 1.7795586585998535ms<br/>Max time: 1.9164085388183594ms |
| e2e_route_ch | Total: 3083.045244216919ms<br/>Min time: 1.3651847839355469ms<br/>Mean time: 3.083045244216919ms<br/>Median time: 3.1058788299560547ms<br/>95th percentile: 4.0335774421691895ms<br/>99th percentile: 4.453186988830566ms<br/>Max time: 5.161046981811523ms | Total: 3032.440185546875ms<br/>Min time: 1.371145248413086ms<br/>Mean time: 3.032440185546875ms<br/>Median time: 3.059864044189453ms<br/>95th percentile: 3.9961934089660645ms<br/>99th percentile: 4.311707019805907ms<br/>Max time: 5.143404006958008ms |
| e2e_route_mld | Total: 3663.024663925171ms<br/>Min time: 1.3585090637207031ms<br/>Mean time: 3.663024663925171ms<br/>Median time: 3.6916732788085938ms<br/>95th percentile: 5.040228366851807ms<br/>99th percentile: 5.5136752128601065ms<br/>Max time: 6.417751312255859ms | Total: 3573.8611221313477ms<br/>Min time: 1.3566017150878906ms<br/>Mean time: 3.5738611221313477ms<br/>Median time: 3.5926103591918945ms<br/>95th percentile: 4.888892173767089ms<br/>99th percentile: 5.334320068359375ms<br/>Max time: 6.010770797729492ms |
| e2e_table_ch | Total: 15801.600933074951ms<br/>Min time: 1.9536018371582031ms<br/>Mean time: 15.801600933074951ms<br/>Median time: 15.149950981140137ms<br/>95th percentile: 28.925037384033203ms<br/>99th percentile: 30.374343395233154ms<br/>Max time: 36.83161735534668ms | Total: 15946.631669998169ms<br/>Min time: 2.074003219604492ms<br/>Mean time: 15.946631669998169ms<br/>Median time: 15.267491340637207ms<br/>95th percentile: 29.214000701904297ms<br/>99th percentile: 30.709753036499023ms<br/>Max time: 31.637907028198242ms |
| e2e_table_mld | Total: 63334.99884605408ms<br/>Min time: 4.02069091796875ms<br/>Mean time: 63.33499884605408ms<br/>Median time: 59.94582176208496ms<br/>95th percentile: 122.96134233474731ms<br/>99th percentile: 130.46648502349854ms<br/>Max time: 133.75496864318848ms | Total: 63675.09055137634ms<br/>Min time: 4.118442535400391ms<br/>Mean time: 63.67509055137634ms<br/>Median time: 60.31608581542969ms<br/>95th percentile: 122.9627251625061ms<br/>99th percentile: 130.34106254577637ms<br/>Max time: 135.53881645202637ms |
| e2e_trip_ch | Total: 10788.586854934692ms<br/>Min time: 1.516580581665039ms<br/>Mean time: 10.788586854934692ms<br/>Median time: 10.32412052154541ms<br/>95th percentile: 18.756473064422607ms<br/>99th percentile: 20.378837585449215ms<br/>Max time: 21.291255950927734ms | Total: 10730.83758354187ms<br/>Min time: 1.5316009521484375ms<br/>Mean time: 10.73083758354187ms<br/>Median time: 10.272383689880371ms<br/>95th percentile: 18.791162967681885ms<br/>99th percentile: 20.490846633911133ms<br/>Max time: 21.323680877685547ms |
| e2e_trip_mld | Total: 17806.45704269409ms<br/>Min time: 1.5561580657958984ms<br/>Mean time: 17.806457042694092ms<br/>Median time: 17.391681671142578ms<br/>95th percentile: 28.77347469329834ms<br/>99th percentile: 31.214325428009033ms<br/>Max time: 34.050703048706055ms | Total: 17549.262046813965ms<br/>Min time: 1.6453266143798828ms<br/>Mean time: 17.549262046813965ms<br/>Median time: 17.08543300628662ms<br/>95th percentile: 28.6484956741333ms<br/>99th percentile: 30.728087425231934ms<br/>Max time: 42.929887771606445ms |
| json-render | String: 6.57248ms<br/>Stringstream: 9.39076ms<br/>Vector: 7.5332ms | String: 6.65029ms<br/>Stringstream: 9.40445ms<br/>Vector: 6.93773ms |
| match_ch | Default radius: <br/>4.37154ms/req at 82 coordinate<br/>0.0533114ms/coordinate<br/>Radius 5m: <br/>4.36068ms/req at 82 coordinate<br/>0.0531791ms/coordinate<br/>Radius 10m: <br/>14.9209ms/req at 82 coordinate<br/>0.181962ms/coordinate<br/>Radius 15m: <br/>36.452ms/req at 82 coordinate<br/>0.444536ms/coordinate<br/>Radius 30m: <br/>311.819ms/req at 82 coordinate<br/>3.80267ms/coordinate | Default radius: <br/>4.40948ms/req at 82 coordinate<br/>0.0537741ms/coordinate<br/>Radius 5m: <br/>4.40146ms/req at 82 coordinate<br/>0.0536763ms/coordinate<br/>Radius 10m: <br/>15.0776ms/req at 82 coordinate<br/>0.183873ms/coordinate<br/>Radius 15m: <br/>36.7469ms/req at 82 coordinate<br/>0.448132ms/coordinate<br/>Radius 30m: <br/>313.656ms/req at 82 coordinate<br/>3.82507ms/coordinate |
| match_mld | Default radius: <br/>2.80976ms/req at 82 coordinate<br/>0.0342653ms/coordinate<br/>Radius 5m: <br/>2.76244ms/req at 82 coordinate<br/>0.0336883ms/coordinate<br/>Radius 10m: <br/>10.2158ms/req at 82 coordinate<br/>0.124583ms/coordinate<br/>Radius 15m: <br/>25.8412ms/req at 82 coordinate<br/>0.315137ms/coordinate<br/>Radius 30m: <br/>304.094ms/req at 82 coordinate<br/>3.70846ms/coordinate | Default radius: <br/>2.83246ms/req at 82 coordinate<br/>0.0345422ms/coordinate<br/>Radius 5m: <br/>2.80843ms/req at 82 coordinate<br/>0.0342491ms/coordinate<br/>Radius 10m: <br/>10.3567ms/req at 82 coordinate<br/>0.126301ms/coordinate<br/>Radius 15m: <br/>26.5291ms/req at 82 coordinate<br/>0.323526ms/coordinate<br/>Radius 30m: <br/>303.222ms/req at 82 coordinate<br/>3.69783ms/coordinate |
| osrm_contract | Time: 94.68s Peak RAM: 185.73MB | Time: 93.22s Peak RAM: 185.52MB |
| osrm_customize | Time: 1.31s Peak RAM: 115.07MB | Time: 1.31s Peak RAM: 114.92MB |
| osrm_extract | Time: 12.03s Peak RAM: 410.06MB | Time: 12.08s Peak RAM: 424.24MB |
| osrm_partition | Time: 2.15s Peak RAM: 148.31MB | Time: 2.16s Peak RAM: 148.50MB |
| packedvector | random write:<br/>std::vector 9780.03 ms<br/>util::packed_vector 73857.3 ms<br/>slowdown: 7.55185<br/>random read:<br/>std::vector 8404.88 ms<br/>util::packed_vector 29948.8 ms<br/>slowdown: 3.56326 | random write:<br/>std::vector 9741.94 ms<br/>util::packed_vector 81890.2 ms<br/>slowdown: 8.40594<br/>random read:<br/>std::vector 8390.63 ms<br/>util::packed_vector 33300.2 ms<br/>slowdown: 3.96874 |
| random_match_ch | 1000 matches, default radius<br/>total: 6881.97ms<br/>avg: 6.88ms<br/>min: 0.00ms<br/>max: 483.15ms<br/>p99: 103.87ms<br/><br/>1000 matches, radius=10<br/>total: 34797.26ms<br/>avg: 34.80ms<br/>min: 0.00ms<br/>max: 1879.66ms<br/>p99: 1862.57ms<br/><br/>1000 matches, radius=20<br/>total: 67922.89ms<br/>avg: 67.92ms<br/>min: 0.00ms<br/>max: 9218.82ms<br/>p99: 1142.97ms | 1000 matches, default radius<br/>total: 6864.43ms<br/>avg: 6.86ms<br/>min: 0.00ms<br/>max: 481.50ms<br/>p99: 103.95ms<br/><br/>1000 matches, radius=10<br/>total: 34524.58ms<br/>avg: 34.52ms<br/>min: 0.00ms<br/>max: 1873.84ms<br/>p99: 1857.43ms<br/><br/>1000 matches, radius=20<br/>total: 67451.44ms<br/>avg: 67.45ms<br/>min: 0.00ms<br/>max: 9240.75ms<br/>p99: 1152.58ms |
| random_match_mld | 1000 matches, default radius<br/>total: 5171.58ms<br/>avg: 5.17ms<br/>min: 0.00ms<br/>max: 386.60ms<br/>p99: 70.56ms<br/><br/>1000 matches, radius=10<br/>total: 26901.75ms<br/>avg: 26.90ms<br/>min: 0.00ms<br/>max: 1569.46ms<br/>p99: 1554.98ms<br/><br/>1000 matches, radius=20<br/>total: 52987.26ms<br/>avg: 52.99ms<br/>min: 0.00ms<br/>max: 7052.29ms<br/>p99: 812.15ms | 1000 matches, default radius<br/>total: 5108.81ms<br/>avg: 5.11ms<br/>min: 0.00ms<br/>max: 381.86ms<br/>p99: 68.98ms<br/><br/>1000 matches, radius=10<br/>total: 26568.37ms<br/>avg: 26.57ms<br/>min: 0.00ms<br/>max: 1552.50ms<br/>p99: 1533.81ms<br/><br/>1000 matches, radius=20<br/>total: 52472.36ms<br/>avg: 52.47ms<br/>min: 0.00ms<br/>max: 7026.61ms<br/>p99: 795.98ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>total: 474.66ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.25ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 607.97ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.21ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 757.30ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.19ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 475.13ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.24ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 609.42ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.20ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 768.42ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.19ms<br/>p99: 0.14ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>total: 476.55ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.27ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 610.41ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.21ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 756.80ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.19ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 472.56ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.27ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 608.83ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.20ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 765.89ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.20ms<br/>p99: 0.14ms |
| random_route_ch | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 21706.40ms<br/>avg: 2.17ms<br/>min: 0.16ms<br/>max: 4.06ms<br/>p99: 3.21ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 10222.37ms<br/>avg: 1.02ms<br/>min: 0.09ms<br/>max: 2.00ms<br/>p99: 1.65ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 18578.95ms<br/>avg: 1.86ms<br/>min: 0.09ms<br/>max: 4.67ms<br/>p99: 4.04ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 10024.82ms<br/>avg: 1.00ms<br/>min: 0.12ms<br/>max: 1.80ms<br/>p99: 1.41ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4088.35ms<br/>avg: 0.41ms<br/>min: 0.05ms<br/>max: 0.76ms<br/>p99: 0.59ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 8970.88ms<br/>avg: 0.90ms<br/>min: 0.06ms<br/>max: 2.56ms<br/>p99: 2.13ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 676.89ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 1.52ms<br/>p99: 0.67ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 705.83ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.60ms<br/>p99: 0.42ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 936.89ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.95ms<br/>p99: 1.18ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 21199.39ms<br/>avg: 2.12ms<br/>min: 0.16ms<br/>max: 4.02ms<br/>p99: 3.14ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 9943.72ms<br/>avg: 0.99ms<br/>min: 0.09ms<br/>max: 2.01ms<br/>p99: 1.61ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 17969.62ms<br/>avg: 1.80ms<br/>min: 0.09ms<br/>max: 5.35ms<br/>p99: 4.55ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 9980.65ms<br/>avg: 1.00ms<br/>min: 0.12ms<br/>max: 1.84ms<br/>p99: 1.39ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4109.36ms<br/>avg: 0.41ms<br/>min: 0.05ms<br/>max: 0.77ms<br/>p99: 0.60ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 8899.19ms<br/>avg: 0.89ms<br/>min: 0.06ms<br/>max: 3.55ms<br/>p99: 2.64ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 673.84ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 1.37ms<br/>p99: 0.65ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 701.52ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.57ms<br/>p99: 0.41ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 905.09ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.76ms<br/>p99: 1.08ms |
| random_route_mld | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 41527.91ms<br/>avg: 4.15ms<br/>min: 0.15ms<br/>max: 10.14ms<br/>p99: 7.08ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 15098.06ms<br/>avg: 1.51ms<br/>min: 0.09ms<br/>max: 3.01ms<br/>p99: 2.65ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 42087.74ms<br/>avg: 4.21ms<br/>min: 0.09ms<br/>max: 9.70ms<br/>p99: 8.47ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 29647.70ms<br/>avg: 2.96ms<br/>min: 0.11ms<br/>max: 9.39ms<br/>p99: 5.24ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 9009.98ms<br/>avg: 0.90ms<br/>min: 0.05ms<br/>max: 1.90ms<br/>p99: 1.61ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 32329.40ms<br/>avg: 3.23ms<br/>min: 0.05ms<br/>max: 7.68ms<br/>p99: 6.49ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 856.37ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 4.35ms<br/>p99: 1.56ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 935.35ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.28ms<br/>p99: 1.00ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1727.22ms<br/>avg: 0.17ms<br/>min: 0.01ms<br/>max: 5.02ms<br/>p99: 3.50ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 41543.88ms<br/>avg: 4.15ms<br/>min: 0.16ms<br/>max: 9.99ms<br/>p99: 7.10ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 14860.46ms<br/>avg: 1.49ms<br/>min: 0.08ms<br/>max: 3.07ms<br/>p99: 2.62ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 41722.87ms<br/>avg: 4.17ms<br/>min: 0.08ms<br/>max: 9.70ms<br/>p99: 8.42ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 30226.49ms<br/>avg: 3.02ms<br/>min: 0.11ms<br/>max: 9.52ms<br/>p99: 5.36ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 8986.71ms<br/>avg: 0.90ms<br/>min: 0.05ms<br/>max: 1.96ms<br/>p99: 1.59ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 32408.02ms<br/>avg: 3.24ms<br/>min: 0.05ms<br/>max: 8.14ms<br/>p99: 6.53ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 870.06ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 4.44ms<br/>p99: 1.59ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 946.09ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.44ms<br/>p99: 1.02ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1725.60ms<br/>avg: 0.17ms<br/>min: 0.01ms<br/>max: 5.02ms<br/>p99: 3.49ms |
| random_table_ch | 250 tables, 3 coordinates<br/>total: 177.99ms<br/>avg: 0.71ms<br/>min: 0.56ms<br/>max: 1.70ms<br/>p99: 1.03ms<br/><br/>250 tables, 25 coordinates<br/>total: 1472.35ms<br/>avg: 5.89ms<br/>min: 5.32ms<br/>max: 7.45ms<br/>p99: 7.05ms<br/><br/>250 tables, 50 coordinates<br/>total: 2964.16ms<br/>avg: 11.86ms<br/>min: 10.75ms<br/>max: 12.90ms<br/>p99: 12.62ms<br/><br/>250 tables, 100 coordinates<br/>total: 6311.28ms<br/>avg: 25.25ms<br/>min: 24.10ms<br/>max: 26.35ms<br/>p99: 26.13ms | 250 tables, 3 coordinates<br/>total: 179.26ms<br/>avg: 0.72ms<br/>min: 0.50ms<br/>max: 1.84ms<br/>p99: 0.98ms<br/><br/>250 tables, 25 coordinates<br/>total: 1466.70ms<br/>avg: 5.87ms<br/>min: 5.26ms<br/>max: 6.30ms<br/>p99: 6.24ms<br/><br/>250 tables, 50 coordinates<br/>total: 2972.75ms<br/>avg: 11.89ms<br/>min: 10.92ms<br/>max: 12.77ms<br/>p99: 12.57ms<br/><br/>250 tables, 100 coordinates<br/>total: 6345.71ms<br/>avg: 25.38ms<br/>min: 23.86ms<br/>max: 26.43ms<br/>p99: 26.31ms |
| random_table_mld | 250 tables, 3 coordinates<br/>total: 729.98ms<br/>avg: 2.92ms<br/>min: 2.34ms<br/>max: 4.00ms<br/>p99: 3.89ms<br/><br/>250 tables, 25 coordinates<br/>total: 6885.40ms<br/>avg: 27.54ms<br/>min: 24.62ms<br/>max: 31.22ms<br/>p99: 30.30ms<br/><br/>250 tables, 50 coordinates<br/>total: 14798.69ms<br/>avg: 59.19ms<br/>min: 54.56ms<br/>max: 63.47ms<br/>p99: 62.70ms<br/><br/>250 tables, 100 coordinates<br/>total: 31759.48ms<br/>avg: 127.04ms<br/>min: 121.16ms<br/>max: 134.90ms<br/>p99: 134.21ms | 250 tables, 3 coordinates<br/>total: 735.60ms<br/>avg: 2.94ms<br/>min: 2.35ms<br/>max: 4.00ms<br/>p99: 3.95ms<br/><br/>250 tables, 25 coordinates<br/>total: 6864.80ms<br/>avg: 27.46ms<br/>min: 24.55ms<br/>max: 30.97ms<br/>p99: 30.42ms<br/><br/>250 tables, 50 coordinates<br/>total: 14685.26ms<br/>avg: 58.74ms<br/>min: 54.46ms<br/>max: 62.55ms<br/>p99: 62.47ms<br/><br/>250 tables, 100 coordinates<br/>total: 31265.66ms<br/>avg: 125.06ms<br/>min: 120.28ms<br/>max: 132.34ms<br/>p99: 131.39ms |
| random_trip_ch | 1000 trips, 3 coordinates<br/>total: 2153.14ms<br/>avg: 2.15ms<br/>min: 0.74ms<br/>max: 3.89ms<br/>p99: 2.77ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2670.00ms<br/>avg: 2.67ms<br/>min: 1.10ms<br/>max: 3.49ms<br/>p99: 3.30ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3196.15ms<br/>avg: 3.20ms<br/>min: 2.00ms<br/>max: 4.15ms<br/>p99: 3.88ms | 1000 trips, 3 coordinates<br/>total: 2135.09ms<br/>avg: 2.14ms<br/>min: 0.69ms<br/>max: 3.95ms<br/>p99: 2.71ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2664.20ms<br/>avg: 2.66ms<br/>min: 1.17ms<br/>max: 3.55ms<br/>p99: 3.29ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3200.51ms<br/>avg: 3.20ms<br/>min: 1.95ms<br/>max: 4.25ms<br/>p99: 3.90ms |
| random_trip_mld | 1000 trips, 3 coordinates<br/>total: 5890.48ms<br/>avg: 5.89ms<br/>min: 2.73ms<br/>max: 8.54ms<br/>p99: 7.92ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7598.65ms<br/>avg: 7.60ms<br/>min: 3.81ms<br/>max: 10.29ms<br/>p99: 9.42ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9270.51ms<br/>avg: 9.27ms<br/>min: 5.66ms<br/>max: 13.44ms<br/>p99: 11.22ms | 1000 trips, 3 coordinates<br/>total: 5877.38ms<br/>avg: 5.88ms<br/>min: 2.75ms<br/>max: 8.32ms<br/>p99: 7.81ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7477.46ms<br/>avg: 7.48ms<br/>min: 3.78ms<br/>max: 10.25ms<br/>p99: 9.36ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9121.81ms<br/>avg: 9.12ms<br/>min: 5.68ms<br/>max: 12.48ms<br/>p99: 11.09ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>510.655ms<br/>0.510655ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>350.281ms<br/>0.350281ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>624.101ms<br/>0.624101ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>154.623ms<br/>0.154623ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>96.2211ms<br/>0.0962211ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>131.241ms<br/>0.131241ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>148.259ms<br/>0.148259ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>96.0707ms<br/>0.0960707ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.171ms<br/>0.131171ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>491.133ms<br/>0.491133ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>334.215ms<br/>0.334215ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>597.679ms<br/>0.597679ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>150.882ms<br/>0.150882ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.2533ms<br/>0.0972533ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>135.123ms<br/>0.135123ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>157.336ms<br/>0.157336ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>98.2499ms<br/>0.0982499ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>131.992ms<br/>0.131992ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>639.363ms<br/>0.639363ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>454.179ms<br/>0.454179ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>807.134ms<br/>0.807134ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>264.625ms<br/>0.264625ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>160.791ms<br/>0.160791ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>288.768ms<br/>0.288768ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>262.666ms<br/>0.262666ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>160.707ms<br/>0.160707ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>287.508ms<br/>0.287508ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>619.172ms<br/>0.619172ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>420.621ms<br/>0.420621ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>777.497ms<br/>0.777497ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>262.727ms<br/>0.262727ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>160.533ms<br/>0.160533ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>286.041ms<br/>0.286041ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>257.147ms<br/>0.257147ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>158.952ms<br/>0.158952ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>281.646ms<br/>0.281646ms/req |
| rtree | 1 result:<br/>207.308ms ->  0.0207308 ms/query<br/>10 results:<br/>241.84ms ->  0.024184 ms/query | 1 result:<br/>206.797ms ->  0.0206797 ms/query<br/>10 results:<br/>241.476ms ->  0.0241476 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
