### PR TITLE
build: fix compilation on newer systems

### DIFF
--- a/include/util/indexed_data.hpp
+++ b/include/util/indexed_data.hpp
@@ -11,6 +11,7 @@
 #include <boost/assert.hpp>
 
 #include <array>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <string>

--- a/src/tools/io-benchmark.cpp
+++ b/src/tools/io-benchmark.cpp
@@ -13,7 +13,7 @@
 #ifdef __linux__
 #include <malloc.h>
 #endif
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__linux__)
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
# Issue
#7588

`std::cref` requires `#include <functional>`
`read`, `write`, `close` and `lseek` require `#include <unistd.h>`

Was this change primarily generated using an AI tool? No

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

none

