### PR TITLE
ci: add new pr title check

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -127,12 +127,6 @@ jobs:
         sudo apt-get install -y clang-format-18
         npm ci --ignore-scripts
         clang-format-18 --version
-    - name: Check PR title format
-      if: github.event_name == 'pull_request'
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
-      run: |
-        node ./scripts/check_pr_title.js
     - name: Run checks
       run: |
         ./scripts/check_taginfo.py taginfo.json profiles/car.lua

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:
-      - gh-pages
-      - main
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,28 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - gh-pages
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-pr-title:
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Validate pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([[:alnum:]_.-]+\))?(!)?: .+$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "PR title must follow Conventional Commits, for example: feat(ui): add route summary"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi


### PR DESCRIPTION
Remove PR title validation step from osrm-backend workflow; PR titles are validated by the separate pr-title-check workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>