### PR TITLE
ci: extend release timeout to 3h, remove python stub check

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -724,15 +724,6 @@ jobs:
             dist/*.tar.gz
           if-no-files-found: error
 
-      - name: Upload Linux wheel for stub check
-        if: ${{ env.BUILD_BINDINGS && runner.os == 'Linux' && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: wheel-linux-stub-check
-          path: dist/*.whl
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Save compiler cache
         if: always() && steps.build.outcome != 'cancelled'
         uses: actions/cache/save@v5
@@ -745,49 +736,9 @@ jobs:
           ccache -p
           ccache -s
 
-  # Verify that committed .pyi stubs match the actual C++ bindings when Python
-  # C++ sources changed. Installs the Linux wheel built by build-matrix,
-  # regenerates stubs via nanobind, ruff-formats them, and diffs against the repo.
-  check-python-stubs:
-    name: Check Python stubs are up to date
-    needs: build-matrix
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: changes
-        with:
-          filters: |
-            python_cpp:
-              - 'src/python/src/**'
-              - 'src/python/include/**'
-              - 'src/python/CMakeLists.txt'
-      - uses: actions/setup-python@v6
-        if: steps.changes.outputs.python_cpp == 'true'
-        with:
-          python-version: '3.12'
-      - uses: actions/download-artifact@v8
-        if: steps.changes.outputs.python_cpp == 'true'
-        with:
-          name: wheel-linux-stub-check
-          path: wheelhouse
-      - name: Install wheel and regenerate stubs
-        if: steps.changes.outputs.python_cpp == 'true'
-        run: |
-          pip install nanobind ruff
-          pip install wheelhouse/*.whl
-          python -m nanobind.stubgen -m osrm.osrm_ext -o src/python/osrm/osrm_ext.pyi
-          ruff format src/python/osrm/osrm_ext.pyi
-      - name: Check for differences
-        if: steps.changes.outputs.python_cpp == 'true'
-        run: |
-          git diff --exit-code src/python/osrm/osrm_ext.pyi \
-            || (echo "::error::Stubs are out of date. Rebuild locally and commit the updated .pyi file." && exit 1)
-
   ci-complete:
     runs-on: ubuntu-latest
-    needs: [build-matrix, vcpkg-windows-release-bindings, docker-image-matrix, check-python-stubs]
+    needs: [build-matrix, vcpkg-windows-release-bindings, docker-image-matrix]
     if: github.repository == 'Project-OSRM/osrm-backend'
     steps:
       - name: Fail if any dependency failed

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -187,7 +187,7 @@ jobs:
           
           echo "Waiting for CI workflow to complete for tag $TAG (commit $TAG_SHA)"
           
-          MAX_WAIT=3600  # 1 hour
+          MAX_WAIT=10800  # 3 hours
           ELAPSED=0
           POLL_INTERVAL=10
           


### PR DESCRIPTION
- Increase MAX_WAIT from 1h to 3h in release-monthly workflow
- Remove check-python-stubs job (we don't check in .pyi stubs anymore)
- Remove stub upload step from build-matrix
- Remove check-python-stubs from ci-complete needs

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

Was this change primarily generated using an AI tool?
Kindly make this transparent and disclose which tool / model you have been using.
Please note our [contribution guidlines](https://github.com/Project-OSRM/osrm-backend/blob/master/CONTRIBUTING.md) on the use of AI tools.

## Tasklist

 - [ ] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?

