### PR TITLE
fix: clamp negative turn duration penalties to prevent negative route durations

### DIFF
--- a/features/testbot/traffic_turn_penalties.feature
+++ b/features/testbot/traffic_turn_penalties.feature
@@ -47,8 +47,20 @@ Feature: Traffic - turn penalties applied to turn onto which a phantom node snap
             | 1    | e  | ab,be,be | 36 km/h  | 30s +-1 |
             | b    | f  | bc,cf,cf | 36 km/h  | 40s +-1 |
             | 2    | f  | bc,cf,cf | 36 km/h  | 30s +-1 |
-            | c    | g  | cd,dg,dg | 72 km/h  | 20s +-1 |
+            | c    | g  | cd,dg,dg | 71 km/h  | 20s +-1 |
             | 3    | g  | cd,dg,dg | 54 km/h  | 20s +-1 |
+
+    Scenario: Negative turn duration penalty on intermediate segment must not produce negative route duration
+        Given the turn penalty file
+            """
+            2,3,4,-70,0
+            """
+        And the contract extra arguments "--turn-penalty-file {penalties_file}"
+        And the customize extra arguments "--turn-penalty-file {penalties_file}"
+
+        When I route I should get
+            | from | to | route       | time    |
+            | a    | d  | ab,bc,cd,cd | 40s +-5 |
 
     Scenario: Weighting based on turn penalty file with weights
         Given the turn penalty file
@@ -65,5 +77,5 @@ Feature: Traffic - turn penalties applied to turn onto which a phantom node snap
             | 1    | e  | ab,be,be | 36 km/h  | 30s +-1 | 6.8,20,0   |
             | b    | f  | bc,cf,cf | 36 km/h  | 40s +-1 | 20,20,0    |
             | 2    | f  | bc,cf,cf | 36 km/h  | 30s +-1 | 10.1,20,0  |
-            | c    | g  | cd,dg,dg | 72 km/h  | 20s +-1 | 120.8,20,0 |
+            | c    | g  | cd,dg,dg | 71 km/h  | 20s +-1 | 120.8,20,0 |
             | 3    | g  | cd,dg,dg | 54 km/h  | 20s +-1 | 110.9,20,0 |

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -1320,6 +1320,10 @@ void Sol2ScriptingEnvironment::ProcessTurn(ExtractionTurn &turn)
         turn.weight = turn.duration;
         break;
     }
+
+    // Cap turn duration to prevent int16_t overflow on storage (duration is always in seconds,
+    // converted to deciseconds at 1/10s resolution, independent of weight_precision).
+    turn.duration = std::max(turn.duration, -from_alias<double>(MAXIMAL_TURN_PENALTY) / 10.0);
 }
 
 void Sol2ScriptingEnvironment::ProcessSegment(ExtractionSegment &segment)

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -467,9 +467,16 @@ updateTurnPenalties(const UpdaterConfig &config,
 
         if (turn_weight_penalty < TurnPenalty{0})
         {
-            util::Log(logWARNING) << "Negative turn penalty at " << osm_turn.from << ", "
+            util::Log(logWARNING) << "Negative turn weight penalty at " << osm_turn.from << ", "
                                   << osm_turn.via << ", " << osm_turn.to << ": turn penalty "
                                   << turn_weight_penalty;
+        }
+
+        if (turn_duration_penalty < TurnPenalty{0})
+        {
+            util::Log(logWARNING) << "Negative turn duration penalty at " << osm_turn.from << ", "
+                                  << osm_turn.via << ", " << osm_turn.to << ": turn penalty "
+                                  << turn_duration_penalty;
         }
     }
 
@@ -788,6 +795,25 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
                 else
                 {
                     new_weight = weight_min_value;
+                }
+            }
+
+            const auto duration_min_value = to_alias<EdgeDuration>(num_nodes);
+            if (alias_cast<EdgeDuration>(turn_duration_penalty) + new_duration < duration_min_value)
+            {
+                if (turn_duration_penalty < TurnPenalty{0})
+                {
+                    util::Log(logWARNING)
+                        << "turn penalty " << turn_duration_penalty << " for turn_id "
+                        << edge.data.turn_id << " (edge " << edge.source << " -> " << edge.target
+                        << ") is too negative: clamping turn duration to " << duration_min_value;
+                    turn_duration_penalty =
+                        alias_cast<TurnPenalty>(duration_min_value - new_duration);
+                    turn_duration_penalties[edge.data.turn_id] = turn_duration_penalty;
+                }
+                else
+                {
+                    new_duration = duration_min_value;
                 }
             }
 


### PR DESCRIPTION
## Issue

Fixes #5967

Negative turn duration penalties were not being clamped during traffic updates or at extraction time, unlike turn *weight* penalties which were. This caused `edge.data.duration` to go negative, producing physically impossible negative route durations.

Was this change primarily generated using an AI tool? Yes — GitHub Copilot (claude-sonnet-4.6) was used to assist with analysis, implementation, and test writing.

## Tasklist

- [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
- [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
- [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
- [ ] CHANGELOG.md entry (see [how to](http://keepachangelog.com/en/1.0.0/#how))
- [ ] review
- [ ] adjust for comments

## Requirements / Relations

No other PRs required.

## Changes

**`src/updater/updater.cpp`** — core fix (traffic update path):
- In `update_edge`, clamp the turn duration penalty using `num_nodes` as the floor (deciseconds), mirroring the existing weight clamping block. Log a warning when the penalty is too negative.
- In `updateTurnPenalties`, add a `logWARNING` for negative `turn_duration_penalty` values (mirrors existing weight warning).

**`src/extractor/scripting_environment_lua.cpp`** — extraction-time fix:
- In `ProcessTurn`, clamp `turn.duration` to `-MAXIMAL_TURN_PENALTY / 10.0` (seconds). This prevents int16_t overflow and keeps durations in a physically meaningful range. Uses the fixed decisecond resolution (÷10), not `GetMaxTurnWeight()` which is scaled by `weight_precision` and only applies to weights.

**`features/testbot/traffic_turn_penalties.feature`** — tests:
- New scenario reproducing issue #5967: a penalty of `-70` on a middle turn that would yield `-10s` total without the fix, now correctly produces `~40s`.
- Updated two existing `c→g` speed expectations from `72 km/h` → `71 km/h`. The old code masked the negative penalty via a phantom-node first-edge clamp in `routing_base.hpp`; with the fix applied upstream the route is 0.1s longer, changing the truncated speed by 1 km/h.

## Testing

All 363 testbot scenarios pass with MLD. Turn penalty feature file also verified with CH.