### PR TITLE
refactor(guidance): return std::optional from findObviousTurn instead of 0 sentinel

### DIFF
--- a/include/guidance/intersection_handler.hpp
+++ b/include/guidance/intersection_handler.hpp
@@ -560,7 +560,12 @@ IntersectionHandler::findObviousTurn(const EdgeID via_edge,
         if (from_data.flags.roundabout != to_data.flags.roundabout)
             return std::nullopt;
 
-        return std::distance(intersection.begin(), iterator);
+        auto const index = std::distance(intersection.begin(), iterator);
+        // index 0 is the u-turn approach road — never an obvious turn
+        if (index == 0)
+            return std::nullopt;
+
+        return index;
     };
 
     // in case the continuing road is distinct, we prefer continuing on the current road.

--- a/include/guidance/intersection_handler.hpp
+++ b/include/guidance/intersection_handler.hpp
@@ -84,7 +84,7 @@ class IntersectionHandler
     // turn angles.
     template <typename IntersectionType> // works with Intersection and IntersectionView
     std::optional<std::size_t> findObviousTurn(const EdgeID via_edge,
-                                                  const IntersectionType &intersection) const;
+                                               const IntersectionType &intersection) const;
 
     // Obvious turns can still take multiple forms. This function looks at the turn onto a road
     // candidate when coming from a via_edge and determines the best instruction to emit.

--- a/include/guidance/intersection_handler.hpp
+++ b/include/guidance/intersection_handler.hpp
@@ -83,7 +83,8 @@ class IntersectionHandler
     // other possible turns. The function will consider road categories and other inputs like the
     // turn angles.
     template <typename IntersectionType> // works with Intersection and IntersectionView
-    std::size_t findObviousTurn(const EdgeID via_edge, const IntersectionType &intersection) const;
+    std::optional<std::size_t> findObviousTurn(const EdgeID via_edge,
+                                                  const IntersectionType &intersection) const;
 
     // Obvious turns can still take multiple forms. This function looks at the turn onto a road
     // candidate when coming from a via_edge and determines the best instruction to emit.
@@ -484,13 +485,14 @@ inline bool IntersectionHandler::IsDistinctTurn(const EdgeID via_edge,
 
 // Impl.
 template <typename IntersectionType> // works with Intersection and IntersectionView
-std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
-                                                 const IntersectionType &intersection) const
+std::optional<std::size_t>
+IntersectionHandler::findObviousTurn(const EdgeID via_edge,
+                                     const IntersectionType &intersection) const
 {
 
     // no obvious road
     if (intersection.size() == 1)
-        return 0;
+        return std::nullopt;
 
     // a single non u-turn is obvious
     if (intersection.size() == 2)
@@ -550,13 +552,13 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
 
     // this check is not part of the main conditions, so that if the turn looks obvious from all
     // other perspectives, a mode change will not result in different classification
-    auto const to_index_if_valid = [&](auto const iterator) -> std::size_t
+    auto const to_index_if_valid = [&](auto const iterator) -> std::optional<std::size_t>
     {
         auto const &from_data = node_based_graph.GetEdgeData(via_edge);
         auto const &to_data = node_based_graph.GetEdgeData(iterator->eid);
 
         if (from_data.flags.roundabout != to_data.flags.roundabout)
-            return 0;
+            return std::nullopt;
 
         return std::distance(intersection.begin(), iterator);
     };
@@ -610,7 +612,7 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
         STRAIGHT_ANGLE, [&](auto const &road) { return !road.entry_allowed; });
     // no valid turns
     if (straightmost_valid == intersection.end())
-        return 0;
+        return std::nullopt;
 
     auto const non_sharp_turns = intersection.Count(
         [&](auto const &road) { return util::angularDeviation(road.angle, STRAIGHT_ANGLE) <= 90; });
@@ -659,7 +661,7 @@ std::size_t IntersectionHandler::findObviousTurn(const EdgeID via_edge,
         return to_index_if_valid(straightmost_valid);
     }
 
-    return 0;
+    return std::nullopt;
 }
 
 } // namespace osrm::guidance

