### PR TITLE
fix(ci): silence most lld linker warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+cmake_policy(SET CMP0156 NEW)
+
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR AND NOT MSVC_IDE)
   message(FATAL_ERROR "In-source builds are not allowed.
 Please create a directory and run cmake from there, passing the path to this source directory as the last argument.


### PR DESCRIPTION
```
[144/151] Linking CXX executable osrm-components
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libz.a'
[146/151] Linking CXX executable osrm-customize
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libz.a'
[147/151] Linking CXX executable osrm-contract
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libz.a'
[150/151] Linking CXX executable osrm-routed
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libz.a'
[151/151] Linking CXX executable osrm-extract
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libbz2.a', 'vcpkg_installed/x64-osx/lib/libz.a'
```

instead of

```
[1/4] Linking CXX executable osrm-io-benchmark
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libboost_date_time.a'
[2/4] Linking CXX executable osrm-components
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/lib/libboost_date_time.a', 'vcpkg_installed/x64-osx/lib/libboost_iostreams.a', 'vcpkg_installed/x64-osx/lib/libboost_thread.a', 'vcpkg_installed/x64-osx/lib/libtbb.a', 'vcpkg_installed/x64-osx/lib/libz.a'
[3/4] Linking CXX executable osrm-extract
ld: warning: ignoring duplicate libraries: 'vcpkg_installed/x64-osx/debug/lib/libbz2d.a', 'vcpkg_installed/x64-osx/debug/lib/libexpat.a', 'vcpkg_installed/x64-osx/lib/libbz2.a', 'vcpkg_installed/x64-osx/lib/libexpat.a', 'vcpkg_installed/x64-osx/lib/libz.a'
```
