### PR TITLE
feat(area): answer tables and trips across a plaza the same way as routes

### DIFF
--- a/features/foot/area_table_trip.feature
+++ b/features/foot/area_table_trip.feature
@@ -1,0 +1,105 @@
+@routing @foot @area @matrix
+Feature: Foot - Tables and trips across a pedestrian area
+
+    # A pair of coordinates on one plaza is a journey the mesh answers badly: it holds
+    # shortest paths *out* of an area, and this journey never leaves.  /route works the
+    # answer out from the polygon instead.  A table is that question asked many times over
+    # and a trip picks its tour from a table before drawing it, so both have to give the
+    # same answer as /route or the three services contradict each other.
+    #
+    # Only pairs with *both* ends on the plaza are asserted here.  A pair with one end on
+    # it is a separate matter and is not yet right -- see plans/area-table-trip.md.
+
+    Background:
+        Given the profile "foot_area"
+        Given a grid size of 50 meters
+
+    Scenario: Foot - Distance table between two points on one plaza
+        Given the node map
+            """
+            e-a-------b-f
+              |       |
+              | m   n |
+            h-d-------c-g
+            """
+
+        And the ways
+            | nodes | highway    | area | name  |
+            | abcda | pedestrian | yes  | Plaza |
+            | ea    | pedestrian |      | A     |
+            | bf    | pedestrian |      | B     |
+            | hd    | pedestrian |      | C     |
+            | cg    | pedestrian |      | D     |
+
+        # m and n can see each other, so the cell between them is the straight line --
+        # 100 m, the same as /route reports, and not a detour by way of a corner
+        When I request a travel distance matrix I should get
+            |   | m     | n     |
+            | m | 0     | 100.1 |
+            | n | 100.1 | 0     |
+
+        # and the same journey in seconds, at the area's walking speed
+        When I request a travel time matrix I should get
+            |   | m    | n    |
+            | m | 0    | 71.5 |
+            | n | 71.5 | 0    |
+
+    Scenario: Foot - Distance table across an obstacle
+        Given the node map
+            """
+            e-a-----------b-f
+              | u-------v |
+              |p|       |q|
+              | x-------w |
+            h-d-----------c-g
+            """
+
+        And the ways
+            | nodes | highway    | name |
+            | abcda | (nil)      |      |
+            | uvwxu | (nil)      |      |
+            | ea    | pedestrian | A    |
+            | bf    | pedestrian | B    |
+            | hd    | pedestrian | C    |
+            | cg    | pedestrian | D    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner |
+            | multipolygon | pedestrian | abcda     | uvwxu     |
+
+        # p and q are on opposite sides of the obstacle, so the cell between them is the
+        # way round it -- the same 312 m /route reports, not the 300 m straight line
+        When I request a travel distance matrix I should get
+            |   | p     | q     |
+            | p | 0     | 311.8 |
+            | q | 311.8 | 0     |
+
+    Scenario: Foot - Trip round three points on one plaza
+        Given the node map
+            """
+            e-a-----------b-f
+              | u-------v |
+              |p|       |q|
+              | x-------w |
+              |     s     |
+            h-d-----------c-g
+            """
+
+        And the ways
+            | nodes | highway    | name |
+            | abcda | (nil)      |      |
+            | uvwxu | (nil)      |      |
+            | ea    | pedestrian | A    |
+            | bf    | pedestrian | B    |
+            | hd    | pedestrian | C    |
+            | cg    | pedestrian | D    |
+
+        And the relations
+            | type         | highway    | way:outer | way:inner |
+            | multipolygon | pedestrian | abcda     | uvwxu     |
+
+        # every leg stays on the plaza, so the tour is chosen from geodesics and drawn as
+        # geodesics -- the same lines /route would give between the same pairs
+        When I plan a trip I should get
+            | waypoints | trips | distance |
+            | p,q,s     | psq   | 647m +-6 |

--- a/include/engine/area_route.hpp
+++ b/include/engine/area_route.hpp
@@ -35,9 +35,25 @@ namespace osrm::engine::area
  * that arises for a profile that meshes plazas.
  */
 void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
