### PR TITLE
feat: implement automated monthly releases with YY-MM-patchlevel versioning

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -4,9 +4,7 @@ on:
     branches:
       - master
     tags:
-      - v[1-9]+.[0-9]+.[0-9]+
-      - v[1-9]+.[0-9]+.[0-9]+-[a-zA-Z]+.[0-9]+
-      - v[1-9]+.[0-9]+-[0-9a-zA-Z]+
+      - v*
   pull_request:
     branches:
       - master

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version_override:
-        description: 'Override version (YYYY-MM-patchlevel format, e.g., 2026-04-0). Leave empty to auto-calculate.'
+        description: 'Override version (semver format, e.g., 26.4.0). Leave empty to auto-calculate.'
         required: false
         type: string
       branch:
@@ -40,9 +40,9 @@ jobs:
       - name: Validate inputs
         run: |
           if [ -n "${{ inputs.version_override }}" ]; then
-            # Validate version_override matches YYYY-MM-patchlevel format
-            if ! echo "${{ inputs.version_override }}" | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]+$' > /dev/null; then
-              echo "Error: version_override must be in YYYY-MM-patchlevel format (e.g., 2026-04-0)"
+            # Validate version_override matches semver format
+            if ! echo "${{ inputs.version_override }}" | grep -E '^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]+$' > /dev/null; then
+              echo "Error: version_override must be in semver format (e.g., 26.4.0)"
               exit 1
             fi
           fi
@@ -60,22 +60,24 @@ jobs:
           if [ -n "${{ inputs.version_override }}" ]; then
             VERSION="${{ inputs.version_override }}"
           else
-            # Calculate YYYY-MM-patchlevel automatically
+            # Calculate semver version automatically
+            # Use (YYYY-2000).MM.patchlevel format
             YEAR=$(date -u +%Y)
             MONTH=$(date -u +%m)
+            YEAR_OFFSET=$((YEAR - 2000))
             
             # Find highest patchlevel for this month
-            LATEST_TAG=$(git tag -l "v${YEAR}-${MONTH}-*" --sort=-version:refname | head -1)
+            LATEST_TAG=$(git tag -l "v${YEAR_OFFSET}.${MONTH}.*" --sort=-version:refname | head -1)
             
             if [ -z "$LATEST_TAG" ]; then
               PATCHLEVEL=0
             else
