### PR TITLE
Add std::vector<...>::reserve in ContiguousInternalMemoryDataFacadeBase::GetOverridesThatStartAt

### DIFF
--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -602,6 +602,8 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
         auto found_range = std::equal_range(
             m_maneuver_overrides.begin(), m_maneuver_overrides.end(), edge_based_node_id, Comp{});
+        
+        results.reserve(std::distance(found_range.first, found_range.second));
 
         std::for_each(found_range.first,
                       found_range.second,

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -602,7 +602,7 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
 
         auto found_range = std::equal_range(
             m_maneuver_overrides.begin(), m_maneuver_overrides.end(), edge_based_node_id, Comp{});
-        
+
         results.reserve(std::distance(found_range.first, found_range.second));
 
         std::for_each(found_range.first,


### PR DESCRIPTION
Yet another microoptimisation...


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 11138.5<br/>plain u32: 10969.9<br/>aliased double: 15142.2<br/>plain double: 15116.6 | aliased u32: 10988.3<br/>plain u32: 10878.6<br/>aliased double: 14968.5<br/>plain double: 14994.3 |
| e2e_match_ch | Ops: 25.39 ± 0.01 ops/s. Best: 25.40 ops/s<br/>Total: 5159.19ms ± 2.59ms. Best: 5156.84ms<br/>Min time: 3.20ms ± 0.03ms<br/>Mean time: 39.38ms ± 0.02ms<br/>Median time: 29.61ms ± 0.08ms<br/>95th percentile: 134.81ms ± 0.25ms<br/>99th percentile: 162.80ms ± 0.45ms<br/>Max time: 180.73ms ± 0.64ms | Ops: 25.14 ± 0.01 ops/s. Best: 25.15 ops/s<br/>Total: 5211.31ms ± 1.07ms. Best: 5209.64ms<br/>Min time: 3.25ms ± 0.02ms<br/>Mean time: 39.78ms ± 0.01ms<br/>Median time: 29.90ms ± 0.11ms<br/>95th percentile: 136.89ms ± 0.31ms<br/>99th percentile: 164.39ms ± 0.60ms<br/>Max time: 183.81ms ± 0.96ms |
| e2e_match_mld | Ops: 43.47 ± 0.02 ops/s. Best: 43.50 ops/s<br/>Total: 3013.23ms ± 1.32ms. Best: 3011.29ms<br/>Min time: 2.59ms ± 0.04ms<br/>Mean time: 23.00ms ± 0.01ms<br/>Median time: 12.08ms ± 0.15ms<br/>95th percentile: 75.32ms ± 0.32ms<br/>99th percentile: 87.34ms ± 0.65ms<br/>Max time: 100.32ms ± 0.68ms | Ops: 43.37 ± 0.02 ops/s. Best: 43.39 ops/s<br/>Total: 3020.79ms ± 1.05ms. Best: 3019.38ms<br/>Min time: 2.56ms ± 0.04ms<br/>Mean time: 23.06ms ± 0.01ms<br/>Median time: 12.09ms ± 0.06ms<br/>95th percentile: 75.65ms ± 0.24ms<br/>99th percentile: 87.41ms ± 0.25ms<br/>Max time: 101.22ms ± 0.30ms |
| e2e_nearest_ch | Ops: 638.16 ± 5.08 ops/s. Best: 644.90 ops/s<br/>Total: 1566.77ms ± 11.93ms. Best: 1550.62ms<br/>Min time: 1.27ms ± 0.00ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.32ms ± 7.42ms | Ops: 635.03 ± 2.96 ops/s. Best: 639.95 ops/s<br/>Total: 1574.74ms ± 7.47ms. Best: 1562.63ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.54ms ± 0.01ms<br/>95th percentile: 1.97ms ± 0.01ms<br/>99th percentile: 2.06ms ± 0.01ms<br/>Max time: 9.36ms ± 7.43ms |
| e2e_nearest_mld | Ops: 639.02 ± 4.24 ops/s. Best: 644.56 ops/s<br/>Total: 1564.72ms ± 10.41ms. Best: 1551.44ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 1.56ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.31ms ± 7.38ms | Ops: 633.76 ± 5.89 ops/s. Best: 645.74 ops/s<br/>Total: 1577.78ms ± 13.48ms. Best: 1548.61ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 1.58ms ± 0.01ms<br/>Median time: 1.54ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.06ms ± 0.01ms<br/>Max time: 9.34ms ± 7.36ms |
| e2e_route_ch | Ops: 216.33 ± 0.50 ops/s. Best: 216.92 ops/s<br/>Total: 4622.34ms ± 10.61ms. Best: 4610.00ms<br/>Min time: 1.88ms ± 0.06ms<br/>Mean time: 4.62ms ± 0.01ms<br/>Median time: 4.71ms ± 0.01ms<br/>95th percentile: 6.08ms ± 0.02ms<br/>99th percentile: 6.60ms ± 0.02ms<br/>Max time: 13.35ms ± 6.36ms | Ops: 215.73 ± 0.55 ops/s. Best: 216.62 ops/s<br/>Total: 4635.43ms ± 11.81ms. Best: 4616.28ms<br/>Min time: 1.86ms ± 0.05ms<br/>Mean time: 4.64ms ± 0.01ms<br/>Median time: 4.72ms ± 0.01ms<br/>95th percentile: 6.11ms ± 0.03ms<br/>99th percentile: 6.64ms ± 0.03ms<br/>Max time: 13.33ms ± 6.40ms |
| e2e_route_mld | Ops: 178.10 ± 0.34 ops/s. Best: 178.74 ops/s<br/>Total: 5614.87ms ± 10.93ms. Best: 5594.73ms<br/>Min time: 1.85ms ± 0.05ms<br/>Mean time: 5.61ms ± 0.01ms<br/>Median time: 5.74ms ± 0.02ms<br/>95th percentile: 7.64ms ± 0.02ms<br/>99th percentile: 8.19ms ± 0.06ms<br/>Max time: 14.78ms ± 5.95ms | Ops: 177.39 ± 0.32 ops/s. Best: 178.00 ops/s<br/>Total: 5637.35ms ± 10.52ms. Best: 5617.88ms<br/>Min time: 1.83ms ± 0.05ms<br/>Mean time: 5.64ms ± 0.01ms<br/>Median time: 5.76ms ± 0.02ms<br/>95th percentile: 7.66ms ± 0.02ms<br/>99th percentile: 8.24ms ± 0.11ms<br/>Max time: 14.80ms ± 5.98ms |
| e2e_table_ch | Ops: 216.42 ± 0.45 ops/s. Best: 217.27 ops/s<br/>Total: 4620.61ms ± 10.58ms. Best: 4602.56ms<br/>Min time: 2.53ms ± 0.02ms<br/>Mean time: 4.62ms ± 0.01ms<br/>Median time: 4.63ms ± 0.01ms<br/>95th percentile: 6.25ms ± 0.01ms<br/>99th percentile: 6.59ms ± 0.03ms<br/>Max time: 13.80ms ± 7.04ms | Ops: 216.16 ± 0.38 ops/s. Best: 216.66 ops/s<br/>Total: 4626.01ms ± 8.41ms. Best: 4615.56ms<br/>Min time: 2.52ms ± 0.02ms<br/>Mean time: 4.63ms ± 0.01ms<br/>Median time: 4.62ms ± 0.01ms<br/>95th percentile: 6.26ms ± 0.02ms<br/>99th percentile: 6.62ms ± 0.01ms<br/>Max time: 13.77ms ± 7.05ms |
| e2e_table_mld | Ops: 69.60 ± 0.04 ops/s. Best: 69.67 ops/s<br/>Total: 14368.34ms ± 9.08ms. Best: 14353.17ms<br/>Min time: 6.01ms ± 0.03ms<br/>Mean time: 14.37ms ± 0.01ms<br/>Median time: 14.30ms ± 0.02ms<br/>95th percentile: 21.91ms ± 0.07ms<br/>99th percentile: 23.08ms ± 0.08ms<br/>Max time: 29.45ms ± 5.79ms | Ops: 69.52 ± 0.04 ops/s. Best: 69.56 ops/s<br/>Total: 14384.15ms ± 8.44ms. Best: 14375.33ms<br/>Min time: 6.01ms ± 0.02ms<br/>Mean time: 14.38ms ± 0.01ms<br/>Median time: 14.30ms ± 0.03ms<br/>95th percentile: 21.92ms ± 0.06ms<br/>99th percentile: 23.16ms ± 0.06ms<br/>Max time: 29.42ms ± 5.71ms |
| e2e_trip_ch | Ops: 62.83 ± 0.03 ops/s. Best: 62.89 ops/s<br/>Total: 15915.76ms ± 8.79ms. Best: 15902.04ms<br/>Min time: 2.37ms ± 0.14ms<br/>Mean time: 15.92ms ± 0.01ms<br/>Median time: 15.17ms ± 0.03ms<br/>95th percentile: 28.10ms ± 0.06ms<br/>99th percentile: 30.20ms ± 0.12ms<br/>Max time: 32.65ms ± 1.32ms | Ops: 62.65 ± 0.03 ops/s. Best: 62.71 ops/s<br/>Total: 15961.06ms ± 7.82ms. Best: 15947.35ms<br/>Min time: 2.41ms ± 0.13ms<br/>Mean time: 15.96ms ± 0.01ms<br/>Median time: 15.19ms ± 0.02ms<br/>95th percentile: 28.13ms ± 0.04ms<br/>99th percentile: 30.33ms ± 0.15ms<br/>Max time: 32.88ms ± 1.33ms |
| e2e_trip_mld | Ops: 36.80 ± 0.01 ops/s. Best: 36.82 ops/s<br/>Total: 27172.89ms ± 9.11ms. Best: 27160.67ms<br/>Min time: 2.42ms ± 0.16ms<br/>Mean time: 27.17ms ± 0.01ms<br/>Median time: 26.28ms ± 0.06ms<br/>95th percentile: 44.23ms ± 0.05ms<br/>99th percentile: 46.96ms ± 0.09ms<br/>Max time: 49.28ms ± 0.15ms | Ops: 36.71 ± 0.02 ops/s. Best: 36.74 ops/s<br/>Total: 27240.05ms ± 12.16ms. Best: 27219.95ms<br/>Min time: 2.44ms ± 0.15ms<br/>Mean time: 27.24ms ± 0.01ms<br/>Median time: 26.35ms ± 0.09ms<br/>95th percentile: 44.34ms ± 0.07ms<br/>99th percentile: 46.95ms ± 0.12ms<br/>Max time: 49.49ms ± 0.12ms |
| json-render | String: 9.06021ms<br/>Stringstream: 14.5667ms<br/>Vector: 9.52587ms | String: 8.85538ms<br/>Stringstream: 14.7637ms<br/>Vector: 9.42569ms |
| match_ch | Default radius: <br/>7.04729ms/req at 82 coordinate<br/>0.0859426ms/coordinate<br/>Radius 10m: <br/>24.9337ms/req at 82 coordinate<br/>0.30407ms/coordinate | Default radius: <br/>7.09777ms/req at 82 coordinate<br/>0.0865582ms/coordinate<br/>Radius 10m: <br/>25.1335ms/req at 82 coordinate<br/>0.306507ms/coordinate |
| match_mld | Default radius: <br/>4.36092ms/req at 82 coordinate<br/>0.053182ms/coordinate<br/>Radius 10m: <br/>16.2441ms/req at 82 coordinate<br/>0.198099ms/coordinate | Default radius: <br/>4.3623ms/req at 82 coordinate<br/>0.0531988ms/coordinate<br/>Radius 10m: <br/>16.1758ms/req at 82 coordinate<br/>0.197266ms/coordinate |
| node_match_ch | Ops: 157.7 ± 0.2 ops/s. Best: 158.1 ops/s | Ops: 155.6 ± 0.9 ops/s. Best: 156.9 ops/s |
| node_match_mld | Ops: 220.0 ± 1.5 ops/s. Best: 222.4 ops/s | Ops: 220.0 ± 1.0 ops/s. Best: 221.7 ops/s |
| node_nearest_ch | Ops: 9768.8 ± 708.7 ops/s. Best: 11316.2 ops/s | Ops: 9435.2 ± 908.5 ops/s. Best: 10491.2 ops/s |
| node_nearest_mld | Ops: 9930.3 ± 440.6 ops/s. Best: 10713.6 ops/s | Ops: 9482.5 ± 945.3 ops/s. Best: 11274.5 ops/s |
| node_route_ch | Ops: 989.5 ± 17.0 ops/s. Best: 1019.5 ops/s | Ops: 982.1 ± 21.5 ops/s. Best: 1013.4 ops/s |
| node_route_mld | Ops: 505.9 ± 4.9 ops/s. Best: 513.2 ops/s | Ops: 504.7 ± 6.8 ops/s. Best: 514.3 ops/s |
| node_table_ch | Ops: 184.0 ± 2.1 ops/s. Best: 186.8 ops/s | Ops: 183.7 ± 2.0 ops/s. Best: 186.0 ops/s |
| node_table_mld | Ops: 37.9 ± 0.1 ops/s. Best: 38.0 ops/s | Ops: 37.9 ± 0.0 ops/s. Best: 37.9 ops/s |
| node_trip_ch | Ops: 184.2 ± 0.5 ops/s. Best: 184.7 ops/s | Ops: 184.0 ± 0.8 ops/s. Best: 185.3 ops/s |
| node_trip_mld | Ops: 61.5 ± 0.1 ops/s. Best: 61.6 ops/s | Ops: 61.4 ± 0.2 ops/s. Best: 61.8 ops/s |
| osrm_contract | Time: 185.57s Peak RAM: 194.39MB | Time: 185.65s Peak RAM: 193.35MB |
| osrm_customize | Time: 2.54s Peak RAM: 112.12MB | Time: 2.52s Peak RAM: 112.12MB |
| osrm_extract | Time: 24.50s Peak RAM: 399.35MB | Time: 24.32s Peak RAM: 397.39MB |
| osrm_partition | Time: 5.90s Peak RAM: 121.60MB | Time: 5.89s Peak RAM: 121.53MB |
| packedvector | random write:<br/>std::vector 184192 ms<br/>util::packed_vector 373516 ms<br/>slowdown: 2.02786<br/>random read:<br/>std::vector 100555 ms<br/>util::packed_vector 190534 ms<br/>slowdown: 1.89482 | random write:<br/>std::vector 180254 ms<br/>util::packed_vector 371602 ms<br/>slowdown: 2.06154<br/>random read:<br/>std::vector 99712.3 ms<br/>util::packed_vector 189411 ms<br/>slowdown: 1.89958 |
| random_match_ch | 500 matches, default radius<br/>ops: 116.85 ± 0.24 ops/s. best: 117.15ops/s.<br/>total: 487.80 ± 1.04ms. best: 486.54ms.<br/>avg: 8.56 ± 0.02ms<br/>min: 0.24 ± 0.00ms<br/>max: 41.97 ± 0.13ms<br/>p99: 41.97 ± 0.13ms<br/><br/>500 matches, radius=10<br/>ops: 33.96 ± 0.04 ops/s. best: 34.02ops/s.<br/>total: 1884.51 ± 2.24ms. best: 1881.01ms.<br/>avg: 29.45 ± 0.04ms<br/>min: 0.23 ± 0.00ms<br/>max: 403.49 ± 0.83ms<br/>p99: 403.49 ± 0.83ms<br/><br/>500 matches, radius=20<br/>ops: 7.98 ± 0.01 ops/s. best: 8.00ops/s.<br/>total: 8141.58 ± 12.51ms. best: 8124.77ms.<br/>avg: 125.26 ± 0.19ms<br/>min: 0.48 ± 0.01ms<br/>max: 2117.25 ± 9.16ms<br/>p99: 2117.25 ± 9.16ms<br/><br/>Peak RAM: 55.500MB | 500 matches, default radius<br/>ops: 116.92 ± 0.23 ops/s. best: 117.22ops/s.<br/>total: 487.51 ± 1.08ms. best: 486.28ms.<br/>avg: 8.55 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 42.00 ± 0.15ms<br/>p99: 42.00 ± 0.15ms<br/><br/>500 matches, radius=10<br/>ops: 33.91 ± 0.04 ops/s. best: 33.97ops/s.<br/>total: 1887.19 ± 2.38ms. best: 1883.85ms.<br/>avg: 29.49 ± 0.04ms<br/>min: 0.23 ± 0.00ms<br/>max: 404.64 ± 0.92ms<br/>p99: 404.64 ± 0.92ms<br/><br/>500 matches, radius=20<br/>ops: 7.97 ± 0.01 ops/s. best: 7.99ops/s.<br/>total: 8156.47 ± 12.92ms. best: 8138.87ms.<br/>avg: 125.48 ± 0.20ms<br/>min: 0.48 ± 0.00ms<br/>max: 2126.12 ± 9.47ms<br/>p99: 2126.12 ± 9.47ms<br/><br/>Peak RAM: 55.500MB |
| random_match_mld | 500 matches, default radius<br/>ops: 205.05 ± 0.45 ops/s. best: 205.53ops/s.<br/>total: 277.98 ± 0.61ms. best: 277.33ms.<br/>avg: 4.88 ± 0.01ms<br/>min: 0.21 ± 0.00ms<br/>max: 27.10 ± 0.05ms<br/>p99: 27.10 ± 0.05ms<br/><br/>500 matches, radius=10<br/>ops: 72.91 ± 0.07 ops/s. best: 73.05ops/s.<br/>total: 877.78 ± 0.80ms. best: 876.11ms.<br/>avg: 13.72 ± 0.01ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.03 ± 0.14ms<br/>p99: 162.03 ± 0.14ms<br/><br/>500 matches, radius=20<br/>ops: 15.34 ± 0.01 ops/s. best: 15.36ops/s.<br/>total: 4237.49 ± 2.77ms. best: 4231.75ms.<br/>avg: 65.19 ± 0.04ms<br/>min: 0.29 ± 0.00ms<br/>max: 842.82 ± 1.91ms<br/>p99: 842.82 ± 1.91ms<br/><br/>Peak RAM: 51.500MB | 500 matches, default radius<br/>ops: 204.84 ± 0.44 ops/s. best: 205.37ops/s.<br/>total: 278.27 ± 0.61ms. best: 277.55ms.<br/>avg: 4.88 ± 0.01ms<br/>min: 0.21 ± 0.01ms<br/>max: 27.13 ± 0.03ms<br/>p99: 27.13 ± 0.03ms<br/><br/>500 matches, radius=10<br/>ops: 72.82 ± 0.07 ops/s. best: 72.97ops/s.<br/>total: 878.85 ± 0.80ms. best: 877.11ms.<br/>avg: 13.73 ± 0.01ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.04 ± 0.18ms<br/>p99: 162.04 ± 0.18ms<br/><br/>500 matches, radius=20<br/>ops: 15.32 ± 0.01 ops/s. best: 15.34ops/s.<br/>total: 4243.67 ± 3.44ms. best: 4236.39ms.<br/>avg: 65.29 ± 0.05ms<br/>min: 0.30 ± 0.00ms<br/>max: 843.19 ± 2.10ms<br/>p99: 843.19 ± 2.10ms<br/><br/>Peak RAM: 51.500MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 21537.74 ± 37.93 ops/s. best: 21570.44ops/s.<br/>total: 464.30 ± 0.82ms. best: 463.60ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15553.23 ± 5.23 ops/s. best: 15559.63ops/s.<br/>total: 642.95 ± 0.22ms. best: 642.69ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 11825.33 ± 2.61 ops/s. best: 11829.63ops/s.<br/>total: 845.64 ± 0.19ms. best: 845.34ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 21496.75 ± 40.73 ops/s. best: 21529.79ops/s.<br/>total: 465.19 ± 0.88ms. best: 464.47ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15552.88 ± 15.20 ops/s. best: 15567.03ops/s.<br/>total: 642.97 ± 0.63ms. best: 642.38ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 11853.70 ± 3.06 ops/s. best: 11858.69ops/s.<br/>total: 843.62 ± 0.22ms. best: 843.26ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 21526.07 ± 35.93 ops/s. best: 21553.93ops/s.<br/>total: 464.56 ± 0.78ms. best: 463.95ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15548.16 ± 5.23 ops/s. best: 15557.85ops/s.<br/>total: 643.16 ± 0.22ms. best: 642.76ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 11820.13 ± 4.86 ops/s. best: 11827.64ops/s.<br/>total: 846.01 ± 0.35ms. best: 845.48ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 21494.65 ± 40.42 ops/s. best: 21525.36ops/s.<br/>total: 465.23 ± 0.88ms. best: 464.57ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.01 ± 0.00ms<br/>max: 0.15 ± 0.01ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 15530.92 ± 15.53 ops/s. best: 15547.32ops/s.<br/>total: 643.88 ± 0.64ms. best: 643.20ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.17 ± 0.00ms<br/>p99: 0.13 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 11849.92 ± 4.89 ops/s. best: 11855.65ops/s.<br/>total: 843.89 ± 0.35ms. best: 843.48ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 284.64 ± 0.13 ops/s. best: 284.83ops/s.<br/>total: 3456.98 ± 1.56ms. best: 3454.72ms.<br/>avg: 3.51 ± 0.00ms<br/>min: 0.51 ± 0.01ms<br/>max: 5.99 ± 0.01ms<br/>p99: 5.23 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 324.07 ± 0.02 ops/s. best: 324.10ops/s.<br/>total: 3085.77 ± 0.20ms. best: 3085.47ms.<br/>avg: 3.09 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.95 ± 0.04ms<br/>p99: 7.19 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 590.42 ± 0.14 ops/s. best: 590.69ops/s.<br/>total: 1666.62 ± 0.40ms. best: 1665.86ms.<br/>avg: 1.69 ± 0.00ms<br/>min: 0.37 ± 0.00ms<br/>max: 2.79 ± 0.01ms<br/>p99: 2.37 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 636.15 ± 0.38 ops/s. best: 636.60ops/s.<br/>total: 1571.97 ± 0.93ms. best: 1570.86ms.<br/>avg: 1.57 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.23 ± 0.01ms<br/>p99: 4.07 ± 0.00ms<br/><br/>Peak RAM: 84.000MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 285.82 ± 0.15 ops/s. best: 286.05ops/s.<br/>total: 3442.75 ± 1.86ms. best: 3439.99ms.<br/>avg: 3.50 ± 0.00ms<br/>min: 0.51 ± 0.00ms<br/>max: 5.97 ± 0.02ms<br/>p99: 5.20 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 324.92 ± 0.10 ops/s. best: 325.10ops/s.<br/>total: 3077.64 ± 0.96ms. best: 3075.98ms.<br/>avg: 3.08 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.92 ± 0.04ms<br/>p99: 7.15 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 592.17 ± 0.21 ops/s. best: 592.67ops/s.<br/>total: 1661.70 ± 0.58ms. best: 1660.29ms.<br/>avg: 1.69 ± 0.00ms<br/>min: 0.36 ± 0.00ms<br/>max: 2.77 ± 0.01ms<br/>p99: 2.36 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 636.30 ± 0.11 ops/s. best: 636.45ops/s.<br/>total: 1571.59 ± 0.26ms. best: 1571.23ms.<br/>avg: 1.57 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.22 ± 0.01ms<br/>p99: 4.06 ± 0.01ms<br/><br/>Peak RAM: 84.000MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 146.52 ± 0.03 ops/s. best: 146.57ops/s.<br/>total: 6715.80 ± 1.43ms. best: 6713.62ms.<br/>avg: 6.83 ± 0.00ms<br/>min: 0.51 ± 0.00ms<br/>max: 16.52 ± 0.03ms<br/>p99: 11.03 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 139.86 ± 0.01 ops/s. best: 139.88ops/s.<br/>total: 7150.18 ± 0.77ms. best: 7148.77ms.<br/>avg: 7.15 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.38 ± 0.01ms<br/>p99: 15.44 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 203.86 ± 0.02 ops/s. best: 203.89ops/s.<br/>total: 4826.83 ± 0.46ms. best: 4826.16ms.<br/>avg: 4.91 ± 0.00ms<br/>min: 0.37 ± 0.00ms<br/>max: 13.74 ± 0.02ms<br/>p99: 8.45 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 176.10 ± 0.02 ops/s. best: 176.13ops/s.<br/>total: 5678.48 ± 0.50ms. best: 5677.56ms.<br/>avg: 5.68 ± 0.00ms<br/>min: 0.05 ± 0.00ms<br/>max: 12.76 ± 0.03ms<br/>p99: 11.86 ± 0.01ms<br/><br/>Peak RAM: 73.672MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 147.25 ± 0.03 ops/s. best: 147.30ops/s.<br/>total: 6682.40 ± 1.26ms. best: 6680.17ms.<br/>avg: 6.79 ± 0.00ms<br/>min: 0.51 ± 0.00ms<br/>max: 16.43 ± 0.03ms<br/>p99: 10.99 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 140.29 ± 0.02 ops/s. best: 140.33ops/s.<br/>total: 7128.24 ± 0.92ms. best: 7126.20ms.<br/>avg: 7.13 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.38 ± 0.02ms<br/>p99: 15.42 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 204.41 ± 0.07 ops/s. best: 204.51ops/s.<br/>total: 4813.89 ± 1.61ms. best: 4811.41ms.<br/>avg: 4.89 ± 0.00ms<br/>min: 0.37 ± 0.00ms<br/>max: 13.70 ± 0.01ms<br/>p99: 8.42 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 176.54 ± 0.03 ops/s. best: 176.58ops/s.<br/>total: 5664.52 ± 0.83ms. best: 5663.19ms.<br/>avg: 5.66 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.72 ± 0.02ms<br/>p99: 11.84 ± 0.02ms<br/><br/>Peak RAM: 73.672MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1133.23 ± 4.66 ops/s. best: 1137.13ops/s.<br/>total: 220.61 ± 0.92ms. best: 219.85ms.<br/>avg: 0.88 ± 0.00ms<br/>min: 0.70 ± 0.00ms<br/>max: 1.21 ± 0.12ms<br/>p99: 1.07 ± 0.00ms<br/><br/>250 tables, 25 coordinates<br/>ops: 126.35 ± 0.04 ops/s. best: 126.41ops/s.<br/>total: 1978.55 ± 0.64ms. best: 1977.73ms.<br/>avg: 7.91 ± 0.00ms<br/>min: 7.32 ± 0.01ms<br/>max: 8.48 ± 0.00ms<br/>p99: 8.43 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 61.52 ± 0.01 ops/s. best: 61.53ops/s.<br/>total: 4064.03 ± 0.79ms. best: 4062.75ms.<br/>avg: 16.26 ± 0.00ms<br/>min: 15.25 ± 0.01ms<br/>max: 17.10 ± 0.02ms<br/>p99: 16.94 ± 0.04ms<br/><br/>Peak RAM: 63.000MB | 250 tables, 3 coordinates<br/>ops: 1128.70 ± 4.32 ops/s. best: 1132.22ops/s.<br/>total: 221.50 ± 0.85ms. best: 220.80ms.<br/>avg: 0.89 ± 0.00ms<br/>min: 0.70 ± 0.00ms<br/>max: 1.22 ± 0.12ms<br/>p99: 1.07 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 126.28 ± 0.03 ops/s. best: 126.32ops/s.<br/>total: 1979.71 ± 0.54ms. best: 1979.13ms.<br/>avg: 7.92 ± 0.00ms<br/>min: 7.32 ± 0.01ms<br/>max: 8.48 ± 0.01ms<br/>p99: 8.44 ± 0.00ms<br/><br/>250 tables, 50 coordinates<br/>ops: 61.39 ± 0.01 ops/s. best: 61.40ops/s.<br/>total: 4072.21 ± 0.73ms. best: 4071.39ms.<br/>avg: 16.29 ± 0.00ms<br/>min: 15.27 ± 0.02ms<br/>max: 17.14 ± 0.02ms<br/>p99: 16.99 ± 0.01ms<br/><br/>Peak RAM: 63.000MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 226.99 ± 0.26 ops/s. best: 227.19ops/s.<br/>total: 1101.37 ± 1.28ms. best: 1100.38ms.<br/>avg: 4.41 ± 0.01ms<br/>min: 3.51 ± 0.00ms<br/>max: 5.61 ± 0.01ms<br/>p99: 5.48 ± 0.04ms<br/><br/>250 tables, 25 coordinates<br/>ops: 23.84 ± 0.02 ops/s. best: 23.86ops/s.<br/>total: 10486.50 ± 6.85ms. best: 10475.66ms.<br/>avg: 41.95 ± 0.03ms<br/>min: 38.84 ± 0.02ms<br/>max: 45.67 ± 0.06ms<br/>p99: 45.21 ± 0.21ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.01 ± 0.00 ops/s. best: 11.02ops/s.<br/>total: 22696.86 ± 4.69ms. best: 22689.45ms.<br/>avg: 90.79 ± 0.02ms<br/>min: 86.42 ± 0.10ms<br/>max: 96.66 ± 0.11ms<br/>p99: 94.86 ± 0.08ms<br/><br/>Peak RAM: 62.688MB | 250 tables, 3 coordinates<br/>ops: 228.29 ± 0.48 ops/s. best: 228.69ops/s.<br/>total: 1095.13 ± 2.31ms. best: 1093.20ms.<br/>avg: 4.38 ± 0.01ms<br/>min: 3.49 ± 0.00ms<br/>max: 5.62 ± 0.01ms<br/>p99: 5.46 ± 0.05ms<br/><br/>250 tables, 25 coordinates<br/>ops: 23.93 ± 0.01 ops/s. best: 23.94ops/s.<br/>total: 10447.70 ± 3.18ms. best: 10442.41ms.<br/>avg: 41.79 ± 0.01ms<br/>min: 38.62 ± 0.02ms<br/>max: 45.51 ± 0.02ms<br/>p99: 44.93 ± 0.04ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.06 ± 0.01 ops/s. best: 11.07ops/s.<br/>total: 22604.23 ± 14.86ms. best: 22590.17ms.<br/>avg: 90.42 ± 0.06ms<br/>min: 86.13 ± 0.19ms<br/>max: 96.22 ± 0.13ms<br/>p99: 94.57 ± 0.23ms<br/><br/>Peak RAM: 62.688MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 327.09 ± 0.49 ops/s. best: 327.49ops/s.<br/>total: 764.32 ± 1.15ms. best: 763.38ms.<br/>avg: 3.06 ± 0.00ms<br/>min: 1.65 ± 0.01ms<br/>max: 4.43 ± 0.01ms<br/>p99: 4.16 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 211.46 ± 0.10 ops/s. best: 211.61ops/s.<br/>total: 1182.27 ± 0.57ms. best: 1181.44ms.<br/>avg: 4.73 ± 0.00ms<br/>min: 3.00 ± 0.01ms<br/>max: 5.99 ± 0.00ms<br/>p99: 5.85 ± 0.01ms<br/><br/>Peak RAM: 73.500MB | 250 trips, 3 coordinates<br/>ops: 327.37 ± 0.46 ops/s. best: 327.74ops/s.<br/>total: 763.67 ± 1.07ms. best: 762.80ms.<br/>avg: 3.05 ± 0.00ms<br/>min: 1.65 ± 0.01ms<br/>max: 4.40 ± 0.01ms<br/>p99: 4.15 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 211.45 ± 0.05 ops/s. best: 211.52ops/s.<br/>total: 1182.29 ± 0.25ms. best: 1181.92ms.<br/>avg: 4.73 ± 0.00ms<br/>min: 3.02 ± 0.00ms<br/>max: 5.99 ± 0.01ms<br/>p99: 5.84 ± 0.02ms<br/><br/>Peak RAM: 73.500MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 106.90 ± 0.07 ops/s. best: 106.96ops/s.<br/>total: 2338.74 ± 1.50ms. best: 2337.35ms.<br/>avg: 9.35 ± 0.01ms<br/>min: 5.50 ± 0.01ms<br/>max: 12.13 ± 0.00ms<br/>p99: 12.05 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 68.84 ± 0.01 ops/s. best: 68.85ops/s.<br/>total: 3631.85 ± 0.36ms. best: 3631.22ms.<br/>avg: 14.53 ± 0.00ms<br/>min: 10.15 ± 0.02ms<br/>max: 17.90 ± 0.03ms<br/>p99: 17.34 ± 0.02ms<br/><br/>Peak RAM: 69.500MB | 250 trips, 3 coordinates<br/>ops: 105.90 ± 0.18 ops/s. best: 106.15ops/s.<br/>total: 2360.75 ± 4.40ms. best: 2355.24ms.<br/>avg: 9.44 ± 0.02ms<br/>min: 5.51 ± 0.05ms<br/>max: 12.28 ± 0.02ms<br/>p99: 12.19 ± 0.08ms<br/><br/>250 trips, 5 coordinates<br/>ops: 68.50 ± 0.16 ops/s. best: 68.81ops/s.<br/>total: 3649.59 ± 8.76ms. best: 3633.13ms.<br/>avg: 14.60 ± 0.04ms<br/>min: 10.12 ± 0.04ms<br/>max: 17.99 ± 0.09ms<br/>p99: 17.42 ± 0.08ms<br/><br/>Peak RAM: 69.500MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>638.725ms<br/>0.638725ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>781.088ms<br/>0.781088ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>245.492ms<br/>0.245492ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>215.578ms<br/>0.215578ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>634.827ms<br/>0.634827ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>775.25ms<br/>0.77525ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>245.389ms<br/>0.245389ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>215.909ms<br/>0.215909ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>808.176ms<br/>0.808176ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1038.55ms<br/>1.03855ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>414.196ms<br/>0.414196ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>461.002ms<br/>0.461002ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>804.082ms<br/>0.804082ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1034ms<br/>1.034ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>413.368ms<br/>0.413368ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>460.797ms<br/>0.460797ms/req |
| rtree | 1 result:<br/>227.414ms ->  0.0227414 ms/query<br/>10 results:<br/>258.191ms ->  0.0258191 ms/query | 1 result:<br/>227.172ms ->  0.0227172 ms/query<br/>10 results:<br/>257.896ms ->  0.0257896 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
