### PR TITLE
ci: don't run workflows on forks

### DIFF
--- a/.github/workflows/osrm-backend-docker.yml
+++ b/.github/workflows/osrm-backend-docker.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-amd64:
+    if: github.repository == 'Project-OSRM/osrm-backend'
     strategy: &docker-base-image-matrix
       matrix:
         docker-base-image: ["debian", "alpine"]
@@ -111,6 +112,7 @@ jobs:
             DOCKER_TAG=${{ join(steps.meta.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
   build-arm64:
+    if: github.repository == 'Project-OSRM/osrm-backend'
     strategy: *docker-base-image-matrix
     runs-on: ubuntu-24.04-arm
     steps:
@@ -206,6 +208,7 @@ jobs:
 
   combine-manifests:
     needs: [build-amd64, build-arm64]
+    if: github.repository == 'Project-OSRM/osrm-backend'
     strategy: *docker-base-image-matrix
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   vcpkg-windows-release-node:
     needs: format-taginfo-docs
+    if: github.repository == 'Project-OSRM/osrm-backend'
     runs-on: windows-2025
     continue-on-error: false
     env:
@@ -107,6 +108,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   format-taginfo-docs:
+    if: github.repository == 'Project-OSRM/osrm-backend'
     runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
@@ -141,6 +143,7 @@ jobs:
       matrix:
         docker-base-image: ['debian', 'alpine']
     needs: format-taginfo-docs
+    if: github.repository == 'Project-OSRM/osrm-backend'
     runs-on: ubuntu-22.04
     continue-on-error: false
     steps:
@@ -194,6 +197,7 @@ jobs:
 
   build-matrix:
     needs: format-taginfo-docs
+    if: github.repository == 'Project-OSRM/osrm-backend'
     strategy:
       matrix:
         include:
@@ -581,5 +585,6 @@ jobs:
   ci-complete:
     runs-on: ubuntu-latest
     needs: [build-matrix, vcpkg-windows-release-node, docker-image-matrix]
+    if: github.repository == 'Project-OSRM/osrm-backend'
     steps:
       - run: echo "CI complete"

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'Project-OSRM/osrm-backend'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
I just had a failed release GHA on my fork :) this blanket-changes all jobs to not run on forks.