--- a/src/guidance/sliproad_handler.cpp
+++ b/src/guidance/sliproad_handler.cpp
@@ -373,12 +373,12 @@ Intersection SliproadHandler::operator()(const NodeID /*nid*/,
         {
             const auto index = findObviousTurn(sliproad_edge, target_intersection);
 
-            if (index == 0)
+            if (!index)
             {
                 continue;
             }
 
-            const auto onto = target_intersection[index];
+            const auto onto = target_intersection[*index];
             const auto angle_deviation = angularDeviation(onto.angle, STRAIGHT_ANGLE);
             const auto is_narrow_turn = angle_deviation <= 2 * NARROW_TURN_ANGLE;
 
@@ -643,9 +643,9 @@ std::optional<std::size_t> SliproadHandler::getObviousIndexWithSliproads(
     // If a turn is obvious without taking Sliproads into account use this
     const auto index = findObviousTurn(from, intersection);
 
-    if (index != 0)
+    if (index)
     {
-        return std::make_optional(index);
+        return index;
     }
 
     // Otherwise check if the road is forking into two and one of them is a Sliproad;

--- a/src/guidance/turn_handler.cpp
+++ b/src/guidance/turn_handler.cpp
@@ -257,7 +257,7 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
         { return node_based_graph.GetEdgeData(road.eid).flags.road_classification.IsLinkClass(); });
 
     auto fork = findFork(via_edge, intersection);
-    if (fork && (all_links || obvious_index == 0))
+    if (fork && (all_links || !obvious_index))
     {
         assignFork(via_edge, fork->getLeft(), fork->getRight());
     }
@@ -269,7 +269,7 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
                 I
                 I
      */
-    else if (isEndOfRoad(intersection[0], intersection[1], intersection[2]) && obvious_index == 0)
+    else if (isEndOfRoad(intersection[0], intersection[1], intersection[2]) && !obvious_index)
     {
         if (intersection[1].entry_allowed)
         {
@@ -286,11 +286,11 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
                 intersection[2].instruction = {TurnType::OnRamp, DirectionModifier::Left};
         }
     }
-    else if (obvious_index != 0) // has an obvious continuing road/obvious turn
+    else if (obvious_index) // has an obvious continuing road/obvious turn
     {
         const auto direction_at_one = getTurnDirection(intersection[1].angle);
         const auto direction_at_two = getTurnDirection(intersection[2].angle);
-        if (obvious_index == 1)
+        if (*obvious_index == 1)
         {
             intersection[1].instruction =
                 getInstructionForObvious(3,
@@ -312,7 +312,7 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
         }
         else
         {
-            BOOST_ASSERT(obvious_index == 2);
+            BOOST_ASSERT(*obvious_index == 2);
             intersection[2].instruction =
                 getInstructionForObvious(3,
                                          via_edge,
@@ -344,7 +344,7 @@ Intersection TurnHandler::handleThreeWayTurn(const EdgeID via_edge, Intersection
 
 Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection intersection) const
 {
-    const std::size_t obvious_index = findObviousTurn(via_edge, intersection);
+    const auto obvious_index = findObviousTurn(via_edge, intersection);
     const auto fork = findFork(via_edge, intersection);
 
     const auto straightmost = intersection.findClosestTurn(STRAIGHT_ANGLE);
@@ -352,22 +352,22 @@ Intersection TurnHandler::handleComplexTurn(const EdgeID via_edge, Intersection 
     const auto straightmost_angle_dev = angularDeviation(straightmost->angle, STRAIGHT_ANGLE);
 
     // check whether the obvious choice is actually a through street
-    if (obvious_index != 0)
+    if (obvious_index)
     {
-        intersection[obvious_index].instruction =
+        intersection[*obvious_index].instruction =
             getInstructionForObvious(intersection.size(),
                                      via_edge,
-                                     isThroughStreet(obvious_index,
+                                     isThroughStreet(*obvious_index,
                                                      intersection,
                                                      node_based_graph,
                                                      node_data_container,
                                                      string_table,
                                                      street_name_suffix_table),
-                                     intersection[obvious_index]);
+                                     intersection[*obvious_index]);
 
         // assign left/right turns
-        intersection = assignLeftTurns(via_edge, std::move(intersection), obvious_index);
-        intersection = assignRightTurns(via_edge, std::move(intersection), obvious_index);
+        intersection = assignLeftTurns(via_edge, std::move(intersection), *obvious_index);
+        intersection = assignRightTurns(via_edge, std::move(intersection), *obvious_index);
     }
     else if (fork) // found fork
     {


### PR DESCRIPTION
## Summary

Replace the ambiguous `return 0 to mean not found` pattern in `IntersectionHandler::findObviousTurn` with `std::optional<std::size_t>`.

### Problem

`findObviousTurn` returned a `std::size_t` index into the intersection array, using `0` as a sentinel for "no obvious turn found". But `intersection[0]` is always the u-turn approach road — overloading `0` with two meanings made the code ambiguous and fragile.

### Change

- Changed return type from `std::size_t` to `std::optional<std::size_t>`
- Replaced 4 `return 0` sentinel values with `return std::nullopt`
- Updated the `to_index_if_valid` lambda inside the function to return `std::optional`
- Updated all 4 call sites across `turn_handler.cpp` and `sliproad_handler.cpp`

### No other functions affected

A full audit confirmed all other guidance functions that previously used sentinel values (`findFork`, `findForkCandidatesByGeometry`, `getObviousIndexWithSliproads`, `getNextIntersection`) already return `std::optional`. `findObviousTurn` was the last holdout.

### Verification

- Clean build (118/118 targets)
- All 29 tests pass (100%)

Fixes #3337

🤖 Claude Code, deepseek-v4-pro