### PR TITLE
refactor(area): stop the area headers leaking names into boost

### DIFF
--- a/include/extractor/area/typedefs.hpp
+++ b/include/extractor/area/typedefs.hpp
@@ -52,8 +52,6 @@ namespace boost
 namespace geometry::traits
 {
 
-using namespace osrm::extractor::area;
-
 // osmium::NodeRef
 
 template <> struct tag<osmium::NodeRef>

--- a/include/extractor/area/visibility_graph.hpp
+++ b/include/extractor/area/visibility_graph.hpp
@@ -22,6 +22,13 @@ namespace osrm::extractor::area
 {
 
 /**
+ * The factor a coordinate is multiplied by after it has been projected into
+ * OSM-Mercator, so that it can be stored in a pair of int64_t.  Integer arithmetic
+ * avoids a host of nasty bugs.
+ */
+inline constexpr double MERCATOR_COEFF = 100.0;
+
+/**
  * @brief Implements the visibility graph
  *
  * This implementation follows the outline in Chapter 15 of: *de Berg, Cheong, van
@@ -132,32 +139,27 @@ class VisibilityGraph
 namespace boost::geometry::traits
 {
 
-using namespace osrm::extractor::area;
-
-// The coordinates are projected into OSM-Mercator and then multipiled by COEFF so to
-// store them in a pair of int64_t.  Integer arithmetic avoids a host of nasty bugs.
-inline constexpr double COEFF = 100.0;
-
-template <> struct tag<VisibilityGraph::Vertex>
+template <> struct tag<osrm::extractor::area::VisibilityGraph::Vertex>
 {
     using type = point_tag;
 };
-template <> struct dimension<VisibilityGraph::Vertex> : boost::mpl::int_<2>
+template <> struct dimension<osrm::extractor::area::VisibilityGraph::Vertex> : boost::mpl::int_<2>
 {
 };
-template <> struct coordinate_type<VisibilityGraph::Vertex>
+template <> struct coordinate_type<osrm::extractor::area::VisibilityGraph::Vertex>
 {
     using type = double;
 };
-template <> struct coordinate_system<VisibilityGraph::Vertex>
+template <> struct coordinate_system<osrm::extractor::area::VisibilityGraph::Vertex>
 {
     using type = boost::geometry::cs::cartesian; // Point is projected into mercator
 };
-template <std::size_t K> struct access<VisibilityGraph::Vertex, K>
+template <std::size_t K> struct access<osrm::extractor::area::VisibilityGraph::Vertex, K>
 {
-    static inline double get(const VisibilityGraph::Vertex &v) { return v.point[K] / COEFF; }
-    static inline void set(VisibilityGraph::Vertex &v, const double &value)
-    { v.point[K] = value * COEFF; }
+    static inline double get(const osrm::extractor::area::VisibilityGraph::Vertex &v)
+    { return v.point[K] / osrm::extractor::area::MERCATOR_COEFF; }
+    static inline void set(osrm::extractor::area::VisibilityGraph::Vertex &v, const double &value)
+    { v.point[K] = value * osrm::extractor::area::MERCATOR_COEFF; }
 };
 
 } // namespace boost::geometry::traits


### PR DESCRIPTION
Addresses [a review comment on #7161](https://github.com/Project-OSRM/osrm-backend/pull/7161#discussion_r2675931790). Small and independent of the area work in flight, so it should go in first; #7684 will rebase on it.

Two headers adapt our types to `boost::geometry`, and both opened the traits block with

```cpp
namespace boost::geometry::traits
{
using namespace osrm::extractor::area;
```

A using-directive at namespace scope in a header is inherited by every translation unit that includes it, and here it lands inside a namespace we do not own.

* In `typedefs.hpp` it was not needed at all. Every specialisation in that block is on an `osmium::` type.
* In `visibility_graph.hpp` it is replaced by naming `osrm::extractor::area::VisibilityGraph::Vertex` in full.

`COEFF` goes with it. It was `inline constexpr double COEFF = 100.0;` declared inside `boost::geometry::traits`, so a name that generic was being added to boost. It is now `osrm::extractor::area::MERCATOR_COEFF`, next to the `Vertex::point` whose scaling it describes.

No behaviour change: same constant, same specialisations, same types.

`extractor-tests` and `util-tests` pass, and the four `features/foot/area_mesh.feature` scenarios pass.

Written with AI assistance: Claude Code, Claude Opus 5 🤖