### PR TITLE
Measure peak RAM in benchmarks

### DIFF
--- a/include/util/meminfo.hpp
+++ b/include/util/meminfo.hpp
@@ -2,6 +2,7 @@
 #define MEMINFO_HPP
 
 #include "util/log.hpp"
+#include <cstddef>
 
 #ifndef _WIN32
 #include <sys/resource.h>
@@ -10,18 +11,27 @@
 namespace osrm::util
 {
 
-inline void DumpMemoryStats()
+inline size_t PeakRAMUsedInBytes()
 {
 #ifndef _WIN32
     rusage usage;
     getrusage(RUSAGE_SELF, &usage);
 #ifdef __linux__
     // Under linux, ru.maxrss is in kb
-    util::Log() << "RAM: peak bytes used: " << usage.ru_maxrss * 1024;
+    return usage.ru_maxrss * 1024;
 #else  // __linux__
     // Under BSD systems (OSX), it's in bytes
-    util::Log() << "RAM: peak bytes used: " << usage.ru_maxrss;
+    return usage.ru_maxrss;
 #endif // __linux__
+#else  // _WIN32
+    return 0;
+#endif // _WIN32
+}
+
+inline void DumpMemoryStats()
+{
+#ifndef _WIN32
+    util::Log() << "RAM: peak bytes used: " << PeakRAMUsedInBytes();
 #else  // _WIN32
     util::Log() << "RAM: peak bytes used: <not implemented on Windows>";
 #endif // _WIN32

--- a/src/benchmarks/bench.cpp
+++ b/src/benchmarks/bench.cpp
@@ -16,8 +16,8 @@
 #include "osrm/osrm.hpp"
 #include "osrm/status.hpp"
 
+#include "util/meminfo.hpp"
 #include <boost/assert.hpp>
-
 #include <boost/optional/optional.hpp>
 #include <cstdlib>
 #include <exception>
@@ -655,10 +655,18 @@ try
         std::cerr << "Unknown benchmark: " << benchmarkToRun << std::endl;
         return EXIT_FAILURE;
     }
+    
+    std::cout 
+        << "Peak RAM: " 
+        << std::setprecision(3) 
+        << static_cast<double>(osrm::util::PeakRAMUsedInBytes()) / static_cast<double>((1024 * 1024)) 
+        << "MB"
+        << std::endl;
+
     return EXIT_SUCCESS;
 }
 catch (const std::exception &e)
 {
-    std::cerr << "Error: " << e.what() << std::endl;
-    return EXIT_FAILURE;
+ std::cerr << "Error: " << e.what() << std::endl;
+ return EXIT_FAILURE;
 }

--- a/src/benchmarks/bench.cpp
+++ b/src/benchmarks/bench.cpp
@@ -655,18 +655,16 @@ try
         std::cerr << "Unknown benchmark: " << benchmarkToRun << std::endl;
         return EXIT_FAILURE;
     }
-    
-    std::cout 
-        << "Peak RAM: " 
-        << std::setprecision(3) 
-        << static_cast<double>(osrm::util::PeakRAMUsedInBytes()) / static_cast<double>((1024 * 1024)) 
-        << "MB"
-        << std::endl;
+
+    std::cout << "Peak RAM: " << std::setprecision(3)
+              << static_cast<double>(osrm::util::PeakRAMUsedInBytes()) /
+                     static_cast<double>((1024 * 1024))
+              << "MB" << std::endl;
 
     return EXIT_SUCCESS;
 }
 catch (const std::exception &e)
 {
- std::cerr << "Error: " << e.what() << std::endl;
- return EXIT_FAILURE;
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
 }


