### PR TITLE
feat(match): always collapse legs in sub_matchings route results

### DIFF
--- a/src/engine/plugins/match.cpp
+++ b/src/engine/plugins/match.cpp
@@ -289,10 +289,11 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
         // possible uturns
         sub_routes[index] = algorithms.ShortestPathSearch(waypoint_candidates, {false});
         BOOST_ASSERT(sub_routes[index].shortest_path_weight != INVALID_EDGE_WEIGHT);
+        
+        std::vector<bool> waypoint_legs;
+        waypoint_legs.reserve(sub_matchings[index].indices.size());
         if (collapse_legs)
         {
-            std::vector<bool> waypoint_legs;
-            waypoint_legs.reserve(sub_matchings[index].indices.size());
             for (unsigned i = 0, j = 0; i < sub_matchings[index].indices.size(); ++i)
             {
                 auto current_wp = tidied.parameters.waypoints[j];
@@ -306,8 +307,17 @@ Status MatchPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
                     waypoint_legs.push_back(false);
                 }
             }
-            sub_routes[index] = CollapseInternalRouteResult(sub_routes[index], waypoint_legs);
         }
+        else 
+        {
+            waypoint_legs.push_back(true);
+            for (unsigned i = 1; i < sub_matchings[index].indices.size()-1; ++i)
+            {
+                waypoint_legs.push_back(false);
+            }
+            waypoint_legs.push_back(true);
+        }
+        sub_routes[index] = CollapseInternalRouteResult(sub_routes[index], waypoint_legs);
     }
 
     api::MatchAPI match_api{facade, parameters, tidied};


### PR DESCRIPTION
# Issue
 
[Legs are not collapsed in /match if no waypoints are provided](https://github.com/Project-OSRM/osrm-backend/issues/7209)

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments


## Requirements / Relations
