### PR TITLE
perf(extractor): optimize obstacle storage and reduce memory

### DIFF
--- a/include/extractor/obstacles.hpp
+++ b/include/extractor/obstacles.hpp
@@ -34,9 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tbb/concurrent_vector.h>
 
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 namespace osrm::extractor
 {
@@ -221,26 +221,36 @@ class ObstacleMap
     std::pair<ConstObstacleIter, ConstObstacleIter> find_range(NodeID to) const
     {
         if (!sorted)
-            throw std::logic_error("ObstacleMap: obstacles not sorted; call sort() before querying");
-        auto lower = std::lower_bound(
-            obstacles.begin(), obstacles.end(), to,
-            [](const InternalObstacle &a, const NodeID value) { return a.to < value; });
-        auto upper = std::upper_bound(
-            lower, obstacles.end(), to,
-            [](const NodeID value, const InternalObstacle &a) { return value < a.to; });
+            throw std::logic_error(
+                "ObstacleMap: obstacles not sorted; call sort() before querying");
+        auto lower = std::lower_bound(obstacles.begin(),
+                                      obstacles.end(),
+                                      to,
+                                      [](const InternalObstacle &a, const NodeID value)
+                                      { return a.to < value; });
+        auto upper = std::upper_bound(lower,
+                                      obstacles.end(),
+                                      to,
+                                      [](const NodeID value, const InternalObstacle &a)
+                                      { return value < a.to; });
         return {lower, upper};
     }
 
     std::pair<ObstacleIter, ObstacleIter> find_range(NodeID to)
     {
         if (!sorted)
-            throw std::logic_error("ObstacleMap: obstacles not sorted; call sort() before querying");
-        auto lower = std::lower_bound(
-            obstacles.begin(), obstacles.end(), to,
-            [](const InternalObstacle &a, const NodeID value) { return a.to < value; });
-        auto upper = std::upper_bound(
-            lower, obstacles.end(), to,
-            [](const NodeID value, const InternalObstacle &a) { return value < a.to; });
+            throw std::logic_error(
+                "ObstacleMap: obstacles not sorted; call sort() before querying");
+        auto lower = std::lower_bound(obstacles.begin(),
+                                      obstacles.end(),
+                                      to,
+                                      [](const InternalObstacle &a, const NodeID value)
+                                      { return a.to < value; });
+        auto upper = std::upper_bound(lower,
+                                      obstacles.end(),
+                                      to,
+                                      [](const NodeID value, const InternalObstacle &a)
+                                      { return value < a.to; });
         return {lower, upper};
     }
 

--- a/include/extractor/obstacles.hpp
+++ b/include/extractor/obstacles.hpp
@@ -33,9 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <osmium/osm/node.hpp>
 #include <tbb/concurrent_vector.h>
 
-#include <ranges>
+#include <algorithm>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace osrm::extractor
@@ -122,7 +121,6 @@ class ObstacleMap
     using WayNodeIDOffsets = std::vector<size_t>;
 
     using OsmFromToObstacle = std::tuple<OSMNodeID, OSMNodeID, Obstacle>;
-    using FromToObstacle = std::pair<NodeID, Obstacle>;
 
   public:
     ObstacleMap() = default;
@@ -133,7 +131,7 @@ class ObstacleMap
     void emplace(OSMNodeID osm_node_id, const Obstacle &obstacle)
     {
         osm_obstacles.emplace_back(SPECIAL_OSM_NODEID, osm_node_id, obstacle);
-    };
+    }
 
     // Insert an obstacle using internal node ids.
     //
@@ -141,8 +139,8 @@ class ObstacleMap
     // Convenient for testing.
     void emplace(NodeID from, NodeID to, const Obstacle &obstacle)
     {
-        obstacles.emplace(to, std::make_pair(from, obstacle));
-    };
+        obstacles.push_back({to, from, obstacle});
+    }
 
     // get all obstacles at node 'to' when coming from node 'from'
     // pass SPECIAL_NODEID as 'from' to get all obstacles at 'to'
