### PR TITLE
fix: Segfault in `UnresolvedManeuverOverride::Turns()` on Australia extracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
       - FIXED: Ensure required file check in osrm-routed is correctly enforced. [#6655](https://github.com/Project-OSRM/osrm-backend/pull/6655)
       - FIXED: Correct HTTP docs to reflect summary output dependency on steps parameter. [#6655](https://github.com/Project-OSRM/osrm-backend/pull/6655)
       - ADDED: Extract prerelease/build information from package semver [#6839](https://github.com/Project-OSRM/osrm-backend/pull/6839)
+      - FIXED: Segfault in `UnresolvedManeuverOverride::Turns()` on Australia extracts [#7112](https://github.com/Project-OSRM/osrm-backend/pull/7112)
     - Profiles:
       - FIXED: Bicycle and foot profiles now don't route on proposed ways [#6615](https://github.com/Project-OSRM/osrm-backend/pull/6615)
       - ADDED: Add optional support of cargo bike exclusion and width to bicyle profile [#7044](https://github.com/Project-OSRM/osrm-backend/pull/7044)

--- a/src/extractor/turn_path_filter.cpp
+++ b/src/extractor/turn_path_filter.cpp
@@ -42,8 +42,11 @@ std::vector<T> removeInvalidTurnPaths(std::vector<T> turn_relations,
                is_valid_edge(via_node_path.via, via_node_path.to);
     };
 
-    const auto is_valid_way = [is_valid_edge](const auto &via_way_path)
+    const auto is_valid_way = [is_valid_edge](const ViaWayPath &via_way_path)
     {
+        if (!via_way_path.Valid())
+            return false;
+
         if (!is_valid_edge(via_way_path.from, via_way_path.via.front()))
             return false;
 
@@ -59,13 +62,16 @@ std::vector<T> removeInvalidTurnPaths(std::vector<T> turn_relations,
 
     const auto is_invalid = [is_valid_way, is_valid_node](const auto &turn_relation)
     {
-        if (turn_relation.turn_path.Type() == TurnPathType::VIA_NODE_TURN_PATH)
+        switch (turn_relation.turn_path.Type())
         {
+        case TurnPathType::VIA_NODE_TURN_PATH:
             return !is_valid_node(turn_relation.turn_path.AsViaNodePath());
+        case TurnPathType::VIA_WAY_TURN_PATH:
+            return !is_valid_way(turn_relation.turn_path.AsViaWayPath());
+        default:
+            break;
         }
-
-        BOOST_ASSERT(turn_relation.turn_path.Type() == TurnPathType::VIA_WAY_TURN_PATH);
-        return !is_valid_way(turn_relation.turn_path.AsViaWayPath());
+        return true;
     };
 
     const auto end_valid_relations =


### PR DESCRIPTION
# Issue

fixes https://github.com/Project-OSRM/osrm-backend/issues/7107

The issue was reproduced on `--bbox 112,-50,157,-9` extract from https://planet.openstreetmap.org/pbf/planet-250210.osm.pbf

Segfault was caused by invalid `ViaWayPath` that had only 1 item inside `via` array. This PR adds check for `ViaWayPath::Valid()` method inside `removeInvalidTurnPaths()` filtration, which looks like an intending place for such checks.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
