### PR TITLE
Fix microtar tar header size field on MinGW Windows

### DIFF
--- a/third_party/microtar/src/microtar.c
+++ b/third_party/microtar/src/microtar.c
@@ -20,6 +20,7 @@
  * IN THE SOFTWARE.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -111,13 +112,12 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   strcpy(h->name, rh->name);
   strcpy(h->linkname, rh->linkname);
 
-  /* Load size field */
+  /* Load size field: use uint64_t with SCNo64 to be explicitly correct
+   * on all platforms, including Windows where long is 32-bit. */
   if ((rh->size[0] & 0x80) == 0) {
-#ifdef _MSC_VER
-      sscanf(rh->size, "%12llo", &h->size);
-#else
-      sscanf(rh->size, "%12lo", &h->size);
-#endif
+      uint64_t tmp_size = 0;
+      sscanf(rh->size, "%12" SCNo64, &tmp_size);
+      h->size = (mtar_size_t)tmp_size;
   } else {
       h->size = (rh->size[0] & 0x7f) | (rh->size[0] & 0x40 ? 0x80 : 0);
       uint8_t *p8 = (uint8_t *)&rh->size + 1;
@@ -140,13 +140,11 @@ static int header_to_raw(mtar_raw_header_t *rh, const mtar_header_t *h) {
   /* Load header into raw header */
   memset(rh, 0, sizeof(*rh));
 
-  /* Store size in ASCII octal digits or base-256 formats */
+  /* Store size in ASCII octal digits or base-256 formats.
+   * Use uint64_t with PRIo64 to be explicitly correct on all platforms,
+   * including Windows where long is 32-bit. */
   if (sizeof(mtar_size_t) <= 4 || filesize <= (mtar_size_t)077777777777LL) {
-#ifdef _MSC_VER
-      sprintf(rh->size, "%llo", h->size);
-#else
-      sprintf(rh->size, "%lo", h->size);
-#endif
+      sprintf(rh->size, "%" PRIo64, (uint64_t)h->size);
   } else if (sizeof(filesize) < sizeof(rh->size)) {
       /* GNU tar uses "base-256 encoding" for very large numbers.
        * Encoding is binary, with highest bit always set as a marker


### PR DESCRIPTION
On Windows (LLP64), `long` is 32-bit even on x86_64. The `_MSC_VER` guard in microtar correctly used `%llo` for MSVC but fell through to `%lo` for MinGW, causing the bug in the Julia binary of OSRM.

Replace the platform-specific `_MSC_VER` ifdef with portable `uint64_t` and `<inttypes.h>` format macros (`SCNo64`/`PRIo64`), which are correct on all platforms and compilers.

With this fix, we get the tests in the Julia wrapper passing. See [OpenSourceRoutingMachine.jl](https://github.com/moviro-hub/OpenSourceRoutingMachine.jl/pull/19) and the build [recipe](https://github.com/JuliaPackaging/Yggdrasil/pull/13479), which contains the patch currently.

PS: It would be great if we could get a new point release we could refer to downstream once this is merged.