-                             const std::vector<util::Coordinate> &coordinates,
                              InternalRouteResult &route,
-                             std::vector<PhantomNodeCandidates> &waypoints);
+                             const std::vector<PhantomNodeCandidates *> &waypoints);
+
+/**
+ * @brief Replace any cell of a table whose two coordinates lie in one open area.
+ *
+ * The same case as above, and for the same reason, but there is no route to write: a
+ * table is numbers.  Durations are in deci-seconds and distances in metres, as the search
+ * leaves them.  @p distances may be empty when none were asked for.
+ *
+ * @p sources and @p destinations map a row and a column onto @p coordinates; either may be
+ * empty, which means every coordinate in order.
+ */
+void useGeodesicInTable(const datafacade::BaseDataFacade &facade,
+                        const std::vector<util::Coordinate> &coordinates,
+                        const std::vector<std::size_t> &sources,
+                        const std::vector<std::size_t> &destinations,
+                        std::vector<EdgeDuration> &durations,
+                        std::vector<EdgeDistance> &distances);
 
 } // namespace osrm::engine::area
 

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -227,9 +227,22 @@ class BasePlugin
         return phantom_nodes;
     }
 
+    /**
+     * Whether a coordinate's place in the list says which end of a journey it is.  It
+     * does for a route.  A trip visits every point and returns to the first, so each of
+     * them is departed from *and* arrived at, which no single approach cost can express;
+     * see area::ApproachRole.
+     */
+    enum class ApproachCharge
+    {
+        ByPosition,
+        NeverCharge
+    };
+
     std::vector<PhantomCandidateAlternatives>
     GetPhantomNodes(const datafacade::BaseDataFacade &facade,
-                    const api::BaseParameters &parameters) const
+                    const api::BaseParameters &parameters,
+                    const ApproachCharge charge = ApproachCharge::ByPosition) const
     {
         std::vector<PhantomCandidateAlternatives> alternatives(parameters.coordinates.size());
 
@@ -252,7 +265,9 @@ class BasePlugin
             // The first coordinate is only ever departed from and the last only ever
             // arrived at.  Everything in between is both at once and so goes uncharged,
             // which costs a little accuracy on the legs either side of it.
-            const auto role = (i + 1 == parameters.coordinates.size()) ? area::ApproachRole::Arrival
+            const auto role = charge == ApproachCharge::NeverCharge ? area::ApproachRole::Via
+                              : (i + 1 == parameters.coordinates.size())
+                                  ? area::ApproachRole::Arrival
                               : (i == 0) ? area::ApproachRole::Departure
                                          : area::ApproachRole::Via;
             if (auto in_area =

--- a/include/engine/plugins/trip.hpp
+++ b/include/engine/plugins/trip.hpp
@@ -21,8 +21,10 @@ class TripPlugin final : public BasePlugin
   private:
     const int max_locations_trip;
 
+    //! Not const: a leg solved inside an open area reports the coordinate that was asked
+    //! for, so the candidates it answers to are corrected too.
     InternalRouteResult ComputeRoute(const RoutingAlgorithmsInterface &algorithms,
-                                     const std::vector<PhantomNodeCandidates> &candidates_list,
+                                     std::vector<PhantomNodeCandidates> &candidates_list,
                                      const std::vector<NodeID> &trip,
                                      const bool roundtrip) const;
 

--- a/src/engine/area_route.cpp
+++ b/src/engine/area_route.cpp
@@ -100,14 +100,24 @@ std::optional<NodeID> nodeAt(const datafacade::BaseDataFacade &facade, const uti
     return std::nullopt;
 }
 
+/** Say that a waypoint is where it was asked for, when the caller is tracking waypoints. */
+void report(const std::vector<PhantomNodeCandidates *> &waypoints,
+            std::size_t which,
+            const util::Coordinate where)
+{
+    if (which < waypoints.size() && waypoints[which] != nullptr && !waypoints[which]->empty())
+    {
+        waypoints[which]->front().location = where;
+    }
+}
+
 } // namespace
 
 void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
-                             const std::vector<util::Coordinate> &coordinates,
                              InternalRouteResult &route,
-                             std::vector<PhantomNodeCandidates> &waypoints)
+                             const std::vector<PhantomNodeCandidates *> &waypoints)
 {
-    if (!route.is_valid() || route.leg_endpoints.size() + 1 != coordinates.size())
+    if (!route.is_valid())
     {
         return;
     }
@@ -116,7 +126,13 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
     bool replaced = false;
     for (std::size_t leg = 0; leg < route.leg_endpoints.size(); ++leg)
     {
-        const auto from = coordinates[leg], to = coordinates[leg + 1];
+        // where the traveller asked to be, which is what the phantoms carry
+        const auto from = route.leg_endpoints[leg].source_phantom.input_location;
+        const auto to = route.leg_endpoints[leg].target_phantom.input_location;
+        if (!from.IsValid() || !to.IsValid())
+        {
+            continue;
+        }
         const auto area = commonArea(facade, from, to);
         if (!area)
         {
@@ -206,14 +222,8 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
         // The journey now starts and ends where it was asked to, so that is what the
         // waypoints report -- and the walk to a snapped vertex, which is no longer part
         // of the story, stops being reported as a snapping error.
-        if (leg < waypoints.size() && !waypoints[leg].empty())
-        {
-            waypoints[leg].front().location = from;
-        }
-        if (leg + 1 < waypoints.size() && !waypoints[leg + 1].empty())
-        {
-            waypoints[leg + 1].front().location = to;
-        }
+        report(waypoints, leg, from);
+        report(waypoints, leg + 1, to);
         replaced = true;
     }
 
@@ -267,10 +277,7 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
                                      0,
                                      std::nullopt});
                 endpoints.source_phantom.location = endpoints.source_phantom.input_location;
