### PR TITLE
fix(contractor): compact the edge list before it overflows the edge index

### DIFF
--- a/include/contractor/graph_contractor.hpp
+++ b/include/contractor/graph_contractor.hpp
@@ -4,6 +4,8 @@
 #include "contractor/contractor_graph.hpp"
 #include "contractor/query_graph.hpp"
 
+#include <cstddef>
+#include <limits>
 #include <vector>
 
 namespace osrm::contractor
@@ -16,10 +18,25 @@ GraphAndFilter contractFullGraph(ContractorGraph contractor_graph);
 GraphAndFilter contractExcludableGraph(ContractorGraph contractor_graph_,
                                        const std::vector<std::vector<bool>> &filters);
 
-std::vector<bool> contractGraph(ContractorGraph &graph,
-                                std::vector<bool> node_is_uncontracted,
-                                std::vector<bool> node_is_contractible,
-                                double core_factor = 1.0);
+// Number of edge slots an edge index can address. The edge list cannot grow beyond it.
+constexpr std::size_t EDGE_LIST_LIMIT = std::numeric_limits<ContractorGraph::EdgeIterator>::max();
+
+// Number of slots contraction leaves free when it compacts. Compaction cannot run inside the
+// parallel sections, so the trigger has to sit far enough below the limit to absorb one whole
+// iteration's growth.
+constexpr std::size_t EDGE_LIST_COMPACTION_SLACK = 300000000;
+
+// Number of edge slots at which the edge list is compacted. Lowering it trades contraction time
+// for a smaller peak edge list.
+constexpr std::size_t DEFAULT_EDGE_LIST_COMPACTION_THRESHOLD =
+    EDGE_LIST_LIMIT - EDGE_LIST_COMPACTION_SLACK;
+
+std::vector<bool>
+contractGraph(ContractorGraph &graph,
+              std::vector<bool> node_is_uncontracted,
+              std::vector<bool> node_is_contractible,
+              double core_factor = 1.0,
+              std::size_t edge_list_compaction_threshold = DEFAULT_EDGE_LIST_COMPACTION_THRESHOLD);
 
 // Overload for contracting all nodes
 inline auto contractGraph(ContractorGraph &graph, double core_factor = 1.0)

--- a/include/util/dynamic_graph.hpp
+++ b/include/util/dynamic_graph.hpp
@@ -220,7 +220,13 @@ template <typename EdgeDataT> class DynamicGraph
 
     unsigned GetNumberOfNodes() const { return number_of_nodes; }
 
+    // Number of live edges. Slots vacated by DeleteEdge() or by InsertEdge() relocating a node
+    // do not count towards it.
     unsigned GetNumberOfEdges() const { return number_of_edges; }
+
+    // Number of edge slots, live and dummied out alike. This is what EdgeIterator has to index,
+    // so it is the quantity bounded by 2^32, and it only shrinks back to GetNumberOfEdges() when
+    // Renumber() compacts the list.
     auto GetEdgeCapacity() const { return edge_list.size(); }
 
     unsigned GetOutDegree(const NodeIterator n) const { return node_array[n].edges; }
@@ -282,8 +288,20 @@ template <typename EdgeDataT> class DynamicGraph
             else
             {
                 // we have to move this nodes edges to the end of the edge_list
-                EdgeIterator newFirstEdge = (EdgeIterator)edge_list.size();
                 unsigned newSize = node.edges * 1.1 + 2;
+                // edge_list is indexed by a 32-bit EdgeIterator but sized by std::size_t. Past
+                // 2^32 slots the cast below truncates and EndEdges() wraps, which does not fail
+                // here but much later, as either an out-of-range target node or an inverted
+                // adjacency range whose size() underflows. Stop while the numbers still mean
+                // something.
+                if (edge_list.size() + newSize >= std::numeric_limits<EdgeIterator>::max())
+                {
+                    throw util::exception("There are too many edges, OSRM only supports 2^32 (" +
+                                          std::to_string(number_of_edges) + " of " +
+                                          std::to_string(edge_list.size()) + " slots are live)" +
+                                          SOURCE_REF);
+                }
+                EdgeIterator newFirstEdge = (EdgeIterator)edge_list.size();
                 EdgeIterator requiredCapacity = newSize + edge_list.size();
                 EdgeIterator oldCapacity = edge_list.capacity();
                 // make sure there is enough space at the end

--- a/include/util/dynamic_graph.hpp
+++ b/include/util/dynamic_graph.hpp
@@ -41,18 +41,21 @@ template <typename NodeIterator, typename EdgeDataT> struct DynamicEdge
 };
 } // namespace detail
 
