### PR TITLE
feat(profiles): add support for surface=laterite in car and bicycle profiles

### DIFF
--- a/features/bicycle/surface.feature
+++ b/features/bicycle/surface.feature
@@ -26,6 +26,7 @@ Feature: Bike - Surfaces
             | cycleway | grass_paver           | 120 s   |
             | cycleway | dirt                  | 90 s    |
             | cycleway | earth                 | 120 s   |
+            | cycleway | laterite              | 144 s   |
             | cycleway | grass                 | 120 s   |
             | cycleway | mud                   | 240 s   |
             | cycleway | sand                  | 240 s   |

--- a/features/car/surface.feature
+++ b/features/car/surface.feature
@@ -33,6 +33,7 @@ Feature: Car - Surfaces
             | trunk   | asphalt  | x     |
             | trunk   | sett     | x     |
             | trunk   | gravel   | x     |
+            | trunk   | laterite | x     |
             | trunk   | ice      | x     |
             | trunk   | snow     | x     |
             | trunk   | nonsense | x     |
@@ -90,6 +91,7 @@ Feature: Car - Surfaces
             | motorway | no     | tartan          | 40 km/h +-1 | 40 km/h +-1 |
             | motorway | no     | cobblestone     | 30 km/h +-1 | 30 km/h +-1 |
             | motorway | no     | clay            | 30 km/h +-1 | 30 km/h +-1 |
+            | motorway | no     | laterite        | 15 km/h +-1 | 15 km/h +-1 |
             | motorway | no     | earth           | 20 km/h +-1 | 20 km/h +-1 |
             | motorway | no     | stone           | 20 km/h +-1 | 20 km/h +-1 |
             | motorway | no     | rocky           | 20 km/h +-1 | 20 km/h +-1 |
@@ -124,8 +126,9 @@ Feature: Car - Surfaces
             | motorway | no     |           |         |               | 90 km/h |
             | service  | no     | grade1    | asphalt | excellent     | 15 km/h |
             | motorway | no     | grade5    | asphalt | excellent     | 20 km/h |
-            | motorway | no     | grade1    | mud     | excellent     | 10 km/h |
-            | motorway | no     | grade1    | asphalt | very_horrible |  5 km/h |
+            | motorway | no     | grade1    | mud      | excellent     | 10 km/h |
+            | motorway | no     | grade1    | laterite | excellent     | 15 km/h |
+            | motorway | no     | grade1    | asphalt  | very_horrible |  5 km/h |
             | service  | no     | grade5    | mud     | very_horrible |  5 km/h |
 
     Scenario: Car - Surfaces should not affect oneway direction

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -199,6 +199,7 @@ function setup()
       ground = 10,
       dirt = 8,
       earth = 6,
+      laterite = 5,
       grass = 6,
       mud = 3,
       sand = 3,

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -268,12 +268,13 @@ function setup()
 
       cobblestone = 30,
       clay = 30,
-      laterite = 15,
 
       earth = 20,
       stone = 20,
       rocky = 20,
       sand = 20,
+
+      laterite = 15,
 
       mud = 10,
 

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -268,6 +268,7 @@ function setup()
 
       cobblestone = 30,
       clay = 30,
+      laterite = 15,
 
       earth = 20,
       stone = 20,

--- a/taginfo.json
+++ b/taginfo.json
@@ -290,6 +290,7 @@
         {"key": "surface", "value": "cobblestone"},
         {"key": "surface", "value": "clay"},
         {"key": "surface", "value": "earth"},
+        {"key": "surface", "value": "laterite"},
         {"key": "surface", "value": "stone"},
         {"key": "surface", "value": "rocky"},
         {"key": "surface", "value": "sand"},


### PR DESCRIPTION
# Issue

Fixes #7639 — adds support for `surface=laterite` in routing profiles.

[surface=laterite](https://wiki.openstreetmap.org/wiki/Tag:surface=laterite) was recently approved on the OSM wiki. It represents natural lateritic road surfaces common in tropical areas. These roads are firm and dusty when dry, but become extremely hazardous when wet — forming a near-frictionless slip layer within minutes of first rain, and progressing to deeply plastic and impassable in sustained rain. The [wiki explicitly recommends](https://wiki.openstreetmap.org/wiki/Tag:surface=laterite) a "significantly higher penalty than `surface=dirt` or `surface=clay`" in routing engines.

Changes:
- **Car profile**: `laterite = 15 km/h` (between `clay` at 30 and `earth` at 20)
- **Bicycle profile**: `laterite = 5 km/h` (between `earth` at 6 and `mud` at 3)
- **Foot profile**: no change (already defaults unknown surfaces to walking speed)
- Tests added for routability and speed reduction in both car and bicycle surface feature files

🤖 Generated with [Claude Code](https://claude.com/claude-code), Claude Sonnet 4.6

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.
