### PR TITLE
ci: deduplicate CI runs and parallelize release publish jobs

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -30,6 +30,10 @@ concurrency:
   # The release workflow pushes a commit to master and then tags it; both events
   # trigger this workflow. Using the SHA means the second push (tag) cancels the
   # first (branch) and runs once — with GITHUB_REF set to the tag, so PUBLISH=On.
+  #
+  # Trade-off: each commit to master now gets its own group (unlike grouping by
+  # ref where all master pushes share one group). This is intentional — fast
+  # successive merges should each get independent CI coverage.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
@@ -278,7 +282,9 @@ jobs:
   build-matrix:
     needs: [format-taginfo-docs, vcpkg-smoke-prereq]
     # Skip non-binding matrix entries for tag pushes (releases).
-    # Only binding builds (Linux + macOS) are needed to produce wheels.
+    # Only binding builds (Linux + macOS) are needed to produce wheels
+    # within this matrix. Windows wheels are built by the separate
+    # vcpkg-windows-release-bindings job.
     # Full CI coverage (compiler variants, sanitizers, etc.) runs on branch pushes.
     if: |
       github.repository == 'Project-OSRM/osrm-backend' &&

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -26,7 +26,11 @@ env:
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-bincache,readwrite"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Use commit SHA so branch+tag pushes for the same commit are deduplicated.
+  # The release workflow pushes a commit to master and then tags it; both events
+  # trigger this workflow. Using the SHA means the second push (tag) cancels the
+  # first (branch) and runs once — with GITHUB_REF set to the tag, so PUBLISH=On.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -78,6 +82,8 @@ jobs:
       BUILD_TYPE: Release
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
       - name: Move temp directory to D drive
         shell: pwsh
         run: |
@@ -169,7 +175,7 @@ jobs:
         # [tool.cibuildwheel.windows] in pyproject.toml. VCPKG_ROOT is
         # exported by lukka/run-vcpkg above and inherited by cibuildwheel.
       - name: Upload Windows wheel
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: env.PUBLISH == 'On'
         uses: actions/upload-artifact@v7
         with:
           name: wheels-windows
@@ -271,7 +277,12 @@ jobs:
 
   build-matrix:
     needs: [format-taginfo-docs, vcpkg-smoke-prereq]
