### PR TITLE
Add .reserve(...) to assembleGeometry function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - NodeJS:
       - CHANGED: Use node-api instead of NAN. [#6452](https://github.com/Project-OSRM/osrm-backend/pull/6452)
     - Misc:
+      - CHANGED: Add .reserve(...) to assembleGeometry function. [#6983](https://github.com/Project-OSRM/osrm-backend/pull/6983)
       - CHANGED: Get rid of boost::optional leftovers. [#6977](https://github.com/Project-OSRM/osrm-backend/pull/6977)
       - CHANGED: Use Link Time Optimisation whenever possible. [#6967](https://github.com/Project-OSRM/osrm-backend/pull/6967)
       - CHANGED: Use struct instead of tuple to define UnpackedPath. [#6974](https://github.com/Project-OSRM/osrm-backend/pull/6974)

--- a/include/engine/guidance/assemble_geometry.hpp
+++ b/include/engine/guidance/assemble_geometry.hpp
@@ -37,6 +37,14 @@ inline LegGeometry assembleGeometry(const datafacade::BaseDataFacade &facade,
 {
     LegGeometry geometry;
 
+    // each container will at most have `leg_data.size()` + 1/2 elements in it
+    // these additional 1/2 elements come from processing of very first and very last segment
+    geometry.locations.reserve(leg_data.size() + 2);
+    geometry.segment_distances.reserve(leg_data.size() + 1);
+    geometry.segment_offsets.reserve(leg_data.size() + 1);
+    geometry.annotations.reserve(leg_data.size() + 1);
+    geometry.node_ids.reserve(leg_data.size() + 2);
+
     // segment 0 first and last
     geometry.segment_offsets.push_back(0);
     geometry.locations.push_back(source_node.location);


### PR DESCRIPTION
I profiled allocations a bit and noticed that this function generates quite a lot of them - should be yet another micro performance improvement.



<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1192.71<br/>plain u32: 1193.21<br/>aliased double: 1229.05<br/>plain double: 1261.03 | aliased u32: 1161.71<br/>plain u32: 1152.3<br/>aliased double: 1201.83<br/>plain double: 1195.68 |
| e2e_match_ch | Ops: 43.67 ± 0.16 ops/s. Best: 43.88 ops/s<br/>Total: 2999.25ms ± 10.62ms. Best: 2985.66ms<br/>Min time: 2.21ms ± 0.02ms<br/>Mean time: 22.90ms ± 0.08ms<br/>Median time: 17.04ms ± 0.17ms<br/>95th percentile: 77.07ms ± 0.64ms<br/>99th percentile: 93.75ms ± 0.57ms<br/>Max time: 104.27ms ± 0.55ms | Ops: 43.71 ± 0.10 ops/s. Best: 43.89 ops/s<br/>Total: 2997.32ms ± 6.13ms. Best: 2984.95ms<br/>Min time: 2.07ms ± 0.05ms<br/>Mean time: 22.88ms ± 0.05ms<br/>Median time: 16.07ms ± 0.16ms<br/>95th percentile: 73.21ms ± 0.15ms<br/>99th percentile: 87.87ms ± 0.29ms<br/>Max time: 102.30ms ± 0.78ms |
| e2e_match_mld | Ops: 64.72 ± 0.11 ops/s. Best: 64.85 ops/s<br/>Total: 2024.14ms ± 3.37ms. Best: 2020.04ms<br/>Min time: 1.73ms ± 0.01ms<br/>Mean time: 15.45ms ± 0.03ms<br/>Median time: 8.19ms ± 0.12ms<br/>95th percentile: 51.09ms ± 0.08ms<br/>99th percentile: 60.13ms ± 0.17ms<br/>Max time: 69.45ms ± 0.40ms | Ops: 64.54 ± 0.10 ops/s. Best: 64.69 ops/s<br/>Total: 2029.83ms ± 3.23ms. Best: 2025.05ms<br/>Min time: 1.74ms ± 0.02ms<br/>Mean time: 15.49ms ± 0.03ms<br/>Median time: 8.22ms ± 0.15ms<br/>95th percentile: 51.62ms ± 0.26ms<br/>99th percentile: 60.05ms ± 0.09ms<br/>Max time: 69.47ms ± 0.32ms |
| e2e_nearest_ch | Ops: 861.60 ± 3.17 ops/s. Best: 867.58 ops/s<br/>Total: 1160.65ms ± 4.36ms. Best: 1152.63ms<br/>Min time: 0.99ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.00ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.61ms ± 0.00ms<br/>99th percentile: 1.66ms ± 0.01ms<br/>Max time: 5.93ms ± 2.69ms | Ops: 857.23 ± 3.13 ops/s. Best: 862.55 ops/s<br/>Total: 1166.57ms ± 4.72ms. Best: 1159.35ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.17ms ± 0.00ms<br/>Median time: 1.08ms ± 0.00ms<br/>95th percentile: 1.62ms ± 0.00ms<br/>99th percentile: 1.69ms ± 0.01ms<br/>Max time: 6.54ms ± 3.17ms |
| e2e_nearest_mld | Ops: 860.86 ± 5.31 ops/s. Best: 868.12 ops/s<br/>Total: 1161.83ms ± 7.27ms. Best: 1151.92ms<br/>Min time: 0.99ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.01ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.61ms ± 0.01ms<br/>99th percentile: 1.66ms ± 0.01ms<br/>Max time: 5.94ms ± 2.78ms | Ops: 856.00 ± 4.98 ops/s. Best: 863.57 ops/s<br/>Total: 1168.39ms ± 7.06ms. Best: 1157.98ms<br/>Min time: 0.99ms ± 0.00ms<br/>Mean time: 1.17ms ± 0.01ms<br/>Median time: 1.08ms ± 0.00ms<br/>95th percentile: 1.62ms ± 0.01ms<br/>99th percentile: 1.68ms ± 0.02ms<br/>Max time: 6.30ms ± 2.89ms |
| e2e_route_ch | Ops: 357.88 ± 1.39 ops/s. Best: 359.75 ops/s<br/>Total: 2793.91ms ± 10.90ms. Best: 2779.74ms<br/>Min time: 1.20ms ± 0.02ms<br/>Mean time: 2.79ms ± 0.01ms<br/>Median time: 2.82ms ± 0.01ms<br/>95th percentile: 3.71ms ± 0.03ms<br/>99th percentile: 4.13ms ± 0.03ms<br/>Max time: 7.01ms ± 2.55ms | Ops: 348.68 ± 2.06 ops/s. Best: 352.61 ops/s<br/>Total: 2867.58ms ± 17.95ms. Best: 2836.01ms<br/>Min time: 1.21ms ± 0.02ms<br/>Mean time: 2.87ms ± 0.02ms<br/>Median time: 2.89ms ± 0.03ms<br/>95th percentile: 3.83ms ± 0.03ms<br/>99th percentile: 4.28ms ± 0.03ms<br/>Max time: 7.44ms ± 2.68ms |
| e2e_route_mld | Ops: 295.59 ± 1.12 ops/s. Best: 298.06 ops/s<br/>Total: 3382.93ms ± 13.47ms. Best: 3355.01ms<br/>Min time: 1.18ms ± 0.01ms<br/>Mean time: 3.38ms ± 0.01ms<br/>Median time: 3.42ms ± 0.02ms<br/>95th percentile: 4.66ms ± 0.04ms<br/>99th percentile: 5.19ms ± 0.06ms<br/>Max time: 7.62ms ± 1.97ms | Ops: 288.81 ± 2.35 ops/s. Best: 293.23 ops/s<br/>Total: 3462.97ms ± 28.09ms. Best: 3410.27ms<br/>Min time: 1.20ms ± 0.02ms<br/>Mean time: 3.46ms ± 0.03ms<br/>Median time: 3.50ms ± 0.04ms<br/>95th percentile: 4.79ms ± 0.03ms<br/>99th percentile: 5.30ms ± 0.08ms<br/>Max time: 8.36ms ± 2.36ms |
| e2e_table_ch | Ops: 306.51 ± 1.30 ops/s. Best: 308.04 ops/s<br/>Total: 3262.95ms ± 13.96ms. Best: 3246.28ms<br/>Min time: 1.55ms ± 0.04ms<br/>Mean time: 3.26ms ± 0.01ms<br/>Median time: 3.25ms ± 0.02ms<br/>95th percentile: 4.58ms ± 0.02ms<br/>99th percentile: 4.93ms ± 0.11ms<br/>Max time: 8.33ms ± 2.30ms | Ops: 310.00 ± 1.26 ops/s. Best: 311.65 ops/s<br/>Total: 3225.24ms ± 13.88ms. Best: 3208.70ms<br/>Min time: 1.68ms ± 0.03ms<br/>Mean time: 3.23ms ± 0.01ms<br/>Median time: 3.22ms ± 0.01ms<br/>95th percentile: 4.49ms ± 0.04ms<br/>99th percentile: 4.85ms ± 0.06ms<br/>Max time: 8.98ms ± 2.80ms |
| e2e_table_mld | Ops: 112.51 ± 0.15 ops/s. Best: 112.79 ops/s<br/>Total: 8887.88ms ± 11.92ms. Best: 8865.70ms<br/>Min time: 3.57ms ± 0.03ms<br/>Mean time: 8.89ms ± 0.01ms<br/>Median time: 8.86ms ± 0.02ms<br/>95th percentile: 13.63ms ± 0.03ms<br/>99th percentile: 14.50ms ± 0.03ms<br/>Max time: 17.74ms ± 2.09ms | Ops: 110.15 ± 0.65 ops/s. Best: 111.56 ops/s<br/>Total: 9077.97ms ± 54.44ms. Best: 8963.48ms<br/>Min time: 3.61ms ± 0.03ms<br/>Mean time: 9.08ms ± 0.06ms<br/>Median time: 9.05ms ± 0.05ms<br/>95th percentile: 13.96ms ± 0.09ms<br/>99th percentile: 14.92ms ± 0.09ms<br/>Max time: 17.83ms ± 1.99ms |
| e2e_trip_ch | Ops: 95.61 ± 0.41 ops/s. Best: 96.24 ops/s<br/>Total: 10458.61ms ± 46.93ms. Best: 10390.54ms<br/>Min time: 1.50ms ± 0.13ms<br/>Mean time: 10.46ms ± 0.05ms<br/>Median time: 9.90ms ± 0.04ms<br/>95th percentile: 18.84ms ± 0.06ms<br/>99th percentile: 20.83ms ± 0.14ms<br/>Max time: 22.64ms ± 0.55ms | Ops: 94.14 ± 0.93 ops/s. Best: 95.15 ops/s<br/>Total: 10625.45ms ± 106.61ms. Best: 10510.03ms<br/>Min time: 1.68ms ± 0.13ms<br/>Mean time: 10.63ms ± 0.11ms<br/>Median time: 10.10ms ± 0.13ms<br/>95th percentile: 18.99ms ± 0.16ms<br/>99th percentile: 21.00ms ± 0.14ms<br/>Max time: 23.34ms ± 0.62ms |
| e2e_trip_mld | Ops: 57.46 ± 0.13 ops/s. Best: 57.68 ops/s<br/>Total: 17402.86ms ± 40.00ms. Best: 17338.47ms<br/>Min time: 1.76ms ± 0.36ms<br/>Mean time: 17.40ms ± 0.04ms<br/>Median time: 16.88ms ± 0.05ms<br/>95th percentile: 28.81ms ± 0.17ms<br/>99th percentile: 31.03ms ± 0.17ms<br/>Max time: 32.78ms ± 0.29ms | Ops: 56.60 ± 0.18 ops/s. Best: 56.98 ops/s<br/>Total: 17669.00ms ± 57.11ms. Best: 17549.52ms<br/>Min time: 1.90ms ± 0.29ms<br/>Mean time: 17.67ms ± 0.06ms<br/>Median time: 17.24ms ± 0.08ms<br/>95th percentile: 28.75ms ± 0.11ms<br/>99th percentile: 31.39ms ± 0.33ms<br/>Max time: 35.22ms ± 2.17ms |
| json-render | String: 5.65867ms<br/>Stringstream: 9.41056ms<br/>Vector: 6.44926ms | String: 5.67585ms<br/>Stringstream: 9.23402ms<br/>Vector: 6.70167ms |
| match_ch | Default radius: <br/>4.61061ms/req at 82 coordinate<br/>0.056227ms/coordinate<br/>Radius 10m: <br/>16.1153ms/req at 82 coordinate<br/>0.196528ms/coordinate | Default radius: <br/>4.72713ms/req at 82 coordinate<br/>0.057648ms/coordinate<br/>Radius 10m: <br/>16.4915ms/req at 82 coordinate<br/>0.201116ms/coordinate |
| match_mld | Default radius: <br/>2.981ms/req at 82 coordinate<br/>0.0363537ms/coordinate<br/>Radius 10m: <br/>11.2352ms/req at 82 coordinate<br/>0.137015ms/coordinate | Default radius: <br/>3.03833ms/req at 82 coordinate<br/>0.0370528ms/coordinate<br/>Radius 10m: <br/>11.2526ms/req at 82 coordinate<br/>0.137227ms/coordinate |
| osrm_contract | Time: 98.00s Peak RAM: 200.84MB | Time: 100.23s Peak RAM: 202.03MB |
| osrm_customize | Time: 1.33s Peak RAM: 117.03MB | Time: 1.30s Peak RAM: 116.95MB |
| osrm_extract | Time: 11.69s Peak RAM: 428.48MB | Time: 11.80s Peak RAM: 430.71MB |
| osrm_partition | Time: 2.12s Peak RAM: 137.89MB | Time: 2.14s Peak RAM: 145.19MB |
| packedvector | random write:<br/>std::vector 11490.7 ms<br/>util::packed_vector 74294.2 ms<br/>slowdown: 6.46562<br/>random read:<br/>std::vector 11207.7 ms<br/>util::packed_vector 30857.1 ms<br/>slowdown: 2.75321 | random write:<br/>std::vector 11440.4 ms<br/>util::packed_vector 73999.4 ms<br/>slowdown: 6.46826<br/>random read:<br/>std::vector 11096.5 ms<br/>util::packed_vector 31033.4 ms<br/>slowdown: 2.79668 |
| random_match_ch | 500 matches, default radius<br/>ops: 202.42 ± 1.33 ops/s. best: 203.54ops/s.<br/>total: 281.61 ± 1.87ms. best: 280.04ms.<br/>avg: 4.94 ± 0.03ms<br/>min: 0.15 ± 0.01ms<br/>max: 25.47 ± 0.18ms<br/>p99: 25.47 ± 0.18ms<br/><br/>500 matches, radius=10<br/>ops: 61.05 ± 0.10 ops/s. best: 61.21ops/s.<br/>total: 1048.30 ± 1.67ms. best: 1045.51ms.<br/>avg: 16.38 ± 0.03ms<br/>min: 0.14 ± 0.00ms<br/>max: 216.72 ± 0.97ms<br/>p99: 216.72 ± 0.97ms<br/><br/>500 matches, radius=20<br/>ops: 14.61 ± 0.05 ops/s. best: 14.73ops/s.<br/>total: 4447.84 ± 16.52ms. best: 4414.23ms.<br/>avg: 68.43 ± 0.25ms<br/>min: 0.33 ± 0.00ms<br/>max: 1117.02 ± 5.40ms<br/>p99: 1117.02 ± 5.40ms | 500 matches, default radius<br/>ops: 204.00 ± 0.57 ops/s. best: 204.82ops/s.<br/>total: 279.41 ± 0.83ms. best: 278.29ms.<br/>avg: 4.90 ± 0.01ms<br/>min: 0.14 ± 0.01ms<br/>max: 25.15 ± 0.12ms<br/>p99: 25.15 ± 0.12ms<br/><br/>500 matches, radius=10<br/>ops: 60.84 ± 0.21 ops/s. best: 61.07ops/s.<br/>total: 1051.98 ± 3.64ms. best: 1047.97ms.<br/>avg: 16.44 ± 0.06ms<br/>min: 0.14 ± 0.00ms<br/>max: 243.78 ± 0.91ms<br/>p99: 243.78 ± 0.91ms<br/><br/>500 matches, radius=20<br/>ops: 14.45 ± 0.04 ops/s. best: 14.54ops/s.<br/>total: 4499.68 ± 12.13ms. best: 4471.86ms.<br/>avg: 69.23 ± 0.19ms<br/>min: 0.33 ± 0.01ms<br/>max: 1234.70 ± 4.28ms<br/>p99: 1234.70 ± 4.28ms |
| random_match_mld | 500 matches, default radius<br/>ops: 308.68 ± 1.51 ops/s. best: 310.33ops/s.<br/>total: 184.67 ± 0.91ms. best: 183.68ms.<br/>avg: 3.24 ± 0.02ms<br/>min: 0.12 ± 0.01ms<br/>max: 18.99 ± 0.05ms<br/>p99: 18.99 ± 0.05ms<br/><br/>500 matches, radius=10<br/>ops: 109.59 ± 0.17 ops/s. best: 109.85ops/s.<br/>total: 583.98 ± 0.92ms. best: 582.60ms.<br/>avg: 9.12 ± 0.01ms<br/>min: 0.13 ± 0.01ms<br/>max: 110.14 ± 0.42ms<br/>p99: 110.14 ± 0.42ms<br/><br/>500 matches, radius=20<br/>ops: 22.22 ± 0.05 ops/s. best: 22.33ops/s.<br/>total: 2925.33 ± 6.77ms. best: 2910.72ms.<br/>avg: 45.01 ± 0.10ms<br/>min: 0.19 ± 0.00ms<br/>max: 575.96 ± 3.00ms<br/>p99: 575.96 ± 3.00ms | 500 matches, default radius<br/>ops: 309.45 ± 1.93 ops/s. best: 311.34ops/s.<br/>total: 184.21 ± 1.16ms. best: 183.08ms.<br/>avg: 3.23 ± 0.02ms<br/>min: 0.13 ± 0.01ms<br/>max: 18.97 ± 0.07ms<br/>p99: 18.97 ± 0.07ms<br/><br/>500 matches, radius=10<br/>ops: 109.83 ± 0.33 ops/s. best: 110.45ops/s.<br/>total: 582.73 ± 1.68ms. best: 579.46ms.<br/>avg: 9.11 ± 0.03ms<br/>min: 0.13 ± 0.00ms<br/>max: 109.86 ± 0.39ms<br/>p99: 109.86 ± 0.39ms<br/><br/>500 matches, radius=20<br/>ops: 22.19 ± 0.06 ops/s. best: 22.26ops/s.<br/>total: 2929.70 ± 8.50ms. best: 2920.32ms.<br/>avg: 45.07 ± 0.13ms<br/>min: 0.19 ± 0.00ms<br/>max: 576.97 ± 2.20ms<br/>p99: 576.97 ± 2.20ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 23220.49 ± 135.70 ops/s. best: 23411.56ops/s.<br/>total: 430.67 ± 2.53ms. best: 427.14ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.18 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18228.38 ± 20.14 ops/s. best: 18253.81ops/s.<br/>total: 548.60 ± 0.61ms. best: 547.83ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14252.44 ± 5.24 ops/s. best: 14260.08ops/s.<br/>total: 701.63 ± 0.25ms. best: 701.26ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.20 ± 0.05ms<br/>p99: 0.13 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 23319.21 ± 46.79 ops/s. best: 23386.24ops/s.<br/>total: 428.83 ± 0.86ms. best: 427.60ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.16 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18199.02 ± 27.35 ops/s. best: 18248.08ops/s.<br/>total: 549.48 ± 0.83ms. best: 548.00ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14193.67 ± 32.89 ops/s. best: 14233.85ops/s.<br/>total: 704.54 ± 1.64ms. best: 702.55ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 23189.63 ± 20.98 ops/s. best: 23220.40ops/s.<br/>total: 431.23 ± 0.39ms. best: 430.66ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.03ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18043.51 ± 52.05 ops/s. best: 18114.68ops/s.<br/>total: 554.22 ± 1.60ms. best: 552.04ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14207.51 ± 10.26 ops/s. best: 14223.89ops/s.<br/>total: 703.85 ± 0.51ms. best: 703.04ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.13 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 23186.50 ± 89.92 ops/s. best: 23313.31ops/s.<br/>total: 431.29 ± 1.67ms. best: 428.94ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18096.38 ± 13.86 ops/s. best: 18123.06ops/s.<br/>total: 552.60 ± 0.42ms. best: 551.78ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14163.49 ± 25.16 ops/s. best: 14205.38ops/s.<br/>total: 706.04 ± 1.21ms. best: 703.96ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.14 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 480.04 ± 5.39 ops/s. best: 486.17ops/s.<br/>total: 2050.18 ± 23.23ms. best: 2023.99ms.<br/>avg: 2.08 ± 0.02ms<br/>min: 0.32 ± 0.01ms<br/>max: 3.93 ± 0.26ms<br/>p99: 3.09 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 572.88 ± 3.14 ops/s. best: 576.59ops/s.<br/>total: 1745.63 ± 9.59ms. best: 1734.34ms.<br/>avg: 1.75 ± 0.01ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.42 ± 0.21ms<br/>p99: 3.74 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 897.69 ± 5.26 ops/s. best: 903.85ops/s.<br/>total: 1096.20 ± 6.40ms. best: 1088.68ms.<br/>avg: 1.11 ± 0.01ms<br/>min: 0.27 ± 0.00ms<br/>max: 2.01 ± 0.12ms<br/>p99: 1.63 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1018.72 ± 7.97 ops/s. best: 1029.89ops/s.<br/>total: 981.71 ± 7.66ms. best: 970.98ms.<br/>avg: 0.98 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.95 ± 0.04ms<br/>p99: 2.17 ± 0.03ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 479.09 ± 3.64 ops/s. best: 484.16ops/s.<br/>total: 2054.06 ± 15.60ms. best: 2032.39ms.<br/>avg: 2.09 ± 0.02ms<br/>min: 0.32 ± 0.01ms<br/>max: 3.63 ± 0.17ms<br/>p99: 3.03 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 587.67 ± 8.91 ops/s. best: 596.80ops/s.<br/>total: 1702.19 ± 26.31ms. best: 1675.61ms.<br/>avg: 1.70 ± 0.03ms<br/>min: 0.05 ± 0.00ms<br/>max: 4.32 ± 0.07ms<br/>p99: 3.68 ± 0.06ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 920.21 ± 6.35 ops/s. best: 927.01ops/s.<br/>total: 1069.39 ± 7.41ms. best: 1061.47ms.<br/>avg: 1.09 ± 0.01ms<br/>min: 0.26 ± 0.00ms<br/>max: 1.93 ± 0.25ms<br/>p99: 1.50 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1060.62 ± 11.24 ops/s. best: 1079.48ops/s.<br/>total: 942.98 ± 9.94ms. best: 926.38ms.<br/>avg: 0.94 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 3.24 ± 0.02ms<br/>p99: 2.07 ± 0.07ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 242.73 ± 1.24 ops/s. best: 244.33ops/s.<br/>total: 4053.95 ± 21.34ms. best: 4027.32ms.<br/>avg: 4.12 ± 0.02ms<br/>min: 0.31 ± 0.00ms<br/>max: 8.97 ± 0.24ms<br/>p99: 6.93 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 230.56 ± 1.35 ops/s. best: 233.33ops/s.<br/>total: 4337.47 ± 25.89ms. best: 4285.85ms.<br/>avg: 4.34 ± 0.03ms<br/>min: 0.05 ± 0.00ms<br/>max: 10.11 ± 0.59ms<br/>p99: 8.65 ± 0.12ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 311.93 ± 3.05 ops/s. best: 317.92ops/s.<br/>total: 3154.99 ± 31.59ms. best: 3095.10ms.<br/>avg: 3.21 ± 0.03ms<br/>min: 0.29 ± 0.00ms<br/>max: 7.62 ± 0.16ms<br/>p99: 5.51 ± 0.11ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 278.17 ± 2.49 ops/s. best: 283.49ops/s.<br/>total: 3595.27 ± 31.96ms. best: 3527.51ms.<br/>avg: 3.60 ± 0.03ms<br/>min: 0.04 ± 0.00ms<br/>max: 8.34 ± 0.55ms<br/>p99: 7.12 ± 0.09ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 228.36 ± 0.42 ops/s. best: 228.92ops/s.<br/>total: 4309.07 ± 7.86ms. best: 4298.48ms.<br/>avg: 4.38 ± 0.01ms<br/>min: 0.32 ± 0.01ms<br/>max: 9.44 ± 0.26ms<br/>p99: 7.36 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 221.60 ± 1.82 ops/s. best: 223.99ops/s.<br/>total: 4512.97 ± 37.05ms. best: 4464.45ms.<br/>avg: 4.51 ± 0.04ms<br/>min: 0.05 ± 0.00ms<br/>max: 10.08 ± 0.25ms<br/>p99: 9.21 ± 0.10ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 303.78 ± 1.60 ops/s. best: 307.07ops/s.<br/>total: 3239.34 ± 16.61ms. best: 3204.47ms.<br/>avg: 3.29 ± 0.02ms<br/>min: 0.29 ± 0.01ms<br/>max: 7.79 ± 0.13ms<br/>p99: 5.63 ± 0.07ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 271.86 ± 0.83 ops/s. best: 272.75ops/s.<br/>total: 3678.43 ± 11.29ms. best: 3666.32ms.<br/>avg: 3.68 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.86 ± 0.14ms<br/>p99: 7.20 ± 0.07ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1364.73 ± 8.10 ops/s. best: 1374.90ops/s.<br/>total: 183.20 ± 1.14ms. best: 181.83ms.<br/>avg: 0.73 ± 0.00ms<br/>min: 0.54 ± 0.01ms<br/>max: 1.12 ± 0.30ms<br/>p99: 0.92 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 159.97 ± 0.20 ops/s. best: 160.36ops/s.<br/>total: 1562.81 ± 2.00ms. best: 1559.03ms.<br/>avg: 6.25 ± 0.01ms<br/>min: 5.65 ± 0.03ms<br/>max: 7.05 ± 0.07ms<br/>p99: 6.86 ± 0.05ms<br/><br/>250 tables, 50 coordinates<br/>ops: 79.11 ± 0.05 ops/s. best: 79.18ops/s.<br/>total: 3160.27 ± 2.10ms. best: 3157.22ms.<br/>avg: 12.64 ± 0.01ms<br/>min: 11.82 ± 0.02ms<br/>max: 13.90 ± 0.13ms<br/>p99: 13.67 ± 0.03ms | 250 tables, 3 coordinates<br/>ops: 1377.03 ± 6.95 ops/s. best: 1385.61ops/s.<br/>total: 181.56 ± 0.92ms. best: 180.43ms.<br/>avg: 0.73 ± 0.00ms<br/>min: 0.54 ± 0.00ms<br/>max: 1.09 ± 0.25ms<br/>p99: 0.91 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 160.64 ± 0.41 ops/s. best: 161.21ops/s.<br/>total: 1556.29 ± 4.02ms. best: 1550.77ms.<br/>avg: 6.23 ± 0.02ms<br/>min: 5.69 ± 0.01ms<br/>max: 6.87 ± 0.13ms<br/>p99: 6.71 ± 0.05ms<br/><br/>250 tables, 50 coordinates<br/>ops: 79.64 ± 0.23 ops/s. best: 79.92ops/s.<br/>total: 3139.17 ± 9.16ms. best: 3128.18ms.<br/>avg: 12.56 ± 0.04ms<br/>min: 11.82 ± 0.04ms<br/>max: 14.21 ± 0.75ms<br/>p99: 13.38 ± 0.05ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 347.96 ± 1.39 ops/s. best: 349.77ops/s.<br/>total: 718.50 ± 2.88ms. best: 714.75ms.<br/>avg: 2.87 ± 0.01ms<br/>min: 2.26 ± 0.01ms<br/>max: 3.96 ± 0.05ms<br/>p99: 3.81 ± 0.06ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.66 ± 0.23 ops/s. best: 38.97ops/s.<br/>total: 6467.36 ± 39.41ms. best: 6414.64ms.<br/>avg: 25.87 ± 0.16ms<br/>min: 23.30 ± 0.18ms<br/>max: 29.87 ± 0.50ms<br/>p99: 28.82 ± 0.31ms<br/><br/>250 tables, 50 coordinates<br/>ops: 18.33 ± 0.02 ops/s. best: 18.36ops/s.<br/>total: 13637.82 ± 15.59ms. best: 13613.46ms.<br/>avg: 54.55 ± 0.06ms<br/>min: 50.50 ± 0.20ms<br/>max: 59.91 ± 0.52ms<br/>p99: 58.83 ± 0.39ms | 250 tables, 3 coordinates<br/>ops: 344.33 ± 1.30 ops/s. best: 345.77ops/s.<br/>total: 726.06 ± 2.75ms. best: 723.02ms.<br/>avg: 2.90 ± 0.01ms<br/>min: 2.28 ± 0.01ms<br/>max: 3.94 ± 0.04ms<br/>p99: 3.79 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 38.19 ± 0.26 ops/s. best: 38.59ops/s.<br/>total: 6546.34 ± 44.15ms. best: 6477.61ms.<br/>avg: 26.19 ± 0.18ms<br/>min: 23.35 ± 0.21ms<br/>max: 30.04 ± 0.39ms<br/>p99: 29.49 ± 0.21ms<br/><br/>250 tables, 50 coordinates<br/>ops: 18.12 ± 0.04 ops/s. best: 18.18ops/s.<br/>total: 13793.23 ± 27.76ms. best: 13749.90ms.<br/>avg: 55.17 ± 0.11ms<br/>min: 51.03 ± 0.29ms<br/>max: 61.72 ± 2.50ms<br/>p99: 59.45 ± 0.62ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 457.66 ± 3.47 ops/s. best: 462.27ops/s.<br/>total: 546.30 ± 4.11ms. best: 540.81ms.<br/>avg: 2.19 ± 0.02ms<br/>min: 1.08 ± 0.01ms<br/>max: 3.29 ± 0.37ms<br/>p99: 2.94 ± 0.06ms<br/><br/>250 trips, 5 coordinates<br/>ops: 304.99 ± 2.02 ops/s. best: 309.11ops/s.<br/>total: 819.74 ± 5.38ms. best: 808.79ms.<br/>avg: 3.28 ± 0.02ms<br/>min: 2.08 ± 0.02ms<br/>max: 4.21 ± 0.03ms<br/>p99: 4.07 ± 0.06ms | 250 trips, 3 coordinates<br/>ops: 461.36 ± 3.21 ops/s. best: 464.47ops/s.<br/>total: 541.91 ± 3.76ms. best: 538.24ms.<br/>avg: 2.17 ± 0.02ms<br/>min: 1.27 ± 0.01ms<br/>max: 3.24 ± 0.29ms<br/>p99: 2.88 ± 0.03ms<br/><br/>250 trips, 5 coordinates<br/>ops: 309.06 ± 0.52 ops/s. best: 309.88ops/s.<br/>total: 808.91 ± 1.37ms. best: 806.77ms.<br/>avg: 3.24 ± 0.01ms<br/>min: 2.16 ± 0.03ms<br/>max: 4.32 ± 0.25ms<br/>p99: 4.16 ± 0.13ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 167.89 ± 0.50 ops/s. best: 168.74ops/s.<br/>total: 1489.08 ± 4.45ms. best: 1481.54ms.<br/>avg: 5.96 ± 0.02ms<br/>min: 3.86 ± 0.02ms<br/>max: 8.21 ± 0.29ms<br/>p99: 7.73 ± 0.07ms<br/><br/>250 trips, 5 coordinates<br/>ops: 110.24 ± 0.37 ops/s. best: 110.89ops/s.<br/>total: 2267.74 ± 7.59ms. best: 2254.44ms.<br/>avg: 9.07 ± 0.03ms<br/>min: 6.30 ± 0.07ms<br/>max: 11.26 ± 0.10ms<br/>p99: 11.00 ± 0.06ms | 250 trips, 3 coordinates<br/>ops: 163.09 ± 1.45 ops/s. best: 165.21ops/s.<br/>total: 1533.03 ± 14.16ms. best: 1513.26ms.<br/>avg: 6.13 ± 0.06ms<br/>min: 3.89 ± 0.04ms<br/>max: 8.42 ± 0.26ms<br/>p99: 8.06 ± 0.09ms<br/><br/>250 trips, 5 coordinates<br/>ops: 107.30 ± 0.33 ops/s. best: 107.63ops/s.<br/>total: 2329.94 ± 7.25ms. best: 2322.75ms.<br/>avg: 9.32 ± 0.03ms<br/>min: 6.37 ± 0.07ms<br/>max: 11.73 ± 0.19ms<br/>p99: 11.42 ± 0.14ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>434.557ms<br/>0.434557ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>522.72ms<br/>0.52272ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>153.983ms<br/>0.153983ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>136.372ms<br/>0.136372ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>428.31ms<br/>0.42831ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>520.584ms<br/>0.520584ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>151.175ms<br/>0.151175ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>133.77ms<br/>0.13377ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>579.241ms<br/>0.579241ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>727.964ms<br/>0.727964ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>294.398ms<br/>0.294398ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>321.595ms<br/>0.321595ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>573.657ms<br/>0.573657ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>722.065ms<br/>0.722065ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>297.116ms<br/>0.297116ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>324.86ms<br/>0.32486ms/req |
| rtree | 1 result:<br/>197.959ms ->  0.0197959 ms/query<br/>10 results:<br/>233.181ms ->  0.0233181 ms/query | 1 result:<br/>197.436ms ->  0.0197436 ms/query<br/>10 results:<br/>233.841ms ->  0.0233841 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->

