### PR TITLE
#7047: Nearest api returning node with id 0

### DIFF
--- a/include/engine/api/nearest_api.hpp
+++ b/include/engine/api/nearest_api.hpp
@@ -149,12 +149,22 @@ class NearestAPI final : public BaseAPI
                 facade.GetOSMNodeIDOfNode(geometry(phantom_node.fwd_segment_position + 1));
             from_node = static_cast<std::uint64_t>(osm_node_id);
         }
-        else if (phantom_node.forward_segment_id.enabled && phantom_node.fwd_segment_position > 0)
+        else if (phantom_node.forward_segment_id.enabled)
         {
             // In the case of one way, rely on forward segment only
-            auto osm_node_id =
-                facade.GetOSMNodeIDOfNode(forward_geometry(phantom_node.fwd_segment_position - 1));
+            if (phantom_node.fwd_segment_position > 0)
+            {
+                auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                    forward_geometry(phantom_node.fwd_segment_position - 1));
             from_node = static_cast<std::uint64_t>(osm_node_id);
+        }
+            else if (phantom_node.fwd_segment_position == 0)
+            {
+                auto osm_node_id = facade.GetOSMNodeIDOfNode(
+                    forward_geometry(phantom_node.fwd_segment_position + 1));
+                from_node = to_node;
+                to_node = static_cast<std::uint64_t>(osm_node_id);
+            }
         }
 
         return std::make_pair(from_node, to_node);


### PR DESCRIPTION
# Issue

[Bug: Nearest api returning node with id 0](https://github.com/Project-OSRM/osrm-backend/issues/7047)

## Tasklist

 - [ ] Resolved this issue by changing the nearest_api.hpp code

[Snapshot of bug fix](https://private-user-images.githubusercontent.com/183595512/372876122-ccf5c208-4c3b-473d-ba48-b810a1f6dad0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjgwMzQ2MjIsIm5iZiI6MTcyODAzNDMyMiwicGF0aCI6Ii8xODM1OTU1MTIvMzcyODc2MTIyLWNjZjVjMjA4LTRjM2ItNDczZC1iYTQ4LWI4MTBhMWY2ZGFkMC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQxMDA0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MTAwNFQwOTMyMDJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0yOTYxOTQ5NTgxYzQxN2UwNTkxNWM0NjA5ODA4N2Q2YjYyMTk1MjVkZTkyMDY0MGIyZDNkODEzMDVlYTYwOTg5JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.Gonl9JY0xPptHcB7k6WUF51K1aVggTkmFhbGdW8oXYs)

FYI @jcoupey 
