### PR TITLE
Apply micro-optimisation for Route API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Apply micro-optimisation for Route API. [#6948](https://github.com/Project-OSRM/osrm-backend/pull/6948)
       - CHANGED: Apply micro-optimisation for Match API. [#6945](https://github.com/Project-OSRM/osrm-backend/pull/6945)
       - CHANGED: Apply micro-optimisation for Nearest API. [#6944](https://github.com/Project-OSRM/osrm-backend/pull/6944)
       - CHANGED: Avoid copy of intersection in totalTurnAngle. [#6938](https://github.com/Project-OSRM/osrm-backend/pull/6938)

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -402,7 +402,7 @@ class RouteAPI : public BaseAPI
             {
                 legBuilder.add_annotations(annotation_buffer);
             }
-            routeLegs.push_back(legBuilder.Finish());
+            routeLegs.emplace_back(legBuilder.Finish());
         }
         auto legs_vector = fb_result.CreateVector(routeLegs);
 
@@ -501,7 +501,7 @@ class RouteAPI : public BaseAPI
             nodes.reserve(leg_geometry.node_ids.size());
             for (const auto node_id : leg_geometry.node_ids)
             {
-                nodes.push_back(static_cast<uint64_t>(facade.GetOSMNodeIDOfNode(node_id)));
+                nodes.emplace_back(static_cast<uint64_t>(facade.GetOSMNodeIDOfNode(node_id)));
             }
         }
         auto nodes_vector = fb_result.CreateVector(nodes);
@@ -518,7 +518,7 @@ class RouteAPI : public BaseAPI
                 // Length of 0 indicates the first empty name, so we can stop here
                 if (name.empty())
                     break;
-                names.push_back(
+                names.emplace_back(
                     fb_result.CreateString(std::string(facade.GetDatasourceName(i))));
             }
             metadata_buffer = fbresult::CreateMetadataDirect(fb_result, &names);

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -103,9 +103,9 @@ class RouteAPI : public BaseAPI
                 continue;
 
             jsRoutes.values.push_back(MakeRoute(route.leg_endpoints,
-                                                   route.unpacked_path_segments,
-                                                   route.source_traversed_in_reverse,
-                                                   route.target_traversed_in_reverse));
+                                                route.unpacked_path_segments,
+                                                route.source_traversed_in_reverse,
+                                                route.target_traversed_in_reverse));
         }
 
         if (!parameters.skip_waypoints)
@@ -136,10 +136,10 @@ class RouteAPI : public BaseAPI
                 continue;
 
             routes.push_back(MakeRoute(fb_result,
-                                          raw_route.leg_endpoints,
-                                          raw_route.unpacked_path_segments,
-                                          raw_route.source_traversed_in_reverse,
-                                          raw_route.target_traversed_in_reverse));
+                                       raw_route.leg_endpoints,
+                                       raw_route.unpacked_path_segments,
+                                       raw_route.source_traversed_in_reverse,
+                                       raw_route.target_traversed_in_reverse));
         }
 
         auto routes_vector = fb_result.CreateVector(routes);
@@ -859,8 +859,7 @@ class RouteAPI : public BaseAPI
                         // Length of 0 indicates the first empty name, so we can stop here
                         if (name.empty())
                             break;
-                        datasource_names.values.push_back(
-                            std::string(facade.GetDatasourceName(i)));
+                        datasource_names.values.push_back(std::string(facade.GetDatasourceName(i)));
                     }
                     metadata.values.emplace("datasource_names", datasource_names);
                     annotation.values.emplace("metadata", metadata);

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -102,7 +102,7 @@ class RouteAPI : public BaseAPI
             if (!route.is_valid())
                 continue;
 
