### PR TITLE
Link libosrm_guidance correctly and work around circular dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,7 +566,17 @@ set(UTIL_LIBRARIES
 target_link_libraries(osrm ${ENGINE_LIBRARIES})
 target_link_libraries(osrm_update ${UPDATER_LIBRARIES})
 target_link_libraries(osrm_contract ${CONTRACTOR_LIBRARIES} osrm_update osrm_store)
-target_link_libraries(osrm_extract osrm_guidance ${EXTRACTOR_LIBRARIES})
+
+# There is a circular dependency between osrm_extract and osrm_guidance. Tell the linker to trust us
+# that the two osrm::guidance functions used in osrm_extract will be available at runtime.
+# We don't need to do this for osrm_guidance, as osrm_extract will already be built when that gets
+# built and symbols can be looked up in osrm_extract directly.
+# https://stackoverflow.com/questions/25421479/
+target_link_libraries(osrm_extract
+  "-Wl,-U,__ZN4osrm8guidance13annotateTurnsERKNS_4util12DynamicGraphINS1_17NodeBasedEdgeDataEEERKNS_9extractor6detail30EdgeBasedNodeDataContainerImplILNS_7storage9OwnershipE0EEERKNSt3__16vectorINS1_10CoordinateENSF_9allocatorISH_EEEERKNS7_23CompressedEdgeContainerERKNSF_13unordered_setIjNSF_4hashIjEENSF_8equal_toIjEENSI_IjEEEERKNS7_18NodeRestrictionMapINS7_17UnconditionalOnlyEEERKNS7_17WayRestrictionMapERKNS8_13NameTableImplILSB_0EEERKNS7_11SuffixTableERKNSF_5tupleIJNSG_IjSV_EENSG_ItNSI_ItEEEEEEERNS1_15ConcurrentIDMapIS1H_tNSR_IS1H_EEEERNS1L_INS1_8guidance15LaneTupleIdPairEtNSR_IS1Q_EEEERNS0_6detail21TurnDataContainerImplILSB_2EEERS1F_RNS1L_INS1P_12BearingClassEjNSR_IS1Z_EEEERNS1L_INS1P_10EntryClassEtNSR_IS23_EEEERj"
+  "-Wl,-U,__ZN4osrm8guidance19findSegregatedNodesERKNS_9extractor21NodeBasedGraphFactoryERKNS1_6detail13NameTableImplILNS_7storage9OwnershipE0EEE"
+  ${EXTRACTOR_LIBRARIES})
+target_link_libraries(osrm_guidance ${GUIDANCE_LIBRARIES} osrm_extract)
 target_link_libraries(osrm_partition ${PARTITIONER_LIBRARIES})
 target_link_libraries(osrm_customize ${CUSTOMIZER_LIBRARIES} osrm_update osrm_store)
 target_link_libraries(osrm_store ${STORAGE_LIBRARIES})


### PR DESCRIPTION
Fixes #6954

# Issue

Building shared libraries on macOS fails, because there is no `target_link_libraries` call for osrm_guidance to tell it what external and internal libraries to link against. This works on Linux because the linker assumes undefined symbols will be defined at runtime, but macOS checks that the symbols are defined at link time. This PR adds the `target_link_libraries` call.

This creates another problem in that there is a circular dependency between osrm_guidance and osrm_extract. osrm_guidance calls a lot of functions from osrm_extract, and osrm_extract only calls two from osrm_guidance. So I fix this by specifying linker options to tell the linker to resolve those two functions at runtime. I've only tested this with clang on macOS, but I think it should work on other platforms as well. It looks like the CI currently doesn't try to build shared libraries on any platform, perhaps we should change that?

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - N/A update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - N/A add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

None
