### PR TITLE
fix: pypi publishing failed bcs of missing GHA permissions

### DIFF
--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -243,6 +243,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
     steps:
       - name: Configure DNS servers
         if: runner.os == 'Linux'


### PR DESCRIPTION
fixes #7623 

I got rid of the OICD error, but apparently we're also missing some permissions to download artifacts from another _workflow_. obvious, but didn't see it..