### PR TITLE
Add Elevator obstacle type to prevent node collapsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
       - FIXED: Prevent MLD route queries from updating removed heap nodes, avoiding `osrm-routed` segfaults/asserts [#7203](https://github.com/Project-OSRM/osrm-backend/issues/7203)
       - FIXED: Crash when route starts or ends at `type=manoeuvre` relation via node [#7287](https://github.com/Project-OSRM/osrm-backend/issues/7287)
     - Extraction:
+      - ADDED: `Elevator` obstacle type preventing degree-2 node collapsing during graph compression [#7434](https://github.com/Project-OSRM/osrm-backend/issues/7434)
       - ADDED: Emit warning when ways reference nodes not present in input data [#1596](https://github.com/Project-OSRM/osrm-backend/issues/1596)
       - FIXED: Compilation error in raster_source [#7422](https://github.com/Project-OSRM/osrm-backend/issues/7422)
     - Profiles:

--- a/include/extractor/obstacles.hpp
+++ b/include/extractor/obstacles.hpp
@@ -71,9 +71,10 @@ struct Obstacle
         TurningCircle = 0x0100,
         StopMinor = 0x0200,
         Gate = 0x0400,
+        Elevator = 0x0800,
 
         Turning = MiniRoundabout | TurningLoop | TurningCircle,
-        Incompressible = Barrier | Turning,
+        Incompressible = Barrier | Turning | Elevator,
         All = 0xFFFF
     };
 

--- a/src/extractor/obstacles.cpp
+++ b/src/extractor/obstacles.cpp
@@ -45,7 +45,8 @@ const std::initializer_list<std::pair<std::string_view, Obstacle::Type>>
                                          {"mini_roundabout", Obstacle::Type::MiniRoundabout},
                                          {"turning_loop", Obstacle::Type::TurningLoop},
                                          {"turning_circle", Obstacle::Type::TurningCircle},
-                                         {"gate", Obstacle::Type::Gate}};
+                                         {"gate", Obstacle::Type::Gate},
+                                         {"elevator", Obstacle::Type::Elevator}};
 
 const std::initializer_list<std::pair<std::string_view, Obstacle::Direction>>
     Obstacle::enum_direction_initializer_list{{"none", Obstacle::Direction::None},

--- a/unit_tests/extractor/graph_compressor.cpp
+++ b/unit_tests/extractor/graph_compressor.cpp
@@ -1,6 +1,7 @@
 #include "extractor/graph_compressor.hpp"
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/maneuver_override.hpp"
+#include "extractor/obstacles.hpp"
 #include "extractor/restriction.hpp"
 #include "util/node_based_graph.hpp"
 #include "util/typedefs.hpp"
@@ -239,6 +240,51 @@ BOOST_AUTO_TEST_CASE(direction_changes)
 
     BOOST_CHECK(graph.FindEdge(0, 1) != SPECIAL_EDGEID);
     BOOST_CHECK(graph.FindEdge(1, 2) != SPECIAL_EDGEID);
+}
+
+BOOST_AUTO_TEST_CASE(elevator_incompressible_test)
+{
+    //
+    // 0---1---2---3---4
+    //         ^
+    //      Elevator
+    //
+    // Node 2 should not be compressed because it has an Elevator obstacle.
+    // Result: 0-2 compressed, 2-4 compressed, but node 2 remains.
+    //
+    GraphCompressor compressor;
+
+    std::vector<TurnRestriction> restrictions;
+    std::vector<NodeBasedEdgeAnnotation> annotations(1);
+    CompressedEdgeContainer container;
+    test::MockScriptingEnvironment scripting_environment;
+    std::vector<UnresolvedManeuverOverride> maneuver_overrides;
+
+    std::vector<InputEdge> edges = {MakeUnitEdge(0, 1),
+                                    MakeUnitEdge(1, 0),
+                                    MakeUnitEdge(1, 2),
+                                    MakeUnitEdge(2, 1),
+                                    MakeUnitEdge(2, 3),
+                                    MakeUnitEdge(3, 2),
+                                    MakeUnitEdge(3, 4),
+                                    MakeUnitEdge(4, 3)};
+
+    Graph graph(5, edges);
+
+    // Mark node 2 as an elevator
+    scripting_environment.m_obstacle_map.emplace(
+        SPECIAL_NODEID, NodeID{2}, Obstacle{Obstacle::Type::Elevator});
+
+    compressor.Compress(
+        scripting_environment, restrictions, maneuver_overrides, graph, annotations, container);
+
+    // Nodes 1 and 3 should be compressed away
+    BOOST_CHECK_EQUAL(graph.FindEdge(0, 1), SPECIAL_EDGEID);
+    BOOST_CHECK_EQUAL(graph.FindEdge(3, 4), SPECIAL_EDGEID);
+
+    // Node 2 should remain — edges to/from it should exist
+    BOOST_CHECK(graph.FindEdge(0, 2) != SPECIAL_EDGEID);
+    BOOST_CHECK(graph.FindEdge(2, 4) != SPECIAL_EDGEID);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Description

Add `Obstacle::Type::Elevator` (`0x0800`) to the Incompressible bitmask so that elevator nodes are preserved during graph compression. This allows foot profiles to apply duration penalties and emit guidance for elevators (`highway=elevator`) instead of having them silently collapsed away.

Changes:
- Add `Elevator` to `Obstacle::Type` enum and Incompressible bitmask
- Register "elevator" in the Lua obstacle_type enum
- Add unit test verifying elevator nodes resist compression

Profile usage:
```lua
    function process_node(profile, node, result)
        local highway = node:get_value_by_key("highway")
        if highway == "elevator" then
            obstacle_map:add(node, Obstacle(obstacle_type.elevator))
        end
    end
```

# Issue

Closes #7434.

Was this change primarily generated using an AI tool?

Claude Code was used as part of this change.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [x] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] CHANGELOG.md entry (see [how to](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] review
 - [ ] adjust for comments

