### PR TITLE
Fix parsing on feature files on other gherkin parser

### DIFF
--- a/features/guidance/collapse.feature
+++ b/features/guidance/collapse.feature
@@ -1061,7 +1061,7 @@ Feature: Collapse
         #    i
         #    """
 
-        And the node locations
+        Given the node locations
           | node |         lat |         lon |        #id |
           | a    | -33.9644254 | 151.1378673 |   33226063 |
           | b    | -33.9644373 | 151.1377172 | 1072787030 |

--- a/features/guidance/roundabout-left-sided.feature
+++ b/features/guidance/roundabout-left-sided.feature
@@ -9,7 +9,7 @@ Feature: Basic Roundabout
             """
 
     Scenario: Roundabout exit counting for left sided driving
-        And a grid size of 10 meters
+        Given a grid size of 10 meters
         And the node map
             """
                 a
@@ -33,7 +33,7 @@ Feature: Basic Roundabout
            | a,h       | ab,gh,gh | depart,roundabout turn right exit-3,arrive    |
 
     Scenario: Mixed Entry and Exit
-        And a grid size of 10 meters
+        Given a grid size of 10 meters
         And the node map
            """
              c   a

--- a/features/testbot/loop.feature
+++ b/features/testbot/loop.feature
@@ -75,7 +75,7 @@ Feature: Avoid weird loops caused by rounding errors
 
     @412 @via
     Scenario: Avoid weird loops 3
-        And the node map
+        Given the node map
             """
             a
             b e

--- a/features/testbot/snap_intersection.feature
+++ b/features/testbot/snap_intersection.feature
@@ -401,12 +401,12 @@ Feature: Snapping at intersections
         Given the extract extra arguments "--small-component-size=4"
 
         And the ways
-            | nodes | oneway |
-            | ab    | no     |
-            | bc    | no     |
-            | cd    | no     |
-            | fed   | no     |
-            | bg    | yes    | # small SCC
+            | nodes | oneway | # comment  |
+            | ab    | no     |            |
+            | bc    | no     |            |
+            | cd    | no     |            |
+            | fed   | no     |            |
+            | bg    | yes    | small SCC  |
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |
@@ -437,14 +437,14 @@ Feature: Snapping at intersections
         Given the extract extra arguments "--small-component-size=4"
 
         And the ways
-            | nodes | oneway |
-            | ab    | no     |
-            | bc    | no     |
-            | cd    | no     |
-            | fed   | no     |
-            | ghi   | no     |
-            | jkl   | no     |
-            | bm    | yes    | # small SCC
+            | nodes | oneway | # comment |
+            | ab    | no     |           |
+            | bc    | no     |           |
+            | cd    | no     |           |
+            | fed   | no     |           |
+            | ghi   | no     |           |
+            | jkl   | no     |           |
+            | bm    | yes    | small SCC |
 
         And the relations
             | type        | way:from | way:to | node:via | restriction   |


