### PR TITLE
refactor(util): migrate util/* SFINAE patterns to C++20 concepts

### DIFF
--- a/include/util/alias.hpp
+++ b/include/util/alias.hpp
@@ -50,36 +50,22 @@ template <typename From, typename Tag> struct Alias final
     explicit operator From &() { return __value; }
     explicit operator From() const { return __value; }
     inline Alias operator+(const Alias rhs_) const
-    {
-        return Alias{__value + static_cast<const From>(rhs_)};
-    }
+    { return Alias{__value + static_cast<const From>(rhs_)}; }
     inline Alias operator-(const Alias rhs_) const
-    {
-        return Alias{__value - static_cast<const From>(rhs_)};
-    }
+    { return Alias{__value - static_cast<const From>(rhs_)}; }
     inline Alias operator-() const
         requires(std::is_signed_v<From> || std::is_floating_point_v<From>)
-    {
-        return Alias{-__value};
-    }
+    { return Alias{-__value}; }
     inline Alias operator*(const Alias rhs_) const
-    {
-        return Alias{__value * static_cast<const From>(rhs_)};
-    }
+    { return Alias{__value * static_cast<const From>(rhs_)}; }
     inline Alias operator*(const double rhs_) const { return Alias{__value * rhs_}; }
     inline Alias operator/(const Alias rhs_) const
-    {
-        return Alias{__value / static_cast<const From>(rhs_)};
-    }
+    { return Alias{__value / static_cast<const From>(rhs_)}; }
     inline Alias operator/(const double rhs_) const { return Alias{__value / rhs_}; }
     inline Alias operator|(const Alias rhs_) const
-    {
-        return Alias{__value | static_cast<const From>(rhs_)};
-    }
+    { return Alias{__value | static_cast<const From>(rhs_)}; }
     inline Alias operator&(const Alias rhs_) const
-    {
-        return Alias{__value & static_cast<const From>(rhs_)};
-    }
+    { return Alias{__value & static_cast<const From>(rhs_)}; }
     auto operator<=>(const Alias &) const = default;
 
     inline Alias operator++()
@@ -142,9 +128,8 @@ template <typename ToNumeric, typename FromAlias> inline ToNumeric from_alias(co
     return {static_cast<ToNumeric>(static_cast<const FromAlias::value_type>(from))};
 }
 
-template <typename ToAlias,
-          typename FromNumeric,
-          typename = std::enable_if_t<!std::is_same<ToAlias, FromNumeric>::value>>
+template <typename ToAlias, typename FromNumeric>
+    requires(!std::is_same_v<ToAlias, FromNumeric>)
 inline ToAlias to_alias(const FromNumeric &from)
 {
     static_assert(std::is_arithmetic<FromNumeric>::value, "Numeric needs to be an arithmetic type");
@@ -160,9 +145,7 @@ template <typename ToAlias> inline ToAlias to_alias(const ToAlias &from) { retur
 
 template <typename From, typename Tag>
 inline std::ostream &operator<<(std::ostream &stream, const Alias<From, Tag> &inst)
-{
-    return stream << inst.__value;
-}
+{ return stream << inst.__value; }
 } // namespace osrm
 
 namespace std
@@ -172,9 +155,7 @@ template <typename From, typename Tag> struct hash<osrm::Alias<From, Tag>>
     using argument_type = osrm::Alias<From, Tag>;
     using result_type = std::size_t;
     result_type operator()(argument_type const &s) const
-    {
-        return std::hash<From>()(static_cast<const From>(s));
-    }
+    { return std::hash<From>()(static_cast<const From>(s)); }
 };
 } // namespace std
 

--- a/include/util/alias.hpp
+++ b/include/util/alias.hpp
@@ -50,22 +50,36 @@ template <typename From, typename Tag> struct Alias final
     explicit operator From &() { return __value; }
     explicit operator From() const { return __value; }
     inline Alias operator+(const Alias rhs_) const
-    { return Alias{__value + static_cast<const From>(rhs_)}; }
+    {
+        return Alias{__value + static_cast<const From>(rhs_)};
+    }
     inline Alias operator-(const Alias rhs_) const
-    { return Alias{__value - static_cast<const From>(rhs_)}; }
+    {
+        return Alias{__value - static_cast<const From>(rhs_)};
+    }
     inline Alias operator-() const
         requires(std::is_signed_v<From> || std::is_floating_point_v<From>)
-    { return Alias{-__value}; }
+    {
+        return Alias{-__value};
+    }
     inline Alias operator*(const Alias rhs_) const
-    { return Alias{__value * static_cast<const From>(rhs_)}; }
+    {
+        return Alias{__value * static_cast<const From>(rhs_)};
+    }
     inline Alias operator*(const double rhs_) const { return Alias{__value * rhs_}; }
     inline Alias operator/(const Alias rhs_) const
-    { return Alias{__value / static_cast<const From>(rhs_)}; }
+    {
+        return Alias{__value / static_cast<const From>(rhs_)};
+    }
     inline Alias operator/(const double rhs_) const { return Alias{__value / rhs_}; }
     inline Alias operator|(const Alias rhs_) const
-    { return Alias{__value | static_cast<const From>(rhs_)}; }
+    {
+        return Alias{__value | static_cast<const From>(rhs_)};
+    }
     inline Alias operator&(const Alias rhs_) const
-    { return Alias{__value & static_cast<const From>(rhs_)}; }
+    {
+        return Alias{__value & static_cast<const From>(rhs_)};
+    }
     auto operator<=>(const Alias &) const = default;
 
     inline Alias operator++()
@@ -145,7 +159,9 @@ template <typename ToAlias> inline ToAlias to_alias(const ToAlias &from) { retur
 
 template <typename From, typename Tag>
 inline std::ostream &operator<<(std::ostream &stream, const Alias<From, Tag> &inst)
-{ return stream << inst.__value; }
+{
+    return stream << inst.__value;
+}
 } // namespace osrm
 
 namespace std
@@ -155,7 +171,9 @@ template <typename From, typename Tag> struct hash<osrm::Alias<From, Tag>>
     using argument_type = osrm::Alias<From, Tag>;
     using result_type = std::size_t;
     result_type operator()(argument_type const &s) const
-    { return std::hash<From>()(static_cast<const From>(s)); }
+    {
+        return std::hash<From>()(static_cast<const From>(s));
+    }
 };
 } // namespace std
 

--- a/include/util/filtered_integer_range.hpp
+++ b/include/util/filtered_integer_range.hpp
@@ -1,9 +1,9 @@
 #ifndef FILTERED_INTEGER_RANGE_HPP
 #define FILTERED_INTEGER_RANGE_HPP
 
+#include <concepts>
 #include <cstddef>
 #include <iterator>
-#include <type_traits>
 
 namespace osrm::util
 {
@@ -41,13 +41,9 @@ template <typename Integer, typename Filter> class filtered_integer_iterator
     }
 
     friend bool operator==(const filtered_integer_iterator &a, const filtered_integer_iterator &b)
-    {
-        return a.value == b.value;
-    }
+    { return a.value == b.value; }
     friend bool operator!=(const filtered_integer_iterator &a, const filtered_integer_iterator &b)
-    {
-        return !(a == b);
-    }
+    { return !(a == b); }
 
   private:
     value_type value;
@@ -80,14 +76,10 @@ template <typename Integer, typename Filter> class filtered_range
 };
 
 template <typename Integer, typename Filter>
-filtered_range<Integer, Filter> filtered_irange(
-    const Integer first,
-    const Integer last,
-    const Filter &filter,
-    typename std::enable_if<std::is_integral<Integer>::value>::type * = nullptr) noexcept
-{
-    return filtered_range<Integer, Filter>(first, last, filter);
-}
+filtered_range<Integer, Filter>
+filtered_irange(const Integer first, const Integer last, const Filter &filter) noexcept
+    requires std::integral<Integer>
+{ return filtered_range<Integer, Filter>(first, last, filter); }
 
 } // namespace osrm::util
 

--- a/include/util/filtered_integer_range.hpp
+++ b/include/util/filtered_integer_range.hpp
@@ -41,9 +41,13 @@ template <typename Integer, typename Filter> class filtered_integer_iterator
     }
 
     friend bool operator==(const filtered_integer_iterator &a, const filtered_integer_iterator &b)
-    { return a.value == b.value; }
+    {
+        return a.value == b.value;
+    }
     friend bool operator!=(const filtered_integer_iterator &a, const filtered_integer_iterator &b)
-    { return !(a == b); }
+    {
+        return !(a == b);
+    }
 
   private:
     value_type value;
@@ -79,7 +83,9 @@ template <typename Integer, typename Filter>
 filtered_range<Integer, Filter>
 filtered_irange(const Integer first, const Integer last, const Filter &filter) noexcept
     requires std::integral<Integer>
-{ return filtered_range<Integer, Filter>(first, last, filter); }
+{
+    return filtered_range<Integer, Filter>(first, last, filter);
+}
 
 } // namespace osrm::util
 

--- a/include/util/indexed_data.hpp
+++ b/include/util/indexed_data.hpp
@@ -11,6 +11,7 @@
 #include <boost/assert.hpp>
 
 #include <array>
+#include <concepts>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -359,24 +360,20 @@ template <typename GroupBlockPolicy, storage::Ownership Ownership> struct Indexe
                                                       const IndexedDataImpl &index_data);
 
   private:
-    template <typename Iter, typename T>
-    using IsValueIterator = std::enable_if_t<
-        std::is_same<T,
-                     std::remove_const_t<typename std::iterator_traits<Iter>::value_type>>::value>;
-
-    template <typename T = ResultType, typename Iter, typename = IsValueIterator<Iter, ValueType>>
-    std::enable_if<!std::is_same<T, std::string_view>::value, T>::type adapt(const Iter first,
-                                                                             const Iter last) const
+    template <typename T = ResultType, typename Iter>
+        requires std::same_as<std::remove_const_t<typename std::iterator_traits<Iter>::value_type>,
+                              ValueType>
+    T adapt(const Iter first, const Iter last) const
     {
-        return ResultType(first, last);
-    }
-
-    template <typename T = ResultType, typename Iter, typename = IsValueIterator<Iter, ValueType>>
-    std::enable_if<std::is_same<T, std::string_view>::value, T>::type adapt(const Iter first,
-                                                                            const Iter last) const
-    {
-        auto diff = std::distance(first, last);
-        return diff == 0 ? ResultType() : ResultType(&*first, diff);
+        if constexpr (std::is_same_v<T, std::string_view>)
+        {
+            auto diff = std::distance(first, last);
+            return diff == 0 ? ResultType() : ResultType(&*first, diff);
+        }
+        else
+        {
+            return ResultType(first, last);
+        }
     }
 
     template <typename T> using Vector = util::ViewOrVector<T, Ownership>;

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -207,9 +207,7 @@ class StaticRTree
         std::uint32_t m_original_index;
 
         inline bool operator<(const WrappedInputElement &other) const
-        {
-            return m_hilbert_value < other.m_hilbert_value;
-        }
+        { return m_hilbert_value < other.m_hilbert_value; }
     };
 
     struct QueryCandidate
@@ -230,9 +228,7 @@ class StaticRTree
         }
 
         inline bool is_segment() const
-        {
-            return segment_index != std::numeric_limits<std::uint32_t>::max();
-        }
+        { return segment_index != std::numeric_limits<std::uint32_t>::max(); }
 
         inline bool operator<(const QueryCandidate &other) const
         {
@@ -454,9 +450,9 @@ class StaticRTree
     /**
      * Constructs an empty RTree for de-serialization.
      */
