### PR TITLE
fix: add npm install step before npm publish in release workflow

### DIFF
--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -216,6 +216,9 @@ jobs:
           echo "✗ Timed out waiting for CI workflow to complete for tag $TAG"
           exit 1
 
+      - name: Install dependencies
+        run: npm install
+
       - name: Publish to npm
         run: npm publish
 


### PR DESCRIPTION
The prepare script runs husky, which is a devDependency. Without running npm install first, husky won't be available and npm publish will fail.

This was causing npm publish to fail with 'husky: not found' errors in the release workflow.