### PR TITLE
Update PL speed limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
       - FIXED: Ensure required file check in osrm-routed is correctly enforced. [#6655](https://github.com/Project-OSRM/osrm-backend/pull/6655)
       - FIXED: Correct HTTP docs to reflect summary output dependency on steps parameter. [#6655](https://github.com/Project-OSRM/osrm-backend/pull/6655)
       - ADDED: Extract prerelease/build information from package semver [#6839](https://github.com/Project-OSRM/osrm-backend/pull/6839)
+      - CHANGED: Replaced PL:trunk with PL:expressway to match the latest changes in Polish tagging [#7079](https://github.com/Project-OSRM/osrm-backend/pull/7079)
     - Profiles:
       - FIXED: Bicycle and foot profiles now don't route on proposed ways [#6615](https://github.com/Project-OSRM/osrm-backend/pull/6615)
       - ADDED: Add optional support of cargo bike exclusion and width to bicyle profile [#7044](https://github.com/Project-OSRM/osrm-backend/pull/7044)

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -300,7 +300,7 @@ function setup()
       ['ph:rural'] = 80,
       ['ph:motorway'] = 100,
       ['pl:rural'] = 100,
-      ['pl:trunk'] = 120,
+      ['pl:expressway'] = 120,
       ['pl:motorway'] = 140,
       ["ro:trunk"] = 100,
       ["ru:living_street"] = 20,

--- a/taginfo.json
+++ b/taginfo.json
@@ -176,7 +176,7 @@
         {"key": "maxspeed", "value": "PH:rural"},
         {"key": "maxspeed", "value": "PH:motorway"},
         {"key": "maxspeed", "value": "PL:rural"},
-        {"key": "maxspeed", "value": "PL:trunk"},
+        {"key": "maxspeed", "value": "PL:expressway"},
         {"key": "maxspeed", "value": "PL:motorway"},
         {"key": "maxspeed", "value": "RO:trunk"},
         {"key": "maxspeed", "value": "RU:living_street"},


### PR DESCRIPTION
# Issue

Due to changes in Polish road classification on OSM, PL:trunk got deprecated. PL:expressway is being used instead: https://www.openstreetmap.org/changeset/159759046

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 None
