### PR TITLE
fix(car): classify access=unknown as restricted instead of fully allowed

### DIFF
--- a/features/car/classes.feature
+++ b/features/car/classes.feature
@@ -82,6 +82,23 @@ Feature: Car - Mode flag
             | from | to | route | turns        | classes                                      |
             | a    | d  | ab,cd | depart,arrive| [(restricted),(motorway,restricted),()],[()] |
 
+    Scenario: Car - We tag access=unknown with a restricted class
+        Given the node map
+            """
+            a b
+              c d
+            """
+
+        And the ways
+            | nodes | highway | access   |
+            | ab    | primary | unknown  |
+            | bc    | motorway| unknown  |
+            | cd    | primary |          |
+
+        When I route I should get
+            | from | to | route | turns        | classes                                      |
+            | a    | d  | ab,cd | depart,arrive| [(restricted),(motorway,restricted),()],[()] |
+
     Scenario: Car - We tag toll with a class
         Given the node map
             """

--- a/profiles/car.lua
+++ b/profiles/car.lua
@@ -86,8 +86,7 @@ function setup()
       'vehicle',
       'permissive',
       'designated',
-      'hov',
-      'unknown'
+      'hov'
     },
 
     access_tag_blacklist = Set {
@@ -125,6 +124,7 @@ function setup()
       'customers',
       'permit',
       'residents',
+      'unknown',
     },
 
     access_tags_hierarchy = Sequence {


### PR DESCRIPTION
# Issue

Related to #6762, which raises the broader problem (car profile whitelists all unrecognized access values, including the literal `access=unknown`, `unknown` is even named explicitly in that issue's own real-world test data as one of the values whose current handling changes under a stricter fix).

This PR takes a deliberately more conservative position than the patch linked in #6762. That patch treats unrecognized/`unknown` access values as fully inaccessible. This PR only addresses the literal `access=unknown` tag value (a real, documented OSM tagging convention meaning "access conditions are unverified, survey needed", see https://wiki.openstreetmap.org/wiki/Tag:access%3Dunknown) and moves it from `access_tag_whitelist` into `restricted_access_tag_list`, the same tier `private`/`destination`/`delivery`/`customers`/`permit`/`residents` already occupy.

Reasoning for the softer treatment specifically for `unknown`: the tag doesn't assert a known restriction the way `private`/`destination`/`no` do, it asserts the opposite, that access status hasn't been determined. Treating it as an outright block asserts something the tag doesn't actually claim. Restricted-tier values aren't excluded from routing by default in this profile today (see `way_handlers.lua`'s `access_tag_blacklist` check being skipped when `forward_restricted`/`backward_restricted` is set), so this change doesn't alter default routability at all, it only gives these ways a correct `"restricted"` edge class instead of being indistinguishable from `access=yes`. I think this is worth maintainers' consideration as an alternative (or complement) to the broader fix in #6762, not a replacement for it.

Was this change primarily generated using an AI tool? Yes, Claude (Anthropic, Claude Sonnet 5), based on manual reading of `profiles/car.lua`, `profiles/lib/access.lua`, and `profiles/lib/way_handlers.lua`, and cross-checked against the existing `access.feature`/`classes.feature` test suites.

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [x] add tests (new scenario in `features/car/classes.feature`, modeled on the existing "We tag restricted with a class" test; existing `access.feature` routability assertions for `unknown` were checked by hand and remain valid since routability itself doesn't change)
 - [ ] update relevant wiki pages
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

References #6762 (broader/stricter version of the same underlying gap). Not based on or blocking that PR's own patch.