-                if (leg < waypoints.size() && !waypoints[leg].empty())
-                {
-                    waypoints[leg].front().location = endpoints.source_phantom.input_location;
-                }
+                report(waypoints, leg, endpoints.source_phantom.input_location);
                 replaced = true;
             }
         }
@@ -299,10 +306,7 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
                 target_weight = weight;
                 target_duration = duration;
                 endpoints.target_phantom.location = endpoints.target_phantom.input_location;
-                if (leg + 1 < waypoints.size() && !waypoints[leg + 1].empty())
-                {
-                    waypoints[leg + 1].front().location = endpoints.target_phantom.input_location;
-                }
+                report(waypoints, leg + 1, endpoints.target_phantom.input_location);
                 replaced = true;
             }
         }
@@ -323,6 +327,57 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
         }
         route.shortest_path_weight =
             route.shortest_path_weight + route.leg_endpoints[leg].target_phantom.forward_weight;
+    }
+}
+
+void useGeodesicInTable(const datafacade::BaseDataFacade &facade,
+                        const std::vector<util::Coordinate> &coordinates,
+                        const std::vector<std::size_t> &sources,
+                        const std::vector<std::size_t> &destinations,
+                        std::vector<EdgeDuration> &durations,
+                        std::vector<EdgeDistance> &distances)
+{
+    const auto rows = sources.empty() ? coordinates.size() : sources.size();
+    const auto columns = destinations.empty() ? coordinates.size() : destinations.size();
+    if (durations.size() != rows * columns)
+    {
+        return;
+    }
+
+    for (std::size_t row = 0; row < rows; ++row)
+    {
+        const auto from = coordinates[sources.empty() ? row : sources[row]];
+        // one lookup for the whole row: a table over one plaza asks about the same area
+        // again and again
+        if (facade.GetOpenAreasAt(from).empty())
+        {
+            continue;
+        }
+
+        for (std::size_t column = 0; column < columns; ++column)
+        {
+            const auto to = coordinates[destinations.empty() ? column : destinations[column]];
+            const auto area = commonArea(facade, from, to);
+            if (!area)
+            {
+                continue;
+            }
+            const auto rings = facade.GetOpenAreaRings(*area);
+            const auto geodesic =
+                geodesic_between(facade.GetCheckSum(), area->vertices_offset, rings, from, to);
+            if (!geodesic)
+            {
+                continue;
+            }
+
+            const auto cell = row * columns + column;
+            durations[cell] =
+                to_alias<EdgeDuration>(std::lround(geodesic->length / area->walking_speed * 10.));
+            if (!distances.empty())
+            {
+                distances[cell] = to_alias<EdgeDistance>(geodesic->length);
+            }
+        }
     }
 }
 

