### PR TITLE
fix: configure git identity in release action before tagging

### DIFF
--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -123,6 +123,8 @@ jobs:
 
       - name: Create git tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
 
       - name: Push changes and tag


### PR DESCRIPTION
## Problem
The release action was failing with:
```
Committer identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

## Root Cause
The 'Create git tag' step requires git identity to be configured, but the identity config only happens in the conditional 'Commit version update' step. When that step is skipped (e.g., when version is unchanged), git identity is never set.

## Solution
Configure git identity directly in the 'Create git tag' step before creating the annotated tag. This ensures git identity is always available regardless of whether the commit step runs.

## Changes
- Added `git config user.name` and `git config user.email` to 'Create git tag' step
- Uses `github-actions[bot]` identity (consistent with commit step)

Fixes the failure in the monthly release workflow.