### PR TITLE
ci: add runs-on to vcpkg cache key to prevent macOS version cache thrashing

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -490,9 +490,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.vcpkg-bincache
-          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ matrix.vcpkg_triplet || matrix.name }}-${{ env.VCPKG_COMMIT_ID }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-overlay-ports/**') }}
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ matrix.runs-on }}-${{ matrix.vcpkg_triplet || matrix.name }}-${{ env.VCPKG_COMMIT_ID }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-overlay-ports/**') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ matrix.vcpkg_triplet || matrix.name }}-${{ env.VCPKG_COMMIT_ID }}-
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ matrix.runs-on }}-${{ matrix.vcpkg_triplet || matrix.name }}-${{ env.VCPKG_COMMIT_ID }}-
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:


### PR DESCRIPTION
macos-15 and macos-26 jobs share the same runner.os/runner.arch/triplet combination, causing cache-key collisions. The first to finish populates the cache with SDK-specific binaries that the other rejects, forcing a full vcpkg rebuild from source on every run. Include matrix.runs-on in the key so macos-15-x64, macos-26-x64 (and the  arm64 equivalents) each get their own bincache.
