### PR TITLE
ci: add cache-from to release docker builds

### DIFF
--- a/.github/workflows/osrm-backend-docker.yml
+++ b/.github/workflows/osrm-backend-docker.yml
@@ -86,6 +86,7 @@ jobs:
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.metadebug.outputs.tags  }}
           labels: ${{ steps.metadebug.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.docker-base-image }}
           build-args: |
             DOCKER_TAG=${{ join(steps.metadebug.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -97,6 +98,7 @@ jobs:
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.metaassertions.outputs.tags  }}
           labels: ${{ steps.metaassertions.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.docker-base-image }}
           build-args: |
             DOCKER_TAG=${{ join(steps.metaassertions.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -108,6 +110,7 @@ jobs:
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.meta.outputs.tags  }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.docker-base-image }}
           build-args: |
             DOCKER_TAG=${{ join(steps.meta.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -181,6 +184,7 @@ jobs:
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.metadebug.outputs.tags  }}
           labels: ${{ steps.metadebug.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.docker-base-image }}
           build-args: |
             DOCKER_TAG=${{ join(steps.metadebug.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -192,6 +196,7 @@ jobs:
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.metaassertions.outputs.tags  }}
           labels: ${{ steps.metaassertions.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.docker-base-image }}
           build-args: |
             DOCKER_TAG=${{ join(steps.metaassertions.outputs.tags ) }}-${{ matrix.docker-base-image }}
 
@@ -203,6 +208,7 @@ jobs:
           file: ./docker/Dockerfile-${{ matrix.docker-base-image }}
           tags: ${{ steps.meta.outputs.tags  }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.docker-base-image }}
           build-args: |
             DOCKER_TAG=${{ join(steps.meta.outputs.tags ) }}-${{ matrix.docker-base-image }}
 

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -212,13 +212,13 @@ jobs:
         npm run docs && ./scripts/error_on_dirty.sh "Run 'npm run docs' locally and commit the changes."
         npm audit --production
 
-  docker-image-matrix:
+  docker-build-extract-test:
     strategy:
       matrix:
         docker-base-image: ['alpine']
     needs: [format-taginfo-docs, vcpkg-smoke-prereq]
     if: github.repository == 'Project-OSRM/osrm-backend'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: false
     steps:
       - name: Check out the repo
@@ -738,7 +738,7 @@ jobs:
 
   ci-complete:
     runs-on: ubuntu-latest
-    needs: [build-matrix, vcpkg-windows-release-bindings, docker-image-matrix]
+    needs: [build-matrix, vcpkg-windows-release-bindings, docker-build-extract-test]
     if: github.repository == 'Project-OSRM/osrm-backend'
     steps:
       - name: Fail if any dependency failed


### PR DESCRIPTION
Read BuildKit GHA cache (scope docker-alpine) written by the CI docker-image-matrix job, so release builds don't start from scratch. 

Read-only: no cache-to, keeping the CI job as the single writer.
