### PR TITLE
feat: add user-defined literals _lat and _lon for typed coordinates

### DIFF
--- a/include/osrm/coordinate.hpp
+++ b/include/osrm/coordinate.hpp
@@ -37,6 +37,8 @@ using util::FixedLatitude;
 using util::FixedLongitude;
 using util::FloatLatitude;
 using util::FloatLongitude;
+using util::operator"" _lat;
+using util::operator"" _lon;
 using util::toFixed;
 using util::toFloating;
 } // namespace osrm

--- a/include/osrm/coordinate.hpp
+++ b/include/osrm/coordinate.hpp
@@ -37,8 +37,8 @@ using util::FixedLatitude;
 using util::FixedLongitude;
 using util::FloatLatitude;
 using util::FloatLongitude;
-using util::operator"" _lat;
-using util::operator"" _lon;
+using util::operator""_lat;
+using util::operator""_lon;
 using util::toFixed;
 using util::toFloating;
 } // namespace osrm

--- a/include/util/alias.hpp
+++ b/include/util/alias.hpp
@@ -57,7 +57,11 @@ template <typename From, typename Tag> struct Alias final
     {
         return Alias{__value - static_cast<const From>(rhs_)};
     }
-    inline Alias operator-() const { return Alias{-__value}; }
+    inline Alias operator-() const
+        requires(std::is_signed_v<From> || std::is_floating_point_v<From>)
+    {
+        return Alias{-__value};
+    }
     inline Alias operator*(const Alias rhs_) const
     {
         return Alias{__value * static_cast<const From>(rhs_)};

--- a/include/util/alias.hpp
+++ b/include/util/alias.hpp
@@ -57,6 +57,7 @@ template <typename From, typename Tag> struct Alias final
     {
         return Alias{__value - static_cast<const From>(rhs_)};
     }
+    inline Alias operator-() const { return Alias{-__value}; }
     inline Alias operator*(const Alias rhs_) const
     {
         return Alias{__value * static_cast<const From>(rhs_)};

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -108,22 +108,22 @@ static_assert(std::is_trivially_default_constructible<UnsafeFloatLongitude>(),
 static_assert(std::is_trivially_copyable<UnsafeFloatLongitude>(),
               "UnsafeFloatLongitude must be trivially copyable.");
 
-inline FixedLatitude operator"" _lat(unsigned long long latitude)
+inline FixedLatitude operator""_lat(unsigned long long latitude)
 {
     return FixedLatitude{boost::numeric_cast<std::int32_t>(latitude)};
 }
 
-constexpr FloatLatitude operator"" _lat(long double latitude)
+constexpr FloatLatitude operator""_lat(long double latitude)
 {
     return FloatLatitude{static_cast<double>(latitude)};
 }
 
-inline FixedLongitude operator"" _lon(unsigned long long longitude)
+inline FixedLongitude operator""_lon(unsigned long long longitude)
 {
     return FixedLongitude{boost::numeric_cast<std::int32_t>(longitude)};
 }
 
-constexpr FloatLongitude operator"" _lon(long double longitude)
+constexpr FloatLongitude operator""_lon(long double longitude)
 {
     return FloatLongitude{static_cast<double>(longitude)};
 }

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -108,9 +108,9 @@ static_assert(std::is_trivially_default_constructible<UnsafeFloatLongitude>(),
 static_assert(std::is_trivially_copyable<UnsafeFloatLongitude>(),
               "UnsafeFloatLongitude must be trivially copyable.");
 
-constexpr FixedLatitude operator"" _lat(unsigned long long latitude)
+inline FixedLatitude operator"" _lat(unsigned long long latitude)
 {
-    return FixedLatitude{static_cast<std::int32_t>(latitude)};
+    return FixedLatitude{boost::numeric_cast<std::int32_t>(latitude)};
 }
 
 constexpr FloatLatitude operator"" _lat(long double latitude)
@@ -118,9 +118,9 @@ constexpr FloatLatitude operator"" _lat(long double latitude)
     return FloatLatitude{static_cast<double>(latitude)};
 }
 
-constexpr FixedLongitude operator"" _lon(unsigned long long longitude)
+inline FixedLongitude operator"" _lon(unsigned long long longitude)
 {
-    return FixedLongitude{static_cast<std::int32_t>(longitude)};
+    return FixedLongitude{boost::numeric_cast<std::int32_t>(longitude)};
 }
 
 constexpr FloatLongitude operator"" _lon(long double longitude)

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -108,6 +108,26 @@ static_assert(std::is_trivially_default_constructible<UnsafeFloatLongitude>(),
 static_assert(std::is_trivially_copyable<UnsafeFloatLongitude>(),
               "UnsafeFloatLongitude must be trivially copyable.");
 
+constexpr FixedLatitude operator"" _lat(unsigned long long latitude)
+{
+    return FixedLatitude{static_cast<std::int32_t>(latitude)};
+}
+
+constexpr FloatLatitude operator"" _lat(long double latitude)
+{
+    return FloatLatitude{static_cast<double>(latitude)};
+}
+
+constexpr FixedLongitude operator"" _lon(unsigned long long longitude)
+{
+    return FixedLongitude{static_cast<std::int32_t>(longitude)};
+}
+
+constexpr FloatLongitude operator"" _lon(long double longitude)
+{
+    return FloatLongitude{static_cast<double>(longitude)};
+}
+
 /**
  * Converts a typed latitude from floating to fixed representation.
  *

--- a/unit_tests/engine/geometry_string.cpp
+++ b/unit_tests/engine/geometry_string.cpp
@@ -22,11 +22,11 @@ BOOST_AUTO_TEST_CASE(decode)
 
     // Test coordinates; these would be the coordinates we give the loc parameter,
     // e.g. loc=10.00,10.0&loc=10.01,10.1...
-    util::Coordinate coord1(util::FloatLongitude{10.0}, util::FloatLatitude{10.00});
-    util::Coordinate coord2(util::FloatLongitude{10.1}, util::FloatLatitude{10.01});
-    util::Coordinate coord3(util::FloatLongitude{10.2}, util::FloatLatitude{10.02});
-    util::Coordinate coord4(util::FloatLongitude{10.3}, util::FloatLatitude{10.03});
-    util::Coordinate coord5(util::FloatLongitude{10.4}, util::FloatLatitude{10.04});
+    util::Coordinate coord1(10.0_lon, 10.00_lat);
+    util::Coordinate coord2(10.1_lon, 10.01_lat);
+    util::Coordinate coord3(10.2_lon, 10.02_lat);
+    util::Coordinate coord4(10.3_lon, 10.03_lat);
+    util::Coordinate coord5(10.4_lon, 10.04_lat);
 
     // Put the test coordinates into the vector for comparison
     std::vector<util::Coordinate> cmp_coords = {coord1, coord2, coord3, coord4, coord5};
@@ -48,11 +48,11 @@ BOOST_AUTO_TEST_CASE(encode)
 {
     // Coordinates; these would be the coordinates we give the loc parameter,
     // e.g. loc=10.00,10.0&loc=10.01,10.1...
-    util::Coordinate coord1(util::FloatLongitude{10.0}, util::FloatLatitude{10.00});
-    util::Coordinate coord2(util::FloatLongitude{10.1}, util::FloatLatitude{10.01});
-    util::Coordinate coord3(util::FloatLongitude{10.2}, util::FloatLatitude{10.02});
-    util::Coordinate coord4(util::FloatLongitude{10.3}, util::FloatLatitude{10.03});
-    util::Coordinate coord5(util::FloatLongitude{10.4}, util::FloatLatitude{10.04});
+    util::Coordinate coord1(10.0_lon, 10.00_lat);
+    util::Coordinate coord2(10.1_lon, 10.01_lat);
+    util::Coordinate coord3(10.2_lon, 10.02_lat);
+    util::Coordinate coord4(10.3_lon, 10.03_lat);
+    util::Coordinate coord5(10.4_lon, 10.04_lat);
 
     // Test polyline string for the 5 coordinates
     const std::string polyline = "_c`|@_c`|@o}@_pRo}@_pRo}@_pRo}@_pR";
@@ -69,11 +69,11 @@ BOOST_AUTO_TEST_CASE(encode6)
 {
     // Coordinates; these would be the coordinates we give the loc parameter,
     // e.g. loc=10.00,10.0&loc=10.01,10.1...
-    util::Coordinate coord1(util::FloatLongitude{10.0}, util::FloatLatitude{10.00});
-    util::Coordinate coord2(util::FloatLongitude{10.1}, util::FloatLatitude{10.01});
-    util::Coordinate coord3(util::FloatLongitude{10.2}, util::FloatLatitude{10.02});
-    util::Coordinate coord4(util::FloatLongitude{10.3}, util::FloatLatitude{10.03});
-    util::Coordinate coord5(util::FloatLongitude{10.4}, util::FloatLatitude{10.04});
+    util::Coordinate coord1(10.0_lon, 10.00_lat);
+    util::Coordinate coord2(10.1_lon, 10.01_lat);
+    util::Coordinate coord3(10.2_lon, 10.02_lat);
+    util::Coordinate coord4(10.3_lon, 10.03_lat);
+    util::Coordinate coord5(10.4_lon, 10.04_lat);
 
     // Test polyline string for the 6 coordinates
     const std::string polyline = "_gjaR_gjaR_pR_ibE_pR_ibE_pR_ibE_pR_ibE";
@@ -90,9 +90,9 @@ BOOST_AUTO_TEST_CASE(polyline_sign_check)
 {
     // check sign conversion correctness from zig-zag encoding to two's complement
     std::vector<util::Coordinate> coords = {
-        {util::FloatLongitude{0}, util::FloatLatitude{0}},
-        {util::FloatLongitude{-0.00001}, util::FloatLatitude{0.00000}},
-        {util::FloatLongitude{0.00000}, util::FloatLatitude{-0.00001}}};
+        {0.0_lon, 0.0_lat},
+        {-0.00001_lon, 0.00000_lat},
+        {0.00000_lon, -0.00001_lat}};
 
     const auto polyline = encodePolyline<100000>(coords.begin(), coords.end());
     const auto result = decodePolyline(polyline);
@@ -109,9 +109,9 @@ BOOST_AUTO_TEST_CASE(polyline_short_strings)
     // check zero longitude difference in the last coordinate
     // the polyline is incorrect, but decodePolyline must not fail
     std::vector<util::Coordinate> coords = {
-        {util::FloatLongitude{13.32476}, util::FloatLatitude{52.52632}},
-        {util::FloatLongitude{13.30179}, util::FloatLatitude{52.59155}},
-        {util::FloatLongitude{13.30179}, util::FloatLatitude{52.60391}}};
+        {13.32476_lon, 52.52632_lat},
+        {13.30179_lon, 52.59155_lat},
+        {13.30179_lon, 52.60391_lat}};
 
     const auto polyline = encodePolyline<100000>(coords.begin(), coords.end());
     BOOST_CHECK(polyline.back() == '?');
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(incorrect_polylines)
         "?_",      // unfinished longitude
         "?_______" // too long longitude (35 bits)
     };
-    util::Coordinate coord{util::FloatLongitude{0}, util::FloatLatitude{0}};
+    util::Coordinate coord{0.0_lon, 0.0_lat};
 
     for (const auto &polyline : polylines)
     {

--- a/unit_tests/engine/geometry_string.cpp
+++ b/unit_tests/engine/geometry_string.cpp
@@ -90,9 +90,7 @@ BOOST_AUTO_TEST_CASE(polyline_sign_check)
 {
     // check sign conversion correctness from zig-zag encoding to two's complement
     std::vector<util::Coordinate> coords = {
-        {0.0_lon, 0.0_lat},
-        {-0.00001_lon, 0.00000_lat},
-        {0.00000_lon, -0.00001_lat}};
+        {0.0_lon, 0.0_lat}, {-0.00001_lon, 0.00000_lat}, {0.00000_lon, -0.00001_lat}};
 
     const auto polyline = encodePolyline<100000>(coords.begin(), coords.end());
     const auto result = decodePolyline(polyline);
@@ -109,9 +107,7 @@ BOOST_AUTO_TEST_CASE(polyline_short_strings)
     // check zero longitude difference in the last coordinate
     // the polyline is incorrect, but decodePolyline must not fail
     std::vector<util::Coordinate> coords = {
-        {13.32476_lon, 52.52632_lat},
-        {13.30179_lon, 52.59155_lat},
-        {13.30179_lon, 52.60391_lat}};
+        {13.32476_lon, 52.52632_lat}, {13.30179_lon, 52.59155_lat}, {13.30179_lon, 52.60391_lat}};
 
     const auto polyline = encodePolyline<100000>(coords.begin(), coords.end());
     BOOST_CHECK(polyline.back() == '?');

--- a/unit_tests/engine/guidance_assembly.cpp
+++ b/unit_tests/engine/guidance_assembly.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    IntermediateIntersection intersection1{{FloatLongitude{-73.981154}, FloatLatitude{40.767762}},
+    IntermediateIntersection intersection1{{-73.981154_lon, 40.767762_lat},
                                            {302},
                                            {1},
                                            IntermediateIntersection::NO_INDEX,
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
                                            {0, 255},
                                            {},
                                            {}};
-    IntermediateIntersection intersection2{{FloatLongitude{-73.981495}, FloatLatitude{40.768275}},
+    IntermediateIntersection intersection2{{-73.981495_lon, 40.768275_lat},
                                            {180},
                                            {1},
                                            0,
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
                                      1.9076601161280742,
                                      0.2,
                                      TRAVEL_MODE_DRIVING,
-                                     {{FloatLongitude{-73.981492}, FloatLatitude{40.768258}},
+                                     {{-73.981492_lon, 40.768258_lat},
                                       329,
                                       348,
                                       {TurnType::ExitRotary, DirectionModifier::Straight},
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
                                      0,
                                      0,
                                      TRAVEL_MODE_DRIVING,
-                                     {{FloatLongitude{-73.981495}, FloatLatitude{40.768275}},
+                                     {{-73.981495_lon, 40.768275_lat},
                                       0,
                                       0,
                                       {TurnType::NoTurn, DirectionModifier::UTurn},
@@ -87,9 +87,9 @@ BOOST_AUTO_TEST_CASE(trim_short_segments)
                                      false}};
 
     LegGeometry geometry;
-    geometry.locations = {{FloatLongitude{-73.981492}, FloatLatitude{40.768258}},
-                          {FloatLongitude{-73.981495}, FloatLatitude{40.768275}},
-                          {FloatLongitude{-73.981495}, FloatLatitude{40.768275}}};
+    geometry.locations = {{-73.981492_lon, 40.768258_lat},
+                          {-73.981495_lon, 40.768275_lat},
+                          {-73.981495_lon, 40.768275_lat}};
     geometry.segment_offsets = {0, 2};
     geometry.segment_distances = {1.9076601161280742};
     geometry.node_ids = {NodeID{0}, NodeID{1}, NodeID{2}};

--- a/unit_tests/engine/polyline_compressor.cpp
+++ b/unit_tests/engine/polyline_compressor.cpp
@@ -95,8 +95,8 @@ BOOST_AUTO_TEST_CASE(polyline_large_coordinate_difference_test)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    const std::vector<Coordinate> coords({{-179.000000_lon, -89.000000_lat},
-                                          {179.000000_lon, 89.000000_lat}});
+    const std::vector<Coordinate> coords(
+        {{-179.000000_lon, -89.000000_lat}, {179.000000_lon, 89.000000_lat}});
 
     const std::string encoded = encodePolyline(coords.begin(), coords.end());
     BOOST_CHECK_EQUAL(encoded, "~xe~O~|oca@_sl}`@_{`hcA");

--- a/unit_tests/engine/polyline_compressor.cpp
+++ b/unit_tests/engine/polyline_compressor.cpp
@@ -13,14 +13,13 @@ BOOST_AUTO_TEST_CASE(polyline5_test_case)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    const std::vector<Coordinate> coords({{FixedLongitude{-73990171}, FixedLatitude{40714701}},
-                                          {FixedLongitude{-73991801}, FixedLatitude{40717571}},
-                                          {FixedLongitude{-73985751}, FixedLatitude{40715651}}});
+    const std::vector<Coordinate> coords({{-73.990171_lon, 40.714701_lat},
+                                          {-73.991801_lon, 40.717571_lat},
+                                          {-73.985751_lon, 40.715651_lat}});
 
-    const std::vector<Coordinate> coords_truncated(
-        {{FixedLongitude{-73990170}, FixedLatitude{40714700}},
-         {FixedLongitude{-73991800}, FixedLatitude{40717570}},
-         {FixedLongitude{-73985750}, FixedLatitude{40715650}}});
+    const std::vector<Coordinate> coords_truncated({{-73.990170_lon, 40.714700_lat},
+                                                    {-73.991800_lon, 40.717570_lat},
+                                                    {-73.985750_lon, 40.715650_lat}});
 
     BOOST_CHECK_EQUAL(encodePolyline(coords.begin(), coords.end()), "{aowFperbM}PdI~Jyd@");
     BOOST_CHECK(std::equal(coords_truncated.begin(),
@@ -33,9 +32,9 @@ BOOST_AUTO_TEST_CASE(polyline6_test_case)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    const std::vector<Coordinate> coords({{FixedLongitude{-73990171}, FixedLatitude{40714701}},
-                                          {FixedLongitude{-73991801}, FixedLatitude{40717571}},
-                                          {FixedLongitude{-73985751}, FixedLatitude{40715651}}});
+    const std::vector<Coordinate> coords({{-73.990171_lon, 40.714701_lat},
+                                          {-73.991801_lon, 40.717571_lat},
+                                          {-73.985751_lon, 40.715651_lat}});
 
     BOOST_CHECK_EQUAL(encodePolyline<1000000>(coords.begin(), coords.end()),
                       "y{_tlAt`_clCkrDzdB~vBcyJ");
@@ -59,15 +58,15 @@ BOOST_AUTO_TEST_CASE(polyline_single_point_test)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    const std::vector<Coordinate> coords({{FixedLongitude{-122414000}, FixedLatitude{37776000}}});
+    const std::vector<Coordinate> coords({{-122.414000_lon, 37.776000_lat}});
 
     const std::string encoded = encodePolyline(coords.begin(), coords.end());
     BOOST_CHECK_EQUAL(encoded, "_cqeFn~cjV");
 
     const auto decoded = decodePolyline(encoded);
     BOOST_CHECK_EQUAL(decoded.size(), 1);
-    BOOST_CHECK_EQUAL(decoded[0].lon, FixedLongitude{-122414000});
-    BOOST_CHECK_EQUAL(decoded[0].lat, FixedLatitude{37776000});
+    BOOST_CHECK_EQUAL(decoded[0].lon, toFixed(-122.414000_lon));
+    BOOST_CHECK_EQUAL(decoded[0].lat, toFixed(37.776000_lat));
 }
 
 BOOST_AUTO_TEST_CASE(polyline_multiple_points_test)
@@ -75,9 +74,9 @@ BOOST_AUTO_TEST_CASE(polyline_multiple_points_test)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    const std::vector<Coordinate> coords({{FixedLongitude{-122414000}, FixedLatitude{37776000}},
-                                          {FixedLongitude{-122420000}, FixedLatitude{37779000}},
-                                          {FixedLongitude{-122421000}, FixedLatitude{37780000}}});
+    const std::vector<Coordinate> coords({{-122.414000_lon, 37.776000_lat},
+                                          {-122.420000_lon, 37.779000_lat},
+                                          {-122.421000_lon, 37.780000_lat}});
 
     const std::string encoded = encodePolyline(coords.begin(), coords.end());
     BOOST_CHECK_EQUAL(encoded, "_cqeFn~cjVwQnd@gEfE");
@@ -96,8 +95,8 @@ BOOST_AUTO_TEST_CASE(polyline_large_coordinate_difference_test)
     using namespace osrm::engine;
     using namespace osrm::util;
 
-    const std::vector<Coordinate> coords({{FixedLongitude{-179000000}, FixedLatitude{-89000000}},
-                                          {FixedLongitude{179000000}, FixedLatitude{89000000}}});
+    const std::vector<Coordinate> coords({{-179.000000_lon, -89.000000_lat},
+                                          {179.000000_lon, 89.000000_lat}});
 
     const std::string encoded = encodePolyline(coords.begin(), coords.end());
     BOOST_CHECK_EQUAL(encoded, "~xe~O~|oca@_sl}`@_{`hcA");

--- a/unit_tests/library/coordinates.hpp
+++ b/unit_tests/library/coordinates.hpp
@@ -15,8 +15,8 @@ using Locations = std::vector<Location>;
 
 inline Locations get_split_trace_locations()
 {
-    using osrm::operator"" _lat;
-    using osrm::operator"" _lon;
+    using osrm::operator""_lat;
+    using osrm::operator""_lon;
     return {{7.420202_lon, 43.732274_lat},
             {7.422369_lon, 43.732282_lat},
             {7.421511_lon, 43.734181_lat},
@@ -25,15 +25,15 @@ inline Locations get_split_trace_locations()
 
 inline Location get_dummy_location()
 {
-    using osrm::operator"" _lat;
-    using osrm::operator"" _lon;
+    using osrm::operator""_lat;
+    using osrm::operator""_lon;
     return {7.437069_lon, 43.749249_lat};
 }
 
 inline Locations get_locations_in_small_component()
 {
-    using osrm::operator"" _lat;
-    using osrm::operator"" _lon;
+    using osrm::operator""_lat;
+    using osrm::operator""_lon;
     return {{7.438023_lon, 43.746465_lat},
             {7.439263_lon, 43.746543_lat},
             {7.438190_lon, 43.747560_lat}};
@@ -41,8 +41,8 @@ inline Locations get_locations_in_small_component()
 
 inline Locations get_locations_in_big_component()
 {
-    using osrm::operator"" _lat;
-    using osrm::operator"" _lon;
+    using osrm::operator""_lat;
+    using osrm::operator""_lon;
     return {{7.415800_lon, 43.734132_lat},
             {7.417710_lon, 43.736721_lat},
             {7.421315_lon, 43.738814_lat}};

--- a/unit_tests/library/coordinates.hpp
+++ b/unit_tests/library/coordinates.hpp
@@ -5,6 +5,9 @@
 
 #include <vector>
 
+using osrm::operator"" _lat;
+using osrm::operator"" _lon;
+
 // Somewhere in 2b8dd9343d5e615afc9c67bcc7028a63 Monaco
 
 // Convenience aliases
@@ -15,29 +18,29 @@ using Locations = std::vector<Location>;
 
 inline Locations get_split_trace_locations()
 {
-    return {{Longitude{7.420202}, Latitude{43.732274}},
-            {Longitude{7.422369}, Latitude{43.732282}},
-            {Longitude{7.421511}, Latitude{43.734181}},
-            {Longitude{7.421489}, Latitude{43.736553}}};
+    return {{7.420202_lon, 43.732274_lat},
+            {7.422369_lon, 43.732282_lat},
+            {7.421511_lon, 43.734181_lat},
+            {7.421489_lon, 43.736553_lat}};
 }
 
 inline Location get_dummy_location()
 {
-    return {osrm::util::FloatLongitude{7.437069}, osrm::util::FloatLatitude{43.749249}};
+    return {7.437069_lon, 43.749249_lat};
 }
 
 inline Locations get_locations_in_small_component()
 {
-    return {{Longitude{7.438023}, Latitude{43.746465}},
-            {Longitude{7.439263}, Latitude{43.746543}},
-            {Longitude{7.438190}, Latitude{43.747560}}};
+    return {{7.438023_lon, 43.746465_lat},
+            {7.439263_lon, 43.746543_lat},
+            {7.438190_lon, 43.747560_lat}};
 }
 
 inline Locations get_locations_in_big_component()
 {
-    return {{Longitude{7.415800}, Latitude{43.734132}},
-            {Longitude{7.417710}, Latitude{43.736721}},
-            {Longitude{7.421315}, Latitude{43.738814}}};
+    return {{7.415800_lon, 43.734132_lat},
+            {7.417710_lon, 43.736721_lat},
+            {7.421315_lon, 43.738814_lat}};
 }
 
 #endif

--- a/unit_tests/library/coordinates.hpp
+++ b/unit_tests/library/coordinates.hpp
@@ -5,9 +5,6 @@
 
 #include <vector>
 
-using osrm::operator"" _lat;
-using osrm::operator"" _lon;
-
 // Somewhere in 2b8dd9343d5e615afc9c67bcc7028a63 Monaco
 
 // Convenience aliases
@@ -18,16 +15,25 @@ using Locations = std::vector<Location>;
 
 inline Locations get_split_trace_locations()
 {
+    using osrm::operator"" _lat;
+    using osrm::operator"" _lon;
     return {{7.420202_lon, 43.732274_lat},
             {7.422369_lon, 43.732282_lat},
             {7.421511_lon, 43.734181_lat},
             {7.421489_lon, 43.736553_lat}};
 }
 
-inline Location get_dummy_location() { return {7.437069_lon, 43.749249_lat}; }
+inline Location get_dummy_location()
+{
+    using osrm::operator"" _lat;
+    using osrm::operator"" _lon;
+    return {7.437069_lon, 43.749249_lat};
+}
 
 inline Locations get_locations_in_small_component()
 {
+    using osrm::operator"" _lat;
+    using osrm::operator"" _lon;
     return {{7.438023_lon, 43.746465_lat},
             {7.439263_lon, 43.746543_lat},
             {7.438190_lon, 43.747560_lat}};
@@ -35,6 +41,8 @@ inline Locations get_locations_in_small_component()
 
 inline Locations get_locations_in_big_component()
 {
+    using osrm::operator"" _lat;
+    using osrm::operator"" _lon;
     return {{7.415800_lon, 43.734132_lat},
             {7.417710_lon, 43.736721_lat},
             {7.421315_lon, 43.738814_lat}};

--- a/unit_tests/library/coordinates.hpp
+++ b/unit_tests/library/coordinates.hpp
@@ -24,10 +24,7 @@ inline Locations get_split_trace_locations()
             {7.421489_lon, 43.736553_lat}};
 }
 
-inline Location get_dummy_location()
-{
-    return {7.437069_lon, 43.749249_lat};
-}
+inline Location get_dummy_location() { return {7.437069_lon, 43.749249_lat}; }
 
 inline Locations get_locations_in_small_component()
 {

--- a/unit_tests/util/coordinate_literals.cpp
+++ b/unit_tests/util/coordinate_literals.cpp
@@ -1,0 +1,29 @@
+#include "osrm/coordinate.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <type_traits>
+
+BOOST_AUTO_TEST_SUITE(coordinate_literals)
+
+using namespace osrm;
+
+BOOST_AUTO_TEST_CASE(lat_literal_type_and_value)
+{
+    static_assert(std::is_same_v<decltype(52_lat), FixedLatitude>);
+    static_assert(std::is_same_v<decltype(52.125_lat), FloatLatitude>);
+
+    BOOST_CHECK(52_lat == FixedLatitude{52});
+    BOOST_CHECK(52.125_lat == FloatLatitude{52.125});
+}
+
+BOOST_AUTO_TEST_CASE(lon_literal_type_and_value)
+{
+    static_assert(std::is_same_v<decltype(13_lon), FixedLongitude>);
+    static_assert(std::is_same_v<decltype(13.25_lon), FloatLongitude>);
+
+    BOOST_CHECK(13_lon == FixedLongitude{13});
+    BOOST_CHECK(13.25_lon == FloatLongitude{13.25});
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes #2028

Adds lower-case user-defined literals to `include/util/coordinate.hpp`:

  - Integer literal  N_lat   -> FixedLatitude{N}
  - Float literal    N.n_lat -> FloatLatitude{N.n}
  - Integer literal  N_lon   -> FixedLongitude{N}
  - Float literal    N.n_lon -> FloatLongitude{N.n}

Literals are re-exported from `include/osrm/coordinate.hpp` via `using util::operator"" _lat/_lon` so consumers of the public header get them automatically.

Also adds unary `operator-()` to `Alias` so that negative literals such as `-73.981_lon` work without extra ceremony.

Unit tests added in `unit_tests/util/coordinate_literals.cpp` covering both type (static_assert) and value correctness for all four overloads.

Existing unit tests in engine/ and library/ are updated to use the new literals where they construct typed coordinates.
