### PR TITLE
test(cucumber): assert response metadata fields

### DIFF
--- a/features/nearest/pick.feature
+++ b/features/nearest/pick.feature
@@ -104,6 +104,59 @@ Feature: Locating Nearest node on a Way - pick closest way
             | y  | b   |
             | z  | c   |
 
+    Scenario: Nearest - multiple results with number parameter
+        Given the node map
+            """
+              0 c 1
+            7   n   2
+            a k x m b
+            6   l   3
+              5 d 4
+            """
+
+        And the ways
+            | nodes |
+            | axb   |
+            | cxd   |
+
+        And the query options
+            | number | 3 |
+
+        When I request nearest I should get
+            | in | result_count |
+            | 0  | 3            |
+            | k  | 3            |
+
+    Scenario: Nearest - waypoint name from named road
+        Given the node map
+            """
+            0
+            a x b
+            """
+
+        And the ways
+            | nodes | name     |
+            | axb   | Main St  |
+
+        When I request nearest I should get
+            | in | out | name    |
+            | 0  | a   | Main St |
+
+    Scenario: Nearest - snapping distance is reported
+        Given the node map
+            """
+            0
+            a x b
+            """
+
+        And the ways
+            | nodes |
+            | axb   |
+
+        When I request nearest I should get
+            | in | out | snapping_distance |
+            | a  | a   | 0.0               |
+
     Scenario: Nearest - data version
         Given the node map
             """

--- a/features/step_definitions/matching.js
+++ b/features/step_definitions/matching.js
@@ -8,7 +8,7 @@ When(/^I match I should get$/, async function (table) {
   let got;
 
   await this.reprocessAndLoadData();
-  const testRow = function (row, ri) {
+  const testRow = function (row, _ri) {
     return new Promise((resolve, reject) => {
       const afterRequest = function (err, res, body) {
         if (err) return reject(err);
@@ -97,6 +97,14 @@ When(/^I match I should get$/, async function (table) {
             duration = json.matchings[0].duration;
           }
 
+          if (headers.has('confidence')) {
+            if (json.matchings.length != 1)
+              throw new Error(
+                '*** Checking confidence only supported for matchings with one subtrace',
+              );
+            got.confidence = json.matchings[0].confidence.toString();
+          }
+
           // annotation response values are requested by 'a:{type_name}'
           let found = false;
           headers.forEach((h) => {
@@ -120,6 +128,12 @@ When(/^I match I should get$/, async function (table) {
 
           if (headers.has('alternatives')) {
             alternatives = this.alternativesList(json);
+          }
+
+          if (headers.has('matchings_index')) {
+            got.matchings_index = json.tracepoints
+              .map(tp => tp === null ? '' : tp.matchings_index.toString())
+              .join(',');
           }
         }
 
@@ -271,6 +285,14 @@ When(/^I match I should get$/, async function (table) {
           got.waypoints = resultWaypoints.join(';');
           got.matchings = encodedResult;
           row.matchings = extendedTarget;
+        }
+
+        const skipFuzzy = new Set(['matchings', 'waypoints', 'timestamps', 'trace']);
+        for (const key in row) {
+          if (skipFuzzy.has(key)) continue;
+          if (this.FuzzyMatch.match(got[key], row[key])) {
+            got[key] = row[key];
+          }
         }
 
         resolve(got);

--- a/features/step_definitions/nearest.js
+++ b/features/step_definitions/nearest.js
@@ -8,7 +8,7 @@ import { When } from '@cucumber/cucumber';
 
 When(/^I request nearest I should get$/, async function (table) {
   await this.reprocessAndLoadData();
-  const testRow = function (row, ri) {
+  const testRow = function (row, _ri) {
     return new Promise((resolve, reject) => {
       const inNode = this.findNodeByName(row.in);
       if (!inNode) return reject(new Error(util.format('*** unknown in-node "%s"', row.in)));
@@ -30,38 +30,53 @@ When(/^I request nearest I should get$/, async function (table) {
               got.data_version = json.data_version || '';
             }
 
-            if (json.waypoints && json.waypoints.length && row.out) {
-              coord = json.waypoints[0].location;
+            if (json.waypoints && json.waypoints.length) {
+              if (headers.has('result_count')) {
+                got.result_count = json.waypoints.length.toString();
+              }
 
-              got.out = row.out;
+              if (headers.has('name')) {
+                got.name = json.waypoints[0].name || '';
+              }
 
-              const outNode = this.findNodeByName(row.out);
-              if (!outNode) return reject(new Error(util.format('*** unknown out-node "%s"', row.out)));
+              if (headers.has('snapping_distance')) {
+                const dist = json.waypoints[0].distance;
+                got.snapping_distance = dist != null ? dist.toFixed(1) : '';
+              }
 
-              Object.keys(row).forEach((key) => {
-                if (key === 'out') {
-                  if (this.FuzzyMatch.matchLocation(coord, outNode)) {
-                    got[key] = row[key];
-                  } else {
-                    row[key] = util.format('%s [%d,%d]', row[key], outNode.lat, outNode.lon);
+              if (row.out) {
+                coord = json.waypoints[0].location;
+
+                got.out = row.out;
+
+                const outNode = this.findNodeByName(row.out);
+                if (!outNode) return reject(new Error(util.format('*** unknown out-node "%s"', row.out)));
+
+                Object.keys(row).forEach((key) => {
+                  if (key === 'out') {
+                    if (this.FuzzyMatch.matchLocation(coord, outNode)) {
+                      got[key] = row[key];
+                    } else {
+                      row[key] = util.format('%s [%d,%d]', row[key], outNode.lat, outNode.lon);
+                    }
+                  } else if (key === 'nodes') {
+                    const nodeNames = row.nodes.split(',').map(n => n.trim()).filter(n => n.length > 0);
+                    if (nodeNames.length !== 2)
+                      throw new Error(util.format('*** nodes column must be "from,to", got "%s"', row.nodes));
+                    const fromNode = this.findNodeByName(nodeNames[0]);
+                    const toNode = this.findNodeByName(nodeNames[1]);
+                    if (!fromNode) throw new Error(util.format('*** unknown from-node "%s"', nodeNames[0]));
+                    if (!toNode) throw new Error(util.format('*** unknown to-node "%s"', nodeNames[1]));
+                    const actualNodes = json.waypoints[0].nodes;
+                    if (actualNodes && actualNodes[0] === fromNode.id && actualNodes[1] === toNode.id) {
+                      got.nodes = row.nodes;
+                    } else {
+                      row.nodes = util.format('%s [got: %s,%s]', row.nodes,
+                        actualNodes ? actualNodes[0] : '?', actualNodes ? actualNodes[1] : '?');
+                    }
                   }
-                } else if (key === 'nodes') {
-                  const nodeNames = row.nodes.split(',').map(n => n.trim()).filter(n => n.length > 0);
-                  if (nodeNames.length !== 2)
-                    throw new Error(util.format('*** nodes column must be "from,to", got "%s"', row.nodes));
-                  const fromNode = this.findNodeByName(nodeNames[0]);
-                  const toNode = this.findNodeByName(nodeNames[1]);
-                  if (!fromNode) throw new Error(util.format('*** unknown from-node "%s"', nodeNames[0]));
-                  if (!toNode) throw new Error(util.format('*** unknown to-node "%s"', nodeNames[1]));
-                  const actualNodes = json.waypoints[0].nodes;
-                  if (actualNodes && actualNodes[0] === fromNode.id && actualNodes[1] === toNode.id) {
-                    got.nodes = row.nodes;
-                  } else {
-                    row.nodes = util.format('%s [got: %s,%s]', row.nodes,
-                      actualNodes ? actualNodes[0] : '?', actualNodes ? actualNodes[1] : '?');
-                  }
-                }
-              });
+                });
+              }
             }
 
           }
@@ -79,7 +94,7 @@ When(/^I request nearest I should get$/, async function (table) {
 
 When(/^I request nearest with flatbuffers I should get$/, async function (table) {
   await this.reprocessAndLoadData();
-  const testRow = function (row, ri) {
+  const testRow = function (row, _ri) {
     return new Promise((resolve, reject) => {
       const inNode = this.findNodeByName(row.in);
       if (!inNode) return reject(new Error(util.format('*** unknown in-node "%s"', row.in)));

--- a/features/step_definitions/trip.js
+++ b/features/step_definitions/trip.js
@@ -68,6 +68,9 @@ When(/^I plan a trip I should get$/, async function (table) {
         let trip_distance;
         let ok = res.statusCode === 200;
         if (ok) {
+          if (headers.has('weight_name')) {
+            got.weight_name = json.trips && json.trips[0] ? json.trips[0].weight_name : '';
+          }
           if (headers.has('trips')) {
             // Prefer waypoint_index/trips_index from the API response to reconstruct
             // trip order. This is robust against route-geometry details and still

--- a/features/testbot/matching.feature
+++ b/features/testbot/matching.feature
@@ -797,3 +797,33 @@ Feature: Basic Map Matching
           | 2345  | 1.00018,1,1.000314,1 | 14.91466649  | 1.4        | 1.4      | 1.4      |
           | 4321  | 1.00027,1,1.000135,1 | 15.02596997  | 1.5        | 1.5      | 1.5      |
 
+    Scenario: Testbot - Map matching matchings_index is reported for split traces
+        Given the node map
+            """
+            a b c d
+                e
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | timestamps | matchings | matchings_index |
+            | abcd  | 0 1 62 63  | ab,cd     | 0,0,1,1         |
+
+    Scenario: Testbot - Map matching confidence is reported
+        Given a grid size of 10 meters
+        Given the node map
+            """
+            a b c d
+            """
+
+        And the ways
+            | nodes | oneway |
+            | abcd  | no     |
+
+        When I match I should get
+            | trace | matchings | confidence |
+            | abcd  | abcd      | 1 ~5%      |
+

--- a/features/testbot/trip.feature
+++ b/features/testbot/trip.feature
@@ -61,6 +61,24 @@ Feature: Basic trip planning
             | waypoints   | trips  | data_version          | code |
             | a,a         | aa     | cucumber_data_version | Ok   |
 
+    Scenario: Testbot - Trip: weight_name is reported
+        Given the node map
+            """
+            a b
+            c d
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+            | bc    |
+            | cb    |
+            | da    |
+
+        When I plan a trip I should get
+            | waypoints   | trips  | weight_name | code |
+            | a,a         | aa     | duration    | Ok   |
+
     Scenario: Testbot - Trip: Roundtrip with waypoints (less than 10)
         Given the node map
             """


### PR DESCRIPTION
Add/extend cucumber step assertions and feature scenarios for Nearest, Matching, and Trip metadata outputs, including result_count, name, snapping_distance, confidence, matchings_index, and weight_name.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
