### PR TITLE
Optimise encodePolyline function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Optimise encodePolyline function. [#6940](https://github.com/Project-OSRM/osrm-backend/pull/6940)
       - CHANGED: Get rid of unused Boost dependencies. [#6960](https://github.com/Project-OSRM/osrm-backend/pull/6960)
       - CHANGED: Apply micro-optimisation for Table & Trip APIs. [#6949](https://github.com/Project-OSRM/osrm-backend/pull/6949)
       - CHANGED: Apply micro-optimisation for Route API. [#6948](https://github.com/Project-OSRM/osrm-backend/pull/6948)

--- a/include/engine/polyline_compressor.hpp
+++ b/include/engine/polyline_compressor.hpp
@@ -12,7 +12,7 @@ namespace osrm::engine
 {
 namespace detail
 {
-std::string encode(std::vector<int> &numbers);
+void encode(int number_to_encode, std::string &output);
 std::int32_t decode_polyline_integer(std::string::const_iterator &first,
                                      std::string::const_iterator last);
 } // namespace detail
@@ -30,27 +30,24 @@ std::string encodePolyline(CoordVectorForwardIter begin, CoordVectorForwardIter 
         return {};
     }
 
-    std::vector<int> delta_numbers;
-    BOOST_ASSERT(size > 0);
-    delta_numbers.reserve((size - 1) * 2);
+    std::string output;
+    // just a guess that we will need ~4 bytes per coordinate to avoid reallocations
+    output.reserve(size * 4);
+
     int current_lat = 0;
     int current_lon = 0;
-    std::for_each(
-        begin,
-        end,
-        [&delta_numbers, &current_lat, &current_lon, coordinate_to_polyline](
-            const util::Coordinate loc)
-        {
-            const int lat_diff =
-                std::round(static_cast<int>(loc.lat) * coordinate_to_polyline) - current_lat;
-            const int lon_diff =
-                std::round(static_cast<int>(loc.lon) * coordinate_to_polyline) - current_lon;
-            delta_numbers.emplace_back(lat_diff);
-            delta_numbers.emplace_back(lon_diff);
-            current_lat += lat_diff;
-            current_lon += lon_diff;
-        });
-    return detail::encode(delta_numbers);
+    for (auto it = begin; it != end; ++it)
+    {
+        const int lat_diff =
+            std::round(static_cast<int>(it->lat) * coordinate_to_polyline) - current_lat;
+        const int lon_diff =
+            std::round(static_cast<int>(it->lon) * coordinate_to_polyline) - current_lon;
+        detail::encode(lat_diff, output);
+        detail::encode(lon_diff, output);
+        current_lat += lat_diff;
+        current_lon += lon_diff;
+    }
+    return output;
 }
 
 // Decodes geometry from polyline format

--- a/src/engine/polyline_compressor.cpp
+++ b/src/engine/polyline_compressor.cpp
@@ -10,9 +10,19 @@
 namespace osrm::engine::detail // anonymous to keep TU local
 {
 
-std::string encode(int number_to_encode)
+void encode(int number_to_encode, std::string &output)
 {
-    std::string output;
+    if (number_to_encode < 0)
+    {
+        const unsigned binary = std::llabs(number_to_encode);
+        const unsigned twos = (~binary) + 1u;
+        const unsigned shl = twos << 1u;
+        number_to_encode = static_cast<int>(~shl);
+    }
+    else
+    {
+        number_to_encode <<= 1u;
+    }
     while (number_to_encode >= 0x20)
     {
         const int next_value = (0x20 | (number_to_encode & 0x1f)) + 63;
@@ -22,31 +32,6 @@ std::string encode(int number_to_encode)
 
     number_to_encode += 63;
     output += static_cast<char>(number_to_encode);
-    return output;
-}
-
-std::string encode(std::vector<int> &numbers)
-{
-    std::string output;
-    for (auto &number : numbers)
-    {
-        if (number < 0)
-        {
-            const unsigned binary = std::llabs(number);
-            const unsigned twos = (~binary) + 1u;
-            const unsigned shl = twos << 1u;
-            number = static_cast<int>(~shl);
-        }
-        else
-        {
-            number <<= 1u;
-        }
-    }
-    for (const int number : numbers)
-    {
-        output += encode(number);
-    }
-    return output;
 }
 
 // https://developers.google.com/maps/documentation/utilities/polylinealgorithm


### PR DESCRIPTION




<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1099.08<br/>plain u32: 1099.36<br/>aliased double: 960.612<br/>plain double: 954.824 | aliased u32: 1153.57<br/>plain u32: 1156.25<br/>aliased double: 1180.28<br/>plain double: 1183.33 |
| e2e_match_ch | Ops: 45.03 ± 0.04 ops/s. Best: 44.97 ops/s<br/>Total: 2908.87ms ± 2.74ms. Best: 2904.70ms<br/>Min time: 2.19ms ± 0.02ms<br/>Mean time: 22.21ms ± 0.02ms<br/>Median time: 16.48ms ± 0.14ms<br/>95th percentile: 76.15ms ± 0.14ms<br/>99th percentile: 91.09ms ± 0.50ms<br/>Max time: 97.61ms ± 0.22ms | Ops: 44.85 ± 0.09 ops/s. Best: 44.68 ops/s<br/>Total: 2920.90ms ± 5.77ms. Best: 2914.38ms<br/>Min time: 2.17ms ± 0.02ms<br/>Mean time: 22.30ms ± 0.04ms<br/>Median time: 15.94ms ± 0.17ms<br/>95th percentile: 75.66ms ± 0.29ms<br/>99th percentile: 90.80ms ± 0.60ms<br/>Max time: 98.87ms ± 0.51ms |
| e2e_match_mld | Ops: 62.43 ± 0.07 ops/s. Best: 62.31 ops/s<br/>Total: 2098.38ms ± 2.60ms. Best: 2093.21ms<br/>Min time: 1.84ms ± 0.02ms<br/>Mean time: 16.02ms ± 0.02ms<br/>Median time: 8.58ms ± 0.03ms<br/>95th percentile: 53.25ms ± 0.09ms<br/>99th percentile: 61.51ms ± 0.26ms<br/>Max time: 71.25ms ± 0.43ms | Ops: 62.78 ± 0.06 ops/s. Best: 62.67 ops/s<br/>Total: 2086.67ms ± 2.06ms. Best: 2083.55ms<br/>Min time: 1.81ms ± 0.03ms<br/>Mean time: 15.93ms ± 0.02ms<br/>Median time: 8.50ms ± 0.04ms<br/>95th percentile: 53.07ms ± 0.16ms<br/>99th percentile: 61.04ms ± 0.21ms<br/>Max time: 70.77ms ± 0.20ms |
| e2e_nearest_ch | Ops: 800.91 ± 3.92 ops/s. Best: 792.89 ops/s<br/>Total: 1248.53ms ± 6.57ms. Best: 1238.54ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.25ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.65ms ± 0.01ms<br/>99th percentile: 1.70ms ± 0.00ms<br/>Max time: 4.15ms ± 2.40ms | Ops: 793.99 ± 7.09 ops/s. Best: 779.88 ops/s<br/>Total: 1259.46ms ± 11.53ms. Best: 1245.90ms<br/>Min time: 1.07ms ± 0.01ms<br/>Mean time: 1.26ms ± 0.01ms<br/>Median time: 1.17ms ± 0.01ms<br/>95th percentile: 1.66ms ± 0.01ms<br/>99th percentile: 1.72ms ± 0.02ms<br/>Max time: 4.51ms ± 2.71ms |
| e2e_nearest_mld | Ops: 802.86 ± 4.39 ops/s. Best: 791.96 ops/s<br/>Total: 1245.50ms ± 7.13ms. Best: 1238.96ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.25ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.70ms ± 0.01ms<br/>Max time: 4.19ms ± 2.29ms | Ops: 803.86 ± 4.79 ops/s. Best: 792.60 ops/s<br/>Total: 1243.93ms ± 7.94ms. Best: 1234.43ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 4.15ms ± 2.36ms |
| e2e_route_ch | Ops: 341.61 ± 1.22 ops/s. Best: 339.64 ops/s<br/>Total: 2927.24ms ± 11.31ms. Best: 2906.59ms<br/>Min time: 1.29ms ± 0.02ms<br/>Mean time: 2.93ms ± 0.01ms<br/>Median time: 2.95ms ± 0.02ms<br/>95th percentile: 3.85ms ± 0.01ms<br/>99th percentile: 4.22ms ± 0.04ms<br/>Max time: 6.52ms ± 1.78ms | Ops: 346.29 ± 1.43 ops/s. Best: 343.06 ops/s<br/>Total: 2887.61ms ± 12.26ms. Best: 2872.36ms<br/>Min time: 1.29ms ± 0.02ms<br/>Mean time: 2.89ms ± 0.01ms<br/>Median time: 2.91ms ± 0.02ms<br/>95th percentile: 3.80ms ± 0.02ms<br/>99th percentile: 4.20ms ± 0.03ms<br/>Max time: 6.82ms ± 2.15ms |
| e2e_route_mld | Ops: 288.06 ± 0.77 ops/s. Best: 286.47 ops/s<br/>Total: 3471.50ms ± 9.56ms. Best: 3455.80ms<br/>Min time: 1.29ms ± 0.01ms<br/>Mean time: 3.47ms ± 0.01ms<br/>Median time: 3.51ms ± 0.01ms<br/>95th percentile: 4.71ms ± 0.01ms<br/>99th percentile: 5.20ms ± 0.04ms<br/>Max time: 7.68ms ± 1.92ms | Ops: 291.54 ± 0.72 ops/s. Best: 289.93 ops/s<br/>Total: 3430.06ms ± 8.29ms. Best: 3420.90ms<br/>Min time: 1.31ms ± 0.02ms<br/>Mean time: 3.43ms ± 0.01ms<br/>Median time: 3.47ms ± 0.01ms<br/>95th percentile: 4.66ms ± 0.02ms<br/>99th percentile: 5.10ms ± 0.04ms<br/>Max time: 7.24ms ± 1.54ms |
| e2e_table_ch | Ops: 304.54 ± 0.61 ops/s. Best: 303.23 ops/s<br/>Total: 3283.52ms ± 6.94ms. Best: 3273.37ms<br/>Min time: 1.72ms ± 0.02ms<br/>Mean time: 3.28ms ± 0.01ms<br/>Median time: 3.28ms ± 0.02ms<br/>95th percentile: 4.53ms ± 0.01ms<br/>99th percentile: 4.85ms ± 0.06ms<br/>Max time: 7.27ms ± 2.25ms | Ops: 306.42 ± 1.22 ops/s. Best: 304.74 ops/s<br/>Total: 3262.99ms ± 13.43ms. Best: 3243.12ms<br/>Min time: 1.70ms ± 0.03ms<br/>Mean time: 3.26ms ± 0.01ms<br/>Median time: 3.26ms ± 0.02ms<br/>95th percentile: 4.49ms ± 0.04ms<br/>99th percentile: 4.82ms ± 0.07ms<br/>Max time: 7.35ms ± 2.36ms |
| e2e_table_mld | Ops: 108.77 ± 0.49 ops/s. Best: 107.89 ops/s<br/>Total: 9195.74ms ± 42.28ms. Best: 9136.25ms<br/>Min time: 3.75ms ± 0.04ms<br/>Mean time: 9.19ms ± 0.04ms<br/>Median time: 9.18ms ± 0.05ms<br/>95th percentile: 14.02ms ± 0.04ms<br/>99th percentile: 15.05ms ± 0.17ms<br/>Max time: 17.69ms ± 1.35ms | Ops: 110.79 ± 0.17 ops/s. Best: 110.46 ops/s<br/>Total: 9025.83ms ± 14.42ms. Best: 9003.57ms<br/>Min time: 3.66ms ± 0.04ms<br/>Mean time: 9.03ms ± 0.01ms<br/>Median time: 9.01ms ± 0.03ms<br/>95th percentile: 13.79ms ± 0.04ms<br/>99th percentile: 14.69ms ± 0.06ms<br/>Max time: 17.10ms ± 1.42ms |
| e2e_trip_ch | Ops: 96.23 ± 0.12 ops/s. Best: 96.08 ops/s<br/>Total: 10391.54ms ± 14.05ms. Best: 10363.65ms<br/>Min time: 1.58ms ± 0.15ms<br/>Mean time: 10.39ms ± 0.01ms<br/>Median time: 9.90ms ± 0.03ms<br/>95th percentile: 18.41ms ± 0.09ms<br/>99th percentile: 19.87ms ± 0.14ms<br/>Max time: 23.06ms ± 2.38ms | Ops: 98.07 ± 0.23 ops/s. Best: 97.72 ops/s<br/>Total: 10196.70ms ± 24.58ms. Best: 10152.70ms<br/>Min time: 1.59ms ± 0.13ms<br/>Mean time: 10.20ms ± 0.03ms<br/>Median time: 9.68ms ± 0.02ms<br/>95th percentile: 18.04ms ± 0.05ms<br/>99th percentile: 19.47ms ± 0.06ms<br/>Max time: 21.97ms ± 1.42ms |
| e2e_trip_mld | Ops: 58.02 ± 0.43 ops/s. Best: 57.32 ops/s<br/>Total: 17243.25ms ± 133.18ms. Best: 17062.16ms<br/>Min time: 1.67ms ± 0.18ms<br/>Mean time: 17.24ms ± 0.13ms<br/>Median time: 16.80ms ± 0.13ms<br/>95th percentile: 28.15ms ± 0.18ms<br/>99th percentile: 30.07ms ± 0.25ms<br/>Max time: 33.10ms ± 1.09ms | Ops: 59.02 ± 0.18 ops/s. Best: 58.62 ops/s<br/>Total: 16942.99ms ± 50.70ms. Best: 16885.55ms<br/>Min time: 1.56ms ± 0.16ms<br/>Mean time: 16.94ms ± 0.05ms<br/>Median time: 16.53ms ± 0.09ms<br/>95th percentile: 27.79ms ± 0.05ms<br/>99th percentile: 29.55ms ± 0.21ms<br/>Max time: 32.20ms ± 0.85ms |
| json-render | String: 6.90795ms<br/>Stringstream: 10.5349ms<br/>Vector: 6.91941ms | String: 6.76496ms<br/>Stringstream: 10.5112ms<br/>Vector: 6.95827ms |
| match_ch | Default radius: <br/>4.60934ms/req at 82 coordinate<br/>0.0562114ms/coordinate<br/>Radius 10m: <br/>16.2021ms/req at 82 coordinate<br/>0.197586ms/coordinate | Default radius: <br/>4.59826ms/req at 82 coordinate<br/>0.0560764ms/coordinate<br/>Radius 10m: <br/>16.1121ms/req at 82 coordinate<br/>0.196489ms/coordinate |
| match_mld | Default radius: <br/>3.36186ms/req at 82 coordinate<br/>0.0409983ms/coordinate<br/>Radius 10m: <br/>11.4652ms/req at 82 coordinate<br/>0.139819ms/coordinate | Default radius: <br/>3.08187ms/req at 82 coordinate<br/>0.0375838ms/coordinate<br/>Radius 10m: <br/>11.5112ms/req at 82 coordinate<br/>0.14038ms/coordinate |
| osrm_contract | Time: 96.05s Peak RAM: 195.96MB | Time: 95.11s Peak RAM: 196.52MB |
| osrm_customize | Time: 1.39s Peak RAM: 116.68MB | Time: 1.36s Peak RAM: 116.57MB |
| osrm_extract | Time: 12.15s Peak RAM: 400.90MB | Time: 12.14s Peak RAM: 412.39MB |
| osrm_partition | Time: 2.06s Peak RAM: 132.32MB | Time: 2.03s Peak RAM: 135.02MB |
| packedvector | random write:<br/>std::vector 11219.2 ms<br/>util::packed_vector 76731.6 ms<br/>slowdown: 6.83928<br/>random read:<br/>std::vector 11097 ms<br/>util::packed_vector 31765.4 ms<br/>slowdown: 2.86251 | random write:<br/>std::vector 11290.2 ms<br/>util::packed_vector 82302.6 ms<br/>slowdown: 7.28977<br/>random read:<br/>std::vector 11142.7 ms<br/>util::packed_vector 33699.8 ms<br/>slowdown: 3.02439 |
| random_match_ch | 500 matches, default radius<br/>ops: 216.97 ± 0.91 ops/s. best: 214.94ops/s.<br/>total: 262.71 ± 1.11ms. best: 261.46ms.<br/>avg: 4.61 ± 0.02ms<br/>min: 0.15 ± 0.01ms<br/>max: 24.88 ± 0.12ms<br/>p99: 24.88 ± 0.12ms<br/><br/>500 matches, radius=10<br/>ops: 63.54 ± 0.16 ops/s. best: 63.17ops/s.<br/>total: 1007.22 ± 2.51ms. best: 1004.64ms.<br/>avg: 15.74 ± 0.04ms<br/>min: 0.14 ± 0.00ms<br/>max: 245.04 ± 1.14ms<br/>p99: 245.04 ± 1.14ms<br/><br/>500 matches, radius=20<br/>ops: 15.01 ± 0.05 ops/s. best: 14.95ops/s.<br/>total: 4331.28 ± 14.91ms. best: 4308.34ms.<br/>avg: 66.64 ± 0.23ms<br/>min: 0.29 ± 0.00ms<br/>max: 1227.98 ± 7.82ms<br/>p99: 1227.98 ± 7.82ms | 500 matches, default radius<br/>ops: 218.05 ± 0.98 ops/s. best: 215.83ops/s.<br/>total: 261.41 ± 1.18ms. best: 260.16ms.<br/>avg: 4.59 ± 0.02ms<br/>min: 0.15 ± 0.01ms<br/>max: 24.40 ± 0.22ms<br/>p99: 24.40 ± 0.22ms<br/><br/>500 matches, radius=10<br/>ops: 65.04 ± 0.15 ops/s. best: 64.73ops/s.<br/>total: 984.03 ± 2.32ms. best: 981.86ms.<br/>avg: 15.38 ± 0.04ms<br/>min: 0.14 ± 0.00ms<br/>max: 236.46 ± 0.90ms<br/>p99: 236.46 ± 0.90ms<br/><br/>500 matches, radius=20<br/>ops: 15.43 ± 0.04 ops/s. best: 15.38ops/s.<br/>total: 4213.96 ± 10.64ms. best: 4196.50ms.<br/>avg: 64.83 ± 0.16ms<br/>min: 0.29 ± 0.00ms<br/>max: 1172.19 ± 6.10ms<br/>p99: 1172.19 ± 6.10ms |
| random_match_mld | 500 matches, default radius<br/>ops: 305.27 ± 1.99 ops/s. best: 300.32ops/s.<br/>total: 186.73 ± 1.24ms. best: 185.66ms.<br/>avg: 3.28 ± 0.02ms<br/>min: 0.13 ± 0.01ms<br/>max: 19.50 ± 0.06ms<br/>p99: 19.50 ± 0.06ms<br/><br/>500 matches, radius=10<br/>ops: 107.49 ± 0.04 ops/s. best: 107.44ops/s.<br/>total: 595.39 ± 0.23ms. best: 594.98ms.<br/>avg: 9.30 ± 0.00ms<br/>min: 0.13 ± 0.00ms<br/>max: 113.93 ± 0.13ms<br/>p99: 113.93 ± 0.13ms<br/><br/>500 matches, radius=20<br/>ops: 21.51 ± 0.05 ops/s. best: 21.41ops/s.<br/>total: 3022.12 ± 7.15ms. best: 3012.01ms.<br/>avg: 46.49 ± 0.11ms<br/>min: 0.19 ± 0.00ms<br/>max: 595.59 ± 1.21ms<br/>p99: 595.59 ± 1.21ms | 500 matches, default radius<br/>ops: 302.05 ± 1.75 ops/s. best: 298.00ops/s.<br/>total: 188.72 ± 1.14ms. best: 187.60ms.<br/>avg: 3.31 ± 0.02ms<br/>min: 0.13 ± 0.00ms<br/>max: 19.67 ± 0.09ms<br/>p99: 19.67 ± 0.09ms<br/><br/>500 matches, radius=10<br/>ops: 105.92 ± 0.31 ops/s. best: 105.52ops/s.<br/>total: 604.26 ± 1.74ms. best: 600.60ms.<br/>avg: 9.44 ± 0.03ms<br/>min: 0.13 ± 0.00ms<br/>max: 115.33 ± 0.28ms<br/>p99: 115.33 ± 0.28ms<br/><br/>500 matches, radius=20<br/>ops: 21.16 ± 0.07 ops/s. best: 21.00ops/s.<br/>total: 3071.67 ± 10.82ms. best: 3060.11ms.<br/>avg: 47.26 ± 0.17ms<br/>min: 0.20 ± 0.00ms<br/>max: 605.77 ± 2.52ms<br/>p99: 605.77 ± 2.52ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 22499.76 ± 43.27 ops/s. best: 22394.90ops/s.<br/>total: 444.45 ± 0.86ms. best: 443.73ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17647.67 ± 104.05 ops/s. best: 17400.05ops/s.<br/>total: 566.68 ± 3.37ms. best: 562.95ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14182.18 ± 12.65 ops/s. best: 14163.11ops/s.<br/>total: 705.11 ± 0.63ms. best: 704.00ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22625.93 ± 40.21 ops/s. best: 22533.52ops/s.<br/>total: 441.97 ± 0.81ms. best: 441.19ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17692.73 ± 114.82 ops/s. best: 17399.81ops/s.<br/>total: 565.24 ± 3.71ms. best: 562.53ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14248.14 ± 10.47 ops/s. best: 14224.36ops/s.<br/>total: 701.85 ± 0.51ms. best: 701.31ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 22707.62 ± 74.16 ops/s. best: 22534.42ops/s.<br/>total: 440.39 ± 1.44ms. best: 439.15ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17808.19 ± 12.68 ops/s. best: 17787.86ops/s.<br/>total: 561.54 ± 0.40ms. best: 560.82ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14206.39 ± 28.52 ops/s. best: 14139.77ops/s.<br/>total: 703.91 ± 1.42ms. best: 702.50ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22603.84 ± 39.14 ops/s. best: 22504.12ops/s.<br/>total: 442.40 ± 0.77ms. best: 441.80ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17801.65 ± 6.74 ops/s. best: 17791.48ops/s.<br/>total: 561.75 ± 0.21ms. best: 561.47ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14201.64 ± 14.90 ops/s. best: 14171.44ops/s.<br/>total: 704.15 ± 0.74ms. best: 703.17ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 476.88 ± 7.83 ops/s. best: 466.90ops/s.<br/>total: 2064.13 ± 33.75ms. best: 2015.29ms.<br/>avg: 2.10 ± 0.03ms<br/>min: 0.32 ± 0.01ms<br/>max: 3.86 ± 0.26ms<br/>p99: 3.02 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 573.74 ± 1.77 ops/s. best: 571.18ops/s.<br/>total: 1742.96 ± 5.36ms. best: 1734.24ms.<br/>avg: 1.74 ± 0.01ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.58 ± 0.04ms<br/>p99: 3.87 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 968.49 ± 6.13 ops/s. best: 955.95ops/s.<br/>total: 1016.07 ± 6.43ms. best: 1007.38ms.<br/>avg: 1.03 ± 0.01ms<br/>min: 0.26 ± 0.01ms<br/>max: 1.56 ± 0.05ms<br/>p99: 1.40 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1095.40 ± 4.57 ops/s. best: 1089.30ops/s.<br/>total: 912.93 ± 3.80ms. best: 906.00ms.<br/>avg: 0.91 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 2.50 ± 0.01ms<br/>p99: 2.13 ± 0.02ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 504.42 ± 1.85 ops/s. best: 501.30ops/s.<br/>total: 1950.80 ± 7.18ms. best: 1940.84ms.<br/>avg: 1.98 ± 0.01ms<br/>min: 0.32 ± 0.00ms<br/>max: 3.54 ± 0.26ms<br/>p99: 2.88 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 608.54 ± 2.37 ops/s. best: 604.07ops/s.<br/>total: 1643.32 ± 6.67ms. best: 1634.33ms.<br/>avg: 1.64 ± 0.01ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.41 ± 0.12ms<br/>p99: 3.62 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 988.03 ± 3.33 ops/s. best: 984.07ops/s.<br/>total: 995.93 ± 3.35ms. best: 989.83ms.<br/>avg: 1.01 ± 0.00ms<br/>min: 0.26 ± 0.00ms<br/>max: 1.63 ± 0.02ms<br/>p99: 1.38 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1159.75 ± 6.30 ops/s. best: 1148.94ops/s.<br/>total: 862.29 ± 4.76ms. best: 854.57ms.<br/>avg: 0.86 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 2.16 ± 0.12ms<br/>p99: 1.91 ± 0.01ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 245.77 ± 1.00 ops/s. best: 244.39ops/s.<br/>total: 4003.82 ± 16.50ms. best: 3980.70ms.<br/>avg: 4.07 ± 0.02ms<br/>min: 0.32 ± 0.01ms<br/>max: 8.78 ± 0.10ms<br/>p99: 6.82 ± 0.14ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 239.63 ± 0.74 ops/s. best: 238.97ops/s.<br/>total: 4173.22 ± 12.77ms. best: 4145.17ms.<br/>avg: 4.17 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.50 ± 0.18ms<br/>p99: 8.30 ± 0.05ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 330.24 ± 0.32 ops/s. best: 329.72ops/s.<br/>total: 2979.62 ± 2.82ms. best: 2975.29ms.<br/>avg: 3.03 ± 0.00ms<br/>min: 0.29 ± 0.00ms<br/>max: 7.21 ± 0.03ms<br/>p99: 5.15 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 302.10 ± 1.12 ops/s. best: 299.35ops/s.<br/>total: 3310.26 ± 12.47ms. best: 3299.49ms.<br/>avg: 3.31 ± 0.01ms<br/>min: 0.05 ± 0.01ms<br/>max: 7.61 ± 0.40ms<br/>p99: 6.46 ± 0.05ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 252.34 ± 1.71 ops/s. best: 248.27ops/s.<br/>total: 3899.70 ± 26.65ms. best: 3875.11ms.<br/>avg: 3.96 ± 0.03ms<br/>min: 0.31 ± 0.00ms<br/>max: 8.51 ± 0.03ms<br/>p99: 6.58 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 246.87 ± 0.44 ops/s. best: 245.98ops/s.<br/>total: 4050.65 ± 7.21ms. best: 4039.85ms.<br/>avg: 4.05 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.14 ± 0.06ms<br/>p99: 8.11 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 336.00 ± 1.31 ops/s. best: 333.30ops/s.<br/>total: 2928.59 ± 11.50ms. best: 2915.44ms.<br/>avg: 2.98 ± 0.01ms<br/>min: 0.29 ± 0.00ms<br/>max: 7.11 ± 0.04ms<br/>p99: 5.08 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 307.24 ± 0.69 ops/s. best: 306.06ops/s.<br/>total: 3254.82 ± 7.27ms. best: 3244.86ms.<br/>avg: 3.25 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.40 ± 0.18ms<br/>p99: 6.33 ± 0.02ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1430.34 ± 10.88 ops/s. best: 1402.98ops/s.<br/>total: 174.80 ± 1.35ms. best: 173.75ms.<br/>avg: 0.70 ± 0.01ms<br/>min: 0.52 ± 0.01ms<br/>max: 1.01 ± 0.26ms<br/>p99: 0.84 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 169.01 ± 0.44 ops/s. best: 168.06ops/s.<br/>total: 1479.22 ± 3.90ms. best: 1475.90ms.<br/>avg: 5.92 ± 0.02ms<br/>min: 5.32 ± 0.02ms<br/>max: 6.74 ± 0.41ms<br/>p99: 6.55 ± 0.30ms<br/><br/>250 tables, 50 coordinates<br/>ops: 83.45 ± 0.14 ops/s. best: 83.24ops/s.<br/>total: 2995.82 ± 5.03ms. best: 2986.36ms.<br/>avg: 11.98 ± 0.02ms<br/>min: 11.31 ± 0.03ms<br/>max: 12.85 ± 0.14ms<br/>p99: 12.69 ± 0.09ms | 250 tables, 3 coordinates<br/>ops: 1455.08 ± 7.87 ops/s. best: 1435.51ops/s.<br/>total: 171.82 ± 0.94ms. best: 171.07ms.<br/>avg: 0.69 ± 0.00ms<br/>min: 0.48 ± 0.00ms<br/>max: 0.99 ± 0.24ms<br/>p99: 0.84 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 172.13 ± 0.21 ops/s. best: 171.90ops/s.<br/>total: 1452.36 ± 1.75ms. best: 1449.87ms.<br/>avg: 5.81 ± 0.01ms<br/>min: 5.27 ± 0.01ms<br/>max: 6.40 ± 0.08ms<br/>p99: 6.29 ± 0.04ms<br/><br/>250 tables, 50 coordinates<br/>ops: 84.93 ± 0.04 ops/s. best: 84.88ops/s.<br/>total: 2943.61 ± 1.31ms. best: 2941.43ms.<br/>avg: 11.77 ± 0.01ms<br/>min: 11.03 ± 0.03ms<br/>max: 12.69 ± 0.18ms<br/>p99: 12.48 ± 0.03ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 344.02 ± 1.00 ops/s. best: 341.79ops/s.<br/>total: 726.72 ± 2.25ms. best: 724.07ms.<br/>avg: 2.91 ± 0.01ms<br/>min: 2.30 ± 0.01ms<br/>max: 4.01 ± 0.05ms<br/>p99: 3.82 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.31 ± 0.02 ops/s. best: 38.26ops/s.<br/>total: 6526.24 ± 4.25ms. best: 6519.78ms.<br/>avg: 26.10 ± 0.02ms<br/>min: 23.62 ± 0.18ms<br/>max: 29.95 ± 0.30ms<br/>p99: 29.01 ± 0.07ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.79 ± 0.01 ops/s. best: 17.77ops/s.<br/>total: 14049.15 ± 8.24ms. best: 14039.34ms.<br/>avg: 56.20 ± 0.03ms<br/>min: 52.30 ± 0.25ms<br/>max: 61.93 ± 2.53ms<br/>p99: 59.99 ± 0.36ms | 250 tables, 3 coordinates<br/>ops: 346.13 ± 1.24 ops/s. best: 343.15ops/s.<br/>total: 722.28 ± 2.59ms. best: 719.91ms.<br/>avg: 2.89 ± 0.01ms<br/>min: 2.28 ± 0.01ms<br/>max: 3.98 ± 0.06ms<br/>p99: 3.82 ± 0.06ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.47 ± 0.02 ops/s. best: 38.44ops/s.<br/>total: 6498.53 ± 3.09ms. best: 6493.94ms.<br/>avg: 25.99 ± 0.01ms<br/>min: 23.46 ± 0.03ms<br/>max: 29.69 ± 0.06ms<br/>p99: 28.65 ± 0.15ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.83 ± 0.01 ops/s. best: 17.80ops/s.<br/>total: 14023.88 ± 11.52ms. best: 14009.76ms.<br/>avg: 56.10 ± 0.05ms<br/>min: 52.22 ± 0.13ms<br/>max: 61.11 ± 0.85ms<br/>p99: 60.13 ± 0.76ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 466.31 ± 3.66 ops/s. best: 460.83ops/s.<br/>total: 536.17 ± 4.20ms. best: 529.57ms.<br/>avg: 2.14 ± 0.02ms<br/>min: 1.18 ± 0.02ms<br/>max: 2.98 ± 0.37ms<br/>p99: 2.73 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 309.80 ± 1.31 ops/s. best: 307.24ops/s.<br/>total: 807.00 ± 3.42ms. best: 803.07ms.<br/>avg: 3.23 ± 0.01ms<br/>min: 2.20 ± 0.04ms<br/>max: 3.96 ± 0.09ms<br/>p99: 3.86 ± 0.04ms | 250 trips, 3 coordinates<br/>ops: 474.83 ± 3.34 ops/s. best: 469.43ops/s.<br/>total: 526.54 ± 3.70ms. best: 521.00ms.<br/>avg: 2.11 ± 0.01ms<br/>min: 1.17 ± 0.01ms<br/>max: 2.93 ± 0.32ms<br/>p99: 2.69 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 317.23 ± 0.58 ops/s. best: 316.46ops/s.<br/>total: 788.07 ± 1.45ms. best: 785.33ms.<br/>avg: 3.15 ± 0.01ms<br/>min: 2.21 ± 0.03ms<br/>max: 3.92 ± 0.03ms<br/>p99: 3.77 ± 0.03ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 171.99 ± 0.75 ops/s. best: 170.68ops/s.<br/>total: 1453.57 ± 6.33ms. best: 1445.01ms.<br/>avg: 5.81 ± 0.03ms<br/>min: 3.85 ± 0.01ms<br/>max: 7.80 ± 0.26ms<br/>p99: 7.43 ± 0.05ms<br/><br/>250 trips, 5 coordinates<br/>ops: 112.41 ± 0.39 ops/s. best: 111.42ops/s.<br/>total: 2223.95 ± 7.82ms. best: 2218.13ms.<br/>avg: 8.90 ± 0.03ms<br/>min: 6.32 ± 0.05ms<br/>max: 11.15 ± 0.21ms<br/>p99: 10.71 ± 0.12ms | 250 trips, 3 coordinates<br/>ops: 173.84 ± 0.71 ops/s. best: 172.50ops/s.<br/>total: 1438.11 ± 5.91ms. best: 1430.80ms.<br/>avg: 5.75 ± 0.02ms<br/>min: 3.84 ± 0.02ms<br/>max: 7.81 ± 0.27ms<br/>p99: 7.36 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 113.35 ± 0.28 ops/s. best: 112.78ops/s.<br/>total: 2205.59 ± 5.79ms. best: 2199.16ms.<br/>avg: 8.82 ± 0.02ms<br/>min: 6.27 ± 0.02ms<br/>max: 11.22 ± 0.41ms<br/>p99: 10.64 ± 0.18ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>465.923ms<br/>0.465923ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>565.498ms<br/>0.565498ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>163.86ms<br/>0.16386ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>146.612ms<br/>0.146612ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>451.329ms<br/>0.451329ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>546.442ms<br/>0.546442ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>162.741ms<br/>0.162741ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>146.532ms<br/>0.146532ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>601.328ms<br/>0.601328ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>762.671ms<br/>0.762671ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>294.626ms<br/>0.294626ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>321.88ms<br/>0.32188ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>584.587ms<br/>0.584587ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>741.682ms<br/>0.741682ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>292.347ms<br/>0.292347ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>315.215ms<br/>0.315215ms/req |
| rtree | 1 result:<br/>208.863ms ->  0.0208863 ms/query<br/>10 results:<br/>245.57ms ->  0.024557 ms/query | 1 result:<br/>210.041ms ->  0.0210041 ms/query<br/>10 results:<br/>246.856ms ->  0.0246856 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->



