### PR TITLE
refactor(util): replace SFINAE with C++20 concepts in packed_vector.hpp

### DIFF
--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -42,17 +42,23 @@ namespace detail
 template <typename WordT, typename T>
 inline T get_lower_half_value(WordT word, WordT mask, std::uint8_t offset)
     requires std::integral<T>
-{ return static_cast<T>((word & mask) >> offset); }
+{
+    return static_cast<T>((word & mask) >> offset);
+}
 
 template <typename WordT, typename T>
 inline T get_lower_half_value(WordT word, WordT mask, std::uint8_t offset)
     requires(!std::integral<T>)
-{ return T{static_cast<T::value_type>((word & mask) >> offset)}; }
+{
+    return T{static_cast<T::value_type>((word & mask) >> offset)};
+}
 
 template <typename WordT, typename T>
 inline T get_upper_half_value(WordT word, WordT mask, std::uint8_t offset)
     requires std::integral<T>
-{ return static_cast<T>((word & mask) << offset); }
+{
+    return static_cast<T>((word & mask) << offset);
+}
 
 template <typename WordT, typename T>
 inline T get_upper_half_value(WordT word, WordT mask, std::uint8_t offset)
@@ -236,7 +242,9 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         std::uint8_t element;
 
         bool operator==(const InternalIndex &other) const
-        { return std::tie(lower_word, element) == std::tie(other.lower_word, other.element); }
+        {
+            return std::tie(lower_word, element) == std::tie(other.lower_word, other.element);
+        }
     };
 
   public:
@@ -261,14 +269,20 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         operator T() const { return container.get_value(internal_index); }
 
         bool operator==(const internal_reference &other) const
-        { return &container == &other.container && internal_index == other.internal_index; }
+        {
+            return &container == &other.container && internal_index == other.internal_index;
+        }
 
         // FIXME: This is needed for tests on Boost ranges to correctly compare Alias values.
         template <typename F, typename U> bool operator!=(const osrm::Alias<F, U> value) const
-        { return container.get_value(internal_index) != value; }
+        {
+            return container.get_value(internal_index) != value;
+        }
 
         friend std::ostream &operator<<(std::ostream &os, const internal_reference &rhs)
-        { return os << static_cast<T>(rhs); }
+        {
+            return os << static_cast<T>(rhs);
+        }
 
       private:
         PackedVector &container;
@@ -355,7 +369,9 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         }
 
         difference_type operator-(const iterator_impl &other) const
-        { return static_cast<difference_type>(index) - static_cast<difference_type>(other.index); }
+        {
+            return static_cast<difference_type>(index) - static_cast<difference_type>(other.index);
+        }
 
         bool operator==(const iterator_impl &other) const { return index == other.index; }
         bool operator!=(const iterator_impl &other) const { return !(*this == other); }
@@ -381,7 +397,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
             push_back(value);
     }
 
-    PackedVector() {};
+    PackedVector(){};
     PackedVector(const PackedVector &) = default;
     PackedVector(PackedVector &&) = default;
     PackedVector &operator=(const PackedVector &) = default;
@@ -406,7 +422,9 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
     auto operator[](const std::size_t index) const { return get_value(get_internal_index(index)); }
 
     auto operator[](const std::size_t index)
