### PR TITLE
fix(profiles): remove leisure=track from foot profile routable ways

### DIFF
--- a/features/foot/way.feature
+++ b/features/foot/way.feature
@@ -34,7 +34,7 @@ Feature: Foot - Accessability of different way types
     Scenario: Foot - Basic access
         Then routability should be
             | highway | leisure  | forw |
-            | (nil)   | track    |   x  |
+            | (nil)   | track    |      |
 
     Scenario: Foot - Proposed ways: unbuilt proposed highways are ignored, real highways with proposed upgrade tags are routed
         Then routability should be

--- a/features/foot/way.feature
+++ b/features/foot/way.feature
@@ -35,6 +35,7 @@ Feature: Foot - Accessability of different way types
         Then routability should be
             | highway | leisure  | forw |
             | (nil)   | track    |      |
+            | footway | (nil)    | x    |
 
     Scenario: Foot - Proposed ways: unbuilt proposed highways are ignored, real highways with proposed upgrade tags are routed
         Then routability should be

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -113,10 +113,6 @@ function setup()
 
       man_made = {
         pier            = walking_speed
-      },
-
-      leisure = {
-        track           = walking_speed
       }
     },
 
@@ -225,7 +221,6 @@ function process_way(profile, way, result)
     highway = way:get_value_by_key('highway'),
     bridge = way:get_value_by_key('bridge'),
     route = way:get_value_by_key('route'),
-    leisure = way:get_value_by_key('leisure'),
     man_made = way:get_value_by_key('man_made'),
     railway = way:get_value_by_key('railway'),
     platform = way:get_value_by_key('platform'),


### PR DESCRIPTION
## Summary

Removes `leisure=track` from the foot profile's list of routable way types, fixing #4312.

## Problem

The foot profile was treating `leisure=track` as a walkable surface and routing pedestrians over it. However, according to the [OSM wiki](http://wiki.openstreetmap.org/wiki/Tag:leisure%3Dtrack), `leisure=track` describes a **sports or race track** (athletics track, velodrome, horse racing circuit, etc.) — not a path intended for general pedestrian use.

This caused OSRM to generate routes through areas that are typically restricted to athletes/competitors, or physically unsuitable for walking (e.g., a running track around a sports field, a velodrome).

## Changes

- Removes `speeds.leisure.track` from the speeds table in `setup()`
- Removes the `leisure` key lookup in `process_way()` (no other leisure tags are used by the profile)

## Functional Impact

Ways tagged with `leisure=track` will no longer be considered routable by the foot profile. Pedestrians will no longer be routed through race/sports tracks.