### PR TITLE
Use std::countl_zero instead of __builtin_clz

### DIFF
--- a/include/util/msb.hpp
+++ b/include/util/msb.hpp
@@ -1,50 +1,24 @@
 #ifndef OSRM_UTIL_MSB_HPP
 #define OSRM_UTIL_MSB_HPP
 
+#include <bit>
 #include <boost/assert.hpp>
-
-#include <climits>
 #include <cstdint>
-#include <utility>
+#include <limits>
 
 namespace osrm::util
 {
 
-// get the msb of an integer
-// return 0 for integers without msb
 template <typename T> std::size_t msb(T value)
 {
+    BOOST_ASSERT(value > 0);
+
     static_assert(std::is_integral<T>::value && !std::is_signed<T>::value, "Integer required.");
-    std::size_t msb = 0;
-    while (value > 0)
-    {
-        value >>= 1u;
-        msb++;
-    }
-    BOOST_ASSERT(msb > 0);
-    return msb - 1;
+    constexpr auto MSB_INDEX = std::numeric_limits<unsigned char>::digits * sizeof(T) - 1;
+
+    return MSB_INDEX - std::countl_zero(value);
 }
 
-#if (defined(__clang__) || defined(__GNUC__) || defined(__GNUG__))
-inline std::size_t msb(unsigned long long v)
-{
-    BOOST_ASSERT(v > 0);
-    constexpr auto MSB_INDEX = CHAR_BIT * sizeof(unsigned long long) - 1;
-    return MSB_INDEX - __builtin_clzll(v);
-}
-inline std::size_t msb(unsigned long v)
-{
-    BOOST_ASSERT(v > 0);
-    constexpr auto MSB_INDEX = CHAR_BIT * sizeof(unsigned long) - 1;
-    return MSB_INDEX - __builtin_clzl(v);
-}
-inline std::size_t msb(unsigned int v)
-{
-    BOOST_ASSERT(v > 0);
-    constexpr auto MSB_INDEX = CHAR_BIT * sizeof(unsigned int) - 1;
-    return MSB_INDEX - __builtin_clz(v);
-}
-#endif
 } // namespace osrm::util
 
 #endif


### PR DESCRIPTION
It is also a microoptimisation since we had no specialization for `unsigned char` and called loop-based generic implementation for it...