@@ -152,17 +150,16 @@ class ObstacleMap
     {
         std::vector<Obstacle> result;
 
-        auto [begin, end] = obstacles.equal_range(to);
-        for (auto &[key, value] : std::ranges::subrange(begin, end))
+        auto [begin, end] = find_range(to);
+        for (auto it = begin; it != end; ++it)
         {
-            auto &[from_id, obstacle] = value;
-            if ((from_id == SPECIAL_NODEID || from_id == from) &&
-                (static_cast<uint16_t>(obstacle.type) & static_cast<uint16_t>(type)))
+            if ((it->from == SPECIAL_NODEID || it->from == from) &&
+                (static_cast<uint16_t>(it->obstacle.type) & static_cast<uint16_t>(type)))
             {
-                result.push_back(obstacle);
+                result.push_back(it->obstacle);
             }
         }
-        return result; // vector has move semantics
+        return result;
     }
 
     std::vector<Obstacle> get(NodeID to) const
@@ -172,7 +169,11 @@ class ObstacleMap
 
     // is there any obstacle at node 'to'?
     // inexpensive general test
-    bool any(NodeID to) const { return obstacles.contains(to); }
+    bool any(NodeID to) const
+    {
+        auto [begin, end] = find_range(to);
+        return begin != end;
+    }
 
     // is there any obstacle of type 'type' at node 'to' when coming from node 'from'?
     // pass SPECIAL_NODEID as 'from' to query all obstacles at 'to'
@@ -200,12 +201,34 @@ class ObstacleMap
     void compress(NodeID from, NodeID delendus, NodeID to);
 
   private:
+    struct InternalObstacle
+    {
+        NodeID to;
+        NodeID from;
+        Obstacle obstacle;
+        bool operator<(const InternalObstacle &other) const { return to < other.to; }
+    };
+
+    using ObstacleIter = std::vector<InternalObstacle>::iterator;
+    using ConstObstacleIter = std::vector<InternalObstacle>::const_iterator;
+
+    std::pair<ConstObstacleIter, ConstObstacleIter> find_range(NodeID to) const
+    {
+        return std::equal_range(
+            obstacles.begin(), obstacles.end(), InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
+    }
+
+    std::pair<ObstacleIter, ObstacleIter> find_range(NodeID to)
+    {
+        return std::equal_range(
+            obstacles.begin(), obstacles.end(), InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
+    }
+
     // obstacles according to external id
     tbb::concurrent_vector<OsmFromToObstacle> osm_obstacles;
 
-    // obstacles according to internal id, with a leading node if unidirectional
-    // bidirectional obstacles are stored with a leading node id == SPECIAL_NODE_ID
-    std::unordered_multimap<NodeID, FromToObstacle> obstacles;
+    // obstacles according to internal id, sorted by 'to' node
+    std::vector<InternalObstacle> obstacles;
 };
 
 } // namespace osrm::extractor