-template <typename EdgeDataT> class DynamicGraph
+// EdgeIteratorT is the type every edge slot is addressed by, so its width caps how large the
+// edge list may grow. It is a template parameter so that the limit can be reached in a test;
+// production code uses the default.
+template <typename EdgeDataT, typename EdgeIteratorT = std::uint32_t> class DynamicGraph
 {
   public:
     using EdgeData = EdgeDataT;
     using NodeIterator = std::uint32_t;
-    using EdgeIterator = std::uint32_t;
+    using EdgeIterator = EdgeIteratorT;
     using EdgeRange = range<EdgeIterator>;
 
     using Node = detail::DynamicNode<EdgeIterator>;
     using Edge = detail::DynamicEdge<NodeIterator, EdgeDataT>;
 
-    template <typename E> friend class DynamicGraph;
+    template <typename, typename> friend class DynamicGraph;
 
     class InputEdge
     {
@@ -432,7 +435,7 @@ template <typename EdgeDataT> class DynamicGraph
             util::inplacePermutation(node_array.begin(), node_array.end(), old_to_new_node);
 
         // Build up edge permutation
-        if (edge_list.size() >= std::numeric_limits<EdgeID>::max())
+        if (edge_list.size() >= std::numeric_limits<EdgeIterator>::max())
         {
             throw util::exception("There are too many edges, OSRM only supports 2^32" + SOURCE_REF);
         }

--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -515,12 +515,14 @@ bool IsNodeIndependent(const ContractorGraph &graph,
  * @param node_is_contractible_
  * @param edge_weights_
  * @param core_factor
+ * @param edge_list_compaction_threshold
  * @return std::vector<bool>
  */
 std::vector<bool> contractGraph(ContractorGraph &graph,
                                 std::vector<bool> node_is_uncontracted_,
                                 std::vector<bool> node_is_contractible_,
-                                double core_factor)
+                                double core_factor,
+                                std::size_t edge_list_compaction_threshold)
 {
     /** A heap kept in thread-local storage to avoid multiple recreations of it. */
     ContractorHeap heap_exemplar(HASH_MAP_CAPACITY);
@@ -587,15 +589,10 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
     // run it whenever the list approaches that ceiling. It rewrites every node's first edge and
     // hence has to stay outside of the parallel sections below.
     //
-    // The trigger is anchored to the ceiling rather than set to a fixed size: a pass costs the
-    // same no matter how much it frees, since its work is proportional to the size of the list.
-    // A threshold sitting just above the live edge count therefore degenerates into compacting
-    // constantly and reclaiming next to nothing. The slack covers the growth of one iteration.
-    constexpr std::size_t EDGE_LIST_LIMIT =
-        std::numeric_limits<ContractorGraph::EdgeIterator>::max();
-    constexpr std::size_t EDGE_LIST_COMPACTION_SLACK = 300000000;
-    constexpr std::size_t EDGE_LIST_COMPACTION_THRESHOLD =
-        EDGE_LIST_LIMIT - EDGE_LIST_COMPACTION_SLACK;
+    // The default trigger is anchored to the ceiling rather than set to a fixed size: a pass
+    // costs the same no matter how much it frees, since its work is proportional to the size of
+    // the list. A threshold sitting just above the live edge count therefore degenerates into
+    // compacting constantly and reclaiming next to nothing.
 
     // Algo 2: while Remaining Graph not Empty
     //
@@ -603,7 +600,7 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
     // contracted
     while (remaining_nodes.size() > number_of_core_nodes)
     {
-        if (graph.GetEdgeCapacity() >= EDGE_LIST_COMPACTION_THRESHOLD)
+        if (graph.GetEdgeCapacity() >= edge_list_compaction_threshold)
         {
             const auto slots_before = graph.GetEdgeCapacity();
             TIMER_START(compaction);
@@ -614,17 +611,17 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
                         << " edges in " << TIMER_MSEC(compaction);
 
             // Every remaining slot now holds a live edge, and the finished hierarchy has to fit
-            // those into the same 32-bit index. If that alone is above the trigger, there is
-            // nothing left to reclaim and every later iteration would compact for nothing.
-            if (slots_after >= EDGE_LIST_COMPACTION_THRESHOLD)
+            // those into the same index. If that alone is above the trigger, there is nothing
+            // left to reclaim and every later iteration would compact for nothing.
+            if (slots_after >= edge_list_compaction_threshold)
             {
                 throw util::exception(
                     "There are too many edges: " + std::to_string(slots_after) +
-                    " of them are live and cannot be compacted away, which leaves fewer than " +
-                    std::to_string(EDGE_LIST_COMPACTION_SLACK) +
-                    " of the 2^32 slots an edge index can address free. That is not enough "
-                    "headroom to keep contracting, so this graph has to be split into smaller "
-                    "parts" +
+                    " of them are live and cannot be compacted away, which leaves only " +
+                    std::to_string(EDGE_LIST_LIMIT - slots_after) + " of the " +
+                    std::to_string(EDGE_LIST_LIMIT) +
+                    " slots an edge index can address free. That is not enough headroom to keep "
+                    "contracting, so this graph has to be split into smaller parts" +
                     SOURCE_REF);
             }
         }

--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -5,6 +5,8 @@
 #include "contractor/contractor_search.hpp"
 #include "contractor/graph_contractor_adaptors.hpp"
 #include "contractor/query_edge.hpp"
+#include "util/exception.hpp"
+#include "util/exception_utils.hpp"
 #include "util/integer_range.hpp"
 #include "util/log.hpp"
 #include "util/percent.hpp"
@@ -26,6 +28,7 @@
 #include <cstddef>
 #include <iomanip>
 #include <limits>
+#include <string>
 #include <vector>
 
 #define SELF_LOOPS
@@ -539,6 +542,7 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
     TIMER_DECLARE(update_core);
     TIMER_DECLARE(adjust_remaining);
     TIMER_DECLARE(renumber);
+    TIMER_DECLARE(compaction);
 
     // Update Priorities of all Nodes with Simulated Contractions
     util::Log() << "initializing node priorities...";
@@ -575,12 +579,54 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
     util::UnbufferedLog log;
     util::Percent p(log, remaining_nodes.size());
 
+    // Inserting an edge grows the edge list by relocating the whole adjacency of a node to its
+    // end and dummying out the vacated slots. Nothing reclaims those slots while contracting, so
+    // on planet-sized input a quarter of the list went dead and its size crossed the 2^32 that a
+    // 32-bit edge index can address, all while the live edge count was still comfortably below
+    // it. Renumber() with an empty permutation compacts the list without renumbering nodes, so
+    // run it whenever the list approaches that ceiling. It rewrites every node's first edge and
+    // hence has to stay outside of the parallel sections below.
+    //
+    // The trigger is anchored to the ceiling rather than set to a fixed size: a pass costs the
+    // same no matter how much it frees, since its work is proportional to the size of the list.
+    // A threshold sitting just above the live edge count therefore degenerates into compacting
+    // constantly and reclaiming next to nothing. The slack covers the growth of one iteration.
+    constexpr std::size_t EDGE_LIST_LIMIT =
+        std::numeric_limits<ContractorGraph::EdgeIterator>::max();
+    constexpr std::size_t EDGE_LIST_COMPACTION_SLACK = 300000000;
+    constexpr std::size_t EDGE_LIST_COMPACTION_THRESHOLD =
+        EDGE_LIST_LIMIT - EDGE_LIST_COMPACTION_SLACK;
+
     // Algo 2: while Remaining Graph not Empty
     //
     // contract a chunk of nodes until a sufficient percentage of all nodes is
     // contracted
     while (remaining_nodes.size() > number_of_core_nodes)
     {
+        if (graph.GetEdgeCapacity() >= EDGE_LIST_COMPACTION_THRESHOLD)
+        {
+            const auto slots_before = graph.GetEdgeCapacity();
+            TIMER_START(compaction);
+            graph.Renumber(std::vector<NodeID>());
+            TIMER_STOP(compaction);
+            const auto slots_after = graph.GetEdgeCapacity();
+            util::Log() << "compacted edge list from " << slots_before << " to " << slots_after
+                        << " edges in " << TIMER_MSEC(compaction);
+
+            // Every remaining slot now holds a live edge, and the finished hierarchy has to fit
+            // those into the same 32-bit index. If that alone is above the trigger, there is
+            // nothing left to reclaim and every later iteration would compact for nothing.
+            if (slots_after >= EDGE_LIST_COMPACTION_THRESHOLD)
+            {
+                throw util::exception(
+                    "There are too many edges, OSRM only supports 2^32: " +
+                    std::to_string(slots_after) +
+                    " of them are live and cannot be compacted away, so this graph has to be "
+                    "split into smaller parts" +
+                    SOURCE_REF);
+            }
+        }
+
         /** List of discovered independent nodes */
         tbb::concurrent_vector<NodeID> independent_nodes;
         /** List of new edges to insert into the graph */

--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -619,10 +619,12 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
             if (slots_after >= EDGE_LIST_COMPACTION_THRESHOLD)
             {
                 throw util::exception(
-                    "There are too many edges, OSRM only supports 2^32: " +
-                    std::to_string(slots_after) +
-                    " of them are live and cannot be compacted away, so this graph has to be "
-                    "split into smaller parts" +
+                    "There are too many edges: " + std::to_string(slots_after) +
+                    " of them are live and cannot be compacted away, which leaves fewer than " +
+                    std::to_string(EDGE_LIST_COMPACTION_SLACK) +
+                    " of the 2^32 slots an edge index can address free. That is not enough "
+                    "headroom to keep contracting, so this graph has to be split into smaller "
+                    "parts" +
                     SOURCE_REF);
             }
         }

--- a/unit_tests/contractor/graph_contractor.cpp
+++ b/unit_tests/contractor/graph_contractor.cpp
@@ -1,12 +1,19 @@
 #include "contractor/graph_contractor.hpp"
 
 #include "contractor/contractor_graph.hpp"
+#include "contractor/graph_contractor_adaptors.hpp"
+#include "contractor/query_edge.hpp"
 #include "helper.hpp"
+#include "util/exception.hpp"
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <tbb/global_control.h>
 #include <tuple>
+#include <vector>
 
 using namespace osrm;
 using namespace osrm::contractor;
@@ -14,6 +21,49 @@ using namespace osrm::unit_test;
 
 #define HAS(a, b) BOOST_CHECK(query_graph.FindEdge(a, b) != SPECIAL_EDGEID);
 #define NOT(a, b) BOOST_CHECK(query_graph.FindEdge(a, b) == SPECIAL_EDGEID);
+
+namespace
+{
+// QueryEdge orders by (source, target) alone and toEdges() sorts with an unstable sort, so
+// parallel edges between the same pair of nodes come out in an arbitrary order. Impose a total
+// order on top of that before comparing the edge lists of two contraction runs.
+bool byAllFields(const QueryEdge &lhs, const QueryEdge &rhs)
+{
+    const auto as_tuple = [](const QueryEdge &edge)
+    {
+        return std::make_tuple(edge.source,
+                               edge.target,
+                               edge.data.weight,
+                               static_cast<std::uint32_t>(edge.data.duration),
+                               edge.data.distance,
+                               static_cast<std::uint32_t>(edge.data.turn_id),
+                               static_cast<bool>(edge.data.shortcut),
+                               static_cast<bool>(edge.data.forward),
+                               static_cast<bool>(edge.data.backward));
+    };
+    return as_tuple(lhs) < as_tuple(rhs);
+}
+
+// A grid is the smallest thing that makes the contractor's edge list grow far enough for a
+// compaction pass to have something to reclaim.
+std::vector<TestEdge> makeGridEdges(const unsigned width, const unsigned height)
+{
+    const auto id = [width](const unsigned x, const unsigned y) { return y * width + x; };
+
+    std::vector<TestEdge> edges;
+    for (const auto y : util::irange(0u, height))
+    {
+        for (const auto x : util::irange(0u, width))
+        {
+            if (x + 1 < width)
+                edges.push_back({id(x, y), id(x + 1, y), 1});
+            if (y + 1 < height)
+                edges.push_back({id(x, y), id(x, y + 1), 1});
+        }
+    }
+    return edges;
+}
+} // namespace
 
 BOOST_AUTO_TEST_SUITE(graph_contractor)
 
@@ -172,6 +222,45 @@ BOOST_AUTO_TEST_CASE(contract_excludable_graph)
         NOT(1, 3)
         NOT(3, 1)
     }
+}
+
+BOOST_AUTO_TEST_CASE(compaction_leaves_the_contracted_graph_unchanged)
+{
+    // The contraction order decides which shortcuts are needed, so pin it to compare two runs.
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism, 1);
+
+    const auto graph = makeGraph(makeGridEdges(20, 20));
+
+    // On this graph the edge list starts at 1520 slots, grows to 5859, and never holds more than
+    // 3722 live edges. A threshold in between compacts repeatedly over the run and always finds
+    // enough dead slots to get back under it.
+    constexpr std::size_t COMPACTION_THRESHOLD = 4500;
+
+    auto compacted = graph;
+    contractGraph(compacted, {}, {}, 1.0, COMPACTION_THRESHOLD);
+
+    auto reference = graph;
+    contractGraph(reference);
+
+    auto compacted_edges = toEdges<QueryEdge>(std::move(compacted));
+    auto reference_edges = toEdges<QueryEdge>(std::move(reference));
+    std::sort(compacted_edges.begin(), compacted_edges.end(), byAllFields);
+    std::sort(reference_edges.begin(), reference_edges.end(), byAllFields);
+
+    BOOST_CHECK_EQUAL(compacted_edges.size(), reference_edges.size());
+    BOOST_CHECK(compacted_edges == reference_edges);
+}
+
+BOOST_AUTO_TEST_CASE(compaction_that_cannot_free_enough_space_throws)
+{
+    // A threshold below the live edge count: no amount of compacting gets back under it, and
+    // contracting on would only repeat the pass for nothing.
+    BOOST_CHECK_THROW(
+        {
+            auto graph = makeGraph({{0, 1, 1}, {1, 2, 1}, {2, 3, 1}, {3, 0, 1}});
+            contractGraph(graph, {}, {}, 1.0, 1);
+        },
+        util::exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/dynamic_graph.cpp
+++ b/unit_tests/util/dynamic_graph.cpp
@@ -1,10 +1,13 @@
 #include "util/dynamic_graph.hpp"
+#include "util/exception.hpp"
 #include "util/typedefs.hpp"
 
 #include "../common/range_tools.hpp"
 
 #include <boost/test/unit_test.hpp>
 
+#include <cstdint>
+#include <limits>
 #include <vector>
 
 BOOST_AUTO_TEST_SUITE(dynamic_graph)
@@ -19,6 +22,10 @@ struct TestData
 
 using TestDynamicGraph = DynamicGraph<TestData>;
 using TestInputEdge = TestDynamicGraph::InputEdge;
+
+// The edge list is addressed by EdgeIterator, so it can never hold more slots than that type can
+// index. Filling 2^32 of them is not testable, so narrow the index instead.
+using NarrowDynamicGraph = DynamicGraph<TestData, std::uint16_t>;
 
 BOOST_AUTO_TEST_CASE(find_test)
 {
@@ -156,6 +163,29 @@ BOOST_AUTO_TEST_CASE(filter_test)
     REQUIRE_SIZE_RANGE(filtered_simple_graph.GetAdjacentEdgeRange(4), 1);
     CHECK_EQUAL_RANGE(filtered_simple_graph.GetAdjacentEdgeRange(4),
                       filtered_simple_graph.FindEdge(4, 1));
+}
+
+BOOST_AUTO_TEST_CASE(edge_list_limit_test)
+{
+    constexpr std::size_t EDGE_LIST_LIMIT = std::numeric_limits<std::uint16_t>::max();
+
+    NarrowDynamicGraph graph(2);
+
+    // InsertEdge moves a node's edges to the end of the edge list whenever it runs out of room
+    // and dummies out the slots it vacates. Nothing reclaims those, so the list outgrows the live
+    // edge count and hits the limit well before as many edges have been inserted.
+    BOOST_CHECK_THROW(
+        {
+            for (auto id : irange<EdgeID>(0, EDGE_LIST_LIMIT))
+            {
+                graph.InsertEdge(0, 1, TestData{id});
+            }
+        },
+        exception);
+
+    // It stops growing while an index into it still means what it says.
+    BOOST_CHECK_LT(graph.GetEdgeCapacity(), EDGE_LIST_LIMIT);
+    BOOST_CHECK_LT(graph.GetNumberOfEdges(), graph.GetEdgeCapacity());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Relates to #7656.

`DynamicGraph::InsertEdge` grows the edge list by relocating a node's whole adjacency to the end of the list and dummying out the vacated slots. Nothing reclaims those slots during contraction, so on planet sized input a quarter of the list goes dead and `edge_list.size()` crosses the 2^32 that a 32-bit `EdgeIterator` can address, while the live edge count is still well below it.

Past that point the cast in `InsertEdge` truncates and `EndEdges()` wraps. The failure surfaces much later, either as a `SPECIAL_NODEID` target that `ContractNode` writes out of bounds, or as an inverted adjacency range whose `size()` underflows into a `length_error` out of `vector::reserve`.

`Renumber()` with an empty permutation compacts the edge list without renumbering nodes. It already runs once after the contraction loop, so this change runs it inside the loop as well, whenever the list approaches the limit. The trigger is anchored to the ceiling rather than set to a fixed size: a pass costs the same no matter how much it frees, so a threshold sitting just above the live edge count degenerates into compacting constantly and reclaiming next to nothing. If a pass cannot get back under the trigger, the live edges alone exceed what the contracted graph can index and the input has to be split, which is reported as an exception.

`InsertEdge` also guards the limit directly, so an overflow reports counts instead of corrupting the graph.

Credit to @Charmik, who diagnosed this and wrote the original patch in Charmik/osrm-backend@709cca22e68caf166ae621985704adc118676285.

## Tests

Neither guard was reachable from a test: the edge list has to hold more than 2^32 slots for `InsertEdge` to throw, and contraction has to drive it there for a compaction pass to run. Two defaulted parameters make them reachable, both defaulted to the values the code used before:

- `DynamicGraph` takes the type its edge slots are addressed by, so a test can narrow the index to 16 bits and fill it.
- `contractGraph` takes the number of slots at which it compacts, so a test can set it to something a small graph reaches.

On top of that, `Renumber` now measures the edge list against the same type the rest of the class indexes it by, rather than against `EdgeID`.

The three new cases cover the `InsertEdge` guard, a run that compacts and completes, and a run whose compaction cannot free enough space. The middle one contracts a 20x20 grid twice, once with a threshold that makes it compact four times over the run, and checks both edge lists come out the same.

## Verification

Charmik's Europe+Asia+Africa graph contracts to completion with the original patch, with five compaction passes. The log is in #7656.

Locally the compaction path was also exercised by lowering the threshold to zero, so that a pass runs on every contraction iteration. The CH cucumber suite passes on that build: 1452 scenarios, 1447 passed, 5 skipped.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Claude Code, Claude Opus 5
