### PR TITLE
Add MSVC warning management to cmake/warnings.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
   - Changes from 6.0.0
+    - Build:
+      - IMPROVED: Reduce MSVC compiler warnings by suppressing informational warnings while preserving bug-indicating warnings [#7253](https://github.com/Project-OSRM/osrm-backend/issues/7253)
     - Misc:
       - CHANGED: Update fmt library to version 11.2.0 [#7238](https://github.com/Project-OSRM/osrm-backend/issues/7238)
       - CHANGED: Upgrade protozero from v1.7.1 to v1.8.1 [#7239](https://github.com/Project-OSRM/osrm-backend/pull/7239)

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,7 +1,7 @@
 include (CheckCXXCompilerFlag)
 include (CheckCCompilerFlag)
 
-# Try to add -Wflag if compiler supports it
+# Try to add -Wflag if compiler supports it (GCC/Clang)
 macro (add_warning flag)
     string(REPLACE "-" "_" underscored_flag ${flag})
     string(REPLACE "+" "x" underscored_flag ${underscored_flag})
@@ -19,6 +19,37 @@ macro (add_warning flag)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W${flag}")
     else()
         message(STATUS "Flag -W${flag} is unsupported")
+    endif()
+endmacro()
+
+# MSVC warning management macros
+macro (msvc_warning_level level)
+    if (MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W${level}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W${level}")
+    endif()
+endmacro()
+
+# Disable specific MSVC warning by code (e.g., 4711)
+macro (msvc_disable_warning code)
+    if (MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd${code}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd${code}")
+    endif()
+endmacro()
+
+# Enable specific MSVC warning by code
+macro (msvc_enable_warning code)
+    if (MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /w1${code}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /w1${code}")
+    endif()
+endmacro()
+
+# Disable MSVC warning for specific target
+macro (target_msvc_disable_warning target code)
+    if (MSVC)
+        target_compile_options(${target} PRIVATE "/wd${code}")
     endif()
 endmacro()
 
@@ -85,4 +116,57 @@ no_warning(restrict)
 no_warning(free-nonheap-object)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   no_warning(stringop-overflow)
+endif()
+
+# MSVC-specific warning configuration
+if(MSVC)
+  # Set warning level 3 (default level with reasonable warnings)
+  msvc_warning_level(3)
+
+  # Disable excessive informational warnings that don't indicate bugs
+  msvc_disable_warning(4711)  # Function selected for automatic inline expansion
+  msvc_disable_warning(4710)  # Function not inlined
+  msvc_disable_warning(4514)  # Unreferenced inline function removed
+  msvc_disable_warning(4820)  # Padding added to struct/class
+
+  # Disable implicit special member function warnings (often unavoidable in modern C++)
+  msvc_disable_warning(4626)  # Assignment operator implicitly deleted
+  msvc_disable_warning(4625)  # Copy constructor implicitly deleted
+  msvc_disable_warning(5027)  # Move assignment operator implicitly deleted
+  msvc_disable_warning(5026)  # Move constructor implicitly deleted
+  msvc_disable_warning(4623)  # Default constructor implicitly deleted
+
+  # Disable other low-value warnings
+  msvc_disable_warning(5219)  # Implicit conversion from T to bool
+  msvc_disable_warning(5045)  # Spectre mitigation
+  msvc_disable_warning(5246)  # Aggregate initialization
+  msvc_disable_warning(4686)  # Template specialization
+  msvc_disable_warning(5266)  # const qualifier discarded
+  msvc_disable_warning(4800)  # Implicit conversion to bool
+  msvc_disable_warning(4868)  # Left-to-right evaluation order
+  msvc_disable_warning(4371)  # Layout change from previous compiler version
+  msvc_disable_warning(4127)  # Conditional expression is constant
+  msvc_disable_warning(4355)  # 'this' used in member initializer list
+  msvc_disable_warning(4668)  # Preprocessor macro not defined
+  msvc_disable_warning(5039)  # Exception specification issue
+  msvc_disable_warning(4777)  # Format string mismatch
+  msvc_disable_warning(5264)  # Variable declared but not used
+
+  # KEEP these warnings enabled - they indicate potential bugs:
+  # C4365: Signed/unsigned mismatch
+  # C4267: Conversion with possible loss of data
+  # C4244: Data conversion with possible loss
+  # C4242: Data conversion with possible loss
+  # C4458: Declaration hides class member
+  # C4245: Signed/unsigned mismatch in conversion
+  # C4389: Signed/unsigned mismatch in equality
+  # C4457: Declaration hides function parameter
+  # C4146: Unary minus applied to unsigned type
+  # C4456: Declaration hides previous local declaration
+  # C4996: Deprecated function usage
+  # C4100: Unreferenced formal parameter
+  # C4101: Unreferenced local variable
+  # C4061: Switch statement case not handled
+
+  message(STATUS "MSVC warning configuration applied - suppressed informational warnings, kept bug-indicating warnings")
 endif()

--- a/include/contractor/contracted_edge_container.hpp
+++ b/include/contractor/contracted_edge_container.hpp
@@ -61,7 +61,7 @@ struct ContractedEdgeContainer
     void Filter(const std::vector<bool> &filter, std::size_t index)
     {
         BOOST_ASSERT(index < sizeof(MergedFlags) * CHAR_BIT);
-        const MergedFlags flag = 1 << index;
+        const MergedFlags flag = MergedFlags{1} << index;
 
         for (auto edge_index : util::irange<std::size_t>(0, edges.size()))
         {
@@ -81,7 +81,7 @@ struct ContractedEdgeContainer
     {
         BOOST_ASSERT(index < sizeof(MergedFlags) * CHAR_BIT);
 
-        const MergedFlags flag = 1 << index++;
+        const MergedFlags flag = MergedFlags{1} << index++;
 
         auto edge_iter = edges.cbegin();
         auto edge_end = edges.cend();
@@ -151,7 +151,7 @@ struct ContractedEdgeContainer
         std::vector<std::vector<bool>> filters(index);
         for (const auto flag_index : util::irange<std::size_t>(0, index))
         {
-            MergedFlags mask = 1 << flag_index;
+            MergedFlags mask = MergedFlags{1} << flag_index;
             for (const auto flag : flags)
             {
                 filters[flag_index].push_back(flag & mask);

--- a/include/util/xor_fast_hash.hpp
+++ b/include/util/xor_fast_hash.hpp
@@ -44,10 +44,10 @@ template <std::size_t MaxNumElements = (1u << 16u)> class XORFastHash
     {
         std::mt19937 generator(1); // impl. defined but deterministic default seed
 
-        std::iota(begin(table1), end(table1), 0u);
+        std::iota(begin(table1), end(table1), std::uint16_t{0});
         std::shuffle(begin(table1), end(table1), generator);
 
-        std::iota(begin(table2), end(table2), 0u);
+        std::iota(begin(table2), end(table2), std::uint16_t{0});
         std::shuffle(begin(table2), end(table2), generator);
     }
 


### PR DESCRIPTION
Fix the #7253 by:

- Add MSVC warning management to cmake/warnings.cmake
- Suppress informational warnings while keeping bug-indicating ones
- Fix type safety warnings in xor_fast_hash.hpp and contracted_edge_container.hpp

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments


## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
