### PR TITLE
fix(bicycle): respect directional access tags like vehicle:forward=agricultural

### DIFF
--- a/features/bicycle/access.feature
+++ b/features/bicycle/access.feature
@@ -186,6 +186,17 @@ Feature: Bike - Access tags on ways
             | residential | tram    |        | yes    | cycling | pushing bike |
             | service     | tram    | psv    | yes    | cycling | pushing bike |
 
+    Scenario: Bike - Directional access tag blacklisting (e.g. vehicle:forward=agricultural)
+        Then routability should be
+            | highway | vehicle:forward | vehicle:backward | bicycle  | forw    | backw   |
+            | primary |                 |                  |          | cycling | cycling |
+            | primary | agricultural    |                  |          |         | cycling |
+            | primary |                 | agricultural     |          | cycling |         |
+            | primary | agricultural    | agricultural     |          |         |         |
+            | primary | agricultural    |                  | yes      | cycling | cycling |
+            | primary |                 | agricultural     | yes      | cycling | cycling |
+            | primary |                 |                  | agricultural |         |         |
+
     Scenario: Bike - Access combinations
         Then routability should be
             | highway    | access     | bothw   |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -7,6 +7,8 @@ Sequence = require('lib/sequence')
 Handlers = require("lib/way_handlers")
 TrafficSignal = require("lib/traffic_signal")
 find_access_tag = require("lib/access").find_access_tag
+resolve_access = require("lib/access").resolve_access
+Tags = require('lib/tags')
 limit = require("lib/maxspeed").limit
 Measure = require("lib/measure")
 
@@ -299,9 +301,16 @@ function handle_bicycle_tags(profile,way,result,data)
     return false
   end
 
-  -- access
+  -- access (supports directional tags like vehicle:forward=agricultural)
   data.access = find_access_tag(way, profile.access_tags_hierarchy)
-  if data.access and profile.access_tag_blacklist[data.access] then
+  data.forward_access, data.backward_access =
+      Tags.get_forward_backward_by_set(way, data, profile.access_tags_hierarchy)
+  data.forward_access = resolve_access(data.forward_access, profile)
+  data.backward_access = resolve_access(data.backward_access, profile)
+  if (data.access and profile.access_tag_blacklist[data.access])
+      or (data.forward_access and data.backward_access
+          and profile.access_tag_blacklist[data.forward_access]
+          and profile.access_tag_blacklist[data.backward_access]) then
     return false
   end
 
@@ -349,6 +358,17 @@ function handle_bicycle_tags(profile,way,result,data)
   end
 
   safety_handler(profile,way,result,data)
+
+  -- Apply per-direction access blacklisting for directional tags
+  -- (e.g. vehicle:forward=agricultural blocks only the forward direction)
+  if data.forward_access and profile.access_tag_blacklist[data.forward_access] then
+    result.forward_mode = mode.inaccessible
+    result.forward_speed = 0
+  end
+  if data.backward_access and profile.access_tag_blacklist[data.backward_access] then
+    result.backward_mode = mode.inaccessible
+    result.backward_speed = 0
+  end
 end
 
 -- Block ways where the cycleway is mapped as a separate parallel way.

--- a/taginfo.json
+++ b/taginfo.json
@@ -297,6 +297,18 @@
         {"key": "motorcar"},
         {"key": "motor_vehicle"},
         {"key": "vehicle"},
+        {"key": "motorcar:forward", "description": "Directional access tag for forward travel direction", "object_types": ["way"]},
+        {"key": "motorcar:backward", "description": "Directional access tag for backward travel direction", "object_types": ["way"]},
+        {"key": "motor_vehicle:forward", "description": "Directional access tag for forward travel direction", "object_types": ["way"]},
+        {"key": "motor_vehicle:backward", "description": "Directional access tag for backward travel direction", "object_types": ["way"]},
+        {"key": "vehicle:forward", "description": "Directional access tag for forward travel direction", "object_types": ["way"]},
+        {"key": "vehicle:backward", "description": "Directional access tag for backward travel direction", "object_types": ["way"]},
+        {"key": "access:forward", "description": "Directional access tag for forward travel direction", "object_types": ["way"]},
+        {"key": "access:backward", "description": "Directional access tag for backward travel direction", "object_types": ["way"]},
+        {"key": "bicycle:forward", "description": "Directional bicycle access tag for forward travel direction", "object_types": ["way"]},
+        {"key": "bicycle:backward", "description": "Directional bicycle access tag for backward travel direction", "object_types": ["way"]},
+        {"key": "foot:forward", "description": "Directional foot access tag for forward travel direction", "object_types": ["way"]},
+        {"key": "foot:backward", "description": "Directional foot access tag for backward travel direction", "object_types": ["way"]},
         {
             "key": "barrier"
         },


### PR DESCRIPTION
# Issue

Fixes #6262

The bicycle profile used `find_access_tag` which only checks non-directional tag variants. This meant directional access restrictions like `vehicle:forward=agricultural` were ignored, allowing bicycle routing in directions that should be blocked.

## Changes
- Use `Tags.get_forward_backward_by_set` in bicycle profile to check `:forward`/`:backward` access tag variants
- Apply per-direction blacklisting when only one direction is restricted by a directional tag
- When an explicit mode-specific tag (e.g. `bicycle=yes`) is present, it correctly overrides lower-priority vehicle-level directional restrictions per OSM access tag hierarchy
- Added cucumber test covering: no directional tags, forward-only blacklisting, backward-only blacklisting, both-direction blacklisting, and interaction with explicit mode-specific tags
- Added directional access tags (`vehicle:forward`, `bicycle:forward`, `foot:forward`, etc.) to taginfo.json

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [x] add tests
 - [ ] update relevant wiki pages
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)