### PR TITLE
Replace std::is_trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
   - Changes from 6.0.0
     - Misc:
+      - CHANGED Replace std::is_trivial with std::is_trivially_default_constructible && std::is_trivially_copyable [#7245] (https://github.com/Project-OSRM/osrm-backend/issues/7245)
       - ADDED: Add husky pre-commit hook for compiling and linting staged JS files [#7228](https://github.com/Project-OSRM/osrm-backend/issues/7228)
       - CHANGED: Standardize linting configuration with ESM-specific rules [#7229](https://github.com/Project-OSRM/osrm-backend/issues/7229)
       - CHANGED: Convert scripts from CommonJS to modern ESM format [#7230](https://github.com/Project-OSRM/osrm-backend/pull/7230)

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -68,19 +68,29 @@ using FloatLongitude = Alias<double, tag::longitude>;
 // range checks on these (toFixed/toFloat, etc)
 using UnsafeFloatLatitude = Alias<double, tag::unsafelatitude>;
 using UnsafeFloatLongitude = Alias<double, tag::unsafelongitude>;
-static_assert(std::is_standard_layout<FixedLatitude>() && std::is_trivial<FixedLatitude>(),
+static_assert(std::is_standard_layout<FixedLatitude>() &&
+                  std::is_trivially_default_constructible<FixedLatitude>() &&
+                  std::is_trivially_copyable<FixedLatitude>(),
               "FixedLatitude is not a valid alias");
-static_assert(std::is_standard_layout<FixedLongitude>() && std::is_trivial<FixedLongitude>(),
+static_assert(std::is_standard_layout<FixedLongitude>() &&
+                  std::is_trivially_default_constructible<FixedLongitude>() &&
+                  std::is_trivially_copyable<FixedLongitude>(),
               "FixedLongitude is not a valid alias");
-static_assert(std::is_standard_layout<FloatLatitude>() && std::is_trivial<FloatLatitude>(),
+static_assert(std::is_standard_layout<FloatLatitude>() &&
+                  std::is_trivially_default_constructible<FloatLatitude>() &&
+                  std::is_trivially_copyable<FloatLatitude>(),
               "FloatLatitude is not a valid alias");
-static_assert(std::is_standard_layout<FloatLongitude>() && std::is_trivial<FloatLongitude>(),
+static_assert(std::is_standard_layout<FloatLongitude>() &&
+                  std::is_trivially_default_constructible<FloatLongitude>() &&
+                  std::is_trivially_copyable<FloatLongitude>(),
               "FloatLongitude is not a valid alias");
 static_assert(std::is_standard_layout<UnsafeFloatLatitude>() &&
-                  std::is_trivial<UnsafeFloatLatitude>(),
+                  std::is_trivially_default_constructible<UnsafeFloatLatitude>() &&
+                  std::is_trivially_copyable<UnsafeFloatLatitude>(),
               "UnsafeFloatLatitude is not a valid alias");
 static_assert(std::is_standard_layout<UnsafeFloatLongitude>() &&
-                  std::is_trivial<UnsafeFloatLongitude>(),
+                  std::is_trivially_default_constructible<UnsafeFloatLongitude>() &&
+                  std::is_trivially_copyable<UnsafeFloatLongitude>(),
               "UnsafeFloatLongitude is not a valid alias");
 
 /**

--- a/include/util/typedefs.hpp
+++ b/include/util/typedefs.hpp
@@ -71,11 +71,15 @@ struct turn_penalty
 using OSMNodeID = osrm::Alias<std::uint64_t, tag::osm_node_id>;
 // clang-tidy fires `bugprone-throw-keyword-missing` here for unknown reason
 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-static_assert(std::is_standard_layout<OSMNodeID>() && std::is_trivial<OSMNodeID>(),
+static_assert(std::is_standard_layout<OSMNodeID>() &&
+                  std::is_trivially_default_constructible<OSMNodeID>() &&
+                  std::is_trivially_copyable<OSMNodeID>(),
               "OSMNodeID is not a valid alias");
 using OSMWayID = osrm::Alias<std::uint64_t, tag::osm_way_id>;
 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-static_assert(std::is_standard_layout<OSMWayID>() && std::is_trivial<OSMWayID>(),
+static_assert(std::is_standard_layout<OSMWayID>() &&
+                  std::is_trivially_default_constructible<OSMWayID>() &&
+                  std::is_trivially_copyable<OSMWayID>(),
               "OSMWayID is not a valid alias");
 
 using DuplicatedNodeID = std::uint64_t;


### PR DESCRIPTION
std::is_trivial is deprecated in c++26 therefore replacing it with std::is_trivially_default_constructible && std::is_trivially_copyable

# Issue

https://github.com/Project-OSRM/osrm-backend/issues/7245

## Tasklist

 - [x ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments


## Requirements / Relations

 n\a