-            jsRoutes.values.emplace_back(MakeRoute(route.leg_endpoints,
+            jsRoutes.values.push_back(MakeRoute(route.leg_endpoints,
                                                    route.unpacked_path_segments,
                                                    route.source_traversed_in_reverse,
                                                    route.target_traversed_in_reverse));
@@ -135,7 +135,7 @@ class RouteAPI : public BaseAPI
             if (!raw_route.is_valid())
                 continue;
 
-            routes.emplace_back(MakeRoute(fb_result,
+            routes.push_back(MakeRoute(fb_result,
                                           raw_route.leg_endpoints,
                                           raw_route.unpacked_path_segments,
                                           raw_route.source_traversed_in_reverse,
@@ -218,7 +218,7 @@ class RouteAPI : public BaseAPI
 
         for (const auto &step : leg.annotations)
         {
-            annotations_store.emplace_back(Get(step));
+            annotations_store.push_back(Get(step));
         }
 
         return fb_result.CreateVector(annotations_store);
@@ -232,7 +232,7 @@ class RouteAPI : public BaseAPI
 
         for (const auto &step : leg.annotations)
         {
-            annotations_store.values.emplace_back(Get(step));
+            annotations_store.values.push_back(Get(step));
         }
 
         return annotations_store;
@@ -323,7 +323,7 @@ class RouteAPI : public BaseAPI
         {
             if (mask[index])
             {
-                result.emplace_back(mapping[index]);
+                result.push_back(mapping[index]);
             }
         }
         return result;
@@ -402,7 +402,7 @@ class RouteAPI : public BaseAPI
             {
                 legBuilder.add_annotations(annotation_buffer);
             }
-            routeLegs.emplace_back(legBuilder.Finish());
+            routeLegs.push_back(legBuilder.Finish());
         }
         auto legs_vector = fb_result.CreateVector(routeLegs);
 
@@ -501,7 +501,7 @@ class RouteAPI : public BaseAPI
             nodes.reserve(leg_geometry.node_ids.size());
             for (const auto node_id : leg_geometry.node_ids)
             {
-                nodes.emplace_back(static_cast<uint64_t>(facade.GetOSMNodeIDOfNode(node_id)));
+                nodes.push_back(static_cast<uint64_t>(facade.GetOSMNodeIDOfNode(node_id)));
             }
         }
         auto nodes_vector = fb_result.CreateVector(nodes);
@@ -518,7 +518,7 @@ class RouteAPI : public BaseAPI
                 // Length of 0 indicates the first empty name, so we can stop here
                 if (name.empty())
                     break;
-                names.emplace_back(
+                names.push_back(
                     fb_result.CreateString(std::string(facade.GetDatasourceName(i))));
             }
             metadata_buffer = fbresult::CreateMetadataDirect(fb_result, &names);
@@ -674,7 +674,7 @@ class RouteAPI : public BaseAPI
                         auto lane_valid = lane_id >= intersection.lanes.first_lane_from_the_right &&
                                           lane_id < intersection.lanes.first_lane_from_the_right +
                                                         intersection.lanes.lanes_in_turn;
-                        lanes.emplace_back(
+                        lanes.push_back(
                             fbresult::CreateLaneDirect(fb_result, &indications, lane_valid));
                     }
                 }
@@ -842,7 +842,7 @@ class RouteAPI : public BaseAPI
                     nodes.values.reserve(leg_geometry.node_ids.size());
                     for (const auto node_id : leg_geometry.node_ids)
                     {
-                        nodes.values.emplace_back(
+                        nodes.values.push_back(
                             static_cast<std::uint64_t>(facade.GetOSMNodeIDOfNode(node_id)));
                     }
                     annotation.values.emplace("nodes", std::move(nodes));
@@ -859,14 +859,14 @@ class RouteAPI : public BaseAPI
                         // Length of 0 indicates the first empty name, so we can stop here
                         if (name.empty())
                             break;
-                        datasource_names.values.emplace_back(
+                        datasource_names.values.push_back(
                             std::string(facade.GetDatasourceName(i)));
                     }
                     metadata.values.emplace("datasource_names", datasource_names);
                     annotation.values.emplace("metadata", metadata);
                 }
 
-                annotations.emplace_back(std::move(annotation));
+                annotations.push_back(std::move(annotation));
             }
         }
 
@@ -992,8 +992,8 @@ class RouteAPI : public BaseAPI
                 }
             }
 
-            leg_geometries.emplace_back(std::move(leg_geometry));
-            legs.emplace_back(std::move(leg));
+            leg_geometries.push_back(std::move(leg_geometry));
+            legs.push_back(std::move(leg));
         }
         return result;
     }


### PR DESCRIPTION


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1103.27<br/>plain u32: 1111.21<br/>aliased double: 999.656<br/>plain double: 1021.23 | aliased u32: 1216.72<br/>plain u32: 1212.3<br/>aliased double: 1283.13<br/>plain double: 1326.51 |
| e2e_match_ch | Total: 2895.4153060913086ms<br/>Min time: 2.288818359375ms<br/>Mean time: 22.102406916727546ms<br/>Median time: 14.584064483642578ms<br/>95th percentile: 70.50120830535889ms<br/>99th percentile: 84.08629894256586ms<br/>Max time: 97.50699996948242ms | Total: 2896.3217735290527ms<br/>Min time: 2.3424625396728516ms<br/>Mean time: 22.109326515488952ms<br/>Median time: 14.678239822387695ms<br/>95th percentile: 70.6014633178711ms<br/>99th percentile: 85.01670360565178ms<br/>Max time: 98.04630279541016ms |
| e2e_match_mld | Total: 2071.8181133270264ms<br/>Min time: 2.0477771759033203ms<br/>Mean time: 15.815405445244476ms<br/>Median time: 8.690118789672852ms<br/>95th percentile: 50.25649070739746ms<br/>99th percentile: 59.35859680175776ms<br/>Max time: 67.16585159301758ms | Total: 1998.084545135498ms<br/>Min time: 2.0847320556640625ms<br/>Mean time: 15.25255377966029ms<br/>Median time: 8.317708969116211ms<br/>95th percentile: 49.01742935180664ms<br/>99th percentile: 58.79719257354728ms<br/>Max time: 67.11053848266602ms |
| e2e_nearest_ch | Total: 1356.6031455993652ms<br/>Min time: 1.1608600616455078ms<br/>Mean time: 1.3566031455993652ms<br/>Median time: 1.270890235900879ms<br/>95th percentile: 1.7709732055664062ms<br/>99th percentile: 1.82175874710083ms<br/>Max time: 1.928091049194336ms | Total: 1339.7812843322754ms<br/>Min time: 1.1489391326904297ms<br/>Mean time: 1.3397812843322754ms<br/>Median time: 1.252889633178711ms<br/>95th percentile: 1.7502665519714355ms<br/>99th percentile: 1.817946434020996ms<br/>Max time: 1.909017562866211ms |
| e2e_nearest_mld | Total: 1374.1099834442139ms<br/>Min time: 1.1775493621826172ms<br/>Mean time: 1.3741099834442139ms<br/>Median time: 1.2807846069335938ms<br/>95th percentile: 1.8105506896972656ms<br/>99th percentile: 1.8570947647094727ms<br/>Max time: 1.9965171813964844ms | Total: 1349.4834899902344ms<br/>Min time: 1.148223876953125ms<br/>Mean time: 1.3494834899902344ms<br/>Median time: 1.2613534927368164ms<br/>95th percentile: 1.7667293548583984ms<br/>99th percentile: 1.8315863609313965ms<br/>Max time: 1.9185543060302734ms |
| e2e_route_ch | Total: 3106.133222579956ms<br/>Min time: 1.3506412506103516ms<br/>Mean time: 3.106133222579956ms<br/>Median time: 3.127932548522949ms<br/>95th percentile: 4.050993919372559ms<br/>99th percentile: 4.331459999084472ms<br/>Max time: 5.722999572753906ms | Total: 3194.7593688964844ms<br/>Min time: 1.3744831085205078ms<br/>Mean time: 3.1947593688964844ms<br/>Median time: 3.241300582885742ms<br/>95th percentile: 4.22365665435791ms<br/>99th percentile: 4.634637832641602ms<br/>Max time: 5.066871643066406ms |
| e2e_route_mld | Total: 3719.96808052063ms<br/>Min time: 1.3384819030761719ms<br/>Mean time: 3.71996808052063ms<br/>Median time: 3.768444061279297ms<br/>95th percentile: 5.129134654998779ms<br/>99th percentile: 5.4608416557312ms<br/>Max time: 7.457256317138672ms | Total: 3572.4477767944336ms<br/>Min time: 1.3604164123535156ms<br/>Mean time: 3.5724477767944336ms<br/>Median time: 3.6116838455200195ms<br/>95th percentile: 4.864966869354248ms<br/>99th percentile: 5.341629981994628ms<br/>Max time: 6.01506233215332ms |
| e2e_table_ch | Total: 16065.431594848633ms<br/>Min time: 2.0751953125ms<br/>Mean time: 16.065431594848633ms<br/>Median time: 15.218377113342285ms<br/>95th percentile: 29.420423507690426ms<br/>99th percentile: 31.045076847076416ms<br/>Max time: 39.51621055603027ms | Total: 15771.047115325928ms<br/>Min time: 2.1038055419921875ms<br/>Mean time: 15.771047115325928ms<br/>Median time: 15.148162841796875ms<br/>95th percentile: 28.934884071350094ms<br/>99th percentile: 30.6211256980896ms<br/>Max time: 31.66794776916504ms |
| e2e_table_mld | Total: 66852.68092155457ms<br/>Min time: 4.5070648193359375ms<br/>Mean time: 66.85268092155457ms<br/>Median time: 63.36832046508789ms<br/>95th percentile: 128.10935974121094ms<br/>99th percentile: 137.134051322937ms<br/>Max time: 143.4183120727539ms | Total: 63009.856939315796ms<br/>Min time: 4.132270812988281ms<br/>Mean time: 63.009856939315796ms<br/>Median time: 59.401631355285645ms<br/>95th percentile: 121.50700092315674ms<br/>99th percentile: 130.09790897369385ms<br/>Max time: 133.18133354187012ms |
| e2e_trip_ch | Total: 10822.209358215332ms<br/>Min time: 1.5268325805664062ms<br/>Mean time: 10.822209358215332ms<br/>Median time: 10.375261306762695ms<br/>95th percentile: 18.832814693450928ms<br/>99th percentile: 20.57438850402832ms<br/>Max time: 25.14958381652832ms | Total: 10700.839757919312ms<br/>Min time: 1.6031265258789062ms<br/>Mean time: 10.700839757919312ms<br/>Median time: 10.168790817260742ms<br/>95th percentile: 18.84620189666748ms<br/>99th percentile: 20.935628414154053ms<br/>Max time: 22.821903228759766ms |
| e2e_trip_mld | Total: 18088.598489761353ms<br/>Min time: 1.6431808471679688ms<br/>Mean time: 18.088598489761353ms<br/>Median time: 17.664194107055664ms<br/>95th percentile: 29.42560911178589ms<br/>99th percentile: 31.278624534606934ms<br/>Max time: 33.153533935546875ms | Total: 17429.44574356079ms<br/>Min time: 1.45721435546875ms<br/>Mean time: 17.42944574356079ms<br/>Median time: 17.049789428710938ms<br/>95th percentile: 28.552222251892086ms<br/>99th percentile: 30.266637802124023ms<br/>Max time: 32.70983695983887ms |
| json-render | String: 6.64419ms<br/>Stringstream: 9.38585ms<br/>Vector: 6.99238ms | String: 6.70944ms<br/>Stringstream: 9.41014ms<br/>Vector: 6.96268ms |
| match_ch | Default radius: <br/>4.41372ms/req at 82 coordinate<br/>0.0538258ms/coordinate<br/>Radius 5m: <br/>4.3865ms/req at 82 coordinate<br/>0.053494ms/coordinate<br/>Radius 10m: <br/>14.9945ms/req at 82 coordinate<br/>0.18286ms/coordinate<br/>Radius 15m: <br/>36.6105ms/req at 82 coordinate<br/>0.446469ms/coordinate<br/>Radius 30m: <br/>311.761ms/req at 82 coordinate<br/>3.80196ms/coordinate | Default radius: <br/>4.49633ms/req at 82 coordinate<br/>0.0548334ms/coordinate<br/>Radius 5m: <br/>4.48899ms/req at 82 coordinate<br/>0.0547438ms/coordinate<br/>Radius 10m: <br/>15.3925ms/req at 82 coordinate<br/>0.187713ms/coordinate<br/>Radius 15m: <br/>37.6369ms/req at 82 coordinate<br/>0.458987ms/coordinate<br/>Radius 30m: <br/>320.341ms/req at 82 coordinate<br/>3.90659ms/coordinate |
| match_mld | Default radius: <br/>2.78958ms/req at 82 coordinate<br/>0.0340193ms/coordinate<br/>Radius 5m: <br/>2.817ms/req at 82 coordinate<br/>0.0343536ms/coordinate<br/>Radius 10m: <br/>10.1815ms/req at 82 coordinate<br/>0.124165ms/coordinate<br/>Radius 15m: <br/>26.0284ms/req at 82 coordinate<br/>0.31742ms/coordinate<br/>Radius 30m: <br/>303.448ms/req at 82 coordinate<br/>3.70059ms/coordinate | Default radius: <br/>2.83986ms/req at 82 coordinate<br/>0.0346324ms/coordinate<br/>Radius 5m: <br/>2.83547ms/req at 82 coordinate<br/>0.0345789ms/coordinate<br/>Radius 10m: <br/>10.4103ms/req at 82 coordinate<br/>0.126955ms/coordinate<br/>Radius 15m: <br/>26.9174ms/req at 82 coordinate<br/>0.328261ms/coordinate<br/>Radius 30m: <br/>303.443ms/req at 82 coordinate<br/>3.70053ms/coordinate |
| osrm_contract | Time: 95.11s Peak RAM: 185.62MB | Time: 94.86s Peak RAM: 185.78MB |
| osrm_customize | Time: 1.31s Peak RAM: 115.03MB | Time: 1.30s Peak RAM: 115.05MB |
| osrm_extract | Time: 12.73s Peak RAM: 411.51MB | Time: 12.61s Peak RAM: 413.10MB |
| osrm_partition | Time: 2.36s Peak RAM: 150.91MB | Time: 2.23s Peak RAM: 148.91MB |
| packedvector | random write:<br/>std::vector 11842.1 ms<br/>util::packed_vector 74879.4 ms<br/>slowdown: 6.32314<br/>random read:<br/>std::vector 11700.9 ms<br/>util::packed_vector 30856.9 ms<br/>slowdown: 2.63714 | random write:<br/>std::vector 12071.5 ms<br/>util::packed_vector 82832.9 ms<br/>slowdown: 6.86187<br/>random read:<br/>std::vector 12046 ms<br/>util::packed_vector 34024 ms<br/>slowdown: 2.8245 |
| random_match_ch | 1000 matches, default radius<br/>total: 6996.47ms<br/>avg: 7.00ms<br/>min: 0.00ms<br/>max: 474.91ms<br/>p99: 111.44ms<br/><br/>1000 matches, radius=10<br/>total: 35064.56ms<br/>avg: 35.06ms<br/>min: 0.00ms<br/>max: 1877.26ms<br/>p99: 1862.80ms<br/><br/>1000 matches, radius=20<br/>total: 68844.19ms<br/>avg: 68.84ms<br/>min: 0.00ms<br/>max: 9354.34ms<br/>p99: 1239.07ms | 1000 matches, default radius<br/>total: 6955.92ms<br/>avg: 6.96ms<br/>min: 0.00ms<br/>max: 471.34ms<br/>p99: 110.53ms<br/><br/>1000 matches, radius=10<br/>total: 34728.60ms<br/>avg: 34.73ms<br/>min: 0.00ms<br/>max: 1883.78ms<br/>p99: 1846.05ms<br/><br/>1000 matches, radius=20<br/>total: 68049.33ms<br/>avg: 68.05ms<br/>min: 0.00ms<br/>max: 9231.46ms<br/>p99: 1227.49ms |
| random_match_mld | 1000 matches, default radius<br/>total: 5132.43ms<br/>avg: 5.13ms<br/>min: 0.00ms<br/>max: 382.56ms<br/>p99: 69.53ms<br/><br/>1000 matches, radius=10<br/>total: 26658.35ms<br/>avg: 26.66ms<br/>min: 0.00ms<br/>max: 1550.52ms<br/>p99: 1531.82ms<br/><br/>1000 matches, radius=20<br/>total: 52489.56ms<br/>avg: 52.49ms<br/>min: 0.00ms<br/>max: 6966.54ms<br/>p99: 791.50ms | 1000 matches, default radius<br/>total: 5171.18ms<br/>avg: 5.17ms<br/>min: 0.00ms<br/>max: 381.96ms<br/>p99: 70.36ms<br/><br/>1000 matches, radius=10<br/>total: 26598.52ms<br/>avg: 26.60ms<br/>min: 0.00ms<br/>max: 1538.21ms<br/>p99: 1527.45ms<br/><br/>1000 matches, radius=20<br/>total: 52294.48ms<br/>avg: 52.29ms<br/>min: 0.00ms<br/>max: 6943.55ms<br/>p99: 786.54ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>total: 424.28ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.23ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 585.40ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 755.16ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.19ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 422.58ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.23ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 574.78ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 739.97ms<br/>avg: 0.07ms<br/>min: 0.03ms<br/>max: 0.18ms<br/>p99: 0.14ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>total: 425.50ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.24ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 585.49ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 750.96ms<br/>avg: 0.08ms<br/>min: 0.03ms<br/>max: 0.19ms<br/>p99: 0.14ms | 10000 nearest, number_of_results=1<br/>total: 418.26ms<br/>avg: 0.04ms<br/>min: 0.01ms<br/>max: 0.23ms<br/>p99: 0.11ms<br/><br/>10000 nearest, number_of_results=5<br/>total: 574.48ms<br/>avg: 0.06ms<br/>min: 0.02ms<br/>max: 0.15ms<br/>p99: 0.12ms<br/><br/>10000 nearest, number_of_results=10<br/>total: 746.25ms<br/>avg: 0.07ms<br/>min: 0.03ms<br/>max: 0.19ms<br/>p99: 0.14ms |
| random_route_ch | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 21846.13ms<br/>avg: 2.18ms<br/>min: 0.15ms<br/>max: 3.95ms<br/>p99: 3.33ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 9789.42ms<br/>avg: 0.98ms<br/>min: 0.07ms<br/>max: 1.87ms<br/>p99: 1.60ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 18642.63ms<br/>avg: 1.86ms<br/>min: 0.06ms<br/>max: 4.78ms<br/>p99: 4.17ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 9988.88ms<br/>avg: 1.00ms<br/>min: 0.08ms<br/>max: 1.95ms<br/>p99: 1.45ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4062.61ms<br/>avg: 0.41ms<br/>min: 0.05ms<br/>max: 0.76ms<br/>p99: 0.60ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 9662.58ms<br/>avg: 0.97ms<br/>min: 0.06ms<br/>max: 2.97ms<br/>p99: 2.38ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 609.29ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 1.73ms<br/>p99: 0.70ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 632.56ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 0.53ms<br/>p99: 0.41ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 863.46ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.82ms<br/>p99: 1.17ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 21922.94ms<br/>avg: 2.19ms<br/>min: 0.14ms<br/>max: 3.93ms<br/>p99: 3.30ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 10359.21ms<br/>avg: 1.04ms<br/>min: 0.08ms<br/>max: 2.32ms<br/>p99: 1.72ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 20033.83ms<br/>avg: 2.00ms<br/>min: 0.06ms<br/>max: 5.32ms<br/>p99: 4.51ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 10972.95ms<br/>avg: 1.10ms<br/>min: 0.08ms<br/>max: 2.07ms<br/>p99: 1.65ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 4398.31ms<br/>avg: 0.44ms<br/>min: 0.05ms<br/>max: 0.89ms<br/>p99: 0.70ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 10623.89ms<br/>avg: 1.06ms<br/>min: 0.06ms<br/>max: 3.68ms<br/>p99: 2.66ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 621.57ms<br/>avg: 0.06ms<br/>min: 0.01ms<br/>max: 1.83ms<br/>p99: 0.77ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 655.41ms<br/>avg: 0.07ms<br/>min: 0.01ms<br/>max: 0.65ms<br/>p99: 0.48ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 901.08ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 2.07ms<br/>p99: 1.31ms |
| random_route_mld | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 42978.50ms<br/>avg: 4.30ms<br/>min: 0.15ms<br/>max: 10.20ms<br/>p99: 7.38ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 16769.54ms<br/>avg: 1.68ms<br/>min: 0.07ms<br/>max: 3.66ms<br/>p99: 3.00ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 45089.78ms<br/>avg: 4.51ms<br/>min: 0.06ms<br/>max: 12.11ms<br/>p99: 9.28ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 32012.49ms<br/>avg: 3.20ms<br/>min: 0.08ms<br/>max: 9.84ms<br/>p99: 5.69ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 10140.88ms<br/>avg: 1.01ms<br/>min: 0.05ms<br/>max: 2.20ms<br/>p99: 1.89ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 34947.65ms<br/>avg: 3.49ms<br/>min: 0.05ms<br/>max: 10.61ms<br/>p99: 7.14ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 816.46ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 4.58ms<br/>p99: 1.67ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 951.30ms<br/>avg: 0.10ms<br/>min: 0.01ms<br/>max: 1.68ms<br/>p99: 1.21ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1751.93ms<br/>avg: 0.18ms<br/>min: 0.01ms<br/>max: 5.57ms<br/>p99: 3.74ms | 10000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>total: 42637.19ms<br/>avg: 4.26ms<br/>min: 0.14ms<br/>max: 10.72ms<br/>p99: 7.41ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>total: 15585.59ms<br/>avg: 1.56ms<br/>min: 0.07ms<br/>max: 3.28ms<br/>p99: 2.80ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>total: 43574.73ms<br/>avg: 4.36ms<br/>min: 0.06ms<br/>max: 10.38ms<br/>p99: 8.93ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>total: 31079.28ms<br/>avg: 3.11ms<br/>min: 0.08ms<br/>max: 9.69ms<br/>p99: 5.55ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>total: 9344.48ms<br/>avg: 0.93ms<br/>min: 0.04ms<br/>max: 2.03ms<br/>p99: 1.70ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>total: 34078.27ms<br/>avg: 3.41ms<br/>min: 0.05ms<br/>max: 10.17ms<br/>p99: 7.02ms<br/><br/>10000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 823.48ms<br/>avg: 0.08ms<br/>min: 0.01ms<br/>max: 4.67ms<br/>p99: 1.71ms<br/><br/>10000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>total: 939.43ms<br/>avg: 0.09ms<br/>min: 0.01ms<br/>max: 1.74ms<br/>p99: 1.18ms<br/><br/>10000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>total: 1791.06ms<br/>avg: 0.18ms<br/>min: 0.01ms<br/>max: 5.50ms<br/>p99: 3.86ms |
| random_table_ch | 250 tables, 3 coordinates<br/>total: 179.52ms<br/>avg: 0.72ms<br/>min: 0.51ms<br/>max: 1.74ms<br/>p99: 1.04ms<br/><br/>250 tables, 25 coordinates<br/>total: 1478.47ms<br/>avg: 5.91ms<br/>min: 5.11ms<br/>max: 6.98ms<br/>p99: 6.53ms<br/><br/>250 tables, 50 coordinates<br/>total: 2986.10ms<br/>avg: 11.94ms<br/>min: 10.93ms<br/>max: 13.64ms<br/>p99: 12.80ms<br/><br/>250 tables, 100 coordinates<br/>total: 6412.02ms<br/>avg: 25.65ms<br/>min: 24.14ms<br/>max: 27.33ms<br/>p99: 26.85ms | 250 tables, 3 coordinates<br/>total: 176.08ms<br/>avg: 0.70ms<br/>min: 0.50ms<br/>max: 1.72ms<br/>p99: 1.01ms<br/><br/>250 tables, 25 coordinates<br/>total: 1467.19ms<br/>avg: 5.87ms<br/>min: 5.10ms<br/>max: 6.87ms<br/>p99: 6.66ms<br/><br/>250 tables, 50 coordinates<br/>total: 2954.49ms<br/>avg: 11.82ms<br/>min: 10.78ms<br/>max: 13.04ms<br/>p99: 12.68ms<br/><br/>250 tables, 100 coordinates<br/>total: 6442.03ms<br/>avg: 25.77ms<br/>min: 23.85ms<br/>max: 27.51ms<br/>p99: 27.44ms |
| random_table_mld | 250 tables, 3 coordinates<br/>total: 757.29ms<br/>avg: 3.03ms<br/>min: 2.34ms<br/>max: 4.08ms<br/>p99: 3.94ms<br/><br/>250 tables, 25 coordinates<br/>total: 7317.11ms<br/>avg: 29.27ms<br/>min: 26.18ms<br/>max: 37.51ms<br/>p99: 33.55ms<br/><br/>250 tables, 50 coordinates<br/>total: 15464.92ms<br/>avg: 61.86ms<br/>min: 55.70ms<br/>max: 70.22ms<br/>p99: 66.82ms<br/><br/>250 tables, 100 coordinates<br/>total: 33449.22ms<br/>avg: 133.80ms<br/>min: 126.37ms<br/>max: 146.57ms<br/>p99: 142.21ms | 250 tables, 3 coordinates<br/>total: 747.41ms<br/>avg: 2.99ms<br/>min: 2.35ms<br/>max: 4.61ms<br/>p99: 3.99ms<br/><br/>250 tables, 25 coordinates<br/>total: 7104.14ms<br/>avg: 28.42ms<br/>min: 25.57ms<br/>max: 32.76ms<br/>p99: 32.36ms<br/><br/>250 tables, 50 coordinates<br/>total: 14991.12ms<br/>avg: 59.96ms<br/>min: 54.82ms<br/>max: 64.35ms<br/>p99: 63.86ms<br/><br/>250 tables, 100 coordinates<br/>total: 32128.20ms<br/>avg: 128.51ms<br/>min: 121.81ms<br/>max: 161.24ms<br/>p99: 137.48ms |
| random_trip_ch | 1000 trips, 3 coordinates<br/>total: 2278.23ms<br/>avg: 2.28ms<br/>min: 0.66ms<br/>max: 3.91ms<br/>p99: 3.08ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2869.58ms<br/>avg: 2.87ms<br/>min: 1.12ms<br/>max: 3.98ms<br/>p99: 3.77ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3426.78ms<br/>avg: 3.43ms<br/>min: 2.04ms<br/>max: 4.75ms<br/>p99: 4.29ms | 1000 trips, 3 coordinates<br/>total: 2386.79ms<br/>avg: 2.39ms<br/>min: 0.67ms<br/>max: 4.20ms<br/>p99: 3.19ms<br/><br/>1000 trips, 4 coordinates<br/>total: 2904.81ms<br/>avg: 2.90ms<br/>min: 1.10ms<br/>max: 4.40ms<br/>p99: 3.75ms<br/><br/>1000 trips, 5 coordinates<br/>total: 3362.90ms<br/>avg: 3.36ms<br/>min: 1.97ms<br/>max: 4.51ms<br/>p99: 4.20ms |
| random_trip_mld | 1000 trips, 3 coordinates<br/>total: 6404.23ms<br/>avg: 6.40ms<br/>min: 2.81ms<br/>max: 10.13ms<br/>p99: 8.71ms<br/><br/>1000 trips, 4 coordinates<br/>total: 8283.84ms<br/>avg: 8.28ms<br/>min: 3.76ms<br/>max: 11.32ms<br/>p99: 10.43ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9976.44ms<br/>avg: 9.98ms<br/>min: 5.92ms<br/>max: 16.17ms<br/>p99: 12.36ms | 1000 trips, 3 coordinates<br/>total: 6407.20ms<br/>avg: 6.41ms<br/>min: 2.77ms<br/>max: 9.16ms<br/>p99: 8.82ms<br/><br/>1000 trips, 4 coordinates<br/>total: 7908.62ms<br/>avg: 7.91ms<br/>min: 3.74ms<br/>max: 10.79ms<br/>p99: 9.87ms<br/><br/>1000 trips, 5 coordinates<br/>total: 9878.86ms<br/>avg: 9.88ms<br/>min: 6.10ms<br/>max: 13.41ms<br/>p99: 12.22ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>498.442ms<br/>0.498442ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>340.538ms<br/>0.340538ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>607.976ms<br/>0.607976ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>154.974ms<br/>0.154974ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>100.26ms<br/>0.10026ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>135.495ms<br/>0.135495ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>154.468ms<br/>0.154468ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>99.9465ms<br/>0.0999465ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>135.057ms<br/>0.135057ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>497.068ms<br/>0.497068ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>335.17ms<br/>0.33517ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>604.738ms<br/>0.604738ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.699ms<br/>0.151699ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>97.7434ms<br/>0.0977434ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>133.256ms<br/>0.133256ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>150.872ms<br/>0.150872ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>97.7369ms<br/>0.0977369ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>132.445ms<br/>0.132445ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>627.293ms<br/>0.627293ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>429.466ms<br/>0.429466ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>793.163ms<br/>0.793163ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>268.819ms<br/>0.268819ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>162.072ms<br/>0.162072ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>289.421ms<br/>0.289421ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>259.82ms<br/>0.25982ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>161.705ms<br/>0.161705ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>283.009ms<br/>0.283009ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>622.387ms<br/>0.622387ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=full, steps=true<br/>421.448ms<br/>0.421448ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>793.195ms<br/>0.793195ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>254.843ms<br/>0.254843ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false<br/>160.49ms<br/>0.16049ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>282.6ms<br/>0.2826ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>260.292ms<br/>0.260292ms/req<br/>1000 routes, 2 coordinates, no alternatives, overview=false, steps=false, radius=750<br/>159.152ms<br/>0.159152ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false, radius=750<br/>280.896ms<br/>0.280896ms/req |
| rtree | 1 result:<br/>207.505ms ->  0.0207505 ms/query<br/>10 results:<br/>243.955ms ->  0.0243955 ms/query | 1 result:<br/>207.434ms ->  0.0207434 ms/query<br/>10 results:<br/>242.668ms ->  0.0242668 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->

