### PR TITLE
do not overwrite vehicle maxspeed with higher value, fixes #6979

### DIFF
--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -438,11 +438,11 @@ function WayHandlers.maxspeed(profile,way,result,data)
   backward = WayHandlers.parse_maxspeed(backward,profile)
 
   if forward and forward > 0 then
-    result.forward_speed = forward * profile.speed_reduction
+    result.forward_speed = math.min(forward * profile.speed_reduction, result.forward_speed)
   end
 
   if backward and backward > 0 then
-    result.backward_speed = backward * profile.speed_reduction
+    result.backward_speed = math.min(backward * profile.speed_reduction, result.backward_speed)
   end
 end
 


### PR DESCRIPTION
# Issue

Fix the overwriting of a lower vehicle-based maxspeed by a higher signposted (edge-based) maxspeed

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