<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 11069.7<br/>plain u32: 11048.5<br/>aliased double: 15115.3<br/>plain double: 15180.6 | aliased u32: 11074.7<br/>plain u32: 10982.7<br/>aliased double: 15061.9<br/>plain double: 15050.6 |
| e2e_match_ch | Ops: 27.27 ± 0.02 ops/s. Best: 27.31 ops/s<br/>Total: 4803.52ms ± 3.42ms. Best: 4796.74ms<br/>Min time: 3.23ms ± 0.05ms<br/>Mean time: 36.67ms ± 0.02ms<br/>Median time: 24.95ms ± 0.20ms<br/>95th percentile: 121.80ms ± 0.29ms<br/>99th percentile: 146.91ms ± 0.26ms<br/>Max time: 155.73ms ± 0.66ms | Ops: 27.20 ± 0.02 ops/s. Best: 27.23 ops/s<br/>Total: 4816.91ms ± 3.59ms. Best: 4811.51ms<br/>Min time: 3.28ms ± 0.03ms<br/>Mean time: 36.77ms ± 0.03ms<br/>Median time: 24.88ms ± 0.10ms<br/>95th percentile: 122.82ms ± 0.14ms<br/>99th percentile: 147.64ms ± 0.57ms<br/>Max time: 156.20ms ± 0.55ms |
| e2e_match_mld | Ops: 43.48 ± 0.03 ops/s. Best: 43.51 ops/s<br/>Total: 3012.93ms ± 1.82ms. Best: 3010.51ms<br/>Min time: 2.61ms ± 0.03ms<br/>Mean time: 23.00ms ± 0.01ms<br/>Median time: 12.06ms ± 0.10ms<br/>95th percentile: 74.89ms ± 0.14ms<br/>99th percentile: 87.10ms ± 0.13ms<br/>Max time: 101.40ms ± 0.33ms | Ops: 43.67 ± 0.01 ops/s. Best: 43.69 ops/s<br/>Total: 2999.48ms ± 0.93ms. Best: 2998.17ms<br/>Min time: 2.56ms ± 0.01ms<br/>Mean time: 22.90ms ± 0.01ms<br/>Median time: 12.15ms ± 0.10ms<br/>95th percentile: 74.45ms ± 0.21ms<br/>99th percentile: 86.59ms ± 0.30ms<br/>Max time: 100.60ms ± 0.50ms |
| e2e_nearest_ch | Ops: 634.41 ± 2.83 ops/s. Best: 639.27 ops/s<br/>Total: 1576.06ms ± 6.62ms. Best: 1564.27ms<br/>Min time: 1.29ms ± 0.01ms<br/>Mean time: 1.58ms ± 0.01ms<br/>Median time: 1.54ms ± 0.01ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.02ms<br/>Max time: 9.32ms ± 7.41ms | Ops: 637.44 ± 4.69 ops/s. Best: 646.62 ops/s<br/>Total: 1569.00ms ± 12.79ms. Best: 1546.51ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.02ms<br/>99th percentile: 2.05ms ± 0.01ms<br/>Max time: 9.32ms ± 7.37ms |
| e2e_nearest_mld | Ops: 637.86 ± 5.64 ops/s. Best: 646.87 ops/s<br/>Total: 1567.53ms ± 13.54ms. Best: 1545.91ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.95ms ± 0.01ms<br/>99th percentile: 2.03ms ± 0.01ms<br/>Max time: 9.29ms ± 7.36ms | Ops: 636.39 ± 2.57 ops/s. Best: 641.54 ops/s<br/>Total: 1571.25ms ± 6.58ms. Best: 1558.76ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.97ms ± 0.01ms<br/>99th percentile: 2.06ms ± 0.02ms<br/>Max time: 9.41ms ± 7.48ms |
| e2e_route_ch | Ops: 216.14 ± 0.61 ops/s. Best: 217.33 ops/s<br/>Total: 4626.72ms ± 13.20ms. Best: 4601.23ms<br/>Min time: 1.85ms ± 0.06ms<br/>Mean time: 4.63ms ± 0.01ms<br/>Median time: 4.73ms ± 0.01ms<br/>95th percentile: 6.06ms ± 0.03ms<br/>99th percentile: 6.65ms ± 0.03ms<br/>Max time: 13.34ms ± 6.33ms | Ops: 215.67 ± 0.40 ops/s. Best: 216.33 ops/s<br/>Total: 4636.53ms ± 8.51ms. Best: 4622.66ms<br/>Min time: 1.88ms ± 0.04ms<br/>Mean time: 4.64ms ± 0.01ms<br/>Median time: 4.74ms ± 0.01ms<br/>95th percentile: 6.08ms ± 0.01ms<br/>99th percentile: 6.65ms ± 0.05ms<br/>Max time: 13.31ms ± 6.36ms |
| e2e_route_mld | Ops: 178.15 ± 0.25 ops/s. Best: 178.52 ops/s<br/>Total: 5613.03ms ± 8.01ms. Best: 5601.67ms<br/>Min time: 1.89ms ± 0.03ms<br/>Mean time: 5.61ms ± 0.01ms<br/>Median time: 5.73ms ± 0.01ms<br/>95th percentile: 7.62ms ± 0.01ms<br/>99th percentile: 8.14ms ± 0.05ms<br/>Max time: 14.72ms ± 5.96ms | Ops: 178.09 ± 0.31 ops/s. Best: 178.58 ops/s<br/>Total: 5614.88ms ± 9.71ms. Best: 5599.62ms<br/>Min time: 1.86ms ± 0.06ms<br/>Mean time: 5.61ms ± 0.01ms<br/>Median time: 5.74ms ± 0.02ms<br/>95th percentile: 7.63ms ± 0.03ms<br/>99th percentile: 8.22ms ± 0.09ms<br/>Max time: 14.70ms ± 5.92ms |
| e2e_table_ch | Ops: 213.31 ± 0.34 ops/s. Best: 213.83 ops/s<br/>Total: 4688.06ms ± 7.40ms. Best: 4676.63ms<br/>Min time: 2.48ms ± 0.05ms<br/>Mean time: 4.69ms ± 0.01ms<br/>Median time: 4.69ms ± 0.01ms<br/>95th percentile: 6.39ms ± 0.01ms<br/>99th percentile: 6.72ms ± 0.02ms<br/>Max time: 13.93ms ± 7.08ms | Ops: 212.93 ± 0.55 ops/s. Best: 213.57 ops/s<br/>Total: 4696.15ms ± 12.20ms. Best: 4682.23ms<br/>Min time: 2.44ms ± 0.04ms<br/>Mean time: 4.70ms ± 0.01ms<br/>Median time: 4.69ms ± 0.01ms<br/>95th percentile: 6.41ms ± 0.01ms<br/>99th percentile: 6.76ms ± 0.02ms<br/>Max time: 13.93ms ± 7.08ms |
| e2e_table_mld | Ops: 69.26 ± 0.04 ops/s. Best: 69.31 ops/s<br/>Total: 14438.90ms ± 8.91ms. Best: 14427.40ms<br/>Min time: 6.05ms ± 0.06ms<br/>Mean time: 14.44ms ± 0.01ms<br/>Median time: 14.38ms ± 0.01ms<br/>95th percentile: 21.99ms ± 0.04ms<br/>99th percentile: 23.29ms ± 0.08ms<br/>Max time: 29.43ms ± 5.63ms | Ops: 69.61 ± 0.06 ops/s. Best: 69.70 ops/s<br/>Total: 14365.38ms ± 11.95ms. Best: 14347.04ms<br/>Min time: 5.97ms ± 0.04ms<br/>Mean time: 14.37ms ± 0.01ms<br/>Median time: 14.27ms ± 0.02ms<br/>95th percentile: 21.89ms ± 0.03ms<br/>99th percentile: 23.10ms ± 0.10ms<br/>Max time: 29.52ms ± 5.66ms |
| e2e_trip_ch | Ops: 62.41 ± 0.02 ops/s. Best: 62.43 ops/s<br/>Total: 16023.15ms ± 6.47ms. Best: 16016.96ms<br/>Min time: 2.49ms ± 0.12ms<br/>Mean time: 16.02ms ± 0.01ms<br/>Median time: 15.21ms ± 0.04ms<br/>95th percentile: 28.21ms ± 0.04ms<br/>99th percentile: 30.26ms ± 0.12ms<br/>Max time: 33.01ms ± 1.35ms | Ops: 62.23 ± 0.05 ops/s. Best: 62.32 ops/s<br/>Total: 16070.08ms ± 14.35ms. Best: 16045.40ms<br/>Min time: 2.45ms ± 0.20ms<br/>Mean time: 16.07ms ± 0.02ms<br/>Median time: 15.30ms ± 0.04ms<br/>95th percentile: 28.29ms ± 0.04ms<br/>99th percentile: 30.28ms ± 0.16ms<br/>Max time: 33.00ms ± 1.34ms |
| e2e_trip_mld | Ops: 36.75 ± 0.01 ops/s. Best: 36.77 ops/s<br/>Total: 27212.10ms ± 10.08ms. Best: 27195.74ms<br/>Min time: 2.47ms ± 0.19ms<br/>Mean time: 27.21ms ± 0.01ms<br/>Median time: 26.35ms ± 0.09ms<br/>95th percentile: 44.36ms ± 0.06ms<br/>99th percentile: 47.05ms ± 0.16ms<br/>Max time: 49.35ms ± 0.16ms | Ops: 36.76 ± 0.02 ops/s. Best: 36.79 ops/s<br/>Total: 27203.11ms ± 18.49ms. Best: 27184.45ms<br/>Min time: 2.36ms ± 0.12ms<br/>Mean time: 27.20ms ± 0.02ms<br/>Median time: 26.34ms ± 0.03ms<br/>95th percentile: 44.29ms ± 0.07ms<br/>99th percentile: 46.99ms ± 0.09ms<br/>Max time: 49.36ms ± 0.20ms |
| json-render | String: 8.93503ms<br/>Stringstream: 14.1241ms<br/>Vector: 9.50397ms | String: 8.96299ms<br/>Stringstream: 14.6894ms<br/>Vector: 9.43614ms |
| match_ch | Default radius: <br/>7.05052ms/req at 82 coordinate<br/>0.0859819ms/coordinate<br/>Radius 10m: <br/>24.9526ms/req at 82 coordinate<br/>0.3043ms/coordinate | Default radius: <br/>7.08165ms/req at 82 coordinate<br/>0.0863615ms/coordinate<br/>Radius 10m: <br/>25.0726ms/req at 82 coordinate<br/>0.305764ms/coordinate |
| match_mld | Default radius: <br/>4.33738ms/req at 82 coordinate<br/>0.0528949ms/coordinate<br/>Radius 10m: <br/>16.243ms/req at 82 coordinate<br/>0.198085ms/coordinate | Default radius: <br/>4.32495ms/req at 82 coordinate<br/>0.0527433ms/coordinate<br/>Radius 10m: <br/>16.1954ms/req at 82 coordinate<br/>0.197505ms/coordinate |
| node_match_ch | Ops: 163.8 ± 0.7 ops/s. Best: 164.9 ops/s | Ops: 164.5 ± 0.8 ops/s. Best: 165.7 ops/s |
| node_match_mld | Ops: 219.9 ± 1.6 ops/s. Best: 222.2 ops/s | Ops: 218.1 ± 0.8 ops/s. Best: 219.2 ops/s |
| node_nearest_ch | Ops: 9923.7 ± 783.5 ops/s. Best: 11215.1 ops/s | Ops: 10537.7 ± 855.8 ops/s. Best: 12030.1 ops/s |
| node_nearest_mld | Ops: 10043.1 ± 678.1 ops/s. Best: 11151.6 ops/s | Ops: 9528.5 ± 310.4 ops/s. Best: 10062.4 ops/s |
| node_route_ch | Ops: 983.3 ± 26.5 ops/s. Best: 1025.5 ops/s | Ops: 996.4 ± 28.3 ops/s. Best: 1023.7 ops/s |
| node_route_mld | Ops: 509.0 ± 5.5 ops/s. Best: 515.4 ops/s | Ops: 508.9 ± 2.8 ops/s. Best: 514.2 ops/s |
| node_table_ch | Ops: 177.9 ± 2.0 ops/s. Best: 181.3 ops/s | Ops: 178.0 ± 1.4 ops/s. Best: 180.6 ops/s |
| node_table_mld | Ops: 37.9 ± 0.1 ops/s. Best: 38.0 ops/s | Ops: 38.0 ± 0.1 ops/s. Best: 38.1 ops/s |
| node_trip_ch | Ops: 180.9 ± 0.7 ops/s. Best: 181.7 ops/s | Ops: 181.2 ± 0.7 ops/s. Best: 182.4 ops/s |
| node_trip_mld | Ops: 60.6 ± 0.2 ops/s. Best: 60.9 ops/s | Ops: 61.7 ± 0.2 ops/s. Best: 61.9 ops/s |
| osrm_contract | Time: 185.71s Peak RAM: 194.96MB | Time: 185.46s Peak RAM: 194.96MB |
| osrm_customize | Time: 2.54s Peak RAM: 112.46MB | Time: 2.52s Peak RAM: 112.46MB |
| osrm_extract | Time: 24.36s Peak RAM: 398.62MB | Time: 24.10s Peak RAM: 398.82MB |
| osrm_partition | Time: 5.91s Peak RAM: 121.54MB | Time: 5.90s Peak RAM: 121.59MB |
| packedvector | random write:<br/>std::vector 186041 ms<br/>util::packed_vector 384681 ms<br/>slowdown: 2.06772<br/>random read:<br/>std::vector 101158 ms<br/>util::packed_vector 195032 ms<br/>slowdown: 1.92799 | random write:<br/>std::vector 183440 ms<br/>util::packed_vector 385823 ms<br/>slowdown: 2.10326<br/>random read:<br/>std::vector 100386 ms<br/>util::packed_vector 195612 ms<br/>slowdown: 1.94859 |
| random_match_ch | 500 matches, default radius<br/>ops: 121.49 ± 0.24 ops/s. best: 121.82ops/s.<br/>total: 469.17 ± 0.94ms. best: 467.91ms.<br/>avg: 8.23 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 43.10 ± 0.12ms<br/>p99: 43.10 ± 0.12ms<br/><br/>500 matches, radius=10<br/>ops: 35.07 ± 0.02 ops/s. best: 35.10ops/s.<br/>total: 1824.79 ± 1.23ms. best: 1823.58ms.<br/>avg: 28.51 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 430.14 ± 1.31ms<br/>p99: 430.14 ± 1.31ms<br/><br/>500 matches, radius=20<br/>ops: 8.16 ± 0.01 ops/s. best: 8.19ops/s.<br/>total: 7961.59 ± 11.99ms. best: 7941.11ms.<br/>avg: 122.49 ± 0.18ms<br/>min: 0.48 ± 0.00ms<br/>max: 2274.79 ± 4.45ms<br/>p99: 2274.79 ± 4.45ms<br/><br/>Peak RAM: 55.500MB | 500 matches, default radius<br/>ops: 120.20 ± 0.24 ops/s. best: 120.47ops/s.<br/>total: 474.21 ± 0.95ms. best: 473.14ms.<br/>avg: 8.32 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 43.67 ± 0.12ms<br/>p99: 43.67 ± 0.12ms<br/><br/>500 matches, radius=10<br/>ops: 34.53 ± 0.02 ops/s. best: 34.55ops/s.<br/>total: 1853.56 ± 1.09ms. best: 1852.60ms.<br/>avg: 28.96 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 439.98 ± 1.22ms<br/>p99: 439.98 ± 1.22ms<br/><br/>500 matches, radius=20<br/>ops: 8.02 ± 0.01 ops/s. best: 8.04ops/s.<br/>total: 8109.03 ± 12.74ms. best: 8087.87ms.<br/>avg: 124.75 ± 0.20ms<br/>min: 0.49 ± 0.00ms<br/>max: 2341.63 ± 4.78ms<br/>p99: 2341.63 ± 4.78ms<br/><br/>Peak RAM: 55.500MB |
| random_match_mld | 500 matches, default radius<br/>ops: 206.63 ± 0.46 ops/s. best: 207.03ops/s.<br/>total: 275.86 ± 0.61ms. best: 275.32ms.<br/>avg: 4.84 ± 0.01ms<br/>min: 0.20 ± 0.00ms<br/>max: 27.13 ± 0.01ms<br/>p99: 27.13 ± 0.01ms<br/><br/>500 matches, radius=10<br/>ops: 73.08 ± 0.10 ops/s. best: 73.29ops/s.<br/>total: 875.71 ± 1.24ms. best: 873.24ms.<br/>avg: 13.68 ± 0.02ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.04 ± 0.71ms<br/>p99: 162.04 ± 0.71ms<br/><br/>500 matches, radius=20<br/>ops: 15.58 ± 0.01 ops/s. best: 15.59ops/s.<br/>total: 4172.86 ± 2.70ms. best: 4168.61ms.<br/>avg: 64.20 ± 0.04ms<br/>min: 0.29 ± 0.00ms<br/>max: 844.20 ± 1.34ms<br/>p99: 844.20 ± 1.34ms<br/><br/>Peak RAM: 51.500MB | 500 matches, default radius<br/>ops: 206.96 ± 0.51 ops/s. best: 207.40ops/s.<br/>total: 275.42 ± 0.68ms. best: 274.83ms.<br/>avg: 4.83 ± 0.01ms<br/>min: 0.20 ± 0.00ms<br/>max: 27.06 ± 0.02ms<br/>p99: 27.06 ± 0.02ms<br/><br/>500 matches, radius=10<br/>ops: 73.19 ± 0.10 ops/s. best: 73.39ops/s.<br/>total: 874.45 ± 1.15ms. best: 872.02ms.<br/>avg: 13.66 ± 0.02ms<br/>min: 0.22 ± 0.00ms<br/>max: 161.82 ± 0.65ms<br/>p99: 161.82 ± 0.65ms<br/><br/>500 matches, radius=20<br/>ops: 15.59 ± 0.01 ops/s. best: 15.61ops/s.<br/>total: 4168.91 ± 2.78ms. best: 4163.56ms.<br/>avg: 64.14 ± 0.04ms<br/>min: 0.29 ± 0.00ms<br/>max: 842.88 ± 1.38ms<br/>p99: 842.88 ± 1.38ms<br/><br/>Peak RAM: 51.500MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 21816.96 ± 38.23 ops/s. best: 21870.55ops/s.<br/>total: 458.36 ± 0.89ms. best: 457.24ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16064.10 ± 16.54 ops/s. best: 16080.89ops/s.<br/>total: 622.51 ± 0.64ms. best: 621.86ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12284.95 ± 6.32 ops/s. best: 12292.23ops/s.<br/>total: 814.00 ± 0.42ms. best: 813.52ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 21871.46 ± 42.45 ops/s. best: 21908.22ops/s.<br/>total: 457.22 ± 0.89ms. best: 456.45ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16156.24 ± 7.22 ops/s. best: 16165.27ops/s.<br/>total: 618.96 ± 0.28ms. best: 618.61ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.16 ± 0.01ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12402.64 ± 5.02 ops/s. best: 12407.32ops/s.<br/>total: 806.28 ± 0.33ms. best: 805.98ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 21844.41 ± 37.74 ops/s. best: 21875.03ops/s.<br/>total: 457.79 ± 0.81ms. best: 457.14ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16073.01 ± 9.85 ops/s. best: 16083.18ops/s.<br/>total: 622.16 ± 0.39ms. best: 621.77ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12283.20 ± 3.86 ops/s. best: 12289.47ops/s.<br/>total: 814.12 ± 0.26ms. best: 813.70ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.01ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 21889.40 ± 36.89 ops/s. best: 21918.04ops/s.<br/>total: 456.84 ± 0.77ms. best: 456.25ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16173.01 ± 5.54 ops/s. best: 16178.22ops/s.<br/>total: 618.31 ± 0.21ms. best: 618.11ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12407.32 ± 5.47 ops/s. best: 12414.73ops/s.<br/>total: 805.98 ± 0.35ms. best: 805.49ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.20 ± 0.01ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 282.93 ± 0.18 ops/s. best: 283.19ops/s.<br/>total: 3477.95 ± 2.20ms. best: 3474.68ms.<br/>avg: 3.53 ± 0.00ms<br/>min: 0.54 ± 0.00ms<br/>max: 6.09 ± 0.05ms<br/>p99: 5.28 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 330.77 ± 0.07 ops/s. best: 330.87ops/s.<br/>total: 3023.24 ± 0.66ms. best: 3022.33ms.<br/>avg: 3.02 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.91 ± 0.05ms<br/>p99: 7.10 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 578.75 ± 0.18 ops/s. best: 578.92ops/s.<br/>total: 1700.23 ± 0.53ms. best: 1699.71ms.<br/>avg: 1.73 ± 0.00ms<br/>min: 0.37 ± 0.00ms<br/>max: 2.78 ± 0.01ms<br/>p99: 2.43 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 626.96 ± 0.58 ops/s. best: 628.03ops/s.<br/>total: 1595.00 ± 1.48ms. best: 1592.28ms.<br/>avg: 1.59 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.22 ± 0.03ms<br/>p99: 3.96 ± 0.01ms<br/><br/>Peak RAM: 84.000MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 281.47 ± 0.12 ops/s. best: 281.57ops/s.<br/>total: 3495.94 ± 1.51ms. best: 3494.70ms.<br/>avg: 3.55 ± 0.00ms<br/>min: 0.51 ± 0.00ms<br/>max: 6.04 ± 0.01ms<br/>p99: 5.28 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 331.21 ± 0.05 ops/s. best: 331.28ops/s.<br/>total: 3019.22 ± 0.45ms. best: 3018.60ms.<br/>avg: 3.02 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.91 ± 0.05ms<br/>p99: 7.10 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 579.30 ± 0.09 ops/s. best: 579.42ops/s.<br/>total: 1698.61 ± 0.25ms. best: 1698.24ms.<br/>avg: 1.73 ± 0.00ms<br/>min: 0.37 ± 0.00ms<br/>max: 2.76 ± 0.01ms<br/>p99: 2.45 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 631.73 ± 0.05 ops/s. best: 631.81ops/s.<br/>total: 1582.95 ± 0.13ms. best: 1582.75ms.<br/>avg: 1.58 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.19 ± 0.00ms<br/>p99: 3.92 ± 0.00ms<br/><br/>Peak RAM: 84.000MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 146.49 ± 0.03 ops/s. best: 146.52ops/s.<br/>total: 6717.05 ± 1.20ms. best: 6715.67ms.<br/>avg: 6.83 ± 0.00ms<br/>min: 0.53 ± 0.01ms<br/>max: 16.52 ± 0.02ms<br/>p99: 11.12 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 139.44 ± 0.00 ops/s. best: 139.44ops/s.<br/>total: 7171.70 ± 0.25ms. best: 7171.38ms.<br/>avg: 7.17 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 16.49 ± 0.02ms<br/>p99: 15.54 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 204.19 ± 0.02 ops/s. best: 204.23ops/s.<br/>total: 4819.03 ± 0.56ms. best: 4818.18ms.<br/>avg: 4.90 ± 0.00ms<br/>min: 0.39 ± 0.01ms<br/>max: 13.73 ± 0.01ms<br/>p99: 8.45 ± 0.00ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 175.75 ± 0.02 ops/s. best: 175.78ops/s.<br/>total: 5689.90 ± 0.81ms. best: 5688.88ms.<br/>avg: 5.69 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.84 ± 0.03ms<br/>p99: 11.91 ± 0.02ms<br/><br/>Peak RAM: 73.984MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 146.89 ± 0.03 ops/s. best: 146.92ops/s.<br/>total: 6699.11 ± 1.32ms. best: 6697.58ms.<br/>avg: 6.81 ± 0.00ms<br/>min: 0.53 ± 0.00ms<br/>max: 16.47 ± 0.02ms<br/>p99: 11.09 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 140.00 ± 0.03 ops/s. best: 140.04ops/s.<br/>total: 7142.85 ± 1.34ms. best: 7140.74ms.<br/>avg: 7.14 ± 0.00ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.42 ± 0.02ms<br/>p99: 15.46 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 204.64 ± 0.02 ops/s. best: 204.68ops/s.<br/>total: 4808.41 ± 0.43ms. best: 4807.53ms.<br/>avg: 4.89 ± 0.00ms<br/>min: 0.39 ± 0.00ms<br/>max: 13.68 ± 0.02ms<br/>p99: 8.44 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 176.21 ± 0.02 ops/s. best: 176.23ops/s.<br/>total: 5675.17 ± 0.52ms. best: 5674.50ms.<br/>avg: 5.68 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.81 ± 0.03ms<br/>p99: 11.87 ± 0.01ms<br/><br/>Peak RAM: 73.984MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1099.06 ± 4.31 ops/s. best: 1102.88ops/s.<br/>total: 227.47 ± 0.90ms. best: 226.68ms.<br/>avg: 0.91 ± 0.00ms<br/>min: 0.61 ± 0.01ms<br/>max: 1.29 ± 0.17ms<br/>p99: 1.15 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 122.93 ± 0.04 ops/s. best: 122.97ops/s.<br/>total: 2033.60 ± 0.60ms. best: 2032.98ms.<br/>avg: 8.13 ± 0.00ms<br/>min: 7.30 ± 0.01ms<br/>max: 9.01 ± 0.01ms<br/>p99: 8.79 ± 0.02ms<br/><br/>250 tables, 50 coordinates<br/>ops: 59.73 ± 0.01 ops/s. best: 59.74ops/s.<br/>total: 4185.51 ± 0.53ms. best: 4184.87ms.<br/>avg: 16.74 ± 0.00ms<br/>min: 15.55 ± 0.01ms<br/>max: 17.74 ± 0.01ms<br/>p99: 17.64 ± 0.01ms<br/><br/>Peak RAM: 63.000MB | 250 tables, 3 coordinates<br/>ops: 1103.16 ± 4.60 ops/s. best: 1106.71ops/s.<br/>total: 226.63 ± 0.95ms. best: 225.89ms.<br/>avg: 0.91 ± 0.00ms<br/>min: 0.61 ± 0.00ms<br/>max: 1.28 ± 0.17ms<br/>p99: 1.15 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 123.65 ± 0.03 ops/s. best: 123.68ops/s.<br/>total: 2021.85 ± 0.53ms. best: 2021.27ms.<br/>avg: 8.09 ± 0.00ms<br/>min: 7.26 ± 0.00ms<br/>max: 8.96 ± 0.01ms<br/>p99: 8.71 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 60.24 ± 0.00 ops/s. best: 60.24ops/s.<br/>total: 4150.22 ± 0.22ms. best: 4149.90ms.<br/>avg: 16.60 ± 0.00ms<br/>min: 15.43 ± 0.02ms<br/>max: 17.57 ± 0.01ms<br/>p99: 17.46 ± 0.00ms<br/><br/>Peak RAM: 63.000MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 224.10 ± 0.36 ops/s. best: 224.55ops/s.<br/>total: 1115.59 ± 2.03ms. best: 1113.34ms.<br/>avg: 4.46 ± 0.01ms<br/>min: 3.52 ± 0.01ms<br/>max: 5.75 ± 0.03ms<br/>p99: 5.56 ± 0.06ms<br/><br/>250 tables, 25 coordinates<br/>ops: 23.59 ± 0.01 ops/s. best: 23.60ops/s.<br/>total: 10597.94 ± 2.64ms. best: 10593.05ms.<br/>avg: 42.39 ± 0.01ms<br/>min: 39.10 ± 0.05ms<br/>max: 46.31 ± 0.03ms<br/>p99: 45.81 ± 0.09ms<br/><br/>250 tables, 50 coordinates<br/>ops: 10.90 ± 0.00 ops/s. best: 10.90ops/s.<br/>total: 22943.27 ± 7.06ms. best: 22929.13ms.<br/>avg: 91.77 ± 0.03ms<br/>min: 86.90 ± 0.13ms<br/>max: 97.13 ± 0.22ms<br/>p99: 95.63 ± 0.08ms<br/><br/>Peak RAM: 63.281MB | 250 tables, 3 coordinates<br/>ops: 228.61 ± 0.28 ops/s. best: 228.83ops/s.<br/>total: 1093.56 ± 1.33ms. best: 1092.50ms.<br/>avg: 4.37 ± 0.01ms<br/>min: 3.48 ± 0.00ms<br/>max: 5.61 ± 0.03ms<br/>p99: 5.43 ± 0.06ms<br/><br/>250 tables, 25 coordinates<br/>ops: 24.11 ± 0.01 ops/s. best: 24.12ops/s.<br/>total: 10370.58 ± 2.91ms. best: 10365.08ms.<br/>avg: 41.48 ± 0.01ms<br/>min: 38.31 ± 0.05ms<br/>max: 45.30 ± 0.04ms<br/>p99: 44.70 ± 0.07ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.12 ± 0.00 ops/s. best: 11.13ops/s.<br/>total: 22479.86 ± 8.73ms. best: 22471.23ms.<br/>avg: 89.92 ± 0.03ms<br/>min: 85.00 ± 0.05ms<br/>max: 95.76 ± 0.24ms<br/>p99: 94.00 ± 0.20ms<br/><br/>Peak RAM: 63.281MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 319.26 ± 0.43 ops/s. best: 319.58ops/s.<br/>total: 783.06 ± 1.05ms. best: 782.27ms.<br/>avg: 3.13 ± 0.00ms<br/>min: 1.62 ± 0.01ms<br/>max: 4.36 ± 0.01ms<br/>p99: 4.23 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 207.43 ± 0.03 ops/s. best: 207.47ops/s.<br/>total: 1205.22 ± 0.16ms. best: 1205.01ms.<br/>avg: 4.82 ± 0.00ms<br/>min: 3.18 ± 0.01ms<br/>max: 6.21 ± 0.00ms<br/>p99: 6.01 ± 0.01ms<br/><br/>Peak RAM: 74.000MB | 250 trips, 3 coordinates<br/>ops: 320.69 ± 0.49 ops/s. best: 321.10ops/s.<br/>total: 779.58 ± 1.20ms. best: 778.57ms.<br/>avg: 3.12 ± 0.00ms<br/>min: 1.63 ± 0.01ms<br/>max: 4.33 ± 0.00ms<br/>p99: 4.21 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 206.85 ± 0.07 ops/s. best: 206.95ops/s.<br/>total: 1208.62 ± 0.44ms. best: 1208.02ms.<br/>avg: 4.83 ± 0.00ms<br/>min: 3.18 ± 0.00ms<br/>max: 6.27 ± 0.01ms<br/>p99: 6.01 ± 0.01ms<br/><br/>Peak RAM: 74.000MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 106.69 ± 0.10 ops/s. best: 106.85ops/s.<br/>total: 2343.34 ± 2.12ms. best: 2339.77ms.<br/>avg: 9.37 ± 0.01ms<br/>min: 5.44 ± 0.01ms<br/>max: 12.30 ± 0.12ms<br/>p99: 12.06 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 68.86 ± 0.04 ops/s. best: 68.92ops/s.<br/>total: 3630.80 ± 1.92ms. best: 3627.39ms.<br/>avg: 14.52 ± 0.01ms<br/>min: 10.13 ± 0.03ms<br/>max: 18.05 ± 0.11ms<br/>p99: 17.39 ± 0.01ms<br/><br/>Peak RAM: 69.500MB | 250 trips, 3 coordinates<br/>ops: 107.60 ± 0.06 ops/s. best: 107.66ops/s.<br/>total: 2323.42 ± 1.25ms. best: 2322.02ms.<br/>avg: 9.29 ± 0.00ms<br/>min: 5.43 ± 0.01ms<br/>max: 12.12 ± 0.01ms<br/>p99: 11.97 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 69.25 ± 0.02 ops/s. best: 69.28ops/s.<br/>total: 3610.09 ± 0.97ms. best: 3608.37ms.<br/>avg: 14.44 ± 0.00ms<br/>min: 10.06 ± 0.01ms<br/>max: 17.82 ± 0.01ms<br/>p99: 17.28 ± 0.02ms<br/><br/>Peak RAM: 69.500MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>638.32ms<br/>0.63832ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>781.296ms<br/>0.781296ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>245.44ms<br/>0.24544ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>216.193ms<br/>0.216193ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>637.409ms<br/>0.637409ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>779.065ms<br/>0.779065ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>249.703ms<br/>0.249703ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>218.527ms<br/>0.218527ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>807.942ms<br/>0.807942ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1039.07ms<br/>1.03907ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>414.341ms<br/>0.414341ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>461.84ms<br/>0.46184ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>809.449ms<br/>0.809449ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1039.48ms<br/>1.03948ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>417.137ms<br/>0.417137ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>464.268ms<br/>0.464268ms/req |
| rtree | 1 result:<br/>227.492ms ->  0.0227492 ms/query<br/>10 results:<br/>258.177ms ->  0.0258177 ms/query | 1 result:<br/>227.203ms ->  0.0227203 ms/query<br/>10 results:<br/>258.055ms ->  0.0258055 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
