### PR TITLE
fix(ci): follow-up to #7485 — unblock certain macOS configurations

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -171,3 +171,8 @@ if(MSVC)
 
   message(STATUS "MSVC warning configuration applied - suppressed informational warnings, kept bug-indicating warnings")
 endif()
+
+if(APPLE)
+  no_warning(unused-command-line-argument)
+  message(STATUS "Apple Clang detected - disabled unused-command-line-argument warning")
+endif()


### PR DESCRIPTION
Follow-up to https://github.com/Project-OSRM/osrm-backend/pull/7485 to unblock certain macOS configurations.