### PR TITLE
fix: use npm install --ignore-scripts to avoid native build in release

### DIFF
--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -216,8 +216,8 @@ jobs:
           echo "✗ Timed out waiting for CI workflow to complete for tag $TAG"
           exit 1
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install dependencies (skip native build scripts)
+        run: npm ci --ignore-scripts
 
       - name: Publish to npm
         run: npm publish


### PR DESCRIPTION
The release workflow should not attempt to build native modules. The native binaries are built separately by the CI job triggered by the tag push and uploaded to the release assets.

Using --ignore-scripts skips the 'install' script (which tries to build native modules) while still installing dependencies needed for npm publish, including husky for the prepare script.

This fixes the issue where npm install would fail trying to download prebuilt binaries that haven't been built yet.