### PR TITLE
Use struct instead of tuple to define UnpackedPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Use struct instead of tuple to define UnpackedPath. [#6974](https://github.com/Project-OSRM/osrm-backend/pull/6974)
       - CHANGED: Re-use priority queue in StaticRTree. [#6952](https://github.com/Project-OSRM/osrm-backend/pull/6952)
       - CHANGED: Optimise encodePolyline function. [#6940](https://github.com/Project-OSRM/osrm-backend/pull/6940)
       - CHANGED: Avoid reallocations in base64 encoding. [#6951](https://github.com/Project-OSRM/osrm-backend/pull/6951)

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -609,7 +609,7 @@ UnpackedPath search(SearchEngineData<Algorithm> &engine_working_data,
                                            INVALID_EDGE_WEIGHT,
                                            sublevel,
                                            parent_cell_id);
-            BOOST_ASSERT(!subpath_edges.empty());
+            BOOST_ASSERT(!unpacked_subpath.edges.empty());
             BOOST_ASSERT(unpacked_subpath.nodes.size() > 1);
             BOOST_ASSERT(unpacked_subpath.nodes.front() == source);
             BOOST_ASSERT(unpacked_subpath.nodes.back() == target);

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -621,27 +621,24 @@ void unpackPackedPaths(InputIt first,
                 BOOST_ASSERT(!facade.ExcludeNode(source));
                 BOOST_ASSERT(!facade.ExcludeNode(target));
 
-                // TODO: when structured bindings will be allowed change to
-                // auto [subpath_weight, subpath_source, subpath_target, subpath] = ...
-                EdgeWeight subpath_weight;
-                std::vector<NodeID> subpath_nodes;
-                std::vector<EdgeID> subpath_edges;
-                std::tie(subpath_weight, subpath_nodes, subpath_edges) = search(search_engine_data,
-                                                                                facade,
-                                                                                forward_heap,
-                                                                                reverse_heap,
-                                                                                {},
-                                                                                INVALID_EDGE_WEIGHT,
-                                                                                sublevel,
-                                                                                parent_cell_id);
-                BOOST_ASSERT(!subpath_edges.empty());
-                BOOST_ASSERT(subpath_nodes.size() > 1);
-                BOOST_ASSERT(subpath_nodes.front() == source);
-                BOOST_ASSERT(subpath_nodes.back() == target);
-                unpacked_nodes.insert(
-                    unpacked_nodes.end(), std::next(subpath_nodes.begin()), subpath_nodes.end());
-                unpacked_edges.insert(
-                    unpacked_edges.end(), subpath_edges.begin(), subpath_edges.end());
+                auto unpacked_subpath = search(search_engine_data,
+                                               facade,
+                                               forward_heap,
+                                               reverse_heap,
+                                               {},
+                                               INVALID_EDGE_WEIGHT,
+                                               sublevel,
+                                               parent_cell_id);
+                BOOST_ASSERT(!unpacked_subpath.edges.empty());
+                BOOST_ASSERT(unpacked_subpath.nodes.size() > 1);
+                BOOST_ASSERT(unpacked_subpath.nodes.front() == source);
+                BOOST_ASSERT(unpacked_subpath.nodes.back() == target);
+                unpacked_nodes.insert(unpacked_nodes.end(),
+                                      std::next(unpacked_subpath.nodes.begin()),
+                                      unpacked_subpath.nodes.end());
+                unpacked_edges.insert(unpacked_edges.end(),
+                                      unpacked_subpath.edges.begin(),
+                                      unpacked_subpath.edges.end());
             }
         }
 

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -70,20 +70,19 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<mld::Algorithm> &e
     auto &reverse_heap = *engine_working_data.reverse_heap_1;
     insertNodesInHeaps(forward_heap, reverse_heap, endpoint_candidates);
 
-    // TODO: when structured bindings will be allowed change to
-    // auto [weight, source_node, target_node, unpacked_edges] = ...
-    EdgeWeight weight = INVALID_EDGE_WEIGHT;
-    std::vector<NodeID> unpacked_nodes;
-    std::vector<EdgeID> unpacked_edges;
-    std::tie(weight, unpacked_nodes, unpacked_edges) = mld::search(engine_working_data,
-                                                                   facade,
-                                                                   forward_heap,
-                                                                   reverse_heap,
-                                                                   {},
-                                                                   INVALID_EDGE_WEIGHT,
-                                                                   endpoint_candidates);
+    auto unpacked_path = mld::search(engine_working_data,
+                                     facade,
+                                     forward_heap,
+                                     reverse_heap,
+                                     {},
+                                     INVALID_EDGE_WEIGHT,
+                                     endpoint_candidates);
 
-    return extractRoute(facade, weight, endpoint_candidates, unpacked_nodes, unpacked_edges);
+    return extractRoute(facade,
+                        unpacked_path.weight,
+                        endpoint_candidates,
+                        unpacked_path.nodes,
+                        unpacked_path.edges);
 }
 
 } // namespace osrm::engine::routing_algorithms


### PR DESCRIPTION
Small readability improvement...





<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1060.53<br/>plain u32: 1095.35<br/>aliased double: 946.394<br/>plain double: 950.497 | aliased u32: 1085.73<br/>plain u32: 1097.12<br/>aliased double: 948.222<br/>plain double: 950.775 |
| e2e_match_ch | Ops: 43.96 ± 0.08 ops/s. Best: 44.11 ops/s<br/>Total: 2979.98ms ± 5.81ms. Best: 2969.75ms<br/>Min time: 2.14ms ± 0.01ms<br/>Mean time: 22.75ms ± 0.04ms<br/>Median time: 15.71ms ± 0.10ms<br/>95th percentile: 80.69ms ± 0.17ms<br/>99th percentile: 96.35ms ± 0.75ms<br/>Max time: 104.69ms ± 0.72ms | Ops: 47.25 ± 0.04 ops/s. Best: 47.31 ops/s<br/>Total: 2772.28ms ± 2.63ms. Best: 2768.74ms<br/>Min time: 2.13ms ± 0.03ms<br/>Mean time: 21.16ms ± 0.02ms<br/>Median time: 14.93ms ± 0.07ms<br/>95th percentile: 63.66ms ± 0.52ms<br/>99th percentile: 96.23ms ± 0.53ms<br/>Max time: 114.01ms ± 0.67ms |
| e2e_match_mld | Ops: 62.64 ± 0.14 ops/s. Best: 62.82 ops/s<br/>Total: 2091.61ms ± 4.39ms. Best: 2085.48ms<br/>Min time: 1.80ms ± 0.02ms<br/>Mean time: 15.97ms ± 0.03ms<br/>Median time: 8.46ms ± 0.08ms<br/>95th percentile: 53.40ms ± 0.12ms<br/>99th percentile: 61.47ms ± 0.41ms<br/>Max time: 71.22ms ± 0.19ms | Ops: 62.76 ± 0.08 ops/s. Best: 62.89 ops/s<br/>Total: 2087.49ms ± 2.71ms. Best: 2082.98ms<br/>Min time: 1.80ms ± 0.03ms<br/>Mean time: 15.93ms ± 0.02ms<br/>Median time: 8.50ms ± 0.04ms<br/>95th percentile: 53.31ms ± 0.10ms<br/>99th percentile: 61.30ms ± 0.12ms<br/>Max time: 70.96ms ± 0.33ms |
| e2e_nearest_ch | Ops: 808.29 ± 5.06 ops/s. Best: 814.92 ops/s<br/>Total: 1237.27ms ± 8.04ms. Best: 1227.11ms<br/>Min time: 1.05ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.02ms<br/>Max time: 4.59ms ± 2.82ms | Ops: 806.06 ± 5.69 ops/s. Best: 813.44 ops/s<br/>Total: 1240.47ms ± 9.55ms. Best: 1229.34ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 4.50ms ± 2.79ms |
| e2e_nearest_mld | Ops: 801.50 ± 5.94 ops/s. Best: 807.99 ops/s<br/>Total: 1247.54ms ± 10.03ms. Best: 1237.64ms<br/>Min time: 1.01ms ± 0.02ms<br/>Mean time: 1.25ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.65ms ± 0.01ms<br/>99th percentile: 1.71ms ± 0.02ms<br/>Max time: 4.40ms ± 2.66ms | Ops: 802.89 ± 5.08 ops/s. Best: 808.24 ops/s<br/>Total: 1245.51ms ± 8.38ms. Best: 1237.26ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.25ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.65ms ± 0.01ms<br/>99th percentile: 1.70ms ± 0.01ms<br/>Max time: 4.11ms ± 2.33ms |
| e2e_route_ch | Ops: 346.40 ± 0.91 ops/s. Best: 347.47 ops/s<br/>Total: 2887.00ms ± 7.87ms. Best: 2877.93ms<br/>Min time: 1.26ms ± 0.02ms<br/>Mean time: 2.89ms ± 0.01ms<br/>Median time: 2.91ms ± 0.02ms<br/>95th percentile: 3.80ms ± 0.01ms<br/>99th percentile: 4.19ms ± 0.01ms<br/>Max time: 6.93ms ± 2.10ms | Ops: 346.60 ± 1.90 ops/s. Best: 349.51 ops/s<br/>Total: 2884.49ms ± 15.93ms. Best: 2861.14ms<br/>Min time: 1.27ms ± 0.02ms<br/>Mean time: 2.89ms ± 0.02ms<br/>Median time: 2.90ms ± 0.02ms<br/>95th percentile: 3.82ms ± 0.05ms<br/>99th percentile: 4.23ms ± 0.10ms<br/>Max time: 6.82ms ± 2.13ms |
| e2e_route_mld | Ops: 290.77 ± 1.16 ops/s. Best: 292.03 ops/s<br/>Total: 3439.51ms ± 14.16ms. Best: 3424.28ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 3.44ms ± 0.01ms<br/>Median time: 3.48ms ± 0.02ms<br/>95th percentile: 4.69ms ± 0.02ms<br/>99th percentile: 5.17ms ± 0.07ms<br/>Max time: 7.57ms ± 1.85ms | Ops: 291.03 ± 1.77 ops/s. Best: 294.10 ops/s<br/>Total: 3435.45ms ± 20.57ms. Best: 3400.15ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 3.44ms ± 0.02ms<br/>Median time: 3.47ms ± 0.02ms<br/>95th percentile: 4.68ms ± 0.05ms<br/>99th percentile: 5.20ms ± 0.13ms<br/>Max time: 7.70ms ± 1.86ms |
| e2e_table_ch | Ops: 313.53 ± 0.92 ops/s. Best: 315.46 ops/s<br/>Total: 3189.23ms ± 9.35ms. Best: 3169.96ms<br/>Min time: 1.69ms ± 0.03ms<br/>Mean time: 3.19ms ± 0.01ms<br/>Median time: 3.18ms ± 0.02ms<br/>95th percentile: 4.41ms ± 0.03ms<br/>99th percentile: 4.73ms ± 0.05ms<br/>Max time: 7.44ms ± 2.41ms | Ops: 310.25 ± 0.65 ops/s. Best: 311.34 ops/s<br/>Total: 3223.06ms ± 6.83ms. Best: 3211.89ms<br/>Min time: 1.62ms ± 0.04ms<br/>Mean time: 3.22ms ± 0.01ms<br/>Median time: 3.24ms ± 0.02ms<br/>95th percentile: 4.44ms ± 0.01ms<br/>99th percentile: 4.76ms ± 0.05ms<br/>Max time: 7.57ms ± 2.60ms |
| e2e_table_mld | Ops: 110.88 ± 0.18 ops/s. Best: 111.12 ops/s<br/>Total: 9018.42ms ± 14.40ms. Best: 8999.20ms<br/>Min time: 3.62ms ± 0.03ms<br/>Mean time: 9.02ms ± 0.02ms<br/>Median time: 9.01ms ± 0.02ms<br/>95th percentile: 13.78ms ± 0.03ms<br/>99th percentile: 14.67ms ± 0.09ms<br/>Max time: 17.12ms ± 1.58ms | Ops: 110.71 ± 0.34 ops/s. Best: 111.20 ops/s<br/>Total: 9033.03ms ± 28.25ms. Best: 8992.72ms<br/>Min time: 3.69ms ± 0.03ms<br/>Mean time: 9.03ms ± 0.03ms<br/>Median time: 9.00ms ± 0.04ms<br/>95th percentile: 13.80ms ± 0.06ms<br/>99th percentile: 14.70ms ± 0.10ms<br/>Max time: 16.87ms ± 1.35ms |
| e2e_trip_ch | Ops: 98.73 ± 0.10 ops/s. Best: 98.93 ops/s<br/>Total: 10128.35ms ± 10.48ms. Best: 10108.11ms<br/>Min time: 1.54ms ± 0.17ms<br/>Mean time: 10.13ms ± 0.01ms<br/>Median time: 9.63ms ± 0.02ms<br/>95th percentile: 18.03ms ± 0.04ms<br/>99th percentile: 19.52ms ± 0.12ms<br/>Max time: 20.99ms ± 0.36ms | Ops: 97.55 ± 0.20 ops/s. Best: 97.76 ops/s<br/>Total: 10251.68ms ± 21.33ms. Best: 10229.40ms<br/>Min time: 1.56ms ± 0.18ms<br/>Mean time: 10.25ms ± 0.02ms<br/>Median time: 9.75ms ± 0.04ms<br/>95th percentile: 18.23ms ± 0.08ms<br/>99th percentile: 19.85ms ± 0.21ms<br/>Max time: 22.88ms ± 1.35ms |
| e2e_trip_mld | Ops: 59.11 ± 0.08 ops/s. Best: 59.25 ops/s<br/>Total: 16918.87ms ± 22.03ms. Best: 16878.80ms<br/>Min time: 1.56ms ± 0.14ms<br/>Mean time: 16.92ms ± 0.02ms<br/>Median time: 16.48ms ± 0.07ms<br/>95th percentile: 27.84ms ± 0.08ms<br/>99th percentile: 29.58ms ± 0.09ms<br/>Max time: 32.75ms ± 0.91ms | Ops: 58.61 ± 0.09 ops/s. Best: 58.72 ops/s<br/>Total: 17061.20ms ± 25.99ms. Best: 17030.77ms<br/>Min time: 1.63ms ± 0.15ms<br/>Mean time: 17.06ms ± 0.03ms<br/>Median time: 16.68ms ± 0.05ms<br/>95th percentile: 27.99ms ± 0.06ms<br/>99th percentile: 29.91ms ± 0.17ms<br/>Max time: 32.09ms ± 0.56ms |
| json-render | String: 6.92779ms<br/>Stringstream: 10.7002ms<br/>Vector: 7.0505ms | String: 6.73623ms<br/>Stringstream: 10.4444ms<br/>Vector: 6.89938ms |
| match_ch | Default radius: <br/>4.59069ms/req at 82 coordinate<br/>0.055984ms/coordinate<br/>Radius 10m: <br/>16.0569ms/req at 82 coordinate<br/>0.195815ms/coordinate | Default radius: <br/>4.52581ms/req at 82 coordinate<br/>0.0551928ms/coordinate<br/>Radius 10m: <br/>15.8297ms/req at 82 coordinate<br/>0.193045ms/coordinate |
| match_mld | Default radius: <br/>3.07974ms/req at 82 coordinate<br/>0.0375578ms/coordinate<br/>Radius 10m: <br/>11.9014ms/req at 82 coordinate<br/>0.145139ms/coordinate | Default radius: <br/>3.11747ms/req at 82 coordinate<br/>0.038018ms/coordinate<br/>Radius 10m: <br/>11.59ms/req at 82 coordinate<br/>0.141341ms/coordinate |
| osrm_contract | Time: 94.22s Peak RAM: 196.25MB | Time: 94.40s Peak RAM: 193.48MB |
| osrm_customize | Time: 1.34s Peak RAM: 116.60MB | Time: 1.34s Peak RAM: 116.62MB |
| osrm_extract | Time: 11.89s Peak RAM: 411.38MB | Time: 11.95s Peak RAM: 415.66MB |
| osrm_partition | Time: 1.97s Peak RAM: 133.22MB | Time: 2.00s Peak RAM: 134.36MB |
| packedvector | random write:<br/>std::vector 11249.3 ms<br/>util::packed_vector 78195 ms<br/>slowdown: 6.95109<br/>random read:<br/>std::vector 11104.2 ms<br/>util::packed_vector 32537.6 ms<br/>slowdown: 2.9302 | random write:<br/>std::vector 11254.2 ms<br/>util::packed_vector 81711.8 ms<br/>slowdown: 7.26055<br/>random read:<br/>std::vector 11161 ms<br/>util::packed_vector 33231.4 ms<br/>slowdown: 2.97747 |
| random_match_ch | 500 matches, default radius<br/>ops: 213.15 ± 0.88 ops/s. best: 214.00ops/s.<br/>total: 267.43 ± 1.11ms. best: 266.36ms.<br/>avg: 4.69 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 26.18 ± 0.06ms<br/>p99: 26.18 ± 0.06ms<br/><br/>500 matches, radius=10<br/>ops: 62.68 ± 0.04 ops/s. best: 62.73ops/s.<br/>total: 1021.03 ± 0.61ms. best: 1020.24ms.<br/>avg: 15.95 ± 0.01ms<br/>min: 0.16 ± 0.00ms<br/>max: 244.17 ± 0.34ms<br/>p99: 244.17 ± 0.34ms<br/><br/>500 matches, radius=20<br/>ops: 14.64 ± 0.05 ops/s. best: 14.72ops/s.<br/>total: 4438.88 ± 16.15ms. best: 4416.19ms.<br/>avg: 68.29 ± 0.25ms<br/>min: 0.31 ± 0.00ms<br/>max: 1269.18 ± 5.60ms<br/>p99: 1269.18 ± 5.60ms | 500 matches, default radius<br/>ops: 216.58 ± 0.79 ops/s. best: 217.55ops/s.<br/>total: 263.19 ± 0.97ms. best: 262.01ms.<br/>avg: 4.62 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 25.73 ± 0.16ms<br/>p99: 25.73 ± 0.16ms<br/><br/>500 matches, radius=10<br/>ops: 63.68 ± 0.10 ops/s. best: 63.79ops/s.<br/>total: 1005.02 ± 1.52ms. best: 1003.28ms.<br/>avg: 15.70 ± 0.02ms<br/>min: 0.16 ± 0.00ms<br/>max: 240.85 ± 0.77ms<br/>p99: 240.85 ± 0.77ms<br/><br/>500 matches, radius=20<br/>ops: 15.13 ± 0.04 ops/s. best: 15.18ops/s.<br/>total: 4296.68 ± 11.31ms. best: 4280.98ms.<br/>avg: 66.10 ± 0.17ms<br/>min: 0.31 ± 0.00ms<br/>max: 1234.57 ± 6.49ms<br/>p99: 1234.57 ± 6.49ms |
| random_match_mld | 500 matches, default radius<br/>ops: 307.22 ± 1.57 ops/s. best: 308.48ops/s.<br/>total: 185.54 ± 0.95ms. best: 184.78ms.<br/>avg: 3.26 ± 0.02ms<br/>min: 0.12 ± 0.00ms<br/>max: 19.28 ± 0.03ms<br/>p99: 19.28 ± 0.03ms<br/><br/>500 matches, radius=10<br/>ops: 107.98 ± 0.18 ops/s. best: 108.17ops/s.<br/>total: 592.70 ± 0.98ms. best: 591.68ms.<br/>avg: 9.26 ± 0.02ms<br/>min: 0.15 ± 0.00ms<br/>max: 112.40 ± 0.25ms<br/>p99: 112.40 ± 0.25ms<br/><br/>500 matches, radius=20<br/>ops: 21.57 ± 0.08 ops/s. best: 21.71ops/s.<br/>total: 3013.34 ± 11.06ms. best: 2994.47ms.<br/>avg: 46.36 ± 0.17ms<br/>min: 0.20 ± 0.00ms<br/>max: 592.03 ± 2.15ms<br/>p99: 592.03 ± 2.15ms | 500 matches, default radius<br/>ops: 304.56 ± 1.65 ops/s. best: 306.38ops/s.<br/>total: 187.16 ± 1.04ms. best: 186.04ms.<br/>avg: 3.28 ± 0.02ms<br/>min: 0.12 ± 0.00ms<br/>max: 19.48 ± 0.04ms<br/>p99: 19.48 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 107.02 ± 0.15 ops/s. best: 107.31ops/s.<br/>total: 598.03 ± 0.86ms. best: 596.38ms.<br/>avg: 9.34 ± 0.01ms<br/>min: 0.15 ± 0.00ms<br/>max: 113.70 ± 0.50ms<br/>p99: 113.70 ± 0.50ms<br/><br/>500 matches, radius=20<br/>ops: 21.34 ± 0.10 ops/s. best: 21.45ops/s.<br/>total: 3046.35 ± 14.29ms. best: 3030.26ms.<br/>avg: 46.87 ± 0.22ms<br/>min: 0.21 ± 0.01ms<br/>max: 599.25 ± 0.79ms<br/>p99: 599.25 ± 0.79ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 22866.57 ± 38.64 ops/s. best: 22900.79ops/s.<br/>total: 437.32 ± 0.74ms. best: 436.67ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17685.61 ± 7.73 ops/s. best: 17693.22ops/s.<br/>total: 565.43 ± 0.25ms. best: 565.19ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14370.26 ± 15.89 ops/s. best: 14386.27ops/s.<br/>total: 695.88 ± 0.77ms. best: 695.11ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 23053.82 ± 54.69 ops/s. best: 23098.00ops/s.<br/>total: 433.77 ± 1.03ms. best: 432.94ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.03ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17729.65 ± 18.91 ops/s. best: 17754.08ops/s.<br/>total: 564.03 ± 0.60ms. best: 563.25ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14363.75 ± 12.55 ops/s. best: 14381.77ops/s.<br/>total: 696.20 ± 0.61ms. best: 695.32ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 23032.05 ± 51.80 ops/s. best: 23082.95ops/s.<br/>total: 434.18 ± 0.98ms. best: 433.22ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17786.80 ± 15.54 ops/s. best: 17805.02ops/s.<br/>total: 562.22 ± 0.49ms. best: 561.64ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14374.32 ± 28.19 ops/s. best: 14417.70ops/s.<br/>total: 695.69 ± 1.40ms. best: 693.59ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22830.79 ± 61.47 ops/s. best: 22898.40ops/s.<br/>total: 438.01 ± 1.18ms. best: 436.71ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.18 ± 0.04ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17727.37 ± 7.76 ops/s. best: 17736.47ops/s.<br/>total: 564.10 ± 0.25ms. best: 563.81ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14339.55 ± 16.82 ops/s. best: 14364.75ops/s.<br/>total: 697.37 ± 0.82ms. best: 696.15ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 516.82 ± 3.05 ops/s. best: 521.13ops/s.<br/>total: 1904.04 ± 11.54ms. best: 1888.20ms.<br/>avg: 1.93 ± 0.01ms<br/>min: 0.33 ± 0.00ms<br/>max: 3.32 ± 0.18ms<br/>p99: 2.84 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 604.38 ± 3.21 ops/s. best: 609.16ops/s.<br/>total: 1654.65 ± 8.54ms. best: 1641.62ms.<br/>avg: 1.65 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 3.93 ± 0.12ms<br/>p99: 3.45 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 1065.84 ± 2.66 ops/s. best: 1071.07ops/s.<br/>total: 923.22 ± 2.29ms. best: 918.70ms.<br/>avg: 0.94 ± 0.00ms<br/>min: 0.24 ± 0.00ms<br/>max: 1.57 ± 0.13ms<br/>p99: 1.30 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1195.45 ± 5.09 ops/s. best: 1204.86ops/s.<br/>total: 836.53 ± 3.41ms. best: 829.97ms.<br/>avg: 0.84 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.78 ± 0.02ms<br/>p99: 1.71 ± 0.02ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 523.51 ± 2.47 ops/s. best: 526.63ops/s.<br/>total: 1879.66 ± 8.89ms. best: 1868.49ms.<br/>avg: 1.91 ± 0.01ms<br/>min: 0.33 ± 0.01ms<br/>max: 3.22 ± 0.26ms<br/>p99: 2.73 ± 0.04ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 594.97 ± 0.39 ops/s. best: 595.62ops/s.<br/>total: 1680.75 ± 1.11ms. best: 1678.92ms.<br/>avg: 1.68 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 3.49 ± 0.02ms<br/>p99: 3.37 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 1072.15 ± 1.45 ops/s. best: 1073.81ops/s.<br/>total: 917.79 ± 1.24ms. best: 916.37ms.<br/>avg: 0.93 ± 0.00ms<br/>min: 0.23 ± 0.00ms<br/>max: 1.36 ± 0.01ms<br/>p99: 1.25 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1124.44 ± 2.61 ops/s. best: 1128.29ops/s.<br/>total: 889.34 ± 2.07ms. best: 886.30ms.<br/>avg: 0.89 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.36 ± 0.02ms<br/>p99: 1.89 ± 0.01ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 254.27 ± 0.74 ops/s. best: 255.33ops/s.<br/>total: 3869.97 ± 11.27ms. best: 3853.76ms.<br/>avg: 3.93 ± 0.01ms<br/>min: 0.33 ± 0.01ms<br/>max: 8.56 ± 0.05ms<br/>p99: 6.63 ± 0.04ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 248.08 ± 0.73 ops/s. best: 249.40ops/s.<br/>total: 4031.01 ± 11.93ms. best: 4009.58ms.<br/>avg: 4.03 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.17 ± 0.09ms<br/>p99: 8.12 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 340.76 ± 1.79 ops/s. best: 343.06ops/s.<br/>total: 2887.79 ± 15.20ms. best: 2868.32ms.<br/>avg: 2.93 ± 0.02ms<br/>min: 0.28 ± 0.00ms<br/>max: 7.03 ± 0.07ms<br/>p99: 5.03 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 309.97 ± 1.13 ops/s. best: 311.51ops/s.<br/>total: 3226.16 ± 11.90ms. best: 3210.14ms.<br/>avg: 3.23 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.21 ± 0.10ms<br/>p99: 6.34 ± 0.09ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 255.40 ± 0.80 ops/s. best: 256.48ops/s.<br/>total: 3852.79 ± 11.99ms. best: 3836.54ms.<br/>avg: 3.92 ± 0.01ms<br/>min: 0.32 ± 0.00ms<br/>max: 8.46 ± 0.03ms<br/>p99: 6.60 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 247.25 ± 0.79 ops/s. best: 248.24ops/s.<br/>total: 4044.61 ± 12.68ms. best: 4028.32ms.<br/>avg: 4.04 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.38 ± 0.32ms<br/>p99: 8.11 ± 0.06ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 340.80 ± 1.07 ops/s. best: 342.03ops/s.<br/>total: 2887.38 ± 9.04ms. best: 2876.92ms.<br/>avg: 2.93 ± 0.01ms<br/>min: 0.28 ± 0.00ms<br/>max: 7.12 ± 0.06ms<br/>p99: 5.05 ± 0.11ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 309.43 ± 0.69 ops/s. best: 310.40ops/s.<br/>total: 3231.79 ± 7.18ms. best: 3221.69ms.<br/>avg: 3.23 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.16 ± 0.04ms<br/>p99: 6.36 ± 0.02ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1521.23 ± 11.03 ops/s. best: 1529.93ops/s.<br/>total: 164.36 ± 1.21ms. best: 163.41ms.<br/>avg: 0.66 ± 0.00ms<br/>min: 0.52 ± 0.00ms<br/>max: 1.01 ± 0.23ms<br/>p99: 0.82 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 177.94 ± 0.31 ops/s. best: 178.38ops/s.<br/>total: 1404.95 ± 2.42ms. best: 1401.49ms.<br/>avg: 5.62 ± 0.01ms<br/>min: 5.09 ± 0.00ms<br/>max: 6.14 ± 0.04ms<br/>p99: 6.06 ± 0.02ms<br/><br/>250 tables, 50 coordinates<br/>ops: 87.85 ± 0.06 ops/s. best: 87.98ops/s.<br/>total: 2845.79 ± 1.96ms. best: 2841.42ms.<br/>avg: 11.38 ± 0.01ms<br/>min: 10.69 ± 0.02ms<br/>max: 12.25 ± 0.22ms<br/>p99: 12.06 ± 0.03ms | 250 tables, 3 coordinates<br/>ops: 1481.77 ± 14.78 ops/s. best: 1493.56ops/s.<br/>total: 168.74 ± 1.71ms. best: 167.38ms.<br/>avg: 0.67 ± 0.01ms<br/>min: 0.45 ± 0.01ms<br/>max: 1.02 ± 0.25ms<br/>p99: 0.87 ± 0.09ms<br/><br/>250 tables, 25 coordinates<br/>ops: 175.04 ± 0.15 ops/s. best: 175.25ops/s.<br/>total: 1428.28 ± 1.22ms. best: 1426.52ms.<br/>avg: 5.71 ± 0.00ms<br/>min: 5.01 ± 0.01ms<br/>max: 6.24 ± 0.01ms<br/>p99: 6.13 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 86.01 ± 0.11 ops/s. best: 86.14ops/s.<br/>total: 2906.57 ± 3.88ms. best: 2902.24ms.<br/>avg: 11.63 ± 0.02ms<br/>min: 10.77 ± 0.07ms<br/>max: 13.06 ± 0.84ms<br/>p99: 12.35 ± 0.07ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 347.23 ± 0.99 ops/s. best: 348.77ops/s.<br/>total: 719.99 ± 2.05ms. best: 716.80ms.<br/>avg: 2.88 ± 0.01ms<br/>min: 2.29 ± 0.01ms<br/>max: 4.13 ± 0.26ms<br/>p99: 3.81 ± 0.07ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.38 ± 0.06 ops/s. best: 38.44ops/s.<br/>total: 6514.21 ± 9.79ms. best: 6503.12ms.<br/>avg: 26.06 ± 0.04ms<br/>min: 23.57 ± 0.16ms<br/>max: 30.57 ± 1.78ms<br/>p99: 28.80 ± 0.32ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.80 ± 0.03 ops/s. best: 17.84ops/s.<br/>total: 14042.91 ± 25.70ms. best: 14009.64ms.<br/>avg: 56.17 ± 0.10ms<br/>min: 52.15 ± 0.08ms<br/>max: 64.02 ± 4.94ms<br/>p99: 59.81 ± 0.31ms | 250 tables, 3 coordinates<br/>ops: 345.13 ± 0.52 ops/s. best: 345.65ops/s.<br/>total: 724.37 ± 1.10ms. best: 723.28ms.<br/>avg: 2.90 ± 0.00ms<br/>min: 2.29 ± 0.01ms<br/>max: 3.99 ± 0.01ms<br/>p99: 3.80 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.21 ± 0.02 ops/s. best: 38.23ops/s.<br/>total: 6542.28 ± 3.44ms. best: 6538.72ms.<br/>avg: 26.17 ± 0.01ms<br/>min: 23.57 ± 0.02ms<br/>max: 29.72 ± 0.10ms<br/>p99: 28.95 ± 0.15ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.62 ± 0.04 ops/s. best: 17.67ops/s.<br/>total: 14190.40 ± 33.21ms. best: 14149.48ms.<br/>avg: 56.76 ± 0.13ms<br/>min: 52.85 ± 0.44ms<br/>max: 66.40 ± 6.52ms<br/>p99: 60.51 ± 0.39ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 506.66 ± 3.95 ops/s. best: 510.31ops/s.<br/>total: 493.48 ± 3.89ms. best: 489.90ms.<br/>avg: 1.97 ± 0.02ms<br/>min: 1.05 ± 0.01ms<br/>max: 2.87 ± 0.28ms<br/>p99: 2.59 ± 0.05ms<br/><br/>250 trips, 5 coordinates<br/>ops: 336.38 ± 1.72 ops/s. best: 338.83ops/s.<br/>total: 743.23 ± 3.91ms. best: 737.84ms.<br/>avg: 2.97 ± 0.02ms<br/>min: 1.84 ± 0.02ms<br/>max: 3.59 ± 0.07ms<br/>p99: 3.51 ± 0.03ms | 250 trips, 3 coordinates<br/>ops: 498.49 ± 2.94 ops/s. best: 504.51ops/s.<br/>total: 501.54 ± 2.94ms. best: 495.53ms.<br/>avg: 2.01 ± 0.01ms<br/>min: 1.28 ± 0.02ms<br/>max: 2.97 ± 0.40ms<br/>p99: 2.68 ± 0.19ms<br/><br/>250 trips, 5 coordinates<br/>ops: 328.30 ± 7.51 ops/s. best: 334.54ops/s.<br/>total: 762.14 ± 18.05ms. best: 747.29ms.<br/>avg: 3.05 ± 0.07ms<br/>min: 2.10 ± 0.01ms<br/>max: 3.90 ± 0.24ms<br/>p99: 3.73 ± 0.20ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 174.82 ± 0.31 ops/s. best: 175.26ops/s.<br/>total: 1430.06 ± 2.55ms. best: 1426.46ms.<br/>avg: 5.72 ± 0.01ms<br/>min: 3.78 ± 0.01ms<br/>max: 7.74 ± 0.21ms<br/>p99: 7.32 ± 0.06ms<br/><br/>250 trips, 5 coordinates<br/>ops: 113.24 ± 0.55 ops/s. best: 114.36ops/s.<br/>total: 2207.70 ± 10.65ms. best: 2186.00ms.<br/>avg: 8.83 ± 0.04ms<br/>min: 6.23 ± 0.04ms<br/>max: 11.11 ± 0.20ms<br/>p99: 10.70 ± 0.08ms | 250 trips, 3 coordinates<br/>ops: 173.03 ± 0.72 ops/s. best: 174.05ops/s.<br/>total: 1444.87 ± 6.04ms. best: 1436.38ms.<br/>avg: 5.78 ± 0.02ms<br/>min: 3.84 ± 0.01ms<br/>max: 7.69 ± 0.19ms<br/>p99: 7.37 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 112.47 ± 0.33 ops/s. best: 113.01ops/s.<br/>total: 2222.81 ± 6.49ms. best: 2212.12ms.<br/>avg: 8.89 ± 0.03ms<br/>min: 6.28 ± 0.03ms<br/>max: 11.18 ± 0.14ms<br/>p99: 10.70 ± 0.10ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>433.344ms<br/>0.433344ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>528.704ms<br/>0.528704ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>158.414ms<br/>0.158414ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>140.397ms<br/>0.140397ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>437.748ms<br/>0.437748ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>526.329ms<br/>0.526329ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>158.638ms<br/>0.158638ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>145.753ms<br/>0.145753ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>573.44ms<br/>0.57344ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>728.495ms<br/>0.728495ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>275.736ms<br/>0.275736ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>307.624ms<br/>0.307624ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>581.287ms<br/>0.581287ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>727.265ms<br/>0.727265ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>284.769ms<br/>0.284769ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>308.304ms<br/>0.308304ms/req |
| rtree | 1 result:<br/>201.866ms ->  0.0201866 ms/query<br/>10 results:<br/>237.514ms ->  0.0237514 ms/query | 1 result:<br/>202.346ms ->  0.0202346 ms/query<br/>10 results:<br/>237.377ms ->  0.0237377 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->