-    template <typename = std::enable_if<Ownership == storage::Ownership::Container>>
     explicit StaticRTree(const std::filesystem::path &on_disk_file_name,
                          const Vector<Coordinate> &coordinate_list)
+        requires(Ownership == storage::Ownership::Container)
         : m_coordinate_list(coordinate_list.data(), coordinate_list.size()),
           m_objects(mmapFile<EdgeDataT>(on_disk_file_name, m_objects_region))
     {

--- a/include/util/static_rtree.hpp
+++ b/include/util/static_rtree.hpp
@@ -207,7 +207,9 @@ class StaticRTree
         std::uint32_t m_original_index;
 
         inline bool operator<(const WrappedInputElement &other) const
-        { return m_hilbert_value < other.m_hilbert_value; }
+        {
+            return m_hilbert_value < other.m_hilbert_value;
+        }
     };
 
     struct QueryCandidate
@@ -228,7 +230,9 @@ class StaticRTree
         }
 
         inline bool is_segment() const
-        { return segment_index != std::numeric_limits<std::uint32_t>::max(); }
+        {
+            return segment_index != std::numeric_limits<std::uint32_t>::max();
+        }
 
         inline bool operator<(const QueryCandidate &other) const
         {


### PR DESCRIPTION
## Issue

Closes #7534
Part of #7530

Replace `enable_if` / `void_t` / SFINAE patterns with `requires` clauses and standard C++20 concepts across four utility headers.

### Changes

- **alias.hpp**: Replace `std::enable_if_t<!std::is_same<...>>` default template parameter with trailing `requires(!std::is_same_v<ToAlias, FromNumeric>)` on `to_alias()`
- **filtered_integer_range.hpp**: Replace `std::enable_if<std::is_integral<Integer>::value>` SFINAE parameter with `requires std::integral<Integer>`; replace now-unused `<type_traits>` with `<concepts>`
- **indexed_data.hpp**: Replace `IsValueIterator` alias template + dual-overload return-type SFINAE with a single `adapt()` function using `requires std::same_as<...>` for the iterator constraint and `if constexpr` for the `string_view` dispatch
- **static_rtree.hpp**: Replace `template <typename = std::enable_if<Ownership == Container>>` constructor SFINAE with trailing `requires(Ownership == storage::Ownership::Container)`

🤖 Generated with [Claude Code](https://claude.com/claude-code), Claude Sonnet 4.6

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [x] add tests (existing unit tests cover all changed code paths)
 - [ ] review
 - [ ] adjust for comments