### PR TITLE
fix: correct EARTH_RADIUS to IUGG mean radius 6371008.7714m

### DIFF
--- a/include/util/coordinate_calculation.hpp
+++ b/include/util/coordinate_calculation.hpp
@@ -21,7 +21,8 @@ const constexpr double DEGREE_TO_RAD = 0.017453292519943295769236907684886;
 const constexpr double RAD_TO_DEGREE = 1. / DEGREE_TO_RAD;
 // earth radius varies between 6,356.750-6,378.135 km (3,949.901-3,963.189mi)
 // The IUGG value for the equatorial radius is 6378.137 km (3963.19 miles)
-const constexpr long double EARTH_RADIUS = 6372797.560856;
+// Using the IUGG mean radius: (2a + b) / 3
+const constexpr long double EARTH_RADIUS = 6371008.771415;
 
 inline double degToRad(const double degree) { return degree * (std::numbers::pi / 180.0); }
 


### PR DESCRIPTION
# Issue

Fixes #5051

The EARTH_RADIUS constant was set to 6372797.560856, which appears to be derived from (3a+b)/4. The IUGG recommended mean radius for great-circle distance calculations is (2a+b)/3 = 6371008.771415 meters.

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [ ] add tests (see testing)
 - [ ] update relevant wiki pages
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)