### PR TITLE
Use libtbb-dev/libtbb12 packages in Dockerfile-debian, sort packages alphabetically in both Dockerfiles

### DIFF
--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.20.0 AS alpine-mimalloc
+FROM alpine:3.20.5 AS alpine-mimalloc
 
 RUN apk add --no-cache mimalloc
 

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -50,7 +50,7 @@ RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
     rm -rf /src
 
 
-# Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
+# Multistage build to reduce image size - https://docs.docker.com/build/building/multi-stage/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
 FROM alpine-mimalloc AS runstage
 

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.20.0 as alpine-mimalloc
+FROM alpine:3.20.0 AS alpine-mimalloc
 
 RUN apk add --no-cache mimalloc
 
@@ -6,15 +6,26 @@ ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2
 ENV MIMALLOC_LARGE_OS_PAGES=1
 
 
-FROM alpine-mimalloc as builder
+FROM alpine-mimalloc AS builder
 ARG DOCKER_TAG
 ARG BUILD_CONCURRENCY
-RUN mkdir -p /src  && mkdir -p /opt
 
-RUN apk add --no-cache \
-    cmake make git clang libbz2 libxml2 \
-    boost-dev boost-program_options boost-filesystem boost-iostreams boost-thread \
-    lua5.4-dev onetbb-dev expat-dev
+RUN mkdir -p /src /opt && \
+    apk add --no-cache \
+    boost-dev \
+    boost-filesystem \
+    boost-iostreams \
+    boost-program_options \
+    boost-thread \
+    clang \
+    cmake \
+    expat-dev \
+    git \
+    libbz2 \
+    libxml2 \
+    lua5.4-dev \
+    make \
+    onetbb-dev
 
 COPY . /src
 WORKDIR /src
@@ -41,14 +52,19 @@ RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
 
 # Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
-FROM alpine-mimalloc as runstage
+FROM alpine-mimalloc AS runstage
 
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt /opt
 
 RUN apk add --no-cache \
-    boost-program_options boost-date_time boost-iostreams boost-thread \
-    expat lua5.4 onetbb && \
+    boost-date_time \
+    boost-iostreams \
+    boost-program_options \
+    boost-thread \
+    expat \
+    lua5.4 \
+    onetbb && \
     ldconfig /usr/local/lib
 
 RUN /usr/local/bin/osrm-extract --help && \
@@ -60,3 +76,4 @@ RUN /usr/local/bin/osrm-extract --help && \
 WORKDIR /opt
 
 EXPOSE 5000
+

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -44,7 +44,7 @@ RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
     rm -rf /src
 
 
-# Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
+# Multistage build to reduce image size - https://docs.docker.com/build/building/multi-stage/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
 FROM debian:bookworm-slim AS runstage
 

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -1,27 +1,30 @@
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 ARG DOCKER_TAG
 ARG BUILD_CONCURRENCY
-RUN mkdir -p /src  && mkdir -p /opt
 
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install ca-certificates cmake make git gcc g++ libbz2-dev libxml2-dev wget \
-    libzip-dev libboost1.81-all-dev lua5.4 liblua5.4-dev pkg-config -o APT::Install-Suggests=0 -o APT::Install-Recommends=0
-
-RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
-    ldconfig /usr/local/lib && \
-    git clone --branch v2021.12.0 --single-branch https://github.com/oneapi-src/oneTBB.git && \
-    cd oneTBB && \
-    mkdir build && \
-    cd build && \
-    cmake -DTBB_TEST=OFF -DCMAKE_BUILD_TYPE=Release ..  && \
-    cmake --build . && \
-    cmake --install .
+RUN mkdir -p /src /opt && \
+    apt-get update && \
+    apt-get -y --no-install-recommends --no-install-suggests install \
+        ca-certificates \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        libboost1.81-all-dev \
+        libbz2-dev \
+        liblua5.4-dev \
+        libtbb-dev \
+        libxml2-dev \
+        libzip-dev \
+        lua5.4 \
+        make \
+        pkg-config
 
 COPY . /src
 WORKDIR /src
 
 RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
-    export CXXFLAGS="-Wno-array-bounds -Wno-uninitialized -Wno-stringop-overflow" && \
+    export CXXFLAGS="-Wno-array-bounds -Wno-uninitialized" && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \
@@ -43,17 +46,22 @@ RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
 
 # Multistage build to reduce image size - https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
 # Only the content below ends up in the image, this helps remove /src from the image (which is large)
-FROM debian:bookworm-slim as runstage
+FROM debian:bookworm-slim AS runstage
 
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt /opt
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libboost-program-options1.81.0 libboost-date-time1.81.0 libboost-iostreams1.81.0 libboost-thread1.81.0 \
-        expat liblua5.4-0 && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        expat \
+        libboost-date-time1.81.0 \
+        libboost-iostreams1.81.0 \
+        libboost-program-options1.81.0 \
+        libboost-thread1.81.0 \
+        liblua5.4-0 \
+        libtbb12 && \
     rm -rf /var/lib/apt/lists/* && \
-# add /usr/local/lib to ldconfig to allow loading libraries from there
+# Add /usr/local/lib to ldconfig to allow loading libraries from there
     ldconfig /usr/local/lib
 
 RUN /usr/local/bin/osrm-extract --help && \
@@ -65,3 +73,4 @@ RUN /usr/local/bin/osrm-extract --help && \
 WORKDIR /opt
 
 EXPOSE 5000
+

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -24,7 +24,7 @@ COPY . /src
 WORKDIR /src
 
 RUN NPROC=${BUILD_CONCURRENCY:-$(nproc)} && \
-    export CXXFLAGS="-Wno-array-bounds -Wno-uninitialized" && \
+    export CXXFLAGS="-Wno-array-bounds -Wno-uninitialized -Wno-stringop-overflow" && \
     echo "Building OSRM ${DOCKER_TAG}" && \
     git show --format="%H" | head -n1 > /opt/OSRM_GITSHA && \
     echo "Building OSRM gitsha $(cat /opt/OSRM_GITSHA)" && \


### PR DESCRIPTION
# Issue

[Improve Dockerfile-debian and Dockerfile-alpine #7094](https://github.com/Project-OSRM/osrm-backend/issues/7094)

## Changes

For Dockerfile-debian:

- Use libtbb-dev in builder stage and libtbb12 package in runstage instead of building oneTBB v2021.12.0 from source code
- Remove wget package from builder stage, because it is not used

For Dockerfile-alpine:

- Update alpine:3.20.0 -> alpine:3.20.5

For Dockerfile-debian and Dockerfile-alpine:

- Fix the warning "FromAsCasing: 'as' and 'FROM' keywords' casing do not match"
- Sort packages alphabetically and put them on separate lines for easier comparison in future
- Update the link to multi staged builds doc in the comment
