### PR TITLE
feat(tools): add --output option to osrm-contract, osrm-customize, osrm-partition

### DIFF
--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -55,6 +55,8 @@ struct ContractorConfig final : storage::IOConfig
 
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {
+        // Validate the extension is configured (throws if not)
+        (void)GetPath(ext);
         if (!output_path.empty())
             return {output_path.string() + ext};
         return GetPath(ext);

--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -53,8 +53,16 @@ struct ContractorConfig final : storage::IOConfig
 
     bool IsValid() const { return IOConfig::IsValid() && updater_config.IsValid(); }
 
+    std::filesystem::path GetOutputPath(const std::string &ext) const
+    {
+        if (!output_path.empty())
+            return {output_path.string() + ext};
+        return GetPath(ext);
+    }
+
     updater::UpdaterConfig updater_config;
 
+    std::filesystem::path output_path;
     unsigned requested_num_threads = 0;
 };
 } // namespace osrm::contractor

--- a/include/contractor/contractor_config.hpp
+++ b/include/contractor/contractor_config.hpp
@@ -56,7 +56,7 @@ struct ContractorConfig final : storage::IOConfig
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {
         // Validate the extension is configured (throws if not)
-        (void)GetPath(ext);
+        GetPath(ext);
         if (!output_path.empty())
             return {output_path.string() + ext};
         return GetPath(ext);

--- a/include/customizer/customizer_config.hpp
+++ b/include/customizer/customizer_config.hpp
@@ -30,6 +30,14 @@ struct CustomizationConfig final : storage::IOConfig
         updater_config.UseDefaultOutputNames(base);
     }
 
+    std::filesystem::path GetOutputPath(const std::string &ext) const
+    {
+        if (!output_path.empty())
+            return {output_path.string() + ext};
+        return GetPath(ext);
+    }
+
+    std::filesystem::path output_path;
     unsigned requested_num_threads;
 
     updater::UpdaterConfig updater_config;

