### PR TITLE
ci: propagate docker/metadata-action labels to published images

### DIFF
--- a/.github/workflows/osrm-backend-docker.yml
+++ b/.github/workflows/osrm-backend-docker.yml
@@ -81,6 +81,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.metadebug.outputs.tags  }}
+          labels: ${{ steps.metadebug.outputs.labels }}
           build-args: |
             DOCKER_TAG=${{ join(steps.metadebug.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -92,6 +93,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.metaassertions.outputs.tags  }}
+          labels: ${{ steps.metaassertions.outputs.labels }}
           build-args: |
             DOCKER_TAG=${{ join(steps.metaassertions.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -103,5 +105,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.meta.outputs.tags  }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             DOCKER_TAG=${{ join(steps.meta.outputs.tags ) }}-${{ matrix.docker-base-image }}


### PR DESCRIPTION
## Problem

`osrm-backend-docker.yml` runs `docker/metadata-action@v6` three times (normal / debug / assertions flavours) to compute tags, but none of the three `docker/build-push-action` steps forward the matching `labels:` output. As a result, every image currently published to `ghcr.io/project-osrm/osrm-backend` has **no OCI labels at all** — no `org.opencontainers.image.source`, no `image.url`, no `image.revision`, no `image.version`.

You can verify against the current image:

\`\`\`console
$ curl -sL -H "Authorization: Bearer \$TOKEN" \
    https://ghcr.io/v2/project-osrm/osrm-backend/blobs/sha256:f4e258e56ca9796897e7ab3a364b9d90c2ed6c246866d17759a8bfc9518f6fb1 \
    | jq '.config.Labels'
null
\`\`\`

## Impact

Anything that relies on OCI labels to discover the upstream repository can't link the published image back to this repo. Concrete example: [Renovate](https://docs.renovatebot.com/modules/datasource/docker/#sourceurl) uses `org.opencontainers.image.source` to auto-populate the \`sourceUrl\` for the docker datasource, which is what gates GitHub release-notes fetching. Without the label, PRs that bump this image have an empty **Release Notes** section even when there are perfectly good GitHub releases to link to. Same story for Dependabot and most supply-chain / SBOM tooling.

## Fix

`docker/metadata-action` already computes the full `org.opencontainers.image.*` label set and exposes it as `steps.<id>.outputs.labels` — the workflow just never forwards it. Three single-line additions to pipe it into each `build-push-action`:

\`\`\`diff
           tags: \${{ steps.metadebug.outputs.tags  }}
+          labels: \${{ steps.metadebug.outputs.labels }}
\`\`\`

…and the same for \`metaassertions\` and \`meta\`. This is the canonical docker/metadata-action pattern — see e.g. [rabbitmq/messaging-topology-operator's build-test-publish.yml](https://github.com/rabbitmq/messaging-topology-operator/blob/main/.github/workflows/build-test-publish.yml) for a reference implementation.

No action-version bumps, no behavioural changes beyond the labels landing on the image manifests.

## Verification

After the next tagged release, the published image should have a populated `Labels` object including `org.opencontainers.image.source: https://github.com/Project-OSRM/osrm-backend`.