### PR TITLE
Fix documentation build ESM/CommonJS conflict and tar vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
       - ADDED: Add exception for audible fences (`barrier=fence` with `sensory=audible` or `sensory=audio`) that deter livestock but do not block vehicles [#6964](https://github.com/Project-OSRM/osrm-backend/issues/6964)
       - ADDED: Use `is_sidepath:of:name` and `street:name` as fallback names for unnamed sidewalks and sidepaths in foot and bicycle profiles [#7259](https://github.com/Project-OSRM/osrm-backend/issues/7259)
     - Build:
+      - FIXED: Documentation build fails with ESM/CommonJS conflict after adding "type": "module" [#7347](https://github.com/Project-OSRM/osrm-backend/issues/7347)
       - FIXED: Set `hwloc:shared=True` in Conan config as required by onetbb [#7342](https://github.com/Project-OSRM/osrm-backend/issues/7342)
       - CHANGED: Cucumber tests now can run in parallel and other improvements [#7309](https://github.com/Project-OSRM/osrm-backend/issues/7309)
       - FIXED: Update Node.js binding path from `lib/binding` to `lib/binding_napi_v8` to match node-pre-gyp versioning conventions [#7272](https://github.com/Project-OSRM/osrm-backend/pull/7272)

--- a/package-lock.json
+++ b/package-lock.json
@@ -21825,9 +21825,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/scripts/build_api_docs.sh
+++ b/scripts/build_api_docs.sh
@@ -40,8 +40,9 @@ cp docs/*.md build/docs/tmp/content
 # Now, run the scripts to generate the actual final product
 pushd build/docs/tmp 
 NODE_ENV=production browserify src/index.js | uglifyjs -c -m > ../bundle.js 
-babel src --out-dir lib 
-node lib/render.js ../index.html 
+# Output as .cjs since package.json has "type": "module"
+babel src --out-dir lib --out-file-extension .cjs
+node lib/render.cjs ../index.html 
 popd
 
 # Cleanup


### PR DESCRIPTION
# Issue

Fixes #7347

- Fix docs build by using Babel's `--out-file-extension .cjs` flag so transpiled output is treated as CommonJS                                           
- Additionally, run "npm audit --fix" to fix GHSA-34x7-hfp2-rc4v vulnerability            

## Tasklist

 - [x] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [x] adjust for comments


## Requirements / Relations

- https://nvd.nist.gov/vuln/detail/CVE-2026-24842
- https://github.com/advisories/GHSA-34x7-hfp2-rc4v