--- a/include/customizer/customizer_config.hpp
+++ b/include/customizer/customizer_config.hpp
@@ -32,6 +32,8 @@ struct CustomizationConfig final : storage::IOConfig
 
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {
+        // Validate the extension is configured (throws if not)
+        (void)GetPath(ext);
         if (!output_path.empty())
             return {output_path.string() + ext};
         return GetPath(ext);

--- a/include/customizer/customizer_config.hpp
+++ b/include/customizer/customizer_config.hpp
@@ -33,7 +33,7 @@ struct CustomizationConfig final : storage::IOConfig
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {
         // Validate the extension is configured (throws if not)
-        (void)GetPath(ext);
+        GetPath(ext);
         if (!output_path.empty())
             return {output_path.string() + ext};
         return GetPath(ext);

--- a/include/partitioner/partitioner_config.hpp
+++ b/include/partitioner/partitioner_config.hpp
@@ -27,9 +27,7 @@ struct PartitionerConfig final : storage::IOConfig
     }
 
     void UseDefaultOutputNames(const std::filesystem::path &base)
-    {
-        IOConfig::UseDefaultOutputNames(base);
-    }
+    { IOConfig::UseDefaultOutputNames(base); }
 
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {

--- a/include/partitioner/partitioner_config.hpp
+++ b/include/partitioner/partitioner_config.hpp
@@ -32,7 +32,7 @@ struct PartitionerConfig final : storage::IOConfig
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {
         // Validate the extension is configured (throws if not)
-        (void)GetPath(ext);
+        GetPath(ext);
         if (!output_path.empty())
             return {output_path.string() + ext};
         return GetPath(ext);

--- a/include/partitioner/partitioner_config.hpp
+++ b/include/partitioner/partitioner_config.hpp
@@ -31,6 +31,8 @@ struct PartitionerConfig final : storage::IOConfig
 
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {
+        // Validate the extension is configured (throws if not)
+        (void)GetPath(ext);
         if (!output_path.empty())
             return {output_path.string() + ext};
         return GetPath(ext);

--- a/include/partitioner/partitioner_config.hpp
+++ b/include/partitioner/partitioner_config.hpp
@@ -27,7 +27,9 @@ struct PartitionerConfig final : storage::IOConfig
     }
 
     void UseDefaultOutputNames(const std::filesystem::path &base)
-    { IOConfig::UseDefaultOutputNames(base); }
+    {
+        IOConfig::UseDefaultOutputNames(base);
+    }
 
     std::filesystem::path GetOutputPath(const std::string &ext) const
     {

--- a/include/partitioner/partitioner_config.hpp
+++ b/include/partitioner/partitioner_config.hpp
@@ -31,6 +31,14 @@ struct PartitionerConfig final : storage::IOConfig
         IOConfig::UseDefaultOutputNames(base);
     }
 
+    std::filesystem::path GetOutputPath(const std::string &ext) const
+    {
+        if (!output_path.empty())
+            return {output_path.string() + ext};
+        return GetPath(ext);
+    }
+
+    std::filesystem::path output_path;
     unsigned requested_num_threads;
 
     double balance;

--- a/src/contractor/contractor.cpp
+++ b/src/contractor/contractor.cpp
@@ -72,7 +72,7 @@ int Contractor::Run()
     std::unordered_map<std::string, ContractedMetric> metrics = {
         {metric_name, {std::move(query_graph), std::move(edge_filters)}}};
 
-    files::writeGraph(config.GetPath(".osrm.hsgr"), metrics, connectivity_checksum);
+    files::writeGraph(config.GetOutputPath(".osrm.hsgr"), metrics, connectivity_checksum);
 
     TIMER_STOP(preparing);
 

--- a/src/customize/customizer.cpp
+++ b/src/customize/customizer.cpp
@@ -166,7 +166,7 @@ int Customizer::Run(const CustomizationConfig &config)
     std::unordered_map<std::string, std::vector<CellMetric>> metric_exclude_classes = {
         {properties.GetWeightName(), std::move(metrics)},
     };
-    files::writeCellMetrics(config.GetPath(".osrm.cell_metrics"), metric_exclude_classes);
+    files::writeCellMetrics(config.GetOutputPath(".osrm.cell_metrics"), metric_exclude_classes);
     TIMER_STOP(writing_mld_data);
     util::Log() << "MLD customization writing took " << TIMER_SEC(writing_mld_data) << " seconds";
 
@@ -176,7 +176,7 @@ int Customizer::Run(const CustomizationConfig &config)
                                           std::move(node_durations),
                                           std::move(node_distances)};
     customizer::files::writeGraph(
-        config.GetPath(".osrm.mldgr"), shaved_graph, connectivity_checksum);
+        config.GetOutputPath(".osrm.mldgr"), shaved_graph, connectivity_checksum);
     TIMER_STOP(writing_graph);
     util::Log() << "Graph writing took " << TIMER_SEC(writing_graph) << " seconds";
 

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -126,19 +126,28 @@ int Partitioner::Run(const PartitionerConfig &config)
     renumber(partitions, permutation);
     {
         renumber(mapping, permutation);
-        extractor::files::writeNBGMapping(config.GetPath(".osrm.cnbg_to_ebg").string(), mapping);
+        extractor::files::writeNBGMapping(
+            config.GetOutputPath(".osrm.cnbg_to_ebg").string(), mapping);
     }
     {
+        // If writing to a different output path, copy the file first since we mmap in-place
+        if (!config.output_path.empty())
+        {
+            std::filesystem::copy_file(
+                config.GetPath(".osrm.fileIndex"),
+                config.GetOutputPath(".osrm.fileIndex"),
+                std::filesystem::copy_options::overwrite_existing);
+        }
         boost::iostreams::mapped_file segment_region;
         auto segments = util::mmapFile<extractor::EdgeBasedNodeSegment>(
-            config.GetPath(".osrm.fileIndex"), segment_region);
+            config.GetOutputPath(".osrm.fileIndex"), segment_region);
         renumber(segments, permutation);
     }
     {
         extractor::EdgeBasedNodeDataContainer node_data;
         extractor::files::readNodeData(config.GetPath(".osrm.ebg_nodes"), node_data);
         renumber(node_data, permutation);
-        extractor::files::writeNodeData(config.GetPath(".osrm.ebg_nodes"), node_data);
+        extractor::files::writeNodeData(config.GetOutputPath(".osrm.ebg_nodes"), node_data);
     }
     {
         std::vector<EdgeWeight> node_weights;
@@ -151,10 +160,11 @@ int Partitioner::Run(const PartitionerConfig &config)
         util::inplacePermutation(node_durations.begin(), node_durations.end(), permutation);
         util::inplacePermutation(node_distances.begin(), node_distances.end(), permutation);
         extractor::files::writeEdgeBasedNodeWeightsDurationsDistances(
-            config.GetPath(".osrm.enw"), node_weights, node_durations, node_distances);
+            config.GetOutputPath(".osrm.enw"), node_weights, node_durations, node_distances);
     }
     {
         const auto &filename = config.GetPath(".osrm.maneuver_overrides");
+        const auto &output_filename = config.GetOutputPath(".osrm.maneuver_overrides");
         std::vector<extractor::StorageManeuverOverride> maneuver_overrides;
         std::vector<NodeID> node_sequences;
         extractor::files::readManeuverOverrides(filename, maneuver_overrides, node_sequences);
@@ -168,13 +178,14 @@ int Partitioner::Run(const PartitionerConfig &config)
                   maneuver_overrides.end(),
                   [](const auto &a, const auto &b) { return a.start_node < b.start_node; });
 