### PR DESCRIPTION
The JavaScript parser of the Gherkin language is lenient.


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1103.54<br/>plain u32: 1099.38<br/>aliased double: 964.409<br/>plain double: 976.443 | aliased u32: 1098.98<br/>plain u32: 1099.41<br/>aliased double: 955.712<br/>plain double: 957.721 |
| e2e_match_ch | Ops: 43.73 ± 0.06 ops/s. Best: 43.81 ops/s<br/>Total: 2995.57ms ± 3.88ms. Best: 2990.52ms<br/>Min time: 2.05ms ± 0.02ms<br/>Mean time: 22.87ms ± 0.03ms<br/>Median time: 16.93ms ± 0.11ms<br/>95th percentile: 75.40ms ± 0.37ms<br/>99th percentile: 95.14ms ± 0.50ms<br/>Max time: 109.13ms ± 0.88ms | Ops: 43.57 ± 0.07 ops/s. Best: 43.68 ops/s<br/>Total: 3006.67ms ± 4.99ms. Best: 2999.15ms<br/>Min time: 2.05ms ± 0.04ms<br/>Mean time: 22.95ms ± 0.04ms<br/>Median time: 16.87ms ± 0.10ms<br/>95th percentile: 76.10ms ± 0.10ms<br/>99th percentile: 93.80ms ± 0.65ms<br/>Max time: 108.05ms ± 0.43ms |
| e2e_match_mld | Ops: 63.47 ± 0.26 ops/s. Best: 63.84 ops/s<br/>Total: 2064.50ms ± 8.57ms. Best: 2051.87ms<br/>Min time: 1.75ms ± 0.03ms<br/>Mean time: 15.76ms ± 0.07ms<br/>Median time: 8.21ms ± 0.10ms<br/>95th percentile: 52.85ms ± 0.26ms<br/>99th percentile: 61.90ms ± 1.46ms<br/>Max time: 70.00ms ± 0.45ms | Ops: 63.64 ± 0.13 ops/s. Best: 63.87 ops/s<br/>Total: 2058.67ms ± 4.12ms. Best: 2051.02ms<br/>Min time: 1.77ms ± 0.03ms<br/>Mean time: 15.71ms ± 0.03ms<br/>Median time: 8.19ms ± 0.07ms<br/>95th percentile: 52.42ms ± 0.17ms<br/>99th percentile: 60.98ms ± 0.24ms<br/>Max time: 70.20ms ± 0.45ms |
| e2e_nearest_ch | Ops: 863.66 ± 4.49 ops/s. Best: 870.47 ops/s<br/>Total: 1157.84ms ± 6.07ms. Best: 1148.81ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.01ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.60ms ± 0.00ms<br/>99th percentile: 1.67ms ± 0.01ms<br/>Max time: 6.28ms ± 3.10ms | Ops: 861.09 ± 3.50 ops/s. Best: 867.47 ops/s<br/>Total: 1161.36ms ± 5.12ms. Best: 1152.77ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.01ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.62ms ± 0.01ms<br/>99th percentile: 1.68ms ± 0.01ms<br/>Max time: 6.57ms ± 3.18ms |
| e2e_nearest_mld | Ops: 862.90 ± 3.44 ops/s. Best: 871.04 ops/s<br/>Total: 1159.00ms ± 4.89ms. Best: 1148.06ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.16ms ± 0.00ms<br/>Median time: 1.07ms ± 0.00ms<br/>95th percentile: 1.61ms ± 0.01ms<br/>99th percentile: 1.67ms ± 0.01ms<br/>Max time: 6.10ms ± 2.90ms | Ops: 856.96 ± 9.58 ops/s. Best: 869.60 ops/s<br/>Total: 1166.58ms ± 13.18ms. Best: 1149.96ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.17ms ± 0.01ms<br/>Median time: 1.08ms ± 0.01ms<br/>95th percentile: 1.62ms ± 0.02ms<br/>99th percentile: 1.69ms ± 0.02ms<br/>Max time: 6.85ms ± 3.37ms |
| e2e_route_ch | Ops: 356.02 ± 4.15 ops/s. Best: 360.44 ops/s<br/>Total: 2808.80ms ± 34.44ms. Best: 2774.42ms<br/>Min time: 1.17ms ± 0.02ms<br/>Mean time: 2.81ms ± 0.03ms<br/>Median time: 2.83ms ± 0.04ms<br/>95th percentile: 3.73ms ± 0.05ms<br/>99th percentile: 4.17ms ± 0.07ms<br/>Max time: 6.95ms ± 2.12ms | Ops: 359.23 ± 1.65 ops/s. Best: 361.58 ops/s<br/>Total: 2784.31ms ± 13.29ms. Best: 2765.66ms<br/>Min time: 1.20ms ± 0.03ms<br/>Mean time: 2.78ms ± 0.01ms<br/>Median time: 2.80ms ± 0.01ms<br/>95th percentile: 3.70ms ± 0.03ms<br/>99th percentile: 4.16ms ± 0.07ms<br/>Max time: 7.12ms ± 2.64ms |
| e2e_route_mld | Ops: 297.35 ± 2.73 ops/s. Best: 303.68 ops/s<br/>Total: 3364.07ms ± 31.82ms. Best: 3292.98ms<br/>Min time: 1.20ms ± 0.02ms<br/>Mean time: 3.36ms ± 0.03ms<br/>Median time: 3.41ms ± 0.03ms<br/>95th percentile: 4.63ms ± 0.05ms<br/>99th percentile: 5.13ms ± 0.10ms<br/>Max time: 7.80ms ± 2.42ms | Ops: 295.26 ± 1.85 ops/s. Best: 298.48 ops/s<br/>Total: 3387.09ms ± 22.76ms. Best: 3350.32ms<br/>Min time: 1.20ms ± 0.02ms<br/>Mean time: 3.39ms ± 0.02ms<br/>Median time: 3.43ms ± 0.02ms<br/>95th percentile: 4.66ms ± 0.03ms<br/>99th percentile: 5.20ms ± 0.08ms<br/>Max time: 8.05ms ± 2.26ms |
| e2e_table_ch | Ops: 320.33 ± 1.14 ops/s. Best: 322.81 ops/s<br/>Total: 3121.71ms ± 11.35ms. Best: 3097.77ms<br/>Min time: 1.62ms ± 0.02ms<br/>Mean time: 3.12ms ± 0.01ms<br/>Median time: 3.12ms ± 0.02ms<br/>95th percentile: 4.33ms ± 0.02ms<br/>99th percentile: 4.69ms ± 0.05ms<br/>Max time: 8.22ms ± 2.37ms | Ops: 318.05 ± 1.18 ops/s. Best: 320.23 ops/s<br/>Total: 3144.43ms ± 12.20ms. Best: 3122.75ms<br/>Min time: 1.62ms ± 0.01ms<br/>Mean time: 3.14ms ± 0.01ms<br/>Median time: 3.14ms ± 0.03ms<br/>95th percentile: 4.39ms ± 0.02ms<br/>99th percentile: 4.75ms ± 0.06ms<br/>Max time: 8.24ms ± 2.36ms |
| e2e_table_mld | Ops: 108.51 ± 0.25 ops/s. Best: 109.07 ops/s<br/>Total: 9216.78ms ± 21.29ms. Best: 9168.50ms<br/>Min time: 3.66ms ± 0.05ms<br/>Mean time: 9.22ms ± 0.02ms<br/>Median time: 9.16ms ± 0.06ms<br/>95th percentile: 14.09ms ± 0.04ms<br/>99th percentile: 14.88ms ± 0.12ms<br/>Max time: 17.48ms ± 2.23ms | Ops: 107.19 ± 1.04 ops/s. Best: 108.54 ops/s<br/>Total: 9325.74ms ± 92.08ms. Best: 9212.91ms<br/>Min time: 3.74ms ± 0.07ms<br/>Mean time: 9.33ms ± 0.09ms<br/>Median time: 9.28ms ± 0.12ms<br/>95th percentile: 14.23ms ± 0.13ms<br/>99th percentile: 15.15ms ± 0.17ms<br/>Max time: 18.37ms ± 2.67ms |
| e2e_trip_ch | Ops: 98.43 ± 0.45 ops/s. Best: 99.15 ops/s<br/>Total: 10159.22ms ± 48.17ms. Best: 10085.98ms<br/>Min time: 1.50ms ± 0.11ms<br/>Mean time: 10.16ms ± 0.05ms<br/>Median time: 9.60ms ± 0.07ms<br/>95th percentile: 18.31ms ± 0.08ms<br/>99th percentile: 20.30ms ± 0.10ms<br/>Max time: 22.37ms ± 0.91ms | Ops: 96.84 ± 0.47 ops/s. Best: 97.61 ops/s<br/>Total: 10327.91ms ± 51.50ms. Best: 10244.62ms<br/>Min time: 1.47ms ± 0.07ms<br/>Mean time: 10.33ms ± 0.05ms<br/>Median time: 9.78ms ± 0.06ms<br/>95th percentile: 18.53ms ± 0.06ms<br/>99th percentile: 20.57ms ± 0.08ms<br/>Max time: 22.55ms ± 0.53ms |
| e2e_trip_mld | Ops: 56.85 ± 0.46 ops/s. Best: 57.80 ops/s<br/>Total: 17591.48ms ± 142.32ms. Best: 17302.45ms<br/>Min time: 1.73ms ± 0.27ms<br/>Mean time: 17.59ms ± 0.15ms<br/>Median time: 17.11ms ± 0.15ms<br/>95th percentile: 28.81ms ± 0.15ms<br/>99th percentile: 31.21ms ± 0.27ms<br/>Max time: 33.44ms ± 0.48ms | Ops: 56.80 ± 0.37 ops/s. Best: 57.71 ops/s<br/>Total: 17606.76ms ± 114.51ms. Best: 17328.73ms<br/>Min time: 1.78ms ± 0.18ms<br/>Mean time: 17.61ms ± 0.12ms<br/>Median time: 17.14ms ± 0.13ms<br/>95th percentile: 28.75ms ± 0.16ms<br/>99th percentile: 31.14ms ± 0.25ms<br/>Max time: 33.52ms ± 0.34ms |
| json-render | String: 5.68327ms<br/>Stringstream: 9.24736ms<br/>Vector: 6.73128ms | String: 5.4652ms<br/>Stringstream: 8.92455ms<br/>Vector: 6.60228ms |
| match_ch | Default radius: <br/>4.60895ms/req at 82 coordinate<br/>0.0562068ms/coordinate<br/>Radius 10m: <br/>16.1486ms/req at 82 coordinate<br/>0.196935ms/coordinate | Default radius: <br/>4.61624ms/req at 82 coordinate<br/>0.0562956ms/coordinate<br/>Radius 10m: <br/>16.1709ms/req at 82 coordinate<br/>0.197206ms/coordinate |
| match_mld | Default radius: <br/>3.15611ms/req at 82 coordinate<br/>0.0384892ms/coordinate<br/>Radius 10m: <br/>11.0733ms/req at 82 coordinate<br/>0.135041ms/coordinate | Default radius: <br/>2.97614ms/req at 82 coordinate<br/>0.0362944ms/coordinate<br/>Radius 10m: <br/>11.2611ms/req at 82 coordinate<br/>0.13733ms/coordinate |
| osrm_contract | Time: 98.64s Peak RAM: 201.03MB | Time: 97.99s Peak RAM: 201.86MB |
| osrm_customize | Time: 1.31s Peak RAM: 117.67MB | Time: 1.30s Peak RAM: 117.69MB |
| osrm_extract | Time: 11.86s Peak RAM: 431.09MB | Time: 11.81s Peak RAM: 425.80MB |
| osrm_partition | Time: 2.14s Peak RAM: 143.26MB | Time: 2.12s Peak RAM: 137.54MB |
| packedvector | random write:<br/>std::vector 9986.82 ms<br/>util::packed_vector 74271.1 ms<br/>slowdown: 7.43692<br/>random read:<br/>std::vector 8847.01 ms<br/>util::packed_vector 30668.9 ms<br/>slowdown: 3.46658 | random write:<br/>std::vector 9826.79 ms<br/>util::packed_vector 74194.2 ms<br/>slowdown: 7.5502<br/>random read:<br/>std::vector 10464.2 ms<br/>util::packed_vector 30952.5 ms<br/>slowdown: 2.95794 |
| random_match_ch | 500 matches, default radius<br/>ops: 202.99 ± 0.73 ops/s. best: 203.61ops/s.<br/>total: 280.81 ± 1.01ms. best: 279.94ms.<br/>avg: 4.93 ± 0.02ms<br/>min: 0.15 ± 0.01ms<br/>max: 26.05 ± 0.10ms<br/>p99: 26.05 ± 0.10ms<br/><br/>500 matches, radius=10<br/>ops: 60.53 ± 0.03 ops/s. best: 60.59ops/s.<br/>total: 1057.41 ± 0.56ms. best: 1056.35ms.<br/>avg: 16.52 ± 0.01ms<br/>min: 0.16 ± 0.00ms<br/>max: 242.59 ± 0.43ms<br/>p99: 242.59 ± 0.43ms<br/><br/>500 matches, radius=20<br/>ops: 14.56 ± 0.03 ops/s. best: 14.60ops/s.<br/>total: 4464.99 ± 9.36ms. best: 4451.97ms.<br/>avg: 68.69 ± 0.14ms<br/>min: 0.31 ± 0.00ms<br/>max: 1209.05 ± 6.89ms<br/>p99: 1209.05 ± 6.89ms | 500 matches, default radius<br/>ops: 201.48 ± 0.35 ops/s. best: 202.07ops/s.<br/>total: 282.90 ± 0.49ms. best: 282.09ms.<br/>avg: 4.96 ± 0.01ms<br/>min: 0.14 ± 0.01ms<br/>max: 26.07 ± 0.17ms<br/>p99: 26.07 ± 0.17ms<br/><br/>500 matches, radius=10<br/>ops: 59.32 ± 0.10 ops/s. best: 59.46ops/s.<br/>total: 1078.97 ± 1.86ms. best: 1076.28ms.<br/>avg: 16.86 ± 0.03ms<br/>min: 0.15 ± 0.00ms<br/>max: 251.10 ± 0.78ms<br/>p99: 251.10 ± 0.78ms<br/><br/>500 matches, radius=20<br/>ops: 14.19 ± 0.02 ops/s. best: 14.23ops/s.<br/>total: 4579.78 ± 5.52ms. best: 4568.04ms.<br/>avg: 70.46 ± 0.08ms<br/>min: 0.31 ± 0.01ms<br/>max: 1268.88 ± 3.61ms<br/>p99: 1268.88 ± 3.61ms |
| random_match_mld | 500 matches, default radius<br/>ops: 300.40 ± 1.16 ops/s. best: 301.30ops/s.<br/>total: 189.75 ± 0.74ms. best: 189.18ms.<br/>avg: 3.33 ± 0.01ms<br/>min: 0.13 ± 0.00ms<br/>max: 19.05 ± 0.03ms<br/>p99: 19.05 ± 0.03ms<br/><br/>500 matches, radius=10<br/>ops: 106.44 ± 0.23 ops/s. best: 106.91ops/s.<br/>total: 601.26 ± 1.28ms. best: 598.62ms.<br/>avg: 9.39 ± 0.02ms<br/>min: 0.15 ± 0.00ms<br/>max: 111.86 ± 0.51ms<br/>p99: 111.86 ± 0.51ms<br/><br/>500 matches, radius=20<br/>ops: 21.67 ± 0.03 ops/s. best: 21.72ops/s.<br/>total: 2999.81 ± 3.91ms. best: 2992.72ms.<br/>avg: 46.15 ± 0.06ms<br/>min: 0.20 ± 0.00ms<br/>max: 587.56 ± 1.24ms<br/>p99: 587.56 ± 1.24ms | 500 matches, default radius<br/>ops: 299.56 ± 1.41 ops/s. best: 300.69ops/s.<br/>total: 190.29 ± 0.90ms. best: 189.56ms.<br/>avg: 3.34 ± 0.02ms<br/>min: 0.12 ± 0.01ms<br/>max: 19.08 ± 0.03ms<br/>p99: 19.08 ± 0.03ms<br/><br/>500 matches, radius=10<br/>ops: 105.74 ± 0.35 ops/s. best: 106.26ops/s.<br/>total: 605.27 ± 2.02ms. best: 602.28ms.<br/>avg: 9.46 ± 0.03ms<br/>min: 0.15 ± 0.00ms<br/>max: 111.84 ± 0.48ms<br/>p99: 111.84 ± 0.48ms<br/><br/>500 matches, radius=20<br/>ops: 21.60 ± 0.03 ops/s. best: 21.65ops/s.<br/>total: 3009.78 ± 4.32ms. best: 3002.67ms.<br/>avg: 46.30 ± 0.07ms<br/>min: 0.19 ± 0.00ms<br/>max: 586.22 ± 1.06ms<br/>p99: 586.22 ± 1.06ms |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 22842.79 ± 179.12 ops/s. best: 23085.77ops/s.<br/>total: 437.81 ± 3.45ms. best: 433.17ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.18 ± 0.06ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17761.33 ± 36.68 ops/s. best: 17806.44ops/s.<br/>total: 563.02 ± 1.16ms. best: 561.59ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.19 ± 0.06ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14223.21 ± 49.87 ops/s. best: 14307.89ops/s.<br/>total: 703.09 ± 2.47ms. best: 698.92ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.00ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22910.05 ± 56.85 ops/s. best: 22981.51ops/s.<br/>total: 436.49 ± 1.09ms. best: 435.13ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.18 ± 0.06ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17720.65 ± 60.51 ops/s. best: 17795.28ops/s.<br/>total: 564.32 ± 1.93ms. best: 561.95ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14207.38 ± 107.81 ops/s. best: 14336.06ops/s.<br/>total: 703.91 ± 5.35ms. best: 697.54ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 22765.47 ± 123.88 ops/s. best: 22918.35ops/s.<br/>total: 439.28 ± 2.41ms. best: 436.33ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.05ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17586.02 ± 154.95 ops/s. best: 17751.03ops/s.<br/>total: 568.69 ± 5.05ms. best: 563.35ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14280.86 ± 28.54 ops/s. best: 14313.42ops/s.<br/>total: 700.24 ± 1.40ms. best: 698.65ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 22972.40 ± 77.38 ops/s. best: 23083.16ops/s.<br/>total: 435.31 ± 1.47ms. best: 433.22ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.05ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17809.66 ± 32.18 ops/s. best: 17850.35ops/s.<br/>total: 561.49 ± 0.98ms. best: 560.21ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14308.91 ± 32.93 ops/s. best: 14354.93ops/s.<br/>total: 698.87 ± 1.57ms. best: 696.62ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.01ms<br/>p99: 0.14 ± 0.00ms |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 493.88 ± 5.63 ops/s. best: 506.37ops/s.<br/>total: 1992.74 ± 22.44ms. best: 1943.22ms.<br/>avg: 2.03 ± 0.02ms<br/>min: 0.31 ± 0.01ms<br/>max: 3.65 ± 0.39ms<br/>p99: 2.93 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 541.74 ± 5.08 ops/s. best: 554.42ops/s.<br/>total: 1846.17 ± 16.95ms. best: 1803.67ms.<br/>avg: 1.85 ± 0.02ms<br/>min: 0.06 ± 0.00ms<br/>max: 5.46 ± 0.29ms<br/>p99: 4.37 ± 0.11ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 892.68 ± 23.42 ops/s. best: 952.04ops/s.<br/>total: 1103.46 ± 27.69ms. best: 1033.57ms.<br/>avg: 1.12 ± 0.03ms<br/>min: 0.26 ± 0.00ms<br/>max: 1.86 ± 0.06ms<br/>p99: 1.63 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 976.30 ± 42.69 ops/s. best: 1016.48ops/s.<br/>total: 1027.34 ± 47.94ms. best: 983.79ms.<br/>avg: 1.03 ± 0.05ms<br/>min: 0.04 ± 0.00ms<br/>max: 4.13 ± 0.08ms<br/>p99: 2.58 ± 0.13ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 501.33 ± 2.48 ops/s. best: 506.27ops/s.<br/>total: 1962.84 ± 9.80ms. best: 1943.62ms.<br/>avg: 1.99 ± 0.01ms<br/>min: 0.30 ± 0.01ms<br/>max: 3.59 ± 0.36ms<br/>p99: 2.92 ± 0.08ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 540.08 ± 6.33 ops/s. best: 546.81ops/s.<br/>total: 1851.92 ± 21.76ms. best: 1828.80ms.<br/>avg: 1.85 ± 0.02ms<br/>min: 0.06 ± 0.00ms<br/>max: 5.26 ± 0.27ms<br/>p99: 4.05 ± 0.06ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 911.65 ± 7.58 ops/s. best: 925.64ops/s.<br/>total: 1079.47 ± 8.94ms. best: 1063.05ms.<br/>avg: 1.10 ± 0.01ms<br/>min: 0.26 ± 0.00ms<br/>max: 1.83 ± 0.02ms<br/>p99: 1.59 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1007.34 ± 6.36 ops/s. best: 1020.20ops/s.<br/>total: 992.77 ± 6.15ms. best: 980.20ms.<br/>avg: 0.99 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 4.08 ± 0.03ms<br/>p99: 2.27 ± 0.02ms |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 234.94 ± 2.50 ops/s. best: 241.30ops/s.<br/>total: 4189.00 ± 43.82ms. best: 4077.99ms.<br/>avg: 4.26 ± 0.04ms<br/>min: 0.32 ± 0.02ms<br/>max: 9.20 ± 0.12ms<br/>p99: 7.11 ± 0.13ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 231.17 ± 3.23 ops/s. best: 235.91ops/s.<br/>total: 4326.87 ± 60.72ms. best: 4238.84ms.<br/>avg: 4.33 ± 0.06ms<br/>min: 0.05 ± 0.01ms<br/>max: 10.59 ± 0.45ms<br/>p99: 9.01 ± 0.17ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 316.96 ± 2.81 ops/s. best: 319.48ops/s.<br/>total: 3104.82 ± 27.80ms. best: 3079.97ms.<br/>avg: 3.16 ± 0.03ms<br/>min: 0.28 ± 0.01ms<br/>max: 7.60 ± 0.14ms<br/>p99: 5.44 ± 0.03ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 282.74 ± 3.89 ops/s. best: 288.84ops/s.<br/>total: 3537.67 ± 48.52ms. best: 3462.14ms.<br/>avg: 3.54 ± 0.05ms<br/>min: 0.04 ± 0.00ms<br/>max: 8.18 ± 0.50ms<br/>p99: 7.08 ± 0.16ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 244.00 ± 1.24 ops/s. best: 246.22ops/s.<br/>total: 4032.96 ± 21.12ms. best: 3996.49ms.<br/>avg: 4.10 ± 0.02ms<br/>min: 0.30 ± 0.01ms<br/>max: 9.05 ± 0.33ms<br/>p99: 6.93 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 232.77 ± 1.10 ops/s. best: 233.91ops/s.<br/>total: 4296.18 ± 20.36ms. best: 4275.12ms.<br/>avg: 4.30 ± 0.02ms<br/>min: 0.05 ± 0.00ms<br/>max: 10.27 ± 0.08ms<br/>p99: 8.95 ± 0.09ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 316.69 ± 4.12 ops/s. best: 321.67ops/s.<br/>total: 3107.84 ± 40.88ms. best: 3059.02ms.<br/>avg: 3.16 ± 0.04ms<br/>min: 0.28 ± 0.00ms<br/>max: 7.58 ± 0.34ms<br/>p99: 5.43 ± 0.09ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 283.05 ± 2.39 ops/s. best: 287.33ops/s.<br/>total: 3533.28 ± 29.70ms. best: 3480.35ms.<br/>avg: 3.53 ± 0.03ms<br/>min: 0.04 ± 0.00ms<br/>max: 8.10 ± 0.62ms<br/>p99: 7.08 ± 0.12ms |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1375.32 ± 19.11 ops/s. best: 1395.74ops/s.<br/>total: 181.82 ± 2.56ms. best: 179.12ms.<br/>avg: 0.73 ± 0.01ms<br/>min: 0.51 ± 0.01ms<br/>max: 1.12 ± 0.29ms<br/>p99: 0.91 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 166.75 ± 1.24 ops/s. best: 168.40ops/s.<br/>total: 1499.36 ± 11.16ms. best: 1484.57ms.<br/>avg: 6.00 ± 0.04ms<br/>min: 5.15 ± 0.04ms<br/>max: 6.78 ± 0.14ms<br/>p99: 6.62 ± 0.08ms<br/><br/>250 tables, 50 coordinates<br/>ops: 83.08 ± 0.73 ops/s. best: 84.08ops/s.<br/>total: 3009.57 ± 26.82ms. best: 2973.47ms.<br/>avg: 12.04 ± 0.11ms<br/>min: 10.90 ± 0.08ms<br/>max: 13.21 ± 0.17ms<br/>p99: 12.96 ± 0.17ms | 250 tables, 3 coordinates<br/>ops: 1392.04 ± 9.27 ops/s. best: 1404.30ops/s.<br/>total: 179.60 ± 1.21ms. best: 178.02ms.<br/>avg: 0.72 ± 0.00ms<br/>min: 0.48 ± 0.01ms<br/>max: 1.09 ± 0.20ms<br/>p99: 0.91 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 166.66 ± 0.13 ops/s. best: 166.92ops/s.<br/>total: 1500.10 ± 1.18ms. best: 1497.76ms.<br/>avg: 6.00 ± 0.00ms<br/>min: 5.08 ± 0.01ms<br/>max: 6.72 ± 0.07ms<br/>p99: 6.60 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 81.75 ± 0.40 ops/s. best: 82.61ops/s.<br/>total: 3058.18 ± 14.79ms. best: 3026.13ms.<br/>avg: 12.23 ± 0.06ms<br/>min: 11.13 ± 0.05ms<br/>max: 13.61 ± 0.15ms<br/>p99: 13.31 ± 0.15ms |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 328.77 ± 2.28 ops/s. best: 331.02ops/s.<br/>total: 760.47 ± 5.32ms. best: 755.25ms.<br/>avg: 3.04 ± 0.02ms<br/>min: 2.50 ± 0.01ms<br/>max: 4.02 ± 0.26ms<br/>p99: 3.74 ± 0.08ms<br/><br/>250 tables, 25 coordinates<br/>ops: 36.17 ± 0.29 ops/s. best: 36.46ops/s.<br/>total: 6912.77 ± 56.78ms. best: 6857.54ms.<br/>avg: 27.65 ± 0.23ms<br/>min: 25.72 ± 0.21ms<br/>max: 30.68 ± 0.47ms<br/>p99: 29.93 ± 0.35ms<br/><br/>250 tables, 50 coordinates<br/>ops: 16.98 ± 0.04 ops/s. best: 17.02ops/s.<br/>total: 14727.08 ± 34.22ms. best: 14684.94ms.<br/>avg: 58.91 ± 0.14ms<br/>min: 55.85 ± 0.43ms<br/>max: 63.69 ± 0.54ms<br/>p99: 62.21 ± 0.23ms | 250 tables, 3 coordinates<br/>ops: 334.61 ± 1.30 ops/s. best: 336.08ops/s.<br/>total: 747.14 ± 3.03ms. best: 743.88ms.<br/>avg: 2.99 ± 0.01ms<br/>min: 2.49 ± 0.02ms<br/>max: 3.84 ± 0.22ms<br/>p99: 3.59 ± 0.07ms<br/><br/>250 tables, 25 coordinates<br/>ops: 36.68 ± 0.14 ops/s. best: 36.83ops/s.<br/>total: 6815.27 ± 26.16ms. best: 6787.63ms.<br/>avg: 27.26 ± 0.10ms<br/>min: 25.31 ± 0.06ms<br/>max: 30.04 ± 0.26ms<br/>p99: 29.75 ± 0.23ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.32 ± 0.06 ops/s. best: 17.39ops/s.<br/>total: 14431.33 ± 51.46ms. best: 14374.61ms.<br/>avg: 57.73 ± 0.21ms<br/>min: 55.02 ± 0.22ms<br/>max: 62.60 ± 0.96ms<br/>p99: 61.11 ± 0.62ms |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 485.23 ± 4.71 ops/s. best: 489.71ops/s.<br/>total: 515.30 ± 5.16ms. best: 510.51ms.<br/>avg: 2.06 ± 0.02ms<br/>min: 1.25 ± 0.03ms<br/>max: 2.96 ± 0.37ms<br/>p99: 2.64 ± 0.06ms<br/><br/>250 trips, 5 coordinates<br/>ops: 319.65 ± 1.75 ops/s. best: 321.99ops/s.<br/>total: 782.13 ± 4.29ms. best: 776.42ms.<br/>avg: 3.13 ± 0.02ms<br/>min: 2.13 ± 0.03ms<br/>max: 4.00 ± 0.11ms<br/>p99: 3.86 ± 0.04ms | 250 trips, 3 coordinates<br/>ops: 469.41 ± 14.75 ops/s. best: 490.36ops/s.<br/>total: 533.30 ± 16.55ms. best: 509.83ms.<br/>avg: 2.13 ± 0.07ms<br/>min: 1.24 ± 0.06ms<br/>max: 3.08 ± 0.33ms<br/>p99: 2.77 ± 0.13ms<br/><br/>250 trips, 5 coordinates<br/>ops: 313.72 ± 5.81 ops/s. best: 319.93ops/s.<br/>total: 797.22 ± 14.94ms. best: 781.41ms.<br/>avg: 3.19 ± 0.06ms<br/>min: 2.07 ± 0.05ms<br/>max: 4.10 ± 0.12ms<br/>p99: 3.98 ± 0.11ms |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 157.22 ± 1.26 ops/s. best: 158.93ops/s.<br/>total: 1590.26 ± 13.60ms. best: 1573.06ms.<br/>avg: 6.36 ± 0.05ms<br/>min: 3.76 ± 0.06ms<br/>max: 8.63 ± 0.36ms<br/>p99: 8.29 ± 0.13ms<br/><br/>250 trips, 5 coordinates<br/>ops: 102.72 ± 0.53 ops/s. best: 103.50ops/s.<br/>total: 2433.92 ± 12.78ms. best: 2415.37ms.<br/>avg: 9.74 ± 0.05ms<br/>min: 6.86 ± 0.02ms<br/>max: 11.87 ± 0.17ms<br/>p99: 11.60 ± 0.09ms | 250 trips, 3 coordinates<br/>ops: 166.47 ± 1.22 ops/s. best: 167.90ops/s.<br/>total: 1501.89 ± 11.05ms. best: 1488.97ms.<br/>avg: 6.01 ± 0.04ms<br/>min: 3.65 ± 0.06ms<br/>max: 8.58 ± 0.63ms<br/>p99: 7.82 ± 0.10ms<br/><br/>250 trips, 5 coordinates<br/>ops: 107.92 ± 0.71 ops/s. best: 109.31ops/s.<br/>total: 2316.69 ± 15.25ms. best: 2287.13ms.<br/>avg: 9.27 ± 0.06ms<br/>min: 6.60 ± 0.06ms<br/>max: 11.67 ± 0.44ms<br/>p99: 11.17 ± 0.35ms |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>424.961ms<br/>0.424961ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>506.029ms<br/>0.506029ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>147.895ms<br/>0.147895ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>130.819ms<br/>0.130819ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>425.199ms<br/>0.425199ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>506.928ms<br/>0.506928ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>148.968ms<br/>0.148968ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>131.957ms<br/>0.131957ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>569.228ms<br/>0.569228ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>712.657ms<br/>0.712657ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>288.437ms<br/>0.288437ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>316.532ms<br/>0.316532ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>569.384ms<br/>0.569384ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>711.946ms<br/>0.711946ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>281.626ms<br/>0.281626ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>310.694ms<br/>0.310694ms/req |
| rtree | 1 result:<br/>197.347ms ->  0.0197347 ms/query<br/>10 results:<br/>232.672ms ->  0.0232672 ms/query | 1 result:<br/>197.914ms ->  0.0197914 ms/query<br/>10 results:<br/>233.442ms ->  0.0233442 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
