### PR TITLE
Experiments with Node bindings optimisation

### DIFF
--- a/include/nodejs/json_v8_renderer.hpp
+++ b/include/nodejs/json_v8_renderer.hpp
@@ -29,7 +29,8 @@ struct V8Renderer
         for (const auto &keyValue : object.values)
         {
             Napi::Value child;
-            std::visit(V8Renderer(env, child), keyValue.second);
+
+            visit(V8Renderer(env, child), keyValue.second);
             obj.Set(keyValue.first, child);
         }
         out = obj;
@@ -41,7 +42,7 @@ struct V8Renderer
         for (auto i = 0u; i < array.values.size(); ++i)
         {
             Napi::Value child;
-            std::visit(V8Renderer(env, child), array.values[i]);
+            visit(V8Renderer(env, child), array.values[i]);
             a.Set(i, child);
         }
         out = a;
@@ -52,6 +53,35 @@ struct V8Renderer
     void operator()(const osrm::json::False &) const { out = Napi::Boolean::New(env, false); }
 
     void operator()(const osrm::json::Null &) const { out = env.Null(); }
+
+  private:
+    void visit(const V8Renderer &renderer, const osrm::json::Value &value) const
+    {
+        switch (value.index())
+        {
+        case 0:
+            renderer(std::get<osrm::json::String>(value));
+            break;
+        case 1:
+            renderer(std::get<osrm::json::Number>(value));
+            break;
+        case 2:
+            renderer(std::get<osrm::json::Object>(value));
+            break;
+        case 3:
+            renderer(std::get<osrm::json::Array>(value));
+            break;
+        case 4:
+            renderer(std::get<osrm::json::True>(value));
+            break;
+        case 5:
+            renderer(std::get<osrm::json::False>(value));
+            break;
+        case 6:
+            renderer(std::get<osrm::json::Null>(value));
+            break;
+        }
+    }
 
   private:
     const Napi::Env &env;

--- a/include/nodejs/json_v8_renderer.hpp
+++ b/include/nodejs/json_v8_renderer.hpp
@@ -28,7 +28,7 @@ struct V8Renderer
         Napi::Object obj = Napi::Object::New(env);
         for (const auto &keyValue : object.values)
         {
-            obj.Set(keyValue.first, visit(V8Renderer(env), keyValue.second));
+            obj.Set(keyValue.first, visit(*this, keyValue.second));
         }
         return obj;
     }
@@ -38,7 +38,7 @@ struct V8Renderer
         Napi::Array a = Napi::Array::New(env, array.values.size());
         for (auto i = 0u; i < array.values.size(); ++i)
         {
-            a.Set(i, visit(V8Renderer(env), array.values[i]));
+            a.Set(i, visit(*this, array.values[i]));
         }
         return a;
     }


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?