### PR DESCRIPTION
Yet another small improvement in benchmarks...


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 1097.65<br/>plain u32: 1094.37<br/>aliased double: 948.365<br/>plain double: 961.812 | aliased u32: 1093.78<br/>plain u32: 1094.46<br/>aliased double: 955.535<br/>plain double: 961.899 |
| e2e_match_ch | Ops: 43.48 ± 0.12 ops/s. Best: 43.63 ops/s<br/>Total: 3013.14ms ± 8.99ms. Best: 3002.68ms<br/>Min time: 2.06ms ± 0.03ms<br/>Mean time: 23.00ms ± 0.07ms<br/>Median time: 16.98ms ± 0.08ms<br/>95th percentile: 75.98ms ± 0.34ms<br/>99th percentile: 94.06ms ± 0.49ms<br/>Max time: 107.15ms ± 0.94ms | Ops: 43.52 ± 0.10 ops/s. Best: 43.65 ops/s<br/>Total: 3010.14ms ± 7.25ms. Best: 3001.21ms<br/>Min time: 2.04ms ± 0.03ms<br/>Mean time: 22.98ms ± 0.06ms<br/>Median time: 17.04ms ± 0.14ms<br/>95th percentile: 75.05ms ± 0.72ms<br/>99th percentile: 95.61ms ± 0.63ms<br/>Max time: 109.66ms ± 0.71ms |
| e2e_match_mld | Ops: 62.89 ± 0.12 ops/s. Best: 63.03 ops/s<br/>Total: 2082.97ms ± 4.08ms. Best: 2078.40ms<br/>Min time: 1.74ms ± 0.04ms<br/>Mean time: 15.90ms ± 0.03ms<br/>Median time: 8.30ms ± 0.12ms<br/>95th percentile: 53.20ms ± 0.88ms<br/>99th percentile: 62.62ms ± 0.78ms<br/>Max time: 71.17ms ± 2.39ms | Ops: 63.99 ± 0.13 ops/s. Best: 64.19 ops/s<br/>Total: 2047.16ms ± 4.36ms. Best: 2040.74ms<br/>Min time: 1.74ms ± 0.02ms<br/>Mean time: 15.63ms ± 0.03ms<br/>Median time: 8.27ms ± 0.06ms<br/>95th percentile: 52.25ms ± 0.09ms<br/>99th percentile: 60.51ms ± 0.15ms<br/>Max time: 69.33ms ± 0.50ms |
| e2e_nearest_ch | Ops: 871.71 ± 2.88 ops/s. Best: 876.10 ops/s<br/>Total: 1147.14ms ± 3.84ms. Best: 1141.42ms<br/>Min time: 0.98ms ± 0.01ms<br/>Mean time: 1.15ms ± 0.00ms<br/>Median time: 1.06ms ± 0.00ms<br/>95th percentile: 1.59ms ± 0.00ms<br/>99th percentile: 1.64ms ± 0.00ms<br/>Max time: 5.59ms ± 2.53ms | Ops: 873.45 ± 4.49 ops/s. Best: 880.35 ops/s<br/>Total: 1144.95ms ± 6.40ms. Best: 1135.91ms<br/>Min time: 0.97ms ± 0.00ms<br/>Mean time: 1.14ms ± 0.01ms<br/>Median time: 1.06ms ± 0.00ms<br/>95th percentile: 1.58ms ± 0.00ms<br/>99th percentile: 1.64ms ± 0.02ms<br/>Max time: 5.67ms ± 2.63ms |
| e2e_nearest_mld | Ops: 868.98 ± 3.34 ops/s. Best: 875.47 ops/s<br/>Total: 1150.75ms ± 4.56ms. Best: 1142.25ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.15ms ± 0.00ms<br/>Median time: 1.06ms ± 0.00ms<br/>95th percentile: 1.60ms ± 0.00ms<br/>99th percentile: 1.66ms ± 0.04ms<br/>Max time: 6.24ms ± 2.79ms | Ops: 875.78 ± 3.40 ops/s. Best: 880.53 ops/s<br/>Total: 1141.89ms ± 4.42ms. Best: 1135.68ms<br/>Min time: 0.98ms ± 0.00ms<br/>Mean time: 1.14ms ± 0.00ms<br/>Median time: 1.06ms ± 0.00ms<br/>95th percentile: 1.58ms ± 0.00ms<br/>99th percentile: 1.63ms ± 0.01ms<br/>Max time: 5.87ms ± 2.76ms |
| e2e_route_ch | Ops: 371.12 ± 6.66 ops/s. Best: 379.12 ops/s<br/>Total: 2694.31ms ± 51.12ms. Best: 2637.70ms<br/>Min time: 1.20ms ± 0.02ms<br/>Mean time: 2.70ms ± 0.05ms<br/>Median time: 2.70ms ± 0.05ms<br/>95th percentile: 3.55ms ± 0.08ms<br/>99th percentile: 3.94ms ± 0.09ms<br/>Max time: 6.83ms ± 2.65ms | Ops: 375.33 ± 4.95 ops/s. Best: 380.19 ops/s<br/>Total: 2664.39ms ± 38.15ms. Best: 2630.29ms<br/>Min time: 1.18ms ± 0.02ms<br/>Mean time: 2.67ms ± 0.04ms<br/>Median time: 2.68ms ± 0.04ms<br/>95th percentile: 3.50ms ± 0.05ms<br/>99th percentile: 3.90ms ± 0.10ms<br/>Max time: 6.75ms ± 2.63ms |
| e2e_route_mld | Ops: 315.38 ± 0.45 ops/s. Best: 316.17 ops/s<br/>Total: 3170.68ms ± 4.57ms. Best: 3162.89ms<br/>Min time: 1.19ms ± 0.02ms<br/>Mean time: 3.17ms ± 0.00ms<br/>Median time: 3.21ms ± 0.01ms<br/>95th percentile: 4.30ms ± 0.01ms<br/>99th percentile: 4.80ms ± 0.03ms<br/>Max time: 7.49ms ± 2.17ms | Ops: 307.93 ± 1.87 ops/s. Best: 311.51 ops/s<br/>Total: 3248.26ms ± 21.13ms. Best: 3210.13ms<br/>Min time: 1.19ms ± 0.01ms<br/>Mean time: 3.25ms ± 0.02ms<br/>Median time: 3.29ms ± 0.02ms<br/>95th percentile: 4.44ms ± 0.02ms<br/>99th percentile: 4.92ms ± 0.09ms<br/>Max time: 7.45ms ± 2.05ms |
| e2e_table_ch | Ops: 322.81 ± 0.73 ops/s. Best: 323.98 ops/s<br/>Total: 3097.98ms ± 7.06ms. Best: 3086.65ms<br/>Min time: 1.61ms ± 0.02ms<br/>Mean time: 3.10ms ± 0.01ms<br/>Median time: 3.09ms ± 0.02ms<br/>95th percentile: 4.30ms ± 0.01ms<br/>99th percentile: 4.66ms ± 0.07ms<br/>Max time: 8.92ms ± 2.15ms | Ops: 328.45 ± 0.73 ops/s. Best: 329.67 ops/s<br/>Total: 3044.47ms ± 7.11ms. Best: 3033.30ms<br/>Min time: 1.57ms ± 0.01ms<br/>Mean time: 3.04ms ± 0.01ms<br/>Median time: 3.04ms ± 0.01ms<br/>95th percentile: 4.23ms ± 0.02ms<br/>99th percentile: 4.55ms ± 0.06ms<br/>Max time: 8.12ms ± 2.41ms |
| e2e_table_mld | Ops: 110.59 ± 0.41 ops/s. Best: 111.13 ops/s<br/>Total: 9041.40ms ± 33.22ms. Best: 8998.57ms<br/>Min time: 3.63ms ± 0.05ms<br/>Mean time: 9.04ms ± 0.03ms<br/>Median time: 9.00ms ± 0.05ms<br/>95th percentile: 13.86ms ± 0.08ms<br/>99th percentile: 14.49ms ± 0.08ms<br/>Max time: 17.46ms ± 2.50ms | Ops: 110.17 ± 0.24 ops/s. Best: 110.61 ops/s<br/>Total: 9076.93ms ± 20.12ms. Best: 9040.74ms<br/>Min time: 3.67ms ± 0.06ms<br/>Mean time: 9.08ms ± 0.02ms<br/>Median time: 9.04ms ± 0.07ms<br/>95th percentile: 13.89ms ± 0.03ms<br/>99th percentile: 14.60ms ± 0.08ms<br/>Max time: 17.09ms ± 2.40ms |
| e2e_trip_ch | Ops: 102.60 ± 0.55 ops/s. Best: 103.20 ops/s<br/>Total: 9746.91ms ± 52.21ms. Best: 9689.97ms<br/>Min time: 1.45ms ± 0.06ms<br/>Mean time: 9.75ms ± 0.05ms<br/>Median time: 9.16ms ± 0.05ms<br/>95th percentile: 17.71ms ± 0.12ms<br/>99th percentile: 19.55ms ± 0.09ms<br/>Max time: 21.42ms ± 0.20ms | Ops: 101.72 ± 0.81 ops/s. Best: 103.35 ops/s<br/>Total: 9835.47ms ± 73.67ms. Best: 9675.57ms<br/>Min time: 1.44ms ± 0.08ms<br/>Mean time: 9.83ms ± 0.07ms<br/>Median time: 9.27ms ± 0.07ms<br/>95th percentile: 17.89ms ± 0.10ms<br/>99th percentile: 19.83ms ± 0.17ms<br/>Max time: 21.63ms ± 0.35ms |
| e2e_trip_mld | Ops: 59.49 ± 0.56 ops/s. Best: 60.21 ops/s<br/>Total: 16812.74ms ± 159.06ms. Best: 16609.88ms<br/>Min time: 1.58ms ± 0.20ms<br/>Mean time: 16.81ms ± 0.16ms<br/>Median time: 16.28ms ± 0.16ms<br/>95th percentile: 27.60ms ± 0.20ms<br/>99th percentile: 29.82ms ± 0.27ms<br/>Max time: 33.93ms ± 2.85ms | Ops: 58.20 ± 0.29 ops/s. Best: 58.73 ops/s<br/>Total: 17184.34ms ± 85.97ms. Best: 17026.74ms<br/>Min time: 1.68ms ± 0.21ms<br/>Mean time: 17.18ms ± 0.09ms<br/>Median time: 16.67ms ± 0.07ms<br/>95th percentile: 28.27ms ± 0.13ms<br/>99th percentile: 30.58ms ± 0.32ms<br/>Max time: 33.32ms ± 1.07ms |
| json-render | String: 5.68798ms<br/>Stringstream: 9.07002ms<br/>Vector: 6.59109ms | String: 5.63621ms<br/>Stringstream: 9.16011ms<br/>Vector: 6.57013ms |
| match_ch | Default radius: <br/>4.60057ms/req at 82 coordinate<br/>0.0561045ms/coordinate<br/>Radius 10m: <br/>16.1239ms/req at 82 coordinate<br/>0.196633ms/coordinate | Default radius: <br/>4.62109ms/req at 82 coordinate<br/>0.0563547ms/coordinate<br/>Radius 10m: <br/>16.1346ms/req at 82 coordinate<br/>0.196763ms/coordinate |
| match_mld | Default radius: <br/>3.05491ms/req at 82 coordinate<br/>0.0372549ms/coordinate<br/>Radius 10m: <br/>11.0042ms/req at 82 coordinate<br/>0.134198ms/coordinate | Default radius: <br/>2.97406ms/req at 82 coordinate<br/>0.036269ms/coordinate<br/>Radius 10m: <br/>11.0627ms/req at 82 coordinate<br/>0.13491ms/coordinate |
| osrm_contract | Time: 96.98s Peak RAM: 201.95MB | Time: 97.11s Peak RAM: 201.95MB |
| osrm_customize | Time: 1.29s Peak RAM: 117.67MB | Time: 1.31s Peak RAM: 117.69MB |
| osrm_extract | Time: 11.76s Peak RAM: 424.48MB | Time: 11.70s Peak RAM: 431.03MB |
| osrm_partition | Time: 2.14s Peak RAM: 144.95MB | Time: 2.08s Peak RAM: 146.87MB |
| packedvector | random write:<br/>std::vector 9837.63 ms<br/>util::packed_vector 73697 ms<br/>slowdown: 7.49134<br/>random read:<br/>std::vector 8457.6 ms<br/>util::packed_vector 30287.8 ms<br/>slowdown: 3.58113 | random write:<br/>std::vector 9828.94 ms<br/>util::packed_vector 73661.4 ms<br/>slowdown: 7.49434<br/>random read:<br/>std::vector 8492.83 ms<br/>util::packed_vector 30287 ms<br/>slowdown: 3.56618 |
| random_match_ch | 500 matches, default radius<br/>ops: 200.36 ± 0.60 ops/s. best: 200.94ops/s.<br/>total: 284.49 ± 0.86ms. best: 283.66ms.<br/>avg: 4.99 ± 0.02ms<br/>min: 0.14 ± 0.01ms<br/>max: 26.32 ± 0.31ms<br/>p99: 26.32 ± 0.31ms<br/><br/>500 matches, radius=10<br/>ops: 59.44 ± 0.65 ops/s. best: 60.26ops/s.<br/>total: 1076.79 ± 11.18ms. best: 1062.10ms.<br/>avg: 16.82 ± 0.17ms<br/>min: 0.15 ± 0.00ms<br/>max: 248.78 ± 6.81ms<br/>p99: 248.78 ± 6.81ms<br/><br/>500 matches, radius=20<br/>ops: 14.37 ± 0.02 ops/s. best: 14.40ops/s.<br/>total: 4523.68 ± 7.18ms. best: 4512.65ms.<br/>avg: 69.60 ± 0.11ms<br/>min: 0.31 ± 0.00ms<br/>max: 1228.31 ± 2.60ms<br/>p99: 1228.31 ± 2.60ms | 500 matches, default radius<br/>ops: 201.56 ± 0.84 ops/s. best: 202.32ops/s.<br/>total: 282.80 ± 1.18ms. best: 281.74ms.<br/>avg: 4.96 ± 0.02ms<br/>min: 0.13 ± 0.01ms<br/>max: 26.21 ± 0.11ms<br/>p99: 26.21 ± 0.11ms<br/><br/>500 matches, radius=10<br/>ops: 59.01 ± 0.10 ops/s. best: 59.09ops/s.<br/>total: 1084.64 ± 1.75ms. best: 1083.14ms.<br/>avg: 16.95 ± 0.03ms<br/>min: 0.15 ± 0.00ms<br/>max: 255.38 ± 1.22ms<br/>p99: 255.38 ± 1.22ms<br/><br/>500 matches, radius=20<br/>ops: 14.14 ± 0.03 ops/s. best: 14.18ops/s.<br/>total: 4596.29 ± 9.02ms. best: 4583.58ms.<br/>avg: 70.71 ± 0.14ms<br/>min: 0.30 ± 0.01ms<br/>max: 1288.74 ± 6.46ms<br/>p99: 1288.74 ± 6.46ms<br/><br/>Peak RAM: 56.293MB |
| random_match_mld | 500 matches, default radius<br/>ops: 301.42 ± 2.30 ops/s. best: 303.71ops/s.<br/>total: 189.12 ± 1.45ms. best: 187.68ms.<br/>avg: 3.32 ± 0.03ms<br/>min: 0.12 ± 0.01ms<br/>max: 19.16 ± 0.25ms<br/>p99: 19.16 ± 0.25ms<br/><br/>500 matches, radius=10<br/>ops: 106.26 ± 0.59 ops/s. best: 107.02ops/s.<br/>total: 602.34 ± 3.33ms. best: 598.02ms.<br/>avg: 9.41 ± 0.05ms<br/>min: 0.14 ± 0.00ms<br/>max: 111.75 ± 0.55ms<br/>p99: 111.75 ± 0.55ms<br/><br/>500 matches, radius=20<br/>ops: 21.56 ± 0.08 ops/s. best: 21.66ops/s.<br/>total: 3015.48 ± 10.99ms. best: 3000.35ms.<br/>avg: 46.39 ± 0.17ms<br/>min: 0.20 ± 0.02ms<br/>max: 584.77 ± 1.96ms<br/>p99: 584.77 ± 1.96ms | 500 matches, default radius<br/>ops: 292.16 ± 8.43 ops/s. best: 302.49ops/s.<br/>total: 195.31 ± 5.63ms. best: 188.44ms.<br/>avg: 3.43 ± 0.10ms<br/>min: 0.12 ± 0.01ms<br/>max: 21.80 ± 3.03ms<br/>p99: 21.80 ± 3.03ms<br/><br/>500 matches, radius=10<br/>ops: 106.25 ± 0.27 ops/s. best: 106.70ops/s.<br/>total: 602.36 ± 1.52ms. best: 599.79ms.<br/>avg: 9.41 ± 0.02ms<br/>min: 0.14 ± 0.00ms<br/>max: 111.80 ± 0.43ms<br/>p99: 111.80 ± 0.43ms<br/><br/>500 matches, radius=20<br/>ops: 21.62 ± 0.05 ops/s. best: 21.68ops/s.<br/>total: 3006.49 ± 7.35ms. best: 2998.32ms.<br/>avg: 46.25 ± 0.11ms<br/>min: 0.19 ± 0.01ms<br/>max: 585.31 ± 1.24ms<br/>p99: 585.31 ± 1.24ms<br/><br/>Peak RAM: 51.922MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 23266.65 ± 56.18 ops/s. best: 23316.47ops/s.<br/>total: 429.80 ± 1.04ms. best: 428.88ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.06ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17942.31 ± 18.47 ops/s. best: 17960.76ops/s.<br/>total: 557.34 ± 0.57ms. best: 556.77ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.18 ± 0.04ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14404.74 ± 88.22 ops/s. best: 14488.12ops/s.<br/>total: 694.25 ± 4.30ms. best: 690.22ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.18 ± 0.02ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 23189.72 ± 106.85 ops/s. best: 23338.91ops/s.<br/>total: 431.24 ± 1.99ms. best: 428.47ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.05ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18031.59 ± 12.63 ops/s. best: 18061.90ops/s.<br/>total: 554.58 ± 0.39ms. best: 553.65ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14588.62 ± 10.16 ops/s. best: 14612.02ops/s.<br/>total: 685.47 ± 0.48ms. best: 684.37ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.21 ± 0.06ms<br/>p99: 0.13 ± 0.00ms<br/><br/>Peak RAM: 37.668MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 22963.51 ± 62.62 ops/s. best: 23050.71ops/s.<br/>total: 435.48 ± 1.19ms. best: 433.83ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.06ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 17830.10 ± 35.14 ops/s. best: 17874.20ops/s.<br/>total: 560.85 ± 1.15ms. best: 559.47ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14399.39 ± 7.04 ops/s. best: 14407.54ops/s.<br/>total: 694.47 ± 0.35ms. best: 694.08ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.14 ± 0.00ms | 10000 nearest, number_of_results=1<br/>ops: 23097.96 ± 88.26 ops/s. best: 23212.76ops/s.<br/>total: 432.95 ± 1.66ms. best: 430.80ms.<br/>avg: 0.04 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.17 ± 0.05ms<br/>p99: 0.11 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 18018.53 ± 36.92 ops/s. best: 18053.17ops/s.<br/>total: 554.99 ± 1.14ms. best: 553.92ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 14615.59 ± 6.82 ops/s. best: 14629.13ops/s.<br/>total: 684.20 ± 0.32ms. best: 683.57ms.<br/>avg: 0.07 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>Peak RAM: 35.043MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 494.88 ± 4.87 ops/s. best: 506.00ops/s.<br/>total: 1988.63 ± 19.32ms. best: 1944.66ms.<br/>avg: 2.02 ± 0.02ms<br/>min: 0.30 ± 0.00ms<br/>max: 4.08 ± 0.50ms<br/>p99: 3.01 ± 0.10ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 565.70 ± 4.54 ops/s. best: 571.92ops/s.<br/>total: 1767.88 ± 13.94ms. best: 1748.49ms.<br/>avg: 1.77 ± 0.01ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.45 ± 0.12ms<br/>p99: 3.89 ± 0.05ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 980.24 ± 11.45 ops/s. best: 997.80ops/s.<br/>total: 1004.01 ± 11.70ms. best: 986.17ms.<br/>avg: 1.02 ± 0.01ms<br/>min: 0.26 ± 0.00ms<br/>max: 1.76 ± 0.06ms<br/>p99: 1.51 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1035.07 ± 11.03 ops/s. best: 1059.12ops/s.<br/>total: 966.26 ± 10.18ms. best: 944.18ms.<br/>avg: 0.97 ± 0.01ms<br/>min: 0.04 ± 0.00ms<br/>max: 2.96 ± 0.04ms<br/>p99: 2.31 ± 0.11ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 546.47 ± 1.46 ops/s. best: 548.07ops/s.<br/>total: 1800.67 ± 4.98ms. best: 1795.41ms.<br/>avg: 1.83 ± 0.01ms<br/>min: 0.30 ± 0.00ms<br/>max: 3.12 ± 0.32ms<br/>p99: 2.61 ± 0.04ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 621.89 ± 0.55 ops/s. best: 622.52ops/s.<br/>total: 1608.02 ± 1.42ms. best: 1606.37ms.<br/>avg: 1.61 ± 0.00ms<br/>min: 0.06 ± 0.01ms<br/>max: 4.97 ± 0.03ms<br/>p99: 3.57 ± 0.02ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 1071.36 ± 1.39 ops/s. best: 1073.06ops/s.<br/>total: 918.46 ± 1.21ms. best: 917.00ms.<br/>avg: 0.93 ± 0.00ms<br/>min: 0.26 ± 0.00ms<br/>max: 1.53 ± 0.01ms<br/>p99: 1.31 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 1162.73 ± 1.09 ops/s. best: 1164.93ops/s.<br/>total: 860.04 ± 0.82ms. best: 858.42ms.<br/>avg: 0.86 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 4.11 ± 0.02ms<br/>p99: 2.12 ± 0.01ms<br/><br/>Peak RAM: 99.012MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 243.56 ± 2.08 ops/s. best: 246.55ops/s.<br/>total: 4040.48 ± 34.70ms. best: 3991.14ms.<br/>avg: 4.11 ± 0.04ms<br/>min: 0.30 ± 0.00ms<br/>max: 8.92 ± 0.13ms<br/>p99: 6.92 ± 0.05ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 233.33 ± 2.22 ops/s. best: 236.53ops/s.<br/>total: 4286.14 ± 40.96ms. best: 4227.82ms.<br/>avg: 4.29 ± 0.04ms<br/>min: 0.05 ± 0.00ms<br/>max: 10.97 ± 1.46ms<br/>p99: 8.91 ± 0.19ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 325.80 ± 0.60 ops/s. best: 326.92ops/s.<br/>total: 3020.31 ± 5.54ms. best: 3009.88ms.<br/>avg: 3.07 ± 0.01ms<br/>min: 0.28 ± 0.00ms<br/>max: 7.30 ± 0.06ms<br/>p99: 5.30 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 296.92 ± 7.40 ops/s. best: 309.08ops/s.<br/>total: 3370.56 ± 83.67ms. best: 3235.40ms.<br/>avg: 3.37 ± 0.08ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.37 ± 0.18ms<br/>p99: 6.71 ± 0.15ms | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 260.62 ± 0.74 ops/s. best: 261.38ops/s.<br/>total: 3775.59 ± 11.04ms. best: 3764.57ms.<br/>avg: 3.84 ± 0.01ms<br/>min: 0.29 ± 0.00ms<br/>max: 8.44 ± 0.05ms<br/>p99: 6.43 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 251.89 ± 0.36 ops/s. best: 252.36ops/s.<br/>total: 3970.06 ± 5.83ms. best: 3962.61ms.<br/>avg: 3.97 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 9.19 ± 0.29ms<br/>p99: 8.22 ± 0.05ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 338.65 ± 3.02 ops/s. best: 341.20ops/s.<br/>total: 2906.03 ± 26.22ms. best: 2883.92ms.<br/>avg: 2.95 ± 0.03ms<br/>min: 0.27 ± 0.00ms<br/>max: 7.15 ± 0.08ms<br/>p99: 5.14 ± 0.09ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 305.02 ± 5.14 ops/s. best: 310.05ops/s.<br/>total: 3279.85 ± 56.64ms. best: 3225.26ms.<br/>avg: 3.28 ± 0.06ms<br/>min: 0.04 ± 0.00ms<br/>max: 7.18 ± 0.26ms<br/>p99: 6.53 ± 0.15ms<br/><br/>Peak RAM: 86.980MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1434.20 ± 12.28 ops/s. best: 1445.95ops/s.<br/>total: 174.33 ± 1.51ms. best: 172.90ms.<br/>avg: 0.70 ± 0.01ms<br/>min: 0.46 ± 0.01ms<br/>max: 1.05 ± 0.18ms<br/>p99: 0.89 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 170.58 ± 0.23 ops/s. best: 170.80ops/s.<br/>total: 1465.57 ± 1.94ms. best: 1463.71ms.<br/>avg: 5.86 ± 0.01ms<br/>min: 5.09 ± 0.01ms<br/>max: 6.48 ± 0.03ms<br/>p99: 6.39 ± 0.04ms<br/><br/>250 tables, 50 coordinates<br/>ops: 83.79 ± 0.18 ops/s. best: 84.06ops/s.<br/>total: 2983.75 ± 6.56ms. best: 2974.16ms.<br/>avg: 11.93 ± 0.03ms<br/>min: 11.04 ± 0.02ms<br/>max: 13.17 ± 0.08ms<br/>p99: 12.82 ± 0.07ms | 250 tables, 3 coordinates<br/>ops: 1465.61 ± 12.52 ops/s. best: 1477.55ops/s.<br/>total: 170.59 ± 1.47ms. best: 169.20ms.<br/>avg: 0.68 ± 0.01ms<br/>min: 0.45 ± 0.01ms<br/>max: 1.03 ± 0.23ms<br/>p99: 0.88 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 175.66 ± 0.66 ops/s. best: 176.20ops/s.<br/>total: 1423.22 ± 5.41ms. best: 1418.84ms.<br/>avg: 5.69 ± 0.02ms<br/>min: 4.79 ± 0.01ms<br/>max: 7.03 ± 1.04ms<br/>p99: 6.70 ± 0.71ms<br/><br/>250 tables, 50 coordinates<br/>ops: 86.97 ± 0.04 ops/s. best: 87.02ops/s.<br/>total: 2874.53 ± 1.35ms. best: 2872.85ms.<br/>avg: 11.50 ± 0.01ms<br/>min: 10.37 ± 0.02ms<br/>max: 12.94 ± 0.30ms<br/>p99: 12.50 ± 0.10ms<br/><br/>Peak RAM: 64.168MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 331.58 ± 1.48 ops/s. best: 333.31ops/s.<br/>total: 753.98 ± 3.39ms. best: 750.05ms.<br/>avg: 3.02 ± 0.01ms<br/>min: 2.49 ± 0.01ms<br/>max: 3.91 ± 0.25ms<br/>p99: 3.68 ± 0.06ms<br/><br/>250 tables, 25 coordinates<br/>ops: 36.67 ± 0.05 ops/s. best: 36.79ops/s.<br/>total: 6817.77 ± 8.92ms. best: 6795.39ms.<br/>avg: 27.27 ± 0.04ms<br/>min: 25.48 ± 0.13ms<br/>max: 33.96 ± 4.95ms<br/>p99: 29.60 ± 0.26ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.41 ± 0.07 ops/s. best: 17.51ops/s.<br/>total: 14361.21 ± 55.31ms. best: 14281.27ms.<br/>avg: 57.44 ± 0.22ms<br/>min: 54.75 ± 0.20ms<br/>max: 66.77 ± 6.83ms<br/>p99: 60.34 ± 0.53ms | 250 tables, 3 coordinates<br/>ops: 336.92 ± 1.07 ops/s. best: 337.81ops/s.<br/>total: 742.04 ± 2.37ms. best: 740.06ms.<br/>avg: 2.97 ± 0.01ms<br/>min: 2.48 ± 0.01ms<br/>max: 3.85 ± 0.21ms<br/>p99: 3.52 ± 0.05ms<br/><br/>250 tables, 25 coordinates<br/>ops: 37.44 ± 0.04 ops/s. best: 37.49ops/s.<br/>total: 6678.16 ± 6.84ms. best: 6668.29ms.<br/>avg: 26.71 ± 0.03ms<br/>min: 25.15 ± 0.05ms<br/>max: 31.48 ± 2.29ms<br/>p99: 28.69 ± 0.13ms<br/><br/>250 tables, 50 coordinates<br/>ops: 17.68 ± 0.07 ops/s. best: 17.76ops/s.<br/>total: 14137.05 ± 54.04ms. best: 14079.41ms.<br/>avg: 56.55 ± 0.22ms<br/>min: 54.24 ± 0.13ms<br/>max: 66.02 ± 6.00ms<br/>p99: 59.47 ± 0.82ms<br/><br/>Peak RAM: 66.211MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 506.28 ± 4.35 ops/s. best: 511.80ops/s.<br/>total: 493.85 ± 4.25ms. best: 488.47ms.<br/>avg: 1.98 ± 0.02ms<br/>min: 1.10 ± 0.03ms<br/>max: 2.72 ± 0.34ms<br/>p99: 2.51 ± 0.06ms<br/><br/>250 trips, 5 coordinates<br/>ops: 332.27 ± 2.86 ops/s. best: 336.57ops/s.<br/>total: 752.47 ± 6.39ms. best: 742.78ms.<br/>avg: 3.01 ± 0.03ms<br/>min: 1.99 ± 0.05ms<br/>max: 3.80 ± 0.13ms<br/>p99: 3.68 ± 0.07ms | 250 trips, 3 coordinates<br/>ops: 519.33 ± 3.48 ops/s. best: 522.69ops/s.<br/>total: 481.42 ± 3.26ms. best: 478.30ms.<br/>avg: 1.93 ± 0.01ms<br/>min: 1.13 ± 0.03ms<br/>max: 2.66 ± 0.40ms<br/>p99: 2.41 ± 0.11ms<br/><br/>250 trips, 5 coordinates<br/>ops: 345.97 ± 0.62 ops/s. best: 346.71ops/s.<br/>total: 722.61 ± 1.31ms. best: 721.07ms.<br/>avg: 2.89 ± 0.01ms<br/>min: 1.97 ± 0.00ms<br/>max: 3.54 ± 0.06ms<br/>p99: 3.46 ± 0.01ms<br/><br/>Peak RAM: 81.898MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 163.74 ± 0.60 ops/s. best: 164.49ops/s.<br/>total: 1526.80 ± 5.46ms. best: 1519.89ms.<br/>avg: 6.11 ± 0.02ms<br/>min: 3.62 ± 0.05ms<br/>max: 8.35 ± 0.37ms<br/>p99: 7.94 ± 0.11ms<br/><br/>250 trips, 5 coordinates<br/>ops: 107.01 ± 0.97 ops/s. best: 108.87ops/s.<br/>total: 2336.49 ± 20.77ms. best: 2296.37ms.<br/>avg: 9.35 ± 0.08ms<br/>min: 6.65 ± 0.05ms<br/>max: 11.72 ± 0.37ms<br/>p99: 11.28 ± 0.22ms | 250 trips, 3 coordinates<br/>ops: 174.56 ± 0.90 ops/s. best: 175.80ops/s.<br/>total: 1432.21 ± 7.38ms. best: 1422.05ms.<br/>avg: 5.73 ± 0.03ms<br/>min: 3.48 ± 0.02ms<br/>max: 7.66 ± 0.58ms<br/>p99: 7.18 ± 0.16ms<br/><br/>250 trips, 5 coordinates<br/>ops: 112.28 ± 1.27 ops/s. best: 114.16ops/s.<br/>total: 2227.01 ± 25.12ms. best: 2189.99ms.<br/>avg: 8.91 ± 0.10ms<br/>min: 6.52 ± 0.02ms<br/>max: 11.98 ± 1.49ms<br/>p99: 10.67 ± 0.36ms<br/><br/>Peak RAM: 76.148MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>421.736ms<br/>0.421736ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>510.922ms<br/>0.510922ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>147.728ms<br/>0.147728ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>130.479ms<br/>0.130479ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>419.19ms<br/>0.41919ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>504.588ms<br/>0.504588ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>147.185ms<br/>0.147185ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>130.711ms<br/>0.130711ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>569.763ms<br/>0.569763ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>712.965ms<br/>0.712965ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>292.168ms<br/>0.292168ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>317.38ms<br/>0.31738ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>568.564ms<br/>0.568564ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>712.704ms<br/>0.712704ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>283.721ms<br/>0.283721ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>315.718ms<br/>0.315718ms/req |
| rtree | 1 result:<br/>192.242ms ->  0.0192242 ms/query<br/>10 results:<br/>227.739ms ->  0.0227739 ms/query | 1 result:<br/>194.139ms ->  0.0194139 ms/query<br/>10 results:<br/>229.201ms ->  0.0229201 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
