### PR TITLE
feat(profiles): add winter_road and ice_road to restricted_highway_whitelist

### DIFF
--- a/features/car/access.feature
+++ b/features/car/access.feature
@@ -313,3 +313,19 @@ Feature: Car - Restricted access
             | primary    | psv          |       |
             | primary    | no           |       |
             | primary    | customers    |   x   |
+
+    Scenario: Car - Winter/ice roads with restricted access
+        Then routability should be
+            | highway    | access      | bothw |
+            | winter_road|             |   x   |
+            | winter_road| yes         |   x   |
+            | winter_road| private     |   x   |
+            | winter_road| delivery    |   x   |
+            | winter_road| destination |   x   |
+            | winter_road| no          |       |
+            | ice_road   |             |   x   |
+            | ice_road   | yes         |   x   |
+            | ice_road   | private     |   x   |
+            | ice_road   | delivery    |   x   |
+            | ice_road   | destination |   x   |
+            | ice_road   | no          |       |

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -198,7 +198,9 @@ function setup()
       'residential',
       'living_street',
       'unclassified',
-      'service'
+      'service',
+      'winter_road',
+      'ice_road'
     },
 
     construction_whitelist = Set {


### PR DESCRIPTION
Addresses code review feedback on #7465.

winter_road and ice_road were added to speeds.highway in #7465, but were not included in restricted_highway_whitelist. This means ways tagged with restricted access values (e.g. access=private|destination|delivery|customers) would be treated as fully inaccessible rather than 'restricted' like other whitelisted highway types.

This change adds these new highway values to restricted_highway_whitelist to keep access semantics consistent with the rest of the car profile.