### PR TITLE
Fix calculation of best ops/sec in benchmarks

### DIFF
--- a/scripts/ci/e2e_benchmark.py
+++ b/scripts/ci/e2e_benchmark.py
@@ -86,9 +86,9 @@ def bootstrap_confidence_interval(data, num_samples=1000, confidence_level=0.95)
     mean = np.mean(means)
     return mean, lower_bound, upper_bound
 
-def calculate_confidence_interval(data):
+def calculate_confidence_interval(data, min_is_best=True):
     mean, lower, upper = bootstrap_confidence_interval(data)
-    min_value = np.min(data)
+    min_value = np.min(data) if min_is_best else np.max(data)
     return mean, (upper - lower) / 2, min_value
 
 
@@ -117,7 +117,7 @@ def main():
 
 
     total_time, total_ci, total_best = calculate_confidence_interval(np.sum(all_times, axis=1))
-    ops_per_sec, ops_per_sec_ci, ops_per_sec_best = calculate_confidence_interval(float(all_times.shape[1]) / np.sum(all_times / 1000, axis=1))
+    ops_per_sec, ops_per_sec_ci, ops_per_sec_best = calculate_confidence_interval(float(all_times.shape[1]) / np.sum(all_times / 1000, axis=1), min_is_best=False)
     min_time, min_ci, _ = calculate_confidence_interval(np.min(all_times, axis=1))
     mean_time, mean_ci, _ = calculate_confidence_interval(np.mean(all_times, axis=1))
     median_time, median_ci, _ = calculate_confidence_interval(np.median(all_times, axis=1))

--- a/src/benchmarks/bench.cpp
+++ b/src/benchmarks/bench.cpp
@@ -134,6 +134,7 @@ struct ConfidenceInterval
     double mean;
     double confidence;
     double min;
+    double max;
 };
 
 // Helper function to calculate the bootstrap confidence interval
@@ -162,7 +163,7 @@ ConfidenceInterval confidenceInterval(const std::vector<double> &data,
     double mean = std::accumulate(means.begin(), means.end(), 0.0) / means.size();
 
     ConfidenceInterval ci = {
-        mean, (upper_bound - lower_bound) / 2, *std::min_element(data.begin(), data.end())};
+        mean, (upper_bound - lower_bound) / 2, *std::min_element(data.begin(), data.end()), *std::max_element(data.begin(), data.end())};
     return ci;
 }
 
@@ -260,7 +261,7 @@ std::ostream &operator<<(std::ostream &os, Statistics &statistics)
     ConfidenceInterval ops_ci = statistics.ops_per_sec();
 
     os << "ops: " << ops_ci.mean << " ± " << ops_ci.confidence << " ops/s. "
-       << "best: " << ops_ci.min << "ops/s." << std::endl;
+       << "best: " << ops_ci.max << "ops/s." << std::endl;
     os << "total: " << total_ci.mean << " ± " << total_ci.confidence << "ms. "
        << "best: " << total_ci.min << "ms." << std::endl;
     os << "avg: " << mean_ci.mean << " ± " << mean_ci.confidence << "ms" << std::endl;

--- a/src/benchmarks/bench.cpp
+++ b/src/benchmarks/bench.cpp
@@ -162,8 +162,10 @@ ConfidenceInterval confidenceInterval(const std::vector<double> &data,
     double upper_bound = means[(int)((1 + confidence_level) / 2 * num_samples)];
     double mean = std::accumulate(means.begin(), means.end(), 0.0) / means.size();
 
-    ConfidenceInterval ci = {
-        mean, (upper_bound - lower_bound) / 2, *std::min_element(data.begin(), data.end()), *std::max_element(data.begin(), data.end())};
+    ConfidenceInterval ci = {mean,
+                             (upper_bound - lower_bound) / 2,
+                             *std::min_element(data.begin(), data.end()),
+                             *std::max_element(data.begin(), data.end())};
     return ci;
 }
 


