### PR TITLE
Micro performance optimisation in map matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Micro performance optimisation in map matching. [#6976](https://github.com/Project-OSRM/osrm-backend/pull/6976)
       - CHANGED: Re-use priority queue in StaticRTree. [#6952](https://github.com/Project-OSRM/osrm-backend/pull/6952)
       - CHANGED: Optimise encodePolyline function. [#6940](https://github.com/Project-OSRM/osrm-backend/pull/6940)
       - CHANGED: Avoid reallocations in base64 encoding. [#6951](https://github.com/Project-OSRM/osrm-backend/pull/6951)

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -1,7 +1,6 @@
 #include "engine/routing_algorithms/map_matching.hpp"
 #include "engine/routing_algorithms/routing_base_ch.hpp"
 #include "engine/routing_algorithms/routing_base_mld.hpp"
-
 #include "engine/map_matching/hidden_markov_model.hpp"
 #include "engine/map_matching/matching_confidence.hpp"
 #include "engine/map_matching/sub_matching.hpp"

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -401,6 +401,7 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
         auto trace_distance = 0.0;
         matching.nodes.reserve(reconstructed_indices.size());
         matching.indices.reserve(reconstructed_indices.size());
+        matching.alternatives_count.reserve(reconstructed_indices.size());
         for (const auto &idx : reconstructed_indices)
         {
             const auto timestamp_index = idx.first;
@@ -428,7 +429,7 @@ SubMatchingList mapMatching(SearchEngineData<Algorithm> &engine_working_data,
 
         matching.confidence = confidence(trace_distance, matching_distance);
 
-        sub_matchings.push_back(matching);
+        sub_matchings.emplace_back(std::move(matching));
         sub_matching_begin = sub_matching_end;
     }
 

--- a/src/engine/routing_algorithms/map_matching.cpp
+++ b/src/engine/routing_algorithms/map_matching.cpp
@@ -1,6 +1,7 @@
 #include "engine/routing_algorithms/map_matching.hpp"
 #include "engine/routing_algorithms/routing_base_ch.hpp"
 #include "engine/routing_algorithms/routing_base_mld.hpp"
+
 #include "engine/map_matching/hidden_markov_model.hpp"
 #include "engine/map_matching/matching_confidence.hpp"
 #include "engine/map_matching/sub_matching.hpp"


### PR DESCRIPTION


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1128.59<br/>plain u32: 1143.64<br/>aliased double: 1171.61<br/>plain double: 1169.24 | aliased u32: 1134.31<br/>plain u32: 1126.16<br/>aliased double: 1166.12<br/>plain double: 1165.48 |
| e2e_match_ch | Ops: 44.43 ± 0.11 ops/s. Best: 44.20 ops/s<br/>Total: 2948.55ms ± 8.12ms. Best: 2934.71ms<br/>Min time: 2.12ms ± 0.02ms<br/>Mean time: 22.51ms ± 0.07ms<br/>Median time: 15.88ms ± 0.10ms<br/>95th percentile: 79.25ms ± 0.26ms<br/>99th percentile: 95.90ms ± 0.45ms<br/>Max time: 103.40ms ± 0.55ms | Ops: 44.59 ± 0.04 ops/s. Best: 44.54 ops/s<br/>Total: 2937.51ms ± 2.84ms. Best: 2931.84ms<br/>Min time: 2.15ms ± 0.02ms<br/>Mean time: 22.42ms ± 0.02ms<br/>Median time: 15.85ms ± 0.14ms<br/>95th percentile: 79.37ms ± 0.34ms<br/>99th percentile: 95.25ms ± 0.34ms<br/>Max time: 103.45ms ± 0.49ms |
| e2e_match_mld | Ops: 63.00 ± 0.07 ops/s. Best: 62.89 ops/s<br/>Total: 2079.21ms ± 2.40ms. Best: 2075.14ms<br/>Min time: 1.79ms ± 0.03ms<br/>Mean time: 15.87ms ± 0.02ms<br/>Median time: 8.48ms ± 0.07ms<br/>95th percentile: 53.00ms ± 0.25ms<br/>99th percentile: 61.52ms ± 0.32ms<br/>Max time: 71.07ms ± 0.30ms | Ops: 62.63 ± 0.08 ops/s. Best: 62.51 ops/s<br/>Total: 2091.65ms ± 2.75ms. Best: 2087.50ms<br/>Min time: 1.81ms ± 0.03ms<br/>Mean time: 15.97ms ± 0.02ms<br/>Median time: 8.47ms ± 0.05ms<br/>95th percentile: 53.48ms ± 0.15ms<br/>99th percentile: 61.64ms ± 0.27ms<br/>Max time: 71.75ms ± 0.40ms |
| e2e_nearest_ch | Ops: 805.05 ± 4.53 ops/s. Best: 794.81 ops/s<br/>Total: 1242.18ms ± 6.80ms. Best: 1235.19ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 4.20ms ± 2.47ms | Ops: 808.34 ± 4.81 ops/s. Best: 796.81 ops/s<br/>Total: 1237.05ms ± 7.80ms. Best: 1229.08ms<br/>Min time: 1.06ms ± 0.00ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.63ms ± 0.01ms<br/>99th percentile: 1.68ms ± 0.01ms<br/>Max time: 4.07ms ± 2.35ms |
| e2e_nearest_mld | Ops: 806.69 ± 4.49 ops/s. Best: 795.47 ops/s<br/>Total: 1239.67ms ± 7.36ms. Best: 1233.87ms<br/>Min time: 1.06ms ± 0.01ms<br/>Mean time: 1.24ms ± 0.01ms<br/>Median time: 1.15ms ± 0.01ms<br/>95th percentile: 1.64ms ± 0.01ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 4.05ms ± 2.35ms | Ops: 802.48 ± 4.62 ops/s. Best: 791.61 ops/s<br/>Total: 1246.08ms ± 7.53ms. Best: 1237.28ms<br/>Min time: 1.07ms ± 0.01ms<br/>Mean time: 1.25ms ± 0.01ms<br/>Median time: 1.16ms ± 0.01ms<br/>95th percentile: 1.65ms ± 0.01ms<br/>99th percentile: 1.70ms ± 0.01ms<br/>Max time: 4.08ms ± 2.33ms |
| e2e_route_ch | Ops: 351.19 ± 0.88 ops/s. Best: 350.23 ops/s<br/>Total: 2847.57ms ± 6.71ms. Best: 2834.43ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 2.85ms ± 0.01ms<br/>Median time: 2.87ms ± 0.01ms<br/>95th percentile: 3.74ms ± 0.03ms<br/>99th percentile: 4.11ms ± 0.06ms<br/>Max time: 6.64ms ± 1.98ms | Ops: 350.36 ± 1.83 ops/s. Best: 346.10 ops/s<br/>Total: 2854.06ms ± 15.58ms. Best: 2838.40ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 2.85ms ± 0.02ms<br/>Median time: 2.87ms ± 0.02ms<br/>95th percentile: 3.75ms ± 0.02ms<br/>99th percentile: 4.14ms ± 0.04ms<br/>Max time: 6.66ms ± 2.10ms |
| e2e_route_mld | Ops: 297.36 ± 0.87 ops/s. Best: 295.46 ops/s<br/>Total: 3362.77ms ± 10.39ms. Best: 3348.86ms<br/>Min time: 1.26ms ± 0.01ms<br/>Mean time: 3.36ms ± 0.01ms<br/>Median time: 3.39ms ± 0.01ms<br/>95th percentile: 4.57ms ± 0.02ms<br/>99th percentile: 5.01ms ± 0.06ms<br/>Max time: 7.25ms ± 1.62ms | Ops: 296.42 ± 0.83 ops/s. Best: 295.00 ops/s<br/>Total: 3373.47ms ± 9.58ms. Best: 3358.90ms<br/>Min time: 1.27ms ± 0.02ms<br/>Mean time: 3.37ms ± 0.01ms<br/>Median time: 3.41ms ± 0.01ms<br/>95th percentile: 4.57ms ± 0.02ms<br/>99th percentile: 5.04ms ± 0.04ms<br/>Max time: 7.28ms ± 1.57ms |
| e2e_table_ch | Ops: 309.82 ± 0.71 ops/s. Best: 308.16 ops/s<br/>Total: 3227.58ms ± 7.75ms. Best: 3218.84ms<br/>Min time: 1.69ms ± 0.02ms<br/>Mean time: 3.23ms ± 0.01ms<br/>Median time: 3.23ms ± 0.02ms<br/>95th percentile: 4.45ms ± 0.03ms<br/>99th percentile: 4.76ms ± 0.03ms<br/>Max time: 7.16ms ± 2.29ms | Ops: 302.48 ± 0.81 ops/s. Best: 300.76 ops/s<br/>Total: 3305.78ms ± 9.23ms. Best: 3296.64ms<br/>Min time: 1.61ms ± 0.03ms<br/>Mean time: 3.31ms ± 0.01ms<br/>Median time: 3.31ms ± 0.01ms<br/>95th percentile: 4.58ms ± 0.02ms<br/>99th percentile: 4.94ms ± 0.07ms<br/>Max time: 7.50ms ± 2.30ms |
| e2e_table_mld | Ops: 111.20 ± 0.14 ops/s. Best: 110.98 ops/s<br/>Total: 8992.11ms ± 11.20ms. Best: 8973.26ms<br/>Min time: 3.66ms ± 0.04ms<br/>Mean time: 8.99ms ± 0.01ms<br/>Median time: 8.95ms ± 0.02ms<br/>95th percentile: 13.73ms ± 0.05ms<br/>99th percentile: 14.65ms ± 0.05ms<br/>Max time: 16.48ms ± 1.42ms | Ops: 111.12 ± 0.18 ops/s. Best: 110.77 ops/s<br/>Total: 8999.66ms ± 16.25ms. Best: 8977.18ms<br/>Min time: 3.63ms ± 0.02ms<br/>Mean time: 9.00ms ± 0.02ms<br/>Median time: 8.97ms ± 0.02ms<br/>95th percentile: 13.74ms ± 0.02ms<br/>99th percentile: 14.65ms ± 0.12ms<br/>Max time: 16.87ms ± 1.62ms |
| e2e_trip_ch | Ops: 99.13 ± 0.24 ops/s. Best: 98.69 ops/s<br/>Total: 10086.59ms ± 26.09ms. Best: 10052.35ms<br/>Min time: 1.53ms ± 0.16ms<br/>Mean time: 10.09ms ± 0.03ms<br/>Median time: 9.59ms ± 0.03ms<br/>95th percentile: 17.95ms ± 0.05ms<br/>99th percentile: 19.49ms ± 0.12ms<br/>Max time: 22.03ms ± 1.52ms | Ops: 98.34 ± 0.12 ops/s. Best: 98.20 ops/s<br/>Total: 10168.66ms ± 11.95ms. Best: 10147.32ms<br/>Min time: 1.53ms ± 0.17ms<br/>Mean time: 10.17ms ± 0.01ms<br/>Median time: 9.67ms ± 0.03ms<br/>95th percentile: 18.11ms ± 0.04ms<br/>99th percentile: 19.49ms ± 0.08ms<br/>Max time: 22.46ms ± 1.53ms |
| e2e_trip_mld | Ops: 59.35 ± 0.30 ops/s. Best: 58.59 ops/s<br/>Total: 16851.90ms ± 86.44ms. Best: 16770.77ms<br/>Min time: 1.53ms ± 0.16ms<br/>Mean time: 16.85ms ± 0.09ms<br/>Median time: 16.42ms ± 0.10ms<br/>95th percentile: 27.70ms ± 0.11ms<br/>99th percentile: 29.67ms ± 0.38ms<br/>Max time: 31.70ms ± 0.42ms | Ops: 59.43 ± 0.22 ops/s. Best: 58.86 ops/s<br/>Total: 16822.61ms ± 63.54ms. Best: 16778.04ms<br/>Min time: 1.57ms ± 0.20ms<br/>Mean time: 16.83ms ± 0.06ms<br/>Median time: 16.41ms ± 0.11ms<br/>95th percentile: 27.64ms ± 0.17ms<br/>99th percentile: 29.55ms ± 0.30ms<br/>Max time: 31.89ms ± 0.14ms |
| json-render | String: 6.80436ms<br/>Stringstream: 10.4155ms<br/>Vector: 6.92967ms | String: 6.71979ms<br/>Stringstream: 10.3084ms<br/>Vector: 6.88586ms |
| match_ch | Default radius: <br/>4.55685ms/req at 82 coordinate<br/>0.0555714ms/coordinate<br/>Radius 10m: <br/>15.9094ms/req at 82 coordinate<br/>0.194018ms/coordinate | Default radius: <br/>4.56459ms/req at 82 coordinate<br/>0.0556657ms/coordinate<br/>Radius 10m: <br/>15.918ms/req at 82 coordinate<br/>0.194121ms/coordinate |
| match_mld | Default radius: <br/>3.2814ms/req at 82 coordinate<br/>0.040017ms/coordinate<br/>Radius 10m: <br/>12.8884ms/req at 82 coordinate<br/>0.157176ms/coordinate | Default radius: <br/>3.13238ms/req at 82 coordinate<br/>0.0381998ms/coordinate<br/>Radius 10m: <br/>11.6032ms/req at 82 coordinate<br/>0.141503ms/coordinate |
| osrm_contract | Time: 92.80s Peak RAM: 196.09MB | Time: 93.42s Peak RAM: 195.78MB |
| osrm_customize | Time: 1.34s Peak RAM: 116.85MB | Time: 1.34s Peak RAM: 116.74MB |
| osrm_extract | Time: 11.99s Peak RAM: 410.74MB | Time: 11.96s Peak RAM: 404.40MB |
| osrm_partition | Time: 1.98s Peak RAM: 138.17MB | Time: 1.98s Peak RAM: 135.23MB |
| packedvector | random write:<br/>std::vector 11179.6 ms<br/>util::packed_vector 81111.6 ms<br/>slowdown: 7.25535<br/>random read:<br/>std::vector 11019.8 ms<br/>util::packed_vector 33347.7 ms<br/>slowdown: 3.02616 | random write:<br/>std::vector 11190.5 ms<br/>util::packed_vector 73865 ms<br/>slowdown: 6.60068<br/>random read:<br/>std::vector 11009.6 ms<br/>util::packed_vector 30389.5 ms<br/>slowdown: 2.76028 |
| random_match_ch | 500 matches, default radius<br/>ops: 212.45 ± 0.93 ops/s. best: 213.45ops/s.<br/>total: 268.30 ± 1.19ms. best: 267.04ms.<br/>avg: 4.71 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 26.34 ± 0.21ms<br/>p99: 26.34 ± 0.21ms<br/><br/>500 matches, radius=10<br/>ops: 62.32 ± 0.11 ops/s. best: 62.48ops/s.<br/>total: 1027.01 ± 1.83ms. best: 1024.29ms.<br/>avg: 16.05 ± 0.03ms<br/>min: 0.16 ± 0.00ms<br/>max: 243.23 ± 0.35ms<br/>p99: 243.23 ± 0.35ms<br/><br/>500 matches, radius=20<br/>ops: 14.63 ± 0.03 ops/s. best: 14.69ops/s.<br/>total: 4442.09 ± 9.19ms. best: 4426.25ms.<br/>avg: 68.34 ± 0.14ms<br/>min: 0.31 ± 0.00ms<br/>max: 1257.82 ± 4.58ms<br/>p99: 1257.82 ± 4.58ms | 500 matches, default radius<br/>ops: 210.69 ± 0.93 ops/s. best: 208.66ops/s.<br/>total: 270.54 ± 1.21ms. best: 269.39ms.<br/>avg: 4.75 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 25.92 ± 0.08ms<br/>p99: 25.92 ± 0.08ms<br/><br/>500 matches, radius=10<br/>ops: 61.71 ± 0.15 ops/s. best: 61.51ops/s.<br/>total: 1037.14 ± 2.40ms. best: 1032.54ms.<br/>avg: 16.21 ± 0.04ms<br/>min: 0.16 ± 0.00ms<br/>max: 247.29 ± 0.57ms<br/>p99: 247.29 ± 0.57ms<br/><br/>500 matches, radius=20<br/>ops: 14.45 ± 0.02 ops/s. best: 14.43ops/s.<br/>total: 4496.89 ± 4.73ms. best: 4488.98ms.<br/>avg: 69.18 ± 0.07ms<br/>min: 0.31 ± 0.00ms<br/>max: 1284.02 ± 1.77ms<br/>p99: 1284.02 ± 1.77ms |
| random_match_mld | 500 matches, default radius<br/>ops: 298.21 ± 1.39 ops/s. best: 299.27ops/s.<br/>total: 191.14 ± 0.90ms. best: 190.47ms.<br/>avg: 3.35 ± 0.02ms<br/>min: 0.13 ± 0.00ms<br/>max: 19.85 ± 0.05ms<br/>p99: 19.85 ± 0.05ms<br/><br/>500 matches, radius=10<br/>ops: 104.35 ± 0.66 ops/s. best: 104.86ops/s.<br/>total: 613.37 ± 3.94ms. best: 610.32ms.<br/>avg: 9.58 ± 0.06ms<br/>min: 0.15 ± 0.00ms<br/>max: 116.41 ± 0.16ms<br/>p99: 116.41 ± 0.16ms<br/><br/>500 matches, radius=20<br/>ops: 20.94 ± 0.03 ops/s. best: 21.01ops/s.<br/>total: 3104.54 ± 4.91ms. best: 3094.01ms.<br/>avg: 47.76 ± 0.08ms<br/>min: 0.20 ± 0.00ms<br/>max: 614.27 ± 1.59ms<br/>p99: 614.27 ± 1.59ms | 500 matches, default radius<br/>ops: 302.04 ± 1.70 ops/s. best: 297.55ops/s.<br/>total: 188.73 ± 1.07ms. best: 188.00ms.<br/>avg: 3.31 ± 0.02ms<br/>min: 0.12 ± 0.00ms<br/>max: 19.61 ± 0.04ms<br/>p99: 19.61 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 105.12 ± 0.29 ops/s. best: 104.79ops/s.<br/>total: 608.86 ± 1.68ms. best: 605.17ms.<br/>avg: 9.51 ± 0.03ms<br/>min: 0.15 ± 0.00ms<br/>max: 116.21 ± 0.40ms<br/>p99: 116.21 ± 0.40ms<br/><br/>500 matches, radius=20<br/>ops: 20.90 ± 0.02 ops/s. best: 20.87ops/s.<br/>total: 3109.55 ± 3.22ms. best: 3105.39ms.<br/>avg: 47.84 ± 0.05ms<br/>min: 0.20 ± 0.00ms<br/>max: 617.40 ± 1.37ms<br/>p99: 617.40 ± 1.37ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 22808.22 ± 127.83 ops/s. best: 22919.66ops/s.<br/>total: 438.46 ± 2.47ms. best: 436.31ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17803.56 ± 27.44 ops/s. best: 17826.00ops/s.<br/>total: 561.69 ± 0.87ms. best: 560.98ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14407.04 ± 3.78 ops/s. best: 14415.00ops/s.<br/>total: 694.11 ± 0.18ms. best: 693.72ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22690.92 ± 56.02 ops/s. best: 22551.28ops/s.<br/>total: 440.71 ± 1.09ms. best: 439.80ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17643.91 ± 19.43 ops/s. best: 17608.59ops/s.<br/>total: 566.77 ± 0.62ms. best: 565.94ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14263.09 ± 93.43 ops/s. best: 14028.20ops/s.<br/>total: 701.16 ± 4.65ms. best: 697.43ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 23023.08 ± 53.88 ops/s. best: 23063.85ops/s.<br/>total: 434.35 ± 1.02ms. best: 433.58ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17758.27 ± 10.11 ops/s. best: 17768.47ops/s.<br/>total: 563.12 ± 0.32ms. best: 562.79ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14382.16 ± 10.33 ops/s. best: 14396.92ops/s.<br/>total: 695.31 ± 0.51ms. best: 694.59ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22854.43 ± 55.26 ops/s. best: 22747.36ops/s.<br/>total: 437.56 ± 1.06ms. best: 436.37ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17683.04 ± 5.38 ops/s. best: 17674.87ops/s.<br/>total: 565.51 ± 0.18ms. best: 565.21ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14334.50 ± 10.06 ops/s. best: 14320.00ops/s.<br/>total: 697.62 ± 0.48ms. best: 697.06ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 519.86 ± 1.01 ops/s. best: 521.32ops/s.<br/>total: 1892.83 ± 3.86ms. best: 1887.52ms.<br/>avg: 1.92 ± 0.00ms<br/>min: 0.33 ± 0.00ms<br/>max: 3.23 ± 0.22ms<br/>p99: 2.77 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 604.84 ± 1.61 ops/s. best: 606.64ops/s.<br/>total: 1653.34 ± 4.41ms. best: 1648.41ms.<br/>avg: 1.65 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.15 ± 0.09ms<br/>p99: 3.57 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 1063.66 ± 0.71 ops/s. best: 1064.66ops/s.<br/>total: 925.11 ± 0.62ms. best: 924.24ms.<br/>avg: 0.94 ± 0.00ms<br/>min: 0.24 ± 0.00ms<br/>max: 1.44 ± 0.02ms<br/>p99: 1.30 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1182.79 ± 3.52 ops/s. best: 1187.85ops/s.<br/>total: 845.47 ± 2.51ms. best: 841.86ms.<br/>avg: 0.85 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.94 ± 0.03ms<br/>p99: 1.78 ± 0.01ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 503.34 ± 0.62 ops/s. best: 502.31ops/s.<br/>total: 1954.96 ± 2.48ms. best: 1951.02ms.<br/>avg: 1.99 ± 0.00ms<br/>min: 0.33 ± 0.01ms<br/>max: 3.23 ± 0.23ms<br/>p99: 2.85 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 588.09 ± 1.21 ops/s. best: 586.10ops/s.<br/>total: 1700.42 ± 3.51ms. best: 1696.03ms.<br/>avg: 1.70 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.24 ± 0.01ms<br/>p99: 3.58 ± 0.02ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 970.75 ± 1.46 ops/s. best: 968.13ops/s.<br/>total: 1013.66 ± 1.53ms. best: 1011.30ms.<br/>avg: 1.03 ± 0.00ms<br/>min: 0.24 ± 0.00ms<br/>max: 1.62 ± 0.01ms<br/>p99: 1.42 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1095.88 ± 1.33 ops/s. best: 1093.11ops/s.<br/>total: 912.51 ± 1.12ms. best: 911.46ms.<br/>avg: 0.91 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 3.33 ± 0.01ms<br/>p99: 2.04 ± 0.01ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 256.08 ± 1.40 ops/s. best: 257.65ops/s.<br/>total: 3842.73 ± 21.87ms. best: 3819.09ms.<br/>avg: 3.91 ± 0.02ms<br/>min: 0.33 ± 0.01ms<br/>max: 8.51 ± 0.03ms<br/>p99: 6.49 ± 0.10ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 251.80 ± 0.38 ops/s. best: 252.21ops/s.<br/>total: 3971.45 ± 6.15ms. best: 3965.02ms.<br/>avg: 3.97 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.15 ± 0.32ms<br/>p99: 8.02 ± 0.08ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 343.55 ± 0.46 ops/s. best: 344.49ops/s.<br/>total: 2864.25 ± 3.84ms. best: 2856.37ms.<br/>avg: 2.91 ± 0.00ms<br/>min: 0.28 ± 0.00ms<br/>max: 7.21 ± 0.23ms<br/>p99: 4.97 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 315.77 ± 0.49 ops/s. best: 316.38ops/s.<br/>total: 3166.83 ± 4.93ms. best: 3160.72ms.<br/>avg: 3.17 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 6.90 ± 0.02ms<br/>p99: 6.23 ± 0.02ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 253.28 ± 1.10 ops/s. best: 250.74ops/s.<br/>total: 3885.18 ± 16.99ms. best: 3869.00ms.<br/>avg: 3.95 ± 0.02ms<br/>min: 0.32 ± 0.00ms<br/>max: 8.60 ± 0.04ms<br/>p99: 6.59 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 248.57 ± 0.20 ops/s. best: 248.29ops/s.<br/>total: 4023.02 ± 3.31ms. best: 4018.52ms.<br/>avg: 4.02 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.13 ± 0.05ms<br/>p99: 8.09 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 336.87 ± 0.70 ops/s. best: 335.87ops/s.<br/>total: 2921.00 ± 6.04ms. best: 2913.76ms.<br/>avg: 2.97 ± 0.01ms<br/>min: 0.29 ± 0.00ms<br/>max: 7.17 ± 0.02ms<br/>p99: 5.05 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 309.83 ± 0.95 ops/s. best: 307.90ops/s.<br/>total: 3227.61 ± 9.87ms. best: 3214.00ms.<br/>avg: 3.23 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.09 ± 0.07ms<br/>p99: 6.33 ± 0.06ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1483.50 ± 11.64 ops/s. best: 1493.10ops/s.<br/>total: 168.54 ± 1.35ms. best: 167.44ms.<br/>avg: 0.67 ± 0.01ms<br/>min: 0.52 ± 0.01ms<br/>max: 1.00 ± 0.24ms<br/>p99: 0.86 ± 0.05ms<br/><br/>250 tables, 25 coordinates<br/>ops: 173.80 ± 0.03 ops/s. best: 173.85ops/s.<br/>total: 1438.41 ± 0.22ms. best: 1438.03ms.<br/>avg: 5.75 ± 0.00ms<br/>min: 5.26 ± 0.01ms<br/>max: 6.22 ± 0.06ms<br/>p99: 6.16 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 85.51 ± 0.02 ops/s. best: 85.55ops/s.<br/>total: 2923.59 ± 0.74ms. best: 2922.18ms.<br/>avg: 11.69 ± 0.00ms<br/>min: 11.07 ± 0.01ms<br/>max: 12.60 ± 0.06ms<br/>p99: 12.39 ± 0.02ms | 250 tables, 3 coordinates<br/>ops: 1405.97 ± 8.19 ops/s. best: 1385.72ops/s.<br/>total: 177.82 ± 1.05ms. best: 177.02ms.<br/>avg: 0.71 ± 0.00ms<br/>min: 0.52 ± 0.00ms<br/>max: 1.05 ± 0.21ms<br/>p99: 0.91 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 165.36 ± 0.19 ops/s. best: 164.96ops/s.<br/>total: 1511.90 ± 1.74ms. best: 1509.82ms.<br/>avg: 6.05 ± 0.01ms<br/>min: 5.50 ± 0.01ms<br/>max: 6.69 ± 0.13ms<br/>p99: 6.53 ± 0.02ms<br/><br/>250 tables, 50 coordinates<br/>ops: 81.27 ± 0.04 ops/s. best: 81.21ops/s.<br/>total: 3076.11 ± 1.47ms. best: 3073.61ms.<br/>avg: 12.30 ± 0.01ms<br/>min: 11.57 ± 0.02ms<br/>max: 13.36 ± 0.23ms<br/>p99: 13.04 ± 0.05ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 346.53 ± 0.60 ops/s. best: 347.08ops/s.<br/>total: 721.45 ± 1.25ms. best: 720.30ms.<br/>avg: 2.89 ± 0.00ms<br/>min: 2.30 ± 0.01ms<br/>max: 3.97 ± 0.01ms<br/>p99: 3.80 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.43 ± 0.02 ops/s. best: 38.47ops/s.<br/>total: 6505.39 ± 4.22ms. best: 6499.37ms.<br/>avg: 26.02 ± 0.02ms<br/>min: 23.50 ± 0.04ms<br/>max: 29.52 ± 0.05ms<br/>p99: 28.50 ± 0.06ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.85 ± 0.01 ops/s. best: 17.87ops/s.<br/>total: 14004.42 ± 10.52ms. best: 13987.25ms.<br/>avg: 56.02 ± 0.04ms<br/>min: 52.16 ± 0.08ms<br/>max: 59.78 ± 0.10ms<br/>p99: 59.43 ± 0.04ms | 250 tables, 3 coordinates<br/>ops: 344.92 ± 0.72 ops/s. best: 343.34ops/s.<br/>total: 724.82 ± 1.52ms. best: 723.18ms.<br/>avg: 2.90 ± 0.01ms<br/>min: 2.31 ± 0.02ms<br/>max: 3.98 ± 0.03ms<br/>p99: 3.81 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.41 ± 0.01 ops/s. best: 38.39ops/s.<br/>total: 6509.00 ± 2.36ms. best: 6504.91ms.<br/>avg: 26.04 ± 0.01ms<br/>min: 23.57 ± 0.03ms<br/>max: 29.63 ± 0.20ms<br/>p99: 28.57 ± 0.15ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.91 ± 0.00 ops/s. best: 17.91ops/s.<br/>total: 13955.48 ± 1.22ms. best: 13953.62ms.<br/>avg: 55.82 ± 0.00ms<br/>min: 51.99 ± 0.07ms<br/>max: 59.49 ± 0.08ms<br/>p99: 59.23 ± 0.07ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 498.79 ± 5.74 ops/s. best: 503.58ops/s.<br/>total: 501.32 ± 5.88ms. best: 496.45ms.<br/>avg: 2.01 ± 0.02ms<br/>min: 1.04 ± 0.02ms<br/>max: 2.90 ± 0.33ms<br/>p99: 2.75 ± 0.28ms<br/><br/>250 trips, 5 coordinates<br/>ops: 333.56 ± 0.46 ops/s. best: 334.07ops/s.<br/>total: 749.50 ± 1.03ms. best: 748.34ms.<br/>avg: 3.00 ± 0.00ms<br/>min: 1.90 ± 0.02ms<br/>max: 3.61 ± 0.01ms<br/>p99: 3.55 ± 0.01ms | 250 trips, 3 coordinates<br/>ops: 471.17 ± 2.05 ops/s. best: 466.12ops/s.<br/>total: 530.61 ± 2.32ms. best: 528.71ms.<br/>avg: 2.12 ± 0.01ms<br/>min: 1.14 ± 0.00ms<br/>max: 2.97 ± 0.26ms<br/>p99: 2.74 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 314.21 ± 0.49 ops/s. best: 313.26ops/s.<br/>total: 795.66 ± 1.24ms. best: 794.18ms.<br/>avg: 3.18 ± 0.00ms<br/>min: 1.96 ± 0.01ms<br/>max: 3.87 ± 0.07ms<br/>p99: 3.77 ± 0.03ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 177.08 ± 0.74 ops/s. best: 178.26ops/s.<br/>total: 1411.84 ± 5.96ms. best: 1402.45ms.<br/>avg: 5.65 ± 0.02ms<br/>min: 3.79 ± 0.02ms<br/>max: 8.02 ± 0.76ms<br/>p99: 7.24 ± 0.09ms<br/><br/>250 trips, 5 coordinates<br/>ops: 115.76 ± 0.17 ops/s. best: 116.01ops/s.<br/>total: 2159.63 ± 3.14ms. best: 2154.90ms.<br/>avg: 8.64 ± 0.01ms<br/>min: 6.10 ± 0.03ms<br/>max: 10.91 ± 0.23ms<br/>p99: 10.32 ± 0.09ms | 250 trips, 3 coordinates<br/>ops: 172.76 ± 0.32 ops/s. best: 172.38ops/s.<br/>total: 1447.13 ± 2.64ms. best: 1441.86ms.<br/>avg: 5.79 ± 0.01ms<br/>min: 3.85 ± 0.02ms<br/>max: 8.10 ± 0.35ms<br/>p99: 7.36 ± 0.10ms<br/><br/>250 trips, 5 coordinates<br/>ops: 113.41 ± 0.16 ops/s. best: 113.10ops/s.<br/>total: 2204.32 ± 3.20ms. best: 2200.84ms.<br/>avg: 8.82 ± 0.01ms<br/>min: 6.20 ± 0.03ms<br/>max: 10.97 ± 0.11ms<br/>p99: 10.57 ± 0.13ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>438.234ms<br/>0.438234ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>537.88ms<br/>0.53788ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>156.713ms<br/>0.156713ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>143.307ms<br/>0.143307ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>434.117ms<br/>0.434117ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>535.236ms<br/>0.535236ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>159.021ms<br/>0.159021ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>141.047ms<br/>0.141047ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>586.131ms<br/>0.586131ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>745.398ms<br/>0.745398ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>289.278ms<br/>0.289278ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>323.146ms<br/>0.323146ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>577.664ms<br/>0.577664ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>727.535ms<br/>0.727535ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>284.734ms<br/>0.284734ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>313.604ms<br/>0.313604ms/req |
| rtree | 1 result:<br/>202.126ms ->  0.0202126 ms/query<br/>10 results:<br/>237.953ms ->  0.0237953 ms/query | 1 result:<br/>203.005ms ->  0.0203005 ms/query<br/>10 results:<br/>239.678ms ->  0.0239678 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->