<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 11079.8<br/>plain u32: 10976.1<br/>aliased double: 15117.7<br/>plain double: 15073.6 | aliased u32: 11100.3<br/>plain u32: 10927.9<br/>aliased double: 15056<br/>plain double: 15064.8 |
| e2e_match_ch | Ops: 25.67 ± 0.02 ops/s. Best: 25.70 ops/s<br/>Total: 5102.99ms ± 3.70ms. Best: 5097.81ms<br/>Min time: 3.07ms ± 0.05ms<br/>Mean time: 38.96ms ± 0.03ms<br/>Median time: 29.05ms ± 0.13ms<br/>95th percentile: 133.82ms ± 0.14ms<br/>99th percentile: 163.28ms ± 0.36ms<br/>Max time: 173.94ms ± 0.95ms | Ops: 25.38 ± 0.01 ops/s. Best: 25.41 ops/s<br/>Total: 5161.05ms ± 2.99ms. Best: 5156.40ms<br/>Min time: 3.03ms ± 0.06ms<br/>Mean time: 39.40ms ± 0.02ms<br/>Median time: 29.36ms ± 0.16ms<br/>95th percentile: 135.54ms ± 0.40ms<br/>99th percentile: 165.62ms ± 0.34ms<br/>Max time: 177.64ms ± 1.07ms |
| e2e_match_mld | Ops: 43.75 ± 0.03 ops/s. Best: 43.80 ops/s<br/>Total: 2994.51ms ± 2.26ms. Best: 2990.80ms<br/>Min time: 2.58ms ± 0.03ms<br/>Mean time: 22.86ms ± 0.02ms<br/>Median time: 12.02ms ± 0.10ms<br/>95th percentile: 74.99ms ± 0.23ms<br/>99th percentile: 86.80ms ± 0.23ms<br/>Max time: 99.90ms ± 0.36ms | Ops: 43.55 ± 0.03 ops/s. Best: 43.60 ops/s<br/>Total: 3008.24ms ± 2.24ms. Best: 3004.69ms<br/>Min time: 2.56ms ± 0.04ms<br/>Mean time: 22.96ms ± 0.02ms<br/>Median time: 11.99ms ± 0.08ms<br/>95th percentile: 75.40ms ± 0.16ms<br/>99th percentile: 87.56ms ± 0.34ms<br/>Max time: 100.66ms ± 0.31ms |
| e2e_nearest_ch | Ops: 636.00 ± 3.77 ops/s. Best: 641.59 ops/s<br/>Total: 1572.32ms ± 9.75ms. Best: 1558.62ms<br/>Min time: 1.27ms ± 0.00ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.54ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.30ms ± 7.34ms | Ops: 637.60 ± 7.08 ops/s. Best: 649.88 ops/s<br/>Total: 1568.77ms ± 18.31ms. Best: 1538.74ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.02ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.38ms ± 7.40ms |
| e2e_nearest_mld | Ops: 638.37 ± 3.77 ops/s. Best: 643.70 ops/s<br/>Total: 1566.28ms ± 9.58ms. Best: 1553.51ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.00ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.34ms ± 7.40ms | Ops: 638.49 ± 3.43 ops/s. Best: 643.17 ops/s<br/>Total: 1566.00ms ± 8.68ms. Best: 1554.80ms<br/>Min time: 1.26ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.52ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.02ms<br/>Max time: 9.44ms ± 7.49ms |
| e2e_route_ch | Ops: 217.34 ± 0.46 ops/s. Best: 218.31 ops/s<br/>Total: 4601.24ms ± 10.11ms. Best: 4580.60ms<br/>Min time: 1.89ms ± 0.03ms<br/>Mean time: 4.60ms ± 0.01ms<br/>Median time: 4.69ms ± 0.01ms<br/>95th percentile: 6.07ms ± 0.02ms<br/>99th percentile: 6.58ms ± 0.03ms<br/>Max time: 13.24ms ± 6.37ms | Ops: 217.50 ± 0.36 ops/s. Best: 218.13 ops/s<br/>Total: 4597.58ms ± 7.68ms. Best: 4584.34ms<br/>Min time: 1.84ms ± 0.05ms<br/>Mean time: 4.60ms ± 0.01ms<br/>Median time: 4.68ms ± 0.02ms<br/>95th percentile: 6.05ms ± 0.02ms<br/>99th percentile: 6.60ms ± 0.03ms<br/>Max time: 13.35ms ± 6.38ms |
| e2e_route_mld | Ops: 179.00 ± 0.35 ops/s. Best: 179.70 ops/s<br/>Total: 5586.59ms ± 10.76ms. Best: 5564.83ms<br/>Min time: 1.83ms ± 0.03ms<br/>Mean time: 5.59ms ± 0.01ms<br/>Median time: 5.70ms ± 0.02ms<br/>95th percentile: 7.63ms ± 0.02ms<br/>99th percentile: 8.16ms ± 0.05ms<br/>Max time: 14.68ms ± 5.92ms | Ops: 179.32 ± 0.39 ops/s. Best: 179.95 ops/s<br/>Total: 5576.75ms ± 11.99ms. Best: 5557.08ms<br/>Min time: 1.84ms ± 0.07ms<br/>Mean time: 5.58ms ± 0.01ms<br/>Median time: 5.69ms ± 0.02ms<br/>95th percentile: 7.60ms ± 0.02ms<br/>99th percentile: 8.14ms ± 0.07ms<br/>Max time: 14.69ms ± 5.93ms |
| e2e_table_ch | Ops: 215.99 ± 0.46 ops/s. Best: 216.69 ops/s<br/>Total: 4629.63ms ± 10.46ms. Best: 4614.90ms<br/>Min time: 2.51ms ± 0.04ms<br/>Mean time: 4.63ms ± 0.01ms<br/>Median time: 4.62ms ± 0.01ms<br/>95th percentile: 6.28ms ± 0.01ms<br/>99th percentile: 6.62ms ± 0.02ms<br/>Max time: 13.71ms ± 7.01ms | Ops: 216.62 ± 0.45 ops/s. Best: 217.26 ops/s<br/>Total: 4615.95ms ± 9.07ms. Best: 4602.70ms<br/>Min time: 2.51ms ± 0.04ms<br/>Mean time: 4.62ms ± 0.01ms<br/>Median time: 4.62ms ± 0.01ms<br/>95th percentile: 6.25ms ± 0.03ms<br/>99th percentile: 6.61ms ± 0.02ms<br/>Max time: 13.72ms ± 7.00ms |
| e2e_table_mld | Ops: 70.53 ± 0.05 ops/s. Best: 70.61 ops/s<br/>Total: 14177.58ms ± 9.80ms. Best: 14163.24ms<br/>Min time: 5.94ms ± 0.04ms<br/>Mean time: 14.18ms ± 0.01ms<br/>Median time: 14.11ms ± 0.02ms<br/>95th percentile: 21.60ms ± 0.03ms<br/>99th percentile: 22.77ms ± 0.09ms<br/>Max time: 29.19ms ± 5.65ms | Ops: 70.81 ± 0.07 ops/s. Best: 70.91 ops/s<br/>Total: 14121.08ms ± 14.57ms. Best: 14101.47ms<br/>Min time: 5.91ms ± 0.03ms<br/>Mean time: 14.12ms ± 0.01ms<br/>Median time: 14.07ms ± 0.03ms<br/>95th percentile: 21.48ms ± 0.07ms<br/>99th percentile: 22.65ms ± 0.08ms<br/>Max time: 29.01ms ± 5.73ms |
| e2e_trip_ch | Ops: 62.79 ± 0.03 ops/s. Best: 62.83 ops/s<br/>Total: 15924.93ms ± 7.45ms. Best: 15915.06ms<br/>Min time: 2.36ms ± 0.16ms<br/>Mean time: 15.93ms ± 0.01ms<br/>Median time: 15.16ms ± 0.03ms<br/>95th percentile: 28.11ms ± 0.02ms<br/>99th percentile: 30.30ms ± 0.06ms<br/>Max time: 32.53ms ± 1.42ms | Ops: 62.83 ± 0.03 ops/s. Best: 62.88 ops/s<br/>Total: 15916.10ms ± 8.98ms. Best: 15903.73ms<br/>Min time: 2.40ms ± 0.12ms<br/>Mean time: 15.92ms ± 0.01ms<br/>Median time: 15.14ms ± 0.03ms<br/>95th percentile: 28.09ms ± 0.02ms<br/>99th percentile: 30.25ms ± 0.11ms<br/>Max time: 32.55ms ± 1.41ms |
| e2e_trip_mld | Ops: 37.05 ± 0.02 ops/s. Best: 37.08 ops/s<br/>Total: 26992.15ms ± 13.01ms. Best: 26971.23ms<br/>Min time: 2.43ms ± 0.17ms<br/>Mean time: 26.99ms ± 0.01ms<br/>Median time: 26.17ms ± 0.08ms<br/>95th percentile: 43.97ms ± 0.06ms<br/>99th percentile: 46.64ms ± 0.06ms<br/>Max time: 48.97ms ± 0.08ms | Ops: 37.13 ± 0.00 ops/s. Best: 37.13 ops/s<br/>Total: 26934.60ms ± 3.08ms. Best: 26930.19ms<br/>Min time: 2.33ms ± 0.15ms<br/>Mean time: 26.93ms ± 0.00ms<br/>Median time: 26.10ms ± 0.07ms<br/>95th percentile: 43.87ms ± 0.04ms<br/>99th percentile: 46.50ms ± 0.12ms<br/>Max time: 48.83ms ± 0.18ms |
| json-render | String: 9.02882ms<br/>Stringstream: 14.6316ms<br/>Vector: 9.4471ms | String: 8.86488ms<br/>Stringstream: 14.731ms<br/>Vector: 9.45713ms |
| match_ch | Default radius: <br/>7.0541ms/req at 82 coordinate<br/>0.0860256ms/coordinate<br/>Radius 10m: <br/>24.9599ms/req at 82 coordinate<br/>0.304389ms/coordinate | Default radius: <br/>7.07333ms/req at 82 coordinate<br/>0.0862601ms/coordinate<br/>Radius 10m: <br/>25.0596ms/req at 82 coordinate<br/>0.305604ms/coordinate |
| match_mld | Default radius: <br/>4.34969ms/req at 82 coordinate<br/>0.053045ms/coordinate<br/>Radius 10m: <br/>16.1763ms/req at 82 coordinate<br/>0.197272ms/coordinate | Default radius: <br/>4.39702ms/req at 82 coordinate<br/>0.0536222ms/coordinate<br/>Radius 10m: <br/>16.2259ms/req at 82 coordinate<br/>0.197877ms/coordinate |
| node_match_ch | Ops: 155.4 ± 0.2 ops/s. Best: 155.8 ops/s | Ops: 156.4 ± 0.8 ops/s. Best: 157.4 ops/s |
| node_match_mld | Ops: 220.6 ± 1.0 ops/s. Best: 221.5 ops/s | Ops: 220.3 ± 1.6 ops/s. Best: 222.4 ops/s |
| node_nearest_ch | Ops: 10126.6 ± 721.4 ops/s. Best: 11141.4 ops/s | Ops: 10230.4 ± 755.3 ops/s. Best: 11166.3 ops/s |
| node_nearest_mld | Ops: 10742.4 ± 763.9 ops/s. Best: 12057.5 ops/s | Ops: 10438.1 ± 989.0 ops/s. Best: 12201.1 ops/s |
| node_route_ch | Ops: 999.6 ± 18.4 ops/s. Best: 1029.4 ops/s | Ops: 996.2 ± 22.2 ops/s. Best: 1033.5 ops/s |
| node_route_mld | Ops: 511.7 ± 2.4 ops/s. Best: 516.5 ops/s | Ops: 513.9 ± 4.6 ops/s. Best: 519.2 ops/s |
| node_table_ch | Ops: 182.5 ± 1.8 ops/s. Best: 185.4 ops/s | Ops: 181.8 ± 1.5 ops/s. Best: 184.4 ops/s |
| node_table_mld | Ops: 38.4 ± 0.1 ops/s. Best: 38.6 ops/s | Ops: 38.6 ± 0.0 ops/s. Best: 38.6 ops/s |
| node_trip_ch | Ops: 183.7 ± 1.1 ops/s. Best: 184.9 ops/s | Ops: 184.1 ± 1.3 ops/s. Best: 186.0 ops/s |
| node_trip_mld | Ops: 62.4 ± 0.2 ops/s. Best: 62.7 ops/s | Ops: 61.6 ± 0.2 ops/s. Best: 61.9 ops/s |
| osrm_contract | Time: 182.82s Peak RAM: 184.39MB | Time: 182.72s Peak RAM: 184.39MB |
| osrm_customize | Time: 2.53s Peak RAM: 111.65MB | Time: 2.52s Peak RAM: 111.65MB |
| osrm_extract | Time: 24.06s Peak RAM: 392.26MB | Time: 24.21s Peak RAM: 398.78MB |
| osrm_partition | Time: 5.82s Peak RAM: 119.40MB | Time: 5.83s Peak RAM: 119.45MB |
| packedvector | random write:<br/>std::vector 184543 ms<br/>util::packed_vector 375034 ms<br/>slowdown: 2.03223<br/>random read:<br/>std::vector 100720 ms<br/>util::packed_vector 191377 ms<br/>slowdown: 1.9001 | random write:<br/>std::vector 177043 ms<br/>util::packed_vector 392198 ms<br/>slowdown: 2.21527<br/>random read:<br/>std::vector 98885.4 ms<br/>util::packed_vector 197416 ms<br/>slowdown: 1.99641 |
| random_match_ch | 500 matches, default radius<br/>ops: 120.25 ± 0.17 ops/s. best: 120.56ops/s.<br/>total: 474.00 ± 0.65ms. best: 472.78ms.<br/>avg: 8.32 ± 0.01ms<br/>min: 0.25 ± 0.00ms<br/>max: 40.69 ± 0.04ms<br/>p99: 40.69 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 34.58 ± 0.03 ops/s. best: 34.62ops/s.<br/>total: 1850.79 ± 1.52ms. best: 1848.78ms.<br/>avg: 28.92 ± 0.02ms<br/>min: 0.24 ± 0.00ms<br/>max: 409.07 ± 0.81ms<br/>p99: 409.07 ± 0.81ms<br/><br/>500 matches, radius=20<br/>ops: 8.17 ± 0.01 ops/s. best: 8.19ops/s.<br/>total: 7953.87 ± 10.58ms. best: 7941.28ms.<br/>avg: 122.37 ± 0.16ms<br/>min: 0.49 ± 0.00ms<br/>max: 2170.78 ± 7.19ms<br/>p99: 2170.78 ± 7.19ms<br/><br/>Peak RAM: 56.000MB | 500 matches, default radius<br/>ops: 119.33 ± 0.16 ops/s. best: 119.62ops/s.<br/>total: 477.68 ± 0.66ms. best: 476.52ms.<br/>avg: 8.38 ± 0.01ms<br/>min: 0.25 ± 0.00ms<br/>max: 41.17 ± 0.04ms<br/>p99: 41.17 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 34.19 ± 0.03 ops/s. best: 34.23ops/s.<br/>total: 1871.99 ± 1.38ms. best: 1869.57ms.<br/>avg: 29.25 ± 0.02ms<br/>min: 0.24 ± 0.00ms<br/>max: 416.08 ± 0.77ms<br/>p99: 416.08 ± 0.77ms<br/><br/>500 matches, radius=20<br/>ops: 8.05 ± 0.01 ops/s. best: 8.06ops/s.<br/>total: 8073.55 ± 9.83ms. best: 8062.94ms.<br/>avg: 124.21 ± 0.15ms<br/>min: 0.50 ± 0.00ms<br/>max: 2224.18 ± 6.89ms<br/>p99: 2224.18 ± 6.89ms<br/><br/>Peak RAM: 56.000MB |
| random_match_mld | 500 matches, default radius<br/>ops: 204.65 ± 0.38 ops/s. best: 205.08ops/s.<br/>total: 278.53 ± 0.52ms. best: 277.94ms.<br/>avg: 4.89 ± 0.01ms<br/>min: 0.21 ± 0.00ms<br/>max: 27.19 ± 0.04ms<br/>p99: 27.19 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 72.96 ± 0.07 ops/s. best: 73.09ops/s.<br/>total: 877.25 ± 0.83ms. best: 875.67ms.<br/>avg: 13.71 ± 0.01ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.64 ± 0.29ms<br/>p99: 162.64 ± 0.29ms<br/><br/>500 matches, radius=20<br/>ops: 15.32 ± 0.01 ops/s. best: 15.34ops/s.<br/>total: 4242.87 ± 3.33ms. best: 4238.37ms.<br/>avg: 65.27 ± 0.05ms<br/>min: 0.29 ± 0.00ms<br/>max: 848.49 ± 1.39ms<br/>p99: 848.49 ± 1.39ms<br/><br/>Peak RAM: 51.500MB | 500 matches, default radius<br/>ops: 205.16 ± 0.40 ops/s. best: 205.61ops/s.<br/>total: 277.83 ± 0.54ms. best: 277.23ms.<br/>avg: 4.87 ± 0.01ms<br/>min: 0.21 ± 0.00ms<br/>max: 27.11 ± 0.04ms<br/>p99: 27.11 ± 0.04ms<br/><br/>500 matches, radius=10<br/>ops: 73.14 ± 0.07 ops/s. best: 73.25ops/s.<br/>total: 875.01 ± 0.79ms. best: 873.70ms.<br/>avg: 13.67 ± 0.01ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.36 ± 0.22ms<br/>p99: 162.36 ± 0.22ms<br/><br/>500 matches, radius=20<br/>ops: 15.38 ± 0.01 ops/s. best: 15.40ops/s.<br/>total: 4225.50 ± 3.51ms. best: 4220.52ms.<br/>avg: 65.01 ± 0.05ms<br/>min: 0.29 ± 0.00ms<br/>max: 845.95 ± 1.44ms<br/>p99: 845.95 ± 1.44ms<br/><br/>Peak RAM: 51.500MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 21650.00 ± 38.12 ops/s. best: 21686.56ops/s.<br/>total: 461.90 ± 0.82ms. best: 461.12ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16019.19 ± 11.67 ops/s. best: 16031.34ops/s.<br/>total: 624.25 ± 0.47ms. best: 623.78ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.17 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12291.19 ± 4.75 ops/s. best: 12296.43ops/s.<br/>total: 813.59 ± 0.31ms. best: 813.24ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.18 ± 0.00ms<br/>p99: 0.14 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 21761.23 ± 43.52 ops/s. best: 21798.16ops/s.<br/>total: 459.54 ± 0.92ms. best: 458.75ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15968.22 ± 15.80 ops/s. best: 15981.23ops/s.<br/>total: 626.24 ± 0.63ms. best: 625.73ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12191.91 ± 4.72 ops/s. best: 12195.40ops/s.<br/>total: 820.22 ± 0.32ms. best: 819.98ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.18 ± 0.00ms<br/>p99: 0.14 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 21653.47 ± 34.63 ops/s. best: 21681.86ops/s.<br/>total: 461.82 ± 0.74ms. best: 461.21ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16019.24 ± 7.75 ops/s. best: 16028.62ops/s.<br/>total: 624.25 ± 0.30ms. best: 623.88ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12283.65 ± 3.11 ops/s. best: 12286.73ops/s.<br/>total: 814.09 ± 0.21ms. best: 813.89ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.01ms<br/>p99: 0.14 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 21766.27 ± 35.05 ops/s. best: 21792.04ops/s.<br/>total: 459.43 ± 0.74ms. best: 458.88ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15976.03 ± 8.31 ops/s. best: 15985.38ops/s.<br/>total: 625.94 ± 0.33ms. best: 625.57ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12192.35 ± 3.14 ops/s. best: 12197.10ops/s.<br/>total: 820.19 ± 0.21ms. best: 819.87ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.18 ± 0.00ms<br/>p99: 0.14 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 286.87 ± 0.21 ops/s. best: 287.14ops/s.<br/>total: 3430.11 ± 2.49ms. best: 3426.87ms.<br/>avg: 3.49 ± 0.00ms<br/>min: 0.43 ± 0.01ms<br/>max: 5.98 ± 0.05ms<br/>p99: 5.17 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 336.80 ± 0.06 ops/s. best: 336.88ops/s.<br/>total: 2969.12 ± 0.53ms. best: 2968.38ms.<br/>avg: 2.97 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.12 ± 0.01ms<br/>p99: 6.73 ± 0.00ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 587.93 ± 0.25 ops/s. best: 588.30ops/s.<br/>total: 1673.67 ± 0.72ms. best: 1672.62ms.<br/>avg: 1.70 ± 0.00ms<br/>min: 0.35 ± 0.00ms<br/>max: 2.55 ± 0.01ms<br/>p99: 2.40 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 652.74 ± 0.58 ops/s. best: 653.68ops/s.<br/>total: 1532.00 ± 1.35ms. best: 1529.79ms.<br/>avg: 1.53 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.54 ± 0.01ms<br/>p99: 3.91 ± 0.02ms<br/><br/>Peak RAM: 84.000MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 285.33 ± 0.13 ops/s. best: 285.48ops/s.<br/>total: 3448.63 ± 1.63ms. best: 3446.80ms.<br/>avg: 3.50 ± 0.00ms<br/>min: 0.44 ± 0.01ms<br/>max: 5.97 ± 0.01ms<br/>p99: 5.19 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 336.23 ± 0.07 ops/s. best: 336.33ops/s.<br/>total: 2974.20 ± 0.60ms. best: 2973.30ms.<br/>avg: 2.97 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.14 ± 0.01ms<br/>p99: 6.72 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 585.46 ± 0.14 ops/s. best: 585.64ops/s.<br/>total: 1680.73 ± 0.39ms. best: 1680.22ms.<br/>avg: 1.71 ± 0.00ms<br/>min: 0.35 ± 0.01ms<br/>max: 2.54 ± 0.01ms<br/>p99: 2.40 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 644.92 ± 0.07 ops/s. best: 645.05ops/s.<br/>total: 1550.57 ± 0.18ms. best: 1550.26ms.<br/>avg: 1.55 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.56 ± 0.01ms<br/>p99: 3.93 ± 0.01ms<br/><br/>Peak RAM: 84.000MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 147.60 ± 0.01 ops/s. best: 147.62ops/s.<br/>total: 6666.60 ± 0.51ms. best: 6665.74ms.<br/>avg: 6.78 ± 0.00ms<br/>min: 0.42 ± 0.00ms<br/>max: 14.19 ± 0.03ms<br/>p99: 10.99 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 141.47 ± 0.01 ops/s. best: 141.50ops/s.<br/>total: 7068.41 ± 0.66ms. best: 7067.29ms.<br/>avg: 7.07 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.60 ± 0.30ms<br/>p99: 15.01 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 205.35 ± 0.02 ops/s. best: 205.37ops/s.<br/>total: 4791.82 ± 0.42ms. best: 4791.32ms.<br/>avg: 4.87 ± 0.00ms<br/>min: 0.36 ± 0.00ms<br/>max: 11.54 ± 0.04ms<br/>p99: 8.38 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 177.47 ± 0.03 ops/s. best: 177.51ops/s.<br/>total: 5634.81 ± 0.83ms. best: 5633.55ms.<br/>avg: 5.63 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 12.74 ± 0.04ms<br/>p99: 11.49 ± 0.02ms<br/><br/>Peak RAM: 73.484MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 147.43 ± 0.18 ops/s. best: 147.64ops/s.<br/>total: 6674.37 ± 8.30ms. best: 6665.05ms.<br/>avg: 6.78 ± 0.01ms<br/>min: 0.42 ± 0.00ms<br/>max: 14.23 ± 0.08ms<br/>p99: 10.97 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 141.70 ± 0.03 ops/s. best: 141.74ops/s.<br/>total: 7057.10 ± 1.34ms. best: 7055.22ms.<br/>avg: 7.06 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.43 ± 0.03ms<br/>p99: 15.04 ± 0.09ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 200.83 ± 0.61 ops/s. best: 201.72ops/s.<br/>total: 4899.77 ± 14.82ms. best: 4878.12ms.<br/>avg: 4.98 ± 0.02ms<br/>min: 0.36 ± 0.00ms<br/>max: 11.82 ± 0.29ms<br/>p99: 8.59 ± 0.12ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 176.16 ± 0.19 ops/s. best: 176.32ops/s.<br/>total: 5676.76 ± 6.02ms. best: 5671.54ms.<br/>avg: 5.68 ± 0.01ms<br/>min: 0.05 ± 0.00ms<br/>max: 12.94 ± 0.17ms<br/>p99: 11.87 ± 0.09ms<br/><br/>Peak RAM: 73.484MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1129.73 ± 4.30 ops/s. best: 1133.46ops/s.<br/>total: 221.30 ± 0.85ms. best: 220.56ms.<br/>avg: 0.89 ± 0.00ms<br/>min: 0.69 ± 0.00ms<br/>max: 1.21 ± 0.14ms<br/>p99: 1.08 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 125.43 ± 0.02 ops/s. best: 125.46ops/s.<br/>total: 1993.11 ± 0.38ms. best: 1992.59ms.<br/>avg: 7.97 ± 0.00ms<br/>min: 7.27 ± 0.01ms<br/>max: 8.59 ± 0.01ms<br/>p99: 8.53 ± 0.00ms<br/><br/>250 tables, 50 coordinates<br/>ops: 61.16 ± 0.01 ops/s. best: 61.17ops/s.<br/>total: 4087.50 ± 0.49ms. best: 4086.77ms.<br/>avg: 16.35 ± 0.00ms<br/>min: 15.37 ± 0.01ms<br/>max: 17.46 ± 0.01ms<br/>p99: 17.23 ± 0.02ms<br/><br/>Peak RAM: 63.500MB | 250 tables, 3 coordinates<br/>ops: 1132.17 ± 3.98 ops/s. best: 1135.57ops/s.<br/>total: 220.82 ± 0.78ms. best: 220.15ms.<br/>avg: 0.88 ± 0.00ms<br/>min: 0.69 ± 0.00ms<br/>max: 1.22 ± 0.15ms<br/>p99: 1.08 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 126.27 ± 0.04 ops/s. best: 126.32ops/s.<br/>total: 1979.84 ± 0.66ms. best: 1979.16ms.<br/>avg: 7.92 ± 0.00ms<br/>min: 7.23 ± 0.01ms<br/>max: 8.53 ± 0.01ms<br/>p99: 8.48 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 61.35 ± 0.01 ops/s. best: 61.36ops/s.<br/>total: 4074.90 ± 0.60ms. best: 4074.22ms.<br/>avg: 16.30 ± 0.00ms<br/>min: 15.28 ± 0.01ms<br/>max: 17.45 ± 0.01ms<br/>p99: 17.18 ± 0.02ms<br/><br/>Peak RAM: 63.500MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 229.14 ± 0.27 ops/s. best: 229.34ops/s.<br/>total: 1091.04 ± 1.27ms. best: 1090.10ms.<br/>avg: 4.36 ± 0.01ms<br/>min: 3.44 ± 0.01ms<br/>max: 5.64 ± 0.01ms<br/>p99: 5.42 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 24.19 ± 0.01 ops/s. best: 24.21ops/s.<br/>total: 10335.52 ± 6.13ms. best: 10324.65ms.<br/>avg: 41.34 ± 0.02ms<br/>min: 38.16 ± 0.12ms<br/>max: 45.23 ± 0.03ms<br/>p99: 44.66 ± 0.13ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.23 ± 0.01 ops/s. best: 11.24ops/s.<br/>total: 22266.93 ± 21.46ms. best: 22234.43ms.<br/>avg: 89.07 ± 0.09ms<br/>min: 84.89 ± 0.32ms<br/>max: 94.40 ± 0.14ms<br/>p99: 93.28 ± 0.38ms<br/><br/>Peak RAM: 62.734MB | 250 tables, 3 coordinates<br/>ops: 228.45 ± 0.31 ops/s. best: 228.76ops/s.<br/>total: 1094.36 ± 1.51ms. best: 1092.87ms.<br/>avg: 4.38 ± 0.01ms<br/>min: 3.46 ± 0.00ms<br/>max: 5.69 ± 0.04ms<br/>p99: 5.42 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 24.11 ± 0.02 ops/s. best: 24.15ops/s.<br/>total: 10370.71 ± 7.85ms. best: 10353.11ms.<br/>avg: 41.48 ± 0.03ms<br/>min: 38.42 ± 0.07ms<br/>max: 45.12 ± 0.15ms<br/>p99: 44.76 ± 0.12ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.04 ± 0.01 ops/s. best: 11.04ops/s.<br/>total: 22651.61 ± 10.77ms. best: 22635.86ms.<br/>avg: 90.61 ± 0.04ms<br/>min: 86.52 ± 0.33ms<br/>max: 96.27 ± 0.15ms<br/>p99: 94.57 ± 0.10ms<br/><br/>Peak RAM: 62.734MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 325.48 ± 0.40 ops/s. best: 325.91ops/s.<br/>total: 768.09 ± 0.95ms. best: 767.09ms.<br/>avg: 3.07 ± 0.00ms<br/>min: 1.60 ± 0.01ms<br/>max: 4.45 ± 0.01ms<br/>p99: 4.23 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 210.75 ± 0.05 ops/s. best: 210.81ops/s.<br/>total: 1186.23 ± 0.31ms. best: 1185.91ms.<br/>avg: 4.74 ± 0.00ms<br/>min: 2.93 ± 0.00ms<br/>max: 5.99 ± 0.01ms<br/>p99: 5.90 ± 0.03ms<br/><br/>Peak RAM: 73.500MB | 250 trips, 3 coordinates<br/>ops: 324.89 ± 0.56 ops/s. best: 325.69ops/s.<br/>total: 769.50 ± 1.32ms. best: 767.61ms.<br/>avg: 3.08 ± 0.01ms<br/>min: 1.60 ± 0.00ms<br/>max: 4.43 ± 0.02ms<br/>p99: 4.23 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 211.20 ± 0.05 ops/s. best: 211.25ops/s.<br/>total: 1183.69 ± 0.28ms. best: 1183.41ms.<br/>avg: 4.73 ± 0.00ms<br/>min: 2.92 ± 0.01ms<br/>max: 5.97 ± 0.01ms<br/>p99: 5.88 ± 0.01ms<br/><br/>Peak RAM: 73.500MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 106.61 ± 0.20 ops/s. best: 106.92ops/s.<br/>total: 2344.94 ± 4.30ms. best: 2338.30ms.<br/>avg: 9.38 ± 0.02ms<br/>min: 5.43 ± 0.01ms<br/>max: 12.30 ± 0.01ms<br/>p99: 12.14 ± 0.05ms<br/><br/>250 trips, 5 coordinates<br/>ops: 69.15 ± 0.21 ops/s. best: 69.58ops/s.<br/>total: 3615.45 ± 10.92ms. best: 3593.11ms.<br/>avg: 14.46 ± 0.04ms<br/>min: 9.99 ± 0.04ms<br/>max: 17.76 ± 0.02ms<br/>p99: 17.28 ± 0.09ms<br/><br/>Peak RAM: 69.000MB | 250 trips, 3 coordinates<br/>ops: 106.43 ± 0.06 ops/s. best: 106.49ops/s.<br/>total: 2349.02 ± 1.43ms. best: 2347.59ms.<br/>avg: 9.40 ± 0.01ms<br/>min: 5.46 ± 0.03ms<br/>max: 12.27 ± 0.02ms<br/>p99: 12.17 ± 0.02ms<br/><br/>250 trips, 5 coordinates<br/>ops: 68.55 ± 0.01 ops/s. best: 68.57ops/s.<br/>total: 3646.80 ± 0.66ms. best: 3645.69ms.<br/>avg: 14.59 ± 0.00ms<br/>min: 10.06 ± 0.01ms<br/>max: 17.69 ± 0.04ms<br/>p99: 17.42 ± 0.03ms<br/><br/>Peak RAM: 69.000MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>638.585ms<br/>0.638585ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>783.566ms<br/>0.783566ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>246.284ms<br/>0.246284ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>217.065ms<br/>0.217065ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>636.288ms<br/>0.636288ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>777.27ms<br/>0.77727ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>247.032ms<br/>0.247032ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>216.497ms<br/>0.216497ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>808.614ms<br/>0.808614ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1040.14ms<br/>1.04014ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>414.193ms<br/>0.414193ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>461.146ms<br/>0.461146ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>806.018ms<br/>0.806018ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1037.05ms<br/>1.03705ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>412.686ms<br/>0.412686ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>460.971ms<br/>0.460971ms/req |
| rtree | 1 result:<br/>227.536ms ->  0.0227536 ms/query<br/>10 results:<br/>258.26ms ->  0.025826 ms/query | 1 result:<br/>227.24ms ->  0.022724 ms/query<br/>10 results:<br/>258.048ms ->  0.0258048 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->

