### PR TITLE
Try to disable TBBMalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,8 @@ if(ENABLE_CONAN)
     KEEP_RPATHS
     NO_OUTPUT_DIRS
     OPTIONS boost:without_stacktrace=True # Apple Silicon cross-compilation fails without it
+            onetbb:tbbmalloc=False
+            onetbb:tbbproxy=False
     BUILD missing
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,7 @@ if(ENABLE_CONAN)
     OPTIONS boost:without_stacktrace=True # Apple Silicon cross-compilation fails without it
             onetbb:tbbmalloc=False
             onetbb:tbbproxy=False
+            onetbb:tbbbind=False
     BUILD missing
   )
 


### PR DESCRIPTION

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 10934.1<br/>plain u32: 10793.3<br/>aliased double: 14861<br/>plain double: 14871.4 | aliased u32: 11107.4<br/>plain u32: 11047.2<br/>aliased double: 15125.8<br/>plain double: 15123.9 |
| e2e_match_ch | Ops: 26.17 ± 0.02 ops/s. Best: 26.20 ops/s<br/>Total: 5006.52ms ± 3.74ms. Best: 4999.12ms<br/>Min time: 3.25ms ± 0.04ms<br/>Mean time: 38.22ms ± 0.03ms<br/>Median time: 26.22ms ± 0.08ms<br/>95th percentile: 130.16ms ± 0.26ms<br/>99th percentile: 158.30ms ± 0.33ms<br/>Max time: 164.60ms ± 0.47ms | Ops: 25.91 ± 0.01 ops/s. Best: 25.92 ops/s<br/>Total: 5056.08ms ± 1.42ms. Best: 5053.52ms<br/>Min time: 3.36ms ± 0.05ms<br/>Mean time: 38.60ms ± 0.01ms<br/>Median time: 25.99ms ± 0.12ms<br/>95th percentile: 134.45ms ± 0.20ms<br/>99th percentile: 155.80ms ± 0.52ms<br/>Max time: 164.57ms ± 0.34ms |
| e2e_match_mld | Ops: 43.45 ± 0.02 ops/s. Best: 43.49 ops/s<br/>Total: 3014.90ms ± 1.52ms. Best: 3012.24ms<br/>Min time: 2.59ms ± 0.07ms<br/>Mean time: 23.01ms ± 0.01ms<br/>Median time: 12.01ms ± 0.04ms<br/>95th percentile: 75.40ms ± 0.26ms<br/>99th percentile: 87.53ms ± 0.27ms<br/>Max time: 99.99ms ± 0.42ms | Ops: 44.51 ± 0.02 ops/s. Best: 44.56 ops/s<br/>Total: 2943.24ms ± 1.61ms. Best: 2939.90ms<br/>Min time: 2.57ms ± 0.04ms<br/>Mean time: 22.47ms ± 0.01ms<br/>Median time: 11.73ms ± 0.10ms<br/>95th percentile: 73.44ms ± 0.20ms<br/>99th percentile: 84.96ms ± 0.31ms<br/>Max time: 97.72ms ± 0.37ms |
| e2e_nearest_ch | Ops: 637.48 ± 1.06 ops/s. Best: 639.43 ops/s<br/>Total: 1568.57ms ± 2.85ms. Best: 1563.90ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.00ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.03ms ± 0.01ms<br/>Max time: 9.34ms ± 7.43ms | Ops: 634.91 ± 5.18 ops/s. Best: 641.60 ops/s<br/>Total: 1574.83ms ± 12.86ms. Best: 1558.59ms<br/>Min time: 1.29ms ± 0.01ms<br/>Mean time: 1.58ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.40ms ± 7.45ms |
| e2e_nearest_mld | Ops: 637.97 ± 3.69 ops/s. Best: 641.88 ops/s<br/>Total: 1567.24ms ± 8.84ms. Best: 1557.91ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.00ms<br/>95th percentile: 1.94ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.39ms ± 7.45ms | Ops: 638.03 ± 2.99 ops/s. Best: 641.83 ops/s<br/>Total: 1567.26ms ± 7.51ms. Best: 1558.03ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.00ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.38ms ± 7.47ms |
| e2e_route_ch | Ops: 217.19 ± 0.51 ops/s. Best: 218.22 ops/s<br/>Total: 4604.33ms ± 11.78ms. Best: 4582.62ms<br/>Min time: 1.87ms ± 0.02ms<br/>Mean time: 4.60ms ± 0.01ms<br/>Median time: 4.70ms ± 0.01ms<br/>95th percentile: 6.06ms ± 0.02ms<br/>99th percentile: 6.57ms ± 0.03ms<br/>Max time: 13.31ms ± 6.40ms | Ops: 212.51 ± 0.32 ops/s. Best: 213.00 ops/s<br/>Total: 4705.49ms ± 7.29ms. Best: 4694.87ms<br/>Min time: 1.87ms ± 0.04ms<br/>Mean time: 4.71ms ± 0.01ms<br/>Median time: 4.80ms ± 0.02ms<br/>95th percentile: 6.19ms ± 0.02ms<br/>99th percentile: 6.69ms ± 0.05ms<br/>Max time: 13.44ms ± 6.32ms |
| e2e_route_mld | Ops: 178.94 ± 0.33 ops/s. Best: 179.46 ops/s<br/>Total: 5588.49ms ± 10.38ms. Best: 5572.29ms<br/>Min time: 1.84ms ± 0.06ms<br/>Mean time: 5.59ms ± 0.01ms<br/>Median time: 5.71ms ± 0.02ms<br/>95th percentile: 7.61ms ± 0.02ms<br/>99th percentile: 8.15ms ± 0.07ms<br/>Max time: 14.73ms ± 5.90ms | Ops: 176.21 ± 0.21 ops/s. Best: 176.63 ops/s<br/>Total: 5675.13ms ± 7.02ms. Best: 5661.54ms<br/>Min time: 1.87ms ± 0.05ms<br/>Mean time: 5.68ms ± 0.01ms<br/>Median time: 5.80ms ± 0.02ms<br/>95th percentile: 7.72ms ± 0.02ms<br/>99th percentile: 8.31ms ± 0.05ms<br/>Max time: 14.77ms ± 5.98ms |
| e2e_table_ch | Ops: 210.70 ± 0.35 ops/s. Best: 211.16 ops/s<br/>Total: 4745.96ms ± 8.18ms. Best: 4735.80ms<br/>Min time: 2.48ms ± 0.05ms<br/>Mean time: 4.75ms ± 0.01ms<br/>Median time: 4.76ms ± 0.01ms<br/>95th percentile: 6.47ms ± 0.02ms<br/>99th percentile: 6.80ms ± 0.02ms<br/>Max time: 13.94ms ± 7.05ms | Ops: 208.71 ± 0.52 ops/s. Best: 209.38 ops/s<br/>Total: 4790.97ms ± 12.04ms. Best: 4775.90ms<br/>Min time: 2.47ms ± 0.06ms<br/>Mean time: 4.79ms ± 0.01ms<br/>Median time: 4.80ms ± 0.01ms<br/>95th percentile: 6.52ms ± 0.01ms<br/>99th percentile: 6.86ms ± 0.02ms<br/>Max time: 14.04ms ± 7.03ms |
| e2e_table_mld | Ops: 69.89 ± 0.04 ops/s. Best: 69.94 ops/s<br/>Total: 14308.34ms ± 7.90ms. Best: 14297.55ms<br/>Min time: 5.98ms ± 0.05ms<br/>Mean time: 14.31ms ± 0.01ms<br/>Median time: 14.25ms ± 0.02ms<br/>95th percentile: 21.77ms ± 0.06ms<br/>99th percentile: 22.99ms ± 0.05ms<br/>Max time: 29.32ms ± 5.65ms | Ops: 69.40 ± 0.05 ops/s. Best: 69.47 ops/s<br/>Total: 14409.70ms ± 9.75ms. Best: 14395.69ms<br/>Min time: 6.09ms ± 0.05ms<br/>Mean time: 14.41ms ± 0.01ms<br/>Median time: 14.33ms ± 0.04ms<br/>95th percentile: 21.99ms ± 0.06ms<br/>99th percentile: 23.14ms ± 0.06ms<br/>Max time: 29.47ms ± 5.60ms |
| e2e_trip_ch | Ops: 62.28 ± 0.02 ops/s. Best: 62.32 ops/s<br/>Total: 16056.55ms ± 6.44ms. Best: 16046.51ms<br/>Min time: 2.45ms ± 0.16ms<br/>Mean time: 16.06ms ± 0.01ms<br/>Median time: 15.32ms ± 0.03ms<br/>95th percentile: 28.26ms ± 0.02ms<br/>99th percentile: 30.42ms ± 0.09ms<br/>Max time: 32.92ms ± 1.36ms | Ops: 59.75 ± 0.06 ops/s. Best: 59.87 ops/s<br/>Total: 16737.88ms ± 17.46ms. Best: 16704.02ms<br/>Min time: 2.47ms ± 0.16ms<br/>Mean time: 16.74ms ± 0.02ms<br/>Median time: 15.93ms ± 0.04ms<br/>95th percentile: 29.10ms ± 0.04ms<br/>99th percentile: 31.53ms ± 0.15ms<br/>Max time: 34.18ms ± 1.18ms |
| e2e_trip_mld | Ops: 36.90 ± 0.01 ops/s. Best: 36.92 ops/s<br/>Total: 27098.64ms ± 9.28ms. Best: 27084.25ms<br/>Min time: 2.41ms ± 0.17ms<br/>Mean time: 27.10ms ± 0.01ms<br/>Median time: 26.21ms ± 0.06ms<br/>95th percentile: 44.19ms ± 0.09ms<br/>99th percentile: 46.77ms ± 0.09ms<br/>Max time: 49.02ms ± 0.04ms | Ops: 35.83 ± 0.03 ops/s. Best: 35.88 ops/s<br/>Total: 27907.06ms ± 19.87ms. Best: 27872.63ms<br/>Min time: 2.50ms ± 0.17ms<br/>Mean time: 27.91ms ± 0.02ms<br/>Median time: 27.03ms ± 0.08ms<br/>95th percentile: 45.29ms ± 0.05ms<br/>99th percentile: 47.90ms ± 0.10ms<br/>Max time: 50.32ms ± 0.13ms |
| json-render | String: 8.87427ms<br/>Stringstream: 14.5113ms<br/>Vector: 9.65078ms | String: 8.32319ms<br/>Stringstream: 14.0587ms<br/>Vector: 9.12987ms |
| match_ch | Default radius: <br/>7.05161ms/req at 82 coordinate<br/>0.0859952ms/coordinate<br/>Radius 10m: <br/>24.9546ms/req at 82 coordinate<br/>0.304324ms/coordinate | Default radius: <br/>6.63888ms/req at 82 coordinate<br/>0.080962ms/coordinate<br/>Radius 10m: <br/>23.2166ms/req at 82 coordinate<br/>0.283129ms/coordinate |
| match_mld | Default radius: <br/>4.33698ms/req at 82 coordinate<br/>0.05289ms/coordinate<br/>Radius 10m: <br/>16.1821ms/req at 82 coordinate<br/>0.197343ms/coordinate | Default radius: <br/>3.88237ms/req at 82 coordinate<br/>0.047346ms/coordinate<br/>Radius 10m: <br/>14.0666ms/req at 82 coordinate<br/>0.171544ms/coordinate |
| node_match_ch | Ops: 164.4 ± 0.9 ops/s. Best: 165.5 ops/s | Ops: 165.2 ± 0.5 ops/s. Best: 165.9 ops/s |
| node_match_mld | Ops: 219.3 ± 0.9 ops/s. Best: 221.1 ops/s | Ops: 219.3 ± 0.5 ops/s. Best: 220.1 ops/s |
| node_nearest_ch | Ops: 9858.2 ± 784.4 ops/s. Best: 11521.4 ops/s | Ops: 10429.8 ± 714.6 ops/s. Best: 12164.3 ops/s |
| node_nearest_mld | Ops: 10013.3 ± 734.1 ops/s. Best: 11153.8 ops/s | Ops: 10006.4 ± 1161.9 ops/s. Best: 11300.3 ops/s |
| node_route_ch | Ops: 994.4 ± 15.5 ops/s. Best: 1018.9 ops/s | Ops: 988.5 ± 19.4 ops/s. Best: 1018.0 ops/s |
| node_route_mld | Ops: 510.5 ± 5.0 ops/s. Best: 517.6 ops/s | Ops: 512.0 ± 4.3 ops/s. Best: 515.3 ops/s |
| node_table_ch | Ops: 174.5 ± 1.3 ops/s. Best: 176.9 ops/s | Ops: 173.5 ± 2.2 ops/s. Best: 176.2 ops/s |
| node_table_mld | Ops: 38.4 ± 0.1 ops/s. Best: 38.5 ops/s | Ops: 38.3 ± 0.1 ops/s. Best: 38.4 ops/s |
| node_trip_ch | Ops: 179.5 ± 0.3 ops/s. Best: 180.0 ops/s | Ops: 177.8 ± 0.8 ops/s. Best: 178.9 ops/s |
| node_trip_mld | Ops: 62.2 ± 0.1 ops/s. Best: 62.5 ops/s | Ops: 62.0 ± 0.2 ops/s. Best: 62.3 ops/s |
| osrm_contract | Time: 183.62s Peak RAM: 183.70MB | Time: 175.78s Peak RAM: 182.18MB |
| osrm_customize | Time: 2.53s Peak RAM: 111.67MB | Time: 2.38s Peak RAM: 109.62MB |
| osrm_extract | Time: 24.05s Peak RAM: 397.92MB | Time: 25.77s Peak RAM: 370.29MB |
| osrm_partition | Time: 5.85s Peak RAM: 122.23MB | Time: 6.21s Peak RAM: 117.34MB |
| packedvector | random write:<br/>std::vector 179742 ms<br/>util::packed_vector 393395 ms<br/>slowdown: 2.18867<br/>random read:<br/>std::vector 99909 ms<br/>util::packed_vector 199244 ms<br/>slowdown: 1.99426 | random write:<br/>std::vector 185571 ms<br/>util::packed_vector 388483 ms<br/>slowdown: 2.09345<br/>random read:<br/>std::vector 100911 ms<br/>util::packed_vector 195907 ms<br/>slowdown: 1.94138 |
| random_match_ch | 500 matches, default radius<br/>ops: 127.02 ± 0.13 ops/s. best: 127.16ops/s.<br/>total: 448.75 ± 0.48ms. best: 448.24ms.<br/>avg: 7.87 ± 0.01ms<br/>min: 0.22 ± 0.01ms<br/>max: 42.80 ± 0.10ms<br/>p99: 42.80 ± 0.10ms<br/><br/>500 matches, radius=10<br/>ops: 36.67 ± 0.03 ops/s. best: 36.75ops/s.<br/>total: 1745.38 ± 1.61ms. best: 1741.42ms.<br/>avg: 27.27 ± 0.03ms<br/>min: 0.24 ± 0.00ms<br/>max: 411.70 ± 1.37ms<br/>p99: 411.70 ± 1.37ms<br/><br/>500 matches, radius=20<br/>ops: 8.67 ± 0.01 ops/s. best: 8.69ops/s.<br/>total: 7501.03 ± 9.02ms. best: 7478.57ms.<br/>avg: 115.40 ± 0.14ms<br/>min: 0.48 ± 0.00ms<br/>max: 2184.74 ± 4.66ms<br/>p99: 2184.74 ± 4.66ms<br/><br/>Peak RAM: 54.500MB | 500 matches, default radius<br/>ops: 133.68 ± 0.16 ops/s. best: 133.89ops/s.<br/>total: 426.39 ± 0.52ms. best: 425.73ms.<br/>avg: 7.48 ± 0.01ms<br/>min: 0.22 ± 0.01ms<br/>max: 41.02 ± 0.03ms<br/>p99: 41.02 ± 0.03ms<br/><br/>500 matches, radius=10<br/>ops: 38.40 ± 0.01 ops/s. best: 38.42ops/s.<br/>total: 1666.47 ± 0.42ms. best: 1665.94ms.<br/>avg: 26.04 ± 0.01ms<br/>min: 0.24 ± 0.00ms<br/>max: 397.48 ± 0.33ms<br/>p99: 397.48 ± 0.33ms<br/><br/>500 matches, radius=20<br/>ops: 9.02 ± 0.00 ops/s. best: 9.03ops/s.<br/>total: 7203.57 ± 3.30ms. best: 7199.66ms.<br/>avg: 110.82 ± 0.05ms<br/>min: 0.45 ± 0.00ms<br/>max: 2141.66 ± 2.69ms<br/>p99: 2141.66 ± 2.69ms<br/><br/>Peak RAM: 52.000MB |
| random_match_mld | 500 matches, default radius<br/>ops: 204.00 ± 0.61 ops/s. best: 204.50ops/s.<br/>total: 279.42 ± 0.84ms. best: 278.73ms.<br/>avg: 4.90 ± 0.01ms<br/>min: 0.21 ± 0.01ms<br/>max: 27.06 ± 0.05ms<br/>p99: 27.06 ± 0.05ms<br/><br/>500 matches, radius=10<br/>ops: 72.38 ± 0.07 ops/s. best: 72.53ops/s.<br/>total: 884.23 ± 0.89ms. best: 882.34ms.<br/>avg: 13.82 ± 0.01ms<br/>min: 0.23 ± 0.00ms<br/>max: 162.34 ± 0.49ms<br/>p99: 162.34 ± 0.49ms<br/><br/>500 matches, radius=20<br/>ops: 15.10 ± 0.02 ops/s. best: 15.12ops/s.<br/>total: 4304.46 ± 4.77ms. best: 4299.14ms.<br/>avg: 66.22 ± 0.07ms<br/>min: 0.29 ± 0.00ms<br/>max: 845.65 ± 1.89ms<br/>p99: 845.65 ± 1.89ms<br/><br/>Peak RAM: 51.000MB | 500 matches, default radius<br/>ops: 231.98 ± 0.30 ops/s. best: 232.30ops/s.<br/>total: 245.71 ± 0.32ms. best: 245.37ms.<br/>avg: 4.31 ± 0.01ms<br/>min: 0.20 ± 0.00ms<br/>max: 24.02 ± 0.08ms<br/>p99: 24.02 ± 0.08ms<br/><br/>500 matches, radius=10<br/>ops: 83.21 ± 0.04 ops/s. best: 83.25ops/s.<br/>total: 769.18 ± 0.37ms. best: 768.75ms.<br/>avg: 12.02 ± 0.01ms<br/>min: 0.23 ± 0.00ms<br/>max: 140.15 ± 0.19ms<br/>p99: 140.15 ± 0.19ms<br/><br/>500 matches, radius=20<br/>ops: 17.00 ± 0.01 ops/s. best: 17.02ops/s.<br/>total: 3823.17 ± 1.78ms. best: 3819.44ms.<br/>avg: 58.82 ± 0.03ms<br/>min: 0.28 ± 0.00ms<br/>max: 743.31 ± 1.36ms<br/>p99: 743.31 ± 1.36ms<br/><br/>Peak RAM: 48.000MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 22040.53 ± 38.80 ops/s. best: 22077.69ops/s.<br/>total: 453.71 ± 0.82ms. best: 452.95ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15931.03 ± 6.96 ops/s. best: 15942.27ops/s.<br/>total: 627.71 ± 0.27ms. best: 627.26ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12122.20 ± 3.49 ops/s. best: 12126.08ops/s.<br/>total: 824.93 ± 0.24ms. best: 824.67ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 34.500MB | 10000 nearest, number_of_results=1<br/>ops: 22144.84 ± 37.97 ops/s. best: 22172.31ops/s.<br/>total: 451.57 ± 0.78ms. best: 451.01ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.14 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16043.20 ± 13.47 ops/s. best: 16060.67ops/s.<br/>total: 623.32 ± 0.56ms. best: 622.64ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12207.92 ± 5.81 ops/s. best: 12217.19ops/s.<br/>total: 819.14 ± 0.39ms. best: 818.52ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 32.500MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 22031.15 ± 54.01 ops/s. best: 22077.15ops/s.<br/>total: 453.91 ± 1.12ms. best: 452.96ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.14 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15939.19 ± 7.34 ops/s. best: 15950.69ops/s.<br/>total: 627.38 ± 0.29ms. best: 626.93ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12116.42 ± 5.32 ops/s. best: 12121.25ops/s.<br/>total: 825.33 ± 0.36ms. best: 825.00ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 34.500MB | 10000 nearest, number_of_results=1<br/>ops: 22139.50 ± 35.94 ops/s. best: 22173.53ops/s.<br/>total: 451.68 ± 0.73ms. best: 450.99ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.14 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16049.87 ± 14.57 ops/s. best: 16060.56ops/s.<br/>total: 623.06 ± 0.57ms. best: 622.64ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12208.03 ± 6.22 ops/s. best: 12215.97ops/s.<br/>total: 819.13 ± 0.43ms. best: 818.60ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 32.500MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 281.38 ± 0.09 ops/s. best: 281.51ops/s.<br/>total: 3497.01 ± 1.16ms. best: 3495.42ms.<br/>avg: 3.55 ± 0.00ms<br/>min: 0.38 ± 0.00ms<br/>max: 6.00 ± 0.04ms<br/>p99: 5.27 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 310.31 ± 0.06 ops/s. best: 310.43ops/s.<br/>total: 3222.62 ± 0.67ms. best: 3221.36ms.<br/>avg: 3.22 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.20 ± 0.01ms<br/>p99: 6.83 ± 0.02ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 570.66 ± 0.14 ops/s. best: 570.89ops/s.<br/>total: 1724.33 ± 0.41ms. best: 1723.64ms.<br/>avg: 1.75 ± 0.00ms<br/>min: 0.31 ± 0.01ms<br/>max: 2.91 ± 0.01ms<br/>p99: 2.47 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 576.67 ± 0.16 ops/s. best: 576.97ops/s.<br/>total: 1734.08 ± 0.47ms. best: 1733.20ms.<br/>avg: 1.73 ± 0.00ms<br/>min: 0.06 ± 0.01ms<br/>max: 5.18 ± 0.01ms<br/>p99: 4.04 ± 0.01ms<br/><br/>Peak RAM: 84.000MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 282.43 ± 0.29 ops/s. best: 282.78ops/s.<br/>total: 3484.02 ± 3.53ms. best: 3479.78ms.<br/>avg: 3.54 ± 0.00ms<br/>min: 0.38 ± 0.00ms<br/>max: 5.87 ± 0.02ms<br/>p99: 5.22 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 308.01 ± 0.30 ops/s. best: 308.55ops/s.<br/>total: 3246.66 ± 3.14ms. best: 3240.97ms.<br/>avg: 3.25 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.14 ± 0.01ms<br/>p99: 6.75 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 571.23 ± 0.15 ops/s. best: 571.56ops/s.<br/>total: 1722.61 ± 0.46ms. best: 1721.61ms.<br/>avg: 1.75 ± 0.00ms<br/>min: 0.31 ± 0.00ms<br/>max: 2.90 ± 0.01ms<br/>p99: 2.47 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 568.55 ± 0.19 ops/s. best: 568.76ops/s.<br/>total: 1758.86 ± 0.57ms. best: 1758.20ms.<br/>avg: 1.76 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 5.12 ± 0.00ms<br/>p99: 4.05 ± 0.00ms<br/><br/>Peak RAM: 78.500MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 147.98 ± 0.05 ops/s. best: 148.02ops/s.<br/>total: 6649.68 ± 2.20ms. best: 6647.55ms.<br/>avg: 6.76 ± 0.00ms<br/>min: 0.37 ± 0.01ms<br/>max: 16.20 ± 0.01ms<br/>p99: 10.97 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 142.19 ± 0.04 ops/s. best: 142.26ops/s.<br/>total: 7032.93 ± 1.97ms. best: 7029.57ms.<br/>avg: 7.03 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.00 ± 0.08ms<br/>p99: 15.01 ± 0.02ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 205.58 ± 0.01 ops/s. best: 205.60ops/s.<br/>total: 4786.36 ± 0.26ms. best: 4785.95ms.<br/>avg: 4.86 ± 0.00ms<br/>min: 0.31 ± 0.00ms<br/>max: 13.47 ± 0.01ms<br/>p99: 8.41 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 177.88 ± 0.14 ops/s. best: 177.99ops/s.<br/>total: 5621.69 ± 4.36ms. best: 5618.17ms.<br/>avg: 5.62 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 12.40 ± 0.14ms<br/>p99: 11.61 ± 0.03ms<br/><br/>Peak RAM: 73.297MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 149.08 ± 0.13 ops/s. best: 149.37ops/s.<br/>total: 6600.62 ± 5.91ms. best: 6587.69ms.<br/>avg: 6.71 ± 0.01ms<br/>min: 0.37 ± 0.00ms<br/>max: 15.94 ± 0.06ms<br/>p99: 10.94 ± 0.06ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 146.05 ± 0.17 ops/s. best: 146.38ops/s.<br/>total: 6846.80 ± 8.11ms. best: 6831.31ms.<br/>avg: 6.85 ± 0.01ms<br/>min: 0.07 ± 0.00ms<br/>max: 15.18 ± 0.08ms<br/>p99: 14.48 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 208.29 ± 0.04 ops/s. best: 208.36ops/s.<br/>total: 4724.08 ± 0.85ms. best: 4722.54ms.<br/>avg: 4.80 ± 0.00ms<br/>min: 0.32 ± 0.00ms<br/>max: 13.15 ± 0.02ms<br/>p99: 8.24 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 185.25 ± 0.05 ops/s. best: 185.33ops/s.<br/>total: 5398.17 ± 1.56ms. best: 5395.71ms.<br/>avg: 5.40 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 11.64 ± 0.03ms<br/>p99: 10.99 ± 0.02ms<br/><br/>Peak RAM: 67.000MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1067.17 ± 4.12 ops/s. best: 1070.56ops/s.<br/>total: 234.27 ± 0.92ms. best: 233.52ms.<br/>avg: 0.94 ± 0.00ms<br/>min: 0.71 ± 0.00ms<br/>max: 1.24 ± 0.15ms<br/>p99: 1.11 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 120.01 ± 0.03 ops/s. best: 120.03ops/s.<br/>total: 2083.24 ± 0.45ms. best: 2082.73ms.<br/>avg: 8.33 ± 0.00ms<br/>min: 7.73 ± 0.00ms<br/>max: 9.02 ± 0.01ms<br/>p99: 8.81 ± 0.00ms<br/><br/>250 tables, 50 coordinates<br/>ops: 58.32 ± 0.01 ops/s. best: 58.33ops/s.<br/>total: 4286.85 ± 0.84ms. best: 4285.64ms.<br/>avg: 17.15 ± 0.00ms<br/>min: 16.32 ± 0.03ms<br/>max: 18.11 ± 0.04ms<br/>p99: 18.00 ± 0.01ms<br/><br/>Peak RAM: 63.000MB | 250 tables, 3 coordinates<br/>ops: 1072.19 ± 4.44 ops/s. best: 1076.06ops/s.<br/>total: 233.17 ± 0.97ms. best: 232.33ms.<br/>avg: 0.93 ± 0.00ms<br/>min: 0.70 ± 0.00ms<br/>max: 1.22 ± 0.12ms<br/>p99: 1.11 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 122.62 ± 0.01 ops/s. best: 122.64ops/s.<br/>total: 2038.82 ± 0.24ms. best: 2038.45ms.<br/>avg: 8.16 ± 0.00ms<br/>min: 7.57 ± 0.00ms<br/>max: 8.80 ± 0.01ms<br/>p99: 8.64 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 59.68 ± 0.01 ops/s. best: 59.70ops/s.<br/>total: 4188.79 ± 0.78ms. best: 4187.70ms.<br/>avg: 16.76 ± 0.00ms<br/>min: 15.94 ± 0.01ms<br/>max: 17.64 ± 0.01ms<br/>p99: 17.55 ± 0.01ms<br/><br/>Peak RAM: 61.000MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 229.98 ± 0.38 ops/s. best: 230.42ops/s.<br/>total: 1087.04 ± 1.81ms. best: 1084.99ms.<br/>avg: 4.35 ± 0.01ms<br/>min: 3.46 ± 0.01ms<br/>max: 5.58 ± 0.02ms<br/>p99: 5.42 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 24.19 ± 0.00 ops/s. best: 24.19ops/s.<br/>total: 10336.82 ± 1.42ms. best: 10335.27ms.<br/>avg: 41.35 ± 0.01ms<br/>min: 38.36 ± 0.04ms<br/>max: 44.93 ± 0.05ms<br/>p99: 44.31 ± 0.08ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.19 ± 0.00 ops/s. best: 11.20ops/s.<br/>total: 22341.32 ± 7.34ms. best: 22328.60ms.<br/>avg: 89.37 ± 0.03ms<br/>min: 85.50 ± 0.05ms<br/>max: 94.97 ± 0.10ms<br/>p99: 93.41 ± 0.10ms<br/><br/>Peak RAM: 63.172MB | 250 tables, 3 coordinates<br/>ops: 231.24 ± 0.22 ops/s. best: 231.51ops/s.<br/>total: 1081.14 ± 1.04ms. best: 1079.84ms.<br/>avg: 4.32 ± 0.00ms<br/>min: 3.44 ± 0.01ms<br/>max: 5.56 ± 0.01ms<br/>p99: 5.42 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 23.93 ± 0.01 ops/s. best: 23.94ops/s.<br/>total: 10447.38 ± 2.26ms. best: 10444.69ms.<br/>avg: 41.79 ± 0.01ms<br/>min: 38.75 ± 0.06ms<br/>max: 45.77 ± 0.08ms<br/>p99: 44.94 ± 0.09ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.00 ± 0.00 ops/s. best: 11.00ops/s.<br/>total: 22736.81 ± 7.30ms. best: 22724.86ms.<br/>avg: 90.95 ± 0.03ms<br/>min: 87.06 ± 0.07ms<br/>max: 96.70 ± 0.14ms<br/>p99: 95.12 ± 0.12ms<br/><br/>Peak RAM: 60.156MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 314.63 ± 0.31 ops/s. best: 314.94ops/s.<br/>total: 794.60 ± 0.80ms. best: 793.81ms.<br/>avg: 3.18 ± 0.00ms<br/>min: 1.72 ± 0.01ms<br/>max: 4.42 ± 0.00ms<br/>p99: 4.22 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 204.89 ± 0.04 ops/s. best: 204.94ops/s.<br/>total: 1220.14 ± 0.23ms. best: 1219.88ms.<br/>avg: 4.88 ± 0.00ms<br/>min: 3.27 ± 0.01ms<br/>max: 6.08 ± 0.01ms<br/>p99: 6.05 ± 0.01ms<br/><br/>Peak RAM: 73.500MB | 250 trips, 3 coordinates<br/>ops: 322.35 ± 0.40 ops/s. best: 322.73ops/s.<br/>total: 775.56 ± 0.97ms. best: 774.64ms.<br/>avg: 3.10 ± 0.00ms<br/>min: 1.69 ± 0.00ms<br/>max: 4.33 ± 0.01ms<br/>p99: 4.13 ± 0.00ms<br/><br/>250 trips, 5 coordinates<br/>ops: 208.76 ± 0.06 ops/s. best: 208.86ops/s.<br/>total: 1197.53 ± 0.32ms. best: 1196.95ms.<br/>avg: 4.79 ± 0.00ms<br/>min: 3.21 ± 0.01ms<br/>max: 5.97 ± 0.01ms<br/>p99: 5.95 ± 0.01ms<br/><br/>Peak RAM: 70.000MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 107.89 ± 0.07 ops/s. best: 107.97ops/s.<br/>total: 2317.10 ± 1.56ms. best: 2315.41ms.<br/>avg: 9.27 ± 0.01ms<br/>min: 5.44 ± 0.01ms<br/>max: 12.02 ± 0.02ms<br/>p99: 11.98 ± 0.02ms<br/><br/>250 trips, 5 coordinates<br/>ops: 69.57 ± 0.00 ops/s. best: 69.58ops/s.<br/>total: 3593.35 ± 0.21ms. best: 3593.08ms.<br/>avg: 14.37 ± 0.00ms<br/>min: 10.02 ± 0.01ms<br/>max: 17.55 ± 0.04ms<br/>p99: 17.22 ± 0.01ms<br/><br/>Peak RAM: 69.000MB | 250 trips, 3 coordinates<br/>ops: 109.72 ± 0.03 ops/s. best: 109.75ops/s.<br/>total: 2278.51 ± 0.56ms. best: 2277.85ms.<br/>avg: 9.11 ± 0.00ms<br/>min: 5.40 ± 0.01ms<br/>max: 11.90 ± 0.02ms<br/>p99: 11.73 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 70.22 ± 0.02 ops/s. best: 70.27ops/s.<br/>total: 3560.06 ± 1.22ms. best: 3557.75ms.<br/>avg: 14.24 ± 0.00ms<br/>min: 9.88 ± 0.02ms<br/>max: 17.43 ± 0.03ms<br/>p99: 17.09 ± 0.01ms<br/><br/>Peak RAM: 65.000MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>638.531ms<br/>0.638531ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>781.693ms<br/>0.781693ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>245.731ms<br/>0.245731ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>216.643ms<br/>0.216643ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>646.975ms<br/>0.646975ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>800.518ms<br/>0.800518ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>242.077ms<br/>0.242077ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>210.855ms<br/>0.210855ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>809.726ms<br/>0.809726ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1040.51ms<br/>1.04051ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>414.751ms<br/>0.414751ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>461.161ms<br/>0.461161ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>804.239ms<br/>0.804239ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1050.04ms<br/>1.05004ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>396.955ms<br/>0.396955ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>441.631ms<br/>0.441631ms/req |
| rtree | 1 result:<br/>227.444ms ->  0.0227444 ms/query<br/>10 results:<br/>258.18ms ->  0.025818 ms/query | 1 result:<br/>226.991ms ->  0.0226991 ms/query<br/>10 results:<br/>256.782ms ->  0.0256782 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
