### PR TITLE
feat: add OSM node IDs to ExtractionSegment for Lua process_segment [wip]

### DIFF
--- a/include/extractor/extraction_segment.hpp
+++ b/include/extractor/extraction_segment.hpp
@@ -14,9 +14,12 @@ struct ExtractionSegment
                       double distance_,
                       double weight_,
                       double duration_,
-                      const NodeBasedEdgeClassification flags_)
+                      const NodeBasedEdgeClassification flags_,
+                      const OSMNodeID osm_source_id_,
+                      const OSMNodeID osm_target_id_)
         : source(source_), target(target_), distance(distance_), weight(weight_),
-          duration(duration_), flags(flags_)
+          duration(duration_), flags(flags_), osm_source_id(osm_source_id_),
+          osm_target_id(osm_target_id_)
     {
     }
 
@@ -26,6 +29,8 @@ struct ExtractionSegment
     double weight;
     double duration;
     const NodeBasedEdgeClassification flags;
+    const OSMNodeID osm_source_id;
+    const OSMNodeID osm_target_id;
 };
 } // namespace osrm::extractor
 

--- a/src/extractor/extraction_containers.cpp
+++ b/src/extractor/extraction_containers.cpp
@@ -704,7 +704,9 @@ void ExtractionContainers::PrepareEdges(ScriptingEnvironment &scripting_environm
                                       distance,
                                       weight,
                                       duration,
-                                      edge_iterator->result.flags);
+                                      edge_iterator->result.flags,
+                                      edge_iterator->result.osm_source_id,
+                                      node_iterator->node_id);
             scripting_environment.ProcessSegment(segment);
 
             auto &edge = edge_iterator->result;

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -577,7 +577,11 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                                                   "duration",
                                                   &ExtractionSegment::duration,
                                                   "flags",
-                                                  &ExtractionSegment::flags);
+                                                  &ExtractionSegment::flags,
+                                                  "osm_source_id",
+                                                  &ExtractionSegment::osm_source_id,
+                                                  "osm_target_id",
+                                                  &ExtractionSegment::osm_target_id);
 
     // Keep in mind .location is available only if .pbf is preprocessed to set the location with the
     // ref using osmium command "osmium add-locations-to-ways"


### PR DESCRIPTION
# Issue

No directly corresponding issue however this came about due to our inability to fix the bug here https://github.com/Project-OSRM/osrm-backend/issues/7332

In the above issue we discovered problems while adjusting the speed of closed segments. We burned a week or two attempting to solve it without success however so we settled on modify the network at extract time as a much more reliable approach to setting road closure for large scale analysis.

To do this we need to be able to close specific segments but the `process_segment` function only exposed the lat/log of the relevant nodes. With this relatively minor change we can get access to the OSM source/target node IDs which are a stable ID vs attempting to use the coordinates themselves.

AI tools: Claude code assisted in generating this change, although with close human intervention/supervision. 

Seeking comments on whether this is something that is generally useful before adding tests etc.

## Change Summary

- Add `osm_source_id` and `osm_target_id` fields to ExtractionSegment struct
- Pass OSM node IDs during segment creation in `extraction_containers`
- Expose node IDs to Lua scripting environment

This allows profiles to:
- Create stable segment identifiers across runs
- Reference segments by OSM node pairs (e.g., 12345->67890)
- Load external segment-specific data by ID
- Pass routing changes by segment ID instead of coordinates

## Tasklist

 - [ ] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

N/A

