### PR TITLE
feat(area): route from any point inside a pedestrian area

### DIFF
--- a/docs/areas.md
+++ b/docs/areas.md
@@ -3,10 +3,18 @@
 How to route inside pedestrian areas, or over the interior of an area where you can
 travel freely in all directions.
 
-%OSRM can create routes crossing the interior of an area by generating virtual ways
-between every pair of entry points to the area. This process is called @em meshing. The
-generated ways follow lines of sight, avoid obstacles, and use existing nodes. An entry
-point is where another way connects to the perimeter of the area.
+%OSRM can create routes crossing the interior of an area by generating virtual ways along
+its lines of sight. This process is called @em meshing. The generated ways avoid obstacles
+and use existing nodes.
+
+By default the whole visibility graph is emitted: every pair of mutually visible vertices
+is joined, and so is every edge of every ring. That is what lets a coordinate *inside* an
+area be snapped to whichever vertex makes its journey shortest, and what makes the
+perimeter of a plaza and the sides of an obstacle walkable in their own right. Set
+`area_emit_visibility_graph = false` in your profile's properties to emit only the
+shortest paths between entry points instead; the routes between entry points are the same
+either way, but coordinates inside the area then have far less to snap to. An entry point
+is where another way connects to the perimeter of the area.
 
 This feature is still EXPERIMENTAL.
 

--- a/features/foot/area_mesh.feature
+++ b/features/foot/area_mesh.feature
@@ -124,3 +124,49 @@ Feature: Foot - Pedestrian areas
             | k    | h  | kebh     |
             | k    | i  | ketci    |
             | k    | j  | kedj     |
+
+    # Two ways in is the smallest arrangement worth meshing.  A plaza entered twice from
+    # the same side has no other graph in it at all, so refusing to mesh it leaves the
+    # two entrances unconnected except by whatever runs around the outside.
+    Scenario: Foot - Mesh an area with only two entrances
+        Given the node map
+            """
+            a-------b
+            |       |
+            d-x---y-c
+              |   |
+              u   v
+            """
+
+        And the ways
+            | nodes    | highway    | area | name  |
+            | abcyxda  | pedestrian | yes  | Plaza |
+            | ux       | pedestrian |      | U     |
+            | vy       | pedestrian |      | V     |
+
+        # the chord x-y is the mesh; without it the two entrances are not connected
+        When I route I should get
+            | from | to | a:nodes | distance |
+            | u    | v  | uxyv    | 300m +-2 |
+            | v    | u  | vyxu    | 300m +-2 |
+
+    # ... but one way touching the area is not an arrangement at all: there is nothing to
+    # cross to, so the mesh would be dead weight.
+    Scenario: Foot - Do not mesh an area with a single entrance
+        Given the node map
+            """
+            a-------b
+            |       |
+            d-x-----c
+              |
+              u
+            """
+
+        And the ways
+            | nodes   | highway    | area | name  |
+            | abcxda  | pedestrian | yes  | Plaza |
+            | ux      | pedestrian |      | U     |
+
+        When I route I should get
+            | from | to | route |
+            | u    | x  | U,U   |

