### PR TITLE
uncomment "cyclability" weight name

### DIFF
--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -18,8 +18,7 @@ function setup()
     properties = {
       u_turn_penalty                = 20,
       traffic_light_penalty         = 2,
-      --weight_name                   = 'cyclability',
-      weight_name                   = 'duration',
+      weight_name                   = 'cyclability',
       process_call_tagless_node     = false,
       max_speed_for_map_matching    = 110/3.6, -- kmph -> m/s
       use_turn_restrictions         = false,


### PR DESCRIPTION
# Issue

It looks like in `profile/bicycle.lua` the `weight_name` in properties was unintentionally commented out

Without it set to `cyclability` the `safety_check` is committed when using this profile. Turns' weights are also calculated differently

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

