### PR TITLE
[lua] Added to_number_uint.

### DIFF
--- a/profiles/lib/guidance.lua
+++ b/profiles/lib/guidance.lua
@@ -68,6 +68,14 @@ parking_class = Set{
     'emergency_access'
 }
 
+local function to_number_uint(s)
+  local n = tonumber(s)
+  if n ~= nil and n > 0 and n % 1 == 0 then
+    return n
+  end
+  return nil
+end
+
 function Guidance.set_classification (highway, result, input_way)
   if motorway_types[highway] then
     result.road_classification.motorway_class = true
@@ -107,7 +115,7 @@ function Guidance.set_classification (highway, result, input_way)
 
   local lane_count = input_way:get_value_by_key("lanes")
   if lane_count then
-    local lc = tonumber(lane_count)
+    local lc = to_number_uint(lane_count)
     if lc ~= nil then
       result.road_classification.num_lanes = lc
     end
@@ -115,14 +123,14 @@ function Guidance.set_classification (highway, result, input_way)
     local total_count = 0
     local forward_count = input_way:get_value_by_key("lanes:forward")
     if forward_count then
-      local fc = tonumber(forward_count)
+      local fc = to_number_uint(forward_count)
       if fc ~= nil then
         total_count = fc
       end
     end
     local backward_count = input_way:get_value_by_key("lanes:backward")
     if backward_count then
-      local bc = tonumber(backward_count)
+      local bc = to_number_uint(backward_count)
       if bc ~= nil then
         total_count = total_count + bc
       end
@@ -137,10 +145,10 @@ end
 local function get_psv_counts(way,data)
   local psv_forward, psv_backward = Tags.get_forward_backward_by_key(way,data,'lanes:psv')
   if psv_forward then
-    psv_forward = tonumber(psv_forward)
+    psv_forward = to_number_uint(psv_forward)
   end
   if psv_backward then
-    psv_backward = tonumber(psv_backward)
+    psv_backward = to_number_uint(psv_backward)
   end
   return psv_forward or 0,
          psv_backward or 0


### PR DESCRIPTION
Fixed bug with non-integer (or negative) lane tags.

Right now, osrm-extract crashes on Switzerland.