### PR TITLE
test: use fixed external seed for reproducible unit tests

### DIFF
--- a/unit_tests/common/random_seed.hpp
+++ b/unit_tests/common/random_seed.hpp
@@ -12,9 +12,14 @@ namespace osrm::test
 inline unsigned getTestRandomSeed()
 {
     const char *env_seed = std::getenv("OSRM_TEST_SEED");
-    if (env_seed != nullptr)
+    if (env_seed != nullptr && env_seed[0] != '\0')
     {
-        return static_cast<unsigned>(std::strtoul(env_seed, nullptr, 0));
+        char *end = nullptr;
+        const auto value = std::strtoul(env_seed, &end, 0);
+        if (end != env_seed && *end == '\0')
+        {
+            return static_cast<unsigned>(value);
+        }
     }
     return 0xdeadbeef;
 }

--- a/unit_tests/common/random_seed.hpp
+++ b/unit_tests/common/random_seed.hpp
@@ -1,0 +1,24 @@
+#ifndef UNIT_TESTS_RANDOM_SEED_HPP
+#define UNIT_TESTS_RANDOM_SEED_HPP
+
+#include <cstdlib>
+
+namespace osrm::test
+{
+
+// Returns the fixed random seed for reproducible tests.
+// The seed can be overridden via the OSRM_TEST_SEED environment variable.
+// Default value is 0xdeadbeef.
+inline unsigned getTestRandomSeed()
+{
+    const char *env_seed = std::getenv("OSRM_TEST_SEED");
+    if (env_seed != nullptr)
+    {
+        return static_cast<unsigned>(std::strtoul(env_seed, nullptr, 0));
+    }
+    return 0xdeadbeef;
+}
+
+} // namespace osrm::test
+
+#endif // UNIT_TESTS_RANDOM_SEED_HPP

--- a/unit_tests/common/temporary_file.hpp
+++ b/unit_tests/common/temporary_file.hpp
@@ -1,6 +1,8 @@
 #ifndef UNIT_TESTS_TEMPORARY_FILE_HPP
 #define UNIT_TESTS_TEMPORARY_FILE_HPP
 
+#include "random_seed.hpp"
+
 #include <cstdlib>
 #include <filesystem>
 #include <random>
@@ -12,7 +14,7 @@ inline std::string random_string(std::string::size_type length)
                         "abcdefghijklmnopqrstuvwxyz"
                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-    thread_local static std::mt19937 rg{std::random_device{}()};
+    thread_local static std::mt19937 rg{osrm::test::getTestRandomSeed()};
     thread_local static std::uniform_int_distribution<std::string::size_type> pick(
         0, sizeof(chrs) - 2);
 

--- a/unit_tests/common/temporary_file.hpp
+++ b/unit_tests/common/temporary_file.hpp
@@ -14,7 +14,12 @@ inline std::string random_string(std::string::size_type length)
                         "abcdefghijklmnopqrstuvwxyz"
                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-    thread_local static std::mt19937 rg{osrm::test::getTestRandomSeed()};
+    // Mix in the address of a local static as a per-process salt (ASLR)
+    // to avoid filename collisions when tests run in parallel, while
+    // preserving deterministic sequences within a single process.
+    thread_local static std::mt19937 rg{
+        osrm::test::getTestRandomSeed() ^
+        static_cast<unsigned>(reinterpret_cast<std::uintptr_t>(&chrs))};
     thread_local static std::uniform_int_distribution<std::string::size_type> pick(
         0, sizeof(chrs) - 2);
 

--- a/unit_tests/partitioner/bisection_graph.cpp
+++ b/unit_tests/partitioner/bisection_graph.cpp
@@ -1,6 +1,7 @@
 #include "partitioner/bisection_graph.hpp"
 #include "partitioner/graph_generator.hpp"
 
+#include "../common/random_seed.hpp"
 #include "util/debug.hpp"
 
 #include <algorithm>
@@ -92,8 +93,7 @@ BOOST_AUTO_TEST_CASE(access_edges)
     const auto coordinates = makeGridCoordinates(rows, cols, step_size, 0, 0);
 
     auto grid_edges = makeGridEdges(rows, cols, 0);
-    std::random_device rd;
-    std::mt19937 rng(rd());
+    std::mt19937 rng(osrm::test::getTestRandomSeed());
     std::shuffle(grid_edges.begin(), grid_edges.end(), rng);
     groupEdgesBySource(grid_edges.begin(), grid_edges.end());
 

--- a/unit_tests/partitioner/bisection_graph_view.cpp
+++ b/unit_tests/partitioner/bisection_graph_view.cpp
@@ -2,6 +2,7 @@
 #include "partitioner/graph_generator.hpp"
 #include "partitioner/recursive_bisection_state.hpp"
 
