### PR TITLE
fix(contractor): deduplicate shortcuts on insertion

### DIFF
--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -406,13 +406,55 @@ void PostProcess(ContractorGraph &graph, const NodeID v, ContractorNodeData &nod
 }
 
 /**
+ * @brief Find an existing shortcut that duplicates a candidate edge.
+ *
+ * The contractor stores each logical shortcut u->w as a forward edge at u and a
+ * backward copy at w, so a node pair legitimately carries one edge per direction;
+ * only a shortcut with identical direction flags duplicates the candidate.
+ * Non-shortcut edges are never considered: their id is an original-edge id, not
+ * a middle node, so they cannot be updated in place. The same restriction holds
+ * for the candidate (asserted): contraction only ever generates shortcuts, and
+ * updating a shortcut in place from a non-shortcut candidate would turn its
+ * middle node into an original-edge id.
+ *
+ * @param graph
+ * @param edge the candidate edge
+ * @return the duplicate's edge id, or SPECIAL_EDGEID
+ */
+EdgeID FindDuplicateShortcut(const ContractorGraph &graph, const ContractorEdge &edge)
+{
+    BOOST_ASSERT(edge.data.shortcut);
+    for (const auto e : graph.GetAdjacentEdgeRange(edge.source))
+    {
+        if (graph.GetTarget(e) != edge.target)
+        {
+            continue;
+        }
+        const ContractorEdgeData &data = graph.GetEdgeData(e);
+        if (data.shortcut && data.forward == edge.data.forward &&
+            data.backward == edge.data.backward)
+        {
+            return e;
+        }
+    }
+    return SPECIAL_EDGEID;
+}
+
+/**
  * @brief Inserts the edges produced by node contraction into the graph.
  *
  * - Algo 2: Insert E into Remaining graph
  *
+ * A shortcut for a node pair may already exist: several contractions in one batch
+ * can emit the same (source, target, direction) pair, and the bounded witness
+ * search of a later round can regenerate a shortcut instead of finding the copy
+ * an earlier round inserted. Keeping the smaller weight in the existing edge instead of
+ * appending a parallel one bounds the node degrees, which otherwise grow
+ * combinatorially on continental input.
+ *
  * This function is not thread-safe because edge insertion is not thread-safe even for
- * "independent" nodes (but edge erasure curiously is!). If the graph ever gets fixed to
- * be thread-safe, this function can use parallel execution too.
+ * "independent" nodes (but edge erasure curiously is!). The in-place duplicate update
+ * relies on the same serialization.
  *
  * @param graph
  * @param inserted_edges
@@ -423,6 +465,16 @@ void InsertEdges(ContractorGraph &graph,
 {
     for (const ContractorEdge &edge : inserted_edges)
     {
+        const EdgeID existing = FindDuplicateShortcut(graph, edge);
+        if (existing != SPECIAL_EDGEID)
+        {
+            auto &data = graph.GetEdgeData(existing);
+            if (edge.data.weight < data.weight)
+            {
+                data = edge.data;
+            }
+            continue;
+        }
         graph.InsertEdge(edge.source, edge.target, edge.data);
     }
 }

--- a/src/contractor/graph_contractor.cpp
+++ b/src/contractor/graph_contractor.cpp
@@ -147,6 +147,17 @@ struct ContractionStats
     int original_edges_added_count{};
 };
 
+/** Duplicate accounting for InsertEdges(). Only written from its serial insertion loop;
+ *  the totals accumulate over all rounds of one contractGraph() call. */
+struct InsertEdgeStats
+{
+    // std::size_t, not int as in ContractionStats: a single continental-scale
+    // contraction appends on the order of 7e8 edges.
+    std::size_t appended_count{};         // no duplicate existed, edge inserted
+    std::size_t updated_in_place_count{}; // duplicate existed, smaller weight written
+    std::size_t dropped_count{};          // duplicate existed, candidate not better
+};
+
 using ThreadData = tbb::enumerable_thread_specific<ContractorHeap>;
 
 /**
@@ -461,7 +472,8 @@ EdgeID FindDuplicateShortcut(const ContractorGraph &graph, const ContractorEdge 
  */
 
 void InsertEdges(ContractorGraph &graph,
-                 const tbb::concurrent_vector<ContractorEdge> &inserted_edges)
+                 const tbb::concurrent_vector<ContractorEdge> &inserted_edges,
+                 InsertEdgeStats &stats)
 {
     for (const ContractorEdge &edge : inserted_edges)
     {
@@ -472,10 +484,16 @@ void InsertEdges(ContractorGraph &graph,
             if (edge.data.weight < data.weight)
             {
                 data = edge.data;
+                ++stats.updated_in_place_count;
+            }
+            else
+            {
+                ++stats.dropped_count;
             }
             continue;
         }
         graph.InsertEdge(edge.source, edge.target, edge.data);
+        ++stats.appended_count;
     }
 }
 
