### PR TITLE
Add optional support of cargo bike exclusion and width to bicyle profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
       - ADDED: Extract prerelease/build information from package semver [#6839](https://github.com/Project-OSRM/osrm-backend/pull/6839)
     - Profiles:
       - FIXED: Bicycle and foot profiles now don't route on proposed ways [#6615](https://github.com/Project-OSRM/osrm-backend/pull/6615)
+      - ADDED: Add optional support of cargo bike exclusion and width to bicyle profile [#7044](https://github.com/Project-OSRM/osrm-backend/pull/7044)
     - Routing:
       - FIXED: Fix adding traffic signal penalties during compression [#6419](https://github.com/Project-OSRM/osrm-backend/pull/6419)
       - FIXED: Correctly handle compressed traffic signals. [#6724](https://github.com/Project-OSRM/osrm-backend/pull/6724)

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -35,6 +35,10 @@ function setup()
     turn_bias                 = 1.4,
     use_public_transport      = true,
 
+    -- Exclude narrow ways, in particular to route with cargo bike
+    width                     = nil, -- Cargo bike could 0.5 width, in meters
+    exclude_cargo_bike        = false,
+
     allowed_start_modes = Set {
       mode.cycling,
       mode.pushing_bike
@@ -243,6 +247,27 @@ function process_node(profile, node, result)
     end
   end
 
+  if profile.exclude_cargo_bike then
+    local cargo_bike = node:get_value_by_key("cargo_bike")
+    if cargo_bike and cargo_bike == "no" then
+      result.barrier = true
+    end
+  end
+
+  -- width
+  if profile.width then
+    -- From barrier=cycle_barrier or other barriers
+    local maxwidth_physical = node:get_value_by_key("maxwidth:physical")
+    local maxwidth_physical_meter = maxwidth_physical and Measure.parse_value_meters(maxwidth_physical) or 99
+    local opening = node:get_value_by_key("opening")
+    local opening_meter = opening and Measure.parse_value_meters(opening) or 99
+    local width_meter = math.min(maxwidth_physical_meter, opening_meter)
+
+    if width_meter and width_meter < profile.width then
+      result.barrier = true
+    end
+  end
+
   -- check if node is a traffic light
   result.traffic_lights = TrafficSignal.get_value(node)
 end
@@ -299,6 +324,8 @@ function handle_bicycle_tags(profile,way,result,data)
 
   bike_push_handler(profile,way,result,data)
 
+  -- width should be after bike_push
+  width_handler(profile,way,result,data)
 
   -- maxspeed
   limit( result, data.maxspeed, data.maxspeed_forward, data.maxspeed_backward )
@@ -450,6 +477,27 @@ function cycleway_handler(profile,way,result,data)
   if data.has_cycleway_forward then
     result.forward_mode = mode.cycling
     result.forward_speed = profile.bicycle_speeds["cycleway"]
+  end
+end
+
+function width_handler(profile,way,result,data)
+  if profile.exclude_cargo_bike then
+    local cargo_bike = way:get_value_by_key("cargo_bike")
+    if cargo_bike and cargo_bike == "no" then
+      result.forward_mode = mode.inaccessible
+      result.backward_mode = mode.inaccessible
+    end
+  end
+
+  if profile.width then
+    local width = way:get_value_by_key("width")
+    if width then
+      local width_meter = Measure.parse_value_meters(width)
+      if width_meter and width_meter < profile.width then
+        result.forward_mode = mode.inaccessible
+        result.backward_mode = mode.inaccessible
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The PR add optional support for large bike.

By default this PR change nothing unless you change default value into it.

It allows to exclude cargo bike, or bike larger bike from ways and nodes.

cc @systemed @tombay