### PR TITLE
Add libcap-setcap to alpine dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
       - CHANGED: Convert scripts from CommonJS to modern ESM format [#7230](https://github.com/Project-OSRM/osrm-backend/pull/7230)
       - CHANGED: Convert remaining scripts from CommonJS to ESM format and use flatbuffers npm package [#7227](https://github.com/Project-OSRM/osrm-backend/pull/7227)
       - CHANGED: Upgrade Cucumber-js to v12 [#7221](https://github.com/Project-OSRM/osrm-backend/pull/7221)
+      - CHANGED: Add libcap-setcap to alpine dockerfile [#7241](https://github.com/Project-OSRM/osrm-backend/issues/7241)
       - FIXED: Minor misspellings found in source code, comments and documents [#7215](https://github.com/Project-OSRM/osrm-backend/pull/7215)
 
 # 6.0.0

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -62,6 +62,7 @@ COPY --from=builder /opt /opt
 RUN apk add --no-cache \
     boost-date_time \
     expat \
+    libcap-setcap \
     lua5.4 \
     onetbb && \
     ldconfig /usr/local/lib


### PR DESCRIPTION
This PR adds `libcap-setcap` package to alpine docker image in order to allow using `setcap` during runtime. I am running ``setcap "cap_ipc_lock=ep" `which osrm-datastore` `` during startup before running `osrm-datastore --dataset-name=us /data/usa.osrm`. 

# Issue

Closes https://github.com/Project-OSRM/osrm-backend/issues/7241

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments
