### PR TITLE
feat(engine): ignore incoming hints during phantom node lookup

### DIFF
--- a/features/testbot/hints.feature
+++ b/features/testbot/hints.feature
@@ -1,0 +1,57 @@
+@routing @testbot
+Feature: Hints handling - incoming hints are ignored but still generated
+
+    Background:
+        Given the profile "testbot"
+        Given a grid size of 100 meters
+
+    Scenario: Normal routing works without hints
+        Given the node map
+            """
+            a b
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+
+        When I route I should get
+            | from | to | route    |
+            | a    | b  | ab,ab    |
+            | b    | a  | ab,ab    |
+
+    Scenario: Route with bogus hints is accepted and produces correct result
+        Given the node map
+            """
+            a b
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+
+        Given the query options
+            | hints | AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA |
+
+        When I route I should get
+            | from | to | route    | status |
+            | a    | b  | ab,ab    | 200    |
+            | b    | a  | ab,ab    | 200    |
+
+    Scenario: Route with empty hints parameter is accepted
+        Given the node map
+            """
+            a b
+            """
+
+        And the ways
+            | nodes |
+            | ab    |
+
+        Given the query options
+            | hints | ; |
+
+        When I route I should get
+            | from | to | route    | status |
+            | a    | b  | ab,ab    | 200    |
+            | b    | a  | ab,ab    | 200    |

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -10,8 +10,7 @@
 #include "engine/status.hpp"
 
 #include "util/coordinate.hpp"
-#include "util/coordinate_calculation.hpp"
-#include "util/format.hpp"
+
 #include "util/integer_range.hpp"
 #include "util/json_container.hpp"
 
@@ -179,25 +178,11 @@ class BasePlugin
             parameters.coordinates.size());
         BOOST_ASSERT(radiuses.size() == parameters.coordinates.size());
 
-        const bool use_hints = !parameters.hints.empty();
         const bool use_bearings = !parameters.bearings.empty();
         const bool use_approaches = !parameters.approaches.empty();
 
         for (const auto i : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
         {
-            if (use_hints && parameters.hints[i] && !parameters.hints[i]->segment_hints.empty() &&
-                parameters.hints[i]->IsValid(parameters.coordinates[i], facade))
-            {
-                for (const auto &seg_hint : parameters.hints[i]->segment_hints)
-                {
-                    phantom_nodes[i].push_back(PhantomNodeWithDistance{
-                        seg_hint.phantom,
-                        util::coordinate_calculation::greatCircleDistance(
-                            parameters.coordinates[i], seg_hint.phantom.location)});
-                }
-                continue;
-            }
-
             phantom_nodes[i] = facade.NearestPhantomNodesInRange(
                 parameters.coordinates[i],
                 radiuses[i],
@@ -218,7 +203,6 @@ class BasePlugin
         std::vector<std::vector<PhantomNodeWithDistance>> phantom_nodes(
             parameters.coordinates.size());
 
-        const bool use_hints = !parameters.hints.empty();
         const bool use_bearings = !parameters.bearings.empty();
         const bool use_radiuses = !parameters.radiuses.empty();
         const bool use_approaches = !parameters.approaches.empty();
@@ -226,19 +210,6 @@ class BasePlugin
         BOOST_ASSERT(parameters.IsValid());
         for (const auto i : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
         {
-            if (use_hints && parameters.hints[i] && !parameters.hints[i]->segment_hints.empty() &&
-                parameters.hints[i]->IsValid(parameters.coordinates[i], facade))
-            {
-                for (const auto &seg_hint : parameters.hints[i]->segment_hints)
-                {
-                    phantom_nodes[i].push_back(PhantomNodeWithDistance{
-                        seg_hint.phantom,
-                        util::coordinate_calculation::greatCircleDistance(
-                            parameters.coordinates[i], seg_hint.phantom.location)});
-                }
-                continue;
-            }
-
             phantom_nodes[i] = facade.NearestPhantomNodes(
                 parameters.coordinates[i],
                 number_of_results,
@@ -262,7 +233,6 @@ class BasePlugin
     {
         std::vector<PhantomCandidateAlternatives> alternatives(parameters.coordinates.size());
 
-        const bool use_hints = !parameters.hints.empty();
         const bool use_bearings = !parameters.bearings.empty();
         const bool use_radiuses = !parameters.radiuses.empty();
         const bool use_approaches = !parameters.approaches.empty();
@@ -271,17 +241,6 @@ class BasePlugin
         BOOST_ASSERT(parameters.IsValid());
         for (const auto i : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
         {
-            if (use_hints && parameters.hints[i] && !parameters.hints[i]->segment_hints.empty() &&
-                parameters.hints[i]->IsValid(parameters.coordinates[i], facade))
-            {
-                std::transform(parameters.hints[i]->segment_hints.begin(),
-                               parameters.hints[i]->segment_hints.end(),
-                               std::back_inserter(alternatives[i].first),
-                               [](const auto &seg_hint) { return seg_hint.phantom; });
-                // we don't set the second one - it will be marked as invalid
-                continue;
-            }
-
             alternatives[i] = facade.NearestCandidatesWithAlternativeFromBigComponent(
                 parameters.coordinates[i],
                 use_radiuses ? parameters.radiuses[i] : default_radius,

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -15,6 +15,7 @@
 #include "util/json_container.hpp"
 
 #include <algorithm>
+#include <format>
 #include <iterator>
 #include <string>
 #include <vector>


### PR DESCRIPTION
# Issue

N/A — this is a behavioral change without a corresponding issue.

Was this change primarily generated using an AI tool?
🤖 Claude Code, Claude Opus 4.8

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

## Description

Incoming hints are still parsed and accepted (backward compatibility), and hints are still generated in API responses. However, the server no longer uses client-provided hints to short-circuit phantom node lookups — it always performs a fresh nearest-node search instead.

This prevents clients from anchoring coordinates to stale or incorrect positions while maintaining full wire-format compatibility.

Changes:
- Removed hint-usage logic from all three `GetPhantomNodes` overloads in `plugin_base.hpp`
- Removed now-unused includes (`coordinate_calculation.hpp`, `format.hpp`)
- Hint parsing (HTTP grammar, Node.js bindings, Python bindings) is unchanged
- Hint generation (`BaseAPI::MakeWaypoint`) is unchanged
- `generate_hints` parameter still defaults to `true`
