### PR TITLE
fix(docker): detect target architecture for vcpkg triplet

### DIFF
--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -59,15 +59,25 @@ WORKDIR /src
 #   - /vcpkg/buildtrees           : partial builds (helps when a single port fails)
 COPY vcpkg.json vcpkg-configuration.json ./
 COPY vcpkg-overlay-ports/ ./vcpkg-overlay-ports/
+# TARGETARCH is auto-populated by BuildKit (amd64, arm64).  Map it to the
+# matching vcpkg triplet so native ARM64 builds don't fail with a hardcoded
+# x64-linux triplet (see docker/build-push-action platforms: linux/arm64).
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/vcpkg/archives,sharing=locked \
     --mount=type=cache,target=/vcpkg/downloads,sharing=locked \
     --mount=type=cache,target=/vcpkg/buildtrees,sharing=locked \
     export VCPKG_DEFAULT_BINARY_CACHE=/root/.cache/vcpkg/archives && \
     mkdir -p build/vcpkg_installed "$VCPKG_DEFAULT_BINARY_CACHE" && \
+    case "${TARGETARCH}" in \
+        amd64) VCPKG_TRIPLET=x64-linux ;; \
+        arm64) VCPKG_TRIPLET=arm64-linux ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    echo "Using vcpkg triplet: ${VCPKG_TRIPLET}" && \
     ${VCPKG_ROOT}/vcpkg install \
         --x-manifest-root=/src \
         --x-install-root=/src/build/vcpkg_installed \
-        --triplet=x64-linux \
+        --triplet=${VCPKG_TRIPLET} \
         --no-print-usage \
         --clean-buildtrees-after-build \
         --clean-packages-after-build


### PR DESCRIPTION
# Issue

The ARM64 Docker build (CI job `build-arm64`) fails because vcpkg is hardcoded to use the `x64-linux` triplet. On the `ubuntu-24.04-arm` runner the native compiler is aarch64 and cannot produce x86_64 binaries, so vcpkg's compiler detection step errors out.

Fixes the `build-arm64` job in `.github/workflows/osrm-backend-docker.yml`.

Was this change primarily generated using an AI tool?
Claude Opus 4.8 🤖

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