@@ -597,6 +615,8 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
     TIMER_DECLARE(adjust_remaining);
     TIMER_DECLARE(renumber);
     TIMER_DECLARE(compaction);
+
+    InsertEdgeStats insert_stats;
 
     // Update Priorities of all Nodes with Simulated Contractions
     util::Log() << "initializing node priorities...";
@@ -746,7 +766,7 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
         // Algo 2: Insert E into Remaining graph
         TIMER_START(insert_edges);
         tbb::parallel_sort(inserted_edges);
-        InsertEdges(graph, inserted_edges);
+        InsertEdges(graph, inserted_edges, insert_stats);
         TIMER_STOP(insert_edges);
 
         // Algo 2: Update Priority of Neighbors of I with Simulated Contractions
@@ -774,6 +794,9 @@ std::vector<bool> contractGraph(ContractorGraph &graph,
     util::Log() << "nodes contracted in " << TIMER_MSEC(contract);
     util::Log() << "nodes post-processed in " << TIMER_MSEC(post_process);
     util::Log() << "edges inserted in " << TIMER_MSEC(insert_edges);
+    util::Log() << "edges appended: " << insert_stats.appended_count
+                << ", shortcut duplicates: " << insert_stats.updated_in_place_count
+                << " updated in place, " << insert_stats.dropped_count << " dropped";
     util::Log() << "node priorities updated in " << TIMER_MSEC(update_priorities);
     util::Log() << "core flags updated in " << TIMER_MSEC(update_core);
     util::Log() << "adjusted remaining nodes left in " << TIMER_MSEC(adjust_remaining);


### PR DESCRIPTION
Restores the per-insert shortcut deduplication that the #7442 rewrite removed. Fixes #7656 — the livelock failure mode; the assertion/segfault reports there are plausibly the same root cause, but we could not reproduce them separately to verify.

**Problem**

- Since #7442, `InsertEdges` blind-appends every shortcut a contraction batch produces. Several contractions in one batch can yield the same `(source, target, direction)` pair at different weights, and a later round can regenerate a shortcut an earlier round already inserted — every copy lands in the graph.
- The duplicates are rare (~0.02 % of insertions at europe scale) but concentrate on the dense hub nodes of the residual core.
- Result: `osrm-contract` livelocks in the residual-core contraction pass — one thread spinning in the `relaxNode` adjacency scan, the other 47 parked in `futex_wait`.
- Full forensics + europe-scale test matrix: https://github.com/Project-OSRM/osrm-backend/issues/7656#issuecomment-5247140072. Score on that workload: 6/6 failures for post-#7442 builds (incl. the merged #7681, whose compaction never triggers at this scale), 3/3 passes for v26.6.5, 3/3 passes with this patch.

**Fix**

- Before appending, `InsertEdges` scans the existing parallel `(source, target)` edges for a shortcut with matching direction flags (`FindDuplicateShortcut`); on a hit it keeps the minimum-weight edge data in place instead of appending a copy.
- This restores the v26.6.5 semantics (`FindEdge` + in-place min-weight update in `_InsertEdges`), adapted to the post-#7442 storage: shortcuts are stored as split forward/backward copies with no intra-batch direction merge, so a first-match `FindEdge` would miss about half the duplicates — the scan has to match the flag pair.
- `InsertEdges` runs in the serial trunk of the contraction loop (already documented not-thread-safe), so the in-place update needs no synchronization.

**Validation**

- europe/car (34.76 GB PBF, 48 cores, 220 GB RAM): **3/3 contract runs PASS, 63 min each** — vs livelock on the identical input without the patch, and 73 min for v26.6.5. Peak RSS unchanged (~60.7 GB).
- Per-pass duplicate totals are deterministic across all three runs (contraction runs in five passes; 261,151 duplicates per run out of 1,356,294,422 insertions); only the update-vs-drop split varies with insertion order.
- Contractor unit tests pass; a small-extract A/B against the unpatched base yields an equivalent, marginally smaller CH with no time/RAM change.

**Notes**

- The second commit adds three counters and one log line per contraction pass (`edges appended: Z, shortcut duplicates: X updated in place, Y dropped`). It produced the determinism evidence above and costs nothing measurable (serial section); kept per review.
- Validated as LogicsSoftwareGmbH/osrm-backend@8b3bb4f51 on the pre-merge #7681 head (`c083f8e26`); this branch is the same two commits rebased onto current master (conflict-free).

*(AI transparency: the analysis, the patch, and this description were prepared with Claude; the europe-scale validation runs and evidence are from our own test infrastructure.)*
