### PR TITLE
Replace d3-queue with native async/await across test infrastructure

### DIFF
--- a/features/lib/hash.js
+++ b/features/lib/hash.js
@@ -1,32 +1,21 @@
 // File content hashing utilities for cache invalidation and content verification
 import fs from 'fs';
 import crypto from 'crypto';
-import d3 from 'd3-queue';
 
 // Computes MD5 hash of multiple files concatenated together
-const hashOfFiles = (paths, cb) => {
-  const queue = d3.queue();
-  for (let i = 0; i < paths.length; ++i) {
-    queue.defer(fs.readFile, paths[i]);
-  }
-  queue.awaitAll((err, results) => {
-    if (err) return cb(err);
-    const checksum = crypto.createHash('md5');
-    for (let i = 0; i < results.length; ++i) {
-      checksum.update(results[i]);
-    }
-    cb(null, checksum.digest('hex'));
-  });
+const hashOfFiles = async (paths) => {
+  const results = await Promise.all(paths.map(p => fs.promises.readFile(p)));
+  const checksum = crypto.createHash('md5');
+  results.forEach(r => checksum.update(r));
+  return checksum.digest('hex');
 };
 
 // Computes MD5 hash of single file with optional additional content
-const hashOfFile = (path, additional_content, cb) => {
-  fs.readFile(path, (err, result) => {
-    if (err) return cb(err);
-    const checksum = crypto.createHash('md5');
-    checksum.update(result + (additional_content || ''));
-    cb(null, checksum.digest('hex'));
-  });
+const hashOfFile = async (path, additional_content) => {
+  const result = await fs.promises.readFile(path);
+  const checksum = crypto.createHash('md5');
+  checksum.update(result + (additional_content || ''));
+  return checksum.digest('hex');
 };
 
 export { hashOfFiles, hashOfFile };

--- a/features/lib/hash.js
+++ b/features/lib/hash.js
@@ -14,7 +14,10 @@ const hashOfFiles = async (paths) => {
 const hashOfFile = async (path, additional_content) => {
   const result = await fs.promises.readFile(path);
   const checksum = crypto.createHash('md5');
-  checksum.update(result + (additional_content || ''));
+  checksum.update(result);
+  if (additional_content) {
+    checksum.update(additional_content);
+  }
   return checksum.digest('hex');
 };
 

--- a/features/step_definitions/data.js
+++ b/features/step_definitions/data.js
@@ -2,7 +2,6 @@
 import util from 'util';
 import path from 'path';
 import fs from 'fs';
-import d3 from 'd3-queue';
 import * as OSM from '../lib/osm.js';
 import { Given } from '@cucumber/cucumber';
 import { env } from '../support/env.js';
@@ -46,18 +45,10 @@ Given(
 );
 
 Given(/^the shortcuts$/, function (table, callback) {
-  const q = d3.queue();
-
-  const addShortcut = (row, cb) => {
-    this.shortcutsHash[row.key] = row.value;
-    cb();
-  };
-
   table.hashes().forEach((row) => {
-    q.defer(addShortcut, row);
+    this.shortcutsHash[row.key] = row.value;
   });
-
-  q.awaitAll(callback);
+  callback();
 });
 
 Given(/^the node map$/, function (docstring, callback) {
@@ -132,9 +123,7 @@ Given(
         '*** Map data already defined - did you pass an input file in this scenario?',
       );
 
-    const q = d3.queue();
-
-    const addWay = (row, cb) => {
+    const addWay = (row) => {
       const way = new OSM.Way(
         this.makeOSMId(),
         env.OSM_USER,
@@ -183,12 +172,10 @@ Given(
       way.setTags(tags);
       this.OSMDB.addWay(way);
       this.nameWayHash[nodes] = way;
-      cb();
     };
 
-    table.hashes().forEach((row) => q.defer(addWay, row));
-
-    q.awaitAll(callback);
+    table.hashes().forEach((row) => addWay(row));
+    callback();
   },
 );
 
@@ -198,9 +185,7 @@ Given(/^the relations$/, function (table, callback) {
       '*** Map data already defined - did you pass an input file in this scenario?',
     );
 
-  const q = d3.queue();
-
-  const addRelation = (headers, row, cb) => {
+  const addRelation = (headers, row) => {
     const relation = new OSM.Relation(
       this.makeOSMId(),
       env.OSM_USER,
@@ -290,14 +275,11 @@ Given(/^the relations$/, function (table, callback) {
     }
 
     this.OSMDB.addRelation(relation);
-
-    cb();
   };
 
   const headers = table.raw()[0];
-  table.rows().forEach((row) => q.defer(addRelation, headers, row));
-
-  q.awaitAll(callback);
+  table.rows().forEach((row) => addRelation(headers, row));
+  callback();
 });
 
 Given(/^the input file ([^"]*)$/, (file, callback) => {

--- a/features/step_definitions/distance_matrix.js
+++ b/features/step_definitions/distance_matrix.js
@@ -33,58 +33,23 @@ const DISTANCES_NO_ROUTE = 3.40282e38; // MAX_FLOAT (meters)
 const FORMAT_JSON = 'json';
 const FORMAT_FB = 'flatbuffers';
 
-When(durationsRegex, function (table, callback) {
-  tableParse.call(
-    this,
-    table,
-    DURATIONS_NO_ROUTE,
-    'durations',
-    FORMAT_JSON,
-    callback
-  );
+When(durationsRegex, async function (table) {
+  await tableParse.call(this, table, DURATIONS_NO_ROUTE, 'durations', FORMAT_JSON);
 });
-When(durationsCodeOnlyRegex, function (table, callback) {
-  tableCodeOnlyParse.call(this, table, 'durations', FORMAT_JSON, callback);
+When(durationsCodeOnlyRegex, async function (table) {
+  await tableCodeOnlyParse.call(this, table, 'durations', FORMAT_JSON);
 });
-When(distancesRegex, function (table, callback) {
-  tableParse.call(
-    this,
-    table,
-    DISTANCES_NO_ROUTE,
-    'distances',
-    FORMAT_JSON,
-    callback
-  );
+When(distancesRegex, async function (table) {
+  await tableParse.call(this, table, DISTANCES_NO_ROUTE, 'distances', FORMAT_JSON);
 });
-When(estimatesRegex, function (table, callback) {
-  tableParse.call(
-    this,
-    table,
-    DISTANCES_NO_ROUTE,
-    'fallback_speed_cells',
-    FORMAT_JSON,
-    callback
-  );
+When(estimatesRegex, async function (table) {
+  await tableParse.call(this, table, DISTANCES_NO_ROUTE, 'fallback_speed_cells', FORMAT_JSON);
 });
-When(durationsRegexFb, function (table, callback) {
-  tableParse.call(
-    this,
-    table,
-    DURATIONS_NO_ROUTE,
-    'durations',
-    FORMAT_FB,
-    callback
-  );
+When(durationsRegexFb, async function (table) {
+  await tableParse.call(this, table, DURATIONS_NO_ROUTE, 'durations', FORMAT_FB);
 });
-When(distancesRegexFb, function (table, callback) {
-  tableParse.call(
-    this,
-    table,
-    DISTANCES_NO_ROUTE,
-    'distances',
-    FORMAT_FB,
-    callback
-  );
+When(distancesRegexFb, async function (table) {
+  await tableParse.call(this, table, DISTANCES_NO_ROUTE, 'distances', FORMAT_FB);
 });
 
 const durationsParse = function (v) {
@@ -97,7 +62,7 @@ const estimatesParse = function (v) {
   return isNaN(parseFloat(v));
 };
 
-function tableCodeOnlyParse(table, annotation, format, callback) {
+async function tableCodeOnlyParse(table, annotation, format) {
   const params = this.queryParams;
   params.annotations =
     ['durations', 'fallback_speed_cells'].indexOf(annotation) !== -1
@@ -107,11 +72,11 @@ function tableCodeOnlyParse(table, annotation, format, callback) {
 
   let got;
 
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
-    const testRow = function (row, ri, cb) {
+  await this.reprocessAndLoadData();
+  const testRow = function (row, ri) {
+    return new Promise((resolve, reject) => {
       const afterRequest = function (err, res, body) {
-        if (err) return cb(err);
+        if (err) return reject(err);
 
         for (const k in row) {
           const match = k.match(/param:(.*)/);
@@ -132,7 +97,7 @@ function tableCodeOnlyParse(table, annotation, format, callback) {
           got.code = json.code;
         }
 
-        cb(null, got);
+        resolve(got);
       }.bind(this);
 
       const params = this.queryParams,
@@ -150,15 +115,15 @@ function tableCodeOnlyParse(table, annotation, format, callback) {
 
         this.requestTable(waypoints, params, afterRequest);
       } else {
-        throw new Error('*** no waypoints');
+        reject(new Error('*** no waypoints'));
       }
-    }.bind(this);
+    });
+  }.bind(this);
 
-    this.processRowsAndDiff(table, testRow, callback);
-  });
+  await this.processRowsAndDiff(table, testRow);
 }
 
-function tableParse(table, noRoute, annotation, format, callback) {
+async function tableParse(table, noRoute, annotation, format) {
   const parse =
     annotation == 'distances'
       ? distancesParse
@@ -206,81 +171,83 @@ function tableParse(table, noRoute, annotation, format, callback) {
     });
   }
 
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
-    // compute matrix
+  await this.reprocessAndLoadData();
+  // compute matrix
 
+  const { response, body } = await new Promise((resolve, reject) => {
     this.requestTable(waypoints, params, (err, response, body) => {
-      if (err) return callback(err);
-      if (!body.length) return callback(new Error('Invalid response body'));
-
-      let result = [];
-      if (format === 'json') {
-        const json = JSON.parse(body);
-
-        if (annotation === 'fallback_speed_cells') {
-          result = table.raw().map((row) => row.map(() => ''));
-          json[annotation].forEach((pair) => {
-            result[pair[0] + 1][pair[1] + 1] = 'Y';
-          });
-          result = result.slice(1).map((row) => {
-            const hashes = {};
-            row.slice(1).forEach((v, i) => {
-              hashes[tableRows[0][i + 1]] = v;
-            });
-            return hashes;
-          });
-        } else {
-          result = json[annotation].map((row) => {
-            const hashes = {};
-            row.forEach((v, i) => {
-              hashes[tableRows[0][i + 1]] = parse(v) ? '' : v;
-            });
-            return hashes;
-          });
-        }
-      } else {
-        //flatbuffers
-        const bytes = new Uint8Array(body.length);
-        for (let indx = 0; indx < body.length; ++indx) {
-          bytes[indx] = body.charCodeAt(indx);
-        }
-        const buf = new flatbuffers.ByteBuffer(bytes);
-        const fb = FBResult.getRootAsFBResult(buf);
-
-        let matrix;
-        if (annotation === 'durations') {
-          matrix = fb.table().durationsArray();
-        }
-        if (annotation === 'distances') {
-          matrix = fb.table().distancesArray();
-        }
-        const cols = fb.table().cols();
-        const rows = fb.table().rows();
-        for (let r = 0; r < rows; ++r) {
-          result[r] = {};
-          for (let c = 0; c < cols; ++c) {
-            result[r][tableRows[0][c + 1]] = matrix[r * cols + c];
-          }
-        }
-      }
-
-      const testRow = function (row, ri, cb) {
-        for (const k in result[ri]) {
-          if (this.FuzzyMatch.match(result[ri][k], row[k])) {
-            result[ri][k] = row[k];
-          } else if (row[k] === '' && result[ri][k] === noRoute) {
-            result[ri][k] = '';
-          } else {
-            result[ri][k] = result[ri][k].toString();
-          }
-        }
-
-        result[ri][''] = row[''];
-        cb(null, result[ri]);
-      }.bind(this);
-
-      this.processRowsAndDiff(table, testRow, callback);
+      if (err) return reject(err);
+      resolve({ response, body });
     });
   });
+
+  if (!body.length) throw new Error('Invalid response body');
+
+  let result = [];
+  if (format === 'json') {
+    const json = JSON.parse(body);
+
+    if (annotation === 'fallback_speed_cells') {
+      result = table.raw().map((row) => row.map(() => ''));
+      json[annotation].forEach((pair) => {
+        result[pair[0] + 1][pair[1] + 1] = 'Y';
+      });
+      result = result.slice(1).map((row) => {
+        const hashes = {};
+        row.slice(1).forEach((v, i) => {
+          hashes[tableRows[0][i + 1]] = v;
+        });
+        return hashes;
+      });
+    } else {
+      result = json[annotation].map((row) => {
+        const hashes = {};
+        row.forEach((v, i) => {
+          hashes[tableRows[0][i + 1]] = parse(v) ? '' : v;
+        });
+        return hashes;
+      });
+    }
+  } else {
+    //flatbuffers
+    const bytes = new Uint8Array(body.length);
+    for (let indx = 0; indx < body.length; ++indx) {
+      bytes[indx] = body.charCodeAt(indx);
+    }
+    const buf = new flatbuffers.ByteBuffer(bytes);
+    const fb = FBResult.getRootAsFBResult(buf);
+
+    let matrix;
+    if (annotation === 'durations') {
+      matrix = fb.table().durationsArray();
+    }
+    if (annotation === 'distances') {
+      matrix = fb.table().distancesArray();
+    }
+    const cols = fb.table().cols();
+    const rows = fb.table().rows();
+    for (let r = 0; r < rows; ++r) {
+      result[r] = {};
+      for (let c = 0; c < cols; ++c) {
+        result[r][tableRows[0][c + 1]] = matrix[r * cols + c];
+      }
+    }
+  }
+
+  const testRow = function (row, ri) {
+    for (const k in result[ri]) {
+      if (this.FuzzyMatch.match(result[ri][k], row[k])) {
+        result[ri][k] = row[k];
+      } else if (row[k] === '' && result[ri][k] === noRoute) {
+        result[ri][k] = '';
+      } else {
+        result[ri][k] = result[ri][k].toString();
+      }
+    }
+
+    result[ri][''] = row[''];
+    return result[ri];
+  }.bind(this);
+
+  await this.processRowsAndDiff(table, testRow);
 }

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -4,14 +4,14 @@ import util from 'util';
 import polyline from '@mapbox/polyline';
 import { When } from '@cucumber/cucumber';
 
-When(/^I match I should get$/, function (table, callback) {
+When(/^I match I should get$/, async function (table) {
   let got;
 
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
-    const testRow = function (row, ri, cb) {
+  await this.reprocessAndLoadData();
+  const testRow = function (row, ri) {
+    return new Promise((resolve, reject) => {
       const afterRequest = function (err, res, body) {
-        if (err) return cb(err);
+        if (err) return reject(err);
         let json;
 
         const headers = new Set(table.raw()[0]);
@@ -152,11 +152,11 @@ When(/^I match I should get$/, function (table, callback) {
           if (k.match(/^a:/)) {
             const a_type = k.slice(2);
             if (whitelist.indexOf(a_type) == -1)
-              return cb(
+              return reject(
                 new Error(`*** Unrecognized annotation field: ${a_type}`),
               );
             if (!annotation[a_type])
-              return cb(
+              return reject(
                 new Error(`*** Annotation not found in response: ${a_type}`),
               );
             got[k] = annotation[a_type];
@@ -214,7 +214,7 @@ When(/^I match I should get$/, function (table, callback) {
 
         if (headers.has('matchings')) {
           if (subMatchings.length != row.matchings.split(',').length) {
-            return cb(
+            return reject(
               new Error(
                 '*** table matchings and api response are not the same',
               ),
@@ -236,7 +236,7 @@ When(/^I match I should get$/, function (table, callback) {
           }
 
           if (row.waypoints.length != got_loc.length)
-            return cb(
+            return reject(
               new Error(
                 `Expected ${row.waypoints.length} waypoints, got ${got_loc.length}`,
               ),
@@ -273,7 +273,7 @@ When(/^I match I should get$/, function (table, callback) {
           row.matchings = extendedTarget;
         }
 
-        cb(null, got);
+        resolve(got);
       }.bind(this);
 
       if (row.request) {
@@ -315,11 +315,11 @@ When(/^I match I should get$/, function (table, callback) {
           got.trace = row.trace;
           this.requestMatching(trace, timestamps, params, afterRequest);
         } else {
-          throw new Error('*** no trace');
+          return reject(new Error('*** no trace'));
         }
       }
-    }.bind(this);
+    });
+  }.bind(this);
 
-    this.processRowsAndDiff(table, testRow, callback);
-  });
+  await this.processRowsAndDiff(table, testRow);
 });

--- a/features/step_definitions/nearest.js
+++ b/features/step_definitions/nearest.js
@@ -6,16 +6,15 @@ import { osrm } from '../support/fbresult_generated.js';
 const FBResult = osrm.engine.api.fbresult.FBResult;
 import { When } from '@cucumber/cucumber';
 
-When(/^I request nearest I should get$/, function (table, callback) {
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
-    const testRow = function (row, ri, cb) {
-
+When(/^I request nearest I should get$/, async function (table) {
+  await this.reprocessAndLoadData();
+  const testRow = function (row, ri) {
+    return new Promise((resolve, reject) => {
       const inNode = this.findNodeByName(row.in);
-      if (!inNode) throw new Error(util.format('*** unknown in-node "%s"', row.in));
+      if (!inNode) return reject(new Error(util.format('*** unknown in-node "%s"', row.in)));
 
       this.requestNearest(inNode, this.queryParams, (err, response, body) => {
-        if (err) return cb(err);
+        if (err) return reject(err);
         let coord;
         const headers = new Set(table.raw()[0]);
 
@@ -37,7 +36,7 @@ When(/^I request nearest I should get$/, function (table, callback) {
               got.out = row.out;
 
               const outNode = this.findNodeByName(row.out);
-              if (!outNode) throw new Error(util.format('*** unknown out-node "%s"', row.out));
+              if (!outNode) return reject(new Error(util.format('*** unknown out-node "%s"', row.out)));
 
               Object.keys(row).forEach((key) => {
                 if (key === 'out') {
@@ -66,31 +65,31 @@ When(/^I request nearest I should get$/, function (table, callback) {
             }
 
           }
-          cb(null, got);
+          resolve(got);
         }
         else {
-          cb();
+          resolve();
         }
       });
-    }.bind(this);
+    });
+  }.bind(this);
 
-    this.processRowsAndDiff(table, testRow, callback);
-  });
+  await this.processRowsAndDiff(table, testRow);
 });
 
-When(/^I request nearest with flatbuffers I should get$/, function (table, callback) {
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
-    const testRow = function (row, ri, cb) {
+When(/^I request nearest with flatbuffers I should get$/, async function (table) {
+  await this.reprocessAndLoadData();
+  const testRow = function (row, ri) {
+    return new Promise((resolve, reject) => {
       const inNode = this.findNodeByName(row.in);
-      if (!inNode) throw new Error(util.format('*** unknown in-node "%s"', row.in));
+      if (!inNode) return reject(new Error(util.format('*** unknown in-node "%s"', row.in)));
 
       const outNode = this.findNodeByName(row.out);
-      if (!outNode) throw new Error(util.format('*** unknown out-node "%s"', row.out));
+      if (!outNode) return reject(new Error(util.format('*** unknown out-node "%s"', row.out)));
 
       this.queryParams.output = 'flatbuffers';
       this.requestNearest(inNode, this.queryParams, (err, response, body) => {
-        if (err) return cb(err);
+        if (err) return reject(err);
         let coord;
 
         if (response.statusCode === 200 && body.length) {
@@ -116,14 +115,14 @@ When(/^I request nearest with flatbuffers I should get$/, function (table, callb
             }
           });
 
-          cb(null, got);
+          resolve(got);
         }
         else {
-          cb();
+          resolve();
         }
       });
-    }.bind(this);
+    });
+  }.bind(this);
 
-    this.processRowsAndDiff(table, testRow, callback);
-  });
+  await this.processRowsAndDiff(table, testRow);
 });

--- a/features/step_definitions/requests.js
+++ b/features/step_definitions/requests.js
@@ -2,13 +2,14 @@
 import assert from 'assert';
 import { When, Then } from '@cucumber/cucumber';
 
-When(/^I request \/(.*)$/, function (path, callback) {
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
+When(/^I request \/(.*)$/, async function (path) {
+  await this.reprocessAndLoadData();
+  await new Promise((resolve, reject) => {
     this.requestUrl(path, (err, res, body) => {
+      if (err) return reject(err);
       this.response = res;
       this.body = body;
-      callback(err, res, body);
+      resolve();
     });
   });
 });

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -4,139 +4,134 @@ import classes from '../support/data_classes.js';
 import { Then } from '@cucumber/cucumber';
 import { env } from '../support/env.js';
 
-Then(/^routability should be$/, function (table, callback) {
-  this.buildWaysFromTable(table, () => {
-    const directions = ['forw', 'backw', 'bothw'],
-      testedHeaders = [
-        'forw',
-        'backw',
-        'bothw',
-        'forw_rate',
-        'backw_rate',
-        'bothw_rate',
-      ],
-      headers = new Set(Object.keys(table.hashes()[0]));
+Then(/^routability should be$/, async function (table) {
+  this.buildWaysFromTable(table);
+  const directions = ['forw', 'backw', 'bothw'],
+    testedHeaders = [
+      'forw',
+      'backw',
+      'bothw',
+      'forw_rate',
+      'backw_rate',
+      'bothw_rate',
+    ],
+    headers = new Set(Object.keys(table.hashes()[0]));
 
-    if (!testedHeaders.some((k) => !!headers.has(k))) {
-      throw new Error(
-        '*** routability table must contain either "forw", "backw", "bothw", "forw_rate" or "backw_mode" column',
-      );
+  if (!testedHeaders.some((k) => !!headers.has(k))) {
+    throw new Error(
+      '*** routability table must contain either "forw", "backw", "bothw", "forw_rate" or "backw_mode" column',
+    );
+  }
+
+  await this.reprocessAndLoadData();
+  const testRow = async function (row, i) {
+    const outputRow = Object.assign({}, row);
+    // clear the fields that are tested for in the copied response object
+    for (const field in outputRow) {
+      if (testedHeaders.indexOf(field) != -1) outputRow[field] = '';
     }
 
-    this.reprocessAndLoadData((e) => {
-      if (e) return callback(e);
-      const testRow = function (row, i, cb) {
-        const outputRow = Object.assign({}, row);
-        // clear the fields that are tested for in the copied response object
-        for (const field in outputRow) {
-          if (testedHeaders.indexOf(field) != -1) outputRow[field] = '';
+    const result = await testRoutabilityRow.call(this, i);
+    directions
+      .filter((d) => headers.has(`${d}_rate`))
+      .forEach((direction) => {
+        const rate = `${direction}_rate`;
+        const want = row[rate];
+
+        switch (true) {
+        case '' === want:
+          outputRow[rate] = result[direction].status
+            ? result[direction].status.toString()
+            : '';
+          break;
+        case /^\d+(\.\d+){0,1}$/.test(want):
+          if (
+            result[direction].rate !== undefined &&
+              !isNaN(result[direction].rate)
+          ) {
+            outputRow[rate] = result[direction].rate.toString();
+          } else {
+            outputRow[rate] = '';
+          }
+          break;
+        default:
+          throw new Error(
+            util.format(
+              '*** Unknown expectation format: %s for header %s',
+              want,
+              rate,
+            ),
+          );
+        }
+      });
+
+    directions
+      .filter((d) => headers.has(d))
+      .forEach((direction) => {
+        let usingShortcut = false,
+          want = row[direction];
+        // shortcuts are when a test has mapped a value like `foot` to
+        // a value like `5 km/h`, to represent the speed that one
+        // can travel by foot. we check for these and use the mapped to
+        // value for later comparison.
+        if (this.shortcutsHash[row[direction]]) {
+          want = this.shortcutsHash[row[direction]];
+          usingShortcut = row[direction];
         }
 
-        testRoutabilityRow.call(this, i, (err, result) => {
-          if (err) return cb(err);
-          directions
-            .filter((d) => headers.has(`${d}_rate`))
-            .forEach((direction) => {
-              const rate = `${direction}_rate`;
-              const want = row[rate];
+        // TODO split out accessible/not accessible value from forw/backw headers
+        // rename forw/backw to forw/backw_speed
+        switch (true) {
+        case '' === want:
+          outputRow[direction] = result[direction].status
+            ? result[direction].mode
+            : '';
+          break;
+        case 'x' === want:
+          outputRow[direction] = result[direction].status ? 'x' : '';
+          break;
+        case /^[\d.]+ s/.test(want):
+          // the result here can come back as a non-number value like
+          // `diff`, but we only want to apply the unit when it comes
+          // back as a number, for tableDiff's literal comparison
+          if (result[direction].time) {
+            outputRow[direction] = !isNaN(result[direction].time)
+              ? `${result[direction].time.toString()} s`
+              : result[direction].time.toString() || '';
+          } else {
+            outputRow[direction] = '';
+          }
+          break;
+        case /^\d+ km\/h/.test(want):
+          if (result[direction].speed) {
+            outputRow[direction] = !isNaN(result[direction].speed)
+              ? `${result[direction].speed.toString()} km/h`
+              : result[direction].speed.toString() || '';
+          } else {
+            outputRow[direction] = '';
+          }
+          break;
+        default:
+          outputRow[direction] = result[direction].mode || '';
+        }
 
-              switch (true) {
-              case '' === want:
-                outputRow[rate] = result[direction].status
-                  ? result[direction].status.toString()
-                  : '';
-                break;
-              case /^\d+(\.\d+){0,1}$/.test(want):
-                if (
-                  result[direction].rate !== undefined &&
-                    !isNaN(result[direction].rate)
-                ) {
-                  outputRow[rate] = result[direction].rate.toString();
-                } else {
-                  outputRow[rate] = '';
-                }
-                break;
-              default:
-                throw new Error(
-                  util.format(
-                    '*** Unknown expectation format: %s for header %s',
-                    want,
-                    rate,
-                  ),
-                );
-              }
-            });
+        if (this.FuzzyMatch.match(outputRow[direction], want)) {
+          outputRow[direction] = usingShortcut
+            ? usingShortcut
+            : row[direction];
+        }
+      });
 
-          directions
-            .filter((d) => headers.has(d))
-            .forEach((direction) => {
-              let usingShortcut = false,
-                want = row[direction];
-              // shortcuts are when a test has mapped a value like `foot` to
-              // a value like `5 km/h`, to represent the speed that one
-              // can travel by foot. we check for these and use the mapped to
-              // value for later comparison.
-              if (this.shortcutsHash[row[direction]]) {
-                want = this.shortcutsHash[row[direction]];
-                usingShortcut = row[direction];
-              }
-
-              // TODO split out accessible/not accessible value from forw/backw headers
-              // rename forw/backw to forw/backw_speed
-              switch (true) {
-              case '' === want:
-                outputRow[direction] = result[direction].status
-                  ? result[direction].mode
-                  : '';
-                break;
-              case 'x' === want:
-                outputRow[direction] = result[direction].status ? 'x' : '';
-                break;
-              case /^[\d.]+ s/.test(want):
-                // the result here can come back as a non-number value like
-                // `diff`, but we only want to apply the unit when it comes
-                // back as a number, for tableDiff's literal comparison
-                if (result[direction].time) {
-                  outputRow[direction] = !isNaN(result[direction].time)
-                    ? `${result[direction].time.toString()} s`
-                    : result[direction].time.toString() || '';
-                } else {
-                  outputRow[direction] = '';
-                }
-                break;
-              case /^\d+ km\/h/.test(want):
-                if (result[direction].speed) {
-                  outputRow[direction] = !isNaN(result[direction].speed)
-                    ? `${result[direction].speed.toString()} km/h`
-                    : result[direction].speed.toString() || '';
-                } else {
-                  outputRow[direction] = '';
-                }
-                break;
-              default:
-                outputRow[direction] = result[direction].mode || '';
-              }
-
-              if (this.FuzzyMatch.match(outputRow[direction], want)) {
-                outputRow[direction] = usingShortcut
-                  ? usingShortcut
-                  : row[direction];
-              }
-            });
-
-          cb(null, outputRow);
-        });
-      }.bind(this);
-      this.processRowsAndDiff(table, testRow, callback);
-    });
-  });
+    return outputRow;
+  }.bind(this);
+  await this.processRowsAndDiff(table, testRow);
 });
 
 // makes simple a-b request using the given cucumber test routability conditions
 // result is an object containing the calculated values for 'rate', 'status',
 // 'time', 'distance', 'speed' and 'mode', for forwards and backwards routing, as well as
 // a bothw object that diffs forwards/backwards
-const testRoutabilityRow = async function (i, cb) {
+const testRoutabilityRow = async function (i) {
   const result = {};
 
   const testDirection = function (dir) {
@@ -193,22 +188,18 @@ const testRoutabilityRow = async function (i, cb) {
     });
   }.bind(this);
 
-  try {
-    // run forw and backw sequentially
-    for (const dir of ['forw', 'backw']) {
-      const dirRes = await testDirection(dir);
-      const which = dirRes.which;
-      delete dirRes.which;
-      result[which] = dirRes;
-    }
-
-    result.bothw = {};
-    ['rate', 'status', 'time', 'distance', 'speed', 'mode'].forEach((key) => {
-      result.bothw[key] = result.forw[key] === result.backw[key] ? result.forw[key] : 'diff';
-    });
-
-    cb(null, result);
-  } catch (err) {
-    cb(err);
+  // run forw and backw sequentially
+  for (const dir of ['forw', 'backw']) {
+    const dirRes = await testDirection(dir);
+    const which = dirRes.which;
+    delete dirRes.which;
+    result[which] = dirRes;
   }
+
+  result.bothw = {};
+  ['rate', 'status', 'time', 'distance', 'speed', 'mode'].forEach((key) => {
+    result.bothw[key] = result.forw[key] === result.backw[key] ? result.forw[key] : 'diff';
+  });
+
+  return result;
 };

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -158,7 +158,11 @@ const testRoutabilityRow = async function (i, cb) {
         (err, res, body) => {
           if (err) return reject(err);
 
-          r.json = JSON.parse(body);
+          try {
+            r.json = JSON.parse(body);
+          } catch (parseErr) {
+            return reject(parseErr);
+          }
           r.code = r.json.code;
           r.status = res.statusCode === 200 ? 'x' : null;
           if (r.status) {

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -19,7 +19,7 @@ Then(/^routability should be$/, async function (table) {
 
   if (!testedHeaders.some((k) => !!headers.has(k))) {
     throw new Error(
-      '*** routability table must contain either "forw", "backw", "bothw", "forw_rate" or "backw_mode" column',
+      '*** routability table must contain at least one of the following columns: "forw", "backw", "bothw", "forw_rate", "backw_rate", or "bothw_rate"',
     );
   }
 

--- a/features/step_definitions/routability.js
+++ b/features/step_definitions/routability.js
@@ -1,6 +1,5 @@
 // Step definitions for testing route accessibility and connectivity
 import util from 'util';
-import d3 from 'd3-queue';
 import classes from '../support/data_classes.js';
 import { Then } from '@cucumber/cucumber';
 import { env } from '../support/env.js';
@@ -137,88 +136,75 @@ Then(/^routability should be$/, function (table, callback) {
 // result is an object containing the calculated values for 'rate', 'status',
 // 'time', 'distance', 'speed' and 'mode', for forwards and backwards routing, as well as
 // a bothw object that diffs forwards/backwards
-const testRoutabilityRow = function (i, cb) {
+const testRoutabilityRow = async function (i, cb) {
   const result = {};
 
-  const testDirection = function (dir, callback) {
-    const coordA = this.offsetOriginBy(1 + env.WAY_SPACING * i, 0);
-    const coordB = this.offsetOriginBy(3 + env.WAY_SPACING * i, 0);
+  const testDirection = function (dir) {
+    return new Promise((resolve, reject) => {
+      const coordA = this.offsetOriginBy(1 + env.WAY_SPACING * i, 0);
+      const coordB = this.offsetOriginBy(3 + env.WAY_SPACING * i, 0);
 
-    const a = new classes.Location(coordA[0], coordA[1]),
-      b = new classes.Location(coordB[0], coordB[1]),
-      r = {};
+      const a = new classes.Location(coordA[0], coordA[1]),
+        b = new classes.Location(coordB[0], coordB[1]),
+        r = {};
 
-    r.which = dir;
+      r.which = dir;
 
-    this.requestRoute(
-      dir === 'forw' ? [a, b] : [b, a],
-      [],
-      [],
-      this.queryParams,
-      (err, res, body) => {
-        if (err) return callback(err);
+      this.requestRoute(
+        dir === 'forw' ? [a, b] : [b, a],
+        [],
+        [],
+        this.queryParams,
+        (err, res, body) => {
+          if (err) return reject(err);
 
-        r.json = JSON.parse(body);
-        r.code = r.json.code;
-        r.status = res.statusCode === 200 ? 'x' : null;
-        if (r.status) {
-          r.route = this.wayList(r.json.routes[0]);
-          r.summary = r.json.routes[0].legs.map((l) => l.summary).join(',');
+          r.json = JSON.parse(body);
+          r.code = r.json.code;
+          r.status = res.statusCode === 200 ? 'x' : null;
+          if (r.status) {
+            r.route = this.wayList(r.json.routes[0]);
+            r.summary = r.json.routes[0].legs.map((l) => l.summary).join(',');
 
-          if (r.route.split(',')[0] === util.format('w%d', i)) {
-            r.time = r.json.routes[0].duration;
-            r.distance = r.json.routes[0].distance;
-            r.rate =
-              Math.round((r.distance / r.json.routes[0].weight) * 10) / 10;
-            r.speed = r.time > 0 ? parseInt((3.6 * r.distance) / r.time) : null;
+            if (r.route.split(',')[0] === util.format('w%d', i)) {
+              r.time = r.json.routes[0].duration;
+              r.distance = r.json.routes[0].distance;
+              r.rate =
+                Math.round((r.distance / r.json.routes[0].weight) * 10) / 10;
+              r.speed = r.time > 0 ? parseInt((3.6 * r.distance) / r.time) : null;
 
-            // use the mode of the first step of the route
-            // for routability table test, we can assume the mode is the same throughout the route,
-            // since the route is just a single way
-            if (r.json.routes[0].legs[0] && r.json.routes[0].legs[0].steps[0]) {
-              r.mode = r.json.routes[0].legs[0].steps[0].mode;
+              // use the mode of the first step of the route
+              // for routability table test, we can assume the mode is the same throughout the route,
+              // since the route is just a single way
+              if (r.json.routes[0].legs[0] && r.json.routes[0].legs[0].steps[0]) {
+                r.mode = r.json.routes[0].legs[0].steps[0].mode;
+              }
+            } else {
+              r.status = null;
             }
-          } else {
-            r.status = null;
           }
-        }
 
-        callback(null, r);
-      },
-    );
+          resolve(r);
+        },
+      );
+    });
   }.bind(this);
 
-  d3.queue(1)
-    .defer(testDirection, 'forw')
-    .defer(testDirection, 'backw')
-    .awaitAll((err, res) => {
-      if (err) return cb(err);
-      // check if forw and backw returned the same values
-      res.forEach((dirRes) => {
-        const which = dirRes.which;
-        delete dirRes.which;
-        result[which] = dirRes;
-      });
+  try {
+    // run forw and backw sequentially
+    for (const dir of ['forw', 'backw']) {
+      const dirRes = await testDirection(dir);
+      const which = dirRes.which;
+      delete dirRes.which;
+      result[which] = dirRes;
+    }
 
-      result.bothw = {};
-
-      const sq = d3.queue();
-
-      const parseRes = function (key, scb) {
-        if (result.forw[key] === result.backw[key]) {
-          result.bothw[key] = result.forw[key];
-        } else {
-          result.bothw[key] = 'diff';
-        }
-        scb();
-      };
-
-      ['rate', 'status', 'time', 'distance', 'speed', 'mode'].forEach((key) => {
-        sq.defer(parseRes, key);
-      });
-
-      sq.awaitAll((err) => {
-        cb(err, result);
-      });
+    result.bothw = {};
+    ['rate', 'status', 'time', 'distance', 'speed', 'mode'].forEach((key) => {
+      result.bothw[key] = result.forw[key] === result.backw[key] ? result.forw[key] : 'diff';
     });
+
+    cb(null, result);
+  } catch (err) {
+    cb(err);
+  }
 };

--- a/features/step_definitions/routing.js
+++ b/features/step_definitions/routing.js
@@ -2,19 +2,14 @@
 import { When, Given } from '@cucumber/cucumber';
 
 
-When(/^I route I should get$/, function (table, callback) {
-  this.WhenIRouteIShouldGet(table, callback);
+When(/^I route I should get$/, async function (table) {
+  await this.WhenIRouteIShouldGet(table);
 });
 
 // Runs routing test multiple times for performance testing
 When(/^I route (\d+) times I should get$/, async function (n, table) {
   for (let i = 0; i < n; i++) {
-    await new Promise((resolve, reject) => {
-      this.WhenIRouteIShouldGet(table, (err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    await this.WhenIRouteIShouldGet(table);
   }
 });
 

--- a/features/step_definitions/routing.js
+++ b/features/step_definitions/routing.js
@@ -1,5 +1,4 @@
 // Step definitions for testing basic routing API functionality
-import d3 from 'd3-queue';
 import { When, Given } from '@cucumber/cucumber';
 
 
@@ -8,14 +7,15 @@ When(/^I route I should get$/, function (table, callback) {
 });
 
 // Runs routing test multiple times for performance testing
-When(/^I route (\d+) times I should get$/, function (n, table, callback) {
-  const q = d3.queue(1);
-
-  for (let i=0; i<n; i++) {
-    q.defer(this.WhenIRouteIShouldGet, table);
+When(/^I route (\d+) times I should get$/, async function (n, table) {
+  for (let i = 0; i < n; i++) {
+    await new Promise((resolve, reject) => {
+      this.WhenIRouteIShouldGet(table, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
   }
-
-  q.awaitAll(callback);
 });
 
 // Sets skip_waypoints parameter for routing requests

--- a/features/step_definitions/trip.js
+++ b/features/step_definitions/trip.js
@@ -7,14 +7,14 @@ function add(a, b) {
   return a + b;
 }
 
-When(/^I plan a trip I should get$/, function (table, callback) {
+When(/^I plan a trip I should get$/, async function (table) {
   let got;
 
-  this.reprocessAndLoadData((e) => {
-    if (e) return callback(e);
-    const testRow = function (row, ri, cb) {
+  await this.reprocessAndLoadData();
+  const testRow = function (row, ri) {
+    return new Promise((resolve, reject) => {
       const afterRequest = function (err, res, body) {
-        if (err) return cb(err);
+        if (err) return reject(err);
         const headers = new Set(table.raw()[0]);
 
         for (const k in row) {
@@ -126,7 +126,7 @@ When(/^I plan a trip I should get$/, function (table, callback) {
           }
         }
 
-        cb(null, got);
+        resolve(got);
       }.bind(this);
 
       if (row.request) {
@@ -137,11 +137,11 @@ When(/^I plan a trip I should get$/, function (table, callback) {
           waypoints = [];
         if (row.from && row.to) {
           const fromNode = this.findNodeByName(row.from);
-          if (!fromNode) throw new Error(util.format('*** unknown from-node "%s"', row.from));
+          if (!fromNode) return reject(new Error(util.format('*** unknown from-node "%s"', row.from)));
           waypoints.push(fromNode);
 
           const toNode = this.findNodeByName(row.to);
-          if (!toNode) throw new Error(util.format('*** unknown to-node "%s"', row.to));
+          if (!toNode) return reject(new Error(util.format('*** unknown to-node "%s"', row.to)));
           waypoints.push(toNode);
 
           got = { from: row.from, to: row.to };
@@ -168,11 +168,11 @@ When(/^I plan a trip I should get$/, function (table, callback) {
 
           this.requestTrip(waypoints, params, afterRequest);
         } else {
-          throw new Error('*** no waypoints');
+          return reject(new Error('*** no waypoints'));
         }
       }
-    }.bind(this);
+    });
+  }.bind(this);
 
-    this.processRowsAndDiff(table, testRow, callback);
-  });
+  await this.processRowsAndDiff(table, testRow);
 });

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -1,7 +1,6 @@
 // Core data manipulation utilities for building synthetic test scenarios and OSM data
 import fs from 'fs';
 import util from 'util';
-import d3 from 'd3-queue';
 
 import CheapRuler from 'cheap-ruler';
 import stripAnsi from 'strip-ansi';
@@ -50,7 +49,7 @@ export default class Data {
   // Builds OSM ways from test table data with synthetic coordinates
   buildWaysFromTable(table, callback) {
     // add one unconnected way for each row
-    const buildRow = (row, ri, cb) => {
+    const buildRow = (row, ri) => {
       // comments ported directly from ruby suite:
       // NOTE: currently osrm crashes when processing an isolated oneway with just 2 nodes, so we use 4 edges
       // this is related to the fact that a oneway dead-end street doesn't make a lot of sense
@@ -131,15 +130,10 @@ export default class Data {
       for (const k in nodeTags) {
         nodes[2].addTag(k, nodeTags[k]);
       }
-      cb();
     };
 
-    const q = d3.queue();
-    table.hashes().forEach((row, ri) => {
-      q.defer(buildRow, row, ri);
-    });
-
-    q.awaitAll(callback);
+    table.hashes().forEach((row, ri) => buildRow(row, ri));
+    callback();
   }
 
   // Converts table grid coordinates to longitude/latitude
@@ -319,16 +313,18 @@ export default class Data {
     callback();
   }
 
-  processRowsAndDiff(table, fn, callback) {
-    const q = d3.queue(1);
-
-    table.hashes().forEach((row, i) => {
-      q.defer(fn, row, i);
-    });
-
-    q.awaitAll((err, actual) => {
-      if (err)
-        return callback(err);
+  async processRowsAndDiff(table, fn, callback) {
+    try {
+      const actual = [];
+      for (const [i, row] of table.hashes().entries()) {
+        const result = await new Promise((resolve, reject) => {
+          fn(row, i, (err, res) => {
+            if (err) reject(err);
+            else resolve(res);
+          });
+        });
+        actual.push(result);
+      }
       const diff = tableDiff(table, actual);
       if (diff) {
         if (env.PLATFORM_CI) {
@@ -341,6 +337,8 @@ export default class Data {
       } else {
         callback();
       }
-    });
+    } catch (err) {
+      callback(err);
+    }
   }
 }

--- a/features/support/data.js
+++ b/features/support/data.js
@@ -47,7 +47,7 @@ export default class Data {
   }
 
   // Builds OSM ways from test table data with synthetic coordinates
-  buildWaysFromTable(table, callback) {
+  buildWaysFromTable(table) {
     // add one unconnected way for each row
     const buildRow = (row, ri) => {
       // comments ported directly from ruby suite:
@@ -133,7 +133,6 @@ export default class Data {
     };
 
     table.hashes().forEach((row, ri) => buildRow(row, ri));
-    callback();
   }
 
   // Converts table grid coordinates to longitude/latitude
@@ -303,42 +302,24 @@ export default class Data {
   // This is called on every "When I X I should Y"
   // On the first call in every scenario it should load the data
   // into osrm-routed or osrm-datastore
-  async reprocessAndLoadData(callback) {
+  async reprocessAndLoadData() {
     if (!this.dataLoaded) {
       this.writeOSM();
       this.runExtractionChain();
       await env.osrmLoader.before(this);
       this.dataLoaded = true;
     }
-    callback();
   }
 
-  async processRowsAndDiff(table, fn, callback) {
-    try {
-      const actual = [];
-      for (const [i, row] of table.hashes().entries()) {
-        const result = await new Promise((resolve, reject) => {
-          fn(row, i, (err, res) => {
-            if (err) reject(err);
-            else resolve(res);
-          });
-        });
-        actual.push(result);
-      }
-      const diff = tableDiff(table, actual);
-      if (diff) {
-        if (env.PLATFORM_CI) {
-          // the github report displays ANSI escapes as characters if passed to the
-          // error callback.
-          callback(stripAnsi(diff));
-        } else {
-          callback(diff);
-        }
-      } else {
-        callback();
-      }
-    } catch (err) {
-      callback(err);
+  async processRowsAndDiff(table, fn) {
+    const actual = [];
+    for (const [i, row] of table.hashes().entries()) {
+      const result = await fn(row, i);
+      actual.push(result);
+    }
+    const diff = tableDiff(table, actual);
+    if (diff) {
+      throw new Error(env.PLATFORM_CI ? stripAnsi(diff) : diff);
     }
   }
 }

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -26,16 +26,16 @@ export default class SharedSteps {
     assert.equal(typeof this.json.status, 'number');
   }
 
-  WhenIRouteIShouldGet(table, callback) {
-    this.reprocessAndLoadData((e) => {
-      if (e) return callback(e);
-      const headers = new Set(table.raw()[0]);
+  async WhenIRouteIShouldGet(table) {
+    await this.reprocessAndLoadData();
+    const headers = new Set(table.raw()[0]);
 
-      const requestRow = (row, ri, cb) => {
+    const requestRow = (row, ri) => {
+      return new Promise((resolve, reject) => {
         let got;
 
         const afterRequest = (err, res, body) => {
-          if (err) return cb(err);
+          if (err) return reject(err);
           if (body && body.length) {
             let destinations,
               exits,
@@ -130,7 +130,7 @@ export default class SharedSteps {
             if (headers.has('distance')) {
               if (row.distance.length) {
                 if (!row.distance.match(/\d+m/))
-                  return cb(
+                  return reject(
                     new Error(
                       '*** Distance must be specified in meters. (ex: 250m)',
                     ),
@@ -144,7 +144,7 @@ export default class SharedSteps {
             if (headers.has('weight')) {
               if (row.weight.length) {
                 if (!row.weight.match(/[\d.]+/))
-                  return cb(
+                  return reject(
                     new Error(
                       '*** Weight must be specified as a numeric value. (ex: 8)',
                     ),
@@ -157,7 +157,7 @@ export default class SharedSteps {
 
             if (headers.has('time')) {
               if (!row.time.match(/\d+s/))
-                return cb(
+                return reject(
                   new Error('*** Time must be specied in seconds. (ex: 60s)'),
                 );
               got.time = instructions ? util.format('%ds', time) : '';
@@ -170,7 +170,7 @@ export default class SharedSteps {
             if (headers.has('speed')) {
               if (row.speed !== '' && instructions) {
                 if (!row.speed.match(/\d+ km\/h/))
-                  cb(
+                  return reject(
                     new Error(
                       '*** Speed must be specied in km/h. (ex: 50 km/h)',
                     ),
@@ -216,21 +216,21 @@ export default class SharedSteps {
               if (k.match(/^a:/)) {
                 const a_type = k.slice(2);
                 if (whitelist.indexOf(a_type) == -1)
-                  return cb(new Error('Unrecognized annotation field', a_type));
+                  return reject(new Error('Unrecognized annotation field', a_type));
                 if (annotation && !annotation[a_type])
-                  return cb(
+                  return reject(
                     new Error('Annotation not found in response', a_type),
                   );
                 got[k] = (annotation && annotation[a_type]) || '';
               } else if (k.match(/^am:/)) {
                 const a_type = k.slice(3);
                 if (metadata_whitelist.indexOf(a_type) == -1)
-                  return cb(new Error('Unrecognized annotation field', a_type));
+                  return reject(new Error('Unrecognized annotation field', a_type));
                 if (
                   annotation &&
                   (!annotation.metadata || !annotation.metadata[a_type])
                 )
-                  return cb(
+                  return reject(
                     new Error('Annotation not found in response', a_type),
                   );
                 got[k] =
@@ -269,9 +269,9 @@ export default class SharedSteps {
                 got[key] = row[key];
               }
             }
-            cb(null, got);
+            resolve(got);
           } else {
-            cb(new Error('request failed to return valid body'));
+            reject(new Error('request failed to return valid body'));
           }
         };
 
@@ -312,14 +312,14 @@ export default class SharedSteps {
           if (row.from && row.to) {
             const fromNode = this.findNodeByName(row.from);
             if (!fromNode)
-              return cb(
+              return reject(
                 new Error(util.format('*** unknown from-node "%s"', row.from)),
               );
             waypoints.push(fromNode);
 
             const toNode = this.findNodeByName(row.to);
             if (!toNode)
-              return cb(
+              return reject(
                 new Error(util.format('*** unknown to-node "%s"', row.to)),
               );
             waypoints.push(toNode);
@@ -337,7 +337,7 @@ export default class SharedSteps {
             row.waypoints.split(',').forEach((n) => {
               const node = this.findNodeByName(n.trim());
               if (!node)
-                return cb(
+                return reject(
                   new Error(
                     util.format('*** unknown waypoint node "%s"', n.trim()),
                   ),
@@ -353,12 +353,12 @@ export default class SharedSteps {
               afterRequest,
             );
           } else {
-            return cb(new Error('*** no waypoints'));
+            return reject(new Error('*** no waypoints'));
           }
         }
-      };
+      });
+    };
 
-      this.processRowsAndDiff(table, requestRow, callback);
-    });
+    await this.processRowsAndDiff(table, requestRow);
   }
 }

--- a/features/support/shared_steps.js
+++ b/features/support/shared_steps.js
@@ -30,7 +30,7 @@ export default class SharedSteps {
     await this.reprocessAndLoadData();
     const headers = new Set(table.raw()[0]);
 
-    const requestRow = (row, ri) => {
+    const requestRow = (row, _ri) => {
       return new Promise((resolve, reject) => {
         let got;
 
@@ -158,7 +158,7 @@ export default class SharedSteps {
             if (headers.has('time')) {
               if (!row.time.match(/\d+s/))
                 return reject(
-                  new Error('*** Time must be specied in seconds. (ex: 60s)'),
+                  new Error('*** Time must be specified in seconds. (ex: 60s)'),
                 );
               got.time = instructions ? util.format('%ds', time) : '';
             }
@@ -172,7 +172,7 @@ export default class SharedSteps {
                 if (!row.speed.match(/\d+ km\/h/))
                   return reject(
                     new Error(
-                      '*** Speed must be specied in km/h. (ex: 50 km/h)',
+                      '*** Speed must be specified in km/h. (ex: 50 km/h)',
                     ),
                   );
                 const speed =
@@ -216,22 +216,22 @@ export default class SharedSteps {
               if (k.match(/^a:/)) {
                 const a_type = k.slice(2);
                 if (whitelist.indexOf(a_type) == -1)
-                  return reject(new Error('Unrecognized annotation field', a_type));
+                  return reject(new Error(`Unrecognized annotation field: ${a_type}`));
                 if (annotation && !annotation[a_type])
                   return reject(
-                    new Error('Annotation not found in response', a_type),
+                    new Error(`Annotation not found in response: ${a_type}`),
                   );
                 got[k] = (annotation && annotation[a_type]) || '';
               } else if (k.match(/^am:/)) {
                 const a_type = k.slice(3);
                 if (metadata_whitelist.indexOf(a_type) == -1)
-                  return reject(new Error('Unrecognized annotation field', a_type));
+                  return reject(new Error(`Unrecognized annotation field: ${a_type}`));
                 if (
                   annotation &&
                   (!annotation.metadata || !annotation.metadata[a_type])
                 )
                   return reject(
-                    new Error('Annotation not found in response', a_type),
+                    new Error(`Annotation not found in response: ${a_type}`),
                   );
                 got[k] =
                   (annotation &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "command-line-args": "6.0.1",
         "command-line-usage": "7.0.3",
         "csv-stringify": "^6.6.0",
-        "d3-queue": "3.0.7",
         "eslint": "^10.0.0",
         "express": "^5.2.1",
         "faucet": "^0.0.4",
@@ -44,7 +43,7 @@
         "xmlbuilder": "15.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -6224,23 +6223,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/algoliasearch": {
       "version": "5.48.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.48.1.tgz",
@@ -6700,16 +6682,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7525,13 +7507,6 @@
         "d3-array": "1"
       }
     },
-    "node_modules/d3-queue": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-      "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
@@ -8270,6 +8245,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
@@ -8409,29 +8408,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/faucet": {
       "version": "0.0.4",
@@ -9995,13 +9984,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11223,9 +11205,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -11423,6 +11405,16 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -11996,16 +11988,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13626,6 +13608,16 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -14128,9 +14120,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "command-line-args": "6.0.1",
     "command-line-usage": "7.0.3",
     "csv-stringify": "^6.6.0",
-    "d3-queue": "3.0.7",
     "eslint": "^10.0.0",
     "express": "^5.2.1",
     "faucet": "^0.0.4",
@@ -83,6 +82,9 @@
   },
   "overrides": {
     "esbuild": "0.27.2",
+    "eslint": {
+      "ajv": "^6"
+    },
     "glob": "^13.0.0",
     "ajv": ">=6.14.0",
     "minimatch": ">=10.2.1",


### PR DESCRIPTION
Removes `d3-queue` dependency and replaces all usages with native `async`/`await` and `Promise`-based patterns. Follow-up to review feedback requiring fully promise-based APIs with no callback mixing.

## Core changes

- **`features/support/data.js`**: `processRowsAndDiff`, `reprocessAndLoadData`, and `buildWaysFromTable` drop their `callback` parameters entirely — errors throw, callers `await`
- **`features/step_definitions/routability.js`**: `testRoutabilityRow` returns a `Promise` instead of calling `cb`; `testRow` is now `async`; step function is `async`
- **All call sites** (`matching.js`, `nearest.js`, `trip.js`, `distance_matrix.js`, `shared_steps.js`, `routing.js`, `requests.js`): step functions converted to `async`, inner `testRow`/`requestRow` functions wrap callback-based HTTP APIs in `new Promise()` and return results directly

## Before / After

```js
// Before: mixed async+callback
async processRowsAndDiff(table, fn, callback) {
  try { /* ... */ callback(); }
  catch (err) { callback(err); }
}
this.processRowsAndDiff(table, testRow, callback); // caller ignores returned Promise

// After: pure async
async processRowsAndDiff(table, fn) {
  for (const [i, row] of table.hashes().entries()) {
    actual.push(await fn(row, i)); // fn returns a Promise
  }
  if (diff) throw new Error(diff);
}
await this.processRowsAndDiff(table, testRow);
```