--- a/features/foot/area_snapping.feature
+++ b/features/foot/area_snapping.feature
@@ -1,0 +1,233 @@
+@routing @foot @area
+Feature: Foot - Snapping inside a pedestrian area
+
+    # A coordinate that falls inside a meshed area does not snap to the nearest meshed
+    # line.  It snaps to the vertex of the area that makes the whole journey shortest,
+    # walking there in a straight line -- the route the visibility graph would have given
+    # if that coordinate had been part of it when it was built.
+    #
+    # These scenarios mirror the fixtures drawn by scripts/debug/area_snapping_report.py,
+    # one per shape, covering a route that starts inside an area, one that ends inside
+    # one, and one that crosses it.  The interior points are nodes that belong to no way,
+    # so the only way to reach them is by snapping into the area.
+    #
+    # Several of them assert a route through a corner of an *obstacle*.  Those corners
+    # only carry edges when the whole visibility graph is emitted; with the entry-point
+    # mesh they are dead ends and the routes detour to the plaza's own corners instead.
+    # So these double as a guard on that.
+
+    Background:
+        Given the profile "foot_area"
+        Given a grid size of 50 meters
+        Given the query options
+            | annotations | nodes |
+
+    Scenario: Foot - Start or end inside a plaza
+        Given the node map
+            """
+            e-a-------b-f
+              |       |
+              |   x   |
+            h-d-------c-g
+            """
+
+        And the ways
+            | nodes | highway    | area | name  |
+            | abcda | pedestrian | yes  | Plaza |
+            | ea    | pedestrian |      | A     |
+            | bf    | pedestrian |      | B     |
+            | hd    | pedestrian |      | C     |
+            | cg    | pedestrian |      | D     |
+
+        # x leaves by whichever corner is on the way to where it is going, and is
+        # arrived at the same way
+        When I route I should get
+            | from | to | a:nodes | route |
+            | x    | f  | bf      | B,B   |
+            | x    | g  | cg      | D,D   |
+            | e    | x  | ea      | A,A   |
+
+    Scenario: Foot - Plaza entered by the middle of an edge
+        Given the node map
+            """
+            e-a---m---b-f
+              |       |
+              |   p   |
+            h-d---n---c-g
+                  |
+                  i
+            """
+
+        And the ways
+            | nodes   | highway    | area | name  |
+            | ambcnda | pedestrian | yes  | Plaza |
+            | ea      | pedestrian |      | A     |
+            | bf      | pedestrian |      | B     |
+            | hd      | pedestrian |      | C     |
+            | cg      | pedestrian |      | D     |
+            | ni      | pedestrian |      | E     |
+
+        # n is nearer than any corner, and is where the route to i should set off from
+        When I route I should get
+            | from | to | a:nodes | route |
+            | p    | i  | ni      | E,E   |
+            | e    | p  | ea      | A,A   |
+
+    Scenario: Foot - Route round an obstacle from inside the plaza
+        Given the node map
+            """
+            e-a-----------b-f
+              | u-------v |
+              |p|       |q|
+              | x-------w |
+            h-d-----------c-g
+            """
+
+        And the ways
+            | nodes | highway    | name |
+            | abcda | (nil)      |      |
+            | uvwxu | (nil)      |      |
+            | ea    | pedestrian | A    |
+            | bf    | pedestrian | B    |
+            | hd    | pedestrian | C    |
+            | cg    | pedestrian | D    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner |
+            | multipolygon | pedestrian | abcda     | uvwxu     |
+
+        # p is wedged between the plaza's edge and the obstacle, so every route out of it
+        # turns a corner of the obstacle -- u going north, x going south
+        When I route I should get
+            | from | to | a:nodes | route |
+            | p    | f  | ubf     | ,B    |
+            | p    | g  | xcg     | ,D    |
+            | e    | q  | eav     | A,,   |
+
+    # Both ends inside one area: they route by way of a shared vertex rather than
+    # straight across, because neither endpoint inserts an edge to the other.  Pinned so
+    # that closing that gap is a visible change -- see plans/open-area-snapping.md.
+    Scenario: Foot - Start and end inside the same plaza
+        Given the node map
+            """
+            e-a-----------b-f
+              | u-------v |
+              |p|       |q|
+              | x-------w |
+            h-d-----------c-g
+            """
+
+        And the ways
+            | nodes | highway    | name |
+            | abcda | (nil)      |      |
+            | uvwxu | (nil)      |      |
+            | ea    | pedestrian | A    |
+            | bf    | pedestrian | B    |
+            | hd    | pedestrian | C    |
+            | cg    | pedestrian | D    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner |
+            | multipolygon | pedestrian | abcda     | uvwxu     |
+
+        When I route I should get
+            | from | to | a:nodes |
+            | p    | q  | uv      |
+
+    Scenario: Foot - Obstacle against one side of the plaza
+        Given the node map
+            """
+            e-a-----------b-f
+              | u-------v |
+              | |       | |
+              | x-------w |
+              |          q|
+            h-d-----------c-g
+            """
+
+        And the ways
+            | nodes | highway    | name |
+            | abcda | (nil)      |      |
+            | uvwxu | (nil)      |      |
+            | ea    | pedestrian | A    |
+            | bf    | pedestrian | B    |
+            | hd    | pedestrian | C    |
+            | cg    | pedestrian | D    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner |
+            | multipolygon | pedestrian | abcda     | uvwxu     |
+
+        # the obstacle hides the whole north-west of the plaza from q, so the way out
+        # runs under it, by way of its south-west corner
+        When I route I should get
+            | from | to | a:nodes | route |
+            | q    | e  | xae     | ,A,A  |
+            | e    | q  | eax     | A,,   |
+
+    Scenario: Foot - Two obstacles with a gap between them
+        Given the node map
+            """
+            e-a---------------b-f
+              | u-v     i-j   |
+              |p| |     | |  s|
+              | x-w     l-k   |
+            h-d---------------c-g
+            """
+
+        And the ways
+            | nodes | highway    | name |
+            | abcda | (nil)      |      |
+            | uvwxu | (nil)      |      |
+            | ijkli | (nil)      |      |
+            | ea    | pedestrian | A    |
+            | bf    | pedestrian | B    |
+            | hd    | pedestrian | C    |
+            | cg    | pedestrian | D    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner   |
+            | multipolygon | pedestrian | abcda     | uvwxu,ijkli |
+
+        # the sight line from one obstacle's corner to the other's runs over both of
+        # them, which is shorter than going round by the plaza's edge.  Asserted as
+        # geometry: the node ids at the ends of a leg name the way the phantom sits on
+        # rather than the way the route took, and CH and MLD do not always pick the same
+        # one (see #7683).
+        When I route I should get
+            | from | to | geometry            |
+            | p    | s  | efbEsnbE?aM         |
+            | p    | g  | o`bEsnbExAsR?yA     |
+
+    Scenario: Foot - Plaza with two entrances on the same side
+        Given the node map
+            """
+            a-------------b
+            | u-------v   |
+            |p|       |   |
+            | x-------w   |
+            d---m-----n---c
+                |     |
+                s     t
+            """
+
+        And the ways
+            | nodes   | highway    | name |
+            | abcnmda | (nil)      |      |
+            | uvwxu   | (nil)      |      |
+            | sm      | pedestrian | S    |
+            | tn      | pedestrian | T    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner |
+            | multipolygon | pedestrian | abcnmda   | uvwxu     |
+
+        # Nothing joins the north of this plaza to anything, so the entry-point mesh is a
+        # single chord along the bottom and p has no graph anywhere near it.  Reaching an
+        # entrance from behind the obstacle is the case the whole visibility graph exists
+        # for.
+        When I route I should get
+            | from | to | a:nodes | route     |
+            | p    | t  | xnt     | ,T,T      |
+            | s    | p  | smx     | S,,       |
+            | s    | t  | smnt    | S,,T,T    |

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -111,7 +111,9 @@ class RouteAPI : public BaseAPI
 
         if (!parameters.skip_waypoints)
         {
-            response.values.emplace("waypoints", BaseAPI::MakeWaypoints(waypoint_candidates));
+            response.values.emplace(
+                "waypoints",
+                BaseAPI::MakeWaypoints(waypointsAsRouted(raw_routes, waypoint_candidates)));
         }
         response.values.emplace("routes", std::move(jsRoutes));
         response.values.emplace("code", "Ok");
@@ -123,6 +125,54 @@ class RouteAPI : public BaseAPI
     }
 
   protected:
+    /**
+     * @brief Put the candidate the route actually set off from at the head of its list.
+     *
+     * A waypoint reports `candidates.front()`, which is right when every candidate for a
+     * coordinate sits at the same snapped point -- the usual case, alternatives at one
+     * intersection.  Snapping inside an open area breaks that assumption on purpose: the
+     * candidates are the area's visible vertices, spread right across it, and only the
+     * search knows which one the journey used.  Reporting the first would put the
+     * waypoint somewhere the route never goes.
+     *
+     * The route carries the phantoms it used in `leg_endpoints`, so use those.  The list
+     * is only reordered when it would change the reported location, which leaves every
+     * ordinary route -- including the order names are joined in -- exactly as it was.
+     */
+    std::vector<PhantomNodeCandidates>
+    waypointsAsRouted(const InternalManyRoutesResult &raw_routes,
+                      const std::vector<PhantomNodeCandidates> &waypoint_candidates) const
+    {
+        const auto route = std::find_if(raw_routes.routes.begin(),
+                                        raw_routes.routes.end(),
+                                        [](const auto &r) { return r.is_valid(); });
+        if (route == raw_routes.routes.end() ||
+            route->leg_endpoints.size() + 1 != waypoint_candidates.size())
+        {
+            return waypoint_candidates;
+        }
+
+        auto candidates = waypoint_candidates;
+        for (std::size_t i = 0; i < candidates.size(); ++i)
+        {
+            const auto &used = i == 0 ? route->leg_endpoints.front().source_phantom
+                                      : route->leg_endpoints[i - 1].target_phantom;
+            if (candidates[i].empty() || candidates[i].front().location == used.location)
+            {
+                continue;
+            }
+            auto found = std::find_if(candidates[i].begin(),
+                                      candidates[i].end(),
+                                      [&used](const PhantomNode &candidate)
+                                      { return candidate.location == used.location; });
+            if (found != candidates[i].end())
+            {
+                std::iter_swap(candidates[i].begin(), found);
+            }
+        }
+        return candidates;
+    }
+
     template <typename GetWptsFn>
     std::unique_ptr<fbresult::FBResultBuilder>
     MakeFBResponse(const InternalManyRoutesResult &raw_routes,

--- a/include/engine/area_snapping.hpp
+++ b/include/engine/area_snapping.hpp
@@ -1,0 +1,61 @@
+#ifndef OSRM_ENGINE_AREA_SNAPPING_HPP
+#define OSRM_ENGINE_AREA_SNAPPING_HPP
+
+#include "engine/approach.hpp"
+#include "engine/datafacade/datafacade_base.hpp"
+#include "engine/phantom_node.hpp"
+
+#include "util/coordinate.hpp"
+
+#include <optional>
+
+namespace osrm::engine::area
+{
+
+/**
+ * @brief Which end of the journey a coordinate is, which decides the sign of the walk.
+ *
+ * The search seeds a source with the negation of `GetForwardWeightPlusOffset()` and a
+ * target with the value itself, so the walk has to be subtracted from the offset in one
+ * case and added in the other.  The stored offset can only hold one of the two, and the
+ * plugin is where the role is known.
+ */
+/**
+ * Which end of a journey a coordinate is, which decides how the walk into the area is
+ * charged.  A `Via` point is both ends at once and so cannot be charged at all: the
+ * search seeds a source with the negation of the offset and a target with the offset
+ * itself, and one number cannot come out positive both ways.  Charging it as a departure
+ * makes the leg that arrives there seed a negative key, which CH does not permit.
+ */
+enum class ApproachRole
+{
+    Departure,
+    Arrival,
+    Via
+};
+
+/**
+ * @brief Snap a coordinate that falls inside a meshed open area.
+ *
+ * Ordinary snapping projects onto the nearest segment, which inside a plaza means the
+ * nearest meshed chord -- and the route then sets off towards wherever that chord goes,
+ * however little sense it makes from where the request actually was.
+ *
+ * Inside an area we do something else: we draw a straight line to every vertex of the
+ * area that the coordinate can see, and offer each of those vertices as a candidate, at a
+ * cost equal to walking the straight line.  The search relaxes all of them and picks the
+ * one that actually leads somewhere, which is the same answer the visibility graph would
+ * have given if the coordinate had been part of it when it was built.  See
+ * plans/open-area-snapping.md, sections R11 and R12.
+ *
+ * @return the candidates, or nothing if the coordinate is not inside any open area, or
+ *         is inside one whose vertices are all unreachable.
+ */
+std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDataFacade &facade,
+                                                        const util::Coordinate coordinate,
+                                                        const Approach approach,
+                                                        const ApproachRole role);
+
+} // namespace osrm::engine::area
+
+#endif // OSRM_ENGINE_AREA_SNAPPING_HPP

--- a/include/engine/area_visibility.hpp
+++ b/include/engine/area_visibility.hpp
@@ -1,0 +1,119 @@
+#ifndef OSRM_ENGINE_AREA_VISIBILITY_HPP
+#define OSRM_ENGINE_AREA_VISIBILITY_HPP
+
+#include "extractor/area/util.hpp"
+
+#include "util/coordinate.hpp"
+#include "util/web_mercator.hpp"
+
+#include <boost/geometry/core/cs.hpp>
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace osrm::engine::area
+{
+
+/**
+ * @brief A projected point, in metres, for the geometry predicates to work on.
+ *
+ * The predicates in extractor/area/util.hpp are templates that read coordinates through
+ * boost::geometry::get(), so they work on any adapted point type.  Rather than
+ * reimplement them here -- they are delicate, and one copy of them is quite enough -- we
+ * adapt a small local type and reuse them unchanged.
+ *
+ * util::Coordinate itself is deliberately not adapted: it is used throughout the engine,
+ * and giving it boost::geometry traits would apply to every translation unit that
+ * happens to include this header.
+ */
+struct Point
+{
+    double x = 0.0;
+    double y = 0.0;
+};
+
+/**
+ * @brief Project a WGS84 coordinate into web mercator degrees.
+ *
+ * Only orientation and intersection are asked of these coordinates, both of which are
+ * preserved by the projection, so the units do not matter as long as they are the same
+ * for every point.  Distances are measured on the original coordinates instead.
+ */
+inline Point project(const util::Coordinate coordinate)
+{
+    return {static_cast<double>(util::toFloating(coordinate.lon)),
+            util::web_mercator::latToY(util::toFloating(coordinate.lat))};
+}
+
+/**
+ * @brief One ring of an area, as a view over the shared vertex array.
+ *
+ * The first ring of an area is its outer boundary, the rest are obstacles.
+ */
+using Ring = std::span<const Point>;
+
+/**
+ * @brief Return true if the open segment from..to crosses the given ring.
+ *
+ * Endpoints are excluded: a segment that merely touches a vertex of the ring, which is
+ * the usual case when the far end *is* one of the ring's vertices, does not cross it.
+ */
+bool crosses_ring(const Point &from, const Point &to, Ring ring);
+
+/**
+ * @brief Return true if the point lies strictly inside the ring.
+ */
+bool inside_ring(const Point &point, Ring ring);
+
+/**
+ * @brief Return true if the point is inside the area: inside its outer ring and outside
+ * every obstacle.
+ */
+bool inside_area(const Point &point, std::span<const Ring> rings);
+
+/**
+ * @brief Return the indices of the area's vertices that the point can see.
+ *
+ * A vertex is visible when the straight line to it stays inside the area: it crosses no
+ * ring, and its midpoint is inside.  These are the vertices the snapping code turns into
+ * phantom candidates, each reached by a straight line and costed at the walking speed --
+ * which is what makes a route leave the area directly instead of first travelling to
+ * whichever meshed line the coordinate happened to land near.
+ *
+ * Indices are into the flattened vertex array, i.e. across all rings in order.
+ */
+std::vector<std::size_t> visible_vertices(const Point &point, std::span<const Ring> rings);
+
+} // namespace osrm::engine::area
+
+namespace boost::geometry::traits
+{
+template <> struct tag<osrm::engine::area::Point>
+{
+    using type = point_tag;
+};
+template <> struct dimension<osrm::engine::area::Point> : boost::mpl::int_<2>
+{
+};
+template <> struct coordinate_type<osrm::engine::area::Point>
+{
+    using type = double;
+};
+template <> struct coordinate_system<osrm::engine::area::Point>
+{
+    using type = boost::geometry::cs::cartesian;
+};
+template <> struct access<osrm::engine::area::Point, 0>
+{
+    static inline double get(const osrm::engine::area::Point &p) { return p.x; }
+    static inline void set(osrm::engine::area::Point &p, const double &value) { p.x = value; }
+};
+template <> struct access<osrm::engine::area::Point, 1>
+{
+    static inline double get(const osrm::engine::area::Point &p) { return p.y; }
+    static inline void set(osrm::engine::area::Point &p, const double &value) { p.y = value; }
+};
+} // namespace boost::geometry::traits
+
+#endif // OSRM_ENGINE_AREA_VISIBILITY_HPP

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -162,6 +162,15 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
     std::unique_ptr<SharedGeospatialQuery> m_geospatial_query;
     std::filesystem::path file_index_path;
 
+    // The meshed open areas.  Optional: only a profile that meshes pedestrian areas
+    // produces them, so every use has to be guarded.
+    using AreaRTree = util::StaticRTree<extractor::AreaPolygonSegment, storage::Ownership::View>;
+    std::optional<AreaRTree> m_open_area_rtree;
+    util::vector_view<extractor::AreaPolygonSegment> m_open_areas;
+    util::vector_view<util::Coordinate> m_open_area_bbox_corners;
+    util::vector_view<util::Coordinate> m_open_area_vertices;
+    util::vector_view<std::uint32_t> m_open_area_ring_lengths;
+
     std::optional<extractor::IntersectionBearingsView> intersection_bearings_view;
 
     std::optional<extractor::StringTableView> m_string_table;
@@ -212,6 +221,15 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         m_static_rtree = make_search_tree_view(index, "/common/rtree");
         m_geospatial_query.reset(
             new SharedGeospatialQuery(m_static_rtree, m_coordinate_list, *this));
+
+        if (isIndexed(index, "/common/open_areas/areas"))
+        {
+            std::tie(m_open_areas,
+                     m_open_area_bbox_corners,
+                     m_open_area_vertices,
+                     m_open_area_ring_lengths) = make_open_areas_view(index, "/common/open_areas");
+            m_open_area_rtree = make_open_area_tree_view(index, "/common/open_areas/rtree");
+        }
 
         edge_based_node_data = make_ebn_data_view(index, "/common/ebg_node_data");
 
@@ -325,6 +343,35 @@ class ContiguousInternalMemoryDataFacadeBase : public BaseDataFacade
         const util::RectangleInt2D bbox{
             south_west.lon, north_east.lon, south_west.lat, north_east.lat};
         return m_geospatial_query->Search(bbox);
+    }
+
+    std::vector<extractor::AreaPolygonSegment>
+    GetOpenAreasAt(const util::Coordinate coordinate) const override final
+    {
+        if (!m_open_area_rtree)
+        {
+            return {};
+        }
+        // a degenerate rectangle: everything whose bounding box covers the point
+        const util::RectangleInt2D box{
+            coordinate.lon, coordinate.lon, coordinate.lat, coordinate.lat};
+        return m_open_area_rtree->SearchInBox(box);
+    }
+
+    std::vector<std::span<const util::Coordinate>>
+    GetOpenAreaRings(const extractor::AreaPolygonSegment &area) const override final
+    {
+        std::vector<std::span<const util::Coordinate>> rings;
+        rings.reserve(area.num_rings);
+
+        const util::Coordinate *vertices = m_open_area_vertices.data() + area.vertices_offset;
+        for (std::uint32_t i = 0; i < area.num_rings; ++i)
+        {
+            const auto length = m_open_area_ring_lengths[area.rings_offset + i];
+            rings.emplace_back(vertices, length);
+            vertices += length;
+        }
+        return rings;
     }
 
     std::vector<PhantomNodeWithDistance>

--- a/include/engine/datafacade/datafacade_base.hpp
+++ b/include/engine/datafacade/datafacade_base.hpp
@@ -8,6 +8,7 @@
 
 #include "contractor/query_edge.hpp"
 
+#include "extractor/area_routing_data.hpp"
 #include "extractor/class_data.hpp"
 #include "extractor/edge_based_node_segment.hpp"
 #include "extractor/maneuver_override.hpp"
@@ -120,6 +121,26 @@ class BaseDataFacade
 
     virtual std::vector<RTreeLeaf> GetEdgesInBox(const util::Coordinate south_west,
                                                  const util::Coordinate north_east) const = 0;
+
+    /**
+     * @brief The meshed open areas whose bounding box contains the coordinate.
+     *
+     * A bounding box hit is not containment -- the caller still has to run the
+     * point-in-polygon test on the rings, which is what GetOpenAreaRings is for.
+     *
+     * Not pure: a dataset extracted by a profile that does not mesh areas has none of
+     * this, and neither does the offline facade, so the honest default is "no areas".
+     */
+    virtual std::vector<extractor::AreaPolygonSegment>
+    GetOpenAreasAt(const util::Coordinate /*coordinate*/) const
+    { return {}; }
+
+    /**
+     * @brief The rings of one area, outer first and then its obstacles.
+     */
+    virtual std::vector<std::span<const util::Coordinate>>
+    GetOpenAreaRings(const extractor::AreaPolygonSegment & /*area*/) const
+    { return {}; }
 
     virtual std::vector<PhantomNodeWithDistance>
     NearestPhantomNodesInRange(const util::Coordinate input_coordinate,

--- a/include/engine/datafacade/mmap_memory_allocator.hpp
+++ b/include/engine/datafacade/mmap_memory_allocator.hpp
@@ -30,6 +30,7 @@ class MMapMemoryAllocator final : public ContiguousBlockAllocator
     storage::SharedDataIndex index;
     std::vector<boost::iostreams::mapped_file_source> mapped_memory_files;
     std::string rtree_filename;
+    std::string open_area_rtree_filename;
 };
 
 } // namespace osrm::engine::datafacade

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -4,6 +4,7 @@
 #include "engine/api/base_parameters.hpp"
 #include "engine/api/base_result.hpp"
 #include "engine/api/flatbuffers/fbresult_generated.h"
+#include "engine/area_snapping.hpp"
 #include "engine/datafacade/datafacade_base.hpp"
 #include "engine/phantom_node.hpp"
 #include "engine/routing_algorithms.hpp"
@@ -240,12 +241,35 @@ class BasePlugin
         BOOST_ASSERT(parameters.IsValid());
         for (const auto i : util::irange<std::size_t>(0UL, parameters.coordinates.size()))
         {
+            const auto approach = use_approaches && parameters.approaches[i]
+                                      ? parameters.approaches[i].value()
+                                      : engine::Approach::UNRESTRICTED;
+
+            // A coordinate inside a meshed open area snaps to the vertices it can see,
+            // one candidate each, rather than to the nearest segment.  The search then
+            // picks whichever vertex makes the whole journey shortest.  See
+            // engine/area_snapping.hpp.
+            // The first coordinate is only ever departed from and the last only ever
+            // arrived at.  Everything in between is both at once and so goes uncharged,
+            // which costs a little accuracy on the legs either side of it.
+            const auto role = (i + 1 == parameters.coordinates.size()) ? area::ApproachRole::Arrival
+                              : (i == 0) ? area::ApproachRole::Departure
+                                         : area::ApproachRole::Via;
+            if (auto in_area =
+                    area::SnapInsideOpenArea(facade, parameters.coordinates[i], approach, role))
+            {
+                // Assign the member rather than the pair: a braced `{}` for the second
+                // element cannot be deduced by pair's forwarding constructor, so the
+                // whole thing would go through `pair(const T1 &, const T2 &)` and copy.
+                alternatives[i].first = std::move(*in_area);
+                continue;
+            }
+
             alternatives[i] = facade.NearestCandidatesWithAlternativeFromBigComponent(
                 parameters.coordinates[i],
                 use_radiuses ? parameters.radiuses[i] : default_radius,
                 use_bearings ? parameters.bearings[i] : std::nullopt,
-                use_approaches && parameters.approaches[i] ? parameters.approaches[i].value()
-                                                           : engine::Approach::UNRESTRICTED,
+                approach,
                 use_all_edges);
 
             // we didn't find a fitting node, return error

--- a/include/extractor/area/area_data_collector.hpp
+++ b/include/extractor/area/area_data_collector.hpp
@@ -1,0 +1,65 @@
+#ifndef OSRM_EXTRACTOR_AREA_AREA_DATA_COLLECTOR_HPP
+#define OSRM_EXTRACTOR_AREA_AREA_DATA_COLLECTOR_HPP
+
+#include "typedefs.hpp"
+
+#include <oneapi/tbb/mutex.h>
+
+#include <osmium/osm/node_ref.hpp>
+
+#include <vector>
+
+namespace osrm::extractor::area
+{
+
+/**
+ * @brief What the engine needs to know about one meshed area.
+ *
+ * Recorded while meshing, because that is the only point where the polygon and its
+ * entry points are both known.  Everything here is still in OSM terms; the translation
+ * to NodeIDs happens later, once the node id map exists.
+ */
+struct PolygonRecord
+{
+    //! The outer ring, open, in the order libosmium delivered it.
+    std::vector<osmium::NodeRef> boundary_vertices;
+    //! The obstacle rings, open.  Snapping needs their corners: they are the vertices a
+    //! coordinate inside the area can see and route around.
+    std::vector<std::vector<osmium::NodeRef>> obstacle_rings;
+    //! Speed in m/s for crossing this area.
+    double walking_speed = 0.0;
+};
+
+/**
+ * @brief Collects a PolygonRecord per meshed area.
+ *
+ * Areas are meshed from a tbb::filter_mode::parallel pipeline filter sharing one
+ * AreaMesher, so record() is called from several threads at once and takes a lock.
+ *
+ * That also means the order in which areas arrive is whatever the scheduler decided, and
+ * the order determines the index by which the engine will later refer to an area.  Call
+ * finalize() once meshing is over to put the records into a deterministic order; two
+ * runs over the same input must produce the same file, or the extracted data stops being
+ * reproducible and every downstream comparison becomes untrustworthy.
+ */
+class AreaDataCollector
+{
+  public:
+    void record(const OsmiumPolygon &poly, double walking_speed);
+
+    /** Sort into a deterministic order.  Call once, after meshing. */
+    void finalize();
+
+    std::vector<PolygonRecord> &polygons() { return m_polygons; }
+    const std::vector<PolygonRecord> &polygons() const { return m_polygons; }
+    std::size_t size() const { return m_polygons.size(); }
+    void clear() { m_polygons.clear(); }
+
+  private:
+    std::vector<PolygonRecord> m_polygons;
+    tbb::mutex m_mutex;
+};
+
+} // namespace osrm::extractor::area
+
+#endif // OSRM_EXTRACTOR_AREA_AREA_DATA_COLLECTOR_HPP

--- a/include/extractor/area/area_mesher.hpp
+++ b/include/extractor/area/area_mesher.hpp
@@ -1,6 +1,7 @@
 #ifndef OSRM_EXTRACTOR_AREA_AREA_MESHER_HPP
 #define OSRM_EXTRACTOR_AREA_AREA_MESHER_HPP
 
+#include "extractor/area/area_data_collector.hpp"
 #include "extractor/extraction_relation.hpp"
 #include "typedefs.hpp"
 
@@ -52,11 +53,34 @@ class AreaMesher
                      ExtractionRelationContainer &relations);
     osmium::memory::Buffer read();
 
+    /** What the engine needs to snap into these areas later. */
+    AreaDataCollector &collector() { return m_collector; }
+    const AreaDataCollector &collector() const { return m_collector; }
+
     int added_ways{0};
     /** Refuse to mesh more vertices */
     size_t max_vertices{100};
+    /** Speed in m/s for crossing an area, taken from the profile. */
+    double area_walking_speed{1.4};
+    /**
+     * Emit the area's whole visibility graph rather than only the shortest paths
+     * between its entry points.
+     *
+     * run_dijkstra() is an approximation: it keeps the edges that carry a shortest path
+     * between two entry points and throws the rest away, which preserves every
+     * entry-to-entry route exactly while cutting the mesh by up to an order of
+     * magnitude.  What it cannot preserve is a route that starts or ends *inside* the
+     * area, since the coordinate may want a chord no pair of entry points had a reason
+     * to keep.  Emitting the whole graph costs more ways and gives those coordinates the
+     * route the visibility graph would have if they had been part of it.
+     *
+     * Either way the ring edges are emitted -- see with_ring_edges().  See docs/areas.md.
+     */
+    bool emit_visibility_graph{true};
 
   private:
+    AreaDataCollector m_collector;
+
     using NodeIDVector = std::vector<OSMNodeID>;
     using WayNodeIDOffsets = std::vector<size_t>;
     using WayIDVector = std::vector<OSMWayID>;

--- a/include/extractor/area_routing_data.hpp
+++ b/include/extractor/area_routing_data.hpp
@@ -1,0 +1,69 @@
+#ifndef OSRM_EXTRACTOR_AREA_ROUTING_DATA_HPP
+#define OSRM_EXTRACTOR_AREA_ROUTING_DATA_HPP
+
+#include "util/typedefs.hpp"
+
+#include <cstdint>
+
+namespace osrm::extractor
+{
+
+/**
+ * @brief One open area, as stored in the area R-tree.
+ *
+ * util::StaticRTree derives each leaf's bounding box from the coordinates its @c u and
+ * @c v members index, so an area is represented to the tree by the two opposite corners
+ * of its bounding box.
+ *
+ * Those indices point into a coordinate list belonging to the area R-tree alone, holding
+ * nothing but these corners -- *not* into the coordinate list shared with the rest of
+ * the engine.  That list is indexed by NodeID and runs parallel to osm_node_ids;
+ * appending corners to it would create NodeIDs corresponding to no OSM node, and every
+ * consumer of that invariant would have to be audited.  Two coordinates per area is a
+ * cheap price for not having that conversation.
+ *
+ * The polygon itself lives in flat arrays alongside the tree, which each area addresses
+ * by offset and count.
+ *
+ * The entry points are deliberately not stored.  What the engine needs to know about a
+ * vertex is whether it has any routable edge, and it can see that directly: a vertex the
+ * mesher gave an edge to has a phantom node sitting exactly on it.  Storing entry points
+ * would answer a narrower question and would mean resolving OSM node ids to NodeIDs at
+ * extraction time, which is a scan over every node in the input.
+ *
+ * Every ring is carried, outer first and then the obstacles, because snapping adds a
+ * virtual edge from the query coordinate to each visibility-graph vertex it can see --
+ * and the obstacle corners are exactly the vertices that make going round the back of an
+ * obstacle possible.  Storing only the outer ring would leave the engine unable to see
+ * them, and unable to work out what blocks a line of sight in the first place.
+ */
+struct AreaPolygonSegment
+{
+    //! Opposite corners of the bounding box, indexing the area R-tree's own coordinates.
+    //! Area @c i owns corners @c 2i and @c 2i+1, so the members are redundant with the
+    //! area's own index -- but StaticRTree reorders its objects while packing, and after
+    //! that the index is gone.  They have to travel with the object.
+    NodeID u = SPECIAL_NODEID;
+    NodeID v = SPECIAL_NODEID;
+
+    //! Every ring flattened, outer first: a range into the shared vertex array.
+    std::uint32_t vertices_offset = 0;
+    std::uint32_t num_vertices = 0;
+
+    //! Where each ring ends within that range: a range into the ring-length array.
+    //! The first ring is the outer one, the rest are obstacles.
+    std::uint32_t rings_offset = 0;
+    std::uint32_t num_rings = 0;
+
+    //! Speed in m/s for crossing this area, taken from the profile at extraction time.
+    double walking_speed = 0.0;
+};
+
+// The R-tree packs leaves into pages, so the size of this decides how many areas share a
+// page.  It is not a correctness constraint, but a change here changes the on-disk
+// layout and wants to be deliberate.
+static_assert(sizeof(AreaPolygonSegment) == 32, "AreaPolygonSegment has unexpected padding");
+
+} // namespace osrm::extractor
+
+#endif // OSRM_EXTRACTOR_AREA_ROUTING_DATA_HPP

--- a/include/extractor/extractor.hpp
+++ b/include/extractor/extractor.hpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef EXTRACTOR_HPP
 #define EXTRACTOR_HPP
 
+#include "extractor/area/area_data_collector.hpp"
 #include "extractor/edge_based_edge.hpp"
 #include "extractor/edge_based_graph_factory.hpp"
 #include "extractor/extractor_config.hpp"
@@ -95,6 +96,12 @@ class Extractor
                         EdgeBasedNodeDataContainer &nodes_container) const;
     void BuildRTree(std::vector<EdgeBasedNodeSegment> edge_based_node_segments,
                     const std::vector<util::Coordinate> &coordinates);
+
+    /**
+     * Write what the engine needs to snap a coordinate that falls inside a meshed area:
+     * the polygons themselves, and an r-tree over their bounding boxes to find them.
+     */
+    void WriteOpenAreas(const std::vector<area::PolygonRecord> &polygons);
 
     void ProcessGuidanceTurns(const util::NodeBasedDynamicGraph &node_based_graph,
                               const EdgeBasedNodeDataContainer &edge_based_node_container,

--- a/include/extractor/extractor_config.hpp
+++ b/include/extractor/extractor_config.hpp
@@ -65,7 +65,11 @@ struct ExtractorConfig final : storage::IOConfig
                ".osrm.icd",
                ".osrm.cnbg",
                ".osrm.cnbg_to_ebg",
-               ".osrm.maneuver_overrides"})
+               ".osrm.maneuver_overrides",
+               // only written when the profile meshes pedestrian areas
+               ".osrm.openareas",
+               ".osrm.openareas.ramIndex",
+               ".osrm.openareas.fileIndex"})
     {
     }
 

--- a/include/extractor/files.hpp
+++ b/include/extractor/files.hpp
@@ -1,6 +1,7 @@
 #ifndef OSRM_EXTRACTOR_FILES_HPP
 #define OSRM_EXTRACTOR_FILES_HPP
 
+#include "extractor/area_routing_data.hpp"
 #include "extractor/edge_based_edge.hpp"
 #include "extractor/node_data_container.hpp"
 #include "extractor/packed_osm_ids.hpp"
@@ -182,6 +183,40 @@ inline void writeDatasources(const std::filesystem::path &path, Datasources &sou
     storage::tar::FileWriter writer{path, fingerprint};
 
     serialization::write(writer, "/common/data_sources_names", sources);
+}
+
+// reads .osrm.openareas
+template <typename AreaVectorT, typename CoordinateVectorT, typename RingLengthVectorT>
+void readOpenAreas(const std::filesystem::path &path,
+                   AreaVectorT &areas,
+                   CoordinateVectorT &bbox_corners,
+                   CoordinateVectorT &vertices,
+                   RingLengthVectorT &ring_lengths)
+{
+    const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
+    storage::tar::FileReader reader{path, fingerprint};
+
+    storage::serialization::read(reader, "/common/open_areas/areas", areas);
+    storage::serialization::read(reader, "/common/open_areas/bbox_corners", bbox_corners);
+    storage::serialization::read(reader, "/common/open_areas/vertices", vertices);
+    storage::serialization::read(reader, "/common/open_areas/ring_lengths", ring_lengths);
+}
+
+// writes .osrm.openareas
+template <typename AreaVectorT, typename CoordinateVectorT, typename RingLengthVectorT>
+void writeOpenAreas(const std::filesystem::path &path,
+                    const AreaVectorT &areas,
+                    const CoordinateVectorT &bbox_corners,
+                    const CoordinateVectorT &vertices,
+                    const RingLengthVectorT &ring_lengths)
+{
+    const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
+    storage::tar::FileWriter writer{path, fingerprint};
+
+    storage::serialization::write(writer, "/common/open_areas/areas", areas);
+    storage::serialization::write(writer, "/common/open_areas/bbox_corners", bbox_corners);
+    storage::serialization::write(writer, "/common/open_areas/vertices", vertices);
+    storage::serialization::write(writer, "/common/open_areas/ring_lengths", ring_lengths);
 }
 
 // reads .osrm.geometry
@@ -539,20 +574,25 @@ void writeEdgeBasedNodeWeightsDurations(const std::filesystem::path &path,
 }
 
 template <typename RTreeT>
-void writeRamIndex(const std::filesystem::path &path, const RTreeT &rtree)
+void writeRamIndex(const std::filesystem::path &path,
+                   const RTreeT &rtree,
+                   const std::string &name = "/common/rtree")
 {
     const auto fingerprint = storage::tar::FileWriter::GenerateFingerprint;
     storage::tar::FileWriter writer{path, fingerprint};
 
-    util::serialization::write(writer, "/common/rtree", rtree);
+    util::serialization::write(writer, name, rtree);
 }
 
-template <typename RTreeT> void readRamIndex(const std::filesystem::path &path, RTreeT &rtree)
+template <typename RTreeT>
+void readRamIndex(const std::filesystem::path &path,
+                  RTreeT &rtree,
+                  const std::string &name = "/common/rtree")
 {
     const auto fingerprint = storage::tar::FileReader::VerifyFingerprint;
     storage::tar::FileReader reader{path, fingerprint};
 
-    util::serialization::read(reader, "/common/rtree", rtree);
+    util::serialization::read(reader, name, rtree);
 }
 
 template <typename EdgeListT>

--- a/include/extractor/profile_properties.hpp
+++ b/include/extractor/profile_properties.hpp
@@ -132,6 +132,14 @@ struct ProfileProperties
     unsigned weight_precision = 1;
     bool force_split_edges = false;
     bool call_tagless_node_function = true;
+    //! emit an open area's whole visibility graph rather than only the shortest paths
+    //! between its entry points, so that a coordinate snapped inside the area can set
+    //! off towards any node it can see.  See docs/areas.md.
+    bool area_emit_visibility_graph = true;
+    //! speed in m/s used to cross the interior of an open area on a straight line.
+    //! Deliberately not called walking_speed: the profiles already use that name for a
+    //! speed in km/h, and mixing the two units would be silent.
+    double area_walking_speed = 1.4;
 };
 } // namespace osrm::extractor
 

--- a/include/storage/storage.hpp
+++ b/include/storage/storage.hpp
@@ -52,6 +52,7 @@ class Storage
     void PopulateLayout(storage::BaseDataLayout &layout,
                         const std::vector<std::pair<bool, std::filesystem::path>> &files);
     std::string PopulateLayoutWithRTree(storage::BaseDataLayout &layout);
+    std::string PopulateLayoutWithOpenAreaRTree(storage::BaseDataLayout &layout);
     std::vector<std::pair<bool, std::filesystem::path>> GetUpdatableFiles();
     std::vector<std::pair<bool, std::filesystem::path>> GetStaticFiles();
 

--- a/include/storage/view_factory.hpp
+++ b/include/storage/view_factory.hpp
@@ -8,6 +8,7 @@
 
 #include "customizer/edge_based_graph.hpp"
 
+#include "extractor/area_routing_data.hpp"
 #include "extractor/class_data.hpp"
 #include "extractor/compressed_edge_container.hpp"
 #include "extractor/edge_based_edge.hpp"
@@ -189,6 +190,50 @@ inline auto make_search_tree_view(const SharedDataIndex &index, const std::strin
         make_vector_view<std::uint64_t>(index, name + "/search_tree_level_starts");
 
     const auto coordinates = make_coordinates_view(index, "/common/nbn_data/coordinates");
+
+    const char *path = index.template GetBlockPtr<char>(name + "/file_index_path");
+
+    if (!std::filesystem::exists(std::filesystem::path{path}))
+    {
+        throw util::exception("Could not load " + std::string(path) + "Does the leaf file exist?" +
+                              SOURCE_REF);
+    }
+
+    return util::StaticRTree<RTreeLeaf, storage::Ownership::View>{
+        search_tree, rtree_level_starts, path, coordinates};
+}
+
+/**
+ * @brief The polygons of the meshed open areas: every ring flattened, outer first.
+ *
+ * Returns the areas, the bounding-box corners the area r-tree indexes, the vertices, and
+ * the length of each ring.
+ */
+inline auto make_open_areas_view(const SharedDataIndex &index, const std::string &name)
+{
+    return std::make_tuple(make_vector_view<extractor::AreaPolygonSegment>(index, name + "/areas"),
+                           make_coordinates_view(index, name + "/bbox_corners"),
+                           make_coordinates_view(index, name + "/vertices"),
+                           make_vector_view<std::uint32_t>(index, name + "/ring_lengths"));
+}
+
+/**
+ * @brief The r-tree that finds the open area a coordinate falls into.
+ *
+ * It indexes the bounding-box corner list that belongs to the areas, not the coordinates
+ * the rest of the engine uses -- see extractor::AreaPolygonSegment.
+ */
+inline auto make_open_area_tree_view(const SharedDataIndex &index, const std::string &name)
+{
+    using RTreeLeaf = extractor::AreaPolygonSegment;
+    using RTreeNode = util::StaticRTree<RTreeLeaf, storage::Ownership::View>::TreeNode;
+
+    const auto search_tree = make_vector_view<RTreeNode>(index, name + "/search_tree");
+
+    const auto rtree_level_starts =
+        make_vector_view<std::uint64_t>(index, name + "/search_tree_level_starts");
+
+    const auto coordinates = make_coordinates_view(index, "/common/open_areas/bbox_corners");
 
     const char *path = index.template GetBlockPtr<char>(name + "/file_index_path");
 

--- a/scripts/debug/area_mesh_stages.py
+++ b/scripts/debug/area_mesh_stages.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Draw what each stage of area meshing adds and removes.
+
+Meshing an area goes through four stages, and which edges survive each one is the thing
+that decides whether a coordinate inside the area can be routed from.  This draws them
+side by side for one plaza with an obstacle:
+
+    1. the rings                  -- the area as it was mapped
+    2. the visibility graph       -- every mutually visible pair, ring edges NOT among them
+    3. the entry-point mesh       -- the shortest paths between entry points, the rest cut
+    4. + the ring edges           -- put back, because nothing works without them
+
+    scripts/debug/area_mesh_stages.py > /tmp/stages.html
+
+The geometry is computed the same way the mesher computes it -- a rotational sweep is
+overkill for a rectangle with one rectangular hole, so visibility is a direct test -- and
+cross-checked against the ways osrm-extract actually emits.
+"""
+
+import itertools
+import math
+import sys
+
+# ------------------------------------------------------------------ the fixture
+
+# A plaza with one obstacle, in metres.  Entry points are the plaza's four corners; ways
+# lead away from each of them to the outside world.
+# the "centre obstacle" fixture of area_snapping_report.py, in metres
+PLAZA = [(0, 0), (400, 0), (400, 400), (0, 400)]
+OBSTACLE = [(150, 150), (250, 150), (250, 250), (150, 250)]
+ENTRIES = [0, 1, 2, 3]  # indices into the flattened vertex list
+
+NAMES = ["a", "b", "c", "d", "o1", "o2", "o3", "o4"]
+VERTICES = PLAZA + OBSTACLE
+RINGS = [list(range(0, 4)), list(range(4, 8))]
+
+
+def ring_edges():
+    edges = set()
+    for ring in RINGS:
+        for i, u in enumerate(ring):
+            v = ring[(i + 1) % len(ring)]
+            edges.add((min(u, v), max(u, v)))
+    return edges
+
+
+def blocked(u, v):
+    """Does the open segment between vertices u and v pass through the obstacle?
+
+    An obstacle edge that shares an endpoint with the segment meets it only there and
+    cannot obstruct it, so it is skipped -- the same rule as VisibilityGraph::visible(),
+    and for the same reason: without it a sight line that ends exactly on a corner is
+    read as crossing the two edges that meet there.
+    """
+    p, q = VERTICES[u], VERTICES[v]
+
+    def side(a, b, c):
+        return (b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1])
+
+    def properly_crosses(a, b, c, d):
+        d1, d2, d3, d4 = side(c, d, a), side(c, d, b), side(a, b, c), side(a, b, d)
+        return ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0))
+
+    mid = ((p[0] + q[0]) / 2, (p[1] + q[1]) / 2)
+    xs = [c[0] for c in OBSTACLE]
+    ys = [c[1] for c in OBSTACLE]
+    if min(xs) < mid[0] < max(xs) and min(ys) < mid[1] < max(ys):
+        return True
+    for ring in RINGS:
+        for i, a in enumerate(ring):
+            b = ring[(i + 1) % len(ring)]
+            if a in (u, v) or b in (u, v):
+                continue
+            if properly_crosses(p, q, VERTICES[a], VERTICES[b]):
+                return True
+    return False
+
+
+def visibility_graph():
+    """Every mutually visible pair -- and, as in the sweep, no ring edges.
+
+    The sweep's cone test excludes a vertex's own ring neighbours, so an edge of a ring
+    is never reported as a sight line even though the two ends can plainly see each
+    other.  That is the whole reason stage 4 exists.
+    """
+    rings = ring_edges()
+    edges = set()
+    for u, v in itertools.combinations(range(len(VERTICES)), 2):
+        if (u, v) in rings:
+            continue
+        if not blocked(u, v):
+            edges.add((u, v))
+    return edges
+
+
+def entry_point_mesh(graph):
+    """The edges carrying a shortest path between two entry points -- run_dijkstra().
+
+    Dijkstra runs on the visibility graph *and* the ring edges, but only reports the
+    edges it used, so a ring edge survives here only when some entry-to-entry path ran
+    along it.
+    """
+    adjacency = {i: [] for i in range(len(VERTICES))}
+    for u, v in graph | ring_edges():
+        w = math.dist(VERTICES[u], VERTICES[v])
+        adjacency[u].append((v, w))
+        adjacency[v].append((u, w))
+
+    kept = set()
+    for source in ENTRIES:
+        dist = {i: math.inf for i in adjacency}
+        prev = {}
+        dist[source] = 0.0
+        unvisited = set(adjacency)
+        while unvisited:
+            here = min(unvisited, key=lambda n: dist[n])
+            if dist[here] == math.inf:
+                break
+            unvisited.remove(here)
+            for other, w in adjacency[here]:
+                if other in unvisited and dist[here] + w < dist[other]:
+                    dist[other] = dist[here] + w
+                    prev[other] = here
+        for target in ENTRIES:
+            node = target
+            while node in prev:
+                kept.add((min(node, prev[node]), max(node, prev[node])))
+                node = prev[node]
+    return kept
+
+
+# ------------------------------------------------------------------- drawing
+
+# One frame for all four panels: same box, same vertices, same scale, so the only thing
+# that changes between them is which edges are drawn.
+W = H = 300
+PAD = 30
+SPAN = 400
+
+
+def xy(p):
+    return (PAD + p[0] / SPAN * (W - 2 * PAD), PAD + p[1] / SPAN * (H - 2 * PAD))
+
+
+def polygon(points, cls):
+    pts = " ".join(f"{x:.1f},{y:.1f}" for x, y in (xy(p) for p in points))
+    return f'<polygon class="{cls}" points="{pts}"/>'
+
+
+def panel(number, title, subtitle, drawn, note):
+    """`drawn` is a list of (edge set, css class), painted in order."""
+    out = ['<figure class="plate">',
+           '<figcaption>',
+           f'<span class="stage">{number}</span>',
+           f'<span class="name">{title}</span>',
+           f'<span class="sub">{subtitle}</span>',
+           '</figcaption>',
+           f'<svg viewBox="0 0 {W} {H}" role="img" aria-label="{title}: {subtitle}">',
+           polygon(PLAZA, "plaza"), polygon(OBSTACLE, "block")]
+    for edges, cls in drawn:
+        for u, v in sorted(edges):
+            (x1, y1), (x2, y2) = xy(VERTICES[u]), xy(VERTICES[v])
+            out.append(f'<line class="{cls}" x1="{x1:.1f}" y1="{y1:.1f}" '
+                       f'x2="{x2:.1f}" y2="{y2:.1f}"/>')
+    for i, p in enumerate(VERTICES):
+        x, y = xy(p)
+        out.append(f'<circle class="{"entry" if i in ENTRIES else "corner"}" '
+                   f'cx="{x:.1f}" cy="{y:.1f}" r="4"/>')
+        dx = -16 if p[0] < SPAN / 2 else 8
+        dy = -8 if p[1] < SPAN / 2 else 18
+        out.append(f'<text x="{x + dx:.1f}" y="{y + dy:.1f}">{NAMES[i]}</text>')
+    out += ["</svg>", f'<p class="tally">{note}</p>', "</figure>"]
+    return "\n".join(out)
+
+
+def main():
+    rings = ring_edges()
+    graph = visibility_graph()
+    pruned = entry_point_mesh(graph)
+    sight_kept = pruned - rings
+    cut = graph - pruned
+
+    whole_mode = graph | rings
+    pruned_mode = pruned | rings
+
+    stranded = sorted(NAMES[i] for i in range(len(VERTICES))
+                      if not any(i in e for e in pruned))
+    stranded_html = " and ".join(f'<code>{o}</code>' for o in stranded)
+
+    plate = "\n".join([
+        panel("1", "The rings", "the area as it was mapped",
+              [(rings, "ring")],
+              f'<b>{len(rings)}</b> ring edges &middot; '
+              f'{len(ENTRIES)} entry points, {len(VERTICES) - len(ENTRIES)} obstacle corners'),
+        panel("2", "The visibility graph", "every mutually visible pair",
+              [(graph, "sight")],
+              f'<b>{len(graph)}</b> sight lines &middot; and not one ring edge among them'),
+        panel("3", "The entry-point mesh", "what the pruning keeps",
+              [(cut, "cut"), (sight_kept, "sight"), (pruned & rings, "ring")],
+              f'<b>{len(pruned)}</b> kept, <b>{len(cut)}</b> cut &middot; '
+              f'no obstacle edge survives; {stranded_html} keep none at all'),
+        panel("4", "Ring edges put back", "what each mode emits",
+              [(sight_kept, "sight"), (rings, "ring")],
+              f'<b>{len(pruned_mode)}</b> ways pruned, <b>{len(whole_mode)}</b> whole graph '
+              '&middot; every vertex has somewhere to go'),
+    ])
+
+    page = TEMPLATE
+    for token, value in [
+        ("%PLATE%", plate),
+        ("%STRANDED%", stranded_html),
+        ("%SIGHT%", str(len(graph))),
+        ("%RINGS%", str(len(rings))),
+        ("%KEPT%", str(len(pruned))),
+        ("%CUT%", str(len(cut))),
+        ("%PRUNED%", str(len(pruned_mode))),
+        ("%WHOLE%", str(len(whole_mode))),
+    ]:
+        page = page.replace(token, value)
+    print(page)
+
+
+TEMPLATE = r"""<title>What area meshing adds and removes</title>
+<style>
+  /* Light is the base palette; both dark paths redefine only tokens. */
+  :root {
+    --paper:#f6f8fb; --card:#ffffff; --ink:#151b24; --muted:#5a6575; --rule:#d9e0ea;
+    --sight:#1f6feb; --ring:#0b8a53; --cut:#c62f2f; --entry:#e08600;
+    --plaza:#e6edf8; --block:#b6c0ce; --block-edge:#7d8899; --plaza-edge:#8ea1bd;
+    --quote:#eef3fa;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --paper:#0e1319; --card:#151b23; --ink:#e5eaf2; --muted:#98a3b3; --rule:#28313d;
+      --sight:#5a9bff; --ring:#3fbe84; --cut:#f0736f; --entry:#f0a63c;
+      --plaza:#1b2634; --block:#333f4f; --block-edge:#5d6b7d; --plaza-edge:#44566e;
+      --quote:#141d27;
+    }
+  }
+  :root[data-theme="dark"] {
+    --paper:#0e1319; --card:#151b23; --ink:#e5eaf2; --muted:#98a3b3; --rule:#28313d;
+    --sight:#5a9bff; --ring:#3fbe84; --cut:#f0736f; --entry:#f0a63c;
+    --plaza:#1b2634; --block:#333f4f; --block-edge:#5d6b7d; --plaza-edge:#44566e;
+    --quote:#141d27;
+  }
+
+  * { box-sizing:border-box; }
+  body {
+    margin:0; padding:40px 22px 64px; background:var(--paper); color:var(--ink);
+    font:16px/1.6 var(--sans); -webkit-font-smoothing:antialiased;
+  }
+  .wrap { max-width:1160px; margin:0 auto; display:flex; flex-direction:column; gap:28px; }
+  header { display:flex; flex-direction:column; gap:8px; max-width:66ch; }
+  h1 { margin:0; font-size:26px; line-height:1.2; letter-spacing:-.02em; text-wrap:balance; }
+  .standfirst { margin:0; color:var(--muted); }
+  code { font:.88em var(--mono); background:var(--quote); padding:1px 5px; border-radius:4px; }
+
+  .plates { display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:16px; }
+  .plate {
+    margin:0; padding:14px 15px 12px; background:var(--card);
+    border:1px solid var(--rule); border-radius:8px;
+    display:flex; flex-direction:column; gap:10px;
+  }
+  figcaption { display:grid; grid-template-columns:auto 1fr; gap:2px 9px; align-items:baseline; }
+  .stage {
+    grid-row:1/3; font:600 12px var(--mono); color:var(--muted);
+    border:1px solid var(--rule); border-radius:4px; padding:2px 6px; align-self:start;
+    font-variant-numeric:tabular-nums;
+  }
+  .name { font-weight:650; font-size:14.5px; letter-spacing:-.01em; }
+  .sub { color:var(--muted); font-size:12.5px; line-height:1.35; }
+  svg { width:100%; height:auto; display:block; }
+  .tally {
+    margin:0; padding-top:9px; border-top:1px solid var(--rule);
+    font:12.5px/1.45 var(--sans); color:var(--muted); font-variant-numeric:tabular-nums;
+  }
+  .tally b { color:var(--ink); font:600 12.5px var(--mono); }
+  .tally code { font-size:12px; padding:0 4px; }
+
+  .plaza { fill:var(--plaza); stroke:var(--plaza-edge); stroke-width:1.1; }
+  .block { fill:var(--block); stroke:var(--block-edge); stroke-width:1.1; }
+  .sight { stroke:var(--sight); stroke-width:1.7; }
+  .ring  { stroke:var(--ring); stroke-width:3.2; stroke-linecap:round; }
+  .cut   { stroke:var(--cut); stroke-width:1.3; stroke-dasharray:3 3.5; }
+  circle.entry  { fill:var(--entry); stroke:var(--card); stroke-width:1.5; }
+  circle.corner { fill:var(--ink); stroke:var(--card); stroke-width:1.5; }
+  svg text { font:10.5px var(--mono); fill:var(--muted); }
+
+  .legend {
+    display:flex; flex-wrap:wrap; gap:8px 22px; padding:12px 15px;
+    border:1px solid var(--rule); border-radius:8px; background:var(--card);
+    font-size:13px; color:var(--muted);
+  }
+  .legend span { display:inline-flex; align-items:center; gap:8px; white-space:nowrap; }
+  .swatch { width:22px; height:3px; border-radius:2px; }
+  .swatch.dot { width:9px; height:9px; border-radius:50%; }
+  .swatch.dash {
+    height:0; border-top:1.5px dashed var(--cut); border-radius:0;
+  }
+
+  .notes { max-width:66ch; display:flex; flex-direction:column; gap:18px; }
+  .notes h2 { margin:0 0 4px; font-size:15px; letter-spacing:-.01em; }
+  .notes p { margin:0; }
+  .notes section { padding-left:14px; border-left:2px solid var(--rule); }
+  .notes section.keyed { border-left-color:var(--sight); }
+  footer { color:var(--muted); font-size:13px; border-top:1px solid var(--rule); padding-top:14px; }
+  a { color:var(--sight); }
+  a:focus-visible, [tabindex]:focus-visible { outline:2px solid var(--sight); outline-offset:2px; }
+</style>
+
+<div class="wrap">
+  <header>
+    <h1>What area meshing adds and removes</h1>
+    <p class="standfirst">A 400&nbsp;m plaza with one obstacle, drawn at each stage of the
+    mesher. Every panel uses the same frame and the same eight vertices, so the only thing
+    that changes is which edges exist. Orange marks an entry point &mdash; where another way
+    meets the plaza; the obstacle&rsquo;s corners connect to nothing outside the area.</p>
+  </header>
+
+  <div class="plates">%PLATE%</div>
+
+  <div class="legend">
+    <span><i class="swatch" style="background:var(--ring)"></i>ring edge</span>
+    <span><i class="swatch" style="background:var(--sight)"></i>sight line</span>
+    <span><i class="swatch dash"></i>cut by the pruning</span>
+    <span><i class="swatch dot" style="background:var(--entry)"></i>entry point</span>
+    <span><i class="swatch dot" style="background:var(--ink)"></i>obstacle corner</span>
+  </div>
+
+  <div class="notes">
+    <section>
+      <h2>The sweep never emits ring edges</h2>
+      <p>Its cone test excludes a vertex&rsquo;s own two neighbours, so the edge between them
+      is never reported as a sight line &mdash; even though the two ends can plainly see each
+      other. Panel&nbsp;2 is what the visibility graph actually contains:
+      %SIGHT% sight lines and none of the %RINGS% ring edges.</p>
+    </section>
+
+    <section>
+      <h2>The pruning is an approximation, and a good one</h2>
+      <p><code>run_dijkstra</code> keeps only the edges carrying a shortest path between two
+      entry points &mdash; here %KEPT% of them, with %CUT% cut. Every entry-to-entry route
+      survives exactly, and on real data the mesh shrinks by up to an order of magnitude.
+      What it cannot keep is a chord that only matters to a coordinate <em>inside</em> the
+      area.</p>
+    </section>
+
+    <section class="keyed">
+      <h2>Ring edges have to go back either way</h2>
+      <p>Not one obstacle edge survives the pruning here, and %STRANDED% end up carrying no
+      edges at all. A coordinate inside the area that can see them has nowhere to go from
+      there, and nobody can walk along the plaza&rsquo;s edge or round the obstacle. Putting
+      the ring edges back costs one edge per vertex: %PRUNED% ways pruned against %WHOLE%
+      for the whole graph.</p>
+    </section>
+
+    <section>
+      <h2>Which leaves one choice, not two</h2>
+      <p>Both modes route between entry points identically. They differ only in what a
+      coordinate inside the area has to work with, and that is what
+      <code>area_emit_visibility_graph</code> selects.</p>
+    </section>
+  </div>
+
+  <footer>Generated by <code>scripts/debug/area_mesh_stages.py</code>. Edge counts match
+  what <code>osrm-extract</code> emits for this fixture: %WHOLE% ways with the whole
+  visibility graph, %PRUNED% with the entry-point mesh.</footer>
+</div>
+"""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/debug/area_snapping_report.py
+++ b/scripts/debug/area_snapping_report.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+"""Measure and draw how OSRM snaps coordinates that lie inside a pedestrian area.
+
+This is the yardstick for the open-area snapping work (plans/open-area-snapping.md).
+Meshing connects an area's entry points to each other, so a coordinate inside the area
+snaps onto the nearest of those lines -- which can be a long way off, and further still
+when an obstacle inside the area hides the nearest ones.
+
+    scripts/debug/area_snapping_report.py --build-dir build --svg /tmp/areas
+
+For each fixture it prints the distribution of `waypoints[0].distance` over a grid of
+interior points, and writes three pictures: a route starting inside the area, one ending
+inside it, and one crossing it end to end.
+
+The feature is done when the excess over the a-priori route is 0.  The walk from the
+request to the vertex the route sets off from is not an error -- it is a leg of the
+journey, drawn dashed in the pictures -- so it is reported but not judged.  A non-zero
+`NO ROUTE` count is a different failure and worth looking at on its own.
+"""
+
+import argparse
+import json
+import re
+import math
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+import urllib.error
+import urllib.request
+
+# One grid step, matching the cucumber node maps: 25 m in x, 50 m in y.
+DLON = 0.0002246128016873
+DLAT = 0.0004521833555069
+LON0, LAT0 = 1.0, 1.0
+
+
+def loc(col, row):
+    return (LON0 + col * DLON, LAT0 - row * DLAT)
+
+
+# ------------------------------------------------------------------- fixtures
+
+
+class Fixture:
+    """A plaza, optionally with obstacles, in the cucumber node-map idiom."""
+
+    def __init__(self, label):
+        self.label = label
+        self.nodes = {}
+        self.ways = []
+        self.relations = []
+        self.outer_ring = []
+        self.inner_rings = []
+        self.bounds = (0, 0, 0, 0)
+        # the ring vertex routes leave by, and the cell outside it they head for.  Not
+        # every plaza has an entrance at its bottom-right corner, and measuring against
+        # one that is not there measures nothing.
+        self.exit_cell = None
+        self.destination_cell = None
+
+    def coords(self, ring):
+        return [loc(self.nodes[n][1], self.nodes[n][2]) for n in ring]
+
+    def slug(self):
+        """A filename-safe form of the whole label -- truncating at the first comma
+        would make every variant of the same plaza size collide."""
+        return re.sub(r"[^a-z0-9]+", "_", self.label.lower()).strip("_")
+
+    def inside(self, col, row):
+        """Is this grid cell inside the plaza and outside every obstacle?"""
+        left, right, top, bottom = self.bounds
+        if not (left < col < right and top < row < bottom):
+            return False
+        for ring in self.inner_rings:
+            cols = [self.nodes[n][1] for n in ring]
+            rows = [self.nodes[n][2] for n in ring]
+            if min(cols) <= col <= max(cols) and min(rows) <= row <= max(rows):
+                return False
+        return True
+
+
+def plaza(width_cols, height_rows, extra_entries=False, obstacles=(), variant=""):
+    """A rectangular plaza with entry ways at its corners.
+
+    `obstacles` are (col, row, width, height) rectangles cut out of it.  An area with
+    obstacles has to be expressed as a multipolygon relation, since a hole cannot be
+    carried by a closed way.
+    """
+    label = f"plaza {width_cols * 25}x{height_rows * 50}m"
+    if extra_entries:
+        label += ", 6 entry points"
+    else:
+        label += ", 4 entry points"
+    if variant:
+        label += f", {variant}"
+    elif obstacles:
+        label += f", {len(obstacles)} obstacle" + ("s" if len(obstacles) > 1 else "")
+
+    f = Fixture(label)
+    left, right, top, bottom = 2, 2 + width_cols, 0, height_rows
+    f.bounds = (left, right, top, bottom)
+    f.nodes = {
+        1: ("a", left, top),
+        2: ("b", right, top),
+        3: ("c", right, bottom),
+        4: ("d", left, bottom),
+        5: ("e", 0, top),
+        6: ("f", right + 2, top),
+        7: ("g", right + 2, bottom),
+        8: ("h", 0, bottom),
+    }
+    f.outer_ring = [1, 2, 3, 4]
+    f.ways = [
+        (11, [5, 1], [("highway", "pedestrian")]),
+        (12, [2, 6], [("highway", "pedestrian")]),
+        (13, [8, 4], [("highway", "pedestrian")]),
+        (14, [3, 7], [("highway", "pedestrian")]),
+    ]
+
+    if extra_entries:
+        mid = (left + right) // 2
+        f.nodes.update({20: ("m", mid, top), 21: ("n", mid, bottom),
+                        22: ("m_out", mid, top - 2), 23: ("n_out", mid, bottom + 2)})
+        f.outer_ring = [1, 20, 2, 3, 21, 4]
+        f.ways += [
+            (15, [22, 20], [("highway", "pedestrian")]),
+            (16, [21, 23], [("highway", "pedestrian")]),
+        ]
+
+    next_node, next_way = 100, 30
+    for col, row, w, h in obstacles:
+        ring = []
+        for dc, dr in ((0, 0), (w, 0), (w, h), (0, h)):
+            f.nodes[next_node] = (f"o{next_node}", col + dc, row + dr)
+            ring.append(next_node)
+            next_node += 1
+        # clockwise, so libosmium reads it as a hole
+        ring.reverse()
+        f.inner_rings.append(ring)
+        f.ways.append((next_way, ring + [ring[0]], []))
+        next_way += 1
+
+    f.exit_cell = (right, bottom)          # 'c'
+    f.destination_cell = (right + 2, bottom)  # 'g', hanging off it
+
+    if f.inner_rings:
+        # the outer ring carries no tags; the relation describes the area
+        f.ways.insert(0, (10, f.outer_ring + [f.outer_ring[0]], []))
+        members = [("way", 10, "outer")] + [
+            ("way", 30 + i, "inner") for i in range(len(f.inner_rings))
+        ]
+        f.relations.append(
+            (50, members, [("type", "multipolygon"), ("highway", "pedestrian"), ("name", "Plaza")])
+        )
+    else:
+        f.ways.insert(
+            0,
+            (10, f.outer_ring + [f.outer_ring[0]],
+             [("highway", "pedestrian"), ("area", "yes"), ("name", "Plaza")]),
+        )
+    return f
+
+
+def two_entrances_at_the_bottom():
+    """The pathological case: two entrances side by side on the bottom edge.
+
+    The straight line between them runs along the bottom of the plaza and is the only
+    entry-to-entry shortest path there is, so the entry-point mesh consists of that one
+    chord and nothing else -- the whole northern half of the plaza, and everything
+    between and behind the obstacles, has no graph in it at all.  Starting or ending
+    anywhere but the bottom strip has to work regardless.
+    """
+    f = Fixture("plaza 400x400m, 2 entrances at the bottom, two obstacles")
+    left, right, top, bottom = 2, 18, 0, 8
+    f.bounds = (left, right, top, bottom)
+    # the outer ring, with the two entrance nodes sitting on the bottom edge
+    f.nodes = {
+        1: ("a", left, top),
+        2: ("b", right, top),
+        3: ("c", right, bottom),
+        4: ("q", 14, bottom),
+        5: ("p", 6, bottom),
+        6: ("d", left, bottom),
+        # the stubs leading up to them from outside
+        20: ("p_out", 6, bottom + 2),
+        21: ("q_out", 14, bottom + 2),
+    }
+    f.outer_ring = [1, 2, 3, 4, 5, 6]
+    f.ways = [
+        (11, [20, 5], [("highway", "pedestrian")]),
+        (12, [21, 4], [("highway", "pedestrian")]),
+    ]
+
+    next_node, next_way = 100, 30
+    for col, row, w, h in ((6, 2, 4, 3), (12, 2, 4, 3)):
+        ring = []
+        for dc, dr in ((0, 0), (w, 0), (w, h), (0, h)):
+            f.nodes[next_node] = (f"o{next_node}", col + dc, row + dr)
+            ring.append(next_node)
+            next_node += 1
+        ring.reverse()  # clockwise, so libosmium reads it as a hole
+        f.inner_rings.append(ring)
+        f.ways.append((next_way, ring + [ring[0]], []))
+        next_way += 1
+
+    f.exit_cell = (14, bottom)           # 'q', the eastern entrance
+    f.destination_cell = (14, bottom + 2)  # 'q_out', the stub beyond it
+
+    f.ways.insert(0, (10, f.outer_ring + [f.outer_ring[0]], []))
+    members = [("way", 10, "outer")] + [("way", 30 + i, "inner") for i in range(2)]
+    f.relations.append(
+        (50, members, [("type", "multipolygon"), ("highway", "pedestrian"), ("name", "Plaza")])
+    )
+    return f
+
+
+def osm_document(f):
+    out = ['<?xml version="1.0" encoding="UTF-8"?>', '<osm generator="osrm-test" version="0.6">']
+    stamp = 'version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z"'
+    for nid, (name, col, row) in sorted(f.nodes.items()):
+        lon, lat = loc(col, row)
+        out.append(
+            f'  <node id="{nid}" {stamp} lon="{lon!r}" lat="{lat!r}">'
+            f'<tag k="name" v="{name}"/></node>'
+        )
+    for wid, refs, tags in f.ways:
+        out.append(f'  <way id="{wid}" {stamp}>')
+        out += [f'    <nd ref="{r}"/>' for r in refs]
+        out += [f'    <tag k="{k}" v="{v}"/>' for k, v in tags]
+        out.append("  </way>")
+    for rid, members, tags in f.relations:
+        out.append(f'  <relation id="{rid}" {stamp}>')
+        out += [f'    <member type="{t}" ref="{r}" role="{role}"/>' for t, r, role in members]
+        out += [f'    <tag k="{k}" v="{v}"/>' for k, v in tags]
+        out.append("  </relation>")
+    out.append("</osm>")
+    return "\n".join(out)
+
+
+# ------------------------------------------------------------------- pipeline
+
+
+def run(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stderr.write(f"$ {' '.join(cmd)}\n{result.stdout}\n{result.stderr}\n")
+        raise SystemExit(f"command failed: {cmd[0]}")
+    return result.stdout
+
+
+def prepare(build_dir, profile, workdir, f, entry_point_mesh=False):
+    osm = os.path.join(workdir, f"{f.slug()}.osm")
+    with open(osm, "w") as handle:
+        handle.write(osm_document(f))
+    base = os.path.join(workdir, f.slug())
+    if entry_point_mesh:
+        # a thin wrapper so the stock profile stays untouched
+        wrapper = os.path.join(workdir, "entry_point_mesh_profile.lua")
+        if not os.path.exists(wrapper):
+            with open(wrapper, "w") as handle:
+                # the stock profile builds its properties inside setup(), and
+                # requires lib/* relative to its own directory, so put that on the
+                # module path and wrap setup() rather than patching the table
+                profile_dir = os.path.dirname(os.path.abspath(profile))
+                handle.write(
+                    f'package.path = "{profile_dir}/?.lua;" .. package.path\n'
+                    f'local profile = assert(dofile("{os.path.abspath(profile)}"))\n'
+                    "local original_setup = profile.setup\n"
+                    "profile.setup = function(...)\n"
+                    "  local result = original_setup(...)\n"
+                    "  result.properties.area_emit_visibility_graph = false\n"
+                    "  return result\n"
+                    "end\n"
+                    "return profile\n"
+                )
+        profile = wrapper
+    extract_log = run([os.path.join(build_dir, "osrm-extract"), "-p", profile, osm])
+    run([os.path.join(build_dir, "osrm-partition"), base + ".osrm"])
+    run([os.path.join(build_dir, "osrm-customize"), base + ".osrm"])
+    meshed = 0
+    for line in extract_log.splitlines():
+        if "yielding" in line:
+            meshed = int(line.split("yielding")[1].split("ways")[0])
+    return base + ".osrm", meshed
+
+
+def serve(build_dir, dataset, port):
+    proc = subprocess.Popen(
+        [os.path.join(build_dir, "osrm-routed"), "-a", "MLD", "-p", str(port), dataset],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    for _ in range(100):
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/route/v1/foot/1,1;1,1", timeout=0.5)
+            return proc
+        except urllib.error.HTTPError:
+            return proc
+        except Exception:
+            time.sleep(0.1)
+    proc.terminate()
+    raise SystemExit("osrm-routed did not come up")
+
+
+def query(port, origin, destination, overview="false"):
+    url = (
+        f"http://127.0.0.1:{port}/route/v1/foot/"
+        f"{origin[0]},{origin[1]};{destination[0]},{destination[1]}"
+        f"?overview={overview}&geometries=geojson"
+    )
+    with urllib.request.urlopen(url, timeout=5) as response:
+        return json.load(response)
+
+
+def metres(a, b):
+    """Great-circle distance, near enough at these sizes."""
+    R = 6371008.8
+    lon1, lat1, lon2, lat2 = (math.radians(v) for v in (a[0], a[1], b[0], b[1]))
+    x = (lon2 - lon1) * math.cos((lat1 + lat2) / 2)
+    return R * math.hypot(x, lat2 - lat1)
+
+
+def sweep(port, f, destination, exit_cell, tail_metres, step=2):
+    """For each interior point: how far it snapped, and how far the route detours.
+
+    Snapping error alone is not enough to tell whether the feature works.  A coordinate
+    can land exactly on a mesh way -- zero snapping error -- and the route still leave
+    the area by the wrong side, because the mesh only joins entry points to each other.
+    So we also compare the route against the straight line from the requested coordinate
+    to the a-priori reference: the route you would get if the coordinate had been part of
+    the visibility graph all along.  That is the requirement, so anything above zero is
+    the gap still to close.
+    """
+    left, right, top, bottom = f.bounds
+    distances, detours, unsnapped = [], [], 0
+    for col in range(left + 1, right, step):
+        for row in range(top + 1, bottom, step):
+            if not f.inside(col, row):
+                continue
+            origin = loc(col, row)
+            body = query(port, origin, destination)
+            if body.get("code") != "Ok":
+                unsnapped += 1
+                continue
+            distances.append(body["waypoints"][0]["distance"])
+            ideal = ideal_route_length(f, (col, row), exit_cell, tail_metres)
+            # OSRM's route length starts at the *snapped* point, so on its own it
+            # understates what the traveller covers.  Add the walk from where they
+            # actually asked to start, or the comparison flatters the status quo and
+            # can even come out below the optimum.
+            travelled = body["routes"][0]["distance"] + body["waypoints"][0]["distance"]
+            detours.append(travelled - ideal)
+    return distances, detours, unsnapped
+
+
+# --------------------------------------------------------------- visual proof
+
+SVG_STYLE = """
+  .plaza    { fill: #dfe8f5; stroke: #7a90b4; stroke-width: 1.5; }
+  .obstacle { fill: #b9c2cf; stroke: #6c7787; stroke-width: 1.5; }
+  .way      { stroke: #8a8a8a; stroke-width: 3; fill: none; stroke-linecap: round; }
+  .route    { stroke: #1a6fd4; stroke-width: 4; fill: none; stroke-linejoin: round;
+              stroke-linecap: round; }
+  .error    { stroke: #d92b2b; stroke-width: 2; stroke-dasharray: 4 3; fill: none; }
+  .input    { fill: #d92b2b; }
+  .snap     { fill: #f08c00; }
+  text      { font: 13px sans-serif; fill: #222; }
+  .title    { font: bold 15px sans-serif; }
+  .legend   { font: 12px sans-serif; fill: #444; }
+"""
+
+
+class Canvas:
+    """Linear lon/lat -> viewport mapping.  The fixtures are small enough that this is
+    indistinguishable from a projection, and staying linear means the picture can be
+    checked against the fixture's grid coordinates by eye."""
+
+    def __init__(self, bounds, width=680, height=520, margin=58):
+        left, right, top, bottom = bounds
+        self.lon0, self.lat0 = loc(left - 3, top - 2)
+        self.lon1, self.lat1 = loc(right + 3, bottom + 2)
+        self.width, self.height, self.margin = width, height, margin
+
+    def xy(self, lon, lat):
+        fx = (lon - self.lon0) / (self.lon1 - self.lon0)
+        fy = (self.lat0 - lat) / (self.lat0 - self.lat1)
+        return (self.margin + fx * (self.width - 2 * self.margin),
+                self.margin + fy * (self.height - 2 * self.margin))
+
+    def points(self, coords):
+        return " ".join(f"{x:.1f},{y:.1f}" for x, y in (self.xy(*c) for c in coords))
+
+
+def render_svg(path, title, subtitle, f, drawing):
+    canvas = Canvas(f.bounds)
+    out = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{canvas.width}" '
+        f'height="{canvas.height}" viewBox="0 0 {canvas.width} {canvas.height}">',
+        f"<style>{SVG_STYLE}</style>",
+        '  <rect width="100%" height="100%" fill="white"/>',
+        f'  <text class="title" x="{canvas.margin}" y="26">{title}</text>',
+        f'  <text class="legend" x="{canvas.margin}" y="44">{subtitle}</text>',
+        f'  <polygon class="plaza" points="{canvas.points(f.coords(f.outer_ring))}"/>',
+    ]
+    for ring in f.inner_rings:
+        out.append(f'  <polygon class="obstacle" points="{canvas.points(f.coords(ring))}"/>')
+    for _, refs, tags in f.ways:
+        if refs[0] == refs[-1]:  # closed rings are drawn as polygons above
+            continue
+        out.append(f'  <polyline class="way" points="{canvas.points(f.coords(refs))}"/>')
+
+    for kind, payload in drawing:
+        if kind in ("route", "error"):
+            out.append(f'  <polyline class="{kind}" points="{canvas.points(payload)}"/>')
+        else:
+            coord, text = payload
+            x, y = canvas.xy(*coord)
+            radius = 5 if kind == "input" else 4
+            dy = -9 if kind == "input" else 15
+            out.append(f'  <circle class="{kind}" cx="{x:.1f}" cy="{y:.1f}" r="{radius}"/>')
+            out.append(f'  <text x="{x + 9:.1f}" y="{y + dy:.1f}">{text}</text>')
+
+    out.append(
+        f'  <text class="legend" x="{canvas.margin}" y="{canvas.height - 20}">'
+        "blue = route &#160; red = requested coordinate &#160; "
+        "orange = where OSRM put it &#160; dashed = requested-to-snapped &#160; "
+        "grey block = obstacle</text>"
+    )
+    out.append("</svg>")
+    with open(path, "w") as handle:
+        handle.write("\n".join(out))
+
+
+def visual_proof(port, outdir, f, stamp):
+    """A picture each for a route starting in, ending in, and crossing the area."""
+    left, right, top, bottom = f.bounds
+
+    # an interior point that is inside the plaza and clear of every obstacle; prefer one
+    # that an obstacle hides from at least one corner, since that is the hard case
+    interior = None
+    for row in range(top + 1, bottom):
+        for col in range(left + 1, right):
+            if f.inside(col, row):
+                interior = loc(col, row)
+                break
+        if interior:
+            break
+
+    # leave by whichever way the fixture actually has, not by assumption
+    west = loc(0, top) if any(n for n in f.nodes.values() if n[1] == 0) else loc(6, bottom + 2)
+    east = loc(*f.destination_cell)
+    cases = [
+        ("starts", "route starts inside the area", interior, east),
+        ("ends", "route ends inside the area", west, interior),
+        ("crosses", "route crosses the area end to end", west, east),
+    ]
+
+    results = []
+    for name, description, origin, destination in cases:
+        body = query(port, origin, destination, overview="full")
+        if body.get("code") != "Ok":
+            results.append((name, None))
+            continue
+        route = body["routes"][0]
+        geometry = [tuple(c) for c in route["geometry"]["coordinates"]]
+        waypoints = body["waypoints"]
+
+        drawing = [("route", geometry)]
+        for requested, waypoint, tag in zip(
+            (origin, destination), waypoints, ("start", "end")
+        ):
+            landed = tuple(waypoint["location"])
+            if waypoint["distance"] > 0.05:
+                drawing.append(("error", [requested, landed]))
+            drawing.append(("input", (requested, f"{tag} requested")))
+            drawing.append(("snap", (landed, f'snapped {waypoint["distance"]:.1f} m')))
+
+        worst = max(w["distance"] for w in waypoints)
+        render_svg(
+            os.path.join(outdir, f"{f.slug()}_{name}.svg"),
+            description,
+            f"{f.label} &#8212; requested-to-snapped {worst:.1f} m "
+            f"&#8212; route {route['distance']:.0f} m",
+            f,
+            drawing,
+        )
+        results.append((name, worst))
+    return results
+
+
+# ------------------------------------------------------- the a-priori reference
+
+def grid_xy(col, row):
+    """Fixture grid in metres.  One column is 25 m, one row 50 m."""
+    return (col * 25.0, row * 50.0)
+
+
+def segment_blocked(p, q, obstacles):
+    """Does the open segment p..q pass through the inside of any obstacle?
+
+    The fixtures use axis-aligned rectangles, so this is a proper-crossing test against
+    each edge plus a containment test for the midpoint, which catches a segment lying
+    wholly inside a rectangle.
+    """
+
+    def side(a, b, c):
+        return (b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1])
+
+    def properly_crosses(a, b, c, d):
+        d1, d2, d3, d4 = side(c, d, a), side(c, d, b), side(a, b, c), side(a, b, d)
+        return ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0))
+
+    mid = ((p[0] + q[0]) / 2, (p[1] + q[1]) / 2)
+    for rect in obstacles:
+        x0, y0, x1, y1 = rect
+        if x0 < mid[0] < x1 and y0 < mid[1] < y1:
+            return True
+        corners = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+        for i in range(4):
+            if properly_crosses(p, q, corners[i], corners[(i + 1) % 4]):
+                return True
+    return False
+
+
+def ideal_route_length(f, origin_cell, exit_cell, tail_metres):
+    """Shortest route as if the origin had been a vertex of the visibility graph.
+
+    This is the requirement, stated exactly: add the coordinate to the graph, connect it
+    to every vertex it can see, and take the shortest path out.  Anything the engine
+    produces above this is a defect.
+    """
+    obstacles = []
+    for ring in f.inner_rings:
+        cols = [f.nodes[n][1] for n in ring]
+        rows = [f.nodes[n][2] for n in ring]
+        obstacles.append(
+            grid_xy(min(cols), min(rows)) + grid_xy(max(cols), max(rows))
+        )
+
+    vertices = {"origin": grid_xy(*origin_cell)}
+    for ring in [f.outer_ring] + f.inner_rings:
+        for n in ring:
+            vertices[n] = grid_xy(f.nodes[n][1], f.nodes[n][2])
+    exit_key = [n for n in f.outer_ring if (f.nodes[n][1], f.nodes[n][2]) == exit_cell][0]
+
+    names = list(vertices)
+    best = {name: math.inf for name in names}
+    best["origin"] = 0.0
+    unvisited = set(names)
+    while unvisited:
+        here = min(unvisited, key=lambda n: best[n])
+        if best[here] == math.inf:
+            break
+        unvisited.remove(here)
+        for other in unvisited:
+            p, q = vertices[here], vertices[other]
+            if segment_blocked(p, q, obstacles):
+                continue
+            step = math.hypot(p[0] - q[0], p[1] - q[1])
+            best[other] = min(best[other], best[here] + step)
+    return best[exit_key] + tail_metres
+
+
+# ------------------------------------------------------------------- reporting
+
+
+def percentile(values, fraction):
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    return ordered[min(len(ordered) - 1, int(math.ceil(fraction * len(ordered)) - 1))]
+
+
+def report(f, meshed, distances, detours, unsnapped):
+    print(f"  {f.label}   ({meshed} meshed ways)")
+    print(f"    interior points  {len(distances) + unsnapped} sampled, {len(distances)} snapped")
+    if unsnapped:
+        print(f"    NO ROUTE         {unsnapped}   <-- not a snapping issue, investigate")
+    if distances:
+        print(
+            f"    requested->snapped  min {min(distances):.1f}  "
+            f"median {statistics.median(distances):.1f}  "
+            f"p95 {percentile(distances, 0.95):.1f}  "
+            f"max {max(distances):.1f}  (metres)"
+        )
+        print(
+            f"    above a-priori   min {min(detours):.1f}  "
+            f"median {statistics.median(detours):.1f}  "
+            f"p95 {percentile(detours, 0.95):.1f}  "
+            f"max {max(detours):.1f}  (metres)"
+        )
+    return (max(distances) if distances else 0.0, max(detours) if detours else 0.0)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--profile", default="profiles/foot_area.lua")
+    parser.add_argument(
+        "--entry-point-mesh",
+        action="store_true",
+        help="emit only the shortest paths between an area's entry points instead of "
+        "its whole visibility graph.  The pruned mesh leaves obstacle corners with no "
+        "edges, so a coordinate inside such an area cannot set off towards them; use "
+        "this to measure what that costs",
+    )
+    parser.add_argument("--port", type=int, default=5199)
+    parser.add_argument("--keep", action="store_true", help="keep the generated datasets")
+    parser.add_argument(
+        "--svg",
+        metavar="DIR",
+        nargs="?",
+        const="plans/area-snapping",
+        help="write pictures of the routes; each run gets its own timestamped "
+        "subdirectory, so the newest iteration is the last one listed and the "
+        "directory as a whole is a log of the feature taking shape "
+        "(default: plans/area-snapping)",
+    )
+    args = parser.parse_args()
+
+    fixtures = [
+        plaza(8, 4),
+        plaza(16, 8),
+        plaza(16, 8, extra_entries=True),
+        # a single block in the middle: the classic fountain or monument
+        plaza(16, 8, obstacles=[(8, 3, 4, 2)], variant="centre obstacle"),
+        # off-centre, so that whole corners of the plaza are hidden from each other
+        plaza(16, 8, obstacles=[(5, 1, 6, 5)], variant="offset obstacle"),
+        # two blocks with a gap: the only sight lines run through the gap
+        plaza(16, 8, obstacles=[(6, 1, 3, 6), (12, 1, 3, 6)], variant="two obstacles"),
+        # the pathological case -- see the docstring
+        two_entrances_at_the_bottom(),
+    ]
+
+    stamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    workdir = tempfile.mkdtemp(prefix="area-snap-")
+    worst = {}
+    try:
+        if args.svg:
+            args.svg = os.path.join(args.svg, stamp)
+            os.makedirs(args.svg, exist_ok=True)
+            print(f"writing pictures to {args.svg}\n")
+        for f in fixtures:
+            dataset, meshed = prepare(
+                args.build_dir, args.profile, workdir, f, args.entry_point_mesh
+            )
+            proc = serve(args.build_dir, dataset, args.port)
+            try:
+                destination = loc(*f.destination_cell)
+                # the straight run from the exit vertex out to the destination, which
+                # the oracle has to include because the route does
+                tail = metres(loc(*f.exit_cell), destination)
+                distances, detours, unsnapped = sweep(
+                    args.port, f, destination, f.exit_cell, tail
+                )
+                worst[f.label] = report(f, meshed, distances, detours, unsnapped)
+                if args.svg:
+                    for name, error in visual_proof(args.port, args.svg, f, stamp):
+                        if error is None:
+                            print(f"    {name:9s} NO ROUTE")
+                        else:
+                            print(f"    {name:9s} requested-to-snapped {error:5.1f} m")
+            finally:
+                proc.terminate()
+                proc.wait(timeout=10)
+    finally:
+        if args.keep:
+            print(f"\ndatasets kept in {workdir}")
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    print()
+    worst_snap = max((snap for snap, _ in worst.values()), default=0.0)
+    worst_detour = max((detour for _, detour in worst.values()), default=0.0)
+    # Inside an area the request is snapped to a *vertex* and the walk to it is a leg of
+    # the journey, not an error, so the snapping distance is reported for information
+    # only.  The excess over the a-priori optimum is what says whether it works.
+    print(f"walk from request to the vertex it set off from: up to {worst_snap:.1f} m")
+    print(f"worst excess over the a-priori route: {worst_detour:.1f} m   <- the metric that matters")
+    if worst_detour <= 1.0:
+        print("\nopen-area snapping is working: every route is the one the visibility "
+              "graph would have given if the coordinate had been part of it")
+    else:
+        print("\nnot there yet -- some routes leave the area by a worse vertex than the "
+              "a-priori optimum")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/engine/area_snapping.cpp
+++ b/src/engine/area_snapping.cpp
@@ -1,0 +1,252 @@
+#include "engine/area_snapping.hpp"
+
+#include "engine/area_visibility.hpp"
+
+#include "util/coordinate_calculation.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace osrm::engine::area
+{
+
+namespace
+{
+
+/**
+ * A vertex is a graph node only if the mesher gave it an edge.  Rather than store which
+ * ones did, we ask: the phantom found at a vertex sits on the vertex itself exactly when
+ * the vertex is an endpoint of some way.  Anything further away is a different place.
+ */
+constexpr double SAME_PLACE_METRES = 0.5;
+
+/** Nothing is visible from further than this, so do not look. */
+constexpr double VERTEX_LOOKUP_RADIUS_METRES = 1.0;
+
+/**
+ * How many phantoms to ask for at a vertex.  Several ways meet at a plaza vertex and we
+ * want the ones that *leave* it, so one is not enough.
+ */
+constexpr std::size_t VERTEX_LOOKUP_RESULTS = 8;
+
+struct ProjectedRings
+{
+    std::vector<std::vector<Point>> storage;
+    std::vector<Ring> views;
+};
+
+ProjectedRings project_rings(const std::vector<std::span<const util::Coordinate>> &rings)
+{
+    ProjectedRings projected;
+    projected.storage.reserve(rings.size());
+    for (const auto &ring : rings)
+    {
+        std::vector<Point> points;
+        points.reserve(ring.size());
+        for (const auto coordinate : ring)
+        {
+            points.push_back(project(coordinate));
+        }
+        projected.storage.push_back(std::move(points));
+    }
+    // only now that storage has stopped growing, so the spans stay valid
+    projected.views.reserve(projected.storage.size());
+    for (const auto &points : projected.storage)
+    {
+        projected.views.emplace_back(points);
+    }
+    return projected;
+}
+
+/** The flat vertex index addresses the rings in order, so walk them to find it. */
+util::Coordinate vertex_at(const std::vector<std::span<const util::Coordinate>> &rings,
+                           std::size_t index)
+{
+    for (const auto &ring : rings)
+    {
+        if (index < ring.size())
+        {
+            return ring[index];
+        }
+        index -= ring.size();
+    }
+    return util::Coordinate{};
+}
+
+/**
+ * Turn a phantom found at a vertex into a candidate that only ever leaves that vertex, or
+ * only ever arrives at it, in one direction, with the straight line from the request
+ * charged to it.
+ *
+ * Restricting it to one direction is what makes the candidate identifiable.  OSRM matches
+ * a finished path back to the candidate it started from by segment id
+ * (`endpointsFromCandidates`), and considers both of a phantom's ids; the two ends of one
+ * meshed way carry the same pair, so two visible vertices would be indistinguishable.
+ * With the unused direction disabled, every candidate has exactly one live id, and no two
+ * candidates share it -- an edge-based node has only one start and only one end.  The id
+ * itself stays put: the API reads `forward_segment_id.id` unconditionally to name a
+ * waypoint.
+ *
+ * The cost of the walk goes into that direction's weight offset.
+ * `GetForwardWeightPlusOffset()` is the cost from the start of the edge-based node to the
+ * phantom, and the search seeds a source with its negation but a target with the value
+ * itself -- so the same walk has to be subtracted in one case and added in the other,
+ * which is what @p role decides.  The result accounting never reads the offsets;
+ * `assembleLeg` works from `forward_weight` and the per-segment values.  So this charges
+ * the search and nothing else.  The types are signed, and a departure going below zero is
+ * exactly what is meant: the journey begins before the graph does.
+ */
+PhantomNode at_vertex(PhantomNode phantom,
+                      const bool forward,
+                      const util::Coordinate from,
+                      const util::Coordinate vertex,
+                      const double walking_speed,
+                      const double weight_multiplier,
+                      const ApproachRole role)
+{
+    const auto metres = util::coordinate_calculation::greatCircleDistance(from, vertex);
+    const auto seconds = metres / walking_speed;
+
+    // durations are stored in deci-seconds, weights in the profile's own unit.
+    // A via point is charged nothing: see ApproachRole.
+    const auto sign = role == ApproachRole::Via ? 0 : (role == ApproachRole::Departure ? -1 : 1);
+    const auto duration = to_alias<EdgeDuration>(sign * std::lround(seconds * 10.));
+    const auto weight = to_alias<EdgeWeight>(sign * std::lround(seconds * weight_multiplier));
+
+    if (forward)
+    {
+        phantom.forward_weight_offset = phantom.forward_weight_offset + weight;
+        phantom.forward_duration_offset = phantom.forward_duration_offset + duration;
+        phantom.reverse_segment_id.enabled = false;
+    }
+    else
+    {
+        phantom.reverse_weight_offset = phantom.reverse_weight_offset + weight;
+        phantom.reverse_duration_offset = phantom.reverse_duration_offset + duration;
+        phantom.forward_segment_id.enabled = false;
+    }
+
+    // where the traveller actually asked to be
+    phantom.input_location = from;
+    return phantom;
+}
+
+} // namespace
+
+std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDataFacade &facade,
+                                                        const util::Coordinate coordinate,
+                                                        const Approach approach,
+                                                        const ApproachRole role)
+{
+    auto areas = facade.GetOpenAreasAt(coordinate);
+    if (areas.empty())
+    {
+        return std::nullopt;
+    }
+
+    // the r-tree hands them back in packing order, which is not a property of the input
+    std::sort(areas.begin(),
+              areas.end(),
+              [](const auto &lhs, const auto &rhs)
+              { return lhs.vertices_offset < rhs.vertices_offset; });
+
+    const auto point = project(coordinate);
+    const auto weight_multiplier = facade.GetWeightMultiplier();
+
+    for (const auto &area : areas)
+    {
+        const auto rings = facade.GetOpenAreaRings(area);
+        if (rings.empty())
+        {
+            continue;
+        }
+
+        const auto projected = project_rings(rings);
+        if (!inside_area(point, projected.views))
+        {
+            // the bounding box is not the area
+            continue;
+        }
+
+        PhantomNodeCandidates candidates;
+        std::vector<NodeID> claimed_nodes;
+        const auto claim = [&claimed_nodes](const NodeID node)
+        {
+            if (std::find(claimed_nodes.begin(), claimed_nodes.end(), node) != claimed_nodes.end())
+                return false;
+            claimed_nodes.push_back(node);
+            return true;
+        };
+
+        for (const auto index : visible_vertices(point, projected.views))
+        {
+            const auto vertex = vertex_at(rings, index);
+            for (const auto &found : facade.NearestPhantomNodes(vertex,
+                                                                VERTEX_LOOKUP_RESULTS,
+                                                                VERTEX_LOOKUP_RADIUS_METRES,
+                                                                std::nullopt,
+                                                                approach))
+            {
+                const auto &phantom = found.phantom_node;
+                if (util::coordinate_calculation::greatCircleDistance(phantom.location, vertex) >
+                    SAME_PLACE_METRES)
+                {
+                    // the mesher gave this vertex no edge, so it is not a place to set
+                    // off from
+                    continue;
+                }
+
+                // A direction a traveller departs by has to begin at the vertex, so that
+                // travelling it leaves the vertex; standing at the far end of a way is
+                // not a way of leaving by it.  A direction they arrive by has to end
+                // there, since the journey stops on reaching the vertex.  One phantom
+                // answers both, because sitting at a segment's first node means carrying
+                // a weight of zero forwards and the whole of the segment in reverse.
+                //
+                // A via point takes the departure convention.  It is both ends at once
+                // and something has to give; see ApproachRole.
+                const bool arriving = role == ApproachRole::Arrival;
+                const auto forward_usable =
+                    arriving ? phantom.IsValidForwardTarget() : phantom.IsValidForwardSource();
+                const auto reverse_usable =
+                    arriving ? phantom.IsValidReverseTarget() : phantom.IsValidReverseSource();
+                const auto forward_at_the_vertex =
+                    (arriving ? phantom.reverse_weight : phantom.forward_weight) == EdgeWeight{0};
+                const auto reverse_at_the_vertex =
+                    (arriving ? phantom.forward_weight : phantom.reverse_weight) == EdgeWeight{0};
+
+                if (forward_usable && forward_at_the_vertex && claim(phantom.forward_segment_id.id))
+                {
+                    candidates.push_back(at_vertex(phantom,
+                                                   true,
+                                                   coordinate,
+                                                   vertex,
+                                                   area.walking_speed,
+                                                   weight_multiplier,
+                                                   role));
+                }
+                if (reverse_usable && reverse_at_the_vertex && claim(phantom.reverse_segment_id.id))
+                {
+                    candidates.push_back(at_vertex(phantom,
+                                                   false,
+                                                   coordinate,
+                                                   vertex,
+                                                   area.walking_speed,
+                                                   weight_multiplier,
+                                                   role));
+                }
+            }
+        }
+
+        if (candidates.empty())
+        {
+            return std::nullopt;
+        }
+        return candidates;
+    }
+
+    return std::nullopt;
+}
+
+} // namespace osrm::engine::area

--- a/src/engine/area_visibility.cpp
+++ b/src/engine/area_visibility.cpp
@@ -1,0 +1,84 @@
+#include "engine/area_visibility.hpp"
+
+#include "extractor/area/util.hpp"
+
+namespace osrm::engine::area
+{
+
+namespace
+{
+/** Call `function` for every edge of the ring, closing it. */
+template <typename Fun> void for_each_edge(Ring ring, Fun function)
+{
+    for (std::size_t i = 0; i < ring.size(); ++i)
+        function(ring[i], ring[(i + 1) % ring.size()]);
+}
+} // namespace
+
+bool crosses_ring(const Point &from, const Point &to, Ring ring)
+{
+    bool crosses = false;
+    for_each_edge(ring,
+                  [&](const Point &a, const Point &b)
+                  {
+                      // an edge sharing an endpoint with from..to meets it only there,
+                      // and cannot obstruct it -- the same reasoning as in the sweep
+                      const auto same = [](const Point &p, const Point &q)
+                      { return p.x == q.x && p.y == q.y; };
+                      if (same(a, from) || same(a, to) || same(b, from) || same(b, to))
+                          return;
+                      if (extractor::area::intersect(&from, &to, &a, &b))
+                          crosses = true;
+                  });
+    return crosses;
+}
+
+bool inside_ring(const Point &point, Ring ring)
+{
+    // ray casting: count the edges crossed by a ray going in +x from the point
+    bool inside = false;
+    for_each_edge(ring,
+                  [&](const Point &a, const Point &b)
+                  {
+                      if ((a.y > point.y) != (b.y > point.y) &&
+                          point.x < (b.x - a.x) * (point.y - a.y) / (b.y - a.y) + a.x)
+                          inside = !inside;
+                  });
+    return inside;
+}
+
+bool inside_area(const Point &point, std::span<const Ring> rings)
+{
+    if (rings.empty() || !inside_ring(point, rings.front()))
+        return false;
+    for (std::size_t i = 1; i < rings.size(); ++i)
+        if (inside_ring(point, rings[i]))
+            return false;
+    return true;
+}
+
+std::vector<std::size_t> visible_vertices(const Point &point, std::span<const Ring> rings)
+{
+    std::vector<std::size_t> visible;
+    std::size_t index = 0;
+    for (const Ring &ring : rings)
+    {
+        for (const Point &vertex : ring)
+        {
+            const Point midpoint{(point.x + vertex.x) / 2, (point.y + vertex.y) / 2};
+            bool blocked = !inside_area(midpoint, rings);
+            for (const Ring &other : rings)
+            {
+                if (blocked)
+                    break;
+                blocked = crosses_ring(point, vertex, other);
+            }
+            if (!blocked)
+                visible.push_back(index);
+            ++index;
+        }
+    }
+    return visible;
+}
+
+} // namespace osrm::engine::area

--- a/src/engine/datafacade/mmap_memory_allocator.cpp
+++ b/src/engine/datafacade/mmap_memory_allocator.cpp
@@ -32,6 +32,20 @@ MMapMemoryAllocator::MMapMemoryAllocator(const storage::StorageConfig &config)
         allocated_regions.push_back({rtree_filename.data(), std::move(fake_layout)});
     }
 
+    {
+        // and the same trick again for the open areas' own r-tree.  It has to be a region
+        // of its own: each of these layouts puts its single block at offset zero, so two
+        // blocks in one layout would send the second one off the end of the first string.
+        std::unique_ptr<storage::BaseDataLayout> fake_layout =
+            std::make_unique<storage::TarDataLayout>();
+
+        open_area_rtree_filename = storage.PopulateLayoutWithOpenAreaRTree(*fake_layout);
+        if (!open_area_rtree_filename.empty())
+        {
+            allocated_regions.push_back({open_area_rtree_filename.data(), std::move(fake_layout)});
+        }
+    }
+
     auto files = storage.GetStaticFiles();
     auto updatable_files = storage.GetUpdatableFiles();
     files.insert(files.end(), updatable_files.begin(), updatable_files.end());

--- a/src/engine/datafacade/process_memory_allocator.cpp
+++ b/src/engine/datafacade/process_memory_allocator.cpp
@@ -14,6 +14,7 @@ ProcessMemoryAllocator::ProcessMemoryAllocator(const storage::StorageConfig &con
     std::unique_ptr<storage::BaseDataLayout> layout =
         std::make_unique<storage::ContiguousDataLayout>();
     storage.PopulateLayoutWithRTree(*layout);
+    storage.PopulateLayoutWithOpenAreaRTree(*layout);
     storage.PopulateLayout(*layout, static_files);
     storage.PopulateLayout(*layout, updatable_files);
 

--- a/src/engine/routing_algorithms/routing_base.cpp
+++ b/src/engine/routing_algorithms/routing_base.cpp
@@ -90,22 +90,34 @@ std::vector<NodeID> getBackwardForceNodes(const PhantomCandidatesToTarget &endpo
 PhantomEndpoints endpointsFromCandidates(const PhantomEndpointCandidates &candidates,
                                          const std::vector<NodeID> &path)
 {
-    auto source_it = std::find_if(candidates.source_phantoms.begin(),
-                                  candidates.source_phantoms.end(),
-                                  [&path](const auto &source_phantom)
-                                  {
-                                      return path.front() == source_phantom.forward_segment_id.id ||
-                                             path.front() == source_phantom.reverse_segment_id.id;
-                                  });
+    auto source_it =
+        std::find_if(candidates.source_phantoms.begin(),
+                     candidates.source_phantoms.end(),
+                     [&path](const auto &source_phantom)
+                     {
+                         // A disabled direction is not a direction the search
+                         // could have set off in, so its id says nothing about
+                         // which candidate this path came from.  Area snapping
+                         // relies on that: it offers one candidate per way
+                         // leaving a vertex, and the two ends of one way carry
+                         // the same pair of ids.
+                         return (source_phantom.forward_segment_id.enabled &&
+                                 path.front() == source_phantom.forward_segment_id.id) ||
+                                (source_phantom.reverse_segment_id.enabled &&
+                                 path.front() == source_phantom.reverse_segment_id.id);
+                     });
     BOOST_ASSERT(source_it != candidates.source_phantoms.end());
 
-    auto target_it = std::find_if(candidates.target_phantoms.begin(),
-                                  candidates.target_phantoms.end(),
-                                  [&path](const auto &target_phantom)
-                                  {
-                                      return path.back() == target_phantom.forward_segment_id.id ||
-                                             path.back() == target_phantom.reverse_segment_id.id;
-                                  });
+    auto target_it =
+        std::find_if(candidates.target_phantoms.begin(),
+                     candidates.target_phantoms.end(),
+                     [&path](const auto &target_phantom)
+                     {
+                         return (target_phantom.forward_segment_id.enabled &&
+                                 path.back() == target_phantom.forward_segment_id.id) ||
+                                (target_phantom.reverse_segment_id.enabled &&
+                                 path.back() == target_phantom.reverse_segment_id.id);
+                     });
     BOOST_ASSERT(target_it != candidates.target_phantoms.end());
 
     return PhantomEndpoints{*source_it, *target_it};

--- a/src/extractor/area/area_data_collector.cpp
+++ b/src/extractor/area/area_data_collector.cpp
@@ -1,0 +1,43 @@
+#include "extractor/area/area_data_collector.hpp"
+
+#include <algorithm>
+#include <iterator>
+#include <tuple>
+
+namespace osrm::extractor::area
+{
+
+void AreaDataCollector::record(const OsmiumPolygon &poly, double walking_speed)
+{
+    PolygonRecord record;
+    record.boundary_vertices.assign(poly.outer().begin(), poly.outer().end());
+    record.obstacle_rings.reserve(poly.inners().size());
+    for (const auto &inner : poly.inners())
+        record.obstacle_rings.emplace_back(inner.begin(), inner.end());
+    record.walking_speed = walking_speed;
+
+    tbb::mutex::scoped_lock lock(m_mutex);
+    m_polygons.push_back(std::move(record));
+}
+
+void AreaDataCollector::finalize()
+{
+    // Order by the node ids of the outer ring.  The ring is a rotation-stable list of
+    // ids for a given area, so this is a property of the input rather than of the run.
+    const auto key = [](const PolygonRecord &r)
+    {
+        std::vector<osmium::object_id_type> ids;
+        ids.reserve(r.boundary_vertices.size());
+        std::transform(r.boundary_vertices.begin(),
+                       r.boundary_vertices.end(),
+                       std::back_inserter(ids),
+                       [](const osmium::NodeRef &n) { return n.ref(); });
+        return ids;
+    };
+
+    std::sort(m_polygons.begin(),
+              m_polygons.end(),
+              [&key](const PolygonRecord &a, const PolygonRecord &b) { return key(a) < key(b); });
+}
+
+} // namespace osrm::extractor::area

--- a/src/extractor/area/area_mesher.cpp
+++ b/src/extractor/area/area_mesher.cpp
@@ -66,6 +66,27 @@ std::string area_id(const osmium::Area &area)
     return strstream.str();
 }
 
+/**
+ * @brief Add every edge of every ring -- the outer boundary and each obstacle.
+ *
+ * The rotational sweep never reports a vertex's own ring neighbours as visible, so the
+ * visibility graph contains no ring edges at all and they have to be put back.  Without
+ * them the boundary is a dead zone: you cannot walk along the edge of a plaza or round a
+ * fountain, and a coordinate wedged into a corner has nowhere to set off for.  One edge
+ * per vertex is nothing beside the graph they complete, so both meshing modes get them.
+ */
+std::set<OsmiumSegment> with_ring_edges(std::set<OsmiumSegment> segments, const OsmiumPolygon &poly)
+{
+    for_each_ring(poly,
+                  [&](auto &ring)
+                  {
+                      for_each_pair_in_ring(ring,
+                                            [&](const osmium::NodeRef &u, const osmium::NodeRef &v)
+                                            { segments.emplace(OsmiumSegment(u, v)); });
+                  });
+    return segments;
+}
+
 } // namespace
 
 /**
@@ -202,7 +223,11 @@ NodeRefSet AreaMesher::get_entry_points(const OsmiumPolygon &poly)
         last_ways = current_ways;
         all_ways.insert(current_ways.begin(), current_ways.end());
     }
-    if (entry_nodes.size() >= 2 and all_ways.size() >= 3)
+    // Two incident ways is the smallest arrangement worth meshing: one way in, one way
+    // out, and a crossing that is not otherwise possible.  Requiring three would drop the
+    // plaza with a pair of entrances on the same side -- a common shape, and one where
+    // the mesh is the only graph the area has.
+    if (entry_nodes.size() >= 2 and all_ways.size() >= 2)
         return entry_nodes;
     return NodeRefSet{};
 }
@@ -347,6 +372,11 @@ void AreaMesher::mesh_area(const osmium::Area &area,
             continue;
         }
 
+        // Hand the engine what it needs to snap a coordinate lying inside this area
+        // onto one of its entry points later.  This is the only point in the pipeline
+        // where the polygon and its entry points are both known.
+        m_collector.record(poly, area_walking_speed);
+
         // The vertices that should be in the visibility map.
         NodeRefSet work_vertices = get_obstacle_vertices(poly);
 
@@ -381,8 +411,13 @@ void AreaMesher::mesh_area(const osmium::Area &area,
         write_debug("osrm-area-routing-visgraph-debug", vis_map);
 #endif
 
-        // std::set<OsmiumSegment> segments = run_dijkstra(OsmiumPolygon(), vis_map, entry_points);
-        std::set<OsmiumSegment> segments = run_dijkstra(poly, vis_map, entry_points);
+        // The modes differ only in how much of the visibility graph survives -- all of
+        // it, or just the edges on a shortest path between two entry points.  Both then
+        // get the ring edges, which the sweep never reports and which nothing works
+        // without.
+        std::set<OsmiumSegment> segments =
+            emit_visibility_graph ? vis_map : run_dijkstra(poly, vis_map, entry_points);
+        segments = with_ring_edges(std::move(segments), poly);
         util::Log(logDEBUG) << "  After running Dijkstra there are " << segments.size()
                             << " edges left.";
         add_to_buffer(segments, out_buffer);

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -653,6 +653,9 @@ Extractor::ParsedOSMData Extractor::ParseOSMData(ScriptingEnvironment &scripting
         // in a big buffer.
 
         area::AreaMesher mesher;
+        const auto &area_properties = scripting_environment.GetProfileProperties();
+        mesher.area_walking_speed = area_properties.area_walking_speed;
+        mesher.emit_visibility_graph = area_properties.area_emit_visibility_graph;
         mesher.init(area_manager, extraction_containers);
 
         tbb::filter<OsmiumBuffer, OsmiumBuffer> mesh_areas_filter(
@@ -671,6 +674,10 @@ Extractor::ParsedOSMData Extractor::ParseOSMData(ScriptingEnvironment &scripting
                                process_elements_filter & extractor_callbacks_filter;
         tbb::parallel_pipeline(num_threads, pipeline2);
         TIMER_STOP(mesh);
+
+        // The pipeline filter is parallel, so the areas arrived in scheduler order.
+        mesher.collector().finalize();
+        WriteOpenAreas(mesher.collector().polygons());
 
         util::Log() << "... " << area_manager.number_of_ways + area_manager.number_of_relations
                     << " areas, yielding " << mesher.added_ways << " ways in " << TIMER_SEC(mesh)
@@ -855,6 +862,100 @@ EdgeID Extractor::BuildEdgeExpandedGraph(
     connectivity_checksum = edge_based_graph_factory.GetConnectivityChecksum();
 
     return number_of_edge_based_nodes;
+}
+
+/**
+    \brief Writing the polygons of the meshed areas, and an r-tree to find them by.
+
+    Saves the polygons into '.openareas' and the tree into '.openareas.ramIndex' /
+    '.openareas.fileIndex'.
+
+    The tree gets a coordinate list of its own, holding two opposite corners of each
+    area's bounding box and nothing else.  util::StaticRTree reads every object's extent
+    through the coordinates its @c u and @c v index, so it needs such a list; giving it
+    the engine's own coordinates instead would mean appending corners to a vector whose
+    indices are NodeIDs running parallel to the OSM node ids.
+ */
+void Extractor::WriteOpenAreas(const std::vector<area::PolygonRecord> &polygons)
+{
+    if (polygons.empty())
+    {
+        return;
+    }
+
+    std::vector<AreaPolygonSegment> areas;
+    std::vector<util::Coordinate> bbox_corners;
+    std::vector<util::Coordinate> vertices;
+    std::vector<std::uint32_t> ring_lengths;
+
+    areas.reserve(polygons.size());
+    bbox_corners.reserve(2 * polygons.size());
+
+    const auto to_coordinate = [](const osmium::NodeRef &node)
+    {
+        return util::Coordinate{util::FloatLongitude{node.location().lon()},
+                                util::FloatLatitude{node.location().lat()}};
+    };
+
+    const auto append_ring = [&](const std::vector<osmium::NodeRef> &ring)
+    {
+        for (const auto &node : ring)
+        {
+            vertices.push_back(to_coordinate(node));
+        }
+        ring_lengths.push_back(boost::numeric_cast<std::uint32_t>(ring.size()));
+    };
+
+    for (const auto &polygon : polygons)
+    {
+        AreaPolygonSegment area;
+        area.vertices_offset = boost::numeric_cast<std::uint32_t>(vertices.size());
+        area.rings_offset = boost::numeric_cast<std::uint32_t>(ring_lengths.size());
+        area.walking_speed = polygon.walking_speed;
+
+        // the outer ring first, then the obstacles: the engine tells them apart by
+        // position alone
+        append_ring(polygon.boundary_vertices);
+        for (const auto &obstacle : polygon.obstacle_rings)
+        {
+            append_ring(obstacle);
+        }
+
+        area.num_vertices =
+            boost::numeric_cast<std::uint32_t>(vertices.size()) - area.vertices_offset;
+        area.num_rings =
+            boost::numeric_cast<std::uint32_t>(ring_lengths.size()) - area.rings_offset;
+
+        // the obstacles lie inside the outer ring, so it alone bounds the area
+        util::Coordinate south_west = vertices[area.vertices_offset];
+        util::Coordinate north_east = south_west;
+        for (std::uint32_t i = 0; i < polygon.boundary_vertices.size(); ++i)
+        {
+            const auto &vertex = vertices[area.vertices_offset + i];
+            south_west.lon = std::min(south_west.lon, vertex.lon);
+            south_west.lat = std::min(south_west.lat, vertex.lat);
+            north_east.lon = std::max(north_east.lon, vertex.lon);
+            north_east.lat = std::max(north_east.lat, vertex.lat);
+        }
+        area.u = boost::numeric_cast<NodeID>(bbox_corners.size());
+        bbox_corners.push_back(south_west);
+        area.v = boost::numeric_cast<NodeID>(bbox_corners.size());
+        bbox_corners.push_back(north_east);
+
+        areas.push_back(area);
+    }
+
+    files::writeOpenAreas(
+        config.GetPath(".osrm.openareas"), areas, bbox_corners, vertices, ring_lengths);
+
+    util::StaticRTree<AreaPolygonSegment> rtree(
+        areas, bbox_corners, config.GetPath(".osrm.openareas.fileIndex"));
+    // a name of its own, so that loading both trees into one layout does not collide
+    files::writeRamIndex(
+        config.GetPath(".osrm.openareas.ramIndex"), rtree, "/common/open_areas/rtree");
+
+    util::Log() << "... wrote " << areas.size() << " areas with " << vertices.size()
+                << " vertices for snapping";
 }
 
 /**

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -231,6 +231,10 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         &ProfileProperties::left_hand_driving,
         "weight_precision",
         &ProfileProperties::weight_precision,
+        "area_walking_speed",
+        &ProfileProperties::area_walking_speed,
+        "area_emit_visibility_graph",
+        &ProfileProperties::area_emit_visibility_graph,
         "weight_name",
         sol::property(&ProfileProperties::GetWeightName, &ProfileProperties::SetWeightName),
         "max_turn_weight",
@@ -774,6 +778,15 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
             sol::optional<bool> force_split_edges = properties["force_split_edges"];
             if (force_split_edges != sol::nullopt)
                 context.properties.force_split_edges = force_split_edges.value();
+
+            sol::optional<double> area_walking_speed = properties["area_walking_speed"];
+            if (area_walking_speed != sol::nullopt)
+                context.properties.area_walking_speed = area_walking_speed.value();
+
+            sol::optional<bool> area_emit_visibility_graph =
+                properties["area_emit_visibility_graph"];
+            if (area_emit_visibility_graph != sol::nullopt)
+                context.properties.area_emit_visibility_graph = area_emit_visibility_graph.value();
         }
     };
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -259,6 +259,7 @@ int Storage::Run(int max_wait, const std::string &dataset_name, bool only_metric
         std::unique_ptr<storage::BaseDataLayout> static_layout =
             std::make_unique<storage::ContiguousDataLayout>();
         Storage::PopulateLayoutWithRTree(*static_layout);
+        Storage::PopulateLayoutWithOpenAreaRTree(*static_layout);
         std::vector<std::pair<bool, std::filesystem::path>> files = Storage::GetStaticFiles();
         Storage::PopulateLayout(*static_layout, files);
         auto static_handle = setupRegion(shared_register, *static_layout);
@@ -295,6 +296,9 @@ std::vector<std::pair<bool, std::filesystem::path>> Storage::GetStaticFiles()
     std::vector<std::pair<bool, std::filesystem::path>> files = {
         {IS_OPTIONAL, config.GetPath(".osrm.cells")},
         {IS_OPTIONAL, config.GetPath(".osrm.partition")},
+        // only present when the profile meshed pedestrian areas
+        {IS_OPTIONAL, config.GetPath(".osrm.openareas")},
+        {IS_OPTIONAL, config.GetPath(".osrm.openareas.ramIndex")},
         {IS_REQUIRED, config.GetPath(".osrm.ebg_nodes")},
         {IS_REQUIRED, config.GetPath(".osrm.maneuver_overrides")},
         {IS_REQUIRED, config.GetPath(".osrm.nbg_nodes")},
@@ -363,6 +367,28 @@ std::string Storage::PopulateLayoutWithRTree(storage::BaseDataLayout &layout)
 }
 
 /**
+ * The same again for the r-tree over the meshed open areas, which has a leaf file of its
+ * own.  Deliberately a separate function rather than another block in the one above:
+ * MMapMemoryAllocator registers the returned string as an entire memory region with the
+ * block at offset zero, so a layout holding two of these needs two regions and two
+ * strings to point them at.
+ *
+ * @return the leaf file's path, or an empty string when the dataset has no meshed areas.
+ */
+std::string Storage::PopulateLayoutWithOpenAreaRTree(storage::BaseDataLayout &layout)
+{
+    if (!std::filesystem::exists(config.GetPath(".osrm.openareas.fileIndex")))
+    {
+        return {};
+    }
+
+    auto filename = std::filesystem::absolute(config.GetPath(".osrm.openareas.fileIndex")).string();
+    layout.SetBlock("/common/open_areas/rtree/file_index_path",
+                    make_block<char>(filename.length() + 1));
+    return filename;
+}
+
+/**
  * This function examines all our data files and figures out how much
  * memory needs to be allocated, and the position of each data structure
  * in that big block.  It updates the fields in the layout parameter.
@@ -396,6 +422,17 @@ void Storage::PopulateStaticData(const SharedDataIndex &index)
                          "/common/rtree/file_index_path")) >= absolute_file_index_path.size());
         std::copy(
             absolute_file_index_path.begin(), absolute_file_index_path.end(), file_index_path_ptr);
+    }
+
+    // and the same for the area r-tree's leaf file, when there is one
+    if (std::filesystem::exists(config.GetPath(".osrm.openareas.fileIndex")))
+    {
+        const auto path_ptr = index.GetBlockPtr<char>("/common/open_areas/rtree/file_index_path");
+        std::fill(
+            path_ptr, path_ptr + index.GetBlockSize("/common/open_areas/rtree/file_index_path"), 0);
+        const auto absolute_path =
+            std::filesystem::absolute(config.GetPath(".osrm.openareas.fileIndex")).string();
+        std::copy(absolute_path.begin(), absolute_path.end(), path_ptr);
     }
 
     // Timestamp mark
@@ -470,6 +507,22 @@ void Storage::PopulateStaticData(const SharedDataIndex &index)
     {
         auto rtree = make_search_tree_view(index, "/common/rtree");
         extractor::files::readRamIndex(config.GetPath(".osrm.ramIndex"), rtree);
+    }
+
+    // the meshed open areas, and the r-tree that finds them.  Only present when the
+    // profile meshed any, so everything downstream has to cope with their absence.
+    if (std::filesystem::exists(config.GetPath(".osrm.openareas")))
+    {
+        auto views = make_open_areas_view(index, "/common/open_areas");
+        extractor::files::readOpenAreas(config.GetPath(".osrm.openareas"),
+                                        std::get<0>(views),
+                                        std::get<1>(views),
+                                        std::get<2>(views),
+                                        std::get<3>(views));
+
+        auto rtree = make_open_area_tree_view(index, "/common/open_areas/rtree");
+        extractor::files::readRamIndex(
+            config.GetPath(".osrm.openareas.ramIndex"), rtree, "/common/open_areas/rtree");
     }
 
     // FIXME we only need to get the weight name

--- a/unit_tests/engine/area_visibility.cpp
+++ b/unit_tests/engine/area_visibility.cpp
@@ -1,0 +1,105 @@
+#include "engine/area_visibility.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <span>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(area_visibility_test)
+
+using namespace osrm;
+using namespace osrm::engine::area;
+
+namespace
+{
+
+/** A 10x10 square with an optional 4x4 block in the middle. */
+struct Fixture
+{
+    std::vector<Point> outer{{0, 0}, {10, 0}, {10, 10}, {0, 10}};
+    std::vector<Point> obstacle{{3, 3}, {7, 3}, {7, 7}, {3, 7}};
+    std::vector<Ring> rings;
+
+    explicit Fixture(bool with_obstacle)
+    {
+        rings.emplace_back(outer);
+        if (with_obstacle)
+            rings.emplace_back(obstacle);
+    }
+};
+
+bool sees(const Fixture &f, Point from, std::size_t vertex)
+{
+    const auto visible = visible_vertices(from, f.rings);
+    return std::find(visible.begin(), visible.end(), vertex) != visible.end();
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(area_visibility_inside_and_outside)
+{
+    Fixture f{true};
+
+    BOOST_CHECK(inside_area(Point{1, 1}, f.rings));
+    BOOST_CHECK(inside_area(Point{9, 9}, f.rings));
+    // outside the outer ring
+    BOOST_CHECK(!inside_area(Point{-1, 5}, f.rings));
+    BOOST_CHECK(!inside_area(Point{11, 5}, f.rings));
+    // inside the obstacle is not inside the area
+    BOOST_CHECK(!inside_area(Point{5, 5}, f.rings));
+}
+
+// With nothing in the way every corner is visible.
+BOOST_AUTO_TEST_CASE(area_visibility_open_square_sees_every_corner)
+{
+    Fixture f{false};
+    const auto visible = visible_vertices(Point{5, 5}, f.rings);
+
+    const std::vector<std::size_t> expected{0, 1, 2, 3};
+    BOOST_CHECK(visible == expected);
+}
+
+// The obstacle hides the corners on its far side, and only those.
+BOOST_AUTO_TEST_CASE(area_visibility_obstacle_hides_what_is_behind_it)
+{
+    Fixture f{true};
+    const Point from{1, 1}; // south-west, with the block to its north-east
+
+    // the two outer corners the block does not stand in front of
+    BOOST_CHECK(sees(f, from, 0)); // (0,0)
+    BOOST_CHECK(sees(f, from, 1)); // (10,0)
+    BOOST_CHECK(sees(f, from, 3)); // (0,10)
+    // the far outer corner is straight through the block
+    BOOST_CHECK(!sees(f, from, 2)); // (10,10)
+
+    // of the block's own corners, the near one and its two neighbours are visible,
+    // the far one is not
+    BOOST_CHECK(sees(f, from, 4));  // (3,3), the near corner
+    BOOST_CHECK(sees(f, from, 5));  // (7,3)
+    BOOST_CHECK(sees(f, from, 7));  // (3,7)
+    BOOST_CHECK(!sees(f, from, 6)); // (7,7), diagonally opposite
+}
+
+// The corners of the obstacle are exactly what makes going round the back possible, so
+// they must be reported even though they belong to a hole rather than the boundary.
+BOOST_AUTO_TEST_CASE(area_visibility_reports_obstacle_corners)
+{
+    Fixture f{true};
+    const auto visible = visible_vertices(Point{1, 5}, f.rings);
+
+    // indices 4..7 are the obstacle's corners
+    const bool any_obstacle_corner =
+        std::any_of(visible.begin(), visible.end(), [](std::size_t i) { return i >= 4; });
+    BOOST_CHECK(any_obstacle_corner);
+}
+
+// A vertex of the ring the segment ends on must not hide that vertex from itself.
+BOOST_AUTO_TEST_CASE(area_visibility_target_vertex_is_not_hidden_by_its_own_edges)
+{
+    Fixture f{true};
+    // sitting right next to a corner of the obstacle
+    BOOST_CHECK(sees(f, Point{2.5, 2.5}, 4)); // (3,3)
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/extractor/area/area_data_collector.cpp
+++ b/unit_tests/extractor/area/area_data_collector.cpp
@@ -1,0 +1,188 @@
+#include "extractor/area/area_data_collector.hpp"
+
+#include "extractor/area/typedefs.hpp"
+#include "extractor/area_routing_data.hpp"
+#include "extractor/profile_properties.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <osmium/osm/location.hpp>
+#include <osmium/osm/node_ref.hpp>
+
+#include <thread>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(area_data_collector_test)
+
+using namespace osrm;
+using namespace osrm::extractor;
+using namespace osrm::extractor::area;
+
+namespace
+{
+
+osmium::NodeRef node(osmium::object_id_type id, double col, double row)
+{ return osmium::NodeRef{id, osmium::Location{1.0 + col * 0.00045, 1.0 - row * 0.00045}}; }
+
+/** A square whose outer ring carries the given ids. */
+OsmiumPolygon square(const std::vector<osmium::object_id_type> &ring_ids)
+{
+    OsmiumPolygon poly;
+    const double cols[] = {0, 4, 4, 0};
+    const double rows[] = {4, 4, 0, 0};
+    poly.outer().reserve(ring_ids.size());
+    for (std::size_t i = 0; i < ring_ids.size(); ++i)
+        poly.outer().push_back(node(ring_ids[i], cols[i % 4], rows[i % 4]));
+    return poly;
+}
+
+std::vector<osmium::object_id_type> ring_ids(const PolygonRecord &record)
+{
+    std::vector<osmium::object_id_type> ids;
+    ids.reserve(record.boundary_vertices.size());
+    for (const auto &n : record.boundary_vertices)
+        ids.push_back(n.ref());
+    return ids;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(area_routing_data_layout_is_stable)
+{
+    // The on-disk layout depends on this, so a change must be deliberate.
+    BOOST_CHECK_EQUAL(sizeof(AreaPolygonSegment), 32u);
+
+    AreaPolygonSegment segment;
+    BOOST_CHECK_EQUAL(segment.u, SPECIAL_NODEID);
+    BOOST_CHECK_EQUAL(segment.v, SPECIAL_NODEID);
+    BOOST_CHECK_EQUAL(segment.num_vertices, 0u);
+    BOOST_CHECK_EQUAL(segment.num_rings, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(area_walking_speed_has_a_sane_default)
+{
+    ProfileProperties properties;
+    // ~5 km/h, and in m/s -- the profiles' own `walking_speed` is in km/h
+    BOOST_CHECK_CLOSE(properties.area_walking_speed, 1.4, 0.001);
+
+    properties.area_walking_speed = 2.0;
+    BOOST_CHECK_CLOSE(properties.area_walking_speed, 2.0, 0.001);
+}
+
+BOOST_AUTO_TEST_CASE(area_data_collector_records_ring_and_speed)
+{
+    AreaDataCollector collector;
+    BOOST_CHECK_EQUAL(collector.size(), 0u);
+
+    collector.record(square({1, 2, 3, 4}), 1.4);
+
+    BOOST_REQUIRE_EQUAL(collector.size(), 1u);
+    const auto &record = collector.polygons()[0];
+    const std::vector<osmium::object_id_type> expected_ring{1, 2, 3, 4};
+    BOOST_CHECK(ring_ids(record) == expected_ring);
+    BOOST_CHECK_CLOSE(record.walking_speed, 1.4, 0.001);
+
+    collector.clear();
+    BOOST_CHECK_EQUAL(collector.size(), 0u);
+}
+
+// Areas are meshed from a parallel pipeline, so the arrival order is the scheduler's
+// choice.  finalize() has to put them back into an order that depends only on the input,
+// otherwise the extracted data differs between runs over the same file.
+BOOST_AUTO_TEST_CASE(area_data_collector_is_deterministic_after_finalize)
+{
+    const std::vector<std::vector<osmium::object_id_type>> rings{
+        {70, 71, 72, 73}, {10, 11, 12, 13}, {50, 51, 52, 53}, {30, 31, 32, 33}};
+
+    const auto collect_in = [&rings](const std::vector<std::size_t> &order)
+    {
+        AreaDataCollector collector;
+        for (const auto i : order)
+            collector.record(square(rings[i]), 1.4);
+        collector.finalize();
+        std::vector<std::vector<osmium::object_id_type>> result;
+        for (const auto &record : collector.polygons())
+            result.push_back(ring_ids(record));
+        return result;
+    };
+
+    const auto forwards = collect_in({0, 1, 2, 3});
+    const auto backwards = collect_in({3, 2, 1, 0});
+    const auto shuffled = collect_in({2, 0, 3, 1});
+
+    BOOST_CHECK(forwards == backwards);
+    BOOST_CHECK(forwards == shuffled);
+    // and the order is the one the ids imply, not the one they arrived in
+    BOOST_REQUIRE_EQUAL(forwards.size(), 4u);
+    BOOST_CHECK_EQUAL(forwards[0][0], 10);
+    BOOST_CHECK_EQUAL(forwards[3][0], 70);
+}
+
+// record() is called concurrently from the meshing pipeline.
+BOOST_AUTO_TEST_CASE(area_data_collector_record_is_thread_safe)
+{
+    AreaDataCollector collector;
+    constexpr int per_thread = 50;
+    constexpr int threads = 4;
+
+    std::vector<std::thread> workers;
+    workers.reserve(threads);
+    for (int t = 0; t < threads; ++t)
+    {
+        workers.emplace_back(
+            [&collector, t]
+            {
+                for (int i = 0; i < per_thread; ++i)
+                {
+                    const osmium::object_id_type base = t * 1000 + i * 4 + 1;
+                    collector.record(square({base, base + 1, base + 2, base + 3}), 1.4);
+                }
+            });
+    }
+    for (auto &worker : workers)
+        worker.join();
+
+    BOOST_CHECK_EQUAL(collector.size(), threads * per_thread);
+
+    collector.finalize();
+    // every record survived intact, and they are strictly ordered
+    for (std::size_t i = 1; i < collector.polygons().size(); ++i)
+    {
+        BOOST_CHECK_EQUAL(collector.polygons()[i].boundary_vertices.size(), 4u);
+        BOOST_CHECK(ring_ids(collector.polygons()[i - 1]) < ring_ids(collector.polygons()[i]));
+    }
+}
+
+// Snapping adds a virtual edge to every visibility-graph vertex the coordinate can see,
+// and the obstacle corners are among them, so the rings have to survive the recording.
+BOOST_AUTO_TEST_CASE(area_data_collector_records_the_obstacle_rings)
+{
+    OsmiumPolygon poly;
+    poly.outer().push_back(node(1, 0, 8));
+    poly.outer().push_back(node(2, 8, 8));
+    poly.outer().push_back(node(3, 8, 0));
+    poly.outer().push_back(node(4, 0, 0));
+    OsmiumPolygon::ring_type obstacle;
+    obstacle.push_back(node(5, 3, 5));
+    obstacle.push_back(node(6, 3, 3));
+    obstacle.push_back(node(7, 5, 3));
+    obstacle.push_back(node(8, 5, 5));
+    poly.inners().push_back(obstacle);
+
+    AreaDataCollector collector;
+    collector.record(poly, 1.4);
+
+    BOOST_REQUIRE_EQUAL(collector.size(), 1u);
+    const auto &record = collector.polygons()[0];
+    BOOST_CHECK_EQUAL(record.boundary_vertices.size(), 4u);
+    BOOST_REQUIRE_EQUAL(record.obstacle_rings.size(), 1u);
+    BOOST_REQUIRE_EQUAL(record.obstacle_rings[0].size(), 4u);
+
+    std::vector<osmium::object_id_type> corners;
+    for (const auto &n : record.obstacle_rings[0])
+        corners.push_back(n.ref());
+    const std::vector<osmium::object_id_type> expected{5, 6, 7, 8};
+    BOOST_CHECK(corners == expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/extractor/area/area_mesher.cpp
+++ b/unit_tests/extractor/area/area_mesher.cpp
@@ -1,5 +1,6 @@
 #include "extractor/area/area_mesher.hpp"
 
+#include "extractor/area/area_data_collector.hpp"
 #include "extractor/area/area_manager.hpp"
 #include "extractor/area/typedefs.hpp"
 #include "extractor/extraction_containers.hpp"
@@ -291,6 +292,130 @@ BOOST_AUTO_TEST_CASE(area_mesher_buffer_reader_batches_then_reports_eof)
     const auto eof = reader.read();
     BOOST_CHECK(!eof); // an invalid buffer signals end of input
     BOOST_CHECK_THROW(reader.read(), osrm::util::exception);
+}
+
+// The engine needs the polygon and its entry points to snap a coordinate lying inside
+// the area later, and meshing is the only point where both are known.
+BOOST_AUTO_TEST_CASE(area_mesher_records_the_area_for_the_engine)
+{
+    ExtractionRelationContainer relations;
+    AreaManager manager{relations};
+    ExtractionContainers containers;
+    attach_ways(manager, containers, {1, 2, 3});
+
+    osmium::memory::Buffer in_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+    build_area(in_buffer);
+    osmium::memory::Buffer out_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+
+    AreaMesher mesher;
+    mesher.init(manager, containers);
+    mesher.area_walking_speed = 1.25;
+    mesher.mesh_area(in_buffer.get<osmium::Area>(0), out_buffer, relations);
+
+    BOOST_REQUIRE_EQUAL(mesher.collector().size(), 1u);
+    const auto &record = mesher.collector().polygons()[0];
+
+    // the outer ring, open, without the repeated closing node
+    std::string ring;
+    for (const auto &n : record.boundary_vertices)
+        ring += (ring.empty() ? "" : " ") + std::to_string(n.ref());
+    BOOST_CHECK_EQUAL(ring, "1 2 3 4");
+
+    BOOST_CHECK_CLOSE(record.walking_speed, 1.25, 0.001);
+}
+
+// An area nobody can enter is of no use to snapping either, so it is not recorded.
+BOOST_AUTO_TEST_CASE(area_mesher_does_not_record_an_area_without_entry_points)
+{
+    ExtractionRelationContainer relations;
+    AreaManager manager{relations};
+    ExtractionContainers containers;
+    // no ways attached, so get_entry_points() finds nothing
+
+    osmium::memory::Buffer in_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+    build_area(in_buffer);
+    osmium::memory::Buffer out_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+
+    AreaMesher mesher;
+    mesher.init(manager, containers);
+    mesher.mesh_area(in_buffer.get<osmium::Area>(0), out_buffer, relations);
+
+    BOOST_CHECK_EQUAL(mesher.collector().size(), 0u);
+}
+
+// An area too large to mesh is exactly where snapping matters most, so it is recorded
+// even though no ways are generated for it.
+BOOST_AUTO_TEST_CASE(area_mesher_records_an_area_it_declined_to_mesh)
+{
+    ExtractionRelationContainer relations;
+    AreaManager manager{relations};
+    ExtractionContainers containers;
+    attach_ways(manager, containers, {1, 2, 3});
+
+    osmium::memory::Buffer in_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+    build_area(in_buffer);
+    osmium::memory::Buffer out_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+
+    AreaMesher mesher;
+    mesher.init(manager, containers);
+    mesher.max_vertices = 1;
+    mesher.mesh_area(in_buffer.get<osmium::Area>(0), out_buffer, relations);
+
+    BOOST_CHECK_EQUAL(mesher.added_ways, 0);
+    BOOST_CHECK_EQUAL(mesher.collector().size(), 1u);
+}
+
+// With the whole visibility graph emitted, every node of the area has onward edges, so a
+// coordinate snapped inside it can set off towards any node it can see.  The entry-point
+// mesh leaves obstacle corners with none.
+BOOST_AUTO_TEST_CASE(area_mesher_can_emit_the_whole_visibility_graph)
+{
+    ExtractionRelationContainer relations;
+    AreaManager manager{relations};
+    ExtractionContainers containers;
+    attach_ways(manager, containers, {1, 2, 3});
+
+    osmium::memory::Buffer in_buffer{4096, osmium::memory::Buffer::auto_grow::yes};
+    build_area(in_buffer);
+
+    const auto mesh = [&](bool whole)
+    {
+        osmium::memory::Buffer out{8192, osmium::memory::Buffer::auto_grow::yes};
+        AreaMesher mesher;
+        mesher.init(manager, containers);
+        mesher.emit_visibility_graph = whole;
+        mesher.mesh_area(in_buffer.get<osmium::Area>(0), out, relations);
+        std::set<std::pair<osmium::object_id_type, osmium::object_id_type>> edges;
+        for (const auto &way : out.select<osmium::Way>())
+        {
+            const auto a = way.nodes()[0].ref(), b = way.nodes()[1].ref();
+            edges.emplace(std::min(a, b), std::max(a, b));
+        }
+        return edges;
+    };
+
+    const auto entry_point_mesh = mesh(false);
+    const auto whole_graph = mesh(true);
+
+    // the whole graph is a superset, and strictly larger for an area with an obstacle
+    BOOST_CHECK_GT(whole_graph.size(), entry_point_mesh.size());
+    for (const auto &edge : entry_point_mesh)
+        BOOST_CHECK_MESSAGE(whole_graph.count(edge) == 1,
+                            "edge " << edge.first << "-" << edge.second
+                                    << " is in the entry-point mesh but not the whole graph");
+
+    // every corner of the obstacle now has at least one edge; in the entry-point mesh
+    // some of them have none, which is what makes a straight line to them a dead end
+    const auto degree = [](const auto &edges, osmium::object_id_type node)
+    {
+        std::size_t count = 0;
+        for (const auto &edge : edges)
+            count += (edge.first == node || edge.second == node);
+        return count;
+    };
+    for (osmium::object_id_type corner : {5, 6, 7, 8})
+        BOOST_CHECK_MESSAGE(degree(whole_graph, corner) > 0,
+                            "obstacle corner " << corner << " has no onward edge");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/extractor/area/open_areas_files.cpp
+++ b/unit_tests/extractor/area/open_areas_files.cpp
@@ -1,0 +1,102 @@
+#include "extractor/area_routing_data.hpp"
+#include "extractor/files.hpp"
+
+#include "../../common/temporary_file.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(open_areas_files_test)
+
+using namespace osrm;
+using namespace osrm::extractor;
+
+// The engine reads what extraction wrote, so the round trip has to be exact -- including
+// the ring lengths, which are what separate an area's outer boundary from its obstacles.
+BOOST_AUTO_TEST_CASE(open_areas_round_trip)
+{
+    TemporaryFile file;
+
+    std::vector<AreaPolygonSegment> areas(2);
+    areas[0].u = 0;
+    areas[0].v = 1;
+    areas[0].vertices_offset = 0;
+    areas[0].num_vertices = 8; // a square with a square hole
+    areas[0].rings_offset = 0;
+    areas[0].num_rings = 2;
+    areas[0].walking_speed = 1.4;
+
+    areas[1].u = 2;
+    areas[1].v = 3;
+    areas[1].vertices_offset = 8;
+    areas[1].num_vertices = 3; // a triangle, no obstacles
+    areas[1].rings_offset = 2;
+    areas[1].num_rings = 1;
+    areas[1].walking_speed = 1.25;
+
+    std::vector<util::Coordinate> bbox_corners;
+    bbox_corners.reserve(2 * areas.size());
+    for (std::size_t i = 0; i < 2 * areas.size(); ++i)
+        bbox_corners.emplace_back(util::FloatLongitude{1.0 + i}, util::FloatLatitude{2.0 + i});
+
+    std::vector<util::Coordinate> vertices;
+    vertices.reserve(11);
+    for (int i = 0; i < 11; ++i)
+        vertices.emplace_back(util::FloatLongitude{1.0 + i * 0.001},
+                              util::FloatLatitude{2.0 - i * 0.001});
+
+    const std::vector<std::uint32_t> ring_lengths{4, 4, 3};
+
+    files::writeOpenAreas(file.path, areas, bbox_corners, vertices, ring_lengths);
+
+    std::vector<AreaPolygonSegment> read_areas;
+    std::vector<util::Coordinate> read_bbox_corners;
+    std::vector<util::Coordinate> read_vertices;
+    std::vector<std::uint32_t> read_ring_lengths;
+    files::readOpenAreas(
+        file.path, read_areas, read_bbox_corners, read_vertices, read_ring_lengths);
+
+    BOOST_REQUIRE_EQUAL(read_areas.size(), areas.size());
+    for (std::size_t i = 0; i < areas.size(); ++i)
+    {
+        BOOST_CHECK_EQUAL(read_areas[i].u, areas[i].u);
+        BOOST_CHECK_EQUAL(read_areas[i].v, areas[i].v);
+        BOOST_CHECK_EQUAL(read_areas[i].vertices_offset, areas[i].vertices_offset);
+        BOOST_CHECK_EQUAL(read_areas[i].num_vertices, areas[i].num_vertices);
+        BOOST_CHECK_EQUAL(read_areas[i].rings_offset, areas[i].rings_offset);
+        BOOST_CHECK_EQUAL(read_areas[i].num_rings, areas[i].num_rings);
+        BOOST_CHECK_CLOSE(read_areas[i].walking_speed, areas[i].walking_speed, 0.0001);
+    }
+
+    const auto same_coordinates =
+        [](const std::vector<util::Coordinate> &read, const std::vector<util::Coordinate> &written)
+    {
+        BOOST_REQUIRE_EQUAL(read.size(), written.size());
+        for (std::size_t i = 0; i < written.size(); ++i)
+        {
+            BOOST_CHECK_EQUAL(static_cast<std::int32_t>(read[i].lon),
+                              static_cast<std::int32_t>(written[i].lon));
+            BOOST_CHECK_EQUAL(static_cast<std::int32_t>(read[i].lat),
+                              static_cast<std::int32_t>(written[i].lat));
+        }
+    };
+    same_coordinates(read_bbox_corners, bbox_corners);
+    same_coordinates(read_vertices, vertices);
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(read_ring_lengths.begin(),
+                                  read_ring_lengths.end(),
+                                  ring_lengths.begin(),
+                                  ring_lengths.end());
+    // the ring lengths must account for exactly the vertices each area claims
+    for (const auto &area : read_areas)
+    {
+        std::uint32_t total = 0;
+        for (std::uint32_t r = 0; r < area.num_rings; ++r)
+            total += read_ring_lengths[area.rings_offset + r];
+        BOOST_CHECK_EQUAL(total, area.num_vertices);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
First of three PRs building on #7161, which taught the extractor to mesh a pedestrian area.
That mesh was only reachable from the entry points where a footway meets the perimeter. This
one lets a coordinate that falls *inside* an area be routed from and to.

**3071 lines, but only 1191 of them are engine and extractor code.** The rest:

| | |
|---|---|
| `src` + `include` | +1191, 26 files |
| debug tooling (`scripts/debug/`, 2 Python scripts) | +1072 |
| unit tests | +520 |
| cucumber | +276 |
| docs | +12 |

The tooling draws what the mesher and the snapper did as SVG, and is what substantiates the
numbers below. It is worth having in the tree, but it is not engine code and does not need to
be read as such.

## What it does

Today a coordinate in the middle of a plaza snaps to whatever way happens to be nearest,
which may be on the far side of a building. After this it snaps to the mesh vertex from which
the rest of the journey is cheapest, and the walk from the coordinate to that vertex is
charged to the route.

Four parts:

**Write the areas at extraction.** A new `.osrm.openareas` holds the polygon of every meshed
area with its rings, plus an r-tree over their bounding boxes so the engine can ask which
areas contain a point. Nothing else about extraction changes.

**Always emit the ring edges.** A bug in its own right, independent of the rest: the perimeter
of an area is not routable by itself, because the profile hands the closed way to the area
code and returns. Without the ring edges in the mesh you cannot walk along the edge of a plaza
or round a fountain. Both the full and the pruned mesh now get them.

**Snap inside an area.** `SnapInsideOpenArea` builds a candidate per mesh vertex visible from
the coordinate, charging the straight-line walk. A candidate keeps only the direction that
leaves its vertex, since arriving at a vertex and then having to leave the way you came is
not a journey anyone wants.

**Report the waypoint the route used.** `endpointsFromCandidates` matched a path back to its
candidate by segment id alone and could pick a disabled one; it now requires the candidate to
be enabled, and `waypointsAsRouted` reports the location the route actually started from.

## Numbers

On a 400x400 m plaza with four entrances and two obstacles, 390 interior points against all
four exits, the snapped route is within **0.1 m** of the true shortest path through the
polygon, worst case over all 1560 pairs.

## What it does not do

A journey with **both** ends inside one area is not handled here; it is the subject of the
next PR. Known defects and deferred review points are tracked in #7683.

## Tests

10 cucumber scenarios in `features/foot/area_snapping.feature`, asserting encoded geometry
rather than node lists, so they do not depend on which algorithm answered. Unit tests cover
the visibility computation, the serialisation round trip, and the mesher's ring edges.

Written with AI assistance: Claude Code, Claude Opus 5 🤖

## Two corrections since this was opened

CI's `clang-20-debug-cov` job builds with assertions on and caught both.

**A via point cannot be charged.** The walk is folded into the phantom's weight offset, and the search seeds a source with the negation of that offset and a target with the offset itself. A coordinate in the middle of a route is both, so charging it as a departure makes the leg arriving there seed a negative key, which CH asserts against. A via point is now charged nothing.

**An arrival stands at the end of an edge-based node, not the start.** A departure candidate has to begin at the vertex, so that travelling it leaves the vertex. An arrival is the mirror image and was getting the departure treatment, which made a leg contained in one segment report `"weight": -36` on a 50 m walk. One phantom answers both, since sitting at a segment's first node means carrying a weight of zero forwards and the whole of the segment in reverse.

The second changes which candidate a route matches back to, so two scenarios now report their terminal node ids in travel order (`ea` rather than `ae`, which is the correct order) and a third asserts geometry instead, because the node list at the ends of a leg is not stable (#7683).