### PR TITLE
Apply micro-optimisation for Nearest API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Apply micro-optimisation for Nearest API. [#6944](https://github.com/Project-OSRM/osrm-backend/pull/6944)
       - CHANGED: Avoid copy of intersection in totalTurnAngle. [#6938](https://github.com/Project-OSRM/osrm-backend/pull/6938)
       - CHANGED: Use std::unordered_map::emplace instead of operator[] when producing JSONs. [#6936](https://github.com/Project-OSRM/osrm-backend/pull/6936)
       - CHANGED: Avoid copy of vectors in MakeRoute function. [#6939](https://github.com/Project-OSRM/osrm-backend/pull/6939)

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -100,23 +100,23 @@ class NearestAPI final : public BaseAPI
                                auto waypoint = MakeWaypoint({phantom_node});
 
                                util::json::Array nodes;
+                               nodes.values.reserve(2);
 
                                auto node_values = MakeNodes(phantom_node);
 
                                nodes.values.push_back(node_values.first);
                                nodes.values.push_back(node_values.second);
-                               waypoint.values["nodes"] = std::move(nodes);
-
+                               waypoint.values.emplace("nodes", std::move(nodes));
                                return waypoint;
                            });
-            response.values["waypoints"] = std::move(waypoints);
+            response.values.emplace("waypoints", std::move(waypoints));
         }
 
-        response.values["code"] = "Ok";
+        response.values.emplace("code", "Ok")
         auto data_timestamp = facade.GetTimestamp();
         if (!data_timestamp.empty())
         {
-            response.values["data_version"] = data_timestamp;
+            response.values.emplace("data_version", data_timestamp);
         }
     }
 

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -112,7 +112,8 @@ class NearestAPI final : public BaseAPI
             response.values.emplace("waypoints", std::move(waypoints));
         }
 
-        response.values.emplace("code", "Ok") auto data_timestamp = facade.GetTimestamp();
+        response.values.emplace("code", "Ok");
+        auto data_timestamp = facade.GetTimestamp();
         if (!data_timestamp.empty())
         {
             response.values.emplace("data_version", data_timestamp);

--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -104,16 +104,15 @@ class NearestAPI final : public BaseAPI
 
                                auto node_values = MakeNodes(phantom_node);
 
-                               nodes.values.push_back(node_values.first);
-                               nodes.values.push_back(node_values.second);
+                               nodes.values.emplace_back(node_values.first);
+                               nodes.values.emplace_back(node_values.second);
                                waypoint.values.emplace("nodes", std::move(nodes));
                                return waypoint;
                            });
             response.values.emplace("waypoints", std::move(waypoints));
         }
 
