### PR TITLE
Fix Windows handling of large files

### DIFF
--- a/third_party/microtar/src/microtar.c
+++ b/third_party/microtar/src/microtar.c
@@ -209,7 +209,12 @@ static int file_read(mtar_t *tar, void *data, mtar_size_t size) {
 }
 
 static int file_seek(mtar_t *tar, mtar_size_t offset) {
-  int res = fseek(tar->stream, offset, SEEK_SET);
+  int res;
+#if defined(_WIN32)
+  res = _fseeki64(tar->stream, (__int64) offset, SEEK_SET);
+#else
+  res = fseek(tar->stream, offset, SEEK_SET);
+#endif
   return (res == 0) ? MTAR_ESUCCESS : MTAR_ESEEKFAIL;
 }
 


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

This PR is targeting OSRM windows build.  issue #7308 

This issue was caused by fseek function in microtar library. According to microsoft [doc ](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fseek-fseeki64?view=msvc-170), on windows _fseeki64 is an better option. 
