### PR TITLE
Fix max excludate classses to 7, not 8

### DIFF
--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -114,9 +114,9 @@ void SetExcludableClasses(const ExtractorCallbacks::ClassesMap &classes_map,
                           const std::vector<std::vector<std::string>> &excludable_classes,
                           ProfileProperties &profile_properties)
 {
-    if (excludable_classes.size() > MAX_EXCLUDABLE_CLASSES)
+    if (excludable_classes.size() > MAX_CLASS_INDEX)
     {
-        throw util::exception("Only " + std::to_string(MAX_EXCLUDABLE_CLASSES) +
+        throw util::exception("Only " + std::to_string(MAX_CLASS_INDEX) +
                               " excludable combinations allowed.");
     }
 


### PR DESCRIPTION
Fix #7280

# Issue

`MAX_EXCLUDABLE_CLASSES` is set 8, and then the number of exclusion sets is checked with `excludable_classes.size() > MAX_EXCLUDABLE_CLASSES` to raise error.

But when we try de define 8 exclusion classes, the last one is not usable at runtime. The API return for this last exclusion `{"message":"Exclude flag combination is not supported.","code":"InvalidValue"}`

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments


## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