--- a/include/extractor/obstacles.hpp
+++ b/include/extractor/obstacles.hpp
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 namespace osrm::extractor
 {
@@ -140,6 +141,7 @@ class ObstacleMap
     void emplace(NodeID from, NodeID to, const Obstacle &obstacle)
     {
         obstacles.push_back({to, from, obstacle});
+        sorted = false;
     }
 
     // get all obstacles at node 'to' when coming from node 'from'
@@ -196,6 +198,9 @@ class ObstacleMap
     // compressed.  Call this function once only.
     void fixupNodes(const NodeIDVector &);
 
+    // Sort internal obstacles by 'to' node. Call before running any queries.
+    void sort();
+
     // Replace a leading node that is going to be deleted during graph
     // compression with the leading node of the leading node.
     void compress(NodeID from, NodeID delendus, NodeID to);
@@ -214,6 +219,8 @@ class ObstacleMap
 
     std::pair<ConstObstacleIter, ConstObstacleIter> find_range(NodeID to) const
     {
+        if (!sorted)
+            throw std::logic_error("ObstacleMap: obstacles not sorted; call sort() before querying");
         return std::equal_range(obstacles.begin(),
                                 obstacles.end(),
                                 InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
@@ -221,6 +228,8 @@ class ObstacleMap
 
     std::pair<ObstacleIter, ObstacleIter> find_range(NodeID to)
     {
+        if (!sorted)
+            throw std::logic_error("ObstacleMap: obstacles not sorted; call sort() before querying");
         return std::equal_range(obstacles.begin(),
                                 obstacles.end(),
                                 InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
@@ -228,6 +237,9 @@ class ObstacleMap
 
     // obstacles according to external id
     tbb::concurrent_vector<OsmFromToObstacle> osm_obstacles;
+
+    // Whether the internal 'obstacles' vector is sorted by 'to'
+    bool sorted{false};
 
     // obstacles according to internal id, sorted by 'to' node
     std::vector<InternalObstacle> obstacles;

--- a/include/extractor/obstacles.hpp
+++ b/include/extractor/obstacles.hpp
@@ -214,14 +214,16 @@ class ObstacleMap
 
     std::pair<ConstObstacleIter, ConstObstacleIter> find_range(NodeID to) const
     {
-        return std::equal_range(
-            obstacles.begin(), obstacles.end(), InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
+        return std::equal_range(obstacles.begin(),
+                                obstacles.end(),
+                                InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
     }
 
     std::pair<ObstacleIter, ObstacleIter> find_range(NodeID to)
     {
-        return std::equal_range(
-            obstacles.begin(), obstacles.end(), InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
+        return std::equal_range(obstacles.begin(),
+                                obstacles.end(),
+                                InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
     }
 
     // obstacles according to external id

--- a/include/extractor/obstacles.hpp
+++ b/include/extractor/obstacles.hpp
@@ -155,7 +155,8 @@ class ObstacleMap
         auto [begin, end] = find_range(to);
         for (auto it = begin; it != end; ++it)
         {
-            if ((it->from == SPECIAL_NODEID || it->from == from) &&
+            // If caller requests all origins (from == SPECIAL_NODEID), accept any stored 'from'.
+            if ((from == SPECIAL_NODEID || it->from == SPECIAL_NODEID || it->from == from) &&
                 (static_cast<uint16_t>(it->obstacle.type) & static_cast<uint16_t>(type)))
             {
                 result.push_back(it->obstacle);
@@ -221,18 +222,26 @@ class ObstacleMap
     {
         if (!sorted)
             throw std::logic_error("ObstacleMap: obstacles not sorted; call sort() before querying");
-        return std::equal_range(obstacles.begin(),
-                                obstacles.end(),
-                                InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
+        auto lower = std::lower_bound(
+            obstacles.begin(), obstacles.end(), to,
+            [](const InternalObstacle &a, const NodeID value) { return a.to < value; });
+        auto upper = std::upper_bound(
+            lower, obstacles.end(), to,
+            [](const NodeID value, const InternalObstacle &a) { return value < a.to; });
+        return {lower, upper};
     }
 
     std::pair<ObstacleIter, ObstacleIter> find_range(NodeID to)
     {
         if (!sorted)
             throw std::logic_error("ObstacleMap: obstacles not sorted; call sort() before querying");
-        return std::equal_range(obstacles.begin(),
-                                obstacles.end(),
-                                InternalObstacle{to, {}, Obstacle{Obstacle::Type::None}});
+        auto lower = std::lower_bound(
+            obstacles.begin(), obstacles.end(), to,
+            [](const InternalObstacle &a, const NodeID value) { return a.to < value; });
+        auto upper = std::upper_bound(
+            lower, obstacles.end(), to,
+            [](const NodeID value, const InternalObstacle &a) { return value < a.to; });
+        return {lower, upper};
     }
 
     // obstacles according to external id

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -411,6 +411,11 @@ void ExtractionContainers::PrepareData(ScriptingEnvironment &scripting_environme
     const auto maneuver_override_ways = IdentifyManeuverOverrideWays();
     scripting_environment.m_obstacle_map.preProcess(used_node_id_list, way_node_id_offsets);
 
+    ways_list.clear();
+    ways_list.shrink_to_fit();
+    way_node_id_offsets.clear();
+    way_node_id_offsets.shrink_to_fit();
+
     PrepareNodes();
     PrepareEdges(scripting_environment);
     scripting_environment.m_obstacle_map.fixupNodes(used_node_id_list);
@@ -547,6 +552,9 @@ void ExtractionContainers::PrepareNodes()
         log << "ok, after " << TIMER_SEC(write_nodes) << "s";
     }
 
+    all_nodes_list.clear();
+    all_nodes_list.shrink_to_fit();
+
     util::Log() << "Processed " << max_internal_node_id << " nodes";
 }
 
@@ -567,13 +575,13 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
         log << "Setting start coords      ... " << std::flush;
         TIMER_START(set_start_coords);
         // Traverse list of edges and nodes in parallel and set start coord
-        auto node_iterator = all_nodes_list.begin();
+        auto node_iterator = used_nodes.begin();
         auto edge_iterator = all_edges_list.begin();
 
         const auto all_edges_list_end = all_edges_list.end();
-        const auto all_nodes_list_end = all_nodes_list.end();
+        const auto used_nodes_end = used_nodes.end();
 
-        while (edge_iterator != all_edges_list_end && node_iterator != all_nodes_list_end)
+        while (edge_iterator != all_edges_list_end && node_iterator != used_nodes_end)
         {
             if (edge_iterator->result.osm_source_id < node_iterator->node_id)
             {
@@ -639,15 +647,15 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
         util::UnbufferedLog log;
         log << "Computing edge weights    ... " << std::flush;
         TIMER_START(compute_weights);
-        auto node_iterator = all_nodes_list.begin();
+        auto node_iterator = used_nodes.begin();
         auto edge_iterator = all_edges_list.begin();
         const auto all_edges_list_end_ = all_edges_list.end();
-        const auto all_nodes_list_end_ = all_nodes_list.end();
+        const auto used_nodes_end_ = used_nodes.end();
 
         const auto weight_multiplier =
             scripting_environment.GetProfileProperties().GetWeightMultiplier();
 
-        while (edge_iterator != all_edges_list_end_ && node_iterator != all_nodes_list_end_)
+        while (edge_iterator != all_edges_list_end_ && node_iterator != used_nodes_end_)
         {
             // skip all invalid edges
             if (edge_iterator->result.source == SPECIAL_NODEID)
@@ -840,9 +848,6 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
             all_edges_list[j].result.target = SPECIAL_NODEID;
         }
     }
-
-    all_nodes_list.clear(); // free all_nodes_list before allocation of used_edges
-    all_nodes_list.shrink_to_fit();
 
     used_edges.reserve(all_edges_list.size());
     {

--- a/src/extractor/graph_compressor.cpp
+++ b/src/extractor/graph_compressor.cpp
@@ -60,6 +60,9 @@ void GraphCompressor::Compress(ScriptingEnvironment &scripting_environment,
     }
 
     {
+        // Ensure obstacle map internal storage is prepared for queries.
+        scripting_environment.m_obstacle_map.sort();
+
         const auto weight_multiplier =
             scripting_environment.GetProfileProperties().GetWeightMultiplier();
         util::UnbufferedLog log;

--- a/src/extractor/obstacles.cpp
+++ b/src/extractor/obstacles.cpp
@@ -30,6 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "util/log.hpp"
 #include "util/timing_util.hpp"
 
+#include <unordered_set>
+
 namespace osrm::extractor
 {
 
@@ -59,52 +61,70 @@ void ObstacleMap::preProcess(const NodeIDVector &node_ids, const WayNodeIDOffset
     log << "Collecting information on " << osm_obstacles.size() << " obstacles...";
     TIMER_START(preProcess);
 
-    // build a map to speed up the next step
-    // multimap of OSMNodeId to index into way_node_offsets
-    std::unordered_multimap<OSMNodeID, size_t> node2start_index;
-
-    for (size_t i = 0, j = 1; j < way_node_offsets.size(); ++i, ++j)
-    {
-        for (size_t k = way_node_offsets[i]; k < way_node_offsets[j]; ++k)
-        {
-            node2start_index.emplace(node_ids[k], i);
-        }
-    }
-
-    // for each unidirectional obstacle
-    //      for each way that crosses the obstacle
-    //          for each node of the crossing way
-    //              find the node immediately before or after the obstacle
-    //              add the unidirectional obstacle
-    //              note that we don't remove the bidirectional obstacle here,
-    //              but in fixupNodes()
-
-    for (auto &[from_id, to_id, obstacle] : osm_obstacles)
+    // collect the node IDs of unidirectional obstacles
+    std::unordered_set<OSMNodeID> directional_obstacle_nodes;
+    for (const auto &[from_id, to_id, obstacle] : osm_obstacles)
     {
         if (obstacle.direction == Obstacle::Direction::Forward ||
             obstacle.direction == Obstacle::Direction::Backward)
         {
-            bool forward = obstacle.direction == Obstacle::Direction::Forward;
-            auto [wno_begin, wno_end] = node2start_index.equal_range(to_id);
-            // for each way that crosses the obstacle
-            for (auto wno_iter = wno_begin; wno_iter != wno_end; ++wno_iter)
+            directional_obstacle_nodes.insert(to_id);
+        }
+    }
+
+    if (!directional_obstacle_nodes.empty())
+    {
+        // build a multimap of OSMNodeId to way index, but only for obstacle nodes
+        std::unordered_multimap<OSMNodeID, size_t> node2start_index;
+
+        for (size_t i = 0, j = 1; j < way_node_offsets.size(); ++i, ++j)
+        {
+            for (size_t k = way_node_offsets[i]; k < way_node_offsets[j]; ++k)
             {
-                using NodeIdIterator = NodeIDVector::const_iterator;
-
-                NodeIdIterator begin = node_ids.cbegin() + way_node_offsets[wno_iter->second];
-                NodeIdIterator end = node_ids.cbegin() + way_node_offsets[wno_iter->second + 1];
-                if (forward)
-                    ++begin;
-                else
-                    --end;
-
-                NodeIdIterator node_iter = find(begin, end, to_id);
-                if (node_iter != end)
+                if (directional_obstacle_nodes.contains(node_ids[k]))
                 {
-                    osm_obstacles.emplace_back(*(node_iter + (forward ? -1 : 1)), to_id, obstacle);
+                    node2start_index.emplace(node_ids[k], i);
                 }
             }
         }
+
+        // For each unidirectional obstacle, find the node immediately before
+        // or after the obstacle on each way that crosses it.  Collect new
+        // entries separately to avoid mutating osm_obstacles during iteration.
+        std::vector<OsmFromToObstacle> new_entries;
+
+        for (const auto &[from_id, to_id, obstacle] : osm_obstacles)
+        {
+            if (obstacle.direction == Obstacle::Direction::Forward ||
+                obstacle.direction == Obstacle::Direction::Backward)
+            {
+                bool forward = obstacle.direction == Obstacle::Direction::Forward;
+                auto [wno_begin, wno_end] = node2start_index.equal_range(to_id);
+                for (auto wno_iter = wno_begin; wno_iter != wno_end; ++wno_iter)
+                {
+                    using NodeIdIterator = NodeIDVector::const_iterator;
+
+                    NodeIdIterator begin =
+                        node_ids.cbegin() + way_node_offsets[wno_iter->second];
+                    NodeIdIterator end =
+                        node_ids.cbegin() + way_node_offsets[wno_iter->second + 1];
+                    if (forward)
+                        ++begin;
+                    else
+                        --end;
+
+                    NodeIdIterator node_iter = find(begin, end, to_id);
+                    if (node_iter != end)
+                    {
+                        new_entries.emplace_back(
+                            *(node_iter + (forward ? -1 : 1)), to_id, obstacle);
+                    }
+                }
+            }
+        }
+
+        for (auto &entry : new_entries)
+            osm_obstacles.push_back(std::move(entry));
     }
 
     TIMER_STOP(preProcess);
@@ -113,43 +133,104 @@ void ObstacleMap::preProcess(const NodeIDVector &node_ids, const WayNodeIDOffset
 
 void ObstacleMap::fixupNodes(const NodeIDVector &node_ids)
 {
-    const auto begin = node_ids.cbegin();
-    const auto end = node_ids.cend();
+    util::UnbufferedLog log;
+    log << "Renumbering " << osm_obstacles.size() << " obstacles...";
+    TIMER_START(obstacle_renumbering);
 
-    auto osm_to_internal = [&](const OSMNodeID &osm_node) -> NodeID
+    const auto should_skip = [](const auto &osm_from, const auto &, const auto &obstacle)
     {
-        if (osm_node == SPECIAL_OSM_NODEID)
-        {
-            return SPECIAL_NODEID;
-        }
-        const auto it = std::lower_bound(begin, end, osm_node);
-        return (it == end || osm_node < *it) ? SPECIAL_NODEID
-                                             : static_cast<NodeID>(std::distance(begin, it));
+        return (obstacle.direction == Obstacle::Direction::Forward ||
+                obstacle.direction == Obstacle::Direction::Backward) &&
+               osm_from == SPECIAL_OSM_NODEID;
     };
+
+    std::vector<OSMNodeID> used_osm_node_ids;
+    used_osm_node_ids.reserve(osm_obstacles.size() * 2);
 
     for (const auto &[osm_from, osm_to, obstacle] : osm_obstacles)
     {
-        if ((obstacle.direction == Obstacle::Direction::Forward ||
-             obstacle.direction == Obstacle::Direction::Backward) &&
-            osm_from == SPECIAL_OSM_NODEID)
-            // drop these bidirectional entries because we have generated an
-            // unidirectional copy of them
+        if (should_skip(osm_from, osm_to, obstacle))
             continue;
-        emplace(osm_to_internal(osm_from), osm_to_internal(osm_to), obstacle);
+
+        if (osm_from != SPECIAL_OSM_NODEID)
+            used_osm_node_ids.push_back(osm_from);
+
+        if (osm_to != SPECIAL_OSM_NODEID)
+            used_osm_node_ids.push_back(osm_to);
     }
+
+    std::sort(used_osm_node_ids.begin(), used_osm_node_ids.end());
+    used_osm_node_ids.erase(std::unique(used_osm_node_ids.begin(), used_osm_node_ids.end()),
+                            used_osm_node_ids.end());
+
+    std::vector<NodeID> internal_node_ids(used_osm_node_ids.size(), SPECIAL_NODEID);
+
+    std::size_t node_index = 0;
+    std::size_t used_index = 0;
+
+    while (node_index < node_ids.size() && used_index < used_osm_node_ids.size())
+    {
+        const auto node_id = node_ids[node_index];
+        const auto used_id = used_osm_node_ids[used_index];
+
+        if (node_id < used_id)
+        {
+            ++node_index;
+        }
+        else if (used_id < node_id)
+        {
+            ++used_index;
+        }
+        else
+        {
+            internal_node_ids[used_index] = static_cast<NodeID>(node_index);
+            ++used_index;
+        }
+    }
+
+    auto osm_to_internal = [&](const OSMNodeID osm_node) -> NodeID
+    {
+        if (osm_node == SPECIAL_OSM_NODEID)
+            return SPECIAL_NODEID;
+
+        const auto it =
+            std::lower_bound(used_osm_node_ids.begin(), used_osm_node_ids.end(), osm_node);
+
+        if (it == used_osm_node_ids.end() || *it != osm_node)
+            return SPECIAL_NODEID;
+
+        return internal_node_ids[static_cast<std::size_t>(
+            std::distance(used_osm_node_ids.begin(), it))];
+    };
+
+    obstacles.reserve(osm_obstacles.size());
+
+    for (const auto &[osm_from, osm_to, obstacle] : osm_obstacles)
+    {
+        if (should_skip(osm_from, osm_to, obstacle))
+            continue;
+
+        const auto from = osm_to_internal(osm_from);
+        const auto to = osm_to_internal(osm_to);
+
+        obstacles.push_back({to, from, obstacle});
+    }
+
     osm_obstacles.clear();
+    std::sort(obstacles.begin(), obstacles.end());
+    TIMER_STOP(obstacle_renumbering);
+    log << "ok, after " << TIMER_SEC(obstacle_renumbering) << "s";
 }
 
-void ObstacleMap::compress(NodeID node1, NodeID delendus, NodeID node2)
+void ObstacleMap::compress(const NodeID node1, const NodeID delendus, const NodeID node2)
 {
-    auto comp = [this, delendus](NodeID first, NodeID last)
+    auto comp = [this, delendus](const NodeID first, const NodeID last)
     {
-        const auto &[begin, end] = obstacles.equal_range(last);
-        for (auto i = begin; i != end; ++i)
+        auto [begin, end] = find_range(last);
+        for (auto it = begin; it != end; ++it)
         {
-            auto &[from, obstacle] = i->second;
-            if (from == delendus)
-                from = first;
+            if (it->from == delendus)
+                it->from = first;
         }
     };
 

--- a/src/extractor/obstacles.cpp
+++ b/src/extractor/obstacles.cpp
@@ -215,9 +215,15 @@ void ObstacleMap::fixupNodes(const NodeIDVector &node_ids)
     }
 
     osm_obstacles.clear();
-    std::sort(obstacles.begin(), obstacles.end());
+    sort();
     TIMER_STOP(obstacle_renumbering);
     log << "ok, after " << TIMER_SEC(obstacle_renumbering) << "s";
+}
+
+void ObstacleMap::sort()
+{
+    std::sort(obstacles.begin(), obstacles.end());
+    sorted = true;
 }
 
 void ObstacleMap::compress(const NodeID node1, const NodeID delendus, const NodeID node2)

--- a/src/extractor/obstacles.cpp
+++ b/src/extractor/obstacles.cpp
@@ -104,10 +104,8 @@ void ObstacleMap::preProcess(const NodeIDVector &node_ids, const WayNodeIDOffset
                 {
                     using NodeIdIterator = NodeIDVector::const_iterator;
 
-                    NodeIdIterator begin =
-                        node_ids.cbegin() + way_node_offsets[wno_iter->second];
-                    NodeIdIterator end =
-                        node_ids.cbegin() + way_node_offsets[wno_iter->second + 1];
+                    NodeIdIterator begin = node_ids.cbegin() + way_node_offsets[wno_iter->second];
+                    NodeIdIterator end = node_ids.cbegin() + way_node_offsets[wno_iter->second + 1];
                     if (forward)
                         ++begin;
                     else

--- a/unit_tests/extractor/intersection_analysis_tests.cpp
+++ b/unit_tests/extractor/intersection_analysis_tests.cpp
@@ -26,6 +26,7 @@ BOOST_AUTO_TEST_CASE(simple_intersection_connectivity)
     test::MockScriptingEnvironment scripting_environment;
     std::vector<UnresolvedManeuverOverride> maneuver_overrides;
     scripting_environment.m_obstacle_map.emplace(SPECIAL_NODEID, 6, {Obstacle::Type::Barrier});
+    scripting_environment.m_obstacle_map.sort();
 
     TurnLanesIndexedArray turn_lanes_data{{0, 0, 3},
                                           {TurnLaneType::uturn | TurnLaneType::left,
@@ -255,6 +256,8 @@ BOOST_AUTO_TEST_CASE(skip_degree_two_nodes)
     scripting_environment.m_obstacle_map.emplace(SPECIAL_NODEID, 1, {Obstacle::Type::Barrier});
     scripting_environment.m_obstacle_map.emplace(
         SPECIAL_NODEID, 2, {Obstacle::Type::TrafficSignals});
+
+    scripting_environment.m_obstacle_map.sort();
 
     TurnLanesIndexedArray turn_lanes_data;
 

--- a/unit_tests/extractor/obstacle_map_tests.cpp
+++ b/unit_tests/extractor/obstacle_map_tests.cpp
@@ -1,0 +1,40 @@
+#include "extractor/obstacles.hpp"
+#include <boost/test/unit_test.hpp>
+
+using namespace osrm::extractor;
+
+BOOST_AUTO_TEST_SUITE(obstacle_map_tests)
+
+BOOST_AUTO_TEST_CASE(unsorted_emplace_query)
+{
+    ObstacleMap map;
+    // insert obstacles with 'to' keys out of ascending order
+    map.emplace(0, 5, Obstacle(Obstacle::Type::Barrier));
+    map.emplace(0, 3, Obstacle(Obstacle::Type::Gate));
+    map.emplace(0, 4, Obstacle(Obstacle::Type::TrafficSignals));
+
+    const auto r3 = map.get(3);
+    BOOST_REQUIRE_EQUAL(r3.size(), 1);
+    BOOST_CHECK(r3[0].type == Obstacle::Type::Gate);
+
+    const auto r4 = map.get(4);
+    BOOST_REQUIRE_EQUAL(r4.size(), 1);
+    BOOST_CHECK(r4[0].type == Obstacle::Type::TrafficSignals);
+
+    const auto r5 = map.get(5);
+    BOOST_REQUIRE_EQUAL(r5.size(), 1);
+    BOOST_CHECK(r5[0].type == Obstacle::Type::Barrier);
+}
+
+BOOST_AUTO_TEST_CASE(any_obstacle_unsorted_insert)
+{
+    ObstacleMap map;
+    map.emplace(0, 2, Obstacle(Obstacle::Type::Stop));
+    map.emplace(0, 1, Obstacle(Obstacle::Type::Stop));
+
+    BOOST_CHECK(map.any(2));
+    BOOST_CHECK(map.any(1));
+    BOOST_CHECK(!map.any(3));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/extractor/obstacle_map_tests.cpp
+++ b/unit_tests/extractor/obstacle_map_tests.cpp
@@ -13,6 +13,9 @@ BOOST_AUTO_TEST_CASE(unsorted_emplace_query)
     map.emplace(0, 3, Obstacle(Obstacle::Type::Gate));
     map.emplace(0, 4, Obstacle(Obstacle::Type::TrafficSignals));
 
+    // Ensure internal storage is sorted before querying
+    map.sort();
+
     const auto r3 = map.get(3);
     BOOST_REQUIRE_EQUAL(r3.size(), 1);
     BOOST_CHECK(r3[0].type == Obstacle::Type::Gate);
@@ -31,6 +34,9 @@ BOOST_AUTO_TEST_CASE(any_obstacle_unsorted_insert)
     ObstacleMap map;
     map.emplace(0, 2, Obstacle(Obstacle::Type::Stop));
     map.emplace(0, 1, Obstacle(Obstacle::Type::Stop));
+
+    // sort internal storage before querying
+    map.sort();
 
     BOOST_CHECK(map.any(2));
     BOOST_CHECK(map.any(1));


### PR DESCRIPTION
Replace unordered_multimap<NodeID,FromToObstacle> with a sorted std::vector<InternalObstacle> and add find_range helpers forefficient lookup. Replace ranges-based iteration with iterator loops. Free large buffers earlier (ways_list,way_node_id_offsets, all_nodes_list) via clear()+shrink_to_fit and iterate over used_nodes to lower peak memory. Add missinginclude in obstacles.cpp.
