### PR TITLE
Remove unused MapStorage and GenerationArrayStorage

### DIFF
--- a/include/util/query_heap.hpp
+++ b/include/util/query_heap.hpp
@@ -15,48 +15,6 @@
 namespace osrm::util
 {
 
-template <typename NodeID, typename Key> class GenerationArrayStorage
-{
-    using GenerationCounter = std::uint16_t;
-
-  public:
-    explicit GenerationArrayStorage(std::size_t size)
-        : positions(size, 0), generation(1), generations(size, 0)
-    {
-    }
-
-    Key &operator[](NodeID node)
-    {
-        generation[node] = generation;
-        return positions[node];
-    }
-
-    Key peek_index(const NodeID node) const
-    {
-        if (generations[node] < generation)
-        {
-            return std::numeric_limits<Key>::max();
-        }
-        return positions[node];
-    }
-
-    void Clear()
-    {
-        generation++;
-        // if generation overflows we end up at 0 again and need to clear the vector
-        if (generation == 0)
-        {
-            generation = 1;
-            std::fill(generations.begin(), generations.end(), 0);
-        }
-    }
-
-  private:
-    GenerationCounter generation;
-    std::vector<GenerationCounter> generations;
-    std::vector<Key> positions;
-};
-
 template <typename NodeID, typename Key> class ArrayStorage
 {
   public:
@@ -70,29 +28,6 @@ template <typename NodeID, typename Key> class ArrayStorage
 
   private:
     std::vector<Key> positions;
-};
-
-template <typename NodeID, typename Key> class MapStorage
-{
-  public:
-    explicit MapStorage(std::size_t) {}
-
-    Key &operator[](NodeID node) { return nodes[node]; }
-
-    void Clear() { nodes.clear(); }
-
-    Key peek_index(const NodeID node) const
-    {
-        const auto iter = nodes.find(node);
-        if (nodes.end() != iter)
-        {
-            return iter->second;
-        }
-        return std::numeric_limits<Key>::max();
-    }
-
-  private:
-    std::map<NodeID, Key> nodes;
 };
 
 template <typename NodeID, typename Key> class UnorderedMapStorage

--- a/unit_tests/util/query_heap.cpp
+++ b/unit_tests/util/query_heap.cpp
@@ -22,9 +22,8 @@ struct TestData
 using TestNodeID = NodeID;
 using TestKey = int;
 using TestWeight = int;
-using storage_types = boost::mpl::list<ArrayStorage<TestNodeID, TestKey>,
-                                       TwoLevelStorage<TestNodeID, TestKey>,
-                                       UnorderedMapStorage<TestNodeID, TestKey>>;
+using storage_types =
+    boost::mpl::list<ArrayStorage<TestNodeID, TestKey>, UnorderedMapStorage<TestNodeID, TestKey>>;
 
 template <unsigned NUM_ELEM> struct RandomDataFixture
 {

--- a/unit_tests/util/query_heap.cpp
+++ b/unit_tests/util/query_heap.cpp
@@ -23,7 +23,7 @@ using TestNodeID = NodeID;
 using TestKey = int;
 using TestWeight = int;
 using storage_types = boost::mpl::list<ArrayStorage<TestNodeID, TestKey>,
-                                       MapStorage<TestNodeID, TestKey>,
+                                       TwoLevelStorage<TestNodeID, TestKey>,
                                        UnorderedMapStorage<TestNodeID, TestKey>>;
 
 template <unsigned NUM_ELEM> struct RandomDataFixture


### PR DESCRIPTION


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1109.99<br/>plain u32: 1104.42<br/>aliased double: 961.989<br/>plain double: 971.441 | aliased u32: 1097.46<br/>plain u32: 1100.22<br/>aliased double: 956.504<br/>plain double: 970.735 |
| e2e_match_ch | Ops: 41.28 ± 0.07 ops/s. Best: 41.38 ops/s<br/>Total: 3173.32ms ± 5.39ms. Best: 3165.94ms<br/>Min time: 2.15ms ± 0.03ms<br/>Mean time: 24.22ms ± 0.04ms<br/>Median time: 18.35ms ± 0.05ms<br/>95th percentile: 83.42ms ± 0.40ms<br/>99th percentile: 101.94ms ± 0.36ms<br/>Max time: 111.13ms ± 0.58ms | Ops: 40.83 ± 0.08 ops/s. Best: 40.95 ops/s<br/>Total: 3208.45ms ± 6.05ms. Best: 3198.89ms<br/>Min time: 2.17ms ± 0.03ms<br/>Mean time: 24.49ms ± 0.05ms<br/>Median time: 18.38ms ± 0.10ms<br/>95th percentile: 85.06ms ± 0.29ms<br/>99th percentile: 103.61ms ± 0.51ms<br/>Max time: 113.38ms ± 0.43ms |
| e2e_match_mld | Ops: 64.24 ± 0.23 ops/s. Best: 64.56 ops/s<br/>Total: 2039.40ms ± 7.32ms. Best: 2029.11ms<br/>Min time: 1.76ms ± 0.03ms<br/>Mean time: 15.57ms ± 0.06ms<br/>Median time: 8.26ms ± 0.11ms<br/>95th percentile: 51.53ms ± 0.17ms<br/>99th percentile: 61.31ms ± 1.84ms<br/>Max time: 71.15ms ± 1.89ms | Ops: 64.82 ± 0.18 ops/s. Best: 65.21 ops/s<br/>Total: 2021.14ms ± 5.42ms. Best: 2009.04ms<br/>Min time: 1.75ms ± 0.02ms<br/>Mean time: 15.43ms ± 0.04ms<br/>Median time: 8.18ms ± 0.15ms<br/>95th percentile: 51.32ms ± 0.24ms<br/>99th percentile: 60.53ms ± 0.45ms<br/>Max time: 69.46ms ± 0.36ms |
| e2e_nearest_ch | Ops: 861.95 ± 4.95 ops/s. Best: 873.94 ops/s<br/>Total: 1160.22ms ± 7.16ms. Best: 1144.25ms<br/>Min time: 0.98ms ± 0.01ms<br/>Mean time: 1.16ms ± 0.01ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.61ms ± 0.01ms<br/>99th percentile: 1.67ms ± 0.02ms<br/>Max time: 5.99ms ± 2.87ms | Ops: 861.37 ± 5.81 ops/s. Best: 870.29 ops/s<br/>Total: 1161.12ms ± 8.57ms. Best: 1149.04ms<br/>Min time: 0.99ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.01ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.61ms ± 0.01ms<br/>99th percentile: 1.67ms ± 0.02ms<br/>Max time: 5.81ms ± 2.73ms |
| e2e_nearest_mld | Ops: 864.65 ± 3.41 ops/s. Best: 869.88 ops/s<br/>Total: 1156.58ms ± 4.71ms. Best: 1149.58ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.00ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.61ms ± 0.01ms<br/>99th percentile: 1.66ms ± 0.01ms<br/>Max time: 5.91ms ± 2.80ms | Ops: 866.54 ± 1.99 ops/s. Best: 869.37 ops/s<br/>Total: 1153.98ms ± 2.79ms. Best: 1150.26ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.15ms ± 0.00ms<br/>Median time: 1.06ms ± 0.00ms<br/>95th percentile: 1.60ms ± 0.00ms<br/>99th percentile: 1.66ms ± 0.01ms<br/>Max time: 5.96ms ± 2.71ms |
| e2e_route_ch | Ops: 372.03 ± 1.37 ops/s. Best: 374.38 ops/s<br/>Total: 2688.06ms ± 10.18ms. Best: 2671.11ms<br/>Min time: 1.21ms ± 0.01ms<br/>Mean time: 2.69ms ± 0.01ms<br/>Median time: 2.70ms ± 0.01ms<br/>95th percentile: 3.56ms ± 0.04ms<br/>99th percentile: 3.99ms ± 0.08ms<br/>Max time: 6.64ms ± 2.12ms | Ops: 355.59 ± 6.92 ops/s. Best: 366.10 ops/s<br/>Total: 2811.17ms ± 55.95ms. Best: 2731.52ms<br/>Min time: 1.21ms ± 0.01ms<br/>Mean time: 2.81ms ± 0.06ms<br/>Median time: 2.84ms ± 0.07ms<br/>95th percentile: 3.73ms ± 0.10ms<br/>99th percentile: 4.18ms ± 0.10ms<br/>Max time: 7.53ms ± 1.90ms |
| e2e_route_mld | Ops: 304.78 ± 2.89 ops/s. Best: 308.87 ops/s<br/>Total: 3282.70ms ± 32.07ms. Best: 3237.64ms<br/>Min time: 1.20ms ± 0.01ms<br/>Mean time: 3.28ms ± 0.03ms<br/>Median time: 3.31ms ± 0.03ms<br/>95th percentile: 4.48ms ± 0.04ms<br/>99th percentile: 4.99ms ± 0.10ms<br/>Max time: 7.43ms ± 1.98ms | Ops: 297.88 ± 2.32 ops/s. Best: 301.49 ops/s<br/>Total: 3358.39ms ± 26.49ms. Best: 3316.86ms<br/>Min time: 1.20ms ± 0.01ms<br/>Mean time: 3.36ms ± 0.03ms<br/>Median time: 3.40ms ± 0.03ms<br/>95th percentile: 4.61ms ± 0.03ms<br/>99th percentile: 5.17ms ± 0.02ms<br/>Max time: 7.62ms ± 2.14ms |
| e2e_table_ch | Ops: 315.90 ± 0.80 ops/s. Best: 316.85 ops/s<br/>Total: 3165.56ms ± 8.07ms. Best: 3156.07ms<br/>Min time: 1.68ms ± 0.01ms<br/>Mean time: 3.17ms ± 0.01ms<br/>Median time: 3.17ms ± 0.01ms<br/>95th percentile: 4.41ms ± 0.02ms<br/>99th percentile: 4.74ms ± 0.05ms<br/>Max time: 8.45ms ± 2.41ms | Ops: 322.71 ± 0.58 ops/s. Best: 323.53 ops/s<br/>Total: 3098.80ms ± 6.15ms. Best: 3090.94ms<br/>Min time: 1.64ms ± 0.02ms<br/>Mean time: 3.10ms ± 0.01ms<br/>Median time: 3.10ms ± 0.02ms<br/>95th percentile: 4.32ms ± 0.01ms<br/>99th percentile: 4.62ms ± 0.07ms<br/>Max time: 8.01ms ± 2.18ms |
| e2e_table_mld | Ops: 110.74 ± 0.43 ops/s. Best: 111.28 ops/s<br/>Total: 9031.98ms ± 36.20ms. Best: 8986.26ms<br/>Min time: 3.62ms ± 0.06ms<br/>Mean time: 9.03ms ± 0.04ms<br/>Median time: 8.99ms ± 0.02ms<br/>95th percentile: 13.85ms ± 0.07ms<br/>99th percentile: 14.56ms ± 0.15ms<br/>Max time: 16.99ms ± 2.40ms | Ops: 107.97 ± 0.67 ops/s. Best: 108.93 ops/s<br/>Total: 9260.51ms ± 58.09ms. Best: 9180.62ms<br/>Min time: 3.69ms ± 0.05ms<br/>Mean time: 9.26ms ± 0.06ms<br/>Median time: 9.22ms ± 0.10ms<br/>95th percentile: 14.12ms ± 0.09ms<br/>99th percentile: 15.02ms ± 0.14ms<br/>Max time: 18.01ms ± 2.19ms |
| e2e_trip_ch | Ops: 94.82 ± 1.06 ops/s. Best: 96.60 ops/s<br/>Total: 10553.49ms ± 113.36ms. Best: 10351.88ms<br/>Min time: 1.57ms ± 0.11ms<br/>Mean time: 10.55ms ± 0.11ms<br/>Median time: 9.98ms ± 0.12ms<br/>95th percentile: 18.99ms ± 0.16ms<br/>99th percentile: 20.94ms ± 0.18ms<br/>Max time: 23.13ms ± 0.58ms | Ops: 99.36 ± 0.94 ops/s. Best: 100.77 ops/s<br/>Total: 10061.95ms ± 97.03ms. Best: 9924.03ms<br/>Min time: 1.48ms ± 0.13ms<br/>Mean time: 10.07ms ± 0.10ms<br/>Median time: 9.51ms ± 0.07ms<br/>95th percentile: 18.06ms ± 0.18ms<br/>99th percentile: 20.09ms ± 0.24ms<br/>Max time: 22.02ms ± 0.25ms |
| e2e_trip_mld | Ops: 58.71 ± 0.32 ops/s. Best: 59.11 ops/s<br/>Total: 17033.96ms ± 94.59ms. Best: 16919.01ms<br/>Min time: 1.67ms ± 0.28ms<br/>Mean time: 17.03ms ± 0.10ms<br/>Median time: 16.47ms ± 0.13ms<br/>95th percentile: 28.38ms ± 0.23ms<br/>99th percentile: 30.80ms ± 0.20ms<br/>Max time: 32.57ms ± 0.39ms | Ops: 56.91 ± 0.44 ops/s. Best: 57.91 ops/s<br/>Total: 17569.07ms ± 134.56ms. Best: 17269.00ms<br/>Min time: 1.84ms ± 0.29ms<br/>Mean time: 17.57ms ± 0.13ms<br/>Median time: 17.10ms ± 0.15ms<br/>95th percentile: 28.63ms ± 0.23ms<br/>99th percentile: 31.04ms ± 0.22ms<br/>Max time: 33.35ms ± 0.31ms |
| json-render | String: 5.66716ms<br/>Stringstream: 9.15704ms<br/>Vector: 6.65651ms | String: 5.65118ms<br/>Stringstream: 9.28508ms<br/>Vector: 6.54708ms |
| match_ch | Default radius: <br/>4.5845ms/req at 82 coordinate<br/>0.0559086ms/coordinate<br/>Radius 10m: <br/>15.9952ms/req at 82 coordinate<br/>0.195063ms/coordinate | Default radius: <br/>4.66868ms/req at 82 coordinate<br/>0.0569351ms/coordinate<br/>Radius 10m: <br/>16.3246ms/req at 82 coordinate<br/>0.199081ms/coordinate |
| match_mld | Default radius: <br/>3.21216ms/req at 82 coordinate<br/>0.0391726ms/coordinate<br/>Radius 10m: <br/>11.2093ms/req at 82 coordinate<br/>0.136699ms/coordinate | Default radius: <br/>3.11746ms/req at 82 coordinate<br/>0.0380178ms/coordinate<br/>Radius 10m: <br/>11.4698ms/req at 82 coordinate<br/>0.139876ms/coordinate |
| osrm_contract | Time: 102.70s Peak RAM: 200.70MB | Time: 102.84s Peak RAM: 201.81MB |
| osrm_customize | Time: 1.30s Peak RAM: 117.66MB | Time: 1.31s Peak RAM: 117.82MB |
| osrm_extract | Time: 11.73s Peak RAM: 423.60MB | Time: 11.83s Peak RAM: 430.24MB |
| osrm_partition | Time: 2.08s Peak RAM: 145.13MB | Time: 2.16s Peak RAM: 146.92MB |
| packedvector | random write:<br/>std::vector 9900.76 ms<br/>util::packed_vector 73931.9 ms<br/>slowdown: 7.4673<br/>random read:<br/>std::vector 8517.06 ms<br/>util::packed_vector 30733.4 ms<br/>slowdown: 3.60845 | random write:<br/>std::vector 9908.1 ms<br/>util::packed_vector 74007 ms<br/>slowdown: 7.46935<br/>random read:<br/>std::vector 8532.84 ms<br/>util::packed_vector 30685.6 ms<br/>slowdown: 3.59618 |
| random_match_ch | 500 matches, default radius<br/>ops: 200.89 ± 0.81 ops/s. best: 201.67ops/s.<br/>total: 283.75 ± 1.14ms. best: 282.65ms.<br/>avg: 4.98 ± 0.02ms<br/>min: 0.13 ± 0.01ms<br/>max: 27.76 ± 0.13ms<br/>p99: 27.76 ± 0.13ms<br/><br/>500 matches, radius=10<br/>ops: 59.24 ± 0.09 ops/s. best: 59.33ops/s.<br/>total: 1080.28 ± 1.66ms. best: 1078.66ms.<br/>avg: 16.88 ± 0.03ms<br/>min: 0.15 ± 0.00ms<br/>max: 243.28 ± 0.97ms<br/>p99: 243.28 ± 0.97ms<br/><br/>500 matches, radius=20<br/>ops: 14.35 ± 0.07 ops/s. best: 14.43ops/s.<br/>total: 4529.72 ± 21.26ms. best: 4505.02ms.<br/>avg: 69.69 ± 0.33ms<br/>min: 0.31 ± 0.01ms<br/>max: 1213.69 ± 5.52ms<br/>p99: 1213.69 ± 5.52ms | 500 matches, default radius<br/>ops: 199.57 ± 0.92 ops/s. best: 200.67ops/s.<br/>total: 285.63 ± 1.32ms. best: 284.05ms.<br/>avg: 5.01 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 27.92 ± 0.06ms<br/>p99: 27.92 ± 0.06ms<br/><br/>500 matches, radius=10<br/>ops: 59.50 ± 0.09 ops/s. best: 59.61ops/s.<br/>total: 1075.67 ± 1.61ms. best: 1073.67ms.<br/>avg: 16.81 ± 0.03ms<br/>min: 0.15 ± 0.00ms<br/>max: 237.66 ± 0.92ms<br/>p99: 237.66 ± 0.92ms<br/><br/>500 matches, radius=20<br/>ops: 14.40 ± 0.01 ops/s. best: 14.43ops/s.<br/>total: 4514.10 ± 4.32ms. best: 4504.42ms.<br/>avg: 69.45 ± 0.07ms<br/>min: 0.31 ± 0.00ms<br/>max: 1179.08 ± 4.23ms<br/>p99: 1179.08 ± 4.23ms |
| random_match_mld | 500 matches, default radius<br/>ops: 308.90 ± 1.89 ops/s. best: 310.30ops/s.<br/>total: 184.54 ± 1.14ms. best: 183.70ms.<br/>avg: 3.24 ± 0.02ms<br/>min: 0.12 ± 0.01ms<br/>max: 18.80 ± 0.04ms<br/>p99: 18.80 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 108.60 ± 0.22 ops/s. best: 108.99ops/s.<br/>total: 589.35 ± 1.18ms. best: 587.20ms.<br/>avg: 9.21 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 110.62 ± 0.53ms<br/>p99: 110.62 ± 0.53ms<br/><br/>500 matches, radius=20<br/>ops: 22.17 ± 0.05 ops/s. best: 22.24ops/s.<br/>total: 2931.29 ± 7.03ms. best: 2922.71ms.<br/>avg: 45.10 ± 0.11ms<br/>min: 0.19 ± 0.00ms<br/>max: 574.39 ± 2.25ms<br/>p99: 574.39 ± 2.25ms | 500 matches, default radius<br/>ops: 305.07 ± 1.86 ops/s. best: 307.49ops/s.<br/>total: 186.85 ± 1.17ms. best: 185.37ms.<br/>avg: 3.28 ± 0.02ms<br/>min: 0.12 ± 0.01ms<br/>max: 19.01 ± 0.04ms<br/>p99: 19.01 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 107.43 ± 0.22 ops/s. best: 107.66ops/s.<br/>total: 595.73 ± 1.21ms. best: 594.49ms.<br/>avg: 9.31 ± 0.02ms<br/>min: 0.14 ± 0.00ms<br/>max: 111.57 ± 0.58ms<br/>p99: 111.57 ± 0.58ms<br/><br/>500 matches, radius=20<br/>ops: 21.84 ± 0.03 ops/s. best: 21.89ops/s.<br/>total: 2976.32 ± 3.46ms. best: 2968.94ms.<br/>avg: 45.79 ± 0.05ms<br/>min: 0.21 ± 0.02ms<br/>max: 583.31 ± 1.59ms<br/>p99: 583.31 ± 1.59ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 24674.40 ± 62.39 ops/s. best: 24719.40ops/s.<br/>total: 405.28 ± 1.03ms. best: 404.54ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.18 ± 0.05ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18957.63 ± 50.68 ops/s. best: 19013.31ops/s.<br/>total: 527.50 ± 1.41ms. best: 525.95ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.20 ± 0.06ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 15026.67 ± 32.13 ops/s. best: 15072.63ops/s.<br/>total: 665.49 ± 1.42ms. best: 663.45ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.13 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 24547.94 ± 97.81 ops/s. best: 24672.28ops/s.<br/>total: 407.37 ± 1.63ms. best: 405.31ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18772.59 ± 26.67 ops/s. best: 18809.54ops/s.<br/>total: 532.69 ± 0.79ms. best: 531.65ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.18 ± 0.05ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14885.95 ± 23.36 ops/s. best: 14920.18ops/s.<br/>total: 671.78 ± 1.05ms. best: 670.23ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.13 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 24875.25 ± 91.65 ops/s. best: 24975.79ops/s.<br/>total: 402.01 ± 1.49ms. best: 400.39ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.04ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 19092.14 ± 29.80 ops/s. best: 19130.41ops/s.<br/>total: 523.78 ± 0.82ms. best: 522.73ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 15013.91 ± 27.02 ops/s. best: 15052.71ops/s.<br/>total: 666.05 ± 1.20ms. best: 664.33ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.13 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 24504.84 ± 108.90 ops/s. best: 24661.63ops/s.<br/>total: 408.09 ± 1.84ms. best: 405.49ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.18 ± 0.05ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18828.23 ± 147.34 ops/s. best: 18992.52ops/s.<br/>total: 531.16 ± 4.19ms. best: 526.52ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.19 ± 0.05ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14987.63 ± 12.54 ops/s. best: 15015.27ops/s.<br/>total: 667.22 ± 0.56ms. best: 665.99ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.13 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 491.91 ± 1.81 ops/s. best: 495.27ops/s.<br/>total: 2000.40 ± 7.34ms. best: 1986.81ms.<br/>avg: 2.03 ± 0.01ms<br/>min: 0.30 ± 0.01ms<br/>max: 3.70 ± 0.22ms<br/>p99: 2.97 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 562.23 ± 5.18 ops/s. best: 570.58ops/s.<br/>total: 1778.81 ± 16.01ms. best: 1752.61ms.<br/>avg: 1.78 ± 0.02ms<br/>min: 0.05 ± 0.00ms<br/>max: 4.59 ± 0.17ms<br/>p99: 3.74 ± 0.12ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 975.56 ± 11.65 ops/s. best: 986.95ops/s.<br/>total: 1008.85 ± 12.26ms. best: 997.01ms.<br/>avg: 1.03 ± 0.01ms<br/>min: 0.27 ± 0.00ms<br/>max: 1.94 ± 0.36ms<br/>p99: 1.50 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1036.10 ± 17.48 ops/s. best: 1068.66ops/s.<br/>total: 965.53 ± 16.07ms. best: 935.75ms.<br/>avg: 0.97 ± 0.02ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.78 ± 0.13ms<br/>p99: 2.11 ± 0.05ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 463.16 ± 4.53 ops/s. best: 470.14ops/s.<br/>total: 2124.80 ± 21.50ms. best: 2093.01ms.<br/>avg: 2.16 ± 0.02ms<br/>min: 0.32 ± 0.01ms<br/>max: 3.89 ± 0.26ms<br/>p99: 3.20 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 534.06 ± 4.51 ops/s. best: 541.86ops/s.<br/>total: 1872.62 ± 15.79ms. best: 1845.51ms.<br/>avg: 1.87 ± 0.02ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.75 ± 0.17ms<br/>p99: 3.87 ± 0.09ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 866.26 ± 13.98 ops/s. best: 885.80ops/s.<br/>total: 1136.25 ± 18.40ms. best: 1110.87ms.<br/>avg: 1.15 ± 0.02ms<br/>min: 0.27 ± 0.00ms<br/>max: 1.87 ± 0.05ms<br/>p99: 1.66 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 940.20 ± 9.05 ops/s. best: 957.70ops/s.<br/>total: 1063.72 ± 10.19ms. best: 1044.17ms.<br/>avg: 1.06 ± 0.01ms<br/>min: 0.05 ± 0.01ms<br/>max: 2.77 ± 0.31ms<br/>p99: 2.25 ± 0.03ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 247.41 ± 3.42 ops/s. best: 251.50ops/s.<br/>total: 3978.24 ± 55.60ms. best: 3912.48ms.<br/>avg: 4.04 ± 0.06ms<br/>min: 0.30 ± 0.01ms<br/>max: 8.96 ± 0.32ms<br/>p99: 6.86 ± 0.18ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 238.41 ± 3.83 ops/s. best: 244.48ops/s.<br/>total: 4195.96 ± 66.82ms. best: 4090.29ms.<br/>avg: 4.20 ± 0.07ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.95 ± 0.29ms<br/>p99: 8.49 ± 0.11ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 325.59 ± 3.02 ops/s. best: 331.66ops/s.<br/>total: 3022.57 ± 24.46ms. best: 2966.90ms.<br/>avg: 3.07 ± 0.02ms<br/>min: 0.27 ± 0.00ms<br/>max: 7.49 ± 0.22ms<br/>p99: 5.28 ± 0.12ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 298.87 ± 1.05 ops/s. best: 300.05ops/s.<br/>total: 3346.03 ± 11.82ms. best: 3332.74ms.<br/>avg: 3.35 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 8.22 ± 0.78ms<br/>p99: 6.64 ± 0.07ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 245.13 ± 2.82 ops/s. best: 248.72ops/s.<br/>total: 4014.81 ± 46.28ms. best: 3956.19ms.<br/>avg: 4.08 ± 0.05ms<br/>min: 0.30 ± 0.01ms<br/>max: 8.90 ± 0.19ms<br/>p99: 6.88 ± 0.14ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 229.85 ± 0.39 ops/s. best: 230.36ops/s.<br/>total: 4350.73 ± 7.20ms. best: 4341.11ms.<br/>avg: 4.35 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 10.08 ± 0.30ms<br/>p99: 8.93 ± 0.11ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 314.06 ± 0.90 ops/s. best: 315.11ops/s.<br/>total: 3133.16 ± 8.99ms. best: 3122.72ms.<br/>avg: 3.18 ± 0.01ms<br/>min: 0.28 ± 0.01ms<br/>max: 7.57 ± 0.04ms<br/>p99: 5.42 ± 0.05ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 274.49 ± 3.49 ops/s. best: 278.88ops/s.<br/>total: 3643.82 ± 46.66ms. best: 3585.78ms.<br/>avg: 3.64 ± 0.05ms<br/>min: 0.04 ± 0.00ms<br/>max: 8.08 ± 0.15ms<br/>p99: 7.25 ± 0.12ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1424.44 ± 7.33 ops/s. best: 1433.48ops/s.<br/>total: 175.51 ± 0.94ms. best: 174.40ms.<br/>avg: 0.70 ± 0.00ms<br/>min: 0.48 ± 0.01ms<br/>max: 1.14 ± 0.29ms<br/>p99: 0.91 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 164.15 ± 1.18 ops/s. best: 165.52ops/s.<br/>total: 1523.13 ± 10.95ms. best: 1510.36ms.<br/>avg: 6.09 ± 0.04ms<br/>min: 5.38 ± 0.05ms<br/>max: 6.91 ± 0.18ms<br/>p99: 6.68 ± 0.10ms<br/><br/>250 tables, 50 coordinates<br/>ops: 82.29 ± 0.76 ops/s. best: 82.84ops/s.<br/>total: 3038.39 ± 28.57ms. best: 3017.94ms.<br/>avg: 12.15 ± 0.11ms<br/>min: 11.28 ± 0.12ms<br/>max: 13.34 ± 0.22ms<br/>p99: 13.02 ± 0.11ms | 250 tables, 3 coordinates<br/>ops: 1426.41 ± 11.63 ops/s. best: 1449.28ops/s.<br/>total: 175.28 ± 1.42ms. best: 172.50ms.<br/>avg: 0.70 ± 0.01ms<br/>min: 0.48 ± 0.01ms<br/>max: 1.11 ± 0.28ms<br/>p99: 0.92 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 166.97 ± 0.53 ops/s. best: 167.54ops/s.<br/>total: 1497.26 ± 4.82ms. best: 1492.21ms.<br/>avg: 5.99 ± 0.02ms<br/>min: 5.25 ± 0.04ms<br/>max: 6.72 ± 0.14ms<br/>p99: 6.57 ± 0.05ms<br/><br/>250 tables, 50 coordinates<br/>ops: 82.26 ± 0.12 ops/s. best: 82.44ops/s.<br/>total: 3039.01 ± 4.46ms. best: 3032.50ms.<br/>avg: 12.16 ± 0.02ms<br/>min: 11.18 ± 0.06ms<br/>max: 13.61 ± 0.42ms<br/>p99: 13.14 ± 0.12ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 333.02 ± 1.08 ops/s. best: 334.54ops/s.<br/>total: 750.72 ± 2.43ms. best: 747.30ms.<br/>avg: 3.00 ± 0.01ms<br/>min: 2.51 ± 0.01ms<br/>max: 3.93 ± 0.21ms<br/>p99: 3.66 ± 0.09ms<br/><br/>250 tables, 25 coordinates<br/>ops: 36.73 ± 0.10 ops/s. best: 36.87ops/s.<br/>total: 6806.78 ± 18.27ms. best: 6780.82ms.<br/>avg: 27.23 ± 0.07ms<br/>min: 25.45 ± 0.03ms<br/>max: 30.39 ± 1.66ms<br/>p99: 29.17 ± 0.16ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.54 ± 0.06 ops/s. best: 17.62ops/s.<br/>total: 14256.79 ± 52.12ms. best: 14185.32ms.<br/>avg: 57.03 ± 0.21ms<br/>min: 54.64 ± 0.09ms<br/>max: 61.83 ± 2.15ms<br/>p99: 60.26 ± 0.96ms | 250 tables, 3 coordinates<br/>ops: 329.89 ± 1.27 ops/s. best: 331.40ops/s.<br/>total: 757.85 ± 2.94ms. best: 754.37ms.<br/>avg: 3.03 ± 0.01ms<br/>min: 2.54 ± 0.01ms<br/>max: 4.04 ± 0.25ms<br/>p99: 3.72 ± 0.10ms<br/><br/>250 tables, 25 coordinates<br/>ops: 36.55 ± 0.26 ops/s. best: 36.96ops/s.<br/>total: 6840.03 ± 49.51ms. best: 6764.00ms.<br/>avg: 27.36 ± 0.20ms<br/>min: 25.56 ± 0.12ms<br/>max: 31.54 ± 1.82ms<br/>p99: 29.49 ± 0.41ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.55 ± 0.06 ops/s. best: 17.63ops/s.<br/>total: 14243.63 ± 50.83ms. best: 14180.92ms.<br/>avg: 56.97 ± 0.20ms<br/>min: 54.81 ± 0.13ms<br/>max: 61.07 ± 2.06ms<br/>p99: 59.86 ± 0.88ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 490.09 ± 3.22 ops/s. best: 493.32ops/s.<br/>total: 510.13 ± 3.37ms. best: 506.77ms.<br/>avg: 2.04 ± 0.01ms<br/>min: 1.11 ± 0.00ms<br/>max: 3.07 ± 0.38ms<br/>p99: 2.69 ± 0.05ms<br/><br/>250 trips, 5 coordinates<br/>ops: 323.94 ± 1.52 ops/s. best: 326.32ops/s.<br/>total: 771.76 ± 3.63ms. best: 766.12ms.<br/>avg: 3.09 ± 0.01ms<br/>min: 1.96 ± 0.02ms<br/>max: 4.07 ± 0.11ms<br/>p99: 3.88 ± 0.03ms | 250 trips, 3 coordinates<br/>ops: 448.27 ± 5.02 ops/s. best: 455.72ops/s.<br/>total: 557.79 ± 6.28ms. best: 548.58ms.<br/>avg: 2.23 ± 0.03ms<br/>min: 1.20 ± 0.02ms<br/>max: 3.34 ± 0.33ms<br/>p99: 3.03 ± 0.07ms<br/><br/>250 trips, 5 coordinates<br/>ops: 293.09 ± 2.71 ops/s. best: 297.96ops/s.<br/>total: 853.06 ± 7.90ms. best: 839.04ms.<br/>avg: 3.41 ± 0.03ms<br/>min: 2.12 ± 0.06ms<br/>max: 4.43 ± 0.02ms<br/>p99: 4.31 ± 0.04ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 167.92 ± 1.22 ops/s. best: 168.99ops/s.<br/>total: 1488.96 ± 10.93ms. best: 1479.36ms.<br/>avg: 5.96 ± 0.04ms<br/>min: 3.58 ± 0.04ms<br/>max: 8.76 ± 0.99ms<br/>p99: 7.82 ± 0.09ms<br/><br/>250 trips, 5 coordinates<br/>ops: 108.85 ± 1.14 ops/s. best: 110.45ops/s.<br/>total: 2297.09 ± 24.13ms. best: 2263.43ms.<br/>avg: 9.19 ± 0.10ms<br/>min: 6.57 ± 0.09ms<br/>max: 11.46 ± 0.23ms<br/>p99: 11.18 ± 0.22ms | 250 trips, 3 coordinates<br/>ops: 170.66 ± 0.72 ops/s. best: 171.92ops/s.<br/>total: 1464.95 ± 6.19ms. best: 1454.16ms.<br/>avg: 5.86 ± 0.02ms<br/>min: 3.51 ± 0.03ms<br/>max: 7.89 ± 0.45ms<br/>p99: 7.39 ± 0.07ms<br/><br/>250 trips, 5 coordinates<br/>ops: 111.30 ± 0.18 ops/s. best: 111.58ops/s.<br/>total: 2246.10 ± 3.54ms. best: 2240.62ms.<br/>avg: 8.98 ± 0.01ms<br/>min: 6.55 ± 0.03ms<br/>max: 11.35 ± 0.89ms<br/>p99: 10.60 ± 0.05ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>424.642ms<br/>0.424642ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>508.849ms<br/>0.508849ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>147.273ms<br/>0.147273ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>130.225ms<br/>0.130225ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>433.277ms<br/>0.433277ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>518.293ms<br/>0.518293ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>154.484ms<br/>0.154484ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>136.171ms<br/>0.136171ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>570.301ms<br/>0.570301ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>716.477ms<br/>0.716477ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>279.792ms<br/>0.279792ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>312.937ms<br/>0.312937ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>569.444ms<br/>0.569444ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>716.631ms<br/>0.716631ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>292.09ms<br/>0.29209ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>317.564ms<br/>0.317564ms/req |
| rtree | 1 result:<br/>198.234ms ->  0.0198234 ms/query<br/>10 results:<br/>233.266ms ->  0.0233266 ms/query | 1 result:<br/>198.761ms ->  0.0198761 ms/query<br/>10 results:<br/>233.755ms ->  0.0233755 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->

