### PR TITLE
Revert "Change Windows Node.js version from 24 to 20"

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -34,7 +34,7 @@ jobs:
       - run: cmake --version
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: node --version
       - run: npm --version
       - name: Prepare environment


### PR DESCRIPTION
Reverts Project-OSRM/osrm-backend#7452 now that Windows build is compatible with node 24. 