-    if: github.repository == 'Project-OSRM/osrm-backend'
+    # Skip non-binding matrix entries for tag pushes (releases).
+    # Only binding builds (Linux + macOS) are needed to produce wheels.
+    # Full CI coverage (compiler variants, sanitizers, etc.) runs on branch pushes.
+    if: |
+      github.repository == 'Project-OSRM/osrm-backend' &&
+      (matrix.build_bindings == true || !startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         include:

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -281,12 +281,9 @@ jobs:
 
   build-matrix:
     needs: [format-taginfo-docs, vcpkg-smoke-prereq]
-    # Skip non-binding matrix entries for tag pushes (releases).
-    # Only binding builds (Linux + macOS) are needed to produce wheels
-    # within this matrix. Windows wheels are built by the separate
-    # vcpkg-windows-release-bindings job.
-    # Full CI coverage (compiler variants, sanitizers, etc.) runs on branch pushes.
-    if: github.repository == 'Project-OSRM/osrm-backend' && (matrix.build_bindings == true || !startsWith(github.ref, 'refs/tags/v'))
+    # Only build-matrix entries with build_bindings: true on tag pushes.
+    # On PRs, branch pushes, and manual dispatches, run every entry.
+    if: github.repository == 'Project-OSRM/osrm-backend' && (matrix.build_bindings == true || github.event_name != 'push' || startsWith(github.ref, 'refs/heads/'))
     strategy:
       matrix:
         include:

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -286,9 +286,7 @@ jobs:
     # within this matrix. Windows wheels are built by the separate
     # vcpkg-windows-release-bindings job.
     # Full CI coverage (compiler variants, sanitizers, etc.) runs on branch pushes.
-    if: |
-      github.repository == 'Project-OSRM/osrm-backend' &&
-      (matrix.build_bindings == true || !startsWith(github.ref, 'refs/tags/v'))
+    if: github.repository == 'Project-OSRM/osrm-backend' && (matrix.build_bindings == true || !startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         include:

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -177,7 +177,8 @@ jobs:
       - name: Capture tag SHA
         id: tag_sha
         run: |
-          echo "sha=$(git rev-list -n 1 "${{ steps.version.outputs.tag }}")" >> "$GITHUB_OUTPUT"
+          TAG="${{ steps.version.outputs.tag }}"
+          echo "sha=$(git rev-list -n 1 "$TAG")" >> "$GITHUB_OUTPUT"
 
 
   publish-npm:
@@ -190,6 +191,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -259,7 +261,7 @@ jobs:
               break
             elif [ "$BINDING_STATUS" = "failed" ]; then
               echo "::error::A required binding job failed — Node binaries not uploaded"
-              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings")) | "  \(.name): \(.status)/\(.conclusion // "null")"'
+              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings")) | "  \(.name): \(.status)/\(.conclusion)"'
               exit 1
             fi
 
@@ -285,6 +287,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -347,7 +350,7 @@ jobs:
               break
             elif [ "$BINDING_STATUS" = "failed" ]; then
               echo "::error::A required binding job failed"
-              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings")) | "  \(.name): \(.status)/\(.conclusion // "null")"'
+              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings")) | "  \(.name): \(.status)/\(.conclusion)"'
               exit 1
             fi
 
@@ -387,6 +390,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -448,7 +452,7 @@ jobs:
               break
             elif [ "$MACOS_STATUS" = "failed" ]; then
               echo "::warning::A macOS binding job failed — skipping macOS wheels"
-              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-macos-.*-bindings")) | "  \(.name): \(.status)/\(.conclusion // "null")"'
+              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-macos-.*-bindings")) | "  \(.name): \(.status)/\(.conclusion)"'
               echo "SKIP_MACOS=true" >> "$GITHUB_ENV"
               break
             fi

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -208,17 +208,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
           TAG_SHA: ${{ needs.release.outputs.tag_sha }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           MAX_WAIT=3600  # 1 hour
           ELAPSED=0
           POLL_INTERVAL=10
           RUN_ID=""
 
-          echo "Finding CI run for commit $TAG_SHA"
+          echo "Finding tag-triggered CI run for commit $TAG_SHA (tag $TAG)"
 
           while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
-            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
-            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,headBranch,displayTitle 2>/dev/null || echo '[]')"
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" --arg tag "$TAG" '.[] | select(.headSha == $sha and .headBranch == $tag) | @json' | head -1)"
 
             if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
               RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
@@ -294,18 +295,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
           TAG_SHA: ${{ needs.release.outputs.tag_sha }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           MAX_WAIT=3600  # 1 hour
           ELAPSED=0
           POLL_INTERVAL=10
           RUN_ID=""
 
-          echo "Finding CI run for commit $TAG_SHA"
+          echo "Finding tag-triggered CI run for commit $TAG_SHA (tag $TAG)"
 
           # Find the CI run for this tag commit
           while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
-            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
-            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,headBranch,displayTitle 2>/dev/null || echo '[]')"
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" --arg tag "$TAG" '.[] | select(.headSha == $sha and .headBranch == $tag) | @json' | head -1)"
 
             if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
               RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
@@ -395,17 +397,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
           TAG_SHA: ${{ needs.release.outputs.tag_sha }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           MAX_WAIT=7200  # 2 hours
           ELAPSED=0
           POLL_INTERVAL=30
           RUN_ID=""
 
-          echo "Finding CI run for commit $TAG_SHA"
+          echo "Finding tag-triggered CI run for commit $TAG_SHA (tag $TAG)"
 
           while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
-            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
-            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,headBranch,displayTitle 2>/dev/null || echo '[]')"
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" --arg tag "$TAG" '.[] | select(.headSha == $sha and .headBranch == $tag) | @json' | head -1)"
 
             if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
               RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
-      run_id: ${{ steps.wait_ci.outputs.run_id }}
+      tag_sha: ${{ steps.tag_sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -174,62 +174,17 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Wait for CI to complete
-        id: wait_ci
-        env:
-          GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
+      - name: Capture tag SHA
+        id: tag_sha
         run: |
-          # Wait for tag CI to complete before publishing npm package
-          # The osrm-backend.yml workflow is triggered by the tag push
-          # and uploads prebuilt binaries to the release assets
-          TAG="${{ steps.version.outputs.tag }}"
-          TAG_SHA="$(git rev-list -n 1 "$TAG")"
-          
-          echo "Waiting for CI workflow to complete for tag $TAG (commit $TAG_SHA)"
-          
-          MAX_WAIT=3600  # 1 hour
-          ELAPSED=0
-          POLL_INTERVAL=10
-          
-          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
-            # Query runs for the osrm-backend.yml workflow for this tag's commit
-            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
-            
-            # Find run matching this tag's commit SHA
-            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
-            
-            if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
-              STATUS="$(echo "$MATCHING_RUN" | jq -r '.status')"
-              CONCLUSION="$(echo "$MATCHING_RUN" | jq -r '.conclusion // empty')"
-              RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
-              
-              echo "Found matching CI run $RUN_ID: status=$STATUS conclusion=$CONCLUSION"
-              
-              if [ "$STATUS" = "completed" ]; then
-                if [ "$CONCLUSION" = "success" ]; then
-                  echo "✓ CI workflow completed successfully, proceeding with npm publish"
-                  echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-                  exit 0
-                else
-                  echo "✗ CI workflow completed with conclusion=$CONCLUSION (expected success)"
-                  exit 1
-                fi
-              else
-                echo "CI workflow still running (status=$STATUS), waiting..."
-              fi
-            else
-              echo "No matching CI run found yet, waiting for workflow to start..."
-            fi
-            
-            sleep "$POLL_INTERVAL"
-            ELAPSED=$((ELAPSED + POLL_INTERVAL))
-          done
-          
-          echo "✗ Timed out waiting for CI workflow to complete for tag $TAG"
-          exit 1
+          echo "sha=$(git rev-list -n 1 "${{ steps.version.outputs.tag }}")" >> "$GITHUB_OUTPUT"
 
 
-  publish:
+  publish-npm:
+    # Publishes the JS wrapper to npm. Must wait for CI binding jobs to
+    # upload the native Node binaries (.tar.gz) to the GitHub Release
+    # first — otherwise `npm install` gets 404s downloading them.
+    # Independent from publish-pypi-* so it can be re-triggered alone.
     needs: release
     runs-on: ubuntu-latest
     permissions:
@@ -248,16 +203,170 @@ jobs:
       - name: Install dependencies (skip native build scripts)
         run: npm ci --ignore-scripts
 
+      - name: Wait for CI binding jobs (Node binaries)
+        id: wait-ci
+        env:
+          GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
+          TAG_SHA: ${{ needs.release.outputs.tag_sha }}
+        run: |
+          MAX_WAIT=3600  # 1 hour
+          ELAPSED=0
+          POLL_INTERVAL=10
+          RUN_ID=""
+
+          echo "Finding CI run for commit $TAG_SHA"
+
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+
+            if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
+              RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
+              echo "Found CI run $RUN_ID"
+              break
+            fi
+
+            echo "Waiting for CI workflow to start..."
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Timed out waiting for CI workflow to start"
+            exit 1
+          fi
+
+          # Poll for Linux + Windows binding jobs (they upload Node binaries)
+          echo "Polling for binding jobs (Linux + Windows) in run $RUN_ID..."
+          ELAPSED=0
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            JOBS_JSON="$(gh run view "$RUN_ID" --json jobs 2>/dev/null || echo '{"jobs":[]}')"
+
+            BINDING_STATUS="$(echo "$JOBS_JSON" | jq -r '
+              [.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings"))]
+              | if length < 2 then "waiting"
+                elif all(.status == "completed" and .conclusion == "success") then "done"
+                elif any(.status == "completed" and .conclusion != "success" and .conclusion != null) then "failed"
+                else "running"
+                end
+            ')"
+
+            echo "Binding jobs: $BINDING_STATUS (elapsed=${ELAPSED}s)"
+
+            if [ "$BINDING_STATUS" = "done" ]; then
+              echo "✓ Binding jobs completed — Node binaries uploaded"
+              break
+            elif [ "$BINDING_STATUS" = "failed" ]; then
+              echo "::error::A required binding job failed — Node binaries not uploaded"
+              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings")) | "  \(.name): \(.status)/\(.conclusion // "null")"'
+              exit 1
+            fi
+
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ "$BINDING_STATUS" != "done" ]; then
+            echo "::error::Timed out waiting for binding jobs"
+            exit 1
+          fi
+
       - name: Publish to npm
         run: npm publish
 
-      - name: Download wheels from CI run
+  publish-pypi-linux-windows:
+    # Waits for Linux + Windows binding CI jobs (the ones that produce
+    # wheels), downloads their artifacts, and publishes to PyPI.
+    # Independent from publish-npm and publish-pypi-macos so a failure
+    # here can be re-triggered without restarting everything.
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Wait for Linux + Windows binding CI jobs
+        id: wait
+        env:
+          GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
+          TAG_SHA: ${{ needs.release.outputs.tag_sha }}
+        run: |
+          MAX_WAIT=3600  # 1 hour
+          ELAPSED=0
+          POLL_INTERVAL=10
+          RUN_ID=""
+
+          echo "Finding CI run for commit $TAG_SHA"
+
+          # Find the CI run for this tag commit
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+
+            if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
+              RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
+              echo "Found CI run $RUN_ID"
+              break
+            fi
+
+            echo "Waiting for CI workflow to start..."
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Timed out waiting for CI workflow to start"
+            exit 1
+          fi
+
+          # Poll for Linux + Windows binding jobs to complete
+          echo "Polling for Linux + Windows binding jobs in run $RUN_ID..."
+          ELAPSED=0
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            JOBS_JSON="$(gh run view "$RUN_ID" --json jobs 2>/dev/null || echo '{"jobs":[]}')"
+
+            BINDING_STATUS="$(echo "$JOBS_JSON" | jq -r '
+              [.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings"))]
+              | if length < 2 then "waiting"
+                elif all(.status == "completed" and .conclusion == "success") then "done"
+                elif any(.status == "completed" and .conclusion != "success" and .conclusion != null) then "failed"
+                else "running"
+                end
+            ')"
+
+            echo "Binding jobs: $BINDING_STATUS (elapsed=${ELAPSED}s)"
+
+            if [ "$BINDING_STATUS" = "done" ]; then
+              echo "✓ Linux + Windows binding jobs completed successfully"
+              break
+            elif [ "$BINDING_STATUS" = "failed" ]; then
+              echo "::error::A required binding job failed"
+              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-linux-release-bindings|vcpkg-windows-release-bindings")) | "  \(.name): \(.status)/\(.conclusion // "null")"'
+              exit 1
+            fi
+
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ "$BINDING_STATUS" != "done" ]; then
+            echo "::error::Timed out waiting for binding jobs"
+            exit 1
+          fi
+
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download Linux + Windows wheels
         uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-          run-id: ${{ needs.release.outputs.run_id }}
+          run-id: ${{ steps.wait.outputs.run_id }}
           github-token: ${{ github.token }}
 
       - name: Publish to PyPI
@@ -265,5 +374,109 @@ jobs:
         with:
           skip-existing: true
           verbose: true
-          # repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi-macos:
+    # MacOS binding builds are slow (1h+). This job runs independently
+    # so the release can complete with Linux + Windows wheels while
+    # macOS wheels follow when ready. If it fails, re-trigger just this
+    # job — no need for a point release.
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Wait for macOS binding CI jobs
+        id: wait-macos
+        env:
+          GH_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
+          TAG_SHA: ${{ needs.release.outputs.tag_sha }}
+        run: |
+          MAX_WAIT=7200  # 2 hours
+          ELAPSED=0
+          POLL_INTERVAL=30
+          RUN_ID=""
+
+          echo "Finding CI run for commit $TAG_SHA"
+
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            RUN_JSON="$(gh run list --workflow=osrm-backend.yml --limit 50 --json databaseId,status,conclusion,headSha,displayTitle 2>/dev/null || echo '[]')"
+            MATCHING_RUN="$(echo "$RUN_JSON" | jq -r --arg sha "$TAG_SHA" '.[] | select(.headSha == $sha) | @json' | head -1)"
+
+            if [ -n "$MATCHING_RUN" ] && [ "$MATCHING_RUN" != "null" ]; then
+              RUN_ID="$(echo "$MATCHING_RUN" | jq -r '.databaseId')"
+              echo "Found CI run $RUN_ID"
+              break
+            fi
+
+            echo "Waiting for CI workflow to start..."
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::warning::Timed out waiting for CI workflow — skipping macOS wheels"
+            echo "SKIP_MACOS=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          echo "Polling for macOS binding jobs in run $RUN_ID..."
+          ELAPSED=0
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            JOBS_JSON="$(gh run view "$RUN_ID" --json jobs 2>/dev/null || echo '{"jobs":[]}')"
+
+            MACOS_STATUS="$(echo "$JOBS_JSON" | jq -r '
+              [.jobs[] | select(.name | test("vcpkg-macos-.*-bindings"))]
+              | if length < 2 then "waiting"
+                elif all(.status == "completed" and .conclusion == "success") then "done"
+                elif any(.status == "completed" and .conclusion != "success" and .conclusion != null) then "failed"
+                else "running"
+                end
+            ')"
+
+            echo "macOS binding jobs: $MACOS_STATUS (elapsed=${ELAPSED}s)"
+
+            if [ "$MACOS_STATUS" = "done" ]; then
+              echo "✓ macOS binding jobs completed successfully"
+              break
+            elif [ "$MACOS_STATUS" = "failed" ]; then
+              echo "::warning::A macOS binding job failed — skipping macOS wheels"
+              echo "$JOBS_JSON" | jq -r '.jobs[] | select(.name | test("vcpkg-macos-.*-bindings")) | "  \(.name): \(.status)/\(.conclusion // "null")"'
+              echo "SKIP_MACOS=true" >> "$GITHUB_ENV"
+              break
+            fi
+
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ "$ELAPSED" -ge "$MAX_WAIT" ] && [ "$MACOS_STATUS" != "done" ]; then
+            echo "::warning::Timed out waiting for macOS binding jobs — skipping macOS wheels"
+            echo "SKIP_MACOS=true" >> "$GITHUB_ENV"
+          fi
+
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download macOS wheels
+        if: env.SKIP_MACOS != 'true'
+        uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-vcpkg-macos-*
+          path: dist
+          merge-multiple: true
+          run-id: ${{ steps.wait-macos.outputs.run_id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true
+
+      - name: Publish macOS wheels to PyPI
+        if: env.SKIP_MACOS != 'true'
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          skip-existing: true
+          verbose: true
+        continue-on-error: true
 


### PR DESCRIPTION
# Issue

Fixes two longstanding issues with the monthly release pipeline.

## Problem 1: CI runs twice for the same commit

The release workflow pushes to `master` AND pushes a tag (`v*`). `osrm-backend.yml` triggers on both events, creating two identical CI runs for the same commit — doubling GH Actions minutes.

**Fix**: Change the concurrency group from `github.ref` to `github.sha`. The branch push and tag push share the same commit SHA, so the second cancels the first. The surviving run has `GITHUB_REF=refs/tags/v*` and sets `PUBLISH=On` correctly. This works for scheduled releases, `workflow_dispatch` on any branch, and regular PR merges.

## Problem 2: macOS 15 binding builds block the release for 1+ hour

The old `wait_ci` step blocked on the entire `osrm-backend.yml` workflow. macOS 15 binding builds are the slowest job, making every release take > 1 hour before publishing to npm/PyPI.

**Fix**: Split the monolithic publish job into three independent, parallel jobs — each polls for only the CI jobs it needs. All `needs: release` only (which finishes in seconds):

- **`publish-npm`** — waits for Linux + Windows binding CI jobs (Node binaries uploaded to GitHub Release), then `npm publish`
- **`publish-pypi-linux-windows`** — waits for the same CI jobs, downloads Linux + Windows wheels, publishes to PyPI
- **`publish-pypi-macos`** — waits for macOS binding CI jobs (up to 2h), downloads macOS wheels, publishes to PyPI. Non-blocking: if macOS fails or times out, the release continues with a warning.

Each job can be **re-triggered individually** from the Actions UI if an infrastructure failure occurs — no point release needed.

## Bonus: Skip non-binding CI for tag pushes

Added `(matrix.build_bindings == true || !startsWith(github.ref, 'refs/tags/v'))` to the `build-matrix` `if` condition. On tag pushes, only the binding builds (Linux, macOS) run — saving GH Actions minutes on compiler variants, sanitizers, and coverage builds.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude Opus 4.8
