### PR TITLE
chore(ci): deprecate GCC-12

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -337,15 +337,6 @@ jobs:
             CXXCOMPILER: g++-13
             ENABLE_COVERAGE: ON
 
-          - name: gcc-12-release
-            continue-on-error: false
-            node: 24
-            runs-on: ubuntu-22.04
-            BUILD_TYPE: Release
-            CCOMPILER: gcc-12
-            CXXCOMPILER: g++-12
-            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
-
           - name: vcpkg-linux-release-bindings
             build_bindings: true
             continue-on-error: false


### PR DESCRIPTION
GCC-12 is out now that Debian Trixie is the new baseline
