### PR TITLE
fix: improve release workflow timeout and changelog generation

### DIFF
--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -136,21 +136,24 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          # Get the previous release tag
-          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged "${{ steps.version.outputs.tag }}" | head -2 | tail -1)
+          CURRENT_TAG="${{ steps.version.outputs.tag }}"
           
-          if [ -z "$PREVIOUS_TAG" ]; then
-            # No previous release, show all commits
-            CHANGELOG=$(git log --oneline "${{ steps.version.outputs.tag }}" --pretty=format:"* %h - %s")
+          # Get the previous release tag
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged "$CURRENT_TAG" | head -2 | tail -1)
+          
+          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$CURRENT_TAG" ]; then
+            # No previous release, or selection resolved to the current tag; show all commits
+            CHANGELOG=$(git log "$CURRENT_TAG" --pretty=format:"* %h - %s")
           else
             # Show commits since last release
-            CHANGELOG=$(git log --oneline "${PREVIOUS_TAG}...${{ steps.version.outputs.tag }}" --pretty=format:"* %h - %s")
+            CHANGELOG=$(git log "${PREVIOUS_TAG}..$CURRENT_TAG" --pretty=format:"* %h - %s")
           fi
           
-          # Output as multiline variable
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          # Output as multiline variable using a unique delimiter to avoid collisions
+          DELIMITER=$(cat /proc/sys/kernel/random/uuid)
+          echo "body<<$DELIMITER" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIMITER" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -131,14 +131,33 @@ jobs:
           git push origin "$BRANCH"
           git push origin "${{ steps.version.outputs.tag }}"
 
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # Get the previous release tag
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged "${{ steps.version.outputs.tag }}" | head -2 | tail -1)
+          
+          if [ -z "$PREVIOUS_TAG" ]; then
+            # No previous release, show all commits
+            CHANGELOG=$(git log --oneline "${{ steps.version.outputs.tag }}" --pretty=format:"* %h - %s")
+          else
+            # Show commits since last release
+            CHANGELOG=$(git log --oneline "${PREVIOUS_TAG}...${{ steps.version.outputs.tag }}" --pretty=format:"* %h - %s")
+          fi
+          
+          # Output as multiline variable
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.version }}
+          body: ${{ steps.changelog.outputs.body }}
           draft: false
           prerelease: false
-          generateReleaseNotes: true
 
       - name: Wait for CI to complete
         env:
@@ -152,7 +171,7 @@ jobs:
           
           echo "Waiting for CI workflow to complete for tag $TAG (commit $TAG_SHA)"
           
-          MAX_WAIT=300  # 5 minutes
+          MAX_WAIT=3600  # 1 hour
           ELAPSED=0
           POLL_INTERVAL=10
           


### PR DESCRIPTION
## Changes

- **Increased CI wait timeout to 1 hour**: Updated MAX_WAIT from 5 minutes (300s) to 3600s to allow more time for CI workflows to complete before npm publish
- **Changelog from git commits**: Generate release notes from actual commits since the last release instead of GitHub's auto-generated notes

## Why

The longer timeout provides more breathing room for CI pipelines that might take longer than 5 minutes, especially when building binaries across multiple platforms. The changelog is now derived directly from commits, giving better control over release notes.