### PR TITLE
build(windows): change bzip2 and xz-utils to not be shared

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,9 +19,9 @@ class OsrmConan(ConanFile):
         self.options["boost"].without_coroutine = True
         self.options["boost"].without_stacktrace = True
         self.options["boost"].without_cobalt = True
-        self.options["bzip2"].shared = True
+        self.options["bzip2"].shared = False
         self.options["hwloc"].shared = True
-        self.options["xz-utils"].shared = True
+        self.options["xz-utils"].shared = False
         
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

Was this change primarily generated using an AI tool?
Kindly make this transparent and disclose which tool / model you have been using.
Please note our [contribution guidlines](https://github.com/Project-OSRM/osrm-backend/blob/master/CONTRIBUTING.md) on the use of AI tools.

## Tasklist

 - [ ] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?