-              # Extract patchlevel from tag (e.g., v2026-04-5 -> 5)
-              PATCHLEVEL=${LATEST_TAG##*-}
+              # Extract patchlevel from tag (e.g., v26.4.5 -> 5)
+              PATCHLEVEL=${LATEST_TAG##*.}
               PATCHLEVEL=$((PATCHLEVEL + 1))
             fi
             
-            VERSION="${YEAR}-${MONTH}-${PATCHLEVEL}"
+            VERSION="${YEAR_OFFSET}.${MONTH}.${PATCHLEVEL}"
           fi
           
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -90,17 +92,10 @@ jobs:
             const pkg = require('./package.json');
             const oldVersion = pkg.version;
             
-            // Convert YYYY-MM-patchlevel to semver-compatible format (YYYY-2000).MM.patchlevel
-            // This allows npm/node-pre-gyp to parse the version correctly
-            const parts = process.env.VERSION.split('-');
-            const year = parseInt(parts[0]) - 2000;
-            const month = parseInt(parts[1]);
-            const patch = parts[2];
-            const semverVersion = year + '.' + month + '.' + patch;
-            
-            pkg.version = semverVersion;
+            // Update package.json with the new semver version
+            pkg.version = process.env.VERSION;
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
-            console.log('Updated version from ' + oldVersion + ' to ' + semverVersion + ' (from ' + process.env.VERSION + ')');
+            console.log('Updated version from ' + oldVersion + ' to ' + process.env.VERSION);
           "
 
       - name: Check for changes

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -141,27 +141,56 @@ jobs:
           generateReleaseNotes: true
 
       - name: Wait for CI to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Wait for tag CI to complete before publishing npm package
-          # The CI workflow is triggered by the tag push and must complete
-          # to upload release assets (prebuilt binaries)
-          echo "Waiting for CI workflow to complete..."
-          
-          # Poll workflow runs for this tag
+          # The osrm-backend.yml workflow is triggered by the tag push
+          # and uploads prebuilt binaries to the release assets
           TAG="${{ steps.version.outputs.tag }}"
+          TAG_SHA="$(git rev-list -n 1 "$TAG")"
+          
+          echo "Waiting for CI workflow to complete for tag $TAG (commit $TAG_SHA)"
+          
           MAX_WAIT=300  # 5 minutes
           ELAPSED=0
           POLL_INTERVAL=10
           
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            RUNS=$(gh run list --workflow=osrm-backend.yml --status=completed --json conclusion,status,name 2>/dev/null | jq -r ". | length")
-            if [ "$RUNS" != "0" ]; then
-              echo "CI workflow completed, proceeding with npm publish"
-              break
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            # Query runs for the osrm-backend.yml workflow for this tag's commit
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
+            
+            # Find run matching this tag's commit SHA
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+            
+            if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
+              STATUS="$(echo "$MATCHING_RUN" | jq -r '.status')"
+              CONCLUSION="$(echo "$MATCHING_RUN" | jq -r '.conclusion // empty')"
+              RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
+              
+              echo "Found matching CI run $RUN_ID: status=$STATUS conclusion=$CONCLUSION"
+              
+              if [ "$STATUS" = "completed" ]; then
+                if [ "$CONCLUSION" = "success" ]; then
+                  echo "✓ CI workflow completed successfully, proceeding with npm publish"
+                  exit 0
+                else
+                  echo "✗ CI workflow completed with conclusion=$CONCLUSION (expected success)"
+                  exit 1
+                fi
+              else
+                echo "CI workflow still running (status=$STATUS), waiting..."
+              fi
+            else
+              echo "No matching CI run found yet, waiting for workflow to start..."
             fi
-            sleep $POLL_INTERVAL
+            
+            sleep "$POLL_INTERVAL"
             ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
+          
+          echo "✗ Timed out waiting for CI workflow to complete for tag $TAG"
+          exit 1
 
       - name: Publish to npm
         env:

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -40,9 +40,10 @@ jobs:
       - name: Validate inputs
         run: |
           if [ -n "${{ inputs.version_override }}" ]; then
-            # Validate version_override matches semver format
-            if ! echo "${{ inputs.version_override }}" | grep -E '^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]+$' > /dev/null; then
-              echo "Error: version_override must be in semver format (e.g., 26.4.0)"
+            # Validate version_override matches semver format (YYYY-2000).M.patchlevel
+            # Month must be 1-12, no leading zeros except single digit 0 for patchlevel
+            if ! echo "${{ inputs.version_override }}" | grep -E '^(0|[1-9][0-9]?)\.(1[0-2]|[1-9])\.(0|[1-9][0-9]*)$' > /dev/null; then
+              echo "Error: version_override must be in format (YYYY-2000).M.patchlevel with month 1-12 and no leading zeros (e.g., 26.4.0)"
               exit 1
             fi
           fi
@@ -61,9 +62,9 @@ jobs:
             VERSION="${{ inputs.version_override }}"
           else
             # Calculate semver version automatically
-            # Use (YYYY-2000).MM.patchlevel format
+            # Use (YYYY-2000).M.patchlevel format (no leading zeros for month/patch)
             YEAR=$(date -u +%Y)
-            MONTH=$(date -u +%m)
+            MONTH=$(date -u +%-m)
             YEAR_OFFSET=$((YEAR - 2000))
             
             # Find highest patchlevel for this month
@@ -83,29 +84,32 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Update package.json
+      - name: Update package.json and package-lock.json
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           node -e "
             const fs = require('fs');
             const pkg = require('./package.json');
+            const lock = require('./package-lock.json');
             const oldVersion = pkg.version;
             
-            // Update package.json with the new semver version
+            // Update both package.json and package-lock.json
             pkg.version = process.env.VERSION;
+            lock.version = process.env.VERSION;
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+            fs.writeFileSync('./package-lock.json', JSON.stringify(lock, null, 2) + '\n');
             console.log('Updated version from ' + oldVersion + ' to ' + process.env.VERSION);
           "
 
       - name: Check for changes
         id: check_changes
         run: |
-          if git diff --quiet package.json; then
-            echo "No changes to package.json (version unchanged)"
+          if git diff --quiet package.json package-lock.json; then
+            echo "No changes to package files (version unchanged)"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "Changes detected in package.json"
+            echo "Changes detected in package files"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
@@ -114,7 +118,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
+          git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
 
       - name: Create git tag

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -1,0 +1,171 @@
+name: Monthly Release
+
+on:
+  schedule:
+    # 1st of each month at 08:00 UTC
+    - cron: '0 8 1 * *'
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: 'Override version (YYYY-MM-patchlevel format, e.g., 2026-04-0). Leave empty to auto-calculate.'
+        required: false
+        type: string
+      branch:
+        description: 'Branch to release from (defaults to master)'
+        required: false
+        type: string
+        default: 'master'
+
+concurrency:
+  group: release-monthly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || 'master' }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Validate inputs
+        run: |
+          if [ -n "${{ inputs.version_override }}" ]; then
+            # Validate version_override matches YYYY-MM-patchlevel format
+            if ! echo "${{ inputs.version_override }}" | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]+$' > /dev/null; then
+              echo "Error: version_override must be in YYYY-MM-patchlevel format (e.g., 2026-04-0)"
+              exit 1
+            fi
+          fi
+          
+          # Validate branch input (prevent shell injection)
+          BRANCH="${{ inputs.branch || 'master' }}"
+          if ! echo "$BRANCH" | grep -E '^[a-zA-Z0-9._/-]+$' > /dev/null; then
+            echo "Error: branch name contains invalid characters"
+            exit 1
+          fi
+
+      - name: Calculate version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version_override }}" ]; then
+            VERSION="${{ inputs.version_override }}"
+          else
+            # Calculate YYYY-MM-patchlevel automatically
+            YEAR=$(date -u +%Y)
+            MONTH=$(date -u +%m)
+            
+            # Find highest patchlevel for this month
+            LATEST_TAG=$(git tag -l "v${YEAR}-${MONTH}-*" --sort=-version:refname | head -1)
+            
+            if [ -z "$LATEST_TAG" ]; then
+              PATCHLEVEL=0
+            else
+              # Extract patchlevel from tag (e.g., v2026-04-5 -> 5)
+              PATCHLEVEL=${LATEST_TAG##*-}
+              PATCHLEVEL=$((PATCHLEVEL + 1))
+            fi
+            
+            VERSION="${YEAR}-${MONTH}-${PATCHLEVEL}"
+          fi
+          
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update package.json
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = require('./package.json');
+            const oldVersion = pkg.version;
+            
+            // Convert YYYY-MM-patchlevel to semver-compatible format (YYYY-2000).MM.patchlevel
+            // This allows npm/node-pre-gyp to parse the version correctly
+            const parts = process.env.VERSION.split('-');
+            const year = parseInt(parts[0]) - 2000;
+            const month = parseInt(parts[1]);
+            const patch = parts[2];
+            const semverVersion = year + '.' + month + '.' + patch;
+            
+            pkg.version = semverVersion;
+            fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+            console.log('Updated version from ' + oldVersion + ' to ' + semverVersion + ' (from ' + process.env.VERSION + ')');
+          "
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet package.json; then
+            echo "No changes to package.json (version unchanged)"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in package.json"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit version update
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+
+      - name: Create git tag
+        run: |
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
+
+      - name: Push changes and tag
+        run: |
+          BRANCH="${{ inputs.branch || 'master' }}"
+          git push origin "$BRANCH"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: false
+          generateReleaseNotes: true
+
+      - name: Wait for CI to complete
+        run: |
+          # Wait for tag CI to complete before publishing npm package
+          # The CI workflow is triggered by the tag push and must complete
+          # to upload release assets (prebuilt binaries)
+          echo "Waiting for CI workflow to complete..."
+          
+          # Poll workflow runs for this tag
+          TAG="${{ steps.version.outputs.tag }}"
+          MAX_WAIT=300  # 5 minutes
+          ELAPSED=0
+          POLL_INTERVAL=10
+          
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            RUNS=$(gh run list --workflow=osrm-backend.yml --status=completed --json conclusion,status,name 2>/dev/null | jq -r ". | length")
+            if [ "$RUNS" != "0" ]; then
+              echo "CI workflow completed, proceeding with npm publish"
+              break
+            fi
+            sleep $POLL_INTERVAL
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ sbeParseJson(packagejson packagejsonraw)
 # The CMake build system also supports legacy semver (e.g., 6.0.0) for backward compatibility
 
 # Try semver format: (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
-if (packagejson.version MATCHES "^([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]+)$")
+if (packagejson.version MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
   # Semver format: (YYYY-2000).MM.patchlevel
   # MAJOR is already offset (year - 2000)
   set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,17 +95,42 @@ include(JSONParser)
 file(READ "package.json" packagejsonraw)
 sbeParseJson(packagejson packagejsonraw)
 
-# This regex is not strict enough, but the correct one is too complicated for cmake matching.
-# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-if (packagejson.version MATCHES "^([0-9]+)\.([0-9]+)\.([0-9]+)([-+][0-9a-zA-Z.-]+)?$")
+# This regex supports multiple version formats:
+# - YYYY-MM-patchlevel: Git tag format (e.g., v2026-04-0)
+# - Semver-offset: npm package format (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
+#   This allows npm/node-pre-gyp to parse versions correctly
+# - Legacy Semver: major.minor.patch (e.g., 6.0.0)
+
+# Try YYYY-MM-patchlevel format (validated month 01-12)
+if (packagejson.version MATCHES "^([0-9]{4})-(0[1-9]|1[0-2])-([0-9]+)$")
+  # YYYY-MM-patchlevel format (git tag format)
+  # Map year to uint8_t range: use (year - 2000) as major version
+  set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
+  math(EXPR OSRM_VERSION_MAJOR "${OSRM_VERSION_MAJOR} - 2000")
+  set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
+  set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
+  set(OSRM_VERSION_PRERELEASE_BUILD "")
+  set(OSRM_VERSION packagejson.version)
+# Try semver-offset format (YYYY-2000).MM.patchlevel (npm package format)
+elseif (packagejson.version MATCHES "^([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]+)$")
+  # Semver-offset format: (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
+  # This is the format used in package.json for npm compatibility
+  # MAJOR is already offset (year - 2000)
+  set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
+  set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
+  set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
+  set(OSRM_VERSION_PRERELEASE_BUILD "")
+  set(OSRM_VERSION packagejson.version)
+# Try legacy semver format (major.minor.patch)
+elseif (packagejson.version MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)([-+][0-9a-zA-Z.-]+)?$")
+  # Legacy semver format (e.g., 6.0.0)
   set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
   set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
   set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
   set(OSRM_VERSION_PRERELEASE_BUILD ${CMAKE_MATCH_4})
-
   set(OSRM_VERSION packagejson.version)
 else()
-  message(FATAL_ERROR "Version from package.json cannot be parsed, expected semver compatible label, but found ${packagejson.version}")
+  message(FATAL_ERROR "Version from package.json cannot be parsed. Expected one of:\n  - YYYY-MM-patchlevel format (git tags, e.g., 2026-04-0)\n  - Semver-offset format (npm, e.g., 26.4.0 where 26=year-2000)\n  - Legacy semver format (e.g., 6.0.0)\nBut found: ${packagejson.version}")
 endif()
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,22 +95,30 @@ include(JSONParser)
 file(READ "package.json" packagejsonraw)
 sbeParseJson(packagejson packagejsonraw)
 
-# This regex supports the unified semver version format:
-# - (YYYY-2000).MM.patchlevel: e.g., 26.4.0 where 26 = year - 2000, 4 = April
-# This format is used for both git tags and npm packages, eliminating format mismatch
-# The CMake build system also supports legacy semver (e.g., 6.0.0) for backward compatibility
+# This regex supports multiple semver version formats:
+# - (YYYY-2000).M.patchlevel: Monthly releases, e.g., 26.4.0 (April 2026)
+#   MAJOR is the year offset (year - 2000)
+# - Legacy semver: traditional major.minor.patch with optional prerelease, e.g., 6.0.0, 6.0.0-rc1
 
-# Try semver format: (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
-if (packagejson.version MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-  # Semver format: (YYYY-2000).MM.patchlevel
+# Try monthly release format: (YYYY-2000).M.patchlevel with month 1-12, no leading zeros
+if (packagejson.version MATCHES "^([0-9]+)\\.(1[0-2]|[1-9])\\.(0|[1-9][0-9]*)$")
+  # Monthly format: (YYYY-2000).M.patchlevel
   # MAJOR is already offset (year - 2000)
   set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
   set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
   set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
   set(OSRM_VERSION_PRERELEASE_BUILD "")
-  set(OSRM_VERSION packagejson.version)
+  set(OSRM_VERSION "${packagejson.version}")
+# Try legacy semver format (major.minor.patch with optional prerelease/build)
+elseif (packagejson.version MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)([-+][0-9a-zA-Z.-]+)?$")
+  # Legacy semver format: major.minor.patch[-+prerelease]
+  set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
+  set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
+  set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
+  set(OSRM_VERSION_PRERELEASE_BUILD ${CMAKE_MATCH_4})
+  set(OSRM_VERSION "${packagejson.version}")
 else()
-  message(FATAL_ERROR "Version from package.json cannot be parsed. Expected semver format:\n  - (YYYY-2000).MM.patchlevel (e.g., 26.4.0 where 26=year-2000)\n  - Legacy semver (e.g., 6.0.0)\nBut found: ${packagejson.version}")
+  message(FATAL_ERROR "Version from package.json cannot be parsed. Expected one of:\n  - Monthly release format: (YYYY-2000).M.patchlevel with month 1-12, no leading zeros (e.g., 26.4.0)\n  - Legacy semver format: major.minor.patch with optional prerelease (e.g., 6.0.0 or 6.0.0-rc1)\nBut found: ${packagejson.version}")
 endif()
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,42 +95,22 @@ include(JSONParser)
 file(READ "package.json" packagejsonraw)
 sbeParseJson(packagejson packagejsonraw)
 
-# This regex supports multiple version formats:
-# - YYYY-MM-patchlevel: Git tag format (e.g., v2026-04-0)
-# - Semver-offset: npm package format (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
-#   This allows npm/node-pre-gyp to parse versions correctly
-# - Legacy Semver: major.minor.patch (e.g., 6.0.0)
+# This regex supports the unified semver version format:
+# - (YYYY-2000).MM.patchlevel: e.g., 26.4.0 where 26 = year - 2000, 4 = April
+# This format is used for both git tags and npm packages, eliminating format mismatch
+# The CMake build system also supports legacy semver (e.g., 6.0.0) for backward compatibility
 
-# Try YYYY-MM-patchlevel format (validated month 01-12)
-if (packagejson.version MATCHES "^([0-9]{4})-(0[1-9]|1[0-2])-([0-9]+)$")
-  # YYYY-MM-patchlevel format (git tag format)
-  # Map year to uint8_t range: use (year - 2000) as major version
-  set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
-  math(EXPR OSRM_VERSION_MAJOR "${OSRM_VERSION_MAJOR} - 2000")
-  set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
-  set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
-  set(OSRM_VERSION_PRERELEASE_BUILD "")
-  set(OSRM_VERSION packagejson.version)
-# Try semver-offset format (YYYY-2000).MM.patchlevel (npm package format)
-elseif (packagejson.version MATCHES "^([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]+)$")
-  # Semver-offset format: (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
-  # This is the format used in package.json for npm compatibility
+# Try semver format: (YYYY-2000).MM.patchlevel (e.g., 26.4.0)
+if (packagejson.version MATCHES "^([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]+)$")
+  # Semver format: (YYYY-2000).MM.patchlevel
   # MAJOR is already offset (year - 2000)
   set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
   set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
   set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
   set(OSRM_VERSION_PRERELEASE_BUILD "")
   set(OSRM_VERSION packagejson.version)
-# Try legacy semver format (major.minor.patch)
-elseif (packagejson.version MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)([-+][0-9a-zA-Z.-]+)?$")
-  # Legacy semver format (e.g., 6.0.0)
-  set(OSRM_VERSION_MAJOR            ${CMAKE_MATCH_1})
-  set(OSRM_VERSION_MINOR            ${CMAKE_MATCH_2})
-  set(OSRM_VERSION_PATCH            ${CMAKE_MATCH_3})
-  set(OSRM_VERSION_PRERELEASE_BUILD ${CMAKE_MATCH_4})
-  set(OSRM_VERSION packagejson.version)
 else()
-  message(FATAL_ERROR "Version from package.json cannot be parsed. Expected one of:\n  - YYYY-MM-patchlevel format (git tags, e.g., 2026-04-0)\n  - Semver-offset format (npm, e.g., 26.4.0 where 26=year-2000)\n  - Legacy semver format (e.g., 6.0.0)\nBut found: ${packagejson.version}")
+  message(FATAL_ERROR "Version from package.json cannot be parsed. Expected semver format:\n  - (YYYY-2000).MM.patchlevel (e.g., 26.4.0 where 26=year-2000)\n  - Legacy semver (e.g., 6.0.0)\nBut found: ${packagejson.version}")
 endif()
 
 if (MSVC)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,10 @@
 # Releasing a new OSRM version
 
-We use a **unified semver versioning scheme** for all releases: `(YYYY-2000).MM.patchlevel`
-- **Format:** `X.MM.patchlevel` where X = year - 2000
+We use a **unified semver versioning scheme** for monthly releases: `(YYYY-2000).M.patchlevel`
+- **Format:** `X.M.patchlevel` where X = year - 2000, M = month (1-12, no leading zeros)
 - **Example:** `26.4.0` represents April 2026, first release
-- **Git tags and npm packages use the same format** (no format mismatch)
+- **Git tags:** Prefixed with `v` (e.g., `v26.4.0`)
+- **npm packages:** Unprefixed semver (e.g., `26.4.0`)
 
 ## Version History
 
@@ -15,23 +16,26 @@ We use a **unified semver versioning scheme** for all releases: `(YYYY-2000).MM.
 - First release: v26.1.0 (January 2026)
 - Automatic monthly releases on the 1st of each month at 08:00 UTC
 - Year offset: 2026 → 26, 2027 → 27, etc.
+- Month: 1-12 (no leading zeros), patch: 0-N per month
 
 ## Versioning Scheme
 
 ### Format
 
-**All releases (Git tags & npm):** `(YYYY-2000).MM.patchlevel` (e.g., `26.4.0`)
-- **YYYY-2000:** Year offset (26 = 2026, 27 = 2027, etc.)
-- **MM:** Month (01-12, zero-padded)
+**Git tags:** `vX.M.patchlevel` where X = year - 2000, M = 1-12
+- **X:** Year offset (26 = 2026, 27 = 2027, etc.)
+- **M:** Month (1-12, no leading zeros)
 - **patchlevel:** Incremental counter starting at 0 per month (0, 1, 2, ...)
+
+**npm packages:** `X.M.patchlevel` (same as git tag without the `v` prefix)
 
 ### Examples
 
-Git tags, GitHub releases, and npm versions are all identical:
-- April 2026, 1st release: `v26.4.0`
-- April 2026, 2nd release: `v26.4.1`
-- May 2026, 1st release: `v26.5.0`
-- January 2027, 1st release: `v27.1.0`
+Git tags and npm versions for the same release:
+- April 2026, 1st release: Git tag `v26.4.0`, npm `26.4.0`
+- April 2026, 2nd release: Git tag `v26.4.1`, npm `26.4.1`
+- May 2026, 1st release: Git tag `v26.5.0`, npm `26.5.0`
+- January 2027, 1st release: Git tag `v27.1.0`, npm `27.1.0`
 
 ## Release Compatibility Guarantees
 
@@ -64,11 +68,11 @@ Git tags, GitHub releases, and npm versions are all identical:
 Releases are created automatically every month on a scheduled basis:
 
 1. A GitHub Actions workflow runs on the 1st of each month at 08:00 UTC
-2. Version is calculated as `(YYYY-2000).MM.patchlevel`
-3. `package.json` version is updated
+2. Version is calculated as `(YYYY-2000).M.patchlevel` with M = 1-12 (no leading zeros)
+3. `package.json` and `package-lock.json` versions are updated
 4. A git tag is created and pushed (e.g., `v26.4.0`)
 5. A GitHub Release is published with auto-generated release notes
-6. The package is published to npm
+6. The package is published to npm (format: `26.4.0` without `v` prefix)
 
 ## Manual Release Trigger
 
@@ -77,7 +81,7 @@ You can also trigger a release manually on any branch:
 1. Go to **Actions** → **Monthly Release** workflow
 2. Click **Run workflow**
 3. Select your branch (defaults to `master`)
-4. Optionally override the version (format: semver `26.4.0`)
+4. Optionally override the version (format: `X.M.patchlevel` with M = 1-12, e.g., `26.4.0`)
 5. Click **Run workflow**
 
 This is useful for:
@@ -91,7 +95,7 @@ When releasing (automated or manual):
 
 1. ✅ All GitHub Actions CI checks pass
 2. ✅ The target branch is in a releasable state
-3. ✅ For manual releases: verify the version format is correct (semver `X.MM.patchlevel`)
+3. ✅ For manual releases: verify the version format is correct (`X.M.patchlevel` with month 1-12, e.g., `26.4.0`)
 4. ✅ The release is created automatically with:
    - Git tag
    - GitHub Release (with auto-generated release notes)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,31 +1,26 @@
 # Releasing a new OSRM version
 
-We use a **YYYY-MM-patchlevel** versioning scheme for all releases, with a dual-format approach:
-- **Git tags & releases:** YYYY-MM-patchlevel format (e.g., `v2026-04-0`, `v2026-04-1`)
-- **npm package:** Semver-compatible format (YYYY-2000).MM.patchlevel (e.g., `26.4.0`, `26.4.1`)
-
-This approach allows git tags to use human-readable year-month formatting while maintaining npm/node-pre-gyp compatibility.
+We use a **unified semver versioning scheme** for all releases: `(YYYY-2000).MM.patchlevel`
+- **Format:** `X.MM.patchlevel` where X = year - 2000
+- **Example:** `26.4.0` represents April 2026, first release
+- **Git tags and npm packages use the same format** (no format mismatch)
 
 ## Versioning Scheme
 
 ### Format
 
-**Git Tags:** `vYYYY-MM-patchlevel` (e.g., v2026-04-0)
-- **YYYY:** Current year (4 digits)
-- **MM:** Current month (01-12)
+**All releases (Git tags & npm):** `(YYYY-2000).MM.patchlevel` (e.g., `26.4.0`)
+- **YYYY-2000:** Year offset (26 = 2026, 27 = 2027, etc.)
+- **MM:** Month (01-12, zero-padded)
 - **patchlevel:** Incremental counter starting at 0 per month (0, 1, 2, ...)
-
-**npm Package:** `(YYYY-2000).MM.patchlevel` (e.g., 26.4.0)
-- **YYYY-2000:** Year offset (fits in uint8_t for fingerprinting)
-- **MM:** Month (01-12)
-- **patchlevel:** Counter (0, 1, 2, ...)
 
 ### Examples
 
-Git tags and npm versions:
-- April 2026, 1st release: tag `v2026-04-0`, npm `26.4.0`
-- April 2026, 2nd release: tag `v2026-04-1`, npm `26.4.1`
-- May 2026, 1st release: tag `v2026-05-0`, npm `26.5.0`
+Git tags, GitHub releases, and npm versions are all identical:
+- April 2026, 1st release: `v26.4.0`
+- April 2026, 2nd release: `v26.4.1`
+- May 2026, 1st release: `v26.5.0`
+- January 2027, 1st release: `v27.1.0`
 
 ## Release Compatibility Guarantees
 
@@ -58,9 +53,9 @@ Git tags and npm versions:
 Releases are created automatically every month on a scheduled basis:
 
 1. A GitHub Actions workflow runs on the 1st of each month at 08:00 UTC
-2. Version is calculated as `YYYY-MM-patchlevel`
+2. Version is calculated as `(YYYY-2000).MM.patchlevel`
 3. `package.json` version is updated
-4. A git tag is created and pushed (e.g., `v2026-04-0`)
+4. A git tag is created and pushed (e.g., `v26.4.0`)
 5. A GitHub Release is published with auto-generated release notes
 6. The package is published to npm
 
@@ -71,7 +66,7 @@ You can also trigger a release manually on any branch:
 1. Go to **Actions** → **Monthly Release** workflow
 2. Click **Run workflow**
 3. Select your branch (defaults to `master`)
-4. Optionally override the version (format: `YYYY-MM-patchlevel`)
+4. Optionally override the version (format: semver `26.4.0`)
 5. Click **Run workflow**
 
 This is useful for:
@@ -85,7 +80,7 @@ When releasing (automated or manual):
 
 1. ✅ All GitHub Actions CI checks pass
 2. ✅ The target branch is in a releasable state
-3. ✅ For manual releases: verify the version format is correct (`YYYY-MM-patchlevel`)
+3. ✅ For manual releases: verify the version format is correct (semver `X.MM.patchlevel`)
 4. ✅ The release is created automatically with:
    - Git tag
    - GitHub Release (with auto-generated release notes)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,6 +5,17 @@ We use a **unified semver versioning scheme** for all releases: `(YYYY-2000).MM.
 - **Example:** `26.4.0` represents April 2026, first release
 - **Git tags and npm packages use the same format** (no format mismatch)
 
+## Version History
+
+**Previous scheme (ended 2025):** Traditional semantic versioning (v6.0, v6.0.1, v6.0.2, etc.)
+- Last release: v6.0.0 in December 2025
+- Manual release process
+
+**New scheme (started 2026):** Monthly date-based versioning with automated releases
+- First release: v26.1.0 (January 2026)
+- Automatic monthly releases on the 1st of each month at 08:00 UTC
+- Year offset: 2026 → 26, 2027 → 27, etc.
+
 ## Versioning Scheme
 
 ### Format

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,26 +1,35 @@
 # Releasing a new OSRM version
 
-We are using http://semver.org/ for versioning with major, minor and patch versions.
+We use a **YYYY-MM-patchlevel** versioning scheme for all releases, with a dual-format approach:
+- **Git tags & releases:** YYYY-MM-patchlevel format (e.g., `v2026-04-0`, `v2026-04-1`)
+- **npm package:** Semver-compatible format (YYYY-2000).MM.patchlevel (e.g., `26.4.0`, `26.4.1`)
 
-## Guarantees
+This approach allows git tags to use human-readable year-month formatting while maintaining npm/node-pre-gyp compatibility.
 
-We are giving the following guarantees between versions:
+## Versioning Scheme
 
-### Major version change
+### Format
 
-- There are no guarantees about compatiblity of APIs or datasets
-- Breaking changes will be noted as `BREAKING` in the changelog
+**Git Tags:** `vYYYY-MM-patchlevel` (e.g., v2026-04-0)
+- **YYYY:** Current year (4 digits)
+- **MM:** Current month (01-12)
+- **patchlevel:** Incremental counter starting at 0 per month (0, 1, 2, ...)
 
-### Minor version change
+**npm Package:** `(YYYY-2000).MM.patchlevel` (e.g., 26.4.0)
+- **YYYY-2000:** Year offset (fits in uint8_t for fingerprinting)
+- **MM:** Month (01-12)
+- **patchlevel:** Counter (0, 1, 2, ...)
 
-We may introduce forward-compatible changes: query parameters and response properties may be added in responses, but existing properties may not be changed or removed. One exception to this is the addition of new turn types, which we see as forward-compatible changes.
+### Examples
 
-- Forward-compatible HTTP API
-- Forward-compatible C++ library API
-- Forward-compatible node-osrm API
-- No compatiblity between OSRM datasets (needs new processing)
+Git tags and npm versions:
+- April 2026, 1st release: tag `v2026-04-0`, npm `26.4.0`
+- April 2026, 2nd release: tag `v2026-04-1`, npm `26.4.1`
+- May 2026, 1st release: tag `v2026-05-0`, npm `26.5.0`
 
-### Patch version change
+## Release Compatibility Guarantees
+
+### Patch version change (new patchlevel in same month)
 
 - No change of query parameters or response formats
 - Compatible HTTP API
@@ -28,32 +37,69 @@ We may introduce forward-compatible changes: query parameters and response prope
 - Compatible node-osrm API
 - Compatible OSRM datasets
 
-## Release and branch management
+### Month change (new YYYY-MM)
 
-- The `master` branch is for the bleeding edge development
-- We create and maintain release branches `x.y` to control the release flow
-- We create the release branch once we create release branches once we want to release the first RC
-- RCs go in the release branch, commits needs to be cherry-picked from master
-- No minor or major version will be released without a code-equal release candidates
-- For quality assurance, release candidates need to be staged beforing tagging a final release
-- Patch versions may be released without a release candidate
-- We may backport fixes to older versions and release them as patch versions
+- May introduce forward-compatible changes: query parameters and response properties may be added in responses, but existing properties may not be changed or removed
+- Forward-compatible HTTP API
+- Forward-compatible C++ library API
+- Forward-compatible node-osrm API
+- No compatibility between OSRM datasets (needs new processing)
 
-## Releasing a version
+## Release Management
 
-1. Check out the appropriate release branch `x.y`
-2. Make sure `CHANGELOG.md` is up to date.
-3. Make sure the `package.json` on branch `x.y` has been committed.
-4. Make sure all tests are passing (e.g. Github Actions CI gives you a :heavy_check_mark:)
-5. Use an annotated tag to mark the release: `git tag vx.y.z -a` Body of the tag description should be the changelog entries. Commit should be one in which the `package.json` version matches the version you want to release.
-6. Use `npm run docs` to generate the API documentation.  Copy `build/docs/*` to `https://github.com/Project-OSRM/project-osrm.github.com` in the `docs/vN.N.N/api` directory
-7. Push tags and commits: `git push; git push --tags`
-8. On https://github.com/Project-OSRM/osrm-backend/releases press `Draft a new release`,
-   write the release tag `vx.y.z` in the `Tag version` field, write the changelog entries in the `Describe this release` field
-   and press `Publish release`. Note that Github Actions CI deployments will create a release when publishing node binaries, so the release
-   may already exist. In which case the description should be updated with the changelog entries.
-9. If not a release-candidate: Write a mailing-list post to osrm-talk@openstreetmap.org to announce the release
-10. Wait until the Github Actions build has been completed and check if the node binaries were published by doing:
-    `rm -rf node_modules && npm install` locally.
-11. For final releases run `npm publish` or `npm publish --tag next` for release candidates.
-12. Bump version in `package.json` to `{MAJOR}.{MINOR+1}.0-unreleased` on the `master` branch after the release.
+- The `master` branch is for development and should always be green
+- **Automated monthly releases** occur on the **1st of each month at 08:00 UTC**
+- All changes in master will be automatically released monthly
+- No release candidates are used; the master branch is the quality gate
+- Patch versions within the same month can be released manually at any time
+
+## Automated Release Process
+
+Releases are created automatically every month on a scheduled basis:
+
+1. A GitHub Actions workflow runs on the 1st of each month at 08:00 UTC
+2. Version is calculated as `YYYY-MM-patchlevel`
+3. `package.json` version is updated
+4. A git tag is created and pushed (e.g., `v2026-04-0`)
+5. A GitHub Release is published with auto-generated release notes
+6. The package is published to npm
+
+## Manual Release Trigger
+
+You can also trigger a release manually on any branch:
+
+1. Go to **Actions** → **Monthly Release** workflow
+2. Click **Run workflow**
+3. Select your branch (defaults to `master`)
+4. Optionally override the version (format: `YYYY-MM-patchlevel`)
+5. Click **Run workflow**
+
+This is useful for:
+- Out-of-schedule patch releases within the same month
+- Emergency releases from other branches
+- Backports to older versions
+
+## Release Checklist
+
+When releasing (automated or manual):
+
+1. ✅ All GitHub Actions CI checks pass
+2. ✅ The target branch is in a releasable state
+3. ✅ For manual releases: verify the version format is correct (`YYYY-MM-patchlevel`)
+4. ✅ The release is created automatically with:
+   - Git tag
+   - GitHub Release (with auto-generated release notes)
+   - npm publication
+
+## After Release
+
+No additional manual steps are required. The automated workflow handles:
+- Version bumping in `package.json`
+- Git commit and tag creation
+- GitHub Release publishing
+- npm package publication
+
+For non-automated releases, monitor:
+- GitHub Actions to verify the release completed successfully
+- npm registry to confirm the new version is published
+

--- a/include/util/version.hpp.in
+++ b/include/util/version.hpp.in
@@ -6,8 +6,22 @@
 #define OSRM_VERSION_PATCH               @OSRM_VERSION_PATCH@
 #define OSRM_VERSION_PRERELEASE_BUILD    "@OSRM_VERSION_PRERELEASE_BUILD@"
 
-#define OSRM_VERSION__(A,B,C,D) "v" #A "." #B "." #C D
-#define OSRM_VERSION_(A,B,C,D) OSRM_VERSION__(A,B,C,D)
-#define OSRM_VERSION OSRM_VERSION_(OSRM_VERSION_MAJOR, OSRM_VERSION_MINOR, OSRM_VERSION_PATCH, OSRM_VERSION_PRERELEASE_BUILD)
+// Detect version format at compile time (YYYY-MM-patchlevel vs semver)
+// YYYY-MM-patchlevel versions have MAJOR >= 2000-2255 in source, but mapped to 0-255 in CMake
+// Semver versions have MAJOR < 100
+// We detect this by checking the PRERELEASE_BUILD: it's empty for YYYY-MM-patchlevel
+#if !defined(OSRM_VERSION_PRERELEASE_BUILD) || OSRM_VERSION_PRERELEASE_BUILD[0] == '\0'
+  // YYYY-MM-patchlevel format: use hyphens to match tag format (vYYYY-MM-patchlevel)
+  // Reconstruct YYYY from offset: major + 2000
+  #define OSRM_VERSION_RECONSTRUCTED_MAJOR (OSRM_VERSION_MAJOR + 2000)
+  #define OSRM_VERSION__(Y,M,P,D) "v" #Y "-" #M "-" #P
+  #define OSRM_VERSION_(Y,M,P,D) OSRM_VERSION__(Y,M,P,D)
+  #define OSRM_VERSION OSRM_VERSION_(OSRM_VERSION_RECONSTRUCTED_MAJOR, OSRM_VERSION_MINOR, OSRM_VERSION_PATCH, "")
+#else
+  // Semver format: use dots (vMAJOR.MINOR.PATCH)
+  #define OSRM_VERSION__(A,B,C,D) "v" #A "." #B "." #C D
+  #define OSRM_VERSION_(A,B,C,D) OSRM_VERSION__(A,B,C,D)
+  #define OSRM_VERSION OSRM_VERSION_(OSRM_VERSION_MAJOR, OSRM_VERSION_MINOR, OSRM_VERSION_PATCH, OSRM_VERSION_PRERELEASE_BUILD)
+#endif
 
 #endif // VERSION_HPP

--- a/include/util/version.hpp.in
+++ b/include/util/version.hpp.in
@@ -6,22 +6,11 @@
 #define OSRM_VERSION_PATCH               @OSRM_VERSION_PATCH@
 #define OSRM_VERSION_PRERELEASE_BUILD    "@OSRM_VERSION_PRERELEASE_BUILD@"
 
-// Detect version format at compile time (YYYY-MM-patchlevel vs semver)
-// YYYY-MM-patchlevel versions have MAJOR >= 2000-2255 in source, but mapped to 0-255 in CMake
-// Semver versions have MAJOR < 100
-// We detect this by checking the PRERELEASE_BUILD: it's empty for YYYY-MM-patchlevel
-#if !defined(OSRM_VERSION_PRERELEASE_BUILD) || OSRM_VERSION_PRERELEASE_BUILD[0] == '\0'
-  // YYYY-MM-patchlevel format: use hyphens to match tag format (vYYYY-MM-patchlevel)
-  // Reconstruct YYYY from offset: major + 2000
-  #define OSRM_VERSION_RECONSTRUCTED_MAJOR (OSRM_VERSION_MAJOR + 2000)
-  #define OSRM_VERSION__(Y,M,P,D) "v" #Y "-" #M "-" #P
-  #define OSRM_VERSION_(Y,M,P,D) OSRM_VERSION__(Y,M,P,D)
-  #define OSRM_VERSION OSRM_VERSION_(OSRM_VERSION_RECONSTRUCTED_MAJOR, OSRM_VERSION_MINOR, OSRM_VERSION_PATCH, "")
-#else
-  // Semver format: use dots (vMAJOR.MINOR.PATCH)
-  #define OSRM_VERSION__(A,B,C,D) "v" #A "." #B "." #C D
-  #define OSRM_VERSION_(A,B,C,D) OSRM_VERSION__(A,B,C,D)
-  #define OSRM_VERSION OSRM_VERSION_(OSRM_VERSION_MAJOR, OSRM_VERSION_MINOR, OSRM_VERSION_PATCH, OSRM_VERSION_PRERELEASE_BUILD)
-#endif
+// Unified semver version format: (YYYY-2000).MM.patchlevel
+// OSRM_VERSION_MAJOR is already offset (year - 2000)
+// e.g., 26.4.0 represents April 2026, patch level 0
+#define OSRM_VERSION__(A,B,C) "v" #A "." #B "." #C
+#define OSRM_VERSION_(A,B,C) OSRM_VERSION__(A,B,C)
+#define OSRM_VERSION OSRM_VERSION_(OSRM_VERSION_MAJOR, OSRM_VERSION_MINOR, OSRM_VERSION_PATCH)
 
 #endif // VERSION_HPP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-osrm/osrm",
-  "version": "6.0.0",
+  "version": "26.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-osrm/osrm",
-      "version": "6.0.0",
+      "version": "26.4.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-osrm/osrm",
-  "version": "6.0.0",
+  "version": "26.4.0",
   "private": false,
   "type": "module",
   "description": "The Open Source Routing Machine is a high performance routing engine written in C++ designed to run on OpenStreetMap data.",


### PR DESCRIPTION
## Summary

This PR implements a new automated monthly release process with YYYY-MM-patchlevel versioning (e.g., 2026-04-0, 2026-04-1).

## Changes

### New Workflow: .github/workflows/release-monthly.yml
- **Scheduled trigger:** 1st of each month @ 08:00 UTC
- **Manual trigger:** `workflow_dispatch` for emergency/out-of-schedule releases
- **Version calculation:** Automatic YYYY-MM-patchlevel with patchlevel auto-increment
- **Full automation:** Commits, tags, releases, and publishes to npm

### Updated Files
- **.github/workflows/osrm-backend.yml:** Added tag pattern for new version format
- **CMakeLists.txt:** Support both YYYY-MM-patchlevel and legacy semver formats
- **package.json:** Updated version to 2026-04-0
- **docs/releasing.md:** Complete documentation rewrite for new release process

## Versioning Scheme

**Format:** YYYY-MM-patchlevel
- **YYYY:** Current year
- **MM:** Current month (01-12)
- **patchlevel:** Counter starting at 0 per month (0, 1, 2, ...)

**Examples:**
- First release in April 2026: `2026-04-0`
- Second release in April 2026: `2026-04-1`
- First release in May 2026: `2026-05-0`

## Compatibility

- ✅ Fully backward compatible with legacy semver tags
- ✅ CMake build system supports both formats
- ✅ Existing CI workflow patterns still trigger

## Release Process

**Automated:**
1. 1st of each month @ 08:00 UTC
2. Auto-calculate version → Update package.json → Commit → Tag → Release → Publish

**Manual:**
1. Actions tab → Monthly Release → Run workflow
2. Select branch (defaults to master)
3. Optional version override
4. Same automated steps execute

## Prerequisites

- Ensure `NPM_TOKEN` secret is configured in repository settings for npm publishing