### PR TITLE
Apply micro-optimisation for Match API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Apply micro-optimisation for Match API. [#6945](https://github.com/Project-OSRM/osrm-backend/pull/6945)
       - CHANGED: Avoid copy of intersection in totalTurnAngle. [#6938](https://github.com/Project-OSRM/osrm-backend/pull/6938)
       - CHANGED: Use std::unordered_map::emplace instead of operator[] when producing JSONs. [#6936](https://github.com/Project-OSRM/osrm-backend/pull/6936)
       - CHANGED: Avoid copy of vectors in MakeRoute function. [#6939](https://github.com/Project-OSRM/osrm-backend/pull/6939)

--- a/include/engine/api/match_api.hpp
+++ b/include/engine/api/match_api.hpp
@@ -209,12 +209,12 @@ class MatchAPI final : public RouteAPI
             {
                 if (tidy_result.was_waypoint[trace_index])
                 {
-                    waypoint.values.emplace("waypoint_index", was_waypoint_idx);
+                    waypoint.values["waypoint_index"] = was_waypoint_idx;
                     was_waypoint_idx++;
                 }
                 else
                 {
-                    waypoint.values.emplace("waypoint_index", util::json::Null());
+                    waypoint.values["waypoint_index"] = util::json::Null();
                 }
             }
             waypoints.values.emplace_back(std::move(waypoint));


### PR DESCRIPTION




<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1130.35<br/>plain u32: 1135.17<br/>aliased double: 1172.4<br/>plain double: 1173.32 | aliased u32: 1123.59<br/>plain u32: 1137.12<br/>aliased double: 1173.1<br/>plain double: 1165.7 |
| e2e_match_ch | Total: 2870.2380657196045ms<br/>Min time: 2.3708343505859375ms<br/>Mean time: 21.910214242134387ms<br/>Median time: 14.554738998413086ms<br/>95th percentile: 70.37889957427979ms<br/>99th percentile: 85.39102077484125ms<br/>Max time: 99.16257858276367ms | Total: 2846.4114665985107ms<br/>Min time: 2.3627281188964844ms<br/>Mean time: 21.7283318060955ms<br/>Median time: 14.681577682495117ms<br/>95th percentile: 69.01681423187256ms<br/>99th percentile: 85.01303195953363ms<br/>Max time: 97.34940528869629ms |
| e2e_match_mld | Total: 2006.1631202697754ms<br/>Min time: 2.0728111267089844ms<br/>Mean time: 15.31422229213569ms<br/>Median time: 8.412361145019531ms<br/>95th percentile: 49.44324493408203ms<br/>99th percentile: 57.456326484680126ms<br/>Max time: 66.32256507873535ms | Total: 2006.0455799102783ms<br/>Min time: 2.0685195922851562ms<br/>Mean time: 15.313325037483041ms<br/>Median time: 8.675098419189453ms<br/>95th percentile: 48.84481430053711ms<br/>99th percentile: 57.733106613159116ms<br/>Max time: 67.48223304748535ms |
| e2e_nearest_ch | Total: 1341.6495323181152ms<br/>Min time: 1.1527538299560547ms<br/>Mean time: 1.3416495323181152ms<br/>Median time: 1.2519359588623047ms<br/>95th percentile: 1.7429471015930176ms<br/>99th percentile: 1.8093609809875488ms<br/>Max time: 1.9485950469970703ms | Total: 1353.553056716919ms<br/>Min time: 1.1625289916992188ms<br/>Mean time: 1.353553056716919ms<br/>Median time: 1.2639760971069336ms<br/>95th percentile: 1.7681360244750977ms<br/>99th percentile: 1.8150949478149414ms<br/>Max time: 1.8911361694335938ms |
| e2e_nearest_mld | Total: 1347.884178161621ms<br/>Min time: 1.155853271484375ms<br/>Mean time: 1.347884178161621ms<br/>Median time: 1.2627840042114258ms<br/>95th percentile: 1.7524480819702148ms<br/>99th percentile: 1.8015289306640625ms<br/>Max time: 1.8694400787353516ms | Total: 1340.8660888671875ms<br/>Min time: 1.142740249633789ms<br/>Mean time: 1.3408660888671875ms<br/>Median time: 1.2514591217041016ms<br/>95th percentile: 1.7429351806640625ms<br/>99th percentile: 1.8061423301696777ms<br/>Max time: 2.12860107421875ms |
| e2e_route_ch | Total: 2996.907949447632ms<br/>Min time: 1.3308525085449219ms<br/>Mean time: 2.996907949447632ms<br/>Median time: 3.007650375366211ms<br/>95th percentile: 3.912854194641113ms<br/>99th percentile: 4.37152624130249ms<br/>Max time: 4.978656768798828ms | Total: 2958.2133293151855ms<br/>Min time: 1.337289810180664ms<br/>Mean time: 2.9582133293151855ms<br/>Median time: 2.967357635498047ms<br/>95th percentile: 3.873443603515625ms<br/>99th percentile: 4.227163791656494ms<br/>Max time: 4.896879196166992ms |
| e2e_route_mld | Total: 3553.4064769744873ms<br/>Min time: 1.3337135314941406ms<br/>Mean time: 3.5534064769744873ms<br/>Median time: 3.586411476135254ms<br/>95th percentile: 4.822790622711182ms<br/>99th percentile: 5.246586799621582ms<br/>Max time: 5.907535552978516ms | Total: 3506.2034130096436ms<br/>Min time: 1.2598037719726562ms<br/>Mean time: 3.5062034130096436ms<br/>Median time: 3.5309791564941406ms<br/>95th percentile: 4.78682518005371ms<br/>99th percentile: 5.198843479156494ms<br/>Max time: 5.867242813110352ms |
| e2e_table_ch | Total: 15892.247676849365ms<br/>Min time: 1.981973648071289ms<br/>Mean time: 15.892247676849365ms<br/>Median time: 15.167236328125ms<br/>95th percentile: 29.24211025238037ms<br/>99th percentile: 30.718016624450684ms<br/>Max time: 31.82053565979004ms | Total: 15921.71859741211ms<br/>Min time: 1.9767284393310547ms<br/>Mean time: 15.92171859741211ms<br/>Median time: 15.18106460571289ms<br/>95th percentile: 29.351699352264404ms<br/>99th percentile: 30.829646587371826ms<br/>Max time: 32.00483322143555ms |
| e2e_table_mld | Total: 62805.75919151306ms<br/>Min time: 4.035472869873047ms<br/>Mean time: 62.80575919151306ms<br/>Median time: 59.78107452392578ms<br/>95th percentile: 120.96208333969116ms<br/>99th percentile: 128.30715894699097ms<br/>Max time: 131.50334358215332ms | Total: 63432.37566947937ms<br/>Min time: 3.994464874267578ms<br/>Mean time: 63.43237566947937ms<br/>Median time: 60.02664566040039ms<br/>95th percentile: 122.36596345901489ms<br/>99th percentile: 129.81054306030273ms<br/>Max time: 147.30167388916016ms |
| e2e_trip_ch | Total: 10536.131381988525ms<br/>Min time: 1.5401840209960938ms<br/>Mean time: 10.536131381988525ms<br/>Median time: 10.113000869750977ms<br/>95th percentile: 18.30199956893921ms<br/>99th percentile: 19.881556034088135ms<br/>Max time: 21.94833755493164ms | Total: 10660.32886505127ms<br/>Min time: 1.4753341674804688ms<br/>Mean time: 10.66032886505127ms<br/>Median time: 10.132670402526855ms<br/>95th percentile: 18.718087673187252ms<br/>99th percentile: 20.562584400177002ms<br/>Max time: 22.382497787475586ms |
| e2e_trip_mld | Total: 17183.58588218689ms<br/>Min time: 1.5516281127929688ms<br/>Mean time: 17.18358588218689ms<br/>Median time: 16.76201820373535ms<br/>95th percentile: 27.93772220611572ms<br/>99th percentile: 29.40589427947998ms<br/>Max time: 31.07142448425293ms | Total: 17241.517782211304ms<br/>Min time: 1.5799999237060547ms<br/>Mean time: 17.241517782211304ms<br/>Median time: 16.748905181884766ms<br/>95th percentile: 28.176271915435784ms<br/>99th percentile: 30.17099857330322ms<br/>Max time: 31.64529800415039ms |
| json-render | String: 6.61834ms<br/>Stringstream: 9.32453ms<br/>Vector: 6.9265ms | String: 6.51992ms<br/>Stringstream: 9.21101ms<br/>Vector: 6.86737ms |
| match_ch | Default radius: <br/>4.4666ms/req at 82 coordinate<br/>0.0544708ms/coordinate<br/>Radius 5m: <br/>4.42306ms/req at 82 coordinate<br/>0.0539398ms/coordinate<br/>Radius 10m: <br/>15.0918ms/req at 82 coordinate<br/>0.184046ms/coordinate<br/>Radius 15m: <br/>36.913ms/req at 82 coordinate<br/>0.450158ms/coordinate<br/>Radius 30m: <br/>314.818ms/req at 82 coordinate<br/>3.83925ms/coordinate | Default radius: <br/>4.45654ms/req at 82 coordinate<br/>0.0543481ms/coordinate<br/>Radius 5m: <br/>4.44546ms/req at 82 coordinate<br/>0.054213ms/coordinate<br/>Radius 10m: <br/>15.1736ms/req at 82 coordinate<br/>0.185044ms/coordinate<br/>Radius 15m: <br/>37.1824ms/req at 82 coordinate<br/>0.453444ms/coordinate<br/>Radius 30m: <br/>316.228ms/req at 82 coordinate<br/>3.85644ms/coordinate |
| match_mld | Default radius: <br/>2.79014ms/req at 82 coordinate<br/>0.0340261ms/coordinate<br/>Radius 5m: <br/>3.07669ms/req at 82 coordinate<br/>0.0375206ms/coordinate<br/>Radius 10m: <br/>10.4528ms/req at 82 coordinate<br/>0.127473ms/coordinate<br/>Radius 15m: <br/>26.1283ms/req at 82 coordinate<br/>0.318638ms/coordinate<br/>Radius 30m: <br/>305.045ms/req at 82 coordinate<br/>3.72006ms/coordinate | Default radius: <br/>2.78718ms/req at 82 coordinate<br/>0.03399ms/coordinate<br/>Radius 5m: <br/>2.77128ms/req at 82 coordinate<br/>0.0337962ms/coordinate<br/>Radius 10m: <br/>10.1941ms/req at 82 coordinate<br/>0.124318ms/coordinate<br/>Radius 15m: <br/>26.0384ms/req at 82 coordinate<br/>0.317541ms/coordinate<br/>Radius 30m: <br/>303.421ms/req at 82 coordinate<br/>3.70026ms/coordinate |
| osrm_contract | Time: 92.01s Peak RAM: 185.72MB | Time: 92.08s Peak RAM: 185.80MB |
| osrm_customize | Time: 1.31s Peak RAM: 115.00MB | Time: 1.30s Peak RAM: 115.05MB |
| osrm_extract | Time: 12.14s Peak RAM: 423.31MB | Time: 12.04s Peak RAM: 406.39MB |
| osrm_partition | Time: 2.15s Peak RAM: 148.89MB | Time: 2.16s Peak RAM: 148.66MB |
| packedvector | random write:<br/>std::vector 11133.6 ms<br/>util::packed_vector 73718.1 ms<br/>slowdown: 6.62124<br/>random read:<br/>std::vector 11062.4 ms<br/>util::packed_vector 30047.4 ms<br/>slowdown: 2.71619 | random write:<br/>std::vector 11162.1 ms<br/>util::packed_vector 78272.6 ms<br/>slowdown: 7.01238<br/>random read:<br/>std::vector 11011.8 ms<br/>util::packed_vector 31599.7 ms<br/>slowdown: 2.86964 |
| random_match_ch | 1000 matches, default radius<br/>total: 6838.00ms<br/>avg: 6.84ms<br/>min: 0.00ms<br/>max: 460.92ms<br/>p99: 109.01ms<br/><br/>1000 matches, radius=10<br/>total: 33981.52ms<br/>avg: 33.98ms<br/>min: 0.00ms<br/>max: 1803.48ms<br/>p99: 1783.00ms<br/><br/>1000 matches, radius=20<br/>total: 66819.99ms<br/>avg: 66.82ms<br/>min: 0.00ms<br/>max: 8853.21ms<br/>p99: 1230.92ms | 1000 matches, default radius<br/>total: 6922.72ms<br/>avg: 6.92ms<br/>min: 0.00ms<br/>max: 463.72ms<br/>p99: 110.55ms<br/><br/>1000 matches, radius=10<br/>total: 34413.23ms<br/>avg: 34.41ms<br/>min: 0.00ms<br/>max: 1825.06ms<br/>p99: 1803.53ms<br/><br/>1000 matches, radius=20<br/>total: 67495.01ms<br/>avg: 67.50ms<br/>min: 0.00ms<br/>max: 8914.21ms<br/>p99: 1244.00ms |
| random_match_mld | 1000 matches, default radius<br/>total: 5142.53ms<br/>avg: 5.14ms<br/>min: 0.00ms<br/>max: 382.13ms<br/>p99: 69.84ms<br/><br/>1000 matches, radius=10<br/>total: 26734.74ms<br/>avg: 26.73ms<br/>min: 0.00ms<br/>max: 1577.19ms<br/>p99: 1539.41ms<br/><br/>1000 matches, radius=20<br/>total: 52737.97ms<br/>avg: 52.74ms<br/>min: 0.00ms<br/>max: 7009.14ms<br/>p99: 792.66ms | 1000 matches, default radius<br/>total: 5154.23ms<br/>avg: 5.15ms<br/>min: 0.00ms<br/>max: 384.64ms<br/>p99: 70.19ms<br/><br/>1000 matches, radius=10<br/>total: 26749.43ms<br/>avg: 26.75ms<br/>min: 0.00ms<br/>max: 1553.79ms<br/>p99: 1539.70ms<br/><br/>1000 matches, radius=20<br/>total: 52708.75ms<br/>avg: 52.71ms<br/>min: 0.00ms<br/>max: 6997.58ms<br/>p99: 794.65ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>total: 411.16ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.19ms<br/>p99: 0.10ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 564.83ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 728.25ms<br/>avg: 0.07ms<br/>min: 0.03ms<br/>max: 0.16ms<br/>p99: 0.13ms | 10000 nearest, number_of_results=1<br/>total: 410.90ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.19ms<br/>p99: 0.10ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 563.29ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.14ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 723.98ms<br/>avg: 0.07ms<br/>min: 0.03ms<br/>max: 0.18ms<br/>p99: 0.13ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>total: 411.65ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.21ms<br/>p99: 0.10ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 563.24ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 723.18ms<br/>avg: 0.07ms<br/>min: 0.03ms<br/>max: 0.17ms<br/>p99: 0.13ms | 10000 nearest, number_of_results=1<br/>total: 412.67ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.21ms<br/>p99: 0.10ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 564.78ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 727.55ms<br/>avg: 0.07ms<br/>min: 0.03ms<br/>max: 0.17ms<br/>p99: 0.13ms |
| random_route_ch | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 20371.72ms<br/>avg: 2.04ms<br/>min: 0.11ms<br/>max: 3.94ms<br/>p99: 2.98ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 9474.89ms<br/>avg: 0.95ms<br/>min: 0.07ms<br/>max: 2.22ms<br/>p99: 1.51ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 17965.22ms<br/>avg: 1.80ms<br/>min: 0.06ms<br/>max: 10.71ms<br/>p99: 3.75ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 10169.16ms<br/>avg: 1.02ms<br/>min: 0.08ms<br/>max: 2.00ms<br/>p99: 1.46ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4289.23ms<br/>avg: 0.43ms<br/>min: 0.05ms<br/>max: 0.88ms<br/>p99: 0.67ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 9886.62ms<br/>avg: 0.99ms<br/>min: 0.06ms<br/>max: 4.38ms<br/>p99: 2.18ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 609.22ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 1.71ms<br/>p99: 0.74ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 637.77ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 0.58ms<br/>p99: 0.44ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 865.12ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.99ms<br/>p99: 1.20ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 20434.00ms<br/>avg: 2.04ms<br/>min: 0.11ms<br/>max: 3.91ms<br/>p99: 3.00ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 9457.83ms<br/>avg: 0.95ms<br/>min: 0.08ms<br/>max: 1.80ms<br/>p99: 1.51ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 17918.35ms<br/>avg: 1.79ms<br/>min: 0.06ms<br/>max: 4.90ms<br/>p99: 3.73ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 9918.74ms<br/>avg: 0.99ms<br/>min: 0.08ms<br/>max: 1.95ms<br/>p99: 1.40ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 3973.43ms<br/>avg: 0.40ms<br/>min: 0.05ms<br/>max: 0.69ms<br/>p99: 0.57ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 9072.60ms<br/>avg: 0.91ms<br/>min: 0.06ms<br/>max: 4.26ms<br/>p99: 1.99ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 596.49ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 1.68ms<br/>p99: 0.69ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 618.60ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 0.48ms<br/>p99: 0.40ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 836.35ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 1.94ms<br/>p99: 1.12ms |
| random_route_mld | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 40543.33ms<br/>avg: 4.05ms<br/>min: 0.12ms<br/>max: 15.39ms<br/>p99: 6.98ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 14647.57ms<br/>avg: 1.46ms<br/>min: 0.07ms<br/>max: 3.13ms<br/>p99: 2.62ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 40940.09ms<br/>avg: 4.09ms<br/>min: 0.06ms<br/>max: 10.21ms<br/>p99: 8.35ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 29235.96ms<br/>avg: 2.92ms<br/>min: 0.08ms<br/>max: 9.29ms<br/>p99: 5.16ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 8702.63ms<br/>avg: 0.87ms<br/>min: 0.04ms<br/>max: 1.77ms<br/>p99: 1.52ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 31580.77ms<br/>avg: 3.16ms<br/>min: 0.05ms<br/>max: 7.48ms<br/>p99: 6.27ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 777.62ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 4.35ms<br/>p99: 1.53ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 850.77ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.22ms<br/>p99: 0.98ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1635.84ms<br/>avg: 0.16ms<br/>min: 0.01ms<br/>max: 4.97ms<br/>p99: 3.46ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 40002.93ms<br/>avg: 4.00ms<br/>min: 0.13ms<br/>max: 9.71ms<br/>p99: 6.80ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 14266.32ms<br/>avg: 1.43ms<br/>min: 0.07ms<br/>max: 2.80ms<br/>p99: 2.48ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 40664.77ms<br/>avg: 4.07ms<br/>min: 0.06ms<br/>max: 15.24ms<br/>p99: 8.19ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 29428.04ms<br/>avg: 2.94ms<br/>min: 0.08ms<br/>max: 9.34ms<br/>p99: 5.18ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 8766.44ms<br/>avg: 0.88ms<br/>min: 0.04ms<br/>max: 2.15ms<br/>p99: 1.53ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 31848.56ms<br/>avg: 3.18ms<br/>min: 0.05ms<br/>max: 7.72ms<br/>p99: 6.34ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 773.24ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 4.38ms<br/>p99: 1.54ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 852.24ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.29ms<br/>p99: 0.99ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1642.58ms<br/>avg: 0.16ms<br/>min: 0.01ms<br/>max: 5.12ms<br/>p99: 3.47ms |
| random_table_ch | 250 tables, 3 coordinates<br/>total: 180.00ms<br/>avg: 0.72ms<br/>min: 0.52ms<br/>max: 1.67ms<br/>p99: 1.05ms<br/><br/>250 tables, 25 coordinates<br/>total: 1474.52ms<br/>avg: 5.90ms<br/>min: 5.22ms<br/>max: 6.39ms<br/>p99: 6.37ms<br/><br/>250 tables, 50 coordinates<br/>total: 2996.96ms<br/>avg: 11.99ms<br/>min: 10.88ms<br/>max: 12.83ms<br/>p99: 12.69ms<br/><br/>250 tables, 100 coordinates<br/>total: 6413.82ms<br/>avg: 25.66ms<br/>min: 24.46ms<br/>max: 26.66ms<br/>p99: 26.58ms | 250 tables, 3 coordinates<br/>total: 178.34ms<br/>avg: 0.71ms<br/>min: 0.53ms<br/>max: 1.66ms<br/>p99: 1.01ms<br/><br/>250 tables, 25 coordinates<br/>total: 1471.35ms<br/>avg: 5.89ms<br/>min: 5.21ms<br/>max: 6.44ms<br/>p99: 6.38ms<br/><br/>250 tables, 50 coordinates<br/>total: 2973.04ms<br/>avg: 11.89ms<br/>min: 10.86ms<br/>max: 12.71ms<br/>p99: 12.59ms<br/><br/>250 tables, 100 coordinates<br/>total: 6357.44ms<br/>avg: 25.43ms<br/>min: 24.17ms<br/>max: 26.49ms<br/>p99: 26.36ms |
| random_table_mld | 250 tables, 3 coordinates<br/>total: 719.24ms<br/>avg: 2.88ms<br/>min: 2.29ms<br/>max: 3.94ms<br/>p99: 3.83ms<br/><br/>250 tables, 25 coordinates<br/>total: 6808.36ms<br/>avg: 27.23ms<br/>min: 24.93ms<br/>max: 36.23ms<br/>p99: 30.72ms<br/><br/>250 tables, 50 coordinates<br/>total: 14563.98ms<br/>avg: 58.26ms<br/>min: 53.90ms<br/>max: 62.14ms<br/>p99: 61.91ms<br/><br/>250 tables, 100 coordinates<br/>total: 31740.37ms<br/>avg: 126.96ms<br/>min: 121.06ms<br/>max: 134.59ms<br/>p99: 133.83ms | 250 tables, 3 coordinates<br/>total: 725.51ms<br/>avg: 2.90ms<br/>min: 2.31ms<br/>max: 3.98ms<br/>p99: 3.86ms<br/><br/>250 tables, 25 coordinates<br/>total: 6796.38ms<br/>avg: 27.19ms<br/>min: 24.65ms<br/>max: 30.56ms<br/>p99: 29.93ms<br/><br/>250 tables, 50 coordinates<br/>total: 14502.78ms<br/>avg: 58.01ms<br/>min: 53.90ms<br/>max: 62.55ms<br/>p99: 62.14ms<br/><br/>250 tables, 100 coordinates<br/>total: 30986.35ms<br/>avg: 123.95ms<br/>min: 118.18ms<br/>max: 132.18ms<br/>p99: 130.88ms |
| random_trip_ch | 1000 trips, 3 coordinates<br/>total: 2187.71ms<br/>avg: 2.19ms<br/>min: 0.75ms<br/>max: 3.83ms<br/>p99: 2.83ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2740.73ms<br/>avg: 2.74ms<br/>min: 1.04ms<br/>max: 4.14ms<br/>p99: 3.45ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3290.45ms<br/>avg: 3.29ms<br/>min: 2.13ms<br/>max: 4.67ms<br/>p99: 4.01ms | 1000 trips, 3 coordinates<br/>total: 2140.45ms<br/>avg: 2.14ms<br/>min: 0.72ms<br/>max: 3.72ms<br/>p99: 2.71ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2679.08ms<br/>avg: 2.68ms<br/>min: 1.06ms<br/>max: 3.56ms<br/>p99: 3.31ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3214.27ms<br/>avg: 3.21ms<br/>min: 2.11ms<br/>max: 4.43ms<br/>p99: 3.88ms |
| random_trip_mld | 1000 trips, 3 coordinates<br/>total: 5984.18ms<br/>avg: 5.98ms<br/>min: 2.72ms<br/>max: 8.65ms<br/>p99: 8.11ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7659.74ms<br/>avg: 7.66ms<br/>min: 3.73ms<br/>max: 10.62ms<br/>p99: 9.58ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9262.08ms<br/>avg: 9.26ms<br/>min: 5.73ms<br/>max: 11.73ms<br/>p99: 11.38ms | 1000 trips, 3 coordinates<br/>total: 6076.98ms<br/>avg: 6.08ms<br/>min: 2.74ms<br/>max: 8.90ms<br/>p99: 8.18ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7483.97ms<br/>avg: 7.48ms<br/>min: 3.75ms<br/>max: 10.50ms<br/>p99: 9.46ms<br/><br/>1000 trips, 5 coordinates<br/>total: 8956.69ms<br/>avg: 8.96ms<br/>min: 5.62ms<br/>max: 11.58ms<br/>p99: 10.87ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>493.397ms<br/>0.493397ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>338.202ms<br/>0.338202ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>602.497ms<br/>0.602497ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.999ms<br/>0.151999ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.7438ms<br/>0.0977438ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>132.799ms<br/>0.132799ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>151.232ms<br/>0.151232ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.7685ms<br/>0.0977685ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.412ms<br/>0.132412ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>494.934ms<br/>0.494934ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>335.28ms<br/>0.33528ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>601.471ms<br/>0.601471ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>157.824ms<br/>0.157824ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>101.469ms<br/>0.101469ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>153.807ms<br/>0.153807ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>156.353ms<br/>0.156353ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>101.088ms<br/>0.101088ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>136.351ms<br/>0.136351ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>623.565ms<br/>0.623565ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>423.999ms<br/>0.423999ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>789.373ms<br/>0.789373ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>269.529ms<br/>0.269529ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>161.174ms<br/>0.161174ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>297.266ms<br/>0.297266ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>270.47ms<br/>0.27047ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.999ms<br/>0.161999ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>288.49ms<br/>0.28849ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>621.221ms<br/>0.621221ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>425.078ms<br/>0.425078ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>784.075ms<br/>0.784075ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>264.866ms<br/>0.264866ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>161.136ms<br/>0.161136ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>288.774ms<br/>0.288774ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>265.899ms<br/>0.265899ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>160.911ms<br/>0.160911ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>291.33ms<br/>0.29133ms/req |
| rtree | 1 result:<br/>207.385ms ->  0.0207385 ms/query<br/>10 results:<br/>242.479ms ->  0.0242479 ms/query | 1 result:<br/>208.73ms ->  0.020873 ms/query<br/>10 results:<br/>242.429ms ->  0.0242429 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->



