### PR TITLE
Fix Windows CI by setting hwloc shared library option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
       - ADDED: Add exception for audible fences (`barrier=fence` with `sensory=audible` or `sensory=audio`) that deter livestock but do not block vehicles [#6964](https://github.com/Project-OSRM/osrm-backend/issues/6964)
       - ADDED: Use `is_sidepath:of:name` and `street:name` as fallback names for unnamed sidewalks and sidepaths in foot and bicycle profiles [#7259](https://github.com/Project-OSRM/osrm-backend/issues/7259)
     - Build:
+      - FIXED: Set `hwloc:shared=True` in Conan config as required by onetbb [#7342](https://github.com/Project-OSRM/osrm-backend/issues/7342)
       - CHANGED: Cucumber tests now can run in parallel and other improvements [#7309](https://github.com/Project-OSRM/osrm-backend/issues/7309)
       - FIXED: Update Node.js binding path from `lib/binding` to `lib/binding_napi_v8` to match node-pre-gyp versioning conventions [#7272](https://github.com/Project-OSRM/osrm-backend/pull/7272)
       - FIXED: Reduce MSVC compiler warnings by suppressing informational warnings while preserving bug-indicating warnings [#7253](https://github.com/Project-OSRM/osrm-backend/issues/7253)

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,6 +20,7 @@ class OsrmConan(ConanFile):
         self.options["boost"].without_stacktrace = True
         self.options["boost"].without_cobalt = True
         self.options["bzip2"].shared = True
+        self.options["hwloc"].shared = True
         self.options["xz-utils"].shared = True
         
     def generate(self):


### PR DESCRIPTION
# Issue

Fixes #7342                                                                                                                    

The `onetbb` Conan recipe validates that `hwloc` must be a shared library.

Since the Windows CI job has no Conan cache, runs that resolve packages fresh fail without this option explicitly set. 

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments


## Requirements / Relations

https://github.com/conan-io/conan-center-index/pull/20976