+#include "../common/random_seed.hpp"
 #include "util/debug.hpp"
 
 #include <algorithm>
@@ -20,8 +21,7 @@ namespace
 {
 void shuffle(std::vector<EdgeWithSomeAdditionalData> &grid_edges)
 {
-    std::random_device rd;
-    std::mt19937 rng(rd());
+    std::mt19937 rng(osrm::test::getTestRandomSeed());
     std::shuffle(grid_edges.begin(), grid_edges.end(), rng);
 }
 } // namespace

--- a/unit_tests/storage/serialization.cpp
+++ b/unit_tests/storage/serialization.cpp
@@ -2,6 +2,7 @@
 
 #include "util/vector_view.hpp"
 
+#include "../common/random_seed.hpp"
 #include "../common/range_tools.hpp"
 #include "../common/temporary_file.hpp"
 
@@ -31,8 +32,7 @@ BOOST_AUTO_TEST_CASE(vector_view_pack_test)
     // what vector_view<bool> expects
 
     // 1. Generate a random bool vector that covers several uint64_t bytes
-    constexpr unsigned RANDOM_SEED = 42;
-    std::mt19937 g(RANDOM_SEED);
+    std::mt19937 g(osrm::test::getTestRandomSeed());
     std::uniform_int_distribution<> binary_distribution(0, 1);
     std::vector<bool> v(150);
     for (std::size_t i = 0; i < v.size(); ++i)

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -5,6 +5,7 @@
 #include "util/exception.hpp"
 
 #include "common/range_tools.hpp"
+#include "../common/random_seed.hpp"
 
 #include <algorithm>
 #include <boost/test/unit_test.hpp>
@@ -26,8 +27,7 @@ BOOST_AUTO_TEST_CASE(insert_and_retrieve_packed_test)
     const constexpr std::size_t num_test_cases = 399;
     const constexpr std::uint64_t max_id = (1ULL << 33) - 1;
 
-    std::mt19937 rng;
-    rng.seed(1337);
+    std::mt19937 rng(osrm::test::getTestRandomSeed());
     std::uniform_int_distribution<std::uint64_t> dist(0, max_id);
 
     for (std::size_t i = 0; i < num_test_cases; i++)

--- a/unit_tests/util/packed_vector.cpp
+++ b/unit_tests/util/packed_vector.cpp
@@ -4,8 +4,8 @@
 #include "extractor/packed_osm_ids.hpp"
 #include "util/exception.hpp"
 
-#include "common/range_tools.hpp"
 #include "../common/random_seed.hpp"
+#include "common/range_tools.hpp"
 
 #include <algorithm>
 #include <boost/test/unit_test.hpp>

--- a/unit_tests/util/query_heap.cpp
+++ b/unit_tests/util/query_heap.cpp
@@ -1,6 +1,8 @@
 #include "util/query_heap.hpp"
 #include "util/typedefs.hpp"
 
+#include "../common/random_seed.hpp"
+
 #include <boost/test/unit_test.hpp>
 
 #include <tuple>
@@ -39,7 +41,7 @@ template <unsigned NUM_ELEM> struct RandomDataFixture
         }
 
         // Choosen by a fair W20 dice roll
-        std::mt19937 g(15);
+        std::mt19937 g(osrm::test::getTestRandomSeed());
 
         std::shuffle(order.begin(), order.end(), g);
     }

--- a/unit_tests/util/query_heap.cpp
+++ b/unit_tests/util/query_heap.cpp
@@ -40,7 +40,7 @@ template <unsigned NUM_ELEM> struct RandomDataFixture
             order.push_back(i);
         }
 
-        // Choosen by a fair W20 dice roll
+        // Chosen by a fair W20 dice roll
         std::mt19937 g(osrm::test::getTestRandomSeed());
 
         std::shuffle(order.begin(), order.end(), g);

--- a/unit_tests/util/static_graph.cpp
+++ b/unit_tests/util/static_graph.cpp
@@ -1,6 +1,8 @@
 #include "util/static_graph.hpp"
 #include "util/typedefs.hpp"
 
