### PR TITLE
Fix build with Boost 1.89.0

### DIFF
--- a/include/server/connection.hpp
+++ b/include/server/connection.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/config.hpp>
 #include <boost/version.hpp>
 

--- a/src/engine/plugins/tile.cpp
+++ b/src/engine/plugins/tile.cpp
@@ -10,7 +10,9 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
+#if __has_include(<boost/geometry/multi/geometries/multi_linestring.hpp>)
 #include <boost/geometry/multi/geometries/multi_linestring.hpp>
+#endif
 
 #include <vtzero/builder.hpp>
 #include <vtzero/geometry.hpp>


### PR DESCRIPTION
# Issue

Fixes #7219

Used `__has_include` (since C++20 standard) though alternative would be `BOOST_VERSION < 108900`

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments


## Requirements / Relations

None