--- a/src/engine/plugins/table.cpp
+++ b/src/engine/plugins/table.cpp
@@ -1,4 +1,5 @@
 #include "engine/plugins/table.hpp"
+#include "engine/area_route.hpp"
 
 #include "engine/api/table_api.hpp"
 #include "engine/api/table_parameters.hpp"
@@ -83,6 +84,16 @@ Status TablePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
     {
         return Error("NoTable", "No table found", result);
     }
+
+    // A pair of coordinates on one plaza is a journey the mesh answers badly, the same as
+    // it is for a route -- see engine/area_route.hpp.  Here there is only a number to put
+    // right.
+    area::useGeodesicInTable(facade,
+                             params.coordinates,
+                             params.sources,
+                             params.destinations,
+                             result_tables_pair.first,
+                             result_tables_pair.second);
 
     std::vector<api::TableAPI::TableCellRef> estimated_pairs;
 

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -1,4 +1,5 @@
 #include "engine/plugins/trip.hpp"
+#include "engine/area_route.hpp"
 
 #include "engine/api/trip_api.hpp"
 #include "engine/api/trip_parameters.hpp"
@@ -30,7 +31,7 @@ bool IsSupportedParameterCombination(const bool fixed_start,
 // so on) and return the result
 InternalRouteResult
 TripPlugin::ComputeRoute(const RoutingAlgorithmsInterface &algorithms,
-                         const std::vector<PhantomNodeCandidates> &waypoint_candidates,
+                         std::vector<PhantomNodeCandidates> &waypoint_candidates,
                          const std::vector<NodeID> &trip,
                          const bool roundtrip) const
 {
@@ -56,6 +57,21 @@ TripPlugin::ComputeRoute(const RoutingAlgorithmsInterface &algorithms,
 
     auto min_route = algorithms.ShortestPathSearch(trip_candidates, {false});
     BOOST_ASSERT_MSG(min_route.shortest_path_weight < INVALID_EDGE_WEIGHT, "unroutable route");
+
+    // The legs run in tour order, so the waypoints they answer to are the original
+    // candidates picked out in that order -- the response reports those, not the copies
+    // ShortestPathSearch was handed.
+    std::vector<PhantomNodeCandidates *> waypoints;
+    waypoints.reserve(trip_candidates.size());
+    for (const auto node : trip)
+    {
+        waypoints.push_back(&waypoint_candidates[node]);
+    }
+    if (roundtrip)
+    {
+        waypoints.push_back(&waypoint_candidates[trip.front()]);
+    }
+    area::useGeodesicWhereShorter(algorithms.GetFacade(), min_route, waypoints);
     return min_route;
 }
 
@@ -190,7 +206,7 @@ Status TripPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
         return Status::Error;
 
     const auto &facade = algorithms.GetFacade();
-    auto phantom_node_pairs = GetPhantomNodes(facade, parameters);
+    auto phantom_node_pairs = GetPhantomNodes(facade, parameters, ApproachCharge::NeverCharge);
     if (phantom_node_pairs.size() != number_of_locations)
     {
         return Error("NoSegment",
@@ -211,9 +227,13 @@ Status TripPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
     BOOST_ASSERT(snapped_phantoms.size() == number_of_locations);
 
     // compute the duration table of all phantom nodes
-    auto result_duration_table = util::DistTableWrapper<EdgeDuration>(
-        algorithms.ManyToManySearch(snapped_phantoms, {}, {}, /*requestDistance*/ false).first,
-        number_of_locations);
+    auto durations = algorithms.ManyToManySearch(snapped_phantoms, {}, {}, false).first;
+    // a pair on one plaza is a journey the mesh answers badly, and the tour is chosen from
+    // these numbers -- see engine/area_route.hpp
+    std::vector<EdgeDistance> no_distances;
+    area::useGeodesicInTable(facade, parameters.coordinates, {}, {}, durations, no_distances);
+    auto result_duration_table =
+        util::DistTableWrapper<EdgeDuration>(std::move(durations), number_of_locations);
 
     if (result_duration_table.size() == 0)
     {

--- a/src/engine/plugins/viaroute.cpp
+++ b/src/engine/plugins/viaroute.cpp
@@ -136,12 +136,17 @@ Status ViaRoutePlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithm
         // the geodesic across the plaza is worked out from the polygon instead.  Done
         // before the legs are collapsed, so that each leg is still one pair of the
         // coordinates that were asked for.
+        std::vector<PhantomNodeCandidates *> waypoints;
+        waypoints.reserve(snapped_phantoms.size());
+        for (auto &candidates : snapped_phantoms)
+        {
+            waypoints.push_back(&candidates);
+        }
         for (auto &route : routes.routes)
         {
             if (route.is_valid())
             {
-                area::useGeodesicWhereShorter(
-                    facade, route_parameters.coordinates, route, snapped_phantoms);
+                area::useGeodesicWhereShorter(facade, route, waypoints);
             }
         }
 


### PR DESCRIPTION
#7684 and #7685 have merged, so this now targets master and is its own single commit.

#7685 made `/route` work out the real path when both ends of a leg lie on one plaza. `/table`
and `/trip` did not, so the three services disagreed about the same journey. 243 lines,
including the tests.

**Table.** Any cell whose two coordinates lie in one area is rewritten, in both the duration
and the distance matrix. There is nothing to draw here, a table is numbers, so that is the
whole of it. One area lookup per *row* short-cuts the common case of a table nowhere near an
area.

**Trip.** Two places, because a trip does two things: the duration matrix it picks its tour
from, so the tour is chosen from the real costs, and the route it draws afterwards, through
the same path `/route` takes. `TripPlugin::ComputeRoute` now takes its candidates by
non-const reference, since the legs run in tour order and the waypoints they answer to are the
original candidates picked out in that order.

On a plaza with a central obstacle and one pair of interior points either side of it, the
three now agree:

| | distance | duration |
|---|---|---|
| `/route` | 386.5 m | 276.1 s |
| `/table` | 386.5 m | 276.0 s |
| `/trip`, roundtrip | 773.0 m | |

773.0 being twice 386.5, and the trip reporting the coordinates that were asked for rather
than the vertices they snapped to.

## Two faults this exposes without fixing

Both predate this change and are in #7683. They are described here because wiring the table is
what made them visible.

**A coordinate in a table is a source and a destination.** The walk into an area is charged to
the phantom's weight offset, and the sign depends on which end of the journey the coordinate
is. That works for a route. In a table, coordinate 0 is the source of row 0 and the
destination of column 0, so one of the two is charged the wrong way round. The fix is to carry
the approach cost on the phantom instead, which grows `PhantomNode` from 80 to 84 bytes and
the public hint string from 112 to 120 characters, so it wants its own PR.

**A trip whose coordinates all snap to one vertex reports 0 m.** On an empty plaza several
coordinates can share a cheapest way out. The search over identical candidate sets returns a
result with no legs, and there is then nothing for the geodesic pass to correct.

## Tests

`features/foot/area_table_trip.feature`, three scenarios: a distance and a time table across a
plain plaza, a distance table either side of an obstacle (311.8 m, the way round, not the
300 m straight line), and a trip round three points. Nothing asserts a pair with one end off
the plaza, or a trip whose points all snap together; pinning either would bless the wrong
answer.

Written with AI assistance: Claude Code, Claude Opus 5 🤖
