### PR TITLE
fix: restore NPM_TOKEN auth and add --access public for scoped package publish

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   CCACHE_TEMPDIR: /tmp/.ccache-temp

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -230,7 +230,5 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish
 

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -133,6 +134,15 @@ jobs:
           git push origin "$BRANCH"
           git push origin "${{ steps.version.outputs.tag }}"
 
+      - name: Trigger CI for tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # GITHUB_TOKEN pushes don't trigger workflow runs (prevents loops).
+          # Explicitly dispatch CI on the tag so binaries get built and uploaded.
+          gh workflow run osrm-backend.yml --ref "${{ steps.version.outputs.tag }}"
+          echo "Dispatched osrm-backend.yml on ${{ steps.version.outputs.tag }}"
+
       - name: Generate changelog
         id: changelog
         run: |
@@ -220,5 +230,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Publish to npm
-        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 


### PR DESCRIPTION
Fixes two issues blocking npm publish of `@project-osrm/osrm`:

1. **Auth failure (404)**: `setup-node` configures `.npmrc` to use `NODE_AUTH_TOKEN`, but that env var was never set at publish time. npm OIDC Trusted Publishers requires explicit configuration on the npm package settings page — without it the auth token is empty and npm returns 404. Restores `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.

2. **Scoped package access**: Scoped packages (`@project-osrm/osrm`) default to private on npm. `--access public` is required for public publishing.