-        extractor::files::writeManeuverOverrides(filename, maneuver_overrides, node_sequences);
+        extractor::files::writeManeuverOverrides(
+            output_filename, maneuver_overrides, node_sequences);
     }
-    if (std::filesystem::exists(config.GetPath(".osrm.hsgr")))
+    if (std::filesystem::exists(config.GetOutputPath(".osrm.hsgr")))
     {
         util::Log(logWARNING) << "Found existing .osrm.hsgr file, removing. You need to re-run "
                                  "osrm-contract after osrm-partition.";
-        std::filesystem::remove(config.GetPath(".osrm.hsgr"));
+        std::filesystem::remove(config.GetOutputPath(".osrm.hsgr"));
     }
     TIMER_STOP(renumber);
     util::Log() << "Renumbered data in " << TIMER_SEC(renumber) << " seconds";
@@ -190,9 +201,9 @@ int Partitioner::Run(const PartitionerConfig &config)
     util::Log() << "CellStorage constructed in " << TIMER_SEC(cell_storage) << " seconds";
 
     TIMER_START(writing_mld_data);
-    files::writePartition(config.GetPath(".osrm.partition"), mlp);
-    files::writeCells(config.GetPath(".osrm.cells"), storage);
-    extractor::files::writeEdgeBasedGraph(config.GetPath(".osrm.ebg"),
+    files::writePartition(config.GetOutputPath(".osrm.partition"), mlp);
+    files::writeCells(config.GetOutputPath(".osrm.cells"), storage);
+    extractor::files::writeEdgeBasedGraph(config.GetOutputPath(".osrm.ebg"),
                                           edge_based_graph.GetNumberOfNodes(),
                                           graphToEdges(edge_based_graph),
                                           edge_based_graph.connectivity_checksum);

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -126,17 +126,16 @@ int Partitioner::Run(const PartitionerConfig &config)
     renumber(partitions, permutation);
     {
         renumber(mapping, permutation);
-        extractor::files::writeNBGMapping(
-            config.GetOutputPath(".osrm.cnbg_to_ebg").string(), mapping);
+        extractor::files::writeNBGMapping(config.GetOutputPath(".osrm.cnbg_to_ebg").string(),
+                                          mapping);
     }
     {
         // If writing to a different output path, copy the file first since we mmap in-place
         if (!config.output_path.empty())
         {
-            std::filesystem::copy_file(
-                config.GetPath(".osrm.fileIndex"),
-                config.GetOutputPath(".osrm.fileIndex"),
-                std::filesystem::copy_options::overwrite_existing);
+            std::filesystem::copy_file(config.GetPath(".osrm.fileIndex"),
+                                       config.GetOutputPath(".osrm.fileIndex"),
+                                       std::filesystem::copy_options::overwrite_existing);
         }
         boost::iostreams::mapped_file segment_region;
         auto segments = util::mmapFile<extractor::EdgeBasedNodeSegment>(

--- a/src/tools/contract.cpp
+++ b/src/tools/contract.cpp
@@ -10,6 +10,7 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/errors.hpp>
 
+#include <array>
 #include <cstdlib>
 #include <filesystem>
 #include <new>
@@ -72,7 +73,10 @@ return_code parseArguments(int argc,
         "time-zone-file",
         boost::program_options::value<std::string>(&contractor_config.updater_config.tz_file_path),
         "Required for conditional turn restriction parsing, provide a geojson file containing "
-        "time zone boundaries");
+        "time zone boundaries")(
+        "output,o",
+        boost::program_options::value<std::filesystem::path>(&contractor_config.output_path),
+        "Output base path for generated files (default: same as input)");
 
     // hidden options, will be allowed on command line, but will not be shown to the user
     boost::program_options::options_description hidden_options("Hidden options");
@@ -165,6 +169,24 @@ try
     util::LogPolicy::GetInstance().SetLevel(verbosity);
 
     contractor_config.UseDefaultOutputNames(contractor_config.base_path);
+
+    if (!contractor_config.output_path.empty())
+    {
+        // Strip known extensions from the user-provided output path
+        std::string path = contractor_config.output_path.string();
+        const std::array<std::string, 6> known_extensions{
+            {".osm.bz2", ".osm.pbf", ".osm.xml", ".pbf", ".osm", ".osrm"}};
+        for (const auto &ext : known_extensions)
+        {
+            const auto pos = path.find(ext);
+            if (pos != std::string::npos)
+            {
+                path.replace(pos, ext.size(), "");
+                break;
+            }
+        }
+        contractor_config.output_path = path;
+    }
 
     if (1 > contractor_config.requested_num_threads)
     {

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -8,6 +8,7 @@
 #include "util/program_options_path.hpp"
 #include <boost/program_options.hpp>
 
+#include <array>
 #include <filesystem>
 #include <iostream>
 #include <set>
@@ -72,7 +73,10 @@ return_code parseArguments(int argc,
                 &customization_config.updater_config.tz_file_path)
                 ->default_value(""),
             "Required for conditional turn restriction parsing, provide a geojson file containing "
-            "time zone boundaries");
+            "time zone boundaries")(
+        "output,o",
+        boost::program_options::value<std::filesystem::path>(&customization_config.output_path),
+        "Output base path for generated files (default: same as input)");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user
@@ -166,6 +170,24 @@ try
 
     // set the default in/output names
     customization_config.UseDefaultOutputNames(customization_config.base_path);
+
+    if (!customization_config.output_path.empty())
+    {
+        // Strip known extensions from the user-provided output path
+        std::string path = customization_config.output_path.string();
+        const std::array<std::string, 6> known_extensions{
+            {".osm.bz2", ".osm.pbf", ".osm.xml", ".pbf", ".osm", ".osrm"}};
+        for (const auto &ext : known_extensions)
+        {
+            const auto pos = path.find(ext);
+            if (pos != std::string::npos)
+            {
+                path.replace(pos, ext.size(), "");
+                break;
+            }
+        }
+        customization_config.output_path = path;
+    }
 
     if (1 > customization_config.requested_num_threads)
     {

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -74,9 +74,9 @@ return_code parseArguments(int argc,
                 ->default_value(""),
             "Required for conditional turn restriction parsing, provide a geojson file containing "
             "time zone boundaries")(
-        "output,o",
-        boost::program_options::value<std::filesystem::path>(&customization_config.output_path),
-        "Output base path for generated files (default: same as input)");
+            "output,o",
+            boost::program_options::value<std::filesystem::path>(&customization_config.output_path),
+            "Output base path for generated files (default: same as input)");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -117,9 +117,9 @@ return_code parseArguments(int argc,
              MaxCellSizesArgument{config.max_cell_sizes}),
          "Maximum cell sizes starting from the level 1. The first cell size value is a bisection "
          "termination citerion")(
-        "output,o",
-        boost::program_options::value<std::filesystem::path>(&config.output_path),
-        "Output base path for generated files (default: same as input)");
+            "output,o",
+            boost::program_options::value<std::filesystem::path>(&config.output_path),
+            "Output base path for generated files (default: same as input)");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -11,6 +11,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/program_options.hpp>
 
