### PR TITLE
Debug osrm-extract CI crash

### DIFF
--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -1254,7 +1254,7 @@ void Sol2ScriptingEnvironment::ProcessSegment(ExtractionSegment &segment)
 
     if (context.has_segment_function)
     {
-        sol::protected_function_result luares;
+        std::optional<sol::protected_function_result> luares;
         switch (context.api_version)
         {
         case 4:
@@ -1274,8 +1274,8 @@ void Sol2ScriptingEnvironment::ProcessSegment(ExtractionSegment &segment)
             break;
         }
 
-        if (!luares.valid())
-            handle_lua_error(luares);
+        if (luares && !luares->valid())
+            handle_lua_error(*luares);
     }
 }
 
@@ -1285,7 +1285,7 @@ void LuaScriptingContext::ProcessNode(const osmium::Node &node,
 {
     BOOST_ASSERT(state.lua_state() != nullptr);
 
-    sol::protected_function_result luares;
+    std::optional<sol::protected_function_result> luares;
 
     // TODO check for api version, make sure luares is always set
     switch (api_version)
@@ -1302,10 +1302,12 @@ void LuaScriptingContext::ProcessNode(const osmium::Node &node,
     case 0:
         luares = node_function(std::cref(node), std::ref(result));
         break;
+    default:
+        BOOST_ASSERT(false && "Invalid API version");
     }
 
-    if (!luares.valid())
-        handle_lua_error(luares);
+    if (luares && !luares->valid())
+        handle_lua_error(*luares);
 }
 
 void LuaScriptingContext::ProcessWay(const osmium::Way &way,
@@ -1314,7 +1316,7 @@ void LuaScriptingContext::ProcessWay(const osmium::Way &way,
 {
     BOOST_ASSERT(state.lua_state() != nullptr);
 
-    sol::protected_function_result luares;
+    std::optional<sol::protected_function_result> luares;
 
     // TODO check for api version, make sure luares is always set
     switch (api_version)
@@ -1331,10 +1333,12 @@ void LuaScriptingContext::ProcessWay(const osmium::Way &way,
     case 0:
         luares = way_function(std::cref(way), std::ref(result));
         break;
+    default:
+        BOOST_ASSERT(false && "Invalid API version");
     }
 
-    if (!luares.valid())
-        handle_lua_error(luares);
+    if (luares && !luares->valid())
+        handle_lua_error(*luares);
 }
 
 } // namespace osrm::extractor


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?





<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1152.64<br/>plain u32: 1140.89<br/>aliased double: 1190.76<br/>plain double: 1189.82 | aliased u32: 1191.5<br/>plain u32: 1188.42<br/>aliased double: 1241.63<br/>plain double: 1246.62 |
| e2e_match_ch | Ops: 45.86 ± 0.13 ops/s. Best: 45.58 ops/s<br/>Total: 2856.35ms ± 8.93ms. Best: 2843.73ms<br/>Min time: 2.15ms ± 0.02ms<br/>Mean time: 21.80ms ± 0.07ms<br/>Median time: 16.30ms ± 0.19ms<br/>95th percentile: 71.08ms ± 0.23ms<br/>99th percentile: 86.08ms ± 0.52ms<br/>Max time: 96.49ms ± 0.78ms | Ops: 43.95 ± 0.13 ops/s. Best: 43.63 ops/s<br/>Total: 2980.79ms ± 9.14ms. Best: 2971.14ms<br/>Min time: 2.23ms ± 0.05ms<br/>Mean time: 22.75ms ± 0.07ms<br/>Median time: 18.35ms ± 0.13ms<br/>95th percentile: 72.83ms ± 0.18ms<br/>99th percentile: 88.49ms ± 0.48ms<br/>Max time: 101.16ms ± 0.39ms |
| e2e_match_mld | Ops: 60.76 ± 0.09 ops/s. Best: 60.63 ops/s<br/>Total: 2155.93ms ± 3.50ms. Best: 2148.97ms<br/>Min time: 1.86ms ± 0.03ms<br/>Mean time: 16.46ms ± 0.03ms<br/>Median time: 8.58ms ± 0.06ms<br/>95th percentile: 54.39ms ± 0.49ms<br/>99th percentile: 62.71ms ± 0.47ms<br/>Max time: 72.59ms ± 0.38ms | Ops: 61.91 ± 0.09 ops/s. Best: 61.78 ops/s<br/>Total: 2115.94ms ± 3.10ms. Best: 2110.30ms<br/>Min time: 1.85ms ± 0.02ms<br/>Mean time: 16.15ms ± 0.03ms<br/>Median time: 8.72ms ± 0.10ms<br/>95th percentile: 53.71ms ± 0.17ms<br/>99th percentile: 62.17ms ± 0.32ms<br/>Max time: 72.42ms ± 0.40ms |
| e2e_nearest_ch | Ops: 793.91 ± 4.08 ops/s. Best: 784.66 ops/s<br/>Total: 1259.57ms ± 6.86ms. Best: 1252.03ms<br/>Min time: 1.06ms ± 0.00ms<br/>Mean time: 1.26ms ± 0.01ms<br/>Median time: 1.17ms ± 0.01ms<br/>95th percentile: 1.67ms ± 0.01ms<br/>99th percentile: 1.72ms ± 0.01ms<br/>Max time: 4.41ms ± 2.64ms | Ops: 803.74 ± 3.68 ops/s. Best: 796.67 ops/s<br/>Total: 1244.20ms ± 5.94ms. Best: 1234.17ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.70ms ± 0.02ms<br/>Max time: 4.68ms ± 2.96ms |
| e2e_nearest_mld | Ops: 795.16 ± 4.46 ops/s. Best: 786.19 ops/s<br/>Total: 1257.46ms ± 7.20ms. Best: 1249.37ms<br/>Min time: 1.07ms ± 0.01ms<br/>Mean time: 1.26ms ± 0.01ms<br/>Median time: 1.17ms ± 0.01ms<br/>95th percentile: 1.66ms ± 0.01ms<br/>99th percentile: 1.71ms ± 0.01ms<br/>Max time: 4.27ms ± 2.46ms | Ops: 801.13 ± 5.30 ops/s. Best: 788.82 ops/s<br/>Total: 1248.23ms ± 8.61ms. Best: 1239.04ms<br/>Min time: 1.06ms ± 0.00ms<br/>Mean time: 1.25ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.65ms ± 0.01ms<br/>99th percentile: 1.70ms ± 0.01ms<br/>Max time: 4.27ms ± 2.53ms |
| e2e_route_ch | Ops: 336.75 ± 4.12 ops/s. Best: 328.13 ops/s<br/>Total: 2969.21ms ± 37.81ms. Best: 2929.01ms<br/>Min time: 1.30ms ± 0.01ms<br/>Mean time: 2.97ms ± 0.04ms<br/>Median time: 2.99ms ± 0.04ms<br/>95th percentile: 3.93ms ± 0.07ms<br/>99th percentile: 4.35ms ± 0.06ms<br/>Max time: 6.91ms ± 2.02ms | Ops: 330.01 ± 1.00 ops/s. Best: 328.44 ops/s<br/>Total: 3030.13ms ± 9.21ms. Best: 3014.87ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 3.03ms ± 0.01ms<br/>Median time: 3.06ms ± 0.02ms<br/>95th percentile: 4.01ms ± 0.03ms<br/>99th percentile: 4.41ms ± 0.05ms<br/>Max time: 6.88ms ± 2.10ms |
| e2e_route_mld | Ops: 284.95 ± 0.77 ops/s. Best: 283.77 ops/s<br/>Total: 3509.05ms ± 9.30ms. Best: 3493.23ms<br/>Min time: 1.30ms ± 0.02ms<br/>Mean time: 3.51ms ± 0.01ms<br/>Median time: 3.55ms ± 0.01ms<br/>95th percentile: 4.76ms ± 0.02ms<br/>99th percentile: 5.25ms ± 0.06ms<br/>Max time: 7.62ms ± 1.86ms | Ops: 281.82 ± 2.86 ops/s. Best: 275.18 ops/s<br/>Total: 3549.27ms ± 36.50ms. Best: 3505.45ms<br/>Min time: 1.29ms ± 0.02ms<br/>Mean time: 3.55ms ± 0.04ms<br/>Median time: 3.59ms ± 0.04ms<br/>95th percentile: 4.86ms ± 0.05ms<br/>99th percentile: 5.32ms ± 0.08ms<br/>Max time: 7.74ms ± 1.79ms |
| e2e_table_ch | Ops: 311.85 ± 0.73 ops/s. Best: 310.54 ops/s<br/>Total: 3206.86ms ± 7.58ms. Best: 3196.61ms<br/>Min time: 1.65ms ± 0.01ms<br/>Mean time: 3.21ms ± 0.01ms<br/>Median time: 3.22ms ± 0.03ms<br/>95th percentile: 4.41ms ± 0.01ms<br/>99th percentile: 4.75ms ± 0.04ms<br/>Max time: 7.79ms ± 2.88ms | Ops: 296.28 ± 1.26 ops/s. Best: 293.66 ops/s<br/>Total: 3374.80ms ± 14.89ms. Best: 3356.56ms<br/>Min time: 1.79ms ± 0.02ms<br/>Mean time: 3.38ms ± 0.01ms<br/>Median time: 3.37ms ± 0.02ms<br/>95th percentile: 4.67ms ± 0.03ms<br/>99th percentile: 5.02ms ± 0.06ms<br/>Max time: 7.90ms ± 2.87ms |
| e2e_table_mld | Ops: 109.43 ± 0.59 ops/s. Best: 108.05 ops/s<br/>Total: 9139.97ms ± 53.96ms. Best: 9074.58ms<br/>Min time: 3.67ms ± 0.02ms<br/>Mean time: 9.14ms ± 0.05ms<br/>Median time: 9.10ms ± 0.06ms<br/>95th percentile: 13.98ms ± 0.07ms<br/>99th percentile: 14.92ms ± 0.12ms<br/>Max time: 17.59ms ± 1.75ms | Ops: 109.09 ± 0.64 ops/s. Best: 107.53 ops/s<br/>Total: 9168.71ms ± 53.87ms. Best: 9117.47ms<br/>Min time: 3.72ms ± 0.07ms<br/>Mean time: 9.17ms ± 0.05ms<br/>Median time: 9.14ms ± 0.09ms<br/>95th percentile: 13.98ms ± 0.08ms<br/>99th percentile: 14.96ms ± 0.08ms<br/>Max time: 17.41ms ± 1.84ms |
| e2e_trip_ch | Ops: 97.30 ± 0.25 ops/s. Best: 96.94 ops/s<br/>Total: 10276.52ms ± 27.11ms. Best: 10227.04ms<br/>Min time: 1.56ms ± 0.16ms<br/>Mean time: 10.28ms ± 0.03ms<br/>Median time: 9.73ms ± 0.02ms<br/>95th percentile: 18.15ms ± 0.05ms<br/>99th percentile: 19.76ms ± 0.09ms<br/>Max time: 22.09ms ± 1.77ms | Ops: 93.38 ± 0.68 ops/s. Best: 92.30 ops/s<br/>Total: 10712.71ms ± 77.87ms. Best: 10584.73ms<br/>Min time: 1.65ms ± 0.16ms<br/>Mean time: 10.71ms ± 0.08ms<br/>Median time: 10.21ms ± 0.07ms<br/>95th percentile: 18.79ms ± 0.12ms<br/>99th percentile: 20.54ms ± 0.16ms<br/>Max time: 23.23ms ± 1.98ms |
| e2e_trip_mld | Ops: 57.00 ± 0.51 ops/s. Best: 55.85 ops/s<br/>Total: 17535.88ms ± 158.58ms. Best: 17390.74ms<br/>Min time: 1.74ms ± 0.20ms<br/>Mean time: 17.54ms ± 0.16ms<br/>Median time: 17.11ms ± 0.11ms<br/>95th percentile: 28.66ms ± 0.19ms<br/>99th percentile: 30.44ms ± 0.38ms<br/>Max time: 32.80ms ± 1.21ms | Ops: 57.37 ± 0.18 ops/s. Best: 57.08 ops/s<br/>Total: 17426.93ms ± 54.36ms. Best: 17349.86ms<br/>Min time: 1.66ms ± 0.18ms<br/>Mean time: 17.43ms ± 0.05ms<br/>Median time: 17.03ms ± 0.02ms<br/>95th percentile: 28.46ms ± 0.08ms<br/>99th percentile: 30.68ms ± 0.17ms<br/>Max time: 32.63ms ± 0.47ms |
| json-render | String: 6.93903ms<br/>Stringstream: 10.9433ms<br/>Vector: 7.12766ms | String: 7.05322ms<br/>Stringstream: 10.85ms<br/>Vector: 7.11523ms |
| match_ch | Default radius: <br/>4.58758ms/req at 82 coordinate<br/>0.0559461ms/coordinate<br/>Radius 10m: <br/>16.0443ms/req at 82 coordinate<br/>0.195662ms/coordinate | Default radius: <br/>4.6402ms/req at 82 coordinate<br/>0.0565878ms/coordinate<br/>Radius 10m: <br/>16.1495ms/req at 82 coordinate<br/>0.196945ms/coordinate |
| match_mld | Default radius: <br/>3.31795ms/req at 82 coordinate<br/>0.0404628ms/coordinate<br/>Radius 10m: <br/>11.8065ms/req at 82 coordinate<br/>0.143982ms/coordinate | Default radius: <br/>3.12392ms/req at 82 coordinate<br/>0.0380966ms/coordinate<br/>Radius 10m: <br/>11.7198ms/req at 82 coordinate<br/>0.142924ms/coordinate |
| osrm_contract | Time: 95.75s Peak RAM: 195.98MB | Time: 97.12s Peak RAM: 195.82MB |
| osrm_customize | Time: 1.37s Peak RAM: 116.86MB | Time: 1.36s Peak RAM: 116.70MB |
| osrm_extract | Time: 12.22s Peak RAM: 407.75MB | Time: 12.13s Peak RAM: 406.00MB |
| osrm_partition | Time: 2.10s Peak RAM: 132.86MB | Time: 2.06s Peak RAM: 130.80MB |
| packedvector | random write:<br/>std::vector 11301.9 ms<br/>util::packed_vector 82291.8 ms<br/>slowdown: 7.28124<br/>random read:<br/>std::vector 11116 ms<br/>util::packed_vector 33500.8 ms<br/>slowdown: 3.01375 | random write:<br/>std::vector 11443.6 ms<br/>util::packed_vector 81823.6 ms<br/>slowdown: 7.15016<br/>random read:<br/>std::vector 11253.4 ms<br/>util::packed_vector 33728.5 ms<br/>slowdown: 2.99719 |
| random_match_ch | 500 matches, default radius<br/>ops: 218.90 ± 0.84 ops/s. best: 217.23ops/s.<br/>total: 260.40 ± 1.00ms. best: 259.53ms.<br/>avg: 4.57 ± 0.02ms<br/>min: 0.16 ± 0.01ms<br/>max: 25.31 ± 0.06ms<br/>p99: 25.31 ± 0.06ms<br/><br/>500 matches, radius=10<br/>ops: 63.63 ± 0.15 ops/s. best: 63.45ops/s.<br/>total: 1005.77 ± 2.37ms. best: 1001.90ms.<br/>avg: 15.72 ± 0.04ms<br/>min: 0.15 ± 0.00ms<br/>max: 250.29 ± 0.70ms<br/>p99: 250.29 ± 0.70ms<br/><br/>500 matches, radius=20<br/>ops: 15.01 ± 0.03 ops/s. best: 14.97ops/s.<br/>total: 4331.18 ± 7.13ms. best: 4317.31ms.<br/>avg: 66.63 ± 0.11ms<br/>min: 0.29 ± 0.00ms<br/>max: 1273.15 ± 5.77ms<br/>p99: 1273.15 ± 5.77ms | 500 matches, default radius<br/>ops: 206.76 ± 0.84 ops/s. best: 205.25ops/s.<br/>total: 275.69 ± 1.15ms. best: 274.27ms.<br/>avg: 4.84 ± 0.02ms<br/>min: 0.15 ± 0.01ms<br/>max: 24.13 ± 0.20ms<br/>p99: 24.13 ± 0.20ms<br/><br/>500 matches, radius=10<br/>ops: 61.11 ± 0.06 ops/s. best: 61.01ops/s.<br/>total: 1047.27 ± 1.00ms. best: 1046.02ms.<br/>avg: 16.36 ± 0.02ms<br/>min: 0.15 ± 0.00ms<br/>max: 235.78 ± 0.29ms<br/>p99: 235.78 ± 0.29ms<br/><br/>500 matches, radius=20<br/>ops: 14.54 ± 0.03 ops/s. best: 14.49ops/s.<br/>total: 4468.92 ± 10.16ms. best: 4451.56ms.<br/>avg: 68.75 ± 0.16ms<br/>min: 0.32 ± 0.01ms<br/>max: 1226.24 ± 6.08ms<br/>p99: 1226.24 ± 6.08ms |
| random_match_mld | 500 matches, default radius<br/>ops: 301.44 ± 1.33 ops/s. best: 298.55ops/s.<br/>total: 189.10 ± 0.90ms. best: 188.12ms.<br/>avg: 3.32 ± 0.02ms<br/>min: 0.13 ± 0.01ms<br/>max: 19.64 ± 0.04ms<br/>p99: 19.64 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 105.62 ± 0.12 ops/s. best: 105.34ops/s.<br/>total: 605.96 ± 0.69ms. best: 605.25ms.<br/>avg: 9.47 ± 0.01ms<br/>min: 0.14 ± 0.00ms<br/>max: 115.36 ± 0.28ms<br/>p99: 115.36 ± 0.28ms<br/><br/>500 matches, radius=20<br/>ops: 21.18 ± 0.03 ops/s. best: 21.14ops/s.<br/>total: 3069.57 ± 3.68ms. best: 3062.47ms.<br/>avg: 47.22 ± 0.06ms<br/>min: 0.21 ± 0.01ms<br/>max: 609.45 ± 0.81ms<br/>p99: 609.45 ± 0.81ms | 500 matches, default radius<br/>ops: 303.07 ± 2.08 ops/s. best: 297.86ops/s.<br/>total: 188.09 ± 1.31ms. best: 187.12ms.<br/>avg: 3.30 ± 0.02ms<br/>min: 0.13 ± 0.00ms<br/>max: 19.59 ± 0.18ms<br/>p99: 19.59 ± 0.18ms<br/><br/>500 matches, radius=10<br/>ops: 107.50 ± 0.20 ops/s. best: 107.11ops/s.<br/>total: 595.35 ± 1.15ms. best: 593.89ms.<br/>avg: 9.30 ± 0.02ms<br/>min: 0.14 ± 0.00ms<br/>max: 112.88 ± 0.25ms<br/>p99: 112.88 ± 0.25ms<br/><br/>500 matches, radius=20<br/>ops: 21.48 ± 0.03 ops/s. best: 21.43ops/s.<br/>total: 3025.59 ± 4.84ms. best: 3019.44ms.<br/>avg: 46.55 ± 0.07ms<br/>min: 0.21 ± 0.00ms<br/>max: 597.39 ± 2.00ms<br/>p99: 597.39 ± 2.00ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 22621.49 ± 89.41 ops/s. best: 22429.13ops/s.<br/>total: 442.07 ± 1.74ms. best: 440.19ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17639.99 ± 28.26 ops/s. best: 17590.23ops/s.<br/>total: 566.90 ± 0.89ms. best: 565.47ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 13849.98 ± 13.85 ops/s. best: 13828.86ops/s.<br/>total: 722.02 ± 0.75ms. best: 721.15ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22499.84 ± 59.68 ops/s. best: 22376.55ops/s.<br/>total: 444.45 ± 1.18ms. best: 442.87ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17273.94 ± 7.32 ops/s. best: 17262.03ops/s.<br/>total: 578.91 ± 0.25ms. best: 578.49ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 13463.85 ± 25.00 ops/s. best: 13418.29ops/s.<br/>total: 742.73 ± 1.38ms. best: 740.65ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 22684.02 ± 39.93 ops/s. best: 22597.81ops/s.<br/>total: 440.84 ± 0.78ms. best: 439.93ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17624.80 ± 34.15 ops/s. best: 17577.45ops/s.<br/>total: 567.38 ± 1.10ms. best: 565.37ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 13927.35 ± 17.58 ops/s. best: 13894.38ops/s.<br/>total: 718.01 ± 0.91ms. best: 716.84ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22370.93 ± 36.67 ops/s. best: 22299.59ops/s.<br/>total: 447.01 ± 0.73ms. best: 446.09ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17224.44 ± 15.87 ops/s. best: 17194.63ops/s.<br/>total: 580.57 ± 0.55ms. best: 579.73ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.01ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 13430.49 ± 16.54 ops/s. best: 13398.48ops/s.<br/>total: 744.58 ± 0.92ms. best: 743.55ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 501.84 ± 2.86 ops/s. best: 495.88ops/s.<br/>total: 1960.89 ± 11.26ms. best: 1950.62ms.<br/>avg: 1.99 ± 0.01ms<br/>min: 0.29 ± 0.01ms<br/>max: 3.45 ± 0.32ms<br/>p99: 2.92 ± 0.05ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 576.28 ± 0.64 ops/s. best: 575.06ops/s.<br/>total: 1735.28 ± 1.93ms. best: 1733.13ms.<br/>avg: 1.74 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.82 ± 0.06ms<br/>p99: 3.71 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 999.39 ± 4.61 ops/s. best: 993.62ops/s.<br/>total: 984.63 ± 4.54ms. best: 976.87ms.<br/>avg: 1.00 ± 0.00ms<br/>min: 0.22 ± 0.00ms<br/>max: 1.59 ± 0.02ms<br/>p99: 1.42 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1043.89 ± 8.26 ops/s. best: 1031.41ops/s.<br/>total: 958.03 ± 7.60ms. best: 948.75ms.<br/>avg: 0.96 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 3.92 ± 0.06ms<br/>p99: 2.07 ± 0.02ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 473.71 ± 1.42 ops/s. best: 470.38ops/s.<br/>total: 2077.27 ± 6.27ms. best: 2071.38ms.<br/>avg: 2.11 ± 0.01ms<br/>min: 0.29 ± 0.01ms<br/>max: 3.81 ± 0.35ms<br/>p99: 3.05 ± 0.04ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 553.98 ± 1.19 ops/s. best: 552.29ops/s.<br/>total: 1805.12 ± 3.89ms. best: 1799.04ms.<br/>avg: 1.81 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.62 ± 0.07ms<br/>p99: 3.97 ± 0.02ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 928.20 ± 4.12 ops/s. best: 922.67ops/s.<br/>total: 1060.15 ± 4.69ms. best: 1051.25ms.<br/>avg: 1.08 ± 0.00ms<br/>min: 0.23 ± 0.00ms<br/>max: 1.74 ± 0.02ms<br/>p99: 1.53 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1026.55 ± 2.61 ops/s. best: 1022.04ops/s.<br/>total: 974.14 ± 2.48ms. best: 969.92ms.<br/>avg: 0.97 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 3.51 ± 0.04ms<br/>p99: 2.32 ± 0.02ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 248.07 ± 0.45 ops/s. best: 247.13ops/s.<br/>total: 3966.58 ± 7.26ms. best: 3957.50ms.<br/>avg: 4.03 ± 0.01ms<br/>min: 0.29 ± 0.01ms<br/>max: 8.86 ± 0.18ms<br/>p99: 6.73 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 242.35 ± 0.51 ops/s. best: 241.41ops/s.<br/>total: 4126.22 ± 8.63ms. best: 4115.44ms.<br/>avg: 4.13 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.25 ± 0.12ms<br/>p99: 8.28 ± 0.07ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 331.86 ± 0.76 ops/s. best: 330.60ops/s.<br/>total: 2965.11 ± 6.83ms. best: 2954.45ms.<br/>avg: 3.01 ± 0.01ms<br/>min: 0.26 ± 0.00ms<br/>max: 7.27 ± 0.08ms<br/>p99: 5.17 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 301.34 ± 1.37 ops/s. best: 298.25ops/s.<br/>total: 3318.59 ± 15.79ms. best: 3300.22ms.<br/>avg: 3.32 ± 0.02ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.39 ± 0.11ms<br/>p99: 6.61 ± 0.05ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 241.72 ± 0.37 ops/s. best: 241.24ops/s.<br/>total: 4070.85 ± 6.37ms. best: 4057.66ms.<br/>avg: 4.14 ± 0.01ms<br/>min: 0.29 ± 0.01ms<br/>max: 9.00 ± 0.21ms<br/>p99: 6.97 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 235.71 ± 0.95 ops/s. best: 234.42ops/s.<br/>total: 4242.60 ± 17.16ms. best: 4220.43ms.<br/>avg: 4.24 ± 0.02ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.97 ± 0.28ms<br/>p99: 8.48 ± 0.06ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 320.25 ± 5.73 ops/s. best: 311.96ops/s.<br/>total: 3073.89 ± 55.29ms. best: 3013.25ms.<br/>avg: 3.12 ± 0.06ms<br/>min: 0.26 ± 0.00ms<br/>max: 7.43 ± 0.15ms<br/>p99: 5.36 ± 0.15ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 296.97 ± 0.93 ops/s. best: 295.25ops/s.<br/>total: 3367.33 ± 10.65ms. best: 3351.47ms.<br/>avg: 3.37 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.38 ± 0.21ms<br/>p99: 6.58 ± 0.04ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1495.95 ± 11.25 ops/s. best: 1473.35ops/s.<br/>total: 167.13 ± 1.31ms. best: 165.31ms.<br/>avg: 0.67 ± 0.01ms<br/>min: 0.47 ± 0.00ms<br/>max: 1.08 ± 0.29ms<br/>p99: 0.86 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 174.73 ± 0.60 ops/s. best: 174.11ops/s.<br/>total: 1430.80 ± 5.06ms. best: 1419.66ms.<br/>avg: 5.72 ± 0.02ms<br/>min: 5.12 ± 0.03ms<br/>max: 6.47 ± 0.16ms<br/>p99: 6.23 ± 0.03ms<br/><br/>250 tables, 50 coordinates<br/>ops: 86.92 ± 0.05 ops/s. best: 86.81ops/s.<br/>total: 2876.26 ± 1.68ms. best: 2874.56ms.<br/>avg: 11.51 ± 0.01ms<br/>min: 10.77 ± 0.03ms<br/>max: 12.43 ± 0.10ms<br/>p99: 12.31 ± 0.04ms | 250 tables, 3 coordinates<br/>ops: 1349.85 ± 9.04 ops/s. best: 1328.27ops/s.<br/>total: 185.22 ± 1.25ms. best: 184.04ms.<br/>avg: 0.74 ± 0.01ms<br/>min: 0.58 ± 0.00ms<br/>max: 1.12 ± 0.21ms<br/>p99: 0.95 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 160.61 ± 0.08 ops/s. best: 160.48ops/s.<br/>total: 1556.55 ± 0.81ms. best: 1554.93ms.<br/>avg: 6.23 ± 0.00ms<br/>min: 5.62 ± 0.01ms<br/>max: 7.08 ± 0.28ms<br/>p99: 6.83 ± 0.03ms<br/><br/>250 tables, 50 coordinates<br/>ops: 78.99 ± 0.10 ops/s. best: 78.82ops/s.<br/>total: 3165.13 ± 4.03ms. best: 3160.03ms.<br/>avg: 12.66 ± 0.02ms<br/>min: 11.70 ± 0.04ms<br/>max: 14.14 ± 0.68ms<br/>p99: 13.54 ± 0.11ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 343.45 ± 1.21 ops/s. best: 341.05ops/s.<br/>total: 727.92 ± 2.58ms. best: 724.62ms.<br/>avg: 2.91 ± 0.01ms<br/>min: 2.30 ± 0.01ms<br/>max: 4.05 ± 0.10ms<br/>p99: 3.82 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.25 ± 0.02 ops/s. best: 38.23ops/s.<br/>total: 6536.20 ± 3.37ms. best: 6529.08ms.<br/>avg: 26.14 ± 0.01ms<br/>min: 23.69 ± 0.06ms<br/>max: 29.84 ± 0.04ms<br/>p99: 28.80 ± 0.07ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.65 ± 0.07 ops/s. best: 17.54ops/s.<br/>total: 14165.60 ± 57.67ms. best: 14074.99ms.<br/>avg: 56.66 ± 0.23ms<br/>min: 52.78 ± 0.29ms<br/>max: 62.38 ± 1.54ms<br/>p99: 60.76 ± 0.62ms | 250 tables, 3 coordinates<br/>ops: 343.12 ± 0.70 ops/s. best: 341.53ops/s.<br/>total: 728.61 ± 1.49ms. best: 726.84ms.<br/>avg: 2.91 ± 0.01ms<br/>min: 2.31 ± 0.01ms<br/>max: 3.97 ± 0.03ms<br/>p99: 3.83 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 37.77 ± 0.28 ops/s. best: 37.21ops/s.<br/>total: 6619.79 ± 49.76ms. best: 6564.94ms.<br/>avg: 26.48 ± 0.20ms<br/>min: 23.74 ± 0.12ms<br/>max: 30.51 ± 0.60ms<br/>p99: 29.41 ± 0.32ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.59 ± 0.07 ops/s. best: 17.46ops/s.<br/>total: 14212.94 ± 53.35ms. best: 14139.27ms.<br/>avg: 56.85 ± 0.21ms<br/>min: 52.56 ± 0.17ms<br/>max: 61.83 ± 0.96ms<br/>p99: 61.15 ± 0.72ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 460.87 ± 7.07 ops/s. best: 450.25ops/s.<br/>total: 542.63 ± 8.23ms. best: 527.62ms.<br/>avg: 2.17 ± 0.03ms<br/>min: 1.08 ± 0.02ms<br/>max: 3.18 ± 0.43ms<br/>p99: 2.87 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 318.27 ± 1.44 ops/s. best: 315.75ops/s.<br/>total: 785.51 ± 3.55ms. best: 781.30ms.<br/>avg: 3.14 ± 0.01ms<br/>min: 2.16 ± 0.03ms<br/>max: 4.01 ± 0.12ms<br/>p99: 3.91 ± 0.06ms | 250 trips, 3 coordinates<br/>ops: 449.14 ± 2.45 ops/s. best: 445.28ops/s.<br/>total: 556.64 ± 3.07ms. best: 552.81ms.<br/>avg: 2.23 ± 0.01ms<br/>min: 1.18 ± 0.01ms<br/>max: 3.10 ± 0.30ms<br/>p99: 2.83 ± 0.03ms<br/><br/>250 trips, 5 coordinates<br/>ops: 299.20 ± 0.69 ops/s. best: 297.66ops/s.<br/>total: 835.58 ± 1.92ms. best: 833.55ms.<br/>avg: 3.34 ± 0.01ms<br/>min: 2.23 ± 0.01ms<br/>max: 4.37 ± 0.18ms<br/>p99: 4.08 ± 0.08ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 170.51 ± 0.54 ops/s. best: 169.46ops/s.<br/>total: 1466.17 ± 4.71ms. best: 1459.61ms.<br/>avg: 5.86 ± 0.02ms<br/>min: 3.89 ± 0.01ms<br/>max: 8.03 ± 0.25ms<br/>p99: 7.57 ± 0.06ms<br/><br/>250 trips, 5 coordinates<br/>ops: 111.20 ± 0.37 ops/s. best: 110.50ops/s.<br/>total: 2248.23 ± 7.71ms. best: 2236.07ms.<br/>avg: 8.99 ± 0.03ms<br/>min: 6.34 ± 0.03ms<br/>max: 11.50 ± 0.40ms<br/>p99: 11.04 ± 0.21ms | 250 trips, 3 coordinates<br/>ops: 166.95 ± 1.70 ops/s. best: 163.88ops/s.<br/>total: 1497.69 ± 15.31ms. best: 1476.80ms.<br/>avg: 5.99 ± 0.06ms<br/>min: 3.90 ± 0.01ms<br/>max: 8.22 ± 0.22ms<br/>p99: 7.81 ± 0.20ms<br/><br/>250 trips, 5 coordinates<br/>ops: 110.10 ± 0.34 ops/s. best: 109.63ops/s.<br/>total: 2270.79 ± 6.83ms. best: 2258.22ms.<br/>avg: 9.08 ± 0.03ms<br/>min: 6.38 ± 0.05ms<br/>max: 11.38 ± 0.13ms<br/>p99: 10.91 ± 0.02ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>445.042ms<br/>0.445042ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>544.645ms<br/>0.544645ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>162.004ms<br/>0.162004ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>145.406ms<br/>0.145406ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>478.143ms<br/>0.478143ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>568.967ms<br/>0.568967ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>163.745ms<br/>0.163745ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>147.019ms<br/>0.147019ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>589.957ms<br/>0.589957ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>734.834ms<br/>0.734834ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>291.979ms<br/>0.291979ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>314.456ms<br/>0.314456ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>604.821ms<br/>0.604821ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>765.669ms<br/>0.765669ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>297.995ms<br/>0.297995ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>324.204ms<br/>0.324204ms/req |
| rtree | 1 result:<br/>209.112ms ->  0.0209112 ms/query<br/>10 results:<br/>249.15ms ->  0.024915 ms/query | 1 result:<br/>209.896ms ->  0.0209896 ms/query<br/>10 results:<br/>241.187ms ->  0.0241187 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->


