### PR TITLE
fix: upgrade tar to >=7.5.11 (GHSA-9ppj-qmqm-q256)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13108,9 +13108,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
tar <=7.5.10 has a high-severity traversal vulnerability via drive-relative linkpaths ([GHSA-9ppj-qmqm-q256](https://github.com/advisories/GHSA-9ppj-qmqm-q256)). Patched in 7.5.11.

```
pm warn config production Use `--omit=dev` instead.
# npm audit report

tar  <=7.5.10
Severity: high
node-tar Symlink Path Traversal via Drive-Relative Linkpath - https://github.com/advisories/GHSA-9ppj-qmqm-q256
fix available via `npm audit fix`
node_modules/tar

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```