### PR TITLE
fix(cmake): osrm backend fetch content patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,22 @@ add_compile_definitions(FMT_HEADER_ONLY)
 find_package(RapidJSON CONFIG REQUIRED)
 find_package(sol2 CONFIG REQUIRED)
 find_package(flatbuffers CONFIG REQUIRED)
+# TBB is linked later, but discover it here so the include-harvesting loop
+# below can see TBB::tbb for OBJECT libraries that were already created.
+find_package(TBB CONFIG REQUIRED)
+# Always link the release build of TBB, even in Debug/Coverage configurations.
+# vcpkg's debug TBB enables internal debug assertions (e.g. intrusive_list
+# invariants) that trip during osrm-extract's test-data generation on
+# ubuntu-24.04 under gcc-13. The master branch never hit this because it
+# linked the system's release-only TBB. Do the same here.
+foreach(_tbb_target TBB::tbb TBB::tbbmalloc TBB::tbbmalloc_proxy)
+  if(TARGET ${_tbb_target})
+    set_target_properties(${_tbb_target} PROPERTIES
+      MAP_IMPORTED_CONFIG_DEBUG        Release
+      MAP_IMPORTED_CONFIG_MINSIZEREL   Release
+      MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
+  endif()
+endforeach()
 
 # Generate flatbuffers C++ headers from .fbs schemas at build time.
 # This removes the need to commit pre-generated headers and pin the
@@ -445,20 +461,6 @@ endif()
 # All dependencies below come from vcpkg (vcpkg.json). The vcpkg toolchain
 # file exposes them via standard CMake find_package() / imported targets.
 find_package(Boost 1.83 REQUIRED CONFIG COMPONENTS ${BOOST_COMPONENTS})
-find_package(TBB CONFIG REQUIRED)
-# Always link the release build of TBB, even in Debug/Coverage configurations.
-# vcpkg's debug TBB enables internal debug assertions (e.g. intrusive_list
-# invariants) that trip during osrm-extract's test-data generation on
-# ubuntu-24.04 under gcc-13. The master branch never hit this because it
-# linked the system's release-only TBB. Do the same here.
-foreach(_tbb_target TBB::tbb TBB::tbbmalloc TBB::tbbmalloc_proxy)
-  if(TARGET ${_tbb_target})
-    set_target_properties(${_tbb_target} PROPERTIES
-      MAP_IMPORTED_CONFIG_DEBUG        Release
-      MAP_IMPORTED_CONFIG_MINSIZEREL   Release
-      MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
-  endif()
-endforeach()
 find_package(EXPAT REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(Lua 5.4 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,15 @@ option(ENABLE_NODE_BINDINGS "Build NodeJs bindings" OFF)
 option(ENABLE_PYTHON_BINDINGS "Build Python bindings" OFF)
 option(ENABLE_SANITIZER "Use memory sanitizer for Debug build" OFF)
 
+if(BUILD_AS_SUBPROJECT)
+  set(OSRM_BUILD_AUXILIARY_TARGETS_DEFAULT OFF)
+else()
+  set(OSRM_BUILD_AUXILIARY_TARGETS_DEFAULT ON)
+endif()
+
+option(OSRM_BUILD_TESTING "Build OSRM test targets" ${OSRM_BUILD_AUXILIARY_TARGETS_DEFAULT})
+option(OSRM_BUILD_BENCHMARKS "Build OSRM benchmark targets" ${OSRM_BUILD_AUXILIARY_TARGETS_DEFAULT})
+
 # Dependencies are provided by vcpkg in manifest mode (see vcpkg.json).
 # The vcpkg toolchain file is wired up via CMakePresets.json or by passing
 # -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake.
@@ -346,8 +355,15 @@ if(OSRM_HAS_STD_FORMAT)
 endif()
 
 find_package(LibArchive REQUIRED)
+add_dependency_includes(${LibArchive_INCLUDE_DIRS})
+if(TARGET LibArchive::LibArchive)
+  get_target_property(_libarchive_includes LibArchive::LibArchive INTERFACE_INCLUDE_DIRECTORIES)
+  if(_libarchive_includes)
+    add_dependency_includes(${_libarchive_includes})
+  endif()
+endif()
 
-# Header-only libraries from vcpkg. Each provides a CMake CONFIG package.
+# Header-only libraries consumed through CMake package configs.
 find_package(fmt CONFIG REQUIRED)
 # fmt is consumed header-only so OSRM targets don't need to link libfmt.
 # Without this, LTO builds emit undefined references to fmt::v12::vformat,
@@ -361,9 +377,11 @@ find_package(flatbuffers CONFIG REQUIRED)
 # Generate flatbuffers C++ headers from .fbs schemas at build time.
 # This removes the need to commit pre-generated headers and pin the
 # flatbuffers version — any compatible flatc will regenerate them.
-# BuildFlatBuffers.cmake is shipped alongside flatbuffers-config.cmake
-# but not on CMAKE_MODULE_PATH, so locate it via the package's own dir.
-include("${flatbuffers_DIR}/BuildFlatBuffers.cmake")
+# Some package configs define this helper command themselves instead of placing
+# BuildFlatBuffers.cmake next to the generated config file.
+if(NOT COMMAND flatbuffers_generate_headers)
+  include("${flatbuffers_DIR}/BuildFlatBuffers.cmake")
+endif()
 set(FLATBUFFERS_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/engine/api/flatbuffers/fbresult.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/include/engine/api/flatbuffers/route.fbs
@@ -401,12 +419,13 @@ include_directories(SYSTEM ${VTZERO_INCLUDE_DIR})
 # target and push them into the directory-level include_directories, which
 # DOES apply retroactively to earlier targets. Consumers (unit tests, etc.)
 # inherit the same search paths via the directory.
-set(_osrm_vcpkg_header_targets
+set(_osrm_dependency_header_targets
     fmt::fmt-header-only fmt::fmt
     sol2::sol2
     rapidjson RapidJSON::RapidJSON
-    flatbuffers::flatbuffers)
-foreach(_dep IN LISTS _osrm_vcpkg_header_targets)
+    flatbuffers::flatbuffers flatbuffers::libflatbuffers
+    TBB::tbb)
+foreach(_dep IN LISTS _osrm_dependency_header_targets)
   if(TARGET ${_dep})
     get_target_property(_inc ${_dep} INTERFACE_INCLUDE_DIRECTORIES)
     if(_inc)
@@ -749,9 +768,13 @@ else()
 endif()
 
 
-# Modular build system: each directory registered here provides its own CMakeLists.txt
-add_subdirectory(unit_tests)
-add_subdirectory(src/benchmarks)
+if(OSRM_BUILD_TESTING)
+  add_subdirectory(unit_tests)
+endif()
+
+if(OSRM_BUILD_BENCHMARKS)
+  add_subdirectory(src/benchmarks)
+endif()
 
 if (ENABLE_NODE_BINDINGS)
   add_subdirectory(src/nodejs)


### PR DESCRIPTION
## Summary

Improve OSRM's CMake behavior when it is consumed as a subproject through
`add_subdirectory()` or `FetchContent`.

This keeps the default standalone OSRM build behavior intact, while making the
library easier to embed in larger CMake projects that already provide
dependencies through standard package config files or imported targets.

## Motivation

OSRM now primarily expects dependencies to come from vcpkg manifest mode, but
CMake superprojects often provide the same dependencies through other package
managers or pre-existing imported targets. In those builds, a few assumptions in
the current CMake setup make embedding OSRM harder than necessary:

- tests and benchmarks are always added to the subproject target graph;
- some dependency include directories are only read from legacy variables;
- some package configs expose include paths through imported targets instead;
- some FlatBuffers package configs define `flatbuffers_generate_headers`
  directly rather than placing `BuildFlatBuffers.cmake` next to the config file.

These are not OSRM source-level issues. They are CMake integration issues that
show up when OSRM is used as a library inside a larger build.

## Changes

- Add `OSRM_BUILD_TESTING` and `OSRM_BUILD_BENCHMARKS`.
  - Defaults remain `ON` for standalone OSRM builds.
  - Defaults are `OFF` when OSRM is included as a subproject.
  - Superprojects can explicitly enable either option if they want OSRM tests or
    benchmark targets.

- Make dependency include harvesting provider-neutral.
  - Rename the internal header-target list away from vcpkg-specific wording.
  - Continue supporting the existing vcpkg targets.
  - Also collect include dirs from `flatbuffers::libflatbuffers` and `TBB::tbb`.

- Add LibArchive imported-target include propagation.
  - If `LibArchive::LibArchive` exposes include directories, add them to
    OSRM's dependency include list.

- Guard FlatBuffers helper inclusion.
  - Only include `${flatbuffers_DIR}/BuildFlatBuffers.cmake` when
    `flatbuffers_generate_headers` is not already defined.

## Why This Is Safe

For normal standalone OSRM builds, tests and benchmarks still default to being
included. Existing vcpkg-based builds continue to use the same package config
flow and the same imported targets.

For subproject builds, this reduces target graph pollution and avoids requiring
parent projects to patch OSRM just to prevent tests or benchmarks from being
configured. The include-directory changes are additive and only use properties
from targets that already exist.

## Validation

- Verified the patch applies cleanly to `v26.5.0`.
- Verified `git diff --check` passes.
- Verified the change in a superproject build that consumes OSRM through
  `FetchContent` while dependencies are supplied by package config/imported
  targets.
