### PR TITLE
fix: invalid TurnLaneData comparators

### DIFF
--- a/src/guidance/turn_lane_data.cpp
+++ b/src/guidance/turn_lane_data.cpp
@@ -25,6 +25,9 @@ bool TurnLaneData::operator<(const TurnLaneData &other) const
     if (to > other.to)
         return false;
 
+    if (tag == other.tag)
+        return false;
+
     // the suppress-assignment flag is ignored, since it does not influence the order
     const constexpr TurnLaneType::Mask tag_by_modifier[] = {TurnLaneType::sharp_right,
                                                             TurnLaneType::right,


### PR DESCRIPTION
# Issue

Fix #7503

## Tasklist

 - [X] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

No additional requirements.
Not based on any other pull request.

## Implementation Notes

Instead of touching the existing special case handling logic, I add an equality guard right after `from`/`to` tie comparison and before the original `tag` comparison.
