### PR TITLE
Use std::popcount instead of __builtin_popcount

### DIFF
--- a/include/util/bit_range.hpp
+++ b/include/util/bit_range.hpp
@@ -2,42 +2,12 @@
 #define OSRM_UTIL_BIT_RANGE_HPP
 
 #include "util/msb.hpp"
-
+#include <bit>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/range/iterator_range.hpp>
 
 namespace osrm::util
 {
-
-namespace detail
-{
-template <typename T> std::size_t countOnes(T value)
-{
-    static_assert(std::is_unsigned<T>::value, "Only unsigned types allowed");
-    std::size_t number_of_ones = 0;
-    while (value > 0)
-    {
-        auto index = msb(value);
-        value = value & ~(T{1} << index);
-        number_of_ones++;
-    }
-    return number_of_ones;
-}
-
-#if (defined(__clang__) || defined(__GNUC__) || defined(__GNUG__))
-inline std::size_t countOnes(std::uint8_t value)
-{
-    return __builtin_popcount(std::uint32_t{value});
-}
-inline std::size_t countOnes(std::uint16_t value)
-{
-    return __builtin_popcount(std::uint32_t{value});
-}
-inline std::size_t countOnes(unsigned int value) { return __builtin_popcount(value); }
-inline std::size_t countOnes(unsigned long value) { return __builtin_popcountl(value); }
-inline std::size_t countOnes(unsigned long long value) { return __builtin_popcountll(value); }
-#endif
-} // namespace detail
 
 // Investigate if we can replace this with
 // http://www.boost.org/doc/libs/1_64_0/libs/dynamic_bitset/dynamic_bitset.html
@@ -70,7 +40,7 @@ class BitIterator : public boost::iterator_facade<BitIterator<DataT>,
 
     difference_type distance_to(const BitIterator &other) const
     {
-        return detail::countOnes(m_value) - detail::countOnes(other.m_value);
+        return std::popcount(m_value) - std::popcount(other.m_value);
     }
 
     bool equal(const BitIterator &other) const { return m_value == other.m_value; }


### PR DESCRIPTION

<!-- BENCHMARK_RESULTS_START -->
<details><summary><h2>Benchmark Results</h2></summary>

| Benchmark | Base | PR |
|-----------|------|----|
| alias | aliased u32: 11082<br/>plain u32: 10970.5<br/>aliased double: 15120.5<br/>plain double: 15110.4 | aliased u32: 11147.6<br/>plain u32: 10972.7<br/>aliased double: 15119.4<br/>plain double: 15112.7 |
| e2e_match_ch | Ops: 27.21 ± 0.01 ops/s. Best: 27.23 ops/s<br/>Total: 4813.88ms ± 1.72ms. Best: 4810.58ms<br/>Min time: 3.27ms ± 0.06ms<br/>Mean time: 36.75ms ± 0.01ms<br/>Median time: 25.06ms ± 0.13ms<br/>95th percentile: 121.97ms ± 0.12ms<br/>99th percentile: 147.28ms ± 0.51ms<br/>Max time: 156.00ms ± 0.42ms | Ops: 27.05 ± 0.01 ops/s. Best: 27.07 ops/s<br/>Total: 4842.01ms ± 1.63ms. Best: 4838.68ms<br/>Min time: 3.26ms ± 0.04ms<br/>Mean time: 36.96ms ± 0.01ms<br/>Median time: 25.22ms ± 0.11ms<br/>95th percentile: 123.02ms ± 0.35ms<br/>99th percentile: 148.35ms ± 0.26ms<br/>Max time: 156.87ms ± 0.50ms |
| e2e_match_mld | Ops: 43.47 ± 0.04 ops/s. Best: 43.53 ops/s<br/>Total: 3013.94ms ± 2.57ms. Best: 3009.54ms<br/>Min time: 2.59ms ± 0.04ms<br/>Mean time: 23.01ms ± 0.02ms<br/>Median time: 12.09ms ± 0.09ms<br/>95th percentile: 74.96ms ± 0.26ms<br/>99th percentile: 87.41ms ± 0.22ms<br/>Max time: 100.88ms ± 0.15ms | Ops: 43.50 ± 0.01 ops/s. Best: 43.51 ops/s<br/>Total: 3011.19ms ± 0.77ms. Best: 3010.52ms<br/>Min time: 2.59ms ± 0.05ms<br/>Mean time: 22.99ms ± 0.01ms<br/>Median time: 12.13ms ± 0.11ms<br/>95th percentile: 74.96ms ± 0.14ms<br/>99th percentile: 87.15ms ± 0.08ms<br/>Max time: 100.82ms ± 0.26ms |
| e2e_nearest_ch | Ops: 635.48 ± 4.01 ops/s. Best: 642.97 ops/s<br/>Total: 1573.36ms ± 10.04ms. Best: 1555.29ms<br/>Min time: 1.28ms ± 0.00ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.54ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.00ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.33ms ± 7.40ms | Ops: 637.56 ± 3.52 ops/s. Best: 643.94 ops/s<br/>Total: 1568.50ms ± 8.85ms. Best: 1552.94ms<br/>Min time: 1.27ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.97ms ± 0.01ms<br/>99th percentile: 2.04ms ± 0.01ms<br/>Max time: 9.38ms ± 7.44ms |
| e2e_nearest_mld | Ops: 635.43 ± 2.30 ops/s. Best: 639.02 ops/s<br/>Total: 1573.63ms ± 5.90ms. Best: 1564.90ms<br/>Min time: 1.28ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.54ms ± 0.00ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.05ms ± 0.01ms<br/>Max time: 9.33ms ± 7.39ms | Ops: 636.03 ± 4.86 ops/s. Best: 642.03 ops/s<br/>Total: 1572.10ms ± 12.52ms. Best: 1557.55ms<br/>Min time: 1.29ms ± 0.01ms<br/>Mean time: 1.57ms ± 0.01ms<br/>Median time: 1.53ms ± 0.01ms<br/>95th percentile: 1.96ms ± 0.01ms<br/>99th percentile: 2.05ms ± 0.01ms<br/>Max time: 9.36ms ± 7.41ms |
| e2e_route_ch | Ops: 215.71 ± 0.42 ops/s. Best: 216.23 ops/s<br/>Total: 4636.04ms ± 9.00ms. Best: 4624.76ms<br/>Min time: 1.83ms ± 0.06ms<br/>Mean time: 4.64ms ± 0.01ms<br/>Median time: 4.73ms ± 0.01ms<br/>95th percentile: 6.09ms ± 0.03ms<br/>99th percentile: 6.66ms ± 0.02ms<br/>Max time: 13.42ms ± 6.36ms | Ops: 215.43 ± 0.50 ops/s. Best: 216.19 ops/s<br/>Total: 4642.20ms ± 10.90ms. Best: 4625.55ms<br/>Min time: 1.87ms ± 0.05ms<br/>Mean time: 4.64ms ± 0.01ms<br/>Median time: 4.75ms ± 0.01ms<br/>95th percentile: 6.08ms ± 0.02ms<br/>99th percentile: 6.64ms ± 0.02ms<br/>Max time: 13.34ms ± 6.33ms |
| e2e_route_mld | Ops: 177.78 ± 0.38 ops/s. Best: 178.57 ops/s<br/>Total: 5625.05ms ± 12.40ms. Best: 5600.16ms<br/>Min time: 1.85ms ± 0.07ms<br/>Mean time: 5.62ms ± 0.01ms<br/>Median time: 5.75ms ± 0.02ms<br/>95th percentile: 7.63ms ± 0.02ms<br/>99th percentile: 8.19ms ± 0.06ms<br/>Max time: 14.74ms ± 5.88ms | Ops: 177.88 ± 0.39 ops/s. Best: 178.73 ops/s<br/>Total: 5622.02ms ± 13.48ms. Best: 5595.14ms<br/>Min time: 1.85ms ± 0.04ms<br/>Mean time: 5.62ms ± 0.01ms<br/>Median time: 5.74ms ± 0.02ms<br/>95th percentile: 7.61ms ± 0.02ms<br/>99th percentile: 8.19ms ± 0.10ms<br/>Max time: 14.77ms ± 5.90ms |
| e2e_table_ch | Ops: 212.94 ± 0.30 ops/s. Best: 213.51 ops/s<br/>Total: 4696.09ms ± 6.57ms. Best: 4683.64ms<br/>Min time: 2.46ms ± 0.04ms<br/>Mean time: 4.70ms ± 0.01ms<br/>Median time: 4.69ms ± 0.01ms<br/>95th percentile: 6.40ms ± 0.01ms<br/>99th percentile: 6.76ms ± 0.03ms<br/>Max time: 13.96ms ± 7.04ms | Ops: 212.94 ± 0.46 ops/s. Best: 213.48 ops/s<br/>Total: 4696.11ms ± 10.18ms. Best: 4684.18ms<br/>Min time: 2.44ms ± 0.06ms<br/>Mean time: 4.70ms ± 0.01ms<br/>Median time: 4.69ms ± 0.01ms<br/>95th percentile: 6.42ms ± 0.01ms<br/>99th percentile: 6.74ms ± 0.04ms<br/>Max time: 13.91ms ± 7.07ms |
| e2e_table_mld | Ops: 69.53 ± 0.03 ops/s. Best: 69.59 ops/s<br/>Total: 14383.01ms ± 7.12ms. Best: 14369.87ms<br/>Min time: 6.02ms ± 0.02ms<br/>Mean time: 14.38ms ± 0.01ms<br/>Median time: 14.30ms ± 0.02ms<br/>95th percentile: 21.94ms ± 0.03ms<br/>99th percentile: 23.17ms ± 0.02ms<br/>Max time: 29.41ms ± 5.60ms | Ops: 69.45 ± 0.04 ops/s. Best: 69.50 ops/s<br/>Total: 14399.04ms ± 8.28ms. Best: 14388.05ms<br/>Min time: 5.97ms ± 0.02ms<br/>Mean time: 14.40ms ± 0.01ms<br/>Median time: 14.33ms ± 0.02ms<br/>95th percentile: 21.95ms ± 0.06ms<br/>99th percentile: 23.19ms ± 0.05ms<br/>Max time: 29.54ms ± 5.76ms |
| e2e_trip_ch | Ops: 62.27 ± 0.04 ops/s. Best: 62.35 ops/s<br/>Total: 16058.15ms ± 9.33ms. Best: 16037.22ms<br/>Min time: 2.40ms ± 0.15ms<br/>Mean time: 16.06ms ± 0.01ms<br/>Median time: 15.28ms ± 0.02ms<br/>95th percentile: 28.26ms ± 0.03ms<br/>99th percentile: 30.26ms ± 0.11ms<br/>Max time: 32.98ms ± 1.24ms | Ops: 62.13 ± 0.04 ops/s. Best: 62.19 ops/s<br/>Total: 16094.39ms ± 10.00ms. Best: 16080.10ms<br/>Min time: 2.44ms ± 0.14ms<br/>Mean time: 16.09ms ± 0.01ms<br/>Median time: 15.30ms ± 0.03ms<br/>95th percentile: 28.31ms ± 0.03ms<br/>99th percentile: 30.33ms ± 0.14ms<br/>Max time: 33.12ms ± 1.27ms |
| e2e_trip_mld | Ops: 36.75 ± 0.02 ops/s. Best: 36.77 ops/s<br/>Total: 27211.44ms ± 16.93ms. Best: 27193.69ms<br/>Min time: 2.45ms ± 0.21ms<br/>Mean time: 27.21ms ± 0.02ms<br/>Median time: 26.35ms ± 0.05ms<br/>95th percentile: 44.29ms ± 0.07ms<br/>99th percentile: 46.98ms ± 0.11ms<br/>Max time: 49.31ms ± 0.23ms | Ops: 36.69 ± 0.02 ops/s. Best: 36.72 ops/s<br/>Total: 27254.71ms ± 14.05ms. Best: 27234.06ms<br/>Min time: 2.42ms ± 0.16ms<br/>Mean time: 27.25ms ± 0.01ms<br/>Median time: 26.38ms ± 0.08ms<br/>95th percentile: 44.40ms ± 0.03ms<br/>99th percentile: 47.03ms ± 0.07ms<br/>Max time: 49.45ms ± 0.17ms |
| json-render | String: 9.00567ms<br/>Stringstream: 14.3008ms<br/>Vector: 9.55194ms | String: 8.94265ms<br/>Stringstream: 14.6225ms<br/>Vector: 9.70468ms |
| match_ch | Default radius: <br/>7.05028ms/req at 82 coordinate<br/>0.085979ms/coordinate<br/>Radius 10m: <br/>24.9688ms/req at 82 coordinate<br/>0.304497ms/coordinate | Default radius: <br/>7.07577ms/req at 82 coordinate<br/>0.0862899ms/coordinate<br/>Radius 10m: <br/>25.0367ms/req at 82 coordinate<br/>0.305326ms/coordinate |
| match_mld | Default radius: <br/>4.55709ms/req at 82 coordinate<br/>0.0555742ms/coordinate<br/>Radius 10m: <br/>17.4315ms/req at 82 coordinate<br/>0.21258ms/coordinate | Default radius: <br/>4.39315ms/req at 82 coordinate<br/>0.053575ms/coordinate<br/>Radius 10m: <br/>16.2283ms/req at 82 coordinate<br/>0.197907ms/coordinate |
| node_match_ch | Ops: 164.2 ± 1.2 ops/s. Best: 165.5 ops/s | Ops: 163.8 ± 1.1 ops/s. Best: 165.3 ops/s |
| node_match_mld | Ops: 220.3 ± 1.4 ops/s. Best: 222.3 ops/s | Ops: 220.5 ± 1.0 ops/s. Best: 221.8 ops/s |
| node_nearest_ch | Ops: 10002.6 ± 942.3 ops/s. Best: 11248.8 ops/s | Ops: 10283.3 ± 834.8 ops/s. Best: 12100.6 ops/s |
| node_nearest_mld | Ops: 10476.4 ± 1035.1 ops/s. Best: 11554.0 ops/s | Ops: 10416.3 ± 903.2 ops/s. Best: 12022.8 ops/s |
| node_route_ch | Ops: 969.4 ± 7.2 ops/s. Best: 979.4 ops/s | Ops: 1002.8 ± 14.8 ops/s. Best: 1025.3 ops/s |
| node_route_mld | Ops: 509.0 ± 5.3 ops/s. Best: 514.9 ops/s | Ops: 509.7 ± 4.9 ops/s. Best: 516.1 ops/s |
| node_table_ch | Ops: 178.5 ± 1.8 ops/s. Best: 181.1 ops/s | Ops: 178.8 ± 1.0 ops/s. Best: 180.6 ops/s |
| node_table_mld | Ops: 38.0 ± 0.1 ops/s. Best: 38.1 ops/s | Ops: 37.8 ± 0.0 ops/s. Best: 37.9 ops/s |
| node_trip_ch | Ops: 180.0 ± 1.1 ops/s. Best: 181.5 ops/s | Ops: 180.4 ± 0.9 ops/s. Best: 181.7 ops/s |
| node_trip_mld | Ops: 61.4 ± 0.1 ops/s. Best: 61.6 ops/s | Ops: 61.6 ± 0.1 ops/s. Best: 61.8 ops/s |
| osrm_contract | Time: 185.57s Peak RAM: 194.98MB | Time: 185.60s Peak RAM: 194.96MB |
| osrm_customize | Time: 2.54s Peak RAM: 112.46MB | Time: 2.52s Peak RAM: 112.46MB |
| osrm_extract | Time: 24.34s Peak RAM: 398.18MB | Time: 24.42s Peak RAM: 397.53MB |
| osrm_partition | Time: 5.91s Peak RAM: 121.64MB | Time: 5.91s Peak RAM: 121.04MB |
| packedvector | random write:<br/>std::vector 185155 ms<br/>util::packed_vector 377709 ms<br/>slowdown: 2.03996<br/>random read:<br/>std::vector 100703 ms<br/>util::packed_vector 192379 ms<br/>slowdown: 1.91035 | random write:<br/>std::vector 184671 ms<br/>util::packed_vector 382463 ms<br/>slowdown: 2.07105<br/>random read:<br/>std::vector 100777 ms<br/>util::packed_vector 195112 ms<br/>slowdown: 1.93607 |
| random_match_ch | 500 matches, default radius<br/>ops: 121.57 ± 0.22 ops/s. best: 121.82ops/s.<br/>total: 468.87 ± 0.83ms. best: 467.92ms.<br/>avg: 8.23 ± 0.01ms<br/>min: 0.23 ± 0.00ms<br/>max: 43.09 ± 0.10ms<br/>p99: 43.09 ± 0.10ms<br/><br/>500 matches, radius=10<br/>ops: 35.09 ± 0.02 ops/s. best: 35.11ops/s.<br/>total: 1824.11 ± 1.11ms. best: 1822.95ms.<br/>avg: 28.50 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 430.15 ± 1.35ms<br/>p99: 430.15 ± 1.35ms<br/><br/>500 matches, radius=20<br/>ops: 8.17 ± 0.01 ops/s. best: 8.19ops/s.<br/>total: 7958.91 ± 12.08ms. best: 7937.36ms.<br/>avg: 122.44 ± 0.19ms<br/>min: 0.49 ± 0.00ms<br/>max: 2275.58 ± 4.44ms<br/>p99: 2275.58 ± 4.44ms<br/><br/>Peak RAM: 55.500MB | 500 matches, default radius<br/>ops: 120.63 ± 0.23 ops/s. best: 120.89ops/s.<br/>total: 472.54 ± 0.90ms. best: 471.49ms.<br/>avg: 8.29 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 43.60 ± 0.11ms<br/>p99: 43.60 ± 0.11ms<br/><br/>500 matches, radius=10<br/>ops: 34.64 ± 0.02 ops/s. best: 34.67ops/s.<br/>total: 1847.64 ± 0.99ms. best: 1845.95ms.<br/>avg: 28.87 ± 0.02ms<br/>min: 0.23 ± 0.00ms<br/>max: 438.62 ± 1.22ms<br/>p99: 438.62 ± 1.22ms<br/><br/>500 matches, radius=20<br/>ops: 8.04 ± 0.01 ops/s. best: 8.06ops/s.<br/>total: 8082.92 ± 11.81ms. best: 8062.45ms.<br/>avg: 124.35 ± 0.18ms<br/>min: 0.49 ± 0.00ms<br/>max: 2334.02 ± 4.47ms<br/>p99: 2334.02 ± 4.47ms<br/><br/>Peak RAM: 55.500MB |
| random_match_mld | 500 matches, default radius<br/>ops: 206.66 ± 0.44 ops/s. best: 207.05ops/s.<br/>total: 275.82 ± 0.59ms. best: 275.29ms.<br/>avg: 4.84 ± 0.01ms<br/>min: 0.20 ± 0.00ms<br/>max: 27.11 ± 0.01ms<br/>p99: 27.11 ± 0.01ms<br/><br/>500 matches, radius=10<br/>ops: 73.07 ± 0.11 ops/s. best: 73.28ops/s.<br/>total: 875.92 ± 1.29ms. best: 873.39ms.<br/>avg: 13.69 ± 0.02ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.06 ± 0.69ms<br/>p99: 162.06 ± 0.69ms<br/><br/>500 matches, radius=20<br/>ops: 15.58 ± 0.01 ops/s. best: 15.60ops/s.<br/>total: 4172.50 ± 2.78ms. best: 4166.67ms.<br/>avg: 64.19 ± 0.04ms<br/>min: 0.29 ± 0.00ms<br/>max: 843.97 ± 1.53ms<br/>p99: 843.97 ± 1.53ms<br/><br/>Peak RAM: 51.500MB | 500 matches, default radius<br/>ops: 206.43 ± 0.51 ops/s. best: 206.92ops/s.<br/>total: 276.12 ± 0.69ms. best: 275.47ms.<br/>avg: 4.84 ± 0.01ms<br/>min: 0.20 ± 0.00ms<br/>max: 27.13 ± 0.00ms<br/>p99: 27.13 ± 0.00ms<br/><br/>500 matches, radius=10<br/>ops: 73.01 ± 0.10 ops/s. best: 73.21ops/s.<br/>total: 876.63 ± 1.22ms. best: 874.20ms.<br/>avg: 13.70 ± 0.02ms<br/>min: 0.22 ± 0.00ms<br/>max: 162.14 ± 0.68ms<br/>p99: 162.14 ± 0.68ms<br/><br/>500 matches, radius=20<br/>ops: 15.56 ± 0.01 ops/s. best: 15.57ops/s.<br/>total: 4178.69 ± 2.53ms. best: 4173.68ms.<br/>avg: 64.29 ± 0.04ms<br/>min: 0.29 ± 0.00ms<br/>max: 844.59 ± 1.46ms<br/>p99: 844.59 ± 1.46ms<br/><br/>Peak RAM: 51.500MB |
| random_nearest_ch | 10000 nearest, number_of_results=1<br/>ops: 21855.25 ± 43.77 ops/s. best: 21889.08ops/s.<br/>total: 457.56 ± 0.92ms. best: 456.85ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16082.78 ± 5.94 ops/s. best: 16089.36ops/s.<br/>total: 621.78 ± 0.23ms. best: 621.53ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12292.98 ± 2.79 ops/s. best: 12297.33ops/s.<br/>total: 813.47 ± 0.18ms. best: 813.18ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 22055.59 ± 38.00 ops/s. best: 22087.10ops/s.<br/>total: 453.40 ± 0.78ms. best: 452.75ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.16 ± 0.03ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16243.27 ± 7.47 ops/s. best: 16251.62ops/s.<br/>total: 615.64 ± 0.28ms. best: 615.32ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12445.89 ± 6.98 ops/s. best: 12453.10ops/s.<br/>total: 803.48 ± 0.46ms. best: 803.01ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_nearest_mld | 10000 nearest, number_of_results=1<br/>ops: 21845.13 ± 35.37 ops/s. best: 21874.40ops/s.<br/>total: 457.77 ± 0.74ms. best: 457.16ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16079.39 ± 7.78 ops/s. best: 16086.51ops/s.<br/>total: 621.91 ± 0.30ms. best: 621.64ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12288.84 ± 5.00 ops/s. best: 12294.13ops/s.<br/>total: 813.75 ± 0.33ms. best: 813.40ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB | 10000 nearest, number_of_results=1<br/>ops: 22051.35 ± 36.51 ops/s. best: 22087.53ops/s.<br/>total: 453.49 ± 0.75ms. best: 452.74ms.<br/>avg: 0.05 ± 0.00ms<br/>min: 0.02 ± 0.00ms<br/>max: 0.15 ± 0.02ms<br/>p99: 0.10 ± 0.00ms<br/><br/>10000 nearest, number_of_results=5<br/>ops: 16252.83 ± 5.61 ops/s. best: 16257.97ops/s.<br/>total: 615.28 ± 0.21ms. best: 615.08ms.<br/>avg: 0.06 ± 0.00ms<br/>min: 0.03 ± 0.00ms<br/>max: 0.15 ± 0.00ms<br/>p99: 0.12 ± 0.00ms<br/><br/>10000 nearest, number_of_results=10<br/>ops: 12455.84 ± 4.00 ops/s. best: 12458.98ops/s.<br/>total: 802.84 ± 0.26ms. best: 802.63ms.<br/>avg: 0.08 ± 0.00ms<br/>min: 0.04 ± 0.00ms<br/>max: 0.19 ± 0.00ms<br/>p99: 0.15 ± 0.00ms<br/><br/>Peak RAM: 35.000MB |
| random_route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 284.51 ± 0.21 ops/s. best: 284.73ops/s.<br/>total: 3458.62 ± 2.51ms. best: 3455.87ms.<br/>avg: 3.51 ± 0.00ms<br/>min: 0.53 ± 0.00ms<br/>max: 6.04 ± 0.03ms<br/>p99: 5.28 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 331.45 ± 0.02 ops/s. best: 331.47ops/s.<br/>total: 3017.02 ± 0.14ms. best: 3016.89ms.<br/>avg: 3.02 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.91 ± 0.05ms<br/>p99: 7.09 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 583.87 ± 0.29 ops/s. best: 584.36ops/s.<br/>total: 1685.31 ± 0.78ms. best: 1683.88ms.<br/>avg: 1.71 ± 0.00ms<br/>min: 0.36 ± 0.00ms<br/>max: 2.74 ± 0.01ms<br/>p99: 2.43 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 634.44 ± 0.28 ops/s. best: 634.75ops/s.<br/>total: 1576.19 ± 0.72ms. best: 1575.42ms.<br/>avg: 1.58 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.16 ± 0.01ms<br/>p99: 3.89 ± 0.00ms<br/><br/>Peak RAM: 84.000MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 283.11 ± 0.10 ops/s. best: 283.23ops/s.<br/>total: 3475.68 ± 1.21ms. best: 3474.23ms.<br/>avg: 3.53 ± 0.00ms<br/>min: 0.51 ± 0.01ms<br/>max: 6.03 ± 0.01ms<br/>p99: 5.25 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 331.63 ± 0.06 ops/s. best: 331.71ops/s.<br/>total: 3015.38 ± 0.53ms. best: 3014.68ms.<br/>avg: 3.02 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 7.91 ± 0.05ms<br/>p99: 7.09 ± 0.01ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 578.59 ± 0.67 ops/s. best: 579.77ops/s.<br/>total: 1700.68 ± 1.98ms. best: 1697.22ms.<br/>avg: 1.73 ± 0.00ms<br/>min: 0.37 ± 0.00ms<br/>max: 2.78 ± 0.01ms<br/>p99: 2.44 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 631.98 ± 0.20 ops/s. best: 632.43ops/s.<br/>total: 1582.34 ± 0.51ms. best: 1581.20ms.<br/>avg: 1.58 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 4.20 ± 0.01ms<br/>p99: 3.92 ± 0.01ms<br/><br/>Peak RAM: 84.000MB |
| random_route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 146.62 ± 0.03 ops/s. best: 146.65ops/s.<br/>total: 6711.00 ± 1.20ms. best: 6709.85ms.<br/>avg: 6.82 ± 0.00ms<br/>min: 0.53 ± 0.01ms<br/>max: 16.54 ± 0.02ms<br/>p99: 11.08 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 139.49 ± 0.05 ops/s. best: 139.54ops/s.<br/>total: 7169.12 ± 2.70ms. best: 7166.26ms.<br/>avg: 7.17 ± 0.00ms<br/>min: 0.08 ± 0.00ms<br/>max: 16.50 ± 0.04ms<br/>p99: 15.51 ± 0.03ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 203.87 ± 0.03 ops/s. best: 203.93ops/s.<br/>total: 4826.62 ± 0.73ms. best: 4825.26ms.<br/>avg: 4.91 ± 0.00ms<br/>min: 0.39 ± 0.00ms<br/>max: 13.72 ± 0.01ms<br/>p99: 8.48 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 175.58 ± 0.02 ops/s. best: 175.60ops/s.<br/>total: 5695.35 ± 0.74ms. best: 5694.62ms.<br/>avg: 5.70 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.90 ± 0.09ms<br/>p99: 11.92 ± 0.02ms<br/><br/>Peak RAM: 73.984MB | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>ops: 146.99 ± 0.03 ops/s. best: 147.03ops/s.<br/>total: 6694.36 ± 1.29ms. best: 6692.36ms.<br/>avg: 6.80 ± 0.00ms<br/>min: 0.53 ± 0.00ms<br/>max: 16.47 ± 0.01ms<br/>p99: 11.08 ± 0.02ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>ops: 139.54 ± 0.13 ops/s. best: 139.69ops/s.<br/>total: 7166.67 ± 6.67ms. best: 7158.83ms.<br/>avg: 7.17 ± 0.01ms<br/>min: 0.07 ± 0.00ms<br/>max: 16.56 ± 0.19ms<br/>p99: 15.51 ± 0.04ms<br/><br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>ops: 204.53 ± 0.03 ops/s. best: 204.58ops/s.<br/>total: 4811.02 ± 0.79ms. best: 4809.77ms.<br/>avg: 4.89 ± 0.00ms<br/>min: 0.39 ± 0.00ms<br/>max: 13.67 ± 0.01ms<br/>p99: 8.45 ± 0.01ms<br/><br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>ops: 175.69 ± 0.07 ops/s. best: 175.80ops/s.<br/>total: 5691.85 ± 2.28ms. best: 5688.26ms.<br/>avg: 5.69 ± 0.00ms<br/>min: 0.06 ± 0.00ms<br/>max: 12.83 ± 0.02ms<br/>p99: 11.94 ± 0.05ms<br/><br/>Peak RAM: 73.984MB |
| random_table_ch | 250 tables, 3 coordinates<br/>ops: 1098.71 ± 3.97 ops/s. best: 1101.63ops/s.<br/>total: 227.54 ± 0.83ms. best: 226.94ms.<br/>avg: 0.91 ± 0.00ms<br/>min: 0.61 ± 0.00ms<br/>max: 1.28 ± 0.17ms<br/>p99: 1.14 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 122.90 ± 0.04 ops/s. best: 122.97ops/s.<br/>total: 2034.10 ± 0.69ms. best: 2032.97ms.<br/>avg: 8.14 ± 0.00ms<br/>min: 7.30 ± 0.01ms<br/>max: 9.02 ± 0.01ms<br/>p99: 8.79 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 59.78 ± 0.01 ops/s. best: 59.78ops/s.<br/>total: 4182.31 ± 0.40ms. best: 4181.73ms.<br/>avg: 16.73 ± 0.00ms<br/>min: 15.55 ± 0.01ms<br/>max: 17.75 ± 0.02ms<br/>p99: 17.63 ± 0.02ms<br/><br/>Peak RAM: 63.000MB | 250 tables, 3 coordinates<br/>ops: 1104.08 ± 4.34 ops/s. best: 1107.50ops/s.<br/>total: 226.44 ± 0.90ms. best: 225.73ms.<br/>avg: 0.91 ± 0.00ms<br/>min: 0.60 ± 0.00ms<br/>max: 1.27 ± 0.15ms<br/>p99: 1.14 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 123.61 ± 0.04 ops/s. best: 123.67ops/s.<br/>total: 2022.51 ± 0.58ms. best: 2021.48ms.<br/>avg: 8.09 ± 0.00ms<br/>min: 7.26 ± 0.01ms<br/>max: 8.97 ± 0.01ms<br/>p99: 8.73 ± 0.01ms<br/><br/>250 tables, 50 coordinates<br/>ops: 60.26 ± 0.01 ops/s. best: 60.27ops/s.<br/>total: 4148.59 ± 0.51ms. best: 4147.84ms.<br/>avg: 16.59 ± 0.00ms<br/>min: 15.43 ± 0.01ms<br/>max: 17.56 ± 0.01ms<br/>p99: 17.46 ± 0.01ms<br/><br/>Peak RAM: 63.000MB |
| random_table_mld | 250 tables, 3 coordinates<br/>ops: 227.31 ± 0.34 ops/s. best: 227.73ops/s.<br/>total: 1099.82 ± 1.71ms. best: 1097.78ms.<br/>avg: 4.40 ± 0.01ms<br/>min: 3.48 ± 0.00ms<br/>max: 5.63 ± 0.02ms<br/>p99: 5.46 ± 0.06ms<br/><br/>250 tables, 25 coordinates<br/>ops: 23.89 ± 0.00 ops/s. best: 23.89ops/s.<br/>total: 10466.09 ± 1.21ms. best: 10464.57ms.<br/>avg: 41.86 ± 0.00ms<br/>min: 38.68 ± 0.05ms<br/>max: 45.75 ± 0.05ms<br/>p99: 45.16 ± 0.04ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.04 ± 0.00 ops/s. best: 11.05ops/s.<br/>total: 22640.52 ± 8.29ms. best: 22625.26ms.<br/>avg: 90.56 ± 0.03ms<br/>min: 85.68 ± 0.10ms<br/>max: 96.41 ± 0.11ms<br/>p99: 94.49 ± 0.11ms<br/><br/>Peak RAM: 63.281MB | 250 tables, 3 coordinates<br/>ops: 225.11 ± 0.28 ops/s. best: 225.43ops/s.<br/>total: 1110.59 ± 1.41ms. best: 1109.00ms.<br/>avg: 4.44 ± 0.01ms<br/>min: 3.50 ± 0.01ms<br/>max: 5.71 ± 0.01ms<br/>p99: 5.51 ± 0.01ms<br/><br/>250 tables, 25 coordinates<br/>ops: 23.72 ± 0.01 ops/s. best: 23.74ops/s.<br/>total: 10538.65 ± 4.09ms. best: 10530.49ms.<br/>avg: 42.15 ± 0.02ms<br/>min: 38.84 ± 0.09ms<br/>max: 46.06 ± 0.15ms<br/>p99: 45.44 ± 0.13ms<br/><br/>250 tables, 50 coordinates<br/>ops: 11.00 ± 0.01 ops/s. best: 11.01ops/s.<br/>total: 22731.33 ± 18.57ms. best: 22698.52ms.<br/>avg: 90.93 ± 0.07ms<br/>min: 86.23 ± 0.28ms<br/>max: 96.34 ± 0.50ms<br/>p99: 95.00 ± 0.22ms<br/><br/>Peak RAM: 63.281MB |
| random_trip_ch | 250 trips, 3 coordinates<br/>ops: 319.75 ± 0.36 ops/s. best: 320.12ops/s.<br/>total: 781.86 ± 0.93ms. best: 780.95ms.<br/>avg: 3.13 ± 0.00ms<br/>min: 1.63 ± 0.00ms<br/>max: 4.35 ± 0.01ms<br/>p99: 4.23 ± 0.00ms<br/><br/>250 trips, 5 coordinates<br/>ops: 207.46 ± 0.03 ops/s. best: 207.50ops/s.<br/>total: 1205.03 ± 0.20ms. best: 1204.81ms.<br/>avg: 4.82 ± 0.00ms<br/>min: 3.18 ± 0.01ms<br/>max: 6.22 ± 0.01ms<br/>p99: 6.00 ± 0.01ms<br/><br/>Peak RAM: 74.000MB | 250 trips, 3 coordinates<br/>ops: 319.17 ± 0.27 ops/s. best: 319.43ops/s.<br/>total: 783.29 ± 0.67ms. best: 782.65ms.<br/>avg: 3.13 ± 0.00ms<br/>min: 1.62 ± 0.01ms<br/>max: 4.36 ± 0.01ms<br/>p99: 4.23 ± 0.00ms<br/><br/>250 trips, 5 coordinates<br/>ops: 207.40 ± 0.03 ops/s. best: 207.43ops/s.<br/>total: 1205.38 ± 0.15ms. best: 1205.23ms.<br/>avg: 4.82 ± 0.00ms<br/>min: 3.18 ± 0.00ms<br/>max: 6.20 ± 0.01ms<br/>p99: 6.01 ± 0.01ms<br/><br/>Peak RAM: 74.000MB |
| random_trip_mld | 250 trips, 3 coordinates<br/>ops: 107.01 ± 0.07 ops/s. best: 107.07ops/s.<br/>total: 2336.20 ± 1.57ms. best: 2334.98ms.<br/>avg: 9.34 ± 0.01ms<br/>min: 5.44 ± 0.01ms<br/>max: 12.18 ± 0.02ms<br/>p99: 12.04 ± 0.01ms<br/><br/>250 trips, 5 coordinates<br/>ops: 68.89 ± 0.01 ops/s. best: 68.90ops/s.<br/>total: 3628.85 ± 0.38ms. best: 3628.31ms.<br/>avg: 14.52 ± 0.00ms<br/>min: 10.08 ± 0.01ms<br/>max: 17.92 ± 0.03ms<br/>p99: 17.40 ± 0.01ms<br/><br/>Peak RAM: 69.500MB | 250 trips, 3 coordinates<br/>ops: 106.00 ± 0.37 ops/s. best: 106.60ops/s.<br/>total: 2358.63 ± 8.14ms. best: 2345.21ms.<br/>avg: 9.43 ± 0.03ms<br/>min: 5.50 ± 0.06ms<br/>max: 12.35 ± 0.03ms<br/>p99: 12.25 ± 0.07ms<br/><br/>250 trips, 5 coordinates<br/>ops: 68.75 ± 0.18 ops/s. best: 68.91ops/s.<br/>total: 3636.58 ± 9.67ms. best: 3627.78ms.<br/>avg: 14.55 ± 0.04ms<br/>min: 10.11 ± 0.03ms<br/>max: 18.10 ± 0.10ms<br/>p99: 17.37 ± 0.06ms<br/><br/>Peak RAM: 69.500MB |
| route_ch | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>637.043ms<br/>0.637043ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>780.275ms<br/>0.780275ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>245.246ms<br/>0.245246ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>215.977ms<br/>0.215977ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>635.93ms<br/>0.63593ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>776.112ms<br/>0.776112ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>247.73ms<br/>0.24773ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>216.441ms<br/>0.216441ms/req |
| route_mld | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>816.249ms<br/>0.816249ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1065.04ms<br/>1.06504ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>423.361ms<br/>0.423361ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>487.551ms<br/>0.487551ms/req | 1000 routes, 3 coordinates, no alternatives, overview=full, steps=true<br/>805.278ms<br/>0.805278ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=full, steps=true<br/>1034.78ms<br/>1.03478ms/req<br/>1000 routes, 3 coordinates, no alternatives, overview=false, steps=false<br/>412.557ms<br/>0.412557ms/req<br/>1000 routes, 2 coordinates, 3 alternatives, overview=false, steps=false<br/>460.689ms<br/>0.460689ms/req |
| rtree | 1 result:<br/>227.555ms ->  0.0227555 ms/query<br/>10 results:<br/>258.264ms ->  0.0258264 ms/query | 1 result:<br/>227.245ms ->  0.0227245 ms/query<br/>10 results:<br/>257.971ms ->  0.0257971 ms/query |
</details>
<!-- BENCHMARK_RESULTS_END -->
