### PR TITLE
Fix json rendering of large osm ids

### DIFF
--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -842,8 +842,7 @@ class RouteAPI : public BaseAPI
                     nodes.values.reserve(leg_geometry.node_ids.size());
                     for (const auto node_id : leg_geometry.node_ids)
                     {
-                        nodes.values.push_back(
-                            static_cast<std::uint64_t>(facade.GetOSMNodeIDOfNode(node_id)));
+                        nodes.values.push_back(facade.GetOSMNodeIDOfNode(node_id));
                     }
                     annotation.values.emplace("nodes", std::move(nodes));
                 }

--- a/include/nodejs/json_v8_renderer.hpp
+++ b/include/nodejs/json_v8_renderer.hpp
@@ -21,6 +21,11 @@ struct V8Renderer
         out = Napi::Number::New(env, number.value);
     }
 
+    void operator()(const osrm::json::OSMID &osmid) const
+    {
+        out = Napi::BigInt::New(env, osmid.value);
+    }
+
     void operator()(const osrm::json::Object &object) const
     {
         Napi::Object obj = Napi::Object::New(env);

--- a/include/util/json_container.hpp
+++ b/include/util/json_container.hpp
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef JSON_CONTAINER_HPP
 #define JSON_CONTAINER_HPP
 
+#include "util/typedefs.hpp"
+
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -70,6 +72,17 @@ struct Number
 };
 
 /**
+ * Typed OSM id.
+ */
+struct OSMID
+{
+    OSMID() = default;
+    OSMID(OSMNodeID id) : value{from_alias<uint64_t>(id)} {};
+    OSMID(OSMWayID id) : value{from_alias<uint64_t>(id)} {};
+    uint64_t value;
+};
+
+/**
  * Typed True.
  */
 struct True
@@ -95,7 +108,7 @@ struct Null
  *
  * Dispatch on its type by either by using apply_visitor or its get function.
  */
-using Value = std::variant<String, Number, Object, Array, True, False, Null>;
+using Value = std::variant<String, Number, Object, Array, True, False, Null, OSMID>;
 
 /**
  * Typed Object.

--- a/include/util/json_deep_compare.hpp
+++ b/include/util/json_deep_compare.hpp
@@ -40,6 +40,17 @@ struct Comparator
         return is_same;
     }
 
+    bool operator()(const OSMID &lhs, const OSMID &rhs) const
+    {
+        bool is_same = lhs.value == rhs.value;
+        if (!is_same)
+        {
+            reason = lhs_path + " (= " + std::to_string(lhs.value) + ") != " + rhs_path +
+                     " (= " + std::to_string(rhs.value) + ")";
+        }
+        return is_same;
+    }
+
     bool operator()(const Object &lhs, const Object &rhs) const
     {
         std::set<std::string_view> lhs_keys;

--- a/include/util/json_renderer.hpp
+++ b/include/util/json_renderer.hpp
@@ -58,6 +58,14 @@ template <typename Out> struct Renderer
         write(buffer.data(), buffer.size());
     }
 
+    void operator()(const OSMID &osmid)
+    {
+        fmt::memory_buffer buffer;
+        fmt::format_to(std::back_inserter(buffer), FMT_COMPILE("{}"), osmid.value);
+
+        write(buffer.data(), buffer.size());
+    }
+
     void operator()(const Object &object)
     {
         write('{');

--- a/unit_tests/library/nearest.cpp
+++ b/unit_tests/library/nearest.cpp
@@ -168,8 +168,8 @@ void test_nearest_response_for_location_in_small_component(bool use_json_only_ap
 
         const auto &nodes = std::get<json::Array>(waypoint_object.values.at("nodes")).values;
         BOOST_CHECK(nodes.size() == 2);
-        BOOST_CHECK(std::get<util::json::Number>(nodes[0]).value != 0);
-        BOOST_CHECK(std::get<util::json::Number>(nodes[1]).value != 0);
+        BOOST_CHECK(std::get<util::json::OSMID>(nodes[0]).value != 0);
+        BOOST_CHECK(std::get<util::json::OSMID>(nodes[1]).value != 0);
     }
 }
 BOOST_AUTO_TEST_CASE(test_nearest_response_for_location_in_small_component_old_api)

--- a/unit_tests/util/json_render.cpp
+++ b/unit_tests/util/json_render.cpp
@@ -1,5 +1,6 @@
 #include "util/json_container.hpp"
 #include "util/json_renderer.hpp"
+#include "util/typedefs.hpp"
 
 #include <boost/test/unit_test.hpp>
 
@@ -23,6 +24,19 @@ BOOST_AUTO_TEST_CASE(integer)
     Renderer<std::string> renderer(str);
     renderer(Number{42.0});
     BOOST_CHECK_EQUAL(str, "42");
+}
+
+BOOST_AUTO_TEST_CASE(osmid)
+{
+    std::string str;
+    Renderer<std::string> renderer(str);
+
+    renderer(OSMNodeID{std::numeric_limits<uint64_t>::min()});
+    BOOST_CHECK_EQUAL(str, "0");
+    str.clear();
+
+    renderer(OSMNodeID{std::numeric_limits<uint64_t>::max()});
+    BOOST_CHECK_EQUAL(str, "18446744073709551615");
 }
 
 BOOST_AUTO_TEST_CASE(test_json_issue_6531)


### PR DESCRIPTION
# Issue

Fixes #7069 #7016 #6758 #6594 #5716

This patch introduces a new class for OSM ids to the JSON stack. 

The current JSON stack rounds OSM ids to a precision of 10 digits, which is insufficient to represent current OSM node ids.

Also, the current JSON stack converts OSM ids from `uint64_t` to `double`. The `double` type has ~53bits of accuracy, the rest going into exponent and sign, which are wasted here. Why is this important even if OSM is still far away from using 53 bits for node ids? Because some people use high ids for their own private data to avoid conflicts with the ids in the OSM database. See: #7069

This patch stores OSM ids into `uint64_t` and provides a different output format thus guaranteeing correct output under all circumstances.

This pull request is an alternative to:  #7096 

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [X] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
