### PR TITLE
Fix no member named 'construct' in 'optional<type-parameter-0-0 &>' error in sol.hpp with Clang 19

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -446,14 +446,14 @@ jobs:
       if: steps.cache-boost.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ENABLE_CONAN != 'ON'
       run: |
         BOOST_VERSION="1.85.0"
-        BOOST_VERSION_UNDERSCORE="${BOOST_VERSION//./_}"
-        wget -q https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
-        tar xzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
-        cd boost_${BOOST_VERSION_UNDERSCORE}
+        BOOST_VERSION_FLAVOR="${BOOST_VERSION}-b2-nodocs"
+        wget -q https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION_FLAVOR}.tar.gz
+        tar xzf boost-${BOOST_VERSION_FLAVOR}.tar.gz
+        cd boost-${BOOST_VERSION_FLAVOR}
         sudo ./bootstrap.sh
         sudo ./b2 install
         cd ..
-        sudo rm -rf boost_${BOOST_VERSION_UNDERSCORE}*
+        sudo rm -rf boost-${BOOST_VERSION_FLAVOR}*
     
     - name: Install dev dependencies
       run: |

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -449,11 +449,11 @@ jobs:
         BOOST_VERSION_FLAVOR="${BOOST_VERSION}-b2-nodocs"
         wget -q https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION_FLAVOR}.tar.gz
         tar xzf boost-${BOOST_VERSION_FLAVOR}.tar.gz
-        cd boost-${BOOST_VERSION_FLAVOR}
+        cd boost-${BOOST_VERSION}
         sudo ./bootstrap.sh
         sudo ./b2 install
         cd ..
-        sudo rm -rf boost-${BOOST_VERSION_FLAVOR}*
+        sudo rm -rf boost-${BOOST_VERSION}*
     
     - name: Install dev dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ endif()
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
+if (POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 project(OSRM C CXX)
 
 

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.20.5 AS alpine-mimalloc
+FROM alpine:3.21.2 AS alpine-mimalloc
 
 RUN apk add --no-cache mimalloc
 

--- a/third_party/sol2/include/sol/sol.hpp
+++ b/third_party/sol2/include/sol/sol.hpp
@@ -6752,7 +6752,8 @@ namespace sol {
 			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
 
 			*this = nullopt;
-			this->construct(std::forward<Args>(args)...);
+                        new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
+                        return **this;
 		}
 
 		/// Swaps this optional with the other.

--- a/third_party/sol2/include/sol/sol.hpp
+++ b/third_party/sol2/include/sol/sol.hpp
@@ -6752,8 +6752,8 @@ namespace sol {
 			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
 
 			*this = nullopt;
-                        new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
-                        return **this;
+			new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
+			return **this;
 		}
 
 		/// Swaps this optional with the other.


### PR DESCRIPTION
# Issue

[no member named 'construct' in 'optional<type-parameter-0-0 &>' error in with Clang 19 #7097](https://github.com/Project-OSRM/osrm-backend/issues/7097)

# Changes

- Update to Alpine Linux 3.21.2 and update the packages (to match Dockerfile-debian)
- Install the 3 common boost-* packages already in the alpine-mimalloc stage
- Fix no member named 'construct' in 'optional<type-parameter-0-0 &>' error in sol.hpp with Clang 19
- Fix Policy CMP0167 is not set: The FindBoost module is removed with cmake 3.31.1
- Change the boost release URL to GitHub, to fix the CI build error "stdin: not in gzip format"
