### PR TITLE
Bump version to 6.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 6.0-RC1
+# 6.0.0 RC1
   - Changes from 5.27.1
     - Features
       - ADDED: Add generic support for obstacles [#7130](https://github.com/Project-OSRM/osrm-backend/pull/7130)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# 6.0-RC1
   - Changes from 5.27.1
     - Features
       - ADDED: Add generic support for obstacles [#7130](https://github.com/Project-OSRM/osrm-backend/pull/7130)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-osrm/osrm",
-  "version": "6.0-RC1",
+  "version": "5.28.0-unreleased",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-osrm/osrm",
-      "version": "6.0-RC1",
+      "version": "5.28.0-unreleased",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-osrm/osrm",
-  "version": "5.28.0-unreleased",
+  "version": "6.0-RC1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-osrm/osrm",
-      "version": "5.28.0-unreleased",
+      "version": "6.0-RC1",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-osrm/osrm",
-  "version": "6.0-RC1",
+  "version": "6.0.0",
   "private": false,
   "description": "The Open Source Routing Machine is a high performance routing engine written in C++ designed to run on OpenStreetMap data.",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-osrm/osrm",
-  "version": "5.28.0-unreleased",
+  "version": "6.0-RC1",
   "private": false,
   "description": "The Open Source Routing Machine is a high performance routing engine written in C++ designed to run on OpenStreetMap data.",
   "dependencies": {
@@ -46,7 +46,7 @@
     "browserify": "^17.0.0",
     "chalk": "^1.1.3",
     "cheap-ruler": "^3.0.2",
-    "command-line-args": "^5.2.1",
+    "command-line-args": "^.1",
     "command-line-usage": "^5.0.4",
     "csv-stringify": "^3.0.0",
     "cucumber": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "browserify": "^17.0.0",
     "chalk": "^1.1.3",
     "cheap-ruler": "^3.0.2",
-    "command-line-args": "^.1",
+    "command-line-args": "^5.2.1",
     "command-line-usage": "^5.0.4",
     "csv-stringify": "^3.0.0",
     "cucumber": "^1.2.1",


### PR DESCRIPTION
### Exciting news for the routing community! 🚀

OSRM v6.0-rc1 is here, packed with performance enhancements, improved algorithm efficiency, and a host of new features designed to take your navigation solutions to the next level. Whether you're building applications or optimizing logistics, this release candidate marks a significant step forward in open-source routing technology. Dive in, explore, and contribute to shaping the future of OSRM! 🌍✨

At the same time we call on all downstream integrators to start testing.

![IMG_8187](https://github.com/user-attachments/assets/522c28cb-0d60-4c6b-b90b-21bad90d84e1)