-        response.values.emplace("code", "Ok")
-        auto data_timestamp = facade.GetTimestamp();
+        response.values.emplace("code", "Ok") auto data_timestamp = facade.GetTimestamp();
         if (!data_timestamp.empty())
         {
             response.values.emplace("data_version", data_timestamp);


### PR DESCRIPTION

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1145.34<br/>plain u32: 1149.98<br/>aliased double: 1179.64<br/>plain double: 1192.66 | aliased u32: 1093.72<br/>plain u32: 1131.29<br/>aliased double: 1168.26<br/>plain double: 1171.98 |
| e2e_match_ch | Total: 2827.2507190704346ms<br/>Min time: 2.2933483123779297ms<br/>Mean time: 21.582066557789577ms<br/>Median time: 16.03388786315918ms<br/>95th percentile: 67.4886703491211ms<br/>99th percentile: 81.91697597503659ms<br/>Max time: 95.11971473693848ms | Total: 2823.749303817749ms<br/>Min time: 2.3796558380126953ms<br/>Mean time: 21.555338197082055ms<br/>Median time: 15.394449234008789ms<br/>95th percentile: 68.82917881011963ms<br/>99th percentile: 79.67803478240957ms<br/>Max time: 94.30909156799316ms |
| e2e_match_mld | Total: 1999.7878074645996ms<br/>Min time: 2.000570297241211ms<br/>Mean time: 15.265555782172516ms<br/>Median time: 8.515596389770508ms<br/>95th percentile: 48.87831211090088ms<br/>99th percentile: 57.36389160156246ms<br/>Max time: 65.96827507019043ms | Total: 2052.5119304656982ms<br/>Min time: 2.173900604248047ms<br/>Mean time: 15.668030003554948ms<br/>Median time: 8.544921875ms<br/>95th percentile: 49.44658279418945ms<br/>99th percentile: 59.89720821380608ms<br/>Max time: 66.8337345123291ms |
| e2e_nearest_ch | Total: 1347.1250534057617ms<br/>Min time: 1.1489391326904297ms<br/>Mean time: 1.3471250534057617ms<br/>Median time: 1.2611150741577148ms<br/>95th percentile: 1.756429672241211ms<br/>99th percentile: 1.80006742477417ms<br/>Max time: 2.040863037109375ms | Total: 1346.2340831756592ms<br/>Min time: 1.1529922485351562ms<br/>Mean time: 1.3462340831756592ms<br/>Median time: 1.2608766555786133ms<br/>95th percentile: 1.7548084259033203ms<br/>99th percentile: 1.8017292022705078ms<br/>Max time: 1.8515586853027344ms |
| e2e_nearest_mld | Total: 1348.1388092041016ms<br/>Min time: 1.1501312255859375ms<br/>Mean time: 1.3481388092041016ms<br/>Median time: 1.2621879577636719ms<br/>95th percentile: 1.7624258995056152ms<br/>99th percentile: 1.8089103698730469ms<br/>Max time: 1.9879341125488281ms | Total: 1346.149206161499ms<br/>Min time: 1.15203857421875ms<br/>Mean time: 1.346149206161499ms<br/>Median time: 1.2623071670532227ms<br/>95th percentile: 1.7604827880859375ms<br/>99th percentile: 1.793665885925293ms<br/>Max time: 1.8453598022460938ms |
| e2e_route_ch | Total: 3016.108989715576ms<br/>Min time: 1.3649463653564453ms<br/>Mean time: 3.016108989715576ms<br/>Median time: 3.042936325073242ms<br/>95th percentile: 3.941011428833008ms<br/>99th percentile: 4.294607639312744ms<br/>Max time: 4.815578460693359ms | Total: 2976.4835834503174ms<br/>Min time: 1.3120174407958984ms<br/>Mean time: 2.9764835834503174ms<br/>Median time: 3.0069351196289062ms<br/>95th percentile: 3.8865208625793453ms<br/>99th percentile: 4.2594218254089355ms<br/>Max time: 4.8427581787109375ms |
| e2e_route_mld | Total: 3590.3491973876953ms<br/>Min time: 1.3265609741210938ms<br/>Mean time: 3.5903491973876953ms<br/>Median time: 3.617405891418457ms<br/>95th percentile: 4.906761646270752ms<br/>99th percentile: 5.32177209854126ms<br/>Max time: 5.858898162841797ms | Total: 3548.17271232605ms<br/>Min time: 1.3325214385986328ms<br/>Mean time: 3.54817271232605ms<br/>Median time: 3.575563430786133ms<br/>95th percentile: 4.837954044342041ms<br/>99th percentile: 5.297956466674804ms<br/>Max time: 5.862951278686523ms |
| e2e_table_ch | Total: 17027.583122253418ms<br/>Min time: 2.0112991333007812ms<br/>Mean time: 17.027583122253418ms<br/>Median time: 16.41261577606201ms<br/>95th percentile: 31.283020973205566ms<br/>99th percentile: 33.1856632232666ms<br/>Max time: 34.3937873840332ms | Total: 15598.774433135986ms<br/>Min time: 1.9397735595703125ms<br/>Mean time: 15.598774433135986ms<br/>Median time: 14.980316162109375ms<br/>95th percentile: 28.541862964630123ms<br/>99th percentile: 29.987568855285645ms<br/>Max time: 31.16440773010254ms |
| e2e_table_mld | Total: 63519.60635185242ms<br/>Min time: 3.9594173431396484ms<br/>Mean time: 63.51960635185242ms<br/>Median time: 60.157060623168945ms<br/>95th percentile: 122.541606426239ms<br/>99th percentile: 130.3108024597168ms<br/>Max time: 132.57598876953125ms | Total: 63550.75454711914ms<br/>Min time: 3.948688507080078ms<br/>Mean time: 63.55075454711914ms<br/>Median time: 60.166001319885254ms<br/>95th percentile: 122.50025272369385ms<br/>99th percentile: 130.46877145767212ms<br/>Max time: 134.42659378051758ms |
| e2e_trip_ch | Total: 10711.437940597534ms<br/>Min time: 1.561880111694336ms<br/>Mean time: 10.711437940597534ms<br/>Median time: 10.20514965057373ms<br/>95th percentile: 18.74927282333374ms<br/>99th percentile: 20.382859706878662ms<br/>Max time: 21.76070213317871ms | Total: 10629.547595977783ms<br/>Min time: 1.5106201171875ms<br/>Mean time: 10.629547595977783ms<br/>Median time: 10.111808776855469ms<br/>95th percentile: 18.554532527923584ms<br/>99th percentile: 20.062847137451172ms<br/>Max time: 21.372318267822266ms |
| e2e_trip_mld | Total: 17376.693964004517ms<br/>Min time: 1.6024112701416016ms<br/>Mean time: 17.376693964004517ms<br/>Median time: 17.000198364257812ms<br/>95th percentile: 28.43571901321411ms<br/>99th percentile: 30.183522701263428ms<br/>Max time: 32.52220153808594ms | Total: 17347.61929512024ms<br/>Min time: 1.481771469116211ms<br/>Mean time: 17.34761929512024ms<br/>Median time: 16.957640647888184ms<br/>95th percentile: 28.17518711090088ms<br/>99th percentile: 29.80940341949463ms<br/>Max time: 31.943321228027344ms |
| json-render | String: 6.62835ms<br/>Stringstream: 9.36398ms<br/>Vector: 6.95289ms | String: 6.60315ms<br/>Stringstream: 9.3637ms<br/>Vector: 6.91963ms |
| match_ch | Default radius: <br/>4.43297ms/req at 82 coordinate<br/>0.0540606ms/coordinate<br/>Radius 5m: <br/>4.42405ms/req at 82 coordinate<br/>0.0539518ms/coordinate<br/>Radius 10m: <br/>15.0165ms/req at 82 coordinate<br/>0.183128ms/coordinate<br/>Radius 15m: <br/>36.7651ms/req at 82 coordinate<br/>0.448355ms/coordinate<br/>Radius 30m: <br/>314.164ms/req at 82 coordinate<br/>3.83127ms/coordinate | Default radius: <br/>4.44841ms/req at 82 coordinate<br/>0.0542489ms/coordinate<br/>Radius 5m: <br/>4.43564ms/req at 82 coordinate<br/>0.0540932ms/coordinate<br/>Radius 10m: <br/>15.1072ms/req at 82 coordinate<br/>0.184234ms/coordinate<br/>Radius 15m: <br/>36.7559ms/req at 82 coordinate<br/>0.448243ms/coordinate<br/>Radius 30m: <br/>314.168ms/req at 82 coordinate<br/>3.83131ms/coordinate |
| match_mld | Default radius: <br/>2.79622ms/req at 82 coordinate<br/>0.0341003ms/coordinate<br/>Radius 5m: <br/>2.9402ms/req at 82 coordinate<br/>0.0358561ms/coordinate<br/>Radius 10m: <br/>10.2652ms/req at 82 coordinate<br/>0.125185ms/coordinate<br/>Radius 15m: <br/>26.0183ms/req at 82 coordinate<br/>0.317296ms/coordinate<br/>Radius 30m: <br/>306.713ms/req at 82 coordinate<br/>3.7404ms/coordinate | Default radius: <br/>2.76649ms/req at 82 coordinate<br/>0.0337377ms/coordinate<br/>Radius 5m: <br/>2.75494ms/req at 82 coordinate<br/>0.0335969ms/coordinate<br/>Radius 10m: <br/>10.0997ms/req at 82 coordinate<br/>0.123167ms/coordinate<br/>Radius 15m: <br/>26.1103ms/req at 82 coordinate<br/>0.318419ms/coordinate<br/>Radius 30m: <br/>303.224ms/req at 82 coordinate<br/>3.69785ms/coordinate |
| osrm_contract | Time: 91.61s Peak RAM: 185.92MB | Time: 92.92s Peak RAM: 187.78MB |
| osrm_customize | Time: 1.31s Peak RAM: 115.05MB | Time: 1.30s Peak RAM: 115.11MB |
| osrm_extract | Time: 12.00s Peak RAM: 408.99MB | Time: 12.10s Peak RAM: 422.53MB |
| osrm_partition | Time: 2.14s Peak RAM: 148.87MB | Time: 2.14s Peak RAM: 148.73MB |
| packedvector | random write:<br/>std::vector 11189 ms<br/>util::packed_vector 73940.7 ms<br/>slowdown: 6.60833<br/>random read:<br/>std::vector 11053.7 ms<br/>util::packed_vector 29975.5 ms<br/>slowdown: 2.71179 | random write:<br/>std::vector 9768.61 ms<br/>util::packed_vector 81744 ms<br/>slowdown: 8.36803<br/>random read:<br/>std::vector 8420.26 ms<br/>util::packed_vector 33482.1 ms<br/>slowdown: 3.97638 |
| random_match_ch | 1000 matches, default radius<br/>total: 6860.11ms<br/>avg: 6.86ms<br/>min: 0.00ms<br/>max: 489.97ms<br/>p99: 106.60ms<br/><br/>1000 matches, radius=10<br/>total: 35305.53ms<br/>avg: 35.31ms<br/>min: 0.00ms<br/>max: 1965.51ms<br/>p99: 1944.21ms<br/><br/>1000 matches, radius=20<br/>total: 68405.36ms<br/>avg: 68.41ms<br/>min: 0.00ms<br/>max: 9639.37ms<br/>p99: 1223.79ms | 1000 matches, default radius<br/>total: 6757.68ms<br/>avg: 6.76ms<br/>min: 0.00ms<br/>max: 468.29ms<br/>p99: 103.72ms<br/><br/>1000 matches, radius=10<br/>total: 34261.68ms<br/>avg: 34.26ms<br/>min: 0.00ms<br/>max: 1857.71ms<br/>p99: 1846.18ms<br/><br/>1000 matches, radius=20<br/>total: 66590.79ms<br/>avg: 66.59ms<br/>min: 0.00ms<br/>max: 9143.80ms<br/>p99: 1158.84ms |
| random_match_mld | 1000 matches, default radius<br/>total: 5121.34ms<br/>avg: 5.12ms<br/>min: 0.00ms<br/>max: 381.88ms<br/>p99: 69.13ms<br/><br/>1000 matches, radius=10<br/>total: 26734.44ms<br/>avg: 26.73ms<br/>min: 0.00ms<br/>max: 1551.40ms<br/>p99: 1538.35ms<br/><br/>1000 matches, radius=20<br/>total: 52853.21ms<br/>avg: 52.85ms<br/>min: 0.00ms<br/>max: 7000.92ms<br/>p99: 799.31ms | 1000 matches, default radius<br/>total: 5137.30ms<br/>avg: 5.14ms<br/>min: 0.00ms<br/>max: 381.96ms<br/>p99: 69.51ms<br/><br/>1000 matches, radius=10<br/>total: 26798.95ms<br/>avg: 26.80ms<br/>min: 0.00ms<br/>max: 1565.25ms<br/>p99: 1538.03ms<br/><br/>1000 matches, radius=20<br/>total: 53053.33ms<br/>avg: 53.05ms<br/>min: 0.00ms<br/>max: 7002.70ms<br/>p99: 820.54ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>total: 451.53ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.23ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 612.83ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.16ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 777.43ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.18ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 451.59ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.23ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 609.38ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.16ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 768.90ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.17ms<br/>p99: 0.14ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>total: 453.46ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.26ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 615.42ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.16ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 785.22ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.20ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 452.38ms<br/>avg: 0.05ms<br/>min: 0.01ms<br/>max: 0.26ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 609.00ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.13ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 769.49ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.17ms<br/>p99: 0.14ms |
| random_route_ch | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 21048.40ms<br/>avg: 2.10ms<br/>min: 0.14ms<br/>max: 3.93ms<br/>p99: 3.11ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 9754.91ms<br/>avg: 0.98ms<br/>min: 0.07ms<br/>max: 1.99ms<br/>p99: 1.56ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 18149.54ms<br/>avg: 1.81ms<br/>min: 0.06ms<br/>max: 5.30ms<br/>p99: 4.07ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 10601.05ms<br/>avg: 1.06ms<br/>min: 0.08ms<br/>max: 2.10ms<br/>p99: 1.50ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4238.74ms<br/>avg: 0.42ms<br/>min: 0.05ms<br/>max: 0.76ms<br/>p99: 0.62ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 9782.45ms<br/>avg: 0.98ms<br/>min: 0.06ms<br/>max: 5.10ms<br/>p99: 2.33ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 650.68ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 1.50ms<br/>p99: 0.68ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 672.88ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.51ms<br/>p99: 0.41ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 924.57ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 2.38ms<br/>p99: 1.26ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 20370.96ms<br/>avg: 2.04ms<br/>min: 0.15ms<br/>max: 3.82ms<br/>p99: 3.01ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 9576.94ms<br/>avg: 0.96ms<br/>min: 0.08ms<br/>max: 1.88ms<br/>p99: 1.54ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 17669.61ms<br/>avg: 1.77ms<br/>min: 0.06ms<br/>max: 5.54ms<br/>p99: 3.83ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 9908.69ms<br/>avg: 0.99ms<br/>min: 0.08ms<br/>max: 1.88ms<br/>p99: 1.40ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4061.75ms<br/>avg: 0.41ms<br/>min: 0.05ms<br/>max: 0.73ms<br/>p99: 0.59ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 8965.15ms<br/>avg: 0.90ms<br/>min: 0.05ms<br/>max: 2.89ms<br/>p99: 2.14ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 643.65ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 1.26ms<br/>p99: 0.65ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 667.72ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.52ms<br/>p99: 0.39ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 888.92ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 2.28ms<br/>p99: 1.14ms |
| random_route_mld | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 40083.74ms<br/>avg: 4.01ms<br/>min: 0.12ms<br/>max: 9.81ms<br/>p99: 6.86ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 14472.37ms<br/>avg: 1.45ms<br/>min: 0.07ms<br/>max: 3.78ms<br/>p99: 2.53ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 40900.68ms<br/>avg: 4.09ms<br/>min: 0.06ms<br/>max: 11.03ms<br/>p99: 8.23ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 29437.63ms<br/>avg: 2.94ms<br/>min: 0.07ms<br/>max: 9.46ms<br/>p99: 5.20ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 8837.59ms<br/>avg: 0.88ms<br/>min: 0.04ms<br/>max: 2.04ms<br/>p99: 1.55ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 32042.97ms<br/>avg: 3.20ms<br/>min: 0.05ms<br/>max: 8.52ms<br/>p99: 6.43ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 828.86ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 4.33ms<br/>p99: 1.54ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 917.54ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.46ms<br/>p99: 1.02ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1692.93ms<br/>avg: 0.17ms<br/>min: 0.01ms<br/>max: 4.94ms<br/>p99: 3.50ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 40485.32ms<br/>avg: 4.05ms<br/>min: 0.13ms<br/>max: 10.73ms<br/>p99: 6.91ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 14432.46ms<br/>avg: 1.44ms<br/>min: 0.07ms<br/>max: 2.83ms<br/>p99: 2.50ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 40869.69ms<br/>avg: 4.09ms<br/>min: 0.06ms<br/>max: 9.50ms<br/>p99: 8.17ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 29912.20ms<br/>avg: 2.99ms<br/>min: 0.08ms<br/>max: 9.40ms<br/>p99: 5.28ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 8892.77ms<br/>avg: 0.89ms<br/>min: 0.05ms<br/>max: 2.12ms<br/>p99: 1.56ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 32330.67ms<br/>avg: 3.23ms<br/>min: 0.05ms<br/>max: 9.21ms<br/>p99: 6.54ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 837.66ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 4.49ms<br/>p99: 1.59ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 908.38ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.28ms<br/>p99: 1.00ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1703.98ms<br/>avg: 0.17ms<br/>min: 0.01ms<br/>max: 4.97ms<br/>p99: 3.52ms |
| random_table_ch | 250 tables, 3 coordinates<br/>total: 191.38ms<br/>avg: 0.77ms<br/>min: 0.50ms<br/>max: 1.94ms<br/>p99: 1.01ms<br/><br/>250 tables, 25 coordinates<br/>total: 1581.38ms<br/>avg: 6.33ms<br/>min: 5.71ms<br/>max: 7.00ms<br/>p99: 6.82ms<br/><br/>250 tables, 50 coordinates<br/>total: 3207.59ms<br/>avg: 12.83ms<br/>min: 11.83ms<br/>max: 13.70ms<br/>p99: 13.58ms<br/><br/>250 tables, 100 coordinates<br/>total: 6885.38ms<br/>avg: 27.54ms<br/>min: 25.78ms<br/>max: 28.84ms<br/>p99: 28.78ms | 250 tables, 3 coordinates<br/>total: 174.89ms<br/>avg: 0.70ms<br/>min: 0.46ms<br/>max: 1.71ms<br/>p99: 0.99ms<br/><br/>250 tables, 25 coordinates<br/>total: 1432.48ms<br/>avg: 5.73ms<br/>min: 5.23ms<br/>max: 6.25ms<br/>p99: 6.17ms<br/><br/>250 tables, 50 coordinates<br/>total: 2897.14ms<br/>avg: 11.59ms<br/>min: 10.86ms<br/>max: 12.39ms<br/>p99: 12.34ms<br/><br/>250 tables, 100 coordinates<br/>total: 6197.79ms<br/>avg: 24.79ms<br/>min: 23.61ms<br/>max: 26.12ms<br/>p99: 25.71ms |
| random_table_mld | 250 tables, 3 coordinates<br/>total: 728.85ms<br/>avg: 2.92ms<br/>min: 2.30ms<br/>max: 4.06ms<br/>p99: 3.93ms<br/><br/>250 tables, 25 coordinates<br/>total: 6816.47ms<br/>avg: 27.27ms<br/>min: 24.55ms<br/>max: 30.79ms<br/>p99: 30.09ms<br/><br/>250 tables, 50 coordinates<br/>total: 14555.03ms<br/>avg: 58.22ms<br/>min: 54.04ms<br/>max: 61.89ms<br/>p99: 61.69ms<br/><br/>250 tables, 100 coordinates<br/>total: 31155.07ms<br/>avg: 124.62ms<br/>min: 119.68ms<br/>max: 134.91ms<br/>p99: 131.54ms | 250 tables, 3 coordinates<br/>total: 726.03ms<br/>avg: 2.90ms<br/>min: 2.28ms<br/>max: 4.13ms<br/>p99: 3.94ms<br/><br/>250 tables, 25 coordinates<br/>total: 6837.23ms<br/>avg: 27.35ms<br/>min: 24.31ms<br/>max: 33.60ms<br/>p99: 30.69ms<br/><br/>250 tables, 50 coordinates<br/>total: 14636.04ms<br/>avg: 58.54ms<br/>min: 53.88ms<br/>max: 62.92ms<br/>p99: 62.27ms<br/><br/>250 tables, 100 coordinates<br/>total: 31751.17ms<br/>avg: 127.00ms<br/>min: 121.70ms<br/>max: 134.97ms<br/>p99: 133.80ms |
| random_trip_ch | 1000 trips, 3 coordinates<br/>total: 2216.20ms<br/>avg: 2.22ms<br/>min: 0.81ms<br/>max: 3.97ms<br/>p99: 2.80ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2782.27ms<br/>avg: 2.78ms<br/>min: 1.30ms<br/>max: 3.63ms<br/>p99: 3.42ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3343.06ms<br/>avg: 3.34ms<br/>min: 2.14ms<br/>max: 4.62ms<br/>p99: 4.10ms | 1000 trips, 3 coordinates<br/>total: 2078.79ms<br/>avg: 2.08ms<br/>min: 0.68ms<br/>max: 3.78ms<br/>p99: 2.66ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2576.05ms<br/>avg: 2.58ms<br/>min: 1.02ms<br/>max: 3.45ms<br/>p99: 3.14ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3085.07ms<br/>avg: 3.09ms<br/>min: 1.90ms<br/>max: 3.95ms<br/>p99: 3.76ms |
| random_trip_mld | 1000 trips, 3 coordinates<br/>total: 5803.24ms<br/>avg: 5.80ms<br/>min: 2.69ms<br/>max: 8.39ms<br/>p99: 7.65ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7404.55ms<br/>avg: 7.40ms<br/>min: 3.77ms<br/>max: 10.18ms<br/>p99: 9.33ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9008.40ms<br/>avg: 9.01ms<br/>min: 5.50ms<br/>max: 11.32ms<br/>p99: 10.86ms | 1000 trips, 3 coordinates<br/>total: 5773.19ms<br/>avg: 5.77ms<br/>min: 2.68ms<br/>max: 8.29ms<br/>p99: 7.67ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7363.63ms<br/>avg: 7.36ms<br/>min: 3.76ms<br/>max: 10.14ms<br/>p99: 9.30ms<br/><br/>1000 trips, 5 coordinates<br/>total: 8950.18ms<br/>avg: 8.95ms<br/>min: 5.49ms<br/>max: 11.32ms<br/>p99: 10.90ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>507.291ms<br/>0.507291ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>337.989ms<br/>0.337989ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>606.611ms<br/>0.606611ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.168ms<br/>0.151168ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>98.4957ms<br/>0.0984957ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>133.648ms<br/>0.133648ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.343ms<br/>0.150343ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>98.4085ms<br/>0.0984085ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>144.464ms<br/>0.144464ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>490.67ms<br/>0.49067ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>333.249ms<br/>0.333249ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>598.617ms<br/>0.598617ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.524ms<br/>0.151524ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.6706ms<br/>0.0976706ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.296ms<br/>0.132296ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.831ms<br/>0.151831ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.9458ms<br/>0.0979458ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.452ms<br/>0.132452ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>621.173ms<br/>0.621173ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>426.155ms<br/>0.426155ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>783.656ms<br/>0.783656ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>268.404ms<br/>0.268404ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>159.731ms<br/>0.159731ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>281.878ms<br/>0.281878ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>259.708ms<br/>0.259708ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>158.72ms<br/>0.15872ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>282.268ms<br/>0.282268ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>621.481ms<br/>0.621481ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>430.749ms<br/>0.430749ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>781.921ms<br/>0.781921ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>265.946ms<br/>0.265946ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>162.041ms<br/>0.162041ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>289.693ms<br/>0.289693ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>265.578ms<br/>0.265578ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.513ms<br/>0.161513ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>288.256ms<br/>0.288256ms/req |
| rtree | 1 result:<br/>207.4ms ->  0.02074 ms/query<br/>10 results:<br/>242.292ms ->  0.0242292 ms/query | 1 result:<br/>207.136ms ->  0.0207136 ms/query<br/>10 results:<br/>242.688ms ->  0.0242688 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
