### PR TITLE
Add Lua 5.5 compatibility stopgap patch

### DIFF
--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -47,7 +47,7 @@ unset(_lua_append_versions)
 
 # this is a function only to have all the variables inside go away automatically
 function(_lua_set_version_vars)
-    set(LUA_VERSIONS5 5.4 5.3 5.2 5.1 5.0)
+    set(LUA_VERSIONS5 5.5 5.4 5.3 5.2 5.1 5.0)
 
     if (Lua_FIND_VERSION_EXACT)
         if (Lua_FIND_VERSION_COUNT GREATER 1)
@@ -102,22 +102,36 @@ function(_lua_check_header_version _hdr_file)
     # At least 5.[012] have different ways to express the version
     # so all of them need to be tested. Lua 5.2 defines LUA_VERSION
     # and LUA_RELEASE as joined by the C preprocessor, so avoid those.
+    # Lua 5.5+ uses integer macros (LUA_VERSION_MAJOR_N) rather than
+    # string literals for the version components.
     file(STRINGS "${_hdr_file}" lua_version_strings
          REGEX "^#define[ \t]+LUA_(RELEASE[ \t]+\"Lua [0-9]|VERSION([ \t]+\"Lua [0-9]|_[MR])).*")
 
+    # Lua 5.2–5.4: LUA_VERSION_MAJOR/MINOR/RELEASE are string literals ("5", "4", …)
     string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MAJOR[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_MAJOR ";${lua_version_strings};")
     if (LUA_VERSION_MAJOR MATCHES "^[0-9]+$")
         string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MINOR[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_MINOR ";${lua_version_strings};")
         string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_RELEASE[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_PATCH ";${lua_version_strings};")
         set(LUA_VERSION_STRING "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
     else ()
-        string(REGEX REPLACE ".*;#define[ \t]+LUA_RELEASE[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
-        if (NOT LUA_VERSION_STRING MATCHES "^[0-9.]+$")
-            string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+        # Lua 5.5+: LUA_VERSION_MAJOR_N/MINOR_N/RELEASE_N are plain integers
+        file(STRINGS "${_hdr_file}" lua_version_strings_n
+             REGEX "^#define[ \t]+LUA_VERSION_(MAJOR|MINOR|RELEASE)_N[ \t]+[0-9]+")
+        string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MAJOR_N[ \t]+([0-9]+)[ \t]*;.*" "\\1" LUA_VERSION_MAJOR ";${lua_version_strings_n};")
+        if (LUA_VERSION_MAJOR MATCHES "^[0-9]+$")
+            string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MINOR_N[ \t]+([0-9]+)[ \t]*;.*" "\\1" LUA_VERSION_MINOR ";${lua_version_strings_n};")
+            string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_RELEASE_N[ \t]+([0-9]+)[ \t]*;.*" "\\1" LUA_VERSION_PATCH ";${lua_version_strings_n};")
+            set(LUA_VERSION_STRING "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
+        else ()
+            # Lua 5.0–5.1: fall back to LUA_RELEASE / LUA_VERSION string literals
+            string(REGEX REPLACE ".*;#define[ \t]+LUA_RELEASE[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+            if (NOT LUA_VERSION_STRING MATCHES "^[0-9.]+$")
+                string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+            endif ()
+            string(REGEX REPLACE "^([0-9]+)\\.[0-9.]*$" "\\1" LUA_VERSION_MAJOR "${LUA_VERSION_STRING}")
+            string(REGEX REPLACE "^[0-9]+\\.([0-9]+)[0-9.]*$" "\\1" LUA_VERSION_MINOR "${LUA_VERSION_STRING}")
+            string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]).*" "\\1" LUA_VERSION_PATCH "${LUA_VERSION_STRING}")
         endif ()
-        string(REGEX REPLACE "^([0-9]+)\\.[0-9.]*$" "\\1" LUA_VERSION_MAJOR "${LUA_VERSION_STRING}")
-        string(REGEX REPLACE "^[0-9]+\\.([0-9]+)[0-9.]*$" "\\1" LUA_VERSION_MINOR "${LUA_VERSION_STRING}")
-        string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]).*" "\\1" LUA_VERSION_PATCH "${LUA_VERSION_STRING}")
     endif ()
     foreach (ver IN LISTS _lua_append_versions)
         if (ver STREQUAL "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}")

--- a/third_party/sol2/include/sol/sol.hpp
+++ b/third_party/sol2/include/sol/sol.hpp
@@ -3535,7 +3535,7 @@ COMPAT53_API void luaL_requiref(lua_State *L, const char *modname,
 #endif /* Lua 5.2 only */
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
 
 #  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
 
@@ -4419,7 +4419,7 @@ extern "C" {
 }
 #endif
 
-#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 504
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 504
 
 #if !defined(LUA_ERRGCMM)
 /* So Lua 5.4 actually removes this, which breaks sol2...
@@ -28250,6 +28250,13 @@ namespace sol {
 
 namespace sol {
 
+	inline lua_State* sol_lua_newstate(lua_Alloc f, void* ud, [[maybe_unused]] unsigned seed = 0) {
+#if LUA_VERSION_NUM >= 505
+		return ::lua_newstate(f, ud, seed);
+#else
+		return ::lua_newstate(f, ud);
+#endif
+	}
 	class state : private std::unique_ptr<lua_State, detail::state_deleter>, public state_view {
 	private:
 		typedef std::unique_ptr<lua_State, detail::state_deleter> unique_base;
@@ -28260,7 +28267,7 @@ namespace sol {
 		}
 
 		state(lua_CFunction panic, lua_Alloc alfunc, void* alpointer = nullptr)
-		: unique_base(lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
+		: unique_base(sol_lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
 			set_default_state(unique_base::get(), panic);
 		}
 


### PR DESCRIPTION
# Issue
This PR introduces a minimally invasive compatibility patch to support Lua 5.5, including:

- a small downstream patch on top of vendored sol2 (sol.hpp)
- corresponding detection/build updates in FindLua.cmake

The intent is to keep the change surface as small as possible, preserve existing behavior, and avoid unrelated refactoring.

This downstream patch is necessary for now because sol2 is in slow maintenance mode, and the required Lua 5.5 support has not landed in an upstream release yet. Once the next sol2 release includes equivalent fixes, we should be able to drop the local patch.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x ] ~~add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))~~
 - [ x] ~~update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)~~
 - [ x] ~~CHANGELOG.md entry (see [how to](http://keepachangelog.com/en/1.0.0/#how))~~
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

Upstream patch proposal and related discussion: https://github.com/ThePhD/sol2/pull/1723/ and https://github.com/ThePhD/sol2/issues/1747