### PR DESCRIPTION

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1086.11<br/>plain u32: 1081.2<br/>aliased double: 951.047<br/>plain double: 942.633 | aliased u32: 1088.22<br/>plain u32: 1094.7<br/>aliased double: 961.666<br/>plain double: 954.113 |
| e2e_match_ch | Ops: 42.77 ± 0.19 ops/s. Best: 43.00 ops/s<br/>Total: 3062.18ms ± 13.54ms. Best: 3046.72ms<br/>Min time: 2.23ms ± 0.02ms<br/>Mean time: 23.38ms ± 0.10ms<br/>Median time: 17.36ms ± 0.08ms<br/>95th percentile: 77.55ms ± 1.55ms<br/>99th percentile: 93.73ms ± 1.46ms<br/>Max time: 97.74ms ± 1.67ms | Ops: 43.52 ± 0.15 ops/s. Best: 43.75 ops/s<br/>Total: 3010.81ms ± 10.29ms. Best: 2994.11ms<br/>Min time: 2.18ms ± 0.03ms<br/>Mean time: 22.98ms ± 0.08ms<br/>Median time: 16.86ms ± 0.13ms<br/>95th percentile: 75.69ms ± 0.23ms<br/>99th percentile: 93.31ms ± 0.95ms<br/>Max time: 96.76ms ± 0.36ms |
| e2e_match_mld | Ops: 62.37 ± 0.11 ops/s. Best: 62.61 ops/s<br/>Total: 2100.32ms ± 3.72ms. Best: 2092.26ms<br/>Min time: 1.84ms ± 0.04ms<br/>Mean time: 16.03ms ± 0.03ms<br/>Median time: 8.65ms ± 0.09ms<br/>95th percentile: 53.19ms ± 0.11ms<br/>99th percentile: 61.34ms ± 0.23ms<br/>Max time: 71.19ms ± 0.39ms | Ops: 62.34 ± 0.07 ops/s. Best: 62.47 ops/s<br/>Total: 2101.34ms ± 2.39ms. Best: 2096.85ms<br/>Min time: 1.84ms ± 0.05ms<br/>Mean time: 16.04ms ± 0.02ms<br/>Median time: 8.55ms ± 0.07ms<br/>95th percentile: 53.23ms ± 0.19ms<br/>99th percentile: 61.79ms ± 0.27ms<br/>Max time: 71.73ms ± 1.25ms |
| e2e_nearest_ch | Ops: 784.86 ± 4.77 ops/s. Best: 791.46 ops/s<br/>Total: 1274.31ms ± 7.79ms. Best: 1263.49ms<br/>Min time: 1.08ms ± 0.01ms<br/>Mean time: 1.27ms ± 0.01ms<br/>Median time: 1.18ms ± 0.01ms<br/>95th percentile: 1.69ms ± 0.02ms<br/>99th percentile: 1.77ms ± 0.02ms<br/>Max time: 4.96ms ± 3.03ms | Ops: 806.48 ± 4.84 ops/s. Best: 812.31 ops/s<br/>Total: 1239.91ms ± 7.75ms. Best: 1231.06ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 4.25ms ± 2.54ms |
| e2e_nearest_mld | Ops: 781.73 ± 5.91 ops/s. Best: 794.21 ops/s<br/>Total: 1279.38ms ± 9.80ms. Best: 1259.10ms<br/>Min time: 1.07ms ± 0.01ms<br/>Mean time: 1.28ms ± 0.01ms<br/>Median time: 1.18ms ± 0.01ms<br/>95th percentile: 1.71ms ± 0.02ms<br/>99th percentile: 1.79ms ± 0.02ms<br/>Max time: 5.33ms ± 3.32ms | Ops: 806.37 ± 4.01 ops/s. Best: 811.71 ops/s<br/>Total: 1240.10ms ± 6.75ms. Best: 1231.97ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 4.23ms ± 2.41ms |
| e2e_route_ch | Ops: 311.72 ± 1.62 ops/s. Best: 315.09 ops/s<br/>Total: 3208.24ms ± 17.61ms. Best: 3173.72ms<br/>Min time: 1.33ms ± 0.02ms<br/>Mean time: 3.21ms ± 0.02ms<br/>Median time: 3.24ms ± 0.02ms<br/>95th percentile: 4.28ms ± 0.03ms<br/>99th percentile: 4.75ms ± 0.07ms<br/>Max time: 7.42ms ± 2.15ms | Ops: 347.08 ± 1.36 ops/s. Best: 348.91 ops/s<br/>Total: 2881.23ms ± 11.19ms. Best: 2866.05ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 2.88ms ± 0.01ms<br/>Median time: 2.90ms ± 0.02ms<br/>95th percentile: 3.79ms ± 0.02ms<br/>99th percentile: 4.19ms ± 0.04ms<br/>Max time: 6.67ms ± 1.84ms |
| e2e_route_mld | Ops: 247.22 ± 5.02 ops/s. Best: 252.98 ops/s<br/>Total: 4048.20ms ± 88.16ms. Best: 3952.82ms<br/>Min time: 1.37ms ± 0.03ms<br/>Mean time: 4.05ms ± 0.09ms<br/>Median time: 4.11ms ± 0.10ms<br/>95th percentile: 5.56ms ± 0.11ms<br/>99th percentile: 6.12ms ± 0.15ms<br/>Max time: 8.59ms ± 1.84ms | Ops: 284.15 ± 7.15 ops/s. Best: 291.22 ops/s<br/>Total: 3522.05ms ± 94.49ms. Best: 3433.88ms<br/>Min time: 1.26ms ± 0.01ms<br/>Mean time: 3.52ms ± 0.09ms<br/>Median time: 3.56ms ± 0.10ms<br/>95th percentile: 4.82ms ± 0.16ms<br/>99th percentile: 5.29ms ± 0.18ms<br/>Max time: 7.69ms ± 1.70ms |
| e2e_table_ch | Ops: 286.55 ± 7.01 ops/s. Best: 295.50 ops/s<br/>Total: 3489.37ms ± 89.26ms. Best: 3384.04ms<br/>Min time: 1.85ms ± 0.07ms<br/>Mean time: 3.49ms ± 0.09ms<br/>Median time: 3.48ms ± 0.09ms<br/>95th percentile: 4.79ms ± 0.10ms<br/>99th percentile: 5.15ms ± 0.11ms<br/>Max time: 8.47ms ± 3.26ms | Ops: 317.05 ± 1.06 ops/s. Best: 318.77 ops/s<br/>Total: 3154.13ms ± 10.50ms. Best: 3137.01ms<br/>Min time: 1.69ms ± 0.02ms<br/>Mean time: 3.15ms ± 0.01ms<br/>Median time: 3.15ms ± 0.02ms<br/>95th percentile: 4.33ms ± 0.02ms<br/>99th percentile: 4.65ms ± 0.02ms<br/>Max time: 7.49ms ± 2.81ms |
| e2e_table_mld | Ops: 110.43 ± 0.30 ops/s. Best: 110.92 ops/s<br/>Total: 9055.48ms ± 26.82ms. Best: 9015.63ms<br/>Min time: 3.73ms ± 0.02ms<br/>Mean time: 9.06ms ± 0.03ms<br/>Median time: 9.02ms ± 0.04ms<br/>95th percentile: 13.82ms ± 0.05ms<br/>99th percentile: 14.75ms ± 0.09ms<br/>Max time: 17.66ms ± 2.43ms | Ops: 109.68 ± 0.88 ops/s. Best: 110.67 ops/s<br/>Total: 9117.71ms ± 73.99ms. Best: 9036.19ms<br/>Min time: 3.68ms ± 0.03ms<br/>Mean time: 9.12ms ± 0.07ms<br/>Median time: 9.05ms ± 0.07ms<br/>95th percentile: 13.92ms ± 0.11ms<br/>99th percentile: 14.90ms ± 0.25ms<br/>Max time: 17.78ms ± 1.94ms |
| e2e_trip_ch | Ops: 87.26 ± 0.78 ops/s. Best: 88.86 ops/s<br/>Total: 11467.28ms ± 105.08ms. Best: 11253.04ms<br/>Min time: 1.94ms ± 0.04ms<br/>Mean time: 11.46ms ± 0.11ms<br/>Median time: 11.00ms ± 0.12ms<br/>95th percentile: 19.85ms ± 0.15ms<br/>99th percentile: 21.51ms ± 0.22ms<br/>Max time: 23.12ms ± 0.36ms | Ops: 97.20 ± 0.20 ops/s. Best: 97.48 ops/s<br/>Total: 10289.35ms ± 21.10ms. Best: 10258.48ms<br/>Min time: 1.58ms ± 0.10ms<br/>Mean time: 10.29ms ± 0.02ms<br/>Median time: 9.77ms ± 0.02ms<br/>95th percentile: 18.21ms ± 0.05ms<br/>99th percentile: 19.95ms ± 0.19ms<br/>Max time: 22.48ms ± 1.12ms |
| e2e_trip_mld | Ops: 52.56 ± 0.44 ops/s. Best: 53.66 ops/s<br/>Total: 19026.74ms ± 157.11ms. Best: 18634.51ms<br/>Min time: 1.92ms ± 0.29ms<br/>Mean time: 19.03ms ± 0.16ms<br/>Median time: 18.64ms ± 0.22ms<br/>95th percentile: 30.68ms ± 0.19ms<br/>99th percentile: 32.73ms ± 0.26ms<br/>Max time: 34.74ms ± 0.66ms | Ops: 57.35 ± 0.28 ops/s. Best: 57.87 ops/s<br/>Total: 17440.20ms ± 77.70ms. Best: 17279.90ms<br/>Min time: 1.75ms ± 0.32ms<br/>Mean time: 17.44ms ± 0.08ms<br/>Median time: 16.99ms ± 0.06ms<br/>95th percentile: 28.52ms ± 0.09ms<br/>99th percentile: 30.37ms ± 0.16ms<br/>Max time: 34.52ms ± 2.46ms |
| json-render | String: 6.78794ms<br/>Stringstream: 10.581ms<br/>Vector: 7.00681ms | String: 6.95215ms<br/>Stringstream: 10.7414ms<br/>Vector: 6.96387ms |
| match_ch | Default radius: <br/>4.59307ms/req at 82 coordinate<br/>0.056013ms/coordinate<br/>Radius 10m: <br/>16.0956ms/req at 82 coordinate<br/>0.196288ms/coordinate | Default radius: <br/>4.59509ms/req at 82 coordinate<br/>0.0560377ms/coordinate<br/>Radius 10m: <br/>15.8894ms/req at 82 coordinate<br/>0.193773ms/coordinate |
| match_mld | Default radius: <br/>3.13701ms/req at 82 coordinate<br/>0.0382563ms/coordinate<br/>Radius 10m: <br/>12.0385ms/req at 82 coordinate<br/>0.146811ms/coordinate | Default radius: <br/>3.26805ms/req at 82 coordinate<br/>0.0398543ms/coordinate<br/>Radius 10m: <br/>11.8268ms/req at 82 coordinate<br/>0.144229ms/coordinate |
| osrm_contract | Time: 96.03s Peak RAM: 195.78MB | Time: 94.35s Peak RAM: 196.54MB |
| osrm_customize | Time: 1.35s Peak RAM: 116.93MB | Time: 1.33s Peak RAM: 116.64MB |
| osrm_extract | Time: 12.17s Peak RAM: 414.25MB | Time: 12.05s Peak RAM: 413.26MB |
| osrm_partition | Time: 2.12s Peak RAM: 133.17MB | Time: 2.02s Peak RAM: 133.48MB |
| packedvector | random write:<br/>std::vector 9770.43 ms<br/>util::packed_vector 73415.5 ms<br/>slowdown: 7.51405<br/>random read:<br/>std::vector 8431.23 ms<br/>util::packed_vector 30084.1 ms<br/>slowdown: 3.56817 | random write:<br/>std::vector 9866.67 ms<br/>util::packed_vector 81699.9 ms<br/>slowdown: 8.28039<br/>random read:<br/>std::vector 8503.38 ms<br/>util::packed_vector 33102 ms<br/>slowdown: 3.8928 |
| random_match_ch | 500 matches, default radius<br/>ops: 215.85 ± 1.21 ops/s. best: 213.26ops/s.<br/>total: 264.08 ± 1.49ms. best: 262.11ms.<br/>avg: 4.63 ± 0.03ms<br/>min: 0.16 ± 0.01ms<br/>max: 23.90 ± 0.11ms<br/>p99: 23.90 ± 0.11ms<br/><br/>500 matches, radius=10<br/>ops: 65.25 ± 0.05 ops/s. best: 65.19ops/s.<br/>total: 980.83 ± 0.71ms. best: 979.53ms.<br/>avg: 15.33 ± 0.01ms<br/>min: 0.16 ± 0.00ms<br/>max: 223.36 ± 0.35ms<br/>p99: 223.36 ± 0.35ms<br/><br/>500 matches, radius=20<br/>ops: 15.72 ± 0.04 ops/s. best: 15.65ops/s.<br/>total: 4134.45 ± 9.60ms. best: 4121.13ms.<br/>avg: 63.61 ± 0.15ms<br/>min: 0.35 ± 0.00ms<br/>max: 1111.49 ± 2.65ms<br/>p99: 1111.49 ± 2.65ms | 500 matches, default radius<br/>ops: 222.40 ± 1.06 ops/s. best: 223.78ops/s.<br/>total: 256.31 ± 1.23ms. best: 254.72ms.<br/>avg: 4.50 ± 0.02ms<br/>min: 0.15 ± 0.01ms<br/>max: 23.32 ± 0.16ms<br/>p99: 23.32 ± 0.16ms<br/><br/>500 matches, radius=10<br/>ops: 66.72 ± 0.36 ops/s. best: 67.05ops/s.<br/>total: 959.25 ± 5.15ms. best: 954.58ms.<br/>avg: 14.99 ± 0.08ms<br/>min: 0.16 ± 0.00ms<br/>max: 218.94 ± 0.85ms<br/>p99: 218.94 ± 0.85ms<br/><br/>500 matches, radius=20<br/>ops: 16.02 ± 0.03 ops/s. best: 16.07ops/s.<br/>total: 4057.13 ± 6.89ms. best: 4044.67ms.<br/>avg: 62.42 ± 0.11ms<br/>min: 0.34 ± 0.00ms<br/>max: 1089.02 ± 1.72ms<br/>p99: 1089.02 ± 1.72ms |
| random_match_mld | 500 matches, default radius<br/>ops: 301.69 ± 1.50 ops/s. best: 298.09ops/s.<br/>total: 188.94 ± 0.96ms. best: 188.00ms.<br/>avg: 3.31 ± 0.02ms<br/>min: 0.14 ± 0.00ms<br/>max: 19.62 ± 0.03ms<br/>p99: 19.62 ± 0.03ms<br/><br/>500 matches, radius=10<br/>ops: 106.93 ± 0.08 ops/s. best: 106.82ops/s.<br/>total: 598.53 ± 0.42ms. best: 597.86ms.<br/>avg: 9.35 ± 0.01ms<br/>min: 0.15 ± 0.00ms<br/>max: 113.43 ± 0.09ms<br/>p99: 113.43 ± 0.09ms<br/><br/>500 matches, radius=20<br/>ops: 21.37 ± 0.07 ops/s. best: 21.20ops/s.<br/>total: 3042.31 ± 10.40ms. best: 3032.12ms.<br/>avg: 46.80 ± 0.16ms<br/>min: 0.21 ± 0.00ms<br/>max: 596.66 ± 1.60ms<br/>p99: 596.66 ± 1.60ms | 500 matches, default radius<br/>ops: 299.80 ± 2.11 ops/s. best: 302.41ops/s.<br/>total: 190.14 ± 1.38ms. best: 188.49ms.<br/>avg: 3.34 ± 0.02ms<br/>min: 0.14 ± 0.00ms<br/>max: 19.73 ± 0.04ms<br/>p99: 19.73 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 105.41 ± 0.12 ops/s. best: 105.66ops/s.<br/>total: 607.15 ± 0.69ms. best: 605.70ms.<br/>avg: 9.49 ± 0.01ms<br/>min: 0.15 ± 0.00ms<br/>max: 115.88 ± 0.36ms<br/>p99: 115.88 ± 0.36ms<br/><br/>500 matches, radius=20<br/>ops: 21.04 ± 0.04 ops/s. best: 21.09ops/s.<br/>total: 3089.47 ± 5.56ms. best: 3081.37ms.<br/>avg: 47.53 ± 0.09ms<br/>min: 0.21 ± 0.00ms<br/>max: 610.30 ± 2.26ms<br/>p99: 610.30 ± 2.26ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 23920.87 ± 55.29 ops/s. best: 23821.01ops/s.<br/>total: 418.05 ± 1.01ms. best: 416.44ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.03ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17835.70 ± 71.77 ops/s. best: 17704.04ops/s.<br/>total: 560.68 ± 2.33ms. best: 557.31ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.19 ± 0.04ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14078.88 ± 54.80 ops/s. best: 13974.72ops/s.<br/>total: 710.30 ± 2.82ms. best: 707.50ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.19 ± 0.01ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 24614.14 ± 115.45 ops/s. best: 24737.45ops/s.<br/>total: 406.28 ± 1.91ms. best: 404.25ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18449.83 ± 32.37 ops/s. best: 18497.82ops/s.<br/>total: 542.01 ± 0.97ms. best: 540.60ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14685.76 ± 6.51 ops/s. best: 14693.08ops/s.<br/>total: 680.93 ± 0.30ms. best: 680.59ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.00ms<br/>p99: 0.13 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 23859.44 ± 25.48 ops/s. best: 23817.80ops/s.<br/>total: 419.12 ± 0.45ms. best: 418.56ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.03ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17833.27 ± 44.26 ops/s. best: 17759.74ops/s.<br/>total: 560.75 ± 1.47ms. best: 558.07ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14076.92 ± 35.10 ops/s. best: 14048.94ops/s.<br/>total: 710.39 ± 1.77ms. best: 706.32ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.19 ± 0.01ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 24842.87 ± 48.75 ops/s. best: 24896.39ops/s.<br/>total: 402.53 ± 0.79ms. best: 401.66ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18550.27 ± 15.87 ops/s. best: 18573.68ops/s.<br/>total: 539.08 ± 0.47ms. best: 538.40ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14787.94 ± 11.09 ops/s. best: 14806.55ops/s.<br/>total: 676.23 ± 0.51ms. best: 675.38ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.00ms<br/>p99: 0.13 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 447.62 ± 4.96 ops/s. best: 440.99ops/s.<br/>total: 2198.64 ± 24.38ms. best: 2169.69ms.<br/>avg: 2.23 ± 0.02ms<br/>min: 0.34 ± 0.00ms<br/>max: 4.00 ± 0.09ms<br/>p99: 3.34 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 519.05 ± 3.16 ops/s. best: 513.37ops/s.<br/>total: 1926.68 ± 12.00ms. best: 1908.78ms.<br/>avg: 1.93 ± 0.01ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.56 ± 0.03ms<br/>p99: 4.03 ± 0.06ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 874.00 ± 11.55 ops/s. best: 853.51ops/s.<br/>total: 1126.14 ± 15.12ms. best: 1098.90ms.<br/>avg: 1.14 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 1.74 ± 0.04ms<br/>p99: 1.63 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 987.18 ± 12.76 ops/s. best: 965.22ops/s.<br/>total: 1013.20 ± 13.25ms. best: 993.91ms.<br/>avg: 1.01 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 3.10 ± 0.02ms<br/>p99: 2.15 ± 0.03ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 523.98 ± 2.22 ops/s. best: 527.03ops/s.<br/>total: 1877.98 ± 7.95ms. best: 1867.08ms.<br/>avg: 1.91 ± 0.01ms<br/>min: 0.33 ± 0.00ms<br/>max: 3.41 ± 0.23ms<br/>p99: 2.76 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 612.28 ± 1.28 ops/s. best: 614.07ops/s.<br/>total: 1633.25 ± 3.49ms. best: 1628.48ms.<br/>avg: 1.63 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 4.11 ± 0.26ms<br/>p99: 3.33 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 1087.95 ± 3.77 ops/s. best: 1095.17ops/s.<br/>total: 904.46 ± 3.13ms. best: 898.49ms.<br/>avg: 0.92 ± 0.00ms<br/>min: 0.21 ± 0.00ms<br/>max: 1.44 ± 0.02ms<br/>p99: 1.28 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1206.32 ± 2.09 ops/s. best: 1209.35ops/s.<br/>total: 828.97 ± 1.44ms. best: 826.89ms.<br/>avg: 0.83 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.77 ± 0.03ms<br/>p99: 1.77 ± 0.01ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 222.97 ± 1.31 ops/s. best: 221.49ops/s.<br/>total: 4413.28 ± 25.78ms. best: 4371.97ms.<br/>avg: 4.49 ± 0.03ms<br/>min: 0.35 ± 0.01ms<br/>max: 9.62 ± 0.07ms<br/>p99: 7.45 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 214.04 ± 2.07 ops/s. best: 209.81ops/s.<br/>total: 4672.71 ± 45.41ms. best: 4601.81ms.<br/>avg: 4.67 ± 0.05ms<br/>min: 0.05 ± 0.00ms<br/>max: 12.92 ± 2.02ms<br/>p99: 9.51 ± 0.17ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 297.46 ± 1.14 ops/s. best: 295.80ops/s.<br/>total: 3308.04 ± 12.67ms. best: 3289.60ms.<br/>avg: 3.36 ± 0.01ms<br/>min: 0.30 ± 0.00ms<br/>max: 7.89 ± 0.05ms<br/>p99: 5.69 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 265.13 ± 1.12 ops/s. best: 263.30ops/s.<br/>total: 3771.77 ± 16.21ms. best: 3749.15ms.<br/>avg: 3.77 ± 0.02ms<br/>min: 0.04 ± 0.00ms<br/>max: 9.15 ± 1.14ms<br/>p99: 7.41 ± 0.05ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 247.18 ± 3.36 ops/s. best: 250.49ops/s.<br/>total: 3981.80 ± 55.48ms. best: 3928.38ms.<br/>avg: 4.05 ± 0.06ms<br/>min: 0.32 ± 0.00ms<br/>max: 8.69 ± 0.10ms<br/>p99: 6.81 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 244.04 ± 1.75 ops/s. best: 246.40ops/s.<br/>total: 4097.93 ± 29.55ms. best: 4058.52ms.<br/>avg: 4.10 ± 0.03ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.75 ± 0.72ms<br/>p99: 8.12 ± 0.12ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 335.61 ± 4.61 ops/s. best: 340.01ops/s.<br/>total: 2932.68 ± 40.72ms. best: 2894.03ms.<br/>avg: 2.98 ± 0.04ms<br/>min: 0.29 ± 0.00ms<br/>max: 7.09 ± 0.17ms<br/>p99: 5.11 ± 0.10ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 305.71 ± 2.23 ops/s. best: 308.97ops/s.<br/>total: 3271.34 ± 23.95ms. best: 3236.57ms.<br/>avg: 3.27 ± 0.02ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.73 ± 0.79ms<br/>p99: 6.39 ± 0.09ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1510.62 ± 16.88 ops/s. best: 1472.49ops/s.<br/>total: 165.52 ± 1.87ms. best: 163.53ms.<br/>avg: 0.66 ± 0.01ms<br/>min: 0.44 ± 0.00ms<br/>max: 1.01 ± 0.24ms<br/>p99: 0.86 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 176.52 ± 1.84 ops/s. best: 173.62ops/s.<br/>total: 1416.48 ± 15.04ms. best: 1399.33ms.<br/>avg: 5.67 ± 0.06ms<br/>min: 5.03 ± 0.04ms<br/>max: 6.27 ± 0.12ms<br/>p99: 6.18 ± 0.08ms<br/><br/>250 tables, 50 coordinates<br/>ops: 85.82 ± 0.19 ops/s. best: 85.55ops/s.<br/>total: 2913.03 ± 6.48ms. best: 2902.48ms.<br/>avg: 11.65 ± 0.03ms<br/>min: 10.72 ± 0.05ms<br/>max: 13.76 ± 1.48ms<br/>p99: 13.26 ± 1.16ms | 250 tables, 3 coordinates<br/>ops: 1564.93 ± 12.93 ops/s. best: 1574.62ops/s.<br/>total: 159.77 ± 1.34ms. best: 158.77ms.<br/>avg: 0.64 ± 0.01ms<br/>min: 0.42 ± 0.00ms<br/>max: 0.96 ± 0.23ms<br/>p99: 0.81 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 183.71 ± 0.08 ops/s. best: 183.83ops/s.<br/>total: 1360.82 ± 0.57ms. best: 1359.97ms.<br/>avg: 5.44 ± 0.00ms<br/>min: 4.94 ± 0.01ms<br/>max: 6.14 ± 0.13ms<br/>p99: 5.88 ± 0.02ms<br/><br/>250 tables, 50 coordinates<br/>ops: 90.25 ± 0.11 ops/s. best: 90.34ops/s.<br/>total: 2770.20 ± 3.50ms. best: 2767.25ms.<br/>avg: 11.08 ± 0.01ms<br/>min: 10.31 ± 0.01ms<br/>max: 12.12 ± 0.15ms<br/>p99: 11.89 ± 0.06ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 321.72 ± 3.16 ops/s. best: 315.44ops/s.<br/>total: 777.17 ± 7.73ms. best: 766.78ms.<br/>avg: 3.11 ± 0.03ms<br/>min: 2.37 ± 0.01ms<br/>max: 4.27 ± 0.14ms<br/>p99: 4.06 ± 0.09ms<br/><br/>250 tables, 25 coordinates<br/>ops: 35.32 ± 0.21 ops/s. best: 35.12ops/s.<br/>total: 7079.17 ± 41.01ms. best: 7007.33ms.<br/>avg: 28.32 ± 0.16ms<br/>min: 24.94 ± 0.21ms<br/>max: 32.68 ± 1.10ms<br/>p99: 31.74 ± 0.58ms<br/><br/>250 tables, 50 coordinates<br/>ops: 16.47 ± 0.03 ops/s. best: 16.42ops/s.<br/>total: 15180.47 ± 29.17ms. best: 15130.44ms.<br/>avg: 60.72 ± 0.12ms<br/>min: 55.14 ± 0.37ms<br/>max: 69.05 ± 2.66ms<br/>p99: 66.47 ± 0.86ms | 250 tables, 3 coordinates<br/>ops: 347.08 ± 0.77 ops/s. best: 347.91ops/s.<br/>total: 720.30 ± 1.59ms. best: 718.57ms.<br/>avg: 2.88 ± 0.01ms<br/>min: 2.29 ± 0.01ms<br/>max: 4.19 ± 0.33ms<br/>p99: 3.81 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.36 ± 0.04 ops/s. best: 38.40ops/s.<br/>total: 6517.15 ± 7.42ms. best: 6510.64ms.<br/>avg: 26.07 ± 0.03ms<br/>min: 23.37 ± 0.06ms<br/>max: 29.75 ± 0.31ms<br/>p99: 28.61 ± 0.10ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.78 ± 0.05 ops/s. best: 17.82ops/s.<br/>total: 14063.94 ± 38.77ms. best: 14029.38ms.<br/>avg: 56.26 ± 0.16ms<br/>min: 52.09 ± 0.12ms<br/>max: 63.20 ± 4.86ms<br/>p99: 60.20 ± 0.54ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 435.04 ± 2.80 ops/s. best: 430.28ops/s.<br/>total: 574.69 ± 3.81ms. best: 569.65ms.<br/>avg: 2.30 ± 0.02ms<br/>min: 1.18 ± 0.01ms<br/>max: 3.39 ± 0.26ms<br/>p99: 3.12 ± 0.02ms<br/><br/>250 trips, 5 coordinates<br/>ops: 289.22 ± 1.90 ops/s. best: 286.95ops/s.<br/>total: 864.44 ± 5.54ms. best: 853.23ms.<br/>avg: 3.46 ± 0.02ms<br/>min: 2.17 ± 0.03ms<br/>max: 4.74 ± 0.36ms<br/>p99: 4.35 ± 0.05ms | 250 trips, 3 coordinates<br/>ops: 500.25 ± 5.85 ops/s. best: 507.18ops/s.<br/>total: 499.84 ± 5.89ms. best: 492.92ms.<br/>avg: 2.00 ± 0.02ms<br/>min: 1.08 ± 0.02ms<br/>max: 2.96 ± 0.32ms<br/>p99: 2.64 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 339.13 ± 1.09 ops/s. best: 341.17ops/s.<br/>total: 737.19 ± 2.42ms. best: 732.77ms.<br/>avg: 2.95 ± 0.01ms<br/>min: 1.99 ± 0.01ms<br/>max: 3.74 ± 0.06ms<br/>p99: 3.61 ± 0.04ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 152.29 ± 1.03 ops/s. best: 150.73ops/s.<br/>total: 1641.71 ± 10.83ms. best: 1623.80ms.<br/>avg: 6.57 ± 0.04ms<br/>min: 4.21 ± 0.04ms<br/>max: 9.01 ± 0.19ms<br/>p99: 8.56 ± 0.12ms<br/><br/>250 trips, 5 coordinates<br/>ops: 98.29 ± 0.61 ops/s. best: 97.50ops/s.<br/>total: 2543.52 ± 15.29ms. best: 2519.92ms.<br/>avg: 10.17 ± 0.06ms<br/>min: 6.81 ± 0.12ms<br/>max: 12.72 ± 0.38ms<br/>p99: 12.34 ± 0.16ms | 250 trips, 3 coordinates<br/>ops: 172.17 ± 1.42 ops/s. best: 174.71ops/s.<br/>total: 1452.16 ± 11.95ms. best: 1430.97ms.<br/>avg: 5.81 ± 0.05ms<br/>min: 3.82 ± 0.01ms<br/>max: 7.93 ± 0.30ms<br/>p99: 7.54 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 112.07 ± 1.43 ops/s. best: 114.18ops/s.<br/>total: 2231.20 ± 28.41ms. best: 2189.54ms.<br/>avg: 8.92 ± 0.11ms<br/>min: 6.26 ± 0.04ms<br/>max: 11.84 ± 1.16ms<br/>p99: 11.28 ± 0.80ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>437.546ms<br/>0.437546ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>542.085ms<br/>0.542085ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>156.829ms<br/>0.156829ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>144.126ms<br/>0.144126ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>436.38ms<br/>0.43638ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>525.673ms<br/>0.525673ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>156.856ms<br/>0.156856ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>141.093ms<br/>0.141093ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>582.321ms<br/>0.582321ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>736.26ms<br/>0.73626ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>280.23ms<br/>0.28023ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>316.813ms<br/>0.316813ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>574.426ms<br/>0.574426ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>727.031ms<br/>0.727031ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>275.455ms<br/>0.275455ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>305.712ms<br/>0.305712ms/req |
| rtree | 1 result:<br/>202.082ms ->  0.0202082 ms/query<br/>10 results:<br/>237.188ms ->  0.0237188 ms/query | 1 result:<br/>201.641ms ->  0.0201641 ms/query<br/>10 results:<br/>237.35ms ->  0.023735 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