-    { return internal_reference{*this, get_internal_index(index)}; }
+    {
+        return internal_reference{*this, get_internal_index(index)};
+    }
 
     auto at(std::size_t index) const
     {
@@ -449,7 +467,9 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
     // Since we only allow passing by value anyway this is just an alias
     template <class... Args> void emplace_back(Args... args)
-    { push_back(T{std::forward<Args>(args)...}); }
+    {
+        push_back(T{std::forward<Args>(args)...});
+    }
 
     void push_back(const T value)
     {
@@ -502,7 +522,9 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
   private:
     void allocate_blocks(std::size_t num_blocks)
-    { vec.resize(vec.size() + num_blocks * BLOCK_WORDS); }
+    {
+        vec.resize(vec.size() + num_blocks * BLOCK_WORDS);
+    }
 
     inline InternalIndex get_internal_index(const std::size_t index) const
     {

--- a/include/util/packed_vector.hpp
+++ b/include/util/packed_vector.hpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <concepts>
 #include <iterator>
 #include <limits>
 #include <tuple>
@@ -39,67 +40,47 @@ namespace detail
 {
 
 template <typename WordT, typename T>
-inline T get_lower_half_value(WordT word,
-                              WordT mask,
-                              std::uint8_t offset,
-                              typename std::enable_if_t<std::is_integral<T>::value> * = nullptr)
-{
-    return static_cast<T>((word & mask) >> offset);
-}
+inline T get_lower_half_value(WordT word, WordT mask, std::uint8_t offset)
+    requires std::integral<T>
+{ return static_cast<T>((word & mask) >> offset); }
 
 template <typename WordT, typename T>
-inline T get_lower_half_value(WordT word,
-                              WordT mask,
-                              std::uint8_t offset,
-                              typename T::value_type * = nullptr)
-{
-    return T{static_cast<T::value_type>((word & mask) >> offset)};
-}
+inline T get_lower_half_value(WordT word, WordT mask, std::uint8_t offset)
+    requires(!std::integral<T>)
+{ return T{static_cast<T::value_type>((word & mask) >> offset)}; }
 
 template <typename WordT, typename T>
-inline T get_upper_half_value(WordT word,
-                              WordT mask,
-                              std::uint8_t offset,
-                              typename std::enable_if_t<std::is_integral<T>::value> * = nullptr)
-{
-    return static_cast<T>((word & mask) << offset);
-}
+inline T get_upper_half_value(WordT word, WordT mask, std::uint8_t offset)
+    requires std::integral<T>
+{ return static_cast<T>((word & mask) << offset); }
 
 template <typename WordT, typename T>
-inline T get_upper_half_value(WordT word,
-                              WordT mask,
-                              std::uint8_t offset,
-                              typename T::value_type * = nullptr)
+inline T get_upper_half_value(WordT word, WordT mask, std::uint8_t offset)
+    requires(!std::integral<T>)
 {
     static_assert(std::is_unsigned<WordT>::value, "Only unsigned word types supported for now.");
     return T{static_cast<T::value_type>((word & mask) << offset)};
 }
 
 template <typename WordT, typename T>
-inline WordT set_lower_value(WordT word,
-                             WordT mask,
-                             std::uint8_t offset,
-                             T value,
-                             typename std::enable_if_t<std::is_integral<T>::value> * = nullptr)
+inline WordT set_lower_value(WordT word, WordT mask, std::uint8_t offset, T value)
+    requires std::integral<T>
 {
     static_assert(std::is_unsigned<WordT>::value, "Only unsigned word types supported for now.");
     return (word & ~mask) | ((static_cast<WordT>(value) << offset) & mask);
 }
 
 template <typename WordT, typename T>
-inline WordT set_upper_value(WordT word,
-                             WordT mask,
-                             std::uint8_t offset,
-                             T value,
-                             typename std::enable_if_t<std::is_integral<T>::value> * = nullptr)
+inline WordT set_upper_value(WordT word, WordT mask, std::uint8_t offset, T value)
+    requires std::integral<T>
 {
     static_assert(std::is_unsigned<WordT>::value, "Only unsigned word types supported for now.");
     return (word & ~mask) | ((static_cast<WordT>(value) >> offset) & mask);
 }
 
 template <typename WordT, typename T>
-inline WordT set_lower_value(
-    WordT word, WordT mask, std::uint8_t offset, T value, typename T::value_type * = nullptr)
+inline WordT set_lower_value(WordT word, WordT mask, std::uint8_t offset, T value)
+    requires(!std::integral<T>)
 {
     static_assert(std::is_unsigned<WordT>::value, "Only unsigned word types supported for now.");
     return (word & ~mask) |
@@ -107,8 +88,8 @@ inline WordT set_lower_value(
 }
 
 template <typename WordT, typename T>
-inline WordT set_upper_value(
-    WordT word, WordT mask, std::uint8_t offset, T value, typename T::value_type * = nullptr)
+inline WordT set_upper_value(WordT word, WordT mask, std::uint8_t offset, T value)
+    requires(!std::integral<T>)
 {
     static_assert(std::is_unsigned<WordT>::value, "Only unsigned word types supported for now.");
     return (word & ~mask) |
@@ -255,9 +236,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         std::uint8_t element;
 
         bool operator==(const InternalIndex &other) const
-        {
-            return std::tie(lower_word, element) == std::tie(other.lower_word, other.element);
-        }
+        { return std::tie(lower_word, element) == std::tie(other.lower_word, other.element); }
     };
 
   public:
@@ -282,20 +261,14 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         operator T() const { return container.get_value(internal_index); }
 
         bool operator==(const internal_reference &other) const
-        {
-            return &container == &other.container && internal_index == other.internal_index;
-        }
+        { return &container == &other.container && internal_index == other.internal_index; }
 
         // FIXME: This is needed for tests on Boost ranges to correctly compare Alias values.
         template <typename F, typename U> bool operator!=(const osrm::Alias<F, U> value) const
-        {
-            return container.get_value(internal_index) != value;
-        }
+        { return container.get_value(internal_index) != value; }
 
         friend std::ostream &operator<<(std::ostream &os, const internal_reference &rhs)
-        {
-            return os << static_cast<T>(rhs);
-        }
+        { return os << static_cast<T>(rhs); }
 
       private:
         PackedVector &container;
@@ -382,9 +355,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
         }
 
         difference_type operator-(const iterator_impl &other) const
-        {
-            return static_cast<difference_type>(index) - static_cast<difference_type>(other.index);
-        }
+        { return static_cast<difference_type>(index) - static_cast<difference_type>(other.index); }
 
         bool operator==(const iterator_impl &other) const { return index == other.index; }
         bool operator!=(const iterator_impl &other) const { return !(*this == other); }
@@ -410,7 +381,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
             push_back(value);
     }
 
-    PackedVector(){};
+    PackedVector() {};
     PackedVector(const PackedVector &) = default;
     PackedVector(PackedVector &&) = default;
     PackedVector &operator=(const PackedVector &) = default;
@@ -435,9 +406,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
     auto operator[](const std::size_t index) const { return get_value(get_internal_index(index)); }
 
     auto operator[](const std::size_t index)
-    {
-        return internal_reference{*this, get_internal_index(index)};
-    }
+    { return internal_reference{*this, get_internal_index(index)}; }
 
     auto at(std::size_t index) const
     {
@@ -480,9 +449,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
     // Since we only allow passing by value anyway this is just an alias
     template <class... Args> void emplace_back(Args... args)
-    {
-        push_back(T{std::forward<Args>(args)...});
-    }
+    { push_back(T{std::forward<Args>(args)...}); }
 
     void push_back(const T value)
     {
@@ -512,8 +479,8 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
     std::size_t capacity() const { return (vec.capacity() / BLOCK_WORDS) * BLOCK_ELEMENTS; }
 
-    template <bool enabled = (Ownership == storage::Ownership::View)>
-    void reserve(std::enable_if<!enabled, std::size_t>::type capacity)
+    void reserve(std::size_t capacity)
+        requires(Ownership != storage::Ownership::View)
     {
         auto num_blocks = (capacity + BLOCK_ELEMENTS - 1) / BLOCK_ELEMENTS;
         vec.reserve(num_blocks * BLOCK_WORDS + 1);
@@ -535,9 +502,7 @@ template <typename T, std::size_t Bits, storage::Ownership Ownership> class Pack
 
   private:
     void allocate_blocks(std::size_t num_blocks)
-    {
-        vec.resize(vec.size() + num_blocks * BLOCK_WORDS);
-    }
+    { vec.resize(vec.size() + num_blocks * BLOCK_WORDS); }
 
     inline InternalIndex get_internal_index(const std::size_t index) const
     {


### PR DESCRIPTION
## Issue

Closes #7533
Part of #7530

Replace all `std::enable_if_t<std::is_integral<T>::value>` and `typename T::value_type * = nullptr` SFINAE patterns with `requires std::integral<T>` / `requires (!std::integral<T>)` clauses. Also replace the `enable_if` SFINAE on `reserve()` with a direct trailing requires clause on the class template parameter, eliminating the artificial `bool enabled` template parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code), Claude Sonnet 4.6

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [x] add tests (existing tests cover both integral and Alias types)
 - [ ] review
 - [ ] adjust for comments