### PR TITLE
Remove unused middle_nodes_table vector

### DIFF
--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -222,7 +222,6 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
     std::vector<EdgeDuration> durations_table(target_indices.size(), MAXIMAL_EDGE_DURATION);
     std::vector<EdgeDistance> distances_table(calculate_distance ? target_indices.size() : 0,
                                               MAXIMAL_EDGE_DISTANCE);
-    std::vector<NodeID> middle_nodes_table(target_indices.size(), SPECIAL_NODEID);
 
     // Collect destination (source) nodes into a map
     std::unordered_multimap<NodeID, std::tuple<std::size_t, EdgeWeight, EdgeDuration, EdgeDistance>>
@@ -307,7 +306,6 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     weights_table[index] = path_weight;
                     durations_table[index] = path_duration;
                     current_distance = path_distance;
-                    middle_nodes_table[index] = node;
                 }
 
                 // Remove node from destinations list


### PR DESCRIPTION
I noticed that never read it...


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 11074.4<br/>plain u32: 10969.9<br/>aliased double: 15119<br/>plain double: 15114.9 | aliased u32: 10977.3<br/>plain u32: 10874.6<br/>aliased double: 15002.5<br/>plain double: 14983.1 |
| e2e_match_ch | Ops: 26.00 ± 0.01 ops/s. Best: 26.01 ops/s<br/>Total: 5038.10ms ± 1.30ms. Best: 5036.20ms<br/>Min time: 3.13ms ± 0.05ms<br/>Mean time: 38.46ms ± 0.01ms<br/>Median time: 24.54ms ± 0.11ms<br/>95th percentile: 134.83ms ± 0.24ms<br/>99th percentile: 166.39ms ± 0.41ms<br/>Max time: 170.36ms ± 0.12ms | Ops: 25.79 ± 0.02 ops/s. Best: 25.84 ops/s<br/>Total: 5078.94ms ± 4.74ms. Best: 5069.44ms<br/>Min time: 3.12ms ± 0.05ms<br/>Mean time: 38.77ms ± 0.04ms<br/>Median time: 24.76ms ± 0.08ms<br/>95th percentile: 136.33ms ± 0.34ms<br/>99th percentile: 167.93ms ± 0.25ms<br/>Max time: 171.08ms ± 0.33ms |
| e2e_match_mld | Ops: 43.49 ± 0.02 ops/s. Best: 43.52 ops/s<br/>Total: 3012.21ms ± 1.50ms. Best: 3009.89ms<br/>Min time: 2.54ms ± 0.02ms<br/>Mean time: 22.99ms ± 0.01ms<br/>Median time: 12.16ms ± 0.12ms<br/>95th percentile: 75.28ms ± 0.13ms<br/>99th percentile: 87.37ms ± 0.27ms<br/>Max time: 100.98ms ± 0.48ms | Ops: 43.79 ± 0.02 ops/s. Best: 43.82 ops/s<br/>Total: 2991.55ms ± 1.16ms. Best: 2989.63ms<br/>Min time: 2.58ms ± 0.02ms<br/>Mean time: 22.84ms ± 0.01ms<br/>Median time: 11.99ms ± 0.10ms<br/>95th percentile: 74.82ms ± 0.14ms<br/>99th percentile: 86.77ms ± 0.08ms<br/>Max time: 99.54ms ± 0.24ms |
| e2e_nearest_ch | Ops: 633.53 ± 2.62 ops/s. Best: 636.32 ops/s<br/>Total: 1578.15ms ± 6.32ms. Best: 1571.53ms<br/>Min time: 1.29ms ± 0.01ms<br/>Mean time: 1.58ms ± 0.01ms<br/>Median time: 1.54ms ± 0.01ms<br/>95th percentile: 1.97ms ± 0.01ms<br/>99th percentile: 2.05ms ± 0.00ms<br/>Max time: 9.32ms ± 7.37ms | Ops: 636.81 ± 3.42 ops/s. Best: 642.90 ops/s<br/>Total: 1570.10ms ± 8.18ms. Best: 1555.44ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.06ms ± 0.01ms<br/>Max time: 9.34ms ± 7.43ms |
| e2e_nearest_mld | Ops: 630.53 ± 4.23 ops/s. Best: 635.84 ops/s<br/>Total: 1586.10ms ± 10.79ms. Best: 1572.73ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.59ms ± 0.01ms<br/>Median time: 1.55ms ± 0.01ms<br/>95th percentile: 1.97ms ± 0.01ms<br/>99th percentile: 2.05ms ± 0.01ms<br/>Max time: 9.33ms ± 7.38ms | Ops: 635.81 ± 4.74 ops/s. Best: 644.49 ops/s<br/>Total: 1573.07ms ± 12.45ms. Best: 1551.62ms<br/>Min time: 1.29ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.06ms ± 0.01ms<br/>Max time: 9.36ms ± 7.44ms |
| e2e_route_ch | Ops: 216.09 ± 0.44 ops/s. Best: 216.86 ops/s<br/>Total: 4627.77ms ± 10.02ms. Best: 4611.34ms<br/>Min time: 1.86ms ± 0.05ms<br/>Mean time: 4.63ms ± 0.01ms<br/>Median time: 4.71ms ± 0.01ms<br/>95th percentile: 6.08ms ± 0.02ms<br/>99th percentile: 6.64ms ± 0.04ms<br/>Max time: 13.39ms ± 6.38ms | Ops: 216.23 ± 0.38 ops/s. Best: 216.95 ops/s<br/>Total: 4624.65ms ± 8.27ms. Best: 4609.34ms<br/>Min time: 1.84ms ± 0.03ms<br/>Mean time: 4.62ms ± 0.01ms<br/>Median time: 4.71ms ± 0.01ms<br/>95th percentile: 6.08ms ± 0.02ms<br/>99th percentile: 6.64ms ± 0.03ms<br/>Max time: 13.31ms ± 6.35ms |
| e2e_route_mld | Ops: 178.35 ± 0.38 ops/s. Best: 179.06 ops/s<br/>Total: 5607.06ms ± 12.83ms. Best: 5584.81ms<br/>Min time: 1.83ms ± 0.03ms<br/>Mean time: 5.61ms ± 0.01ms<br/>Median time: 5.72ms ± 0.02ms<br/>95th percentile: 7.61ms ± 0.02ms<br/>99th percentile: 8.16ms ± 0.07ms<br/>Max time: 14.67ms ± 5.93ms | Ops: 178.70 ± 0.39 ops/s. Best: 179.61 ops/s<br/>Total: 5595.92ms ± 12.09ms. Best: 5567.55ms<br/>Min time: 1.90ms ± 0.03ms<br/>Mean time: 5.60ms ± 0.01ms<br/>Median time: 5.73ms ± 0.02ms<br/>95th percentile: 7.59ms ± 0.02ms<br/>99th percentile: 8.19ms ± 0.07ms<br/>Max time: 14.73ms ± 5.90ms |
| e2e_table_ch | Ops: 210.28 ± 0.52 ops/s. Best: 210.89 ops/s<br/>Total: 4755.15ms ± 11.14ms. Best: 4741.70ms<br/>Min time: 2.53ms ± 0.07ms<br/>Mean time: 4.76ms ± 0.01ms<br/>Median time: 4.77ms ± 0.01ms<br/>95th percentile: 6.46ms ± 0.02ms<br/>99th percentile: 6.79ms ± 0.02ms<br/>Max time: 13.94ms ± 7.11ms | Ops: 210.44 ± 0.36 ops/s. Best: 210.93 ops/s<br/>Total: 4751.56ms ± 7.85ms. Best: 4740.94ms<br/>Min time: 2.55ms ± 0.03ms<br/>Mean time: 4.75ms ± 0.01ms<br/>Median time: 4.76ms ± 0.01ms<br/>95th percentile: 6.45ms ± 0.02ms<br/>99th percentile: 6.79ms ± 0.02ms<br/>Max time: 13.92ms ± 7.08ms |
| e2e_table_mld | Ops: 69.65 ± 0.04 ops/s. Best: 69.71 ops/s<br/>Total: 14358.05ms ± 7.41ms. Best: 14344.96ms<br/>Min time: 6.01ms ± 0.03ms<br/>Mean time: 14.36ms ± 0.01ms<br/>Median time: 14.32ms ± 0.04ms<br/>95th percentile: 21.86ms ± 0.07ms<br/>99th percentile: 23.02ms ± 0.06ms<br/>Max time: 29.51ms ± 5.64ms | Ops: 70.21 ± 0.02 ops/s. Best: 70.26 ops/s<br/>Total: 14242.51ms ± 5.40ms. Best: 14233.18ms<br/>Min time: 5.95ms ± 0.05ms<br/>Mean time: 14.24ms ± 0.01ms<br/>Median time: 14.19ms ± 0.03ms<br/>95th percentile: 21.70ms ± 0.04ms<br/>99th percentile: 22.91ms ± 0.09ms<br/>Max time: 29.26ms ± 5.68ms |
| e2e_trip_ch | Ops: 62.11 ± 0.04 ops/s. Best: 62.17 ops/s<br/>Total: 16100.76ms ± 9.38ms. Best: 16085.11ms<br/>Min time: 2.40ms ± 0.13ms<br/>Mean time: 16.10ms ± 0.01ms<br/>Median time: 15.31ms ± 0.02ms<br/>95th percentile: 28.34ms ± 0.05ms<br/>99th percentile: 30.46ms ± 0.07ms<br/>Max time: 32.99ms ± 1.33ms | Ops: 62.08 ± 0.05 ops/s. Best: 62.16 ops/s<br/>Total: 16109.20ms ± 12.10ms. Best: 16086.49ms<br/>Min time: 2.37ms ± 0.19ms<br/>Mean time: 16.11ms ± 0.01ms<br/>Median time: 15.32ms ± 0.02ms<br/>95th percentile: 28.34ms ± 0.03ms<br/>99th percentile: 30.40ms ± 0.09ms<br/>Max time: 32.99ms ± 1.40ms |
| e2e_trip_mld | Ops: 36.79 ± 0.01 ops/s. Best: 36.81 ops/s<br/>Total: 27183.32ms ± 10.49ms. Best: 27166.16ms<br/>Min time: 2.39ms ± 0.13ms<br/>Mean time: 27.18ms ± 0.01ms<br/>Median time: 26.33ms ± 0.09ms<br/>95th percentile: 44.27ms ± 0.03ms<br/>99th percentile: 47.04ms ± 0.12ms<br/>Max time: 49.19ms ± 0.15ms | Ops: 36.93 ± 0.01 ops/s. Best: 36.95 ops/s<br/>Total: 27080.46ms ± 8.96ms. Best: 27067.25ms<br/>Min time: 2.41ms ± 0.20ms<br/>Mean time: 27.08ms ± 0.01ms<br/>Median time: 26.25ms ± 0.06ms<br/>95th percentile: 44.13ms ± 0.06ms<br/>99th percentile: 46.92ms ± 0.19ms<br/>Max time: 49.01ms ± 0.19ms |
| json-render | String: 8.96327ms<br/>Stringstream: 14.1848ms<br/>Vector: 9.48551ms | String: 8.77171ms<br/>Stringstream: 14.49ms<br/>Vector: 9.44942ms |
| match_ch | Default radius: <br/>7.05469ms/req at 82 coordinate<br/>0.0860328ms/coordinate<br/>Radius 10m: <br/>24.965ms/req at 82 coordinate<br/>0.304452ms/coordinate | Default radius: <br/>7.07456ms/req at 82 coordinate<br/>0.0862752ms/coordinate<br/>Radius 10m: <br/>25.0318ms/req at 82 coordinate<br/>0.305266ms/coordinate |
| match_mld | Default radius: <br/>4.57203ms/req at 82 coordinate<br/>0.0557564ms/coordinate<br/>Radius 10m: <br/>17.3695ms/req at 82 coordinate<br/>0.211824ms/coordinate | Default radius: <br/>4.37163ms/req at 82 coordinate<br/>0.0533125ms/coordinate<br/>Radius 10m: <br/>16.2161ms/req at 82 coordinate<br/>0.197758ms/coordinate |
| node_match_ch | Ops: 156.8 ± 0.8 ops/s. Best: 158.0 ops/s | Ops: 157.5 ± 0.5 ops/s. Best: 158.2 ops/s |
| node_match_mld | Ops: 219.7 ± 1.5 ops/s. Best: 222.0 ops/s | Ops: 217.4 ± 1.6 ops/s. Best: 219.9 ops/s |
| node_nearest_ch | Ops: 9296.2 ± 313.9 ops/s. Best: 9751.4 ops/s | Ops: 9911.4 ± 872.1 ops/s. Best: 11788.0 ops/s |
| node_nearest_mld | Ops: 9726.8 ± 751.5 ops/s. Best: 11232.0 ops/s | Ops: 9132.9 ± 637.8 ops/s. Best: 10083.8 ops/s |
| node_route_ch | Ops: 988.7 ± 23.3 ops/s. Best: 1022.1 ops/s | Ops: 986.3 ± 17.4 ops/s. Best: 1011.1 ops/s |
| node_route_mld | Ops: 506.3 ± 6.5 ops/s. Best: 515.0 ops/s | Ops: 510.8 ± 4.0 ops/s. Best: 516.2 ops/s |
| node_table_ch | Ops: 174.2 ± 1.6 ops/s. Best: 177.2 ops/s | Ops: 173.8 ± 1.3 ops/s. Best: 175.6 ops/s |
| node_table_mld | Ops: 38.2 ± 0.1 ops/s. Best: 38.3 ops/s | Ops: 38.5 ± 0.1 ops/s. Best: 38.6 ops/s |
| node_trip_ch | Ops: 179.8 ± 0.6 ops/s. Best: 180.7 ops/s | Ops: 179.6 ± 0.5 ops/s. Best: 180.2 ops/s |
| node_trip_mld | Ops: 61.2 ± 0.1 ops/s. Best: 61.3 ops/s | Ops: 62.3 ± 0.3 ops/s. Best: 62.5 ops/s |
| osrm_contract | Time: 181.68s Peak RAM: 193.28MB | Time: 181.65s Peak RAM: 193.29MB |
| osrm_customize | Time: 2.53s Peak RAM: 112.04MB | Time: 2.52s Peak RAM: 112.04MB |
| osrm_extract | Time: 24.05s Peak RAM: 398.62MB | Time: 24.33s Peak RAM: 401.28MB |
| osrm_partition | Time: 5.94s Peak RAM: 121.29MB | Time: 5.94s Peak RAM: 121.48MB |
| packedvector | random write:<br/>std::vector 184972 ms<br/>util::packed_vector 373398 ms<br/>slowdown: 2.01868<br/>random read:<br/>std::vector 100559 ms<br/>util::packed_vector 190687 ms<br/>slowdown: 1.89628 | random write:<br/>std::vector 180504 ms<br/>util::packed_vector 378605 ms<br/>slowdown: 2.09749<br/>random read:<br/>std::vector 99508.8 ms<br/>util::packed_vector 192647 ms<br/>slowdown: 1.93598 |
| random_match_ch | 500 matches, default radius<br/>ops: 128.65 ± 0.19 ops/s. best: 128.94ops/s.<br/>total: 443.07 ± 0.65ms. best: 442.08ms.<br/>avg: 7.77 ± 0.01ms<br/>min: 0.25 ± 0.00ms<br/>max: 42.60 ± 0.06ms<br/>p99: 42.60 ± 0.06ms<br/><br/>500 matches, radius=10<br/>ops: 36.60 ± 0.04 ops/s. best: 36.66ops/s.<br/>total: 1748.54 ± 2.20ms. best: 1745.95ms.<br/>avg: 27.32 ± 0.03ms<br/>min: 0.25 ± 0.00ms<br/>max: 432.49 ± 1.25ms<br/>p99: 432.49 ± 1.25ms<br/><br/>500 matches, radius=20<br/>ops: 8.45 ± 0.01 ops/s. best: 8.46ops/s.<br/>total: 7693.12 ± 7.43ms. best: 7684.25ms.<br/>avg: 118.36 ± 0.11ms<br/>min: 0.51 ± 0.00ms<br/>max: 2313.11 ± 5.74ms<br/>p99: 2313.11 ± 5.74ms<br/><br/>Peak RAM: 55.000MB | 500 matches, default radius<br/>ops: 127.67 ± 0.17 ops/s. best: 127.94ops/s.<br/>total: 446.48 ± 0.59ms. best: 445.53ms.<br/>avg: 7.83 ± 0.01ms<br/>min: 0.25 ± 0.00ms<br/>max: 42.89 ± 0.06ms<br/>p99: 42.89 ± 0.06ms<br/><br/>500 matches, radius=10<br/>ops: 36.11 ± 0.05 ops/s. best: 36.17ops/s.<br/>total: 1772.49 ± 2.24ms. best: 1769.44ms.<br/>avg: 27.70 ± 0.03ms<br/>min: 0.25 ± 0.00ms<br/>max: 441.55 ± 1.26ms<br/>p99: 441.55 ± 1.26ms<br/><br/>500 matches, radius=20<br/>ops: 8.29 ± 0.01 ops/s. best: 8.31ops/s.<br/>total: 7836.09 ± 7.74ms. best: 7825.92ms.<br/>avg: 120.56 ± 0.12ms<br/>min: 0.51 ± 0.00ms<br/>max: 2391.16 ± 5.44ms<br/>p99: 2391.16 ± 5.44ms<br/><br/>Peak RAM: 55.000MB |
| random_match_mld | 500 matches, default radius<br/>ops: 205.21 ± 0.34 ops/s. best: 205.58ops/s.<br/>total: 277.77 ± 0.47ms. best: 277.26ms.<br/>avg: 4.87 ± 0.01ms<br/>min: 0.19 ± 0.00ms<br/>max: 27.06 ± 0.05ms<br/>p99: 27.06 ± 0.05ms<br/><br/>500 matches, radius=10<br/>ops: 73.02 ± 0.06 ops/s. best: 73.09ops/s.<br/>total: 876.42 ± 0.70ms. best: 875.60ms.<br/>avg: 13.69 ± 0.01ms<br/>min: 0.23 ± 0.00ms<br/>max: 162.11 ± 0.41ms<br/>p99: 162.11 ± 0.41ms<br/><br/>500 matches, radius=20<br/>ops: 15.33 ± 0.01 ops/s. best: 15.35ops/s.<br/>total: 4239.68 ± 3.84ms. best: 4234.20ms.<br/>avg: 65.23 ± 0.06ms<br/>min: 0.29 ± 0.00ms<br/>max: 847.07 ± 2.20ms<br/>p99: 847.07 ± 2.20ms<br/><br/>Peak RAM: 51.000MB | 500 matches, default radius<br/>ops: 205.44 ± 0.38 ops/s. best: 205.82ops/s.<br/>total: 277.45 ± 0.53ms. best: 276.94ms.<br/>avg: 4.87 ± 0.01ms<br/>min: 0.19 ± 0.00ms<br/>max: 27.03 ± 0.05ms<br/>p99: 27.03 ± 0.05ms<br/><br/>500 matches, radius=10<br/>ops: 73.11 ± 0.05 ops/s. best: 73.17ops/s.<br/>total: 875.44 ± 0.57ms. best: 874.69ms.<br/>avg: 13.68 ± 0.01ms<br/>min: 0.23 ± 0.00ms<br/>max: 161.89 ± 0.32ms<br/>p99: 161.89 ± 0.32ms<br/><br/>500 matches, radius=20<br/>ops: 15.36 ± 0.01 ops/s. best: 15.38ops/s.<br/>total: 4232.25 ± 3.98ms. best: 4227.39ms.<br/>avg: 65.11 ± 0.06ms<br/>min: 0.30 ± 0.00ms<br/>max: 846.42 ± 2.27ms<br/>p99: 846.42 ± 2.27ms<br/><br/>Peak RAM: 51.000MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 20657.32 ± 35.85 ops/s. best: 20687.22ops/s.<br/>total: 484.09 ± 0.84ms. best: 483.39ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15504.99 ± 8.29 ops/s. best: 15514.49ops/s.<br/>total: 644.95 ± 0.35ms. best: 644.56ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12009.62 ± 3.42 ops/s. best: 12013.58ops/s.<br/>total: 832.67 ± 0.24ms. best: 832.39ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 34.500MB | 10000 nearest, number_of_results=1<br/>ops: 20779.76 ± 28.79 ops/s. best: 20802.93ops/s.<br/>total: 481.24 ± 0.67ms. best: 480.70ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15547.45 ± 6.35 ops/s. best: 15553.38ops/s.<br/>total: 643.19 ± 0.26ms. best: 642.95ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12021.04 ± 5.03 ops/s. best: 12025.78ops/s.<br/>total: 831.88 ± 0.35ms. best: 831.55ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 34.500MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 20657.31 ± 35.72 ops/s. best: 20686.63ops/s.<br/>total: 484.09 ± 0.84ms. best: 483.40ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15508.57 ± 5.50 ops/s. best: 15514.86ops/s.<br/>total: 644.80 ± 0.23ms. best: 644.54ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12010.19 ± 1.68 ops/s. best: 12012.27ops/s.<br/>total: 832.63 ± 0.12ms. best: 832.48ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 34.500MB | 10000 nearest, number_of_results=1<br/>ops: 20768.35 ± 37.32 ops/s. best: 20803.34ops/s.<br/>total: 481.50 ± 0.87ms. best: 480.69ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15545.27 ± 3.94 ops/s. best: 15549.56ops/s.<br/>total: 643.28 ± 0.16ms. best: 643.11ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12025.96 ± 4.00 ops/s. best: 12031.94ops/s.<br/>total: 831.53 ± 0.27ms. best: 831.12ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 34.500MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 282.43 ± 0.15 ops/s. best: 282.60ops/s.<br/>total: 3483.99 ± 1.84ms. best: 3481.90ms.<br/>avg: 3.54 ± 0.00ms<br/>min: 0.45 ± 0.00ms<br/>max: 6.05 ± 0.05ms<br/>p99: 5.27 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 328.87 ± 0.04 ops/s. best: 328.92ops/s.<br/>total: 3040.71 ± 0.36ms. best: 3040.25ms.<br/>avg: 3.04 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.92 ± 0.05ms<br/>p99: 7.33 ± 0.02ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 573.79 ± 0.13 ops/s. best: 573.99ops/s.<br/>total: 1714.93 ± 0.38ms. best: 1714.32ms.<br/>avg: 1.74 ± 0.00ms<br/>min: 0.36 ± 0.01ms<br/>max: 2.84 ± 0.00ms<br/>p99: 2.46 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 629.07 ± 0.10 ops/s. best: 629.20ops/s.<br/>total: 1589.65 ± 0.26ms. best: 1589.31ms.<br/>avg: 1.59 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.42 ± 0.00ms<br/>p99: 4.12 ± 0.01ms<br/><br/>Peak RAM: 84.000MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 284.63 ± 0.19 ops/s. best: 284.84ops/s.<br/>total: 3457.14 ± 2.31ms. best: 3454.54ms.<br/>avg: 3.51 ± 0.00ms<br/>min: 0.46 ± 0.01ms<br/>max: 6.04 ± 0.03ms<br/>p99: 5.23 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 329.87 ± 0.10 ops/s. best: 329.97ops/s.<br/>total: 3031.54 ± 0.95ms. best: 3030.56ms.<br/>avg: 3.03 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.98 ± 0.08ms<br/>p99: 7.34 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 571.83 ± 0.04 ops/s. best: 571.89ops/s.<br/>total: 1720.80 ± 0.13ms. best: 1720.62ms.<br/>avg: 1.75 ± 0.00ms<br/>min: 0.36 ± 0.00ms<br/>max: 2.87 ± 0.03ms<br/>p99: 2.46 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 619.84 ± 0.16 ops/s. best: 619.99ops/s.<br/>total: 1613.32 ± 0.42ms. best: 1612.92ms.<br/>avg: 1.61 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.52 ± 0.01ms<br/>p99: 4.20 ± 0.00ms<br/><br/>Peak RAM: 84.000MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 147.08 ± 0.01 ops/s. best: 147.09ops/s.<br/>total: 6690.25 ± 0.39ms. best: 6689.70ms.<br/>avg: 6.80 ± 0.00ms<br/>min: 0.44 ± 0.01ms<br/>max: 16.32 ± 0.01ms<br/>p99: 11.02 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 140.76 ± 0.02 ops/s. best: 140.79ops/s.<br/>total: 7104.30 ± 1.26ms. best: 7103.01ms.<br/>avg: 7.10 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 16.40 ± 0.02ms<br/>p99: 15.09 ± 0.08ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 204.59 ± 0.03 ops/s. best: 204.62ops/s.<br/>total: 4809.64 ± 0.64ms. best: 4808.99ms.<br/>avg: 4.89 ± 0.00ms<br/>min: 0.38 ± 0.00ms<br/>max: 13.57 ± 0.02ms<br/>p99: 8.42 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 176.64 ± 0.04 ops/s. best: 176.68ops/s.<br/>total: 5661.16 ± 1.16ms. best: 5659.87ms.<br/>avg: 5.66 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.92 ± 0.18ms<br/>p99: 11.60 ± 0.08ms<br/><br/>Peak RAM: 73.328MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 147.30 ± 0.02 ops/s. best: 147.32ops/s.<br/>total: 6680.22 ± 0.85ms. best: 6679.23ms.<br/>avg: 6.79 ± 0.00ms<br/>min: 0.44 ± 0.00ms<br/>max: 16.32 ± 0.04ms<br/>p99: 11.01 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 140.96 ± 0.05 ops/s. best: 141.02ops/s.<br/>total: 7093.99 ± 2.45ms. best: 7091.02ms.<br/>avg: 7.09 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.37 ± 0.03ms<br/>p99: 15.07 ± 0.08ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 204.80 ± 0.04 ops/s. best: 204.86ops/s.<br/>total: 4804.69 ± 0.96ms. best: 4803.30ms.<br/>avg: 4.88 ± 0.00ms<br/>min: 0.39 ± 0.01ms<br/>max: 13.55 ± 0.01ms<br/>p99: 8.42 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 176.73 ± 0.08 ops/s. best: 176.85ops/s.<br/>total: 5658.46 ± 2.63ms. best: 5654.58ms.<br/>avg: 5.66 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.79 ± 0.02ms<br/>p99: 11.59 ± 0.06ms<br/><br/>Peak RAM: 73.328MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1070.58 ± 3.90 ops/s. best: 1074.02ops/s.<br/>total: 233.52 ± 0.86ms. best: 232.77ms.<br/>avg: 0.93 ± 0.00ms<br/>min: 0.74 ± 0.00ms<br/>max: 1.21 ± 0.14ms<br/>p99: 1.11 ± 0.00ms<br/><br/>250 tables, 25 coordinates<br/>ops: 119.73 ± 0.02 ops/s. best: 119.76ops/s.<br/>total: 2088.08 ± 0.30ms. best: 2087.57ms.<br/>avg: 8.35 ± 0.00ms<br/>min: 7.73 ± 0.02ms<br/>max: 8.94 ± 0.02ms<br/>p99: 8.83 ± 0.02ms<br/><br/>250 tables, 50 coordinates<br/>ops: 58.07 ± 0.01 ops/s. best: 58.08ops/s.<br/>total: 4305.44 ± 1.09ms. best: 4304.38ms.<br/>avg: 17.22 ± 0.00ms<br/>min: 16.38 ± 0.02ms<br/>max: 18.10 ± 0.02ms<br/>p99: 18.03 ± 0.02ms<br/><br/>Peak RAM: 63.500MB | 250 tables, 3 coordinates<br/>ops: 1069.04 ± 3.85 ops/s. best: 1072.47ops/s.<br/>total: 233.86 ± 0.85ms. best: 233.11ms.<br/>avg: 0.94 ± 0.00ms<br/>min: 0.74 ± 0.00ms<br/>max: 1.20 ± 0.13ms<br/>p99: 1.11 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 120.13 ± 0.03 ops/s. best: 120.16ops/s.<br/>total: 2081.17 ± 0.47ms. best: 2080.57ms.<br/>avg: 8.32 ± 0.00ms<br/>min: 7.71 ± 0.01ms<br/>max: 8.89 ± 0.01ms<br/>p99: 8.80 ± 0.02ms<br/><br/>250 tables, 50 coordinates<br/>ops: 58.31 ± 0.01 ops/s. best: 58.33ops/s.<br/>total: 4287.44 ± 0.50ms. best: 4286.23ms.<br/>avg: 17.15 ± 0.00ms<br/>min: 16.28 ± 0.01ms<br/>max: 18.11 ± 0.08ms<br/>p99: 17.96 ± 0.01ms<br/><br/>Peak RAM: 63.500MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 229.66 ± 0.27 ops/s. best: 229.90ops/s.<br/>total: 1088.56 ± 1.28ms. best: 1087.44ms.<br/>avg: 4.35 ± 0.01ms<br/>min: 3.46 ± 0.01ms<br/>max: 5.62 ± 0.02ms<br/>p99: 5.42 ± 0.03ms<br/><br/>250 tables, 25 coordinates<br/>ops: 24.15 ± 0.00 ops/s. best: 24.16ops/s.<br/>total: 10349.88 ± 1.87ms. best: 10346.19ms.<br/>avg: 41.40 ± 0.01ms<br/>min: 38.20 ± 0.03ms<br/>max: 45.13 ± 0.06ms<br/>p99: 44.34 ± 0.07ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.18 ± 0.00 ops/s. best: 11.18ops/s.<br/>total: 22364.69 ± 2.52ms. best: 22361.12ms.<br/>avg: 89.46 ± 0.01ms<br/>min: 85.13 ± 0.09ms<br/>max: 95.02 ± 0.09ms<br/>p99: 93.69 ± 0.10ms<br/><br/>Peak RAM: 62.172MB | 250 tables, 3 coordinates<br/>ops: 229.70 ± 0.53 ops/s. best: 230.11ops/s.<br/>total: 1088.39 ± 2.54ms. best: 1086.45ms.<br/>avg: 4.35 ± 0.01ms<br/>min: 3.47 ± 0.01ms<br/>max: 5.67 ± 0.02ms<br/>p99: 5.47 ± 0.02ms<br/><br/>250 tables, 25 coordinates<br/>ops: 24.11 ± 0.02 ops/s. best: 24.14ops/s.<br/>total: 10371.24 ± 6.92ms. best: 10355.70ms.<br/>avg: 41.48 ± 0.03ms<br/>min: 38.19 ± 0.19ms<br/>max: 45.37 ± 0.03ms<br/>p99: 44.49 ± 0.08ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.13 ± 0.01 ops/s. best: 11.14ops/s.<br/>total: 22456.34 ± 13.37ms. best: 22434.55ms.<br/>avg: 89.83 ± 0.05ms<br/>min: 85.17 ± 0.20ms<br/>max: 95.49 ± 0.61ms<br/>p99: 93.89 ± 0.27ms<br/><br/>Peak RAM: 62.172MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 317.26 ± 0.49 ops/s. best: 317.63ops/s.<br/>total: 788.00 ± 1.22ms. best: 787.07ms.<br/>avg: 3.15 ± 0.00ms<br/>min: 1.60 ± 0.00ms<br/>max: 4.38 ± 0.01ms<br/>p99: 4.20 ± 0.00ms<br/><br/>250 trips, 5 coordinates<br/>ops: 204.80 ± 0.05 ops/s. best: 204.86ops/s.<br/>total: 1220.73 ± 0.32ms. best: 1220.32ms.<br/>avg: 4.88 ± 0.00ms<br/>min: 2.98 ± 0.01ms<br/>max: 6.16 ± 0.01ms<br/>p99: 5.99 ± 0.01ms<br/><br/>Peak RAM: 74.000MB | 250 trips, 3 coordinates<br/>ops: 315.78 ± 0.43 ops/s. best: 316.10ops/s.<br/>total: 791.70 ± 1.07ms. best: 790.88ms.<br/>avg: 3.17 ± 0.00ms<br/>min: 1.60 ± 0.00ms<br/>max: 4.40 ± 0.00ms<br/>p99: 4.20 ± 0.00ms<br/><br/>250 trips, 5 coordinates<br/>ops: 205.48 ± 0.04 ops/s. best: 205.54ops/s.<br/>total: 1216.65 ± 0.27ms. best: 1216.30ms.<br/>avg: 4.87 ± 0.00ms<br/>min: 2.98 ± 0.01ms<br/>max: 6.08 ± 0.01ms<br/>p99: 5.98 ± 0.01ms<br/><br/>Peak RAM: 74.000MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 107.76 ± 0.07 ops/s. best: 107.82ops/s.<br/>total: 2319.93 ± 1.46ms. best: 2318.64ms.<br/>avg: 9.28 ± 0.01ms<br/>min: 5.43 ± 0.01ms<br/>max: 12.09 ± 0.01ms<br/>p99: 11.95 ± 0.02ms<br/><br/>250 trips, 5 coordinates<br/>ops: 69.36 ± 0.02 ops/s. best: 69.38ops/s.<br/>total: 3604.41 ± 0.88ms. best: 3603.32ms.<br/>avg: 14.42 ± 0.00ms<br/>min: 10.02 ± 0.01ms<br/>max: 17.64 ± 0.02ms<br/>p99: 17.23 ± 0.01ms<br/><br/>Peak RAM: 69.500MB | 250 trips, 3 coordinates<br/>ops: 108.08 ± 0.08 ops/s. best: 108.19ops/s.<br/>total: 2313.18 ± 1.80ms. best: 2310.68ms.<br/>avg: 9.25 ± 0.01ms<br/>min: 5.40 ± 0.01ms<br/>max: 12.06 ± 0.03ms<br/>p99: 11.95 ± 0.03ms<br/><br/>250 trips, 5 coordinates<br/>ops: 69.69 ± 0.01 ops/s. best: 69.70ops/s.<br/>total: 3587.42 ± 0.61ms. best: 3586.76ms.<br/>avg: 14.35 ± 0.00ms<br/>min: 9.99 ± 0.00ms<br/>max: 17.54 ± 0.03ms<br/>p99: 17.15 ± 0.01ms<br/><br/>Peak RAM: 69.500MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>639.886ms<br/>0.639886ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>783.416ms<br/>0.783416ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>245.891ms<br/>0.245891ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>216.225ms<br/>0.216225ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>636.569ms<br/>0.636569ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>777.607ms<br/>0.777607ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>247.098ms<br/>0.247098ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>217.609ms<br/>0.217609ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>818.373ms<br/>0.818373ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1065.76ms<br/>1.06576ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>424.401ms<br/>0.424401ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>487.475ms<br/>0.487475ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>805.797ms<br/>0.805797ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1037.03ms<br/>1.03703ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>413.598ms<br/>0.413598ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>461.975ms<br/>0.461975ms/req |
| rtree | 1 result:<br/>227.513ms ->  0.0227513 ms/query<br/>10 results:<br/>258.299ms ->  0.0258299 ms/query | 1 result:<br/>227.318ms ->  0.0227318 ms/query<br/>10 results:<br/>258.027ms ->  0.0258027 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