+#include "../common/random_seed.hpp"
+
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
@@ -26,14 +28,12 @@ static_assert(traits::HasDataMember<TestInputEdge>, "TestInputEdge needs to have
 
 constexpr unsigned TEST_NUM_NODES = 100;
 constexpr unsigned TEST_NUM_EDGES = 500;
-// Chosen by a fair W20 dice roll (this value is completely arbitrary)
-constexpr unsigned RANDOM_SEED = 15;
 
 template <unsigned NUM_NODES, unsigned NUM_EDGES> struct RandomArrayEntryFixture
 {
     RandomArrayEntryFixture()
     {
-        std::mt19937 g(RANDOM_SEED);
+        std::mt19937 g(osrm::test::getTestRandomSeed());
 
         std::uniform_int_distribution<> edge_udist(0, NUM_EDGES - 1);
         std::vector<unsigned> offsets;

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -8,6 +8,7 @@
 #include "util/std_hash.hpp"
 #include "util/typedefs.hpp"
 
+#include "../common/random_seed.hpp"
 #include "../common/temporary_file.hpp"
 #include "mocks/mock_datafacade.hpp"
 
@@ -41,7 +42,6 @@ using MiniStaticRTree = StaticRTree<TestData, osrm::storage::Ownership::Containe
 using TestDataFacade = MockDataFacade<osrm::engine::routing_algorithms::ch::Algorithm>;
 
 // Choosen by a fair W20 dice roll (this value is completely arbitrary)
-constexpr unsigned RANDOM_SEED = 42;
 static const int32_t WORLD_MIN_LAT = -85 * COORDINATE_PRECISION;
 static const int32_t WORLD_MAX_LAT = 85 * COORDINATE_PRECISION;
 static const int32_t WORLD_MIN_LON = -180 * COORDINATE_PRECISION;
@@ -92,7 +92,7 @@ template <unsigned NUM_NODES, unsigned NUM_EDGES> struct RandomGraphFixture
 {
     RandomGraphFixture()
     {
-        std::mt19937 g(RANDOM_SEED);
+        std::mt19937 g(osrm::test::getTestRandomSeed());
 
         std::uniform_int_distribution<> lat_udist(WORLD_MIN_LAT, WORLD_MAX_LAT);
         std::uniform_int_distribution<> lon_udist(WORLD_MIN_LON, WORLD_MAX_LON);
@@ -196,7 +196,7 @@ void sampling_verify_rtree(RTreeT &rtree,
                            const std::vector<Coordinate> &coords,
                            unsigned num_samples)
 {
-    std::mt19937 g(RANDOM_SEED);
+    std::mt19937 g(osrm::test::getTestRandomSeed());
     std::uniform_int_distribution<> lat_udist(WORLD_MIN_LAT, WORLD_MAX_LAT);
     std::uniform_int_distribution<> lon_udist(WORLD_MIN_LON, WORLD_MAX_LON);
     std::vector<Coordinate> queries;

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -41,7 +41,7 @@ using TestStaticRTree = StaticRTree<TestData,
 using MiniStaticRTree = StaticRTree<TestData, osrm::storage::Ownership::Container, 2, 128>;
 using TestDataFacade = MockDataFacade<osrm::engine::routing_algorithms::ch::Algorithm>;
 
-// Choosen by a fair W20 dice roll (this value is completely arbitrary)
+// Chosen by a fair W20 dice roll (this value is completely arbitrary)
 static const int32_t WORLD_MIN_LAT = -85 * COORDINATE_PRECISION;
 static const int32_t WORLD_MAX_LAT = 85 * COORDINATE_PRECISION;
 static const int32_t WORLD_MIN_LON = -180 * COORDINATE_PRECISION;

--- a/unit_tests/util/vector_view.cpp
+++ b/unit_tests/util/vector_view.cpp
@@ -1,6 +1,8 @@
 #include "util/vector_view.hpp"
 #include "util/typedefs.hpp"
 
+#include "../common/random_seed.hpp"
+
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
@@ -20,8 +22,7 @@ BOOST_AUTO_TEST_CASE(rw_short)
                                           num_elements);
     std::vector<std::uint16_t> reference;
 
-    std::mt19937 rng;
-    rng.seed(1337);
+    std::mt19937 rng(osrm::test::getTestRandomSeed());
     std::uniform_int_distribution<std::mt19937::result_type> dist(0, (1UL << 16));
 
     for (std::size_t i = 0; i < num_elements; i++)
@@ -47,8 +48,7 @@ BOOST_AUTO_TEST_CASE(rw_bool)
                                  num_elements);
     std::vector<bool> reference;
 
-    std::mt19937 rng;
-    rng.seed(1337);
+    std::mt19937 rng(osrm::test::getTestRandomSeed());
     std::uniform_int_distribution<std::mt19937::result_type> dist(0, 2);
 
     for (std::size_t i = 0; i < num_elements; i++)


### PR DESCRIPTION
Replace hardcoded seeds and std::random_device usage in unit tests with
a centralized osrm::test::getTestRandomSeed() function. The seed defaults
to 0xdeadbeef and can be overridden via the OSRM_TEST_SEED environment
variable, supporting both decimal and hex (0x-prefix) values.

This change should stabilize the codecov.io reported coverage numbers