+#include <array>
 #include <filesystem>
 #include <iostream>
 #include <iterator>
@@ -115,7 +116,10 @@ return_code parseArguments(int argc,
          boost::program_options::value<MaxCellSizesArgument>()->default_value(
              MaxCellSizesArgument{config.max_cell_sizes}),
          "Maximum cell sizes starting from the level 1. The first cell size value is a bisection "
-         "termination citerion");
+         "termination citerion")(
+        "output,o",
+        boost::program_options::value<std::filesystem::path>(&config.output_path),
+        "Output base path for generated files (default: same as input)");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user
@@ -219,6 +223,24 @@ try
 
     // set the default in/output names
     partition_config.UseDefaultOutputNames(partition_config.base_path);
+
+    if (!partition_config.output_path.empty())
+    {
+        // Strip known extensions from the user-provided output path
+        std::string path = partition_config.output_path.string();
+        const std::array<std::string, 6> known_extensions{
+            {".osm.bz2", ".osm.pbf", ".osm.xml", ".pbf", ".osm", ".osrm"}};
+        for (const auto &ext : known_extensions)
+        {
+            const auto pos = path.find(ext);
+            if (pos != std::string::npos)
+            {
+                path.replace(pos, ext.size(), "");
+                break;
+            }
+        }
+        partition_config.output_path = path;
+    }
 
     if (1 > partition_config.requested_num_threads)
     {

--- a/src/tools/partition.cpp
+++ b/src/tools/partition.cpp
@@ -116,7 +116,7 @@ return_code parseArguments(int argc,
          boost::program_options::value<MaxCellSizesArgument>()->default_value(
              MaxCellSizesArgument{config.max_cell_sizes}),
          "Maximum cell sizes starting from the level 1. The first cell size value is a bisection "
-         "termination citerion")(
+         "termination criterion")(
             "output,o",
             boost::program_options::value<std::filesystem::path>(&config.output_path),
             "Output base path for generated files (default: same as input)");


### PR DESCRIPTION
## Summary

Adds `--output`/`-o` to `osrm-contract`, `osrm-customize`, and `osrm-partition`, completing the feature requested in #1228.

### Background

Issue #1228 (2014) requested the ability to specify output file paths for both extraction and preparation steps. `osrm-extract` got `--output`/`-o` in PR #7349, but the downstream tools still lacked it.

### Changes

Each tool now supports:
```
osrm-contract data.osrm -o /custom/output/path
osrm-customize data.osrm -o /custom/output/path
osrm-partition data.osrm -o /custom/output/path
```

- **Config headers**: Added `output_path` field and `GetOutputPath()` helper to `ContractorConfig`, `CustomizationConfig`, and `PartitionerConfig`. The helper falls back to `GetPath()` when no custom output is set, maintaining full backward compatibility.
- **CLI tools**: Added `--output`/`-o` flag with extension-stripping logic (same pattern as `osrm-extract`).
- **Library code**: Updated write calls to use `GetOutputPath()` instead of `GetPath()` for all output files. Input reads continue to use the original `GetPath()`.
- **Partitioner mmap handling**: When `--output` is set, `.osrm.fileIndex` is copied to the output path before memory-mapping, since `mmap` modifies files in-place.

### Files changed (9)

| File | Change |
|---|---|
| `include/contractor/contractor_config.hpp` | Add `output_path` + `GetOutputPath()` |
| `include/customizer/customizer_config.hpp` | Add `output_path` + `GetOutputPath()` |
| `include/partitioner/partitioner_config.hpp` | Add `output_path` + `GetOutputPath()` |
| `src/tools/contract.cpp` | Add `--output`/`-o` CLI flag |
| `src/tools/customize.cpp` | Add `--output`/`-o` CLI flag |
| `src/tools/partition.cpp` | Add `--output`/`-o` CLI flag |
| `src/contractor/contractor.cpp` | Use `GetOutputPath()` for `.osrm.hsgr` write |
| `src/customize/customizer.cpp` | Use `GetOutputPath()` for `.osrm.cell_metrics` and `.osrm.mldgr` writes |
| `src/partitioner/partitioner.cpp` | Use `GetOutputPath()` for all 9 output file writes |

Closes #1228.

🤖 Claude Code, deepseek-v4-pro