### PR TITLE
Fix build on FreeBSD.

### DIFF
--- a/src/tools/io-benchmark.cpp
+++ b/src/tools/io-benchmark.cpp
@@ -1,3 +1,7 @@
+#ifdef __FreeBSD__
+#pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
+
 #include "util/exception.hpp"
 #include "util/exception_utils.hpp"
 #include "util/log.hpp"
@@ -8,6 +12,9 @@
 #include <fcntl.h>
 #ifdef __linux__
 #include <malloc.h>
+#endif
+#ifdef __FreeBSD__
+#include <unistd.h>
 #endif
 
 #include <algorithm>
@@ -88,6 +95,14 @@ int main(int argc, char *argv[])
         write(fileno(fd), (char *)random_array, osrm::tools::NUMBER_OF_ELEMENTS * sizeof(unsigned));
         TIMER_STOP(write_1gb);
         fclose(fd);
+#endif
+#ifdef __FreeBSD__
+        int fd = open(test_path.string().c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_DIRECT, 0644);
+        fcntl(fd, F_RDAHEAD, 0);
+        TIMER_START(write_1gb);
+        write(fd, (char *)random_array, osrm::tools::NUMBER_OF_ELEMENTS * sizeof(unsigned));
+        TIMER_STOP(write_1gb);
+        close(fd);
 #endif
 #ifdef __linux__
         int file_desc =


### PR DESCRIPTION
# Issue

Building the release branch ([v6.0.0](https://github.com/Project-OSRM/osrm-backend/releases/tag/v6.0.0)) fails on FreeBSD.

This is the error:

```
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/src/tools/io-benchmark.cpp:112:65: error: use of undeclared identifier 'write_1gb_stop'
  112 |         osrm::util::Log(logDEBUG) << "writing raw 1GB took " << TIMER_SEC(write_1gb) << "s";
      |                                                                 ^
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/include/util/timing_util.hpp:20:60: note: expanded from macro 'TIMER_SEC'
   20 |      std::chrono::duration_cast<std::chrono::microseconds>(_X##_stop - _X##_start).count())
      |                                                            ^
<scratch space>:309:1: note: expanded from here
  309 | write_1gb_stop
      | ^
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/src/tools/io-benchmark.cpp:112:65: error: use of undeclared identifier 'write_1gb_start'
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/include/util/timing_util.hpp:20:72: note: expanded from macro 'TIMER_SEC'
   20 |      std::chrono::duration_cast<std::chrono::microseconds>(_X##_stop - _X##_start).count())
      |                                                                        ^
<scratch space>:310:1: note: expanded from here
  310 | write_1gb_start
      | ^
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/src/tools/io-benchmark.cpp:114:44: error: use of undeclared identifier 'write_1gb_stop'
  114 |                           << 1024 * 1024 / TIMER_SEC(write_1gb) << "MB/sec";
      |                                            ^
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/include/util/timing_util.hpp:20:60: note: expanded from macro 'TIMER_SEC'
   20 |      std::chrono::duration_cast<std::chrono::microseconds>(_X##_stop - _X##_start).count())
      |                                                            ^
<scratch space>:311:1: note: expanded from here
  311 | write_1gb_stop
      | ^
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/src/tools/io-benchmark.cpp:114:44: error: use of undeclared identifier 'write_1gb_start'
/usr/ports/www/osrm-backend/work/osrm-backend-6.0.0/include/util/timing_util.hpp:20:72: note: expanded from macro 'TIMER_SEC'
   20 |      std::chrono::duration_cast<std::chrono::microseconds>(_X##_stop - _X##_start).count())
      |                                                                        ^
<scratch space>:312:1: note: expanded from here
  312 | write_1gb_start
      | ^
4 errors generated. 
```

The issue is that calls to the `TIMER_START` and `TIMER_STOP` macros are required in order to initialize the values of  `write_1gb_start` and `write_1gb_stop` respectively.  Before this PR, these calls occurred only for `__APPLE__` and `__linux__` features in [io-benchmark.cpp](https://github.com/Project-OSRM/osrm-backend/blob/v6.0.0/src/tools/io-benchmark.cpp).