### PR TITLE
refactor(engine): carry the approach cost on the phantom, not in its offset

### DIFF
--- a/include/engine/area_snapping.hpp
+++ b/include/engine/area_snapping.hpp
@@ -13,19 +13,15 @@ namespace osrm::engine::area
 {
 
 /**
- * @brief Which end of the journey a coordinate is, which decides the sign of the walk.
+ * @brief Which end of a journey a coordinate is.
  *
- * The search seeds a source with the negation of `GetForwardWeightPlusOffset()` and a
- * target with the value itself, so the walk has to be subtracted from the offset in one
- * case and added in the other.  The stored offset can only hold one of the two, and the
- * plugin is where the role is known.
- */
-/**
- * Which end of a journey a coordinate is, which decides how the walk into the area is
- * charged.  A `Via` point is both ends at once and so cannot be charged at all: the
- * search seeds a source with the negation of the offset and a target with the offset
- * itself, and one number cannot come out positive both ways.  Charging it as a departure
- * makes the leg that arrives there seed a negative key, which CH does not permit.
+ * This decides where the candidate stands, not what it costs.  A candidate departed from
+ * has to stand at the start of an edge-based node, so that travelling it leaves the
+ * vertex; one arrived at has to stand at the node's end, or a leg contained in a single
+ * segment ends before it begins and comes out with a negative weight.
+ *
+ * A via point is both at once and takes the departing shape.  What a coordinate costs
+ * does not depend on its role at all; see `PhantomNode::approach_weight`.
  */
 enum class ApproachRole
 {

--- a/include/engine/phantom_node.hpp
+++ b/include/engine/phantom_node.hpp
@@ -50,9 +50,9 @@ struct PhantomNode
           forward_distance(INVALID_EDGE_DISTANCE), reverse_distance(INVALID_EDGE_DISTANCE),
           forward_distance_offset{0}, reverse_distance_offset{0},
           forward_duration(MAXIMAL_EDGE_DURATION), reverse_duration(MAXIMAL_EDGE_DURATION),
-          forward_duration_offset{0}, reverse_duration_offset{0},
-          component({INVALID_COMPONENTID, 0}), fwd_segment_position(0),
-          is_valid_forward_source{false}, is_valid_forward_target{false},
+          forward_duration_offset{0}, reverse_duration_offset{0}, approach_weight{0},
+          approach_duration{0}, approach_distance{0}, component({INVALID_COMPONENTID, 0}),
+          fwd_segment_position(0), is_valid_forward_source{false}, is_valid_forward_target{false},
           is_valid_reverse_source{false}, is_valid_reverse_target{false}, bearing(0)
 
     {
@@ -105,6 +105,44 @@ struct PhantomNode
         BOOST_ASSERT(reverse_segment_id.enabled);
         return reverse_distance + reverse_distance_offset;
     }
+
+    //
+    // What a search puts in its heap for this phantom.  A source is seeded with the
+    // negation of its own cost, which the path then makes up as it travels the rest of
+    // the segment; a target with the cost itself.  The approach walk is added in both
+    // roles, being travelled either way.
+    //
+    // Deliberately not folded into the Get*PlusOffset accessors: leg assembly reads
+    // those to work out what a route costs, and the walk is already drawn into the leg
+    // itself (engine/area_route.hpp).  These are for seeding a heap and nothing else.
+    //
+
+    EdgeWeight GetForwardWeightAsSource() const
+    { return approach_weight - GetForwardWeightPlusOffset(); }
+    EdgeWeight GetForwardWeightAsTarget() const
+    { return approach_weight + GetForwardWeightPlusOffset(); }
+    EdgeWeight GetReverseWeightAsSource() const
+    { return approach_weight - GetReverseWeightPlusOffset(); }
+    EdgeWeight GetReverseWeightAsTarget() const
+    { return approach_weight + GetReverseWeightPlusOffset(); }
+
+    EdgeDuration GetForwardDurationAsSource() const
+    { return approach_duration - GetForwardDuration(); }
+    EdgeDuration GetForwardDurationAsTarget() const
+    { return approach_duration + GetForwardDuration(); }
+    EdgeDuration GetReverseDurationAsSource() const
+    { return approach_duration - GetReverseDuration(); }
+    EdgeDuration GetReverseDurationAsTarget() const
+    { return approach_duration + GetReverseDuration(); }
+
+    EdgeDistance GetForwardDistanceAsSource() const
+    { return approach_distance - GetForwardDistance(); }
+    EdgeDistance GetForwardDistanceAsTarget() const
+    { return approach_distance + GetForwardDistance(); }
+    EdgeDistance GetReverseDistanceAsSource() const
+    { return approach_distance - GetReverseDistance(); }
+    EdgeDistance GetReverseDistanceAsTarget() const
+    { return approach_distance + GetReverseDistance(); }
 
     bool IsBidirected() const { return forward_segment_id.enabled && reverse_segment_id.enabled; }
 
@@ -173,9 +211,10 @@ struct PhantomNode
           reverse_distance{reverse_distance}, forward_distance_offset{forward_distance_offset},
           reverse_distance_offset{reverse_distance_offset}, forward_duration{forward_duration},
           reverse_duration{reverse_duration}, forward_duration_offset{forward_duration_offset},
-          reverse_duration_offset{reverse_duration_offset},
-          component{component.id, component.is_tiny}, location{location},
-          input_location{input_location}, fwd_segment_position{other.fwd_segment_position},
+          reverse_duration_offset{reverse_duration_offset}, approach_weight{0},
+          approach_duration{0}, approach_distance{0}, component{component.id, component.is_tiny},
+          location{location}, input_location{input_location},
+          fwd_segment_position{other.fwd_segment_position},
           is_valid_forward_source{is_valid_forward_source},
           is_valid_forward_target{is_valid_forward_target},
           is_valid_reverse_source{is_valid_reverse_source},
@@ -197,6 +236,22 @@ struct PhantomNode
     EdgeDuration reverse_duration;
     EdgeDuration forward_duration_offset; // TODO: try to remove -> requires path unpacking changes
     EdgeDuration reverse_duration_offset; // TODO: try to remove -> requires path unpacking changes
+
+    /**
+     * The walk from where the traveller asked to be to where this phantom sits, for a
+     * coordinate that snapped into an open area (engine/area_snapping.hpp).  Zero for
+     * every ordinary phantom.
+     *
+     * It cannot live in the offsets above.  A search seeds a source with the negation of
+     * its offset and a target with the offset itself, so one stored number would have to
+     * carry both signs, and the same coordinate is a source in one journey and a target
+     * in another: every coordinate of a table is both at once, and so is a via point.
+     * Kept separately, it is added by the seeding accessors below in either role.
+     */
+    EdgeWeight approach_weight;
+    EdgeDuration approach_duration;
+    EdgeDistance approach_distance;
+
     ComponentID component;
 
     util::Coordinate location; // this is the coordinate of x
@@ -211,7 +266,7 @@ struct PhantomNode
     unsigned short bearing : 12;
 };
 
-static_assert(sizeof(PhantomNode) == 80, "PhantomNode has more padding then expected");
+static_assert(sizeof(PhantomNode) == 92, "PhantomNode has more padding than expected");
 
 using PhantomNodeCandidates = std::vector<PhantomNode>;
 using PhantomCandidateAlternatives = std::pair<PhantomNodeCandidates, PhantomNodeCandidates>;

--- a/include/engine/plugins/plugin_base.hpp
+++ b/include/engine/plugins/plugin_base.hpp
@@ -227,22 +227,9 @@ class BasePlugin
         return phantom_nodes;
     }
 
-    /**
-     * Whether a coordinate's place in the list says which end of a journey it is.  It
-     * does for a route.  A trip visits every point and returns to the first, so each of
-     * them is departed from *and* arrived at, which no single approach cost can express;
-     * see area::ApproachRole.
-     */
-    enum class ApproachCharge
-    {
-        ByPosition,
-        NeverCharge
-    };
-
     std::vector<PhantomCandidateAlternatives>
     GetPhantomNodes(const datafacade::BaseDataFacade &facade,
-                    const api::BaseParameters &parameters,
-                    const ApproachCharge charge = ApproachCharge::ByPosition) const
+                    const api::BaseParameters &parameters) const
     {
         std::vector<PhantomCandidateAlternatives> alternatives(parameters.coordinates.size());
 
@@ -263,11 +250,9 @@ class BasePlugin
             // picks whichever vertex makes the whole journey shortest.  See
             // engine/area_snapping.hpp.
             // The first coordinate is only ever departed from and the last only ever
-            // arrived at.  Everything in between is both at once and so goes uncharged,
-            // which costs a little accuracy on the legs either side of it.
-            const auto role = charge == ApproachCharge::NeverCharge ? area::ApproachRole::Via
-                              : (i + 1 == parameters.coordinates.size())
-                                  ? area::ApproachRole::Arrival
+            // arrived at.  Everything in between is both at once and takes the departing
+            // shape; the walk it costs is charged either way.
+            const auto role = (i + 1 == parameters.coordinates.size()) ? area::ApproachRole::Arrival
                               : (i == 0) ? area::ApproachRole::Departure
                                          : area::ApproachRole::Via;
             if (auto in_area =

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -34,14 +34,14 @@ void insertSourceInForwardHeap(Heap &forward_heap, const PhantomNode &source)
     if (source.IsValidForwardSource())
     {
         forward_heap.Insert(source.forward_segment_id.id,
-                            EdgeWeight{0} - source.GetForwardWeightPlusOffset(),
+                            source.GetForwardWeightAsSource(),
                             source.forward_segment_id.id);
     }
 
     if (source.IsValidReverseSource())
     {
         forward_heap.Insert(source.reverse_segment_id.id,
-                            EdgeWeight{0} - source.GetReverseWeightPlusOffset(),
+                            source.GetReverseWeightAsSource(),
                             source.reverse_segment_id.id);
     }
 }
@@ -52,14 +52,14 @@ void insertTargetInReverseHeap(Heap &reverse_heap, const PhantomNode &target)
     if (target.IsValidForwardTarget())
     {
         reverse_heap.Insert(target.forward_segment_id.id,
-                            target.GetForwardWeightPlusOffset(),
+                            target.GetForwardWeightAsTarget(),
                             target.forward_segment_id.id);
     }
 
     if (target.IsValidReverseTarget())
     {
         reverse_heap.Insert(target.reverse_segment_id.id,
-                            target.GetReverseWeightPlusOffset(),
+                            target.GetReverseWeightAsTarget(),
                             target.reverse_segment_id.id);
     }
 }
@@ -121,18 +121,18 @@ void insertSourceInHeap(ManyToManyQueryHeap &heap, const PhantomNodeCandidates &
         if (phantom_node.IsValidForwardSource())
         {
             heap.Insert(phantom_node.forward_segment_id.id,
-                        EdgeWeight{0} - phantom_node.GetForwardWeightPlusOffset(),
+                        phantom_node.GetForwardWeightAsSource(),
                         {phantom_node.forward_segment_id.id,
-                         EdgeDuration{0} - phantom_node.GetForwardDuration(),
-                         EdgeDistance{0} - phantom_node.GetForwardDistance()});
+                         phantom_node.GetForwardDurationAsSource(),
+                         phantom_node.GetForwardDistanceAsSource()});
         }
         if (phantom_node.IsValidReverseSource())
         {
             heap.Insert(phantom_node.reverse_segment_id.id,
-                        EdgeWeight{0} - phantom_node.GetReverseWeightPlusOffset(),
+                        phantom_node.GetReverseWeightAsSource(),
                         {phantom_node.reverse_segment_id.id,
-                         EdgeDuration{0} - phantom_node.GetReverseDuration(),
-                         EdgeDistance{0} - phantom_node.GetReverseDistance()});
+                         phantom_node.GetReverseDurationAsSource(),
+                         phantom_node.GetReverseDistanceAsSource()});
         }
     }
 }
@@ -145,18 +145,18 @@ void insertTargetInHeap(ManyToManyQueryHeap &heap, const PhantomNodeCandidates &
         if (phantom_node.IsValidForwardTarget())
         {
             heap.Insert(phantom_node.forward_segment_id.id,
-                        phantom_node.GetForwardWeightPlusOffset(),
+                        phantom_node.GetForwardWeightAsTarget(),
                         {phantom_node.forward_segment_id.id,
-                         phantom_node.GetForwardDuration(),
-                         phantom_node.GetForwardDistance()});
+                         phantom_node.GetForwardDurationAsTarget(),
+                         phantom_node.GetForwardDistanceAsTarget()});
         }
         if (phantom_node.IsValidReverseTarget())
         {
             heap.Insert(phantom_node.reverse_segment_id.id,
-                        phantom_node.GetReverseWeightPlusOffset(),
+                        phantom_node.GetReverseWeightAsTarget(),
                         {phantom_node.reverse_segment_id.id,
-                         phantom_node.GetReverseDuration(),
-                         phantom_node.GetReverseDistance()});
+                         phantom_node.GetReverseDurationAsTarget(),
+                         phantom_node.GetReverseDistanceAsTarget()});
         }
     }
 }

--- a/include/engine/routing_algorithms/routing_base_mld.hpp
+++ b/include/engine/routing_algorithms/routing_base_mld.hpp
@@ -745,35 +745,37 @@ double getNetworkDistance(SearchEngineData<Algorithm> &engine_working_data,
     if (source_phantom.IsValidForwardSource())
     {
         forward_heap.Insert(source_phantom.forward_segment_id.id,
-                            EdgeWeight{0} - source_phantom.GetForwardWeightPlusOffset(),
+                            source_phantom.GetForwardWeightAsSource(),
                             {source_phantom.forward_segment_id.id,
                              false,
-                             EdgeDistance{0} - source_phantom.GetForwardDistance()});
+                             source_phantom.GetForwardDistanceAsSource()});
     }
 
     if (source_phantom.IsValidReverseSource())
     {
         forward_heap.Insert(source_phantom.reverse_segment_id.id,
-                            EdgeWeight{0} - source_phantom.GetReverseWeightPlusOffset(),
+                            source_phantom.GetReverseWeightAsSource(),
                             {source_phantom.reverse_segment_id.id,
                              false,
-                             EdgeDistance{0} - source_phantom.GetReverseDistance()});
+                             source_phantom.GetReverseDistanceAsSource()});
     }
 
     if (target_phantom.IsValidForwardTarget())
     {
-        reverse_heap.Insert(
-            target_phantom.forward_segment_id.id,
-            target_phantom.GetForwardWeightPlusOffset(),
-            {target_phantom.forward_segment_id.id, false, target_phantom.GetForwardDistance()});
+        reverse_heap.Insert(target_phantom.forward_segment_id.id,
+                            target_phantom.GetForwardWeightAsTarget(),
+                            {target_phantom.forward_segment_id.id,
+                             false,
+                             target_phantom.GetForwardDistanceAsTarget()});
     }
 
     if (target_phantom.IsValidReverseTarget())
     {
-        reverse_heap.Insert(
-            target_phantom.reverse_segment_id.id,
-            target_phantom.GetReverseWeightPlusOffset(),
-            {target_phantom.reverse_segment_id.id, false, target_phantom.GetReverseDistance()});
+        reverse_heap.Insert(target_phantom.reverse_segment_id.id,
+                            target_phantom.GetReverseWeightAsTarget(),
+                            {target_phantom.reverse_segment_id.id,
+                             false,
+                             target_phantom.GetReverseDistanceAsTarget()});
     }
 
     const PhantomEndpoints endpoints{source_phantom, target_phantom};

--- a/include/engine/routing_algorithms/shortest_path_impl.hpp
+++ b/include/engine/routing_algorithms/shortest_path_impl.hpp
@@ -30,14 +30,14 @@ void searchWithUTurn(SearchEngineData<Algorithm> &engine_working_data,
         if (source.IsValidForwardSource())
         {
             forward_heap.Insert(source.forward_segment_id.id,
-                                EdgeWeight{0} - source.GetForwardWeightPlusOffset(),
+                                source.GetForwardWeightAsSource(),
                                 source.forward_segment_id.id);
         }
 
         if (source.IsValidReverseSource())
         {
             forward_heap.Insert(source.reverse_segment_id.id,
-                                EdgeWeight{0} - source.GetReverseWeightPlusOffset(),
+                                source.GetReverseWeightAsSource(),
                                 source.reverse_segment_id.id);
         }
     }
@@ -46,13 +46,13 @@ void searchWithUTurn(SearchEngineData<Algorithm> &engine_working_data,
         if (target.IsValidForwardTarget())
         {
             reverse_heap.Insert(target.forward_segment_id.id,
-                                target.GetForwardWeightPlusOffset(),
+                                target.GetForwardWeightAsTarget(),
                                 target.forward_segment_id.id);
         }
         if (target.IsValidReverseTarget())
         {
             reverse_heap.Insert(target.reverse_segment_id.id,
-                                target.GetReverseWeightPlusOffset(),
+                                target.GetReverseWeightAsTarget(),
                                 target.reverse_segment_id.id);
         }
     }
@@ -94,7 +94,7 @@ void search(SearchEngineData<Algorithm> &engine_working_data,
         forward_heap.Clear();
         reverse_heap.Clear();
         reverse_heap.Insert(target.forward_segment_id.id,
-                            target.GetForwardWeightPlusOffset(),
+                            target.GetForwardWeightAsTarget(),
                             target.forward_segment_id.id);
 
         for (const auto i : util::irange<std::size_t>(0UL, source_candidates.size()))
@@ -103,16 +103,16 @@ void search(SearchEngineData<Algorithm> &engine_working_data,
             if (search_from_forward_node[i] && candidate.IsValidForwardSource())
             {
                 forward_heap.Insert(candidate.forward_segment_id.id,
-                                    total_weight_to_forward[i] -
-                                        candidate.GetForwardWeightPlusOffset(),
+                                    total_weight_to_forward[i] +
+                                        candidate.GetForwardWeightAsSource(),
                                     candidate.forward_segment_id.id);
             }
 
             if (search_from_reverse_node[i] && candidate.IsValidReverseSource())
             {
                 forward_heap.Insert(candidate.reverse_segment_id.id,
-                                    total_weight_to_reverse[i] -
-                                        candidate.GetReverseWeightPlusOffset(),
+                                    total_weight_to_reverse[i] +
+                                        candidate.GetReverseWeightAsSource(),
                                     candidate.reverse_segment_id.id);
             }
         }
@@ -132,7 +132,7 @@ void search(SearchEngineData<Algorithm> &engine_working_data,
         forward_heap.Clear();
         reverse_heap.Clear();
         reverse_heap.Insert(target.reverse_segment_id.id,
-                            target.GetReverseWeightPlusOffset(),
+                            target.GetReverseWeightAsTarget(),
                             target.reverse_segment_id.id);
 
         BOOST_ASSERT(search_from_forward_node.size() == source_candidates.size());
@@ -142,16 +142,16 @@ void search(SearchEngineData<Algorithm> &engine_working_data,
             if (search_from_forward_node[i] && candidate.IsValidForwardSource())
             {
                 forward_heap.Insert(candidate.forward_segment_id.id,
-                                    total_weight_to_forward[i] -
-                                        candidate.GetForwardWeightPlusOffset(),
+                                    total_weight_to_forward[i] +
+                                        candidate.GetForwardWeightAsSource(),
                                     candidate.forward_segment_id.id);
             }
 
             if (search_from_reverse_node[i] && candidate.IsValidReverseSource())
             {
                 forward_heap.Insert(candidate.reverse_segment_id.id,
-                                    total_weight_to_reverse[i] -
-                                        candidate.GetReverseWeightPlusOffset(),
+                                    total_weight_to_reverse[i] +
+                                        candidate.GetReverseWeightAsSource(),
                                     candidate.reverse_segment_id.id);
             }
         }

--- a/src/engine/area_snapping.cpp
+++ b/src/engine/area_snapping.cpp
@@ -88,42 +88,35 @@ util::Coordinate vertex_at(const std::vector<std::span<const util::Coordinate>> 
  * itself stays put: the API reads `forward_segment_id.id` unconditionally to name a
  * waypoint.
  *
- * The cost of the walk goes into that direction's weight offset.
- * `GetForwardWeightPlusOffset()` is the cost from the start of the edge-based node to the
- * phantom, and the search seeds a source with its negation but a target with the value
- * itself -- so the same walk has to be subtracted in one case and added in the other,
- * which is what @p role decides.  The result accounting never reads the offsets;
- * `assembleLeg` works from `forward_weight` and the per-segment values.  So this charges
- * the search and nothing else.  The types are signed, and a departure going below zero is
- * exactly what is meant: the journey begins before the graph does.
+ * The cost of the walk goes on the phantom itself, not into the direction's offset.  A
+ * search seeds a source with the negation of its offset and a target with the offset
+ * itself, so an offset would have to carry both signs at once for a coordinate that is
+ * both, which every coordinate of a table is and so is a via point.  Carried separately,
+ * it is added in either role; see `PhantomNode::approach_weight`.  Leg assembly never
+ * reads it, and does not need to: the walk is drawn into the leg as a stretch of its own
+ * (engine/area_route.hpp).
  */
 PhantomNode at_vertex(PhantomNode phantom,
                       const bool forward,
                       const util::Coordinate from,
                       const util::Coordinate vertex,
                       const double walking_speed,
-                      const double weight_multiplier,
-                      const ApproachRole role)
+                      const double weight_multiplier)
 {
     const auto metres = util::coordinate_calculation::greatCircleDistance(from, vertex);
     const auto seconds = metres / walking_speed;
 
-    // durations are stored in deci-seconds, weights in the profile's own unit.
-    // A via point is charged nothing: see ApproachRole.
-    const auto sign = role == ApproachRole::Via ? 0 : (role == ApproachRole::Departure ? -1 : 1);
-    const auto duration = to_alias<EdgeDuration>(sign * std::lround(seconds * 10.));
-    const auto weight = to_alias<EdgeWeight>(sign * std::lround(seconds * weight_multiplier));
+    // durations are stored in deci-seconds, weights in the profile's own unit
+    phantom.approach_weight = to_alias<EdgeWeight>(std::lround(seconds * weight_multiplier));
+    phantom.approach_duration = to_alias<EdgeDuration>(std::lround(seconds * 10.));
+    phantom.approach_distance = to_alias<EdgeDistance>(metres);
 
     if (forward)
     {
-        phantom.forward_weight_offset = phantom.forward_weight_offset + weight;
-        phantom.forward_duration_offset = phantom.forward_duration_offset + duration;
         phantom.reverse_segment_id.enabled = false;
     }
     else
     {
-        phantom.reverse_weight_offset = phantom.reverse_weight_offset + weight;
-        phantom.reverse_duration_offset = phantom.reverse_duration_offset + duration;
         phantom.forward_segment_id.enabled = false;
     }
 
@@ -204,8 +197,10 @@ std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDa
                 // answers both, because sitting at a segment's first node means carrying
                 // a weight of zero forwards and the whole of the segment in reverse.
                 //
-                // A via point takes the departure convention.  It is both ends at once
-                // and something has to give; see ApproachRole.
+                // Getting this wrong does not merely cost accuracy.  A candidate that
+                // stands at a node's start and is then used as a target sits *before* a
+                // source that is further along the same node, and the journey between
+                // them comes out short by the stretch in between.
                 const bool arriving = role == ApproachRole::Arrival;
                 const auto forward_usable =
                     arriving ? phantom.IsValidForwardTarget() : phantom.IsValidForwardSource();
@@ -218,23 +213,13 @@ std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDa
 
                 if (forward_usable && forward_at_the_vertex && claim(phantom.forward_segment_id.id))
                 {
-                    candidates.push_back(at_vertex(phantom,
-                                                   true,
-                                                   coordinate,
-                                                   vertex,
-                                                   area.walking_speed,
-                                                   weight_multiplier,
-                                                   role));
+                    candidates.push_back(at_vertex(
+                        phantom, true, coordinate, vertex, area.walking_speed, weight_multiplier));
                 }
                 if (reverse_usable && reverse_at_the_vertex && claim(phantom.reverse_segment_id.id))
                 {
-                    candidates.push_back(at_vertex(phantom,
-                                                   false,
-                                                   coordinate,
-                                                   vertex,
-                                                   area.walking_speed,
-                                                   weight_multiplier,
-                                                   role));
+                    candidates.push_back(at_vertex(
+                        phantom, false, coordinate, vertex, area.walking_speed, weight_multiplier));
                 }
             }
         }

--- a/src/engine/plugins/trip.cpp
+++ b/src/engine/plugins/trip.cpp
@@ -206,7 +206,7 @@ Status TripPlugin::HandleRequest(const RoutingAlgorithmsInterface &algorithms,
         return Status::Error;
 
     const auto &facade = algorithms.GetFacade();
-    auto phantom_node_pairs = GetPhantomNodes(facade, parameters, ApproachCharge::NeverCharge);
+    auto phantom_node_pairs = GetPhantomNodes(facade, parameters);
     if (phantom_node_pairs.size() != number_of_locations)
     {
         return Error("NoSegment",

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -236,17 +236,17 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     target_nodes_index.insert(
                         {phantom_node.forward_segment_id.id,
                          std::make_tuple(index,
-                                         phantom_node.GetForwardWeightPlusOffset(),
-                                         phantom_node.GetForwardDuration(),
-                                         phantom_node.GetForwardDistance())});
+                                         phantom_node.GetForwardWeightAsTarget(),
+                                         phantom_node.GetForwardDurationAsTarget(),
+                                         phantom_node.GetForwardDistanceAsTarget())});
 
                 if (phantom_node.IsValidReverseTarget())
                     target_nodes_index.insert(
                         {phantom_node.reverse_segment_id.id,
                          std::make_tuple(index,
-                                         phantom_node.GetReverseWeightPlusOffset(),
-                                         phantom_node.GetReverseDuration(),
-                                         phantom_node.GetReverseDistance())});
+                                         phantom_node.GetReverseWeightAsTarget(),
+                                         phantom_node.GetReverseDurationAsTarget(),
+                                         phantom_node.GetReverseDistanceAsTarget())});
             }
             else if (DIRECTION == REVERSE_DIRECTION)
             {
@@ -254,17 +254,17 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     target_nodes_index.insert(
                         {phantom_node.forward_segment_id.id,
                          std::make_tuple(index,
-                                         EdgeWeight{0} - phantom_node.GetForwardWeightPlusOffset(),
-                                         EdgeDuration{0} - phantom_node.GetForwardDuration(),
-                                         EdgeDistance{0} - phantom_node.GetForwardDistance())});
+                                         phantom_node.GetForwardWeightAsSource(),
+                                         phantom_node.GetForwardDurationAsSource(),
+                                         phantom_node.GetForwardDistanceAsSource())});
 
                 if (phantom_node.IsValidReverseSource())
                     target_nodes_index.insert(
                         {phantom_node.reverse_segment_id.id,
                          std::make_tuple(index,
-                                         EdgeWeight{0} - phantom_node.GetReverseWeightPlusOffset(),
-                                         EdgeDuration{0} - phantom_node.GetReverseDuration(),
-                                         EdgeDistance{0} - phantom_node.GetReverseDistance())});
+                                         phantom_node.GetReverseWeightAsSource(),
+                                         phantom_node.GetReverseDurationAsSource(),
+                                         phantom_node.GetReverseDistanceAsSource())});
             }
         }
     }
@@ -346,17 +346,17 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                 if (phantom_node.IsValidForwardSource())
                 {
                     insert_node(phantom_node.forward_segment_id.id,
-                                EdgeWeight{0} - phantom_node.GetForwardWeightPlusOffset(),
-                                EdgeDuration{0} - phantom_node.GetForwardDuration(),
-                                EdgeDistance{0} - phantom_node.GetForwardDistance());
+                                phantom_node.GetForwardWeightAsSource(),
+                                phantom_node.GetForwardDurationAsSource(),
+                                phantom_node.GetForwardDistanceAsSource());
                 }
 
                 if (phantom_node.IsValidReverseSource())
                 {
                     insert_node(phantom_node.reverse_segment_id.id,
-                                EdgeWeight{0} - phantom_node.GetReverseWeightPlusOffset(),
-                                EdgeDuration{0} - phantom_node.GetReverseDuration(),
-                                EdgeDistance{0} - phantom_node.GetReverseDistance());
+                                phantom_node.GetReverseWeightAsSource(),
+                                phantom_node.GetReverseDurationAsSource(),
+                                phantom_node.GetReverseDistanceAsSource());
                 }
             }
             else if (DIRECTION == REVERSE_DIRECTION)
@@ -364,17 +364,17 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                 if (phantom_node.IsValidForwardTarget())
                 {
                     insert_node(phantom_node.forward_segment_id.id,
-                                phantom_node.GetForwardWeightPlusOffset(),
-                                phantom_node.GetForwardDuration(),
-                                phantom_node.GetForwardDistance());
+                                phantom_node.GetForwardWeightAsTarget(),
+                                phantom_node.GetForwardDurationAsTarget(),
+                                phantom_node.GetForwardDistanceAsTarget());
                 }
 
                 if (phantom_node.IsValidReverseTarget())
                 {
                     insert_node(phantom_node.reverse_segment_id.id,
-                                phantom_node.GetReverseWeightPlusOffset(),
-                                phantom_node.GetReverseDuration(),
-                                phantom_node.GetReverseDistance());
+                                phantom_node.GetReverseWeightAsTarget(),
+                                phantom_node.GetReverseDurationAsTarget(),
+                                phantom_node.GetReverseDistanceAsTarget());
                 }
             }
         }


### PR DESCRIPTION
Fixes the sign half of defect 1 in #7683, and the two follow-ups recorded under it: the uncharged via point and the uncharged trip.

## The problem

Snapping a coordinate that falls inside an open area charges the walk to the vertex it snapped to. That cost went into the phantom's weight offset, and a search seeds a source with the negation of the offset and a target with the offset itself, so one stored number had to mean both signs. Which one it got was decided by the coordinate's place in the request: first is a departure, last an arrival.

That works for a route and for nothing else.

* **A table.** Every coordinate is a source and a destination at once, so half the matrix was charged backwards.
* **A via point.** Charged as a departure, the leg arriving there seeds a negative key, which CH asserts against. It was made uncharged to stop the crash, at the cost of accuracy on both legs either side.
* **A trip.** The same case for all of its coordinates, since the tour returns to the first, so it had to opt out of the charge entirely with `ApproachCharge::NeverCharge`.

## The change

The walk lives on the phantom now, in three fields of its own, and the seeding accessors add it in either role:

```cpp
EdgeWeight GetForwardWeightAsSource() const
{ return approach_weight - GetForwardWeightPlusOffset(); }
EdgeWeight GetForwardWeightAsTarget() const
{ return approach_weight + GetForwardWeightPlusOffset(); }
```

Nothing has to know which end of a journey a coordinate is in order to cost it. The sign is fixed by the accessor rather than by the caller, a target's key can no longer go negative, and the trip opt-out is gone.

They are deliberately not folded into the `Get*PlusOffset` accessors, which leg assembly reads to work out what a route costs. The walk is already drawn into the leg as a stretch of its own, so a route's reported distance and duration are unchanged.

## Size

`sizeof(PhantomNode)` goes from 80 to 92 bytes. **Nothing public moves with it.** #7649 replaced the `PhantomNode` inside `SegmentHint` with a fixed 80 byte placeholder, so the hint string stays 112 characters. #7683 says this fix costs a longer hint; that was written before #7649 landed and is no longer true.

## What this does not fix

A table cell with one end on a plaza. The remaining error is not the sign, and it took some digging to see why:

```
CELL r=1 c=0 heap_d=-49.98 bucket_d=111.76 new_d=61.78
```

A candidate departed from stands at an edge-based node's start; one arrived at stands at its end. A coordinate that is both can only have one shape, so when the departing shape is used as a target it sits *before* a source further along the same node, and the cell comes out short by the stretch in between. Worse, the many-to-many code detects that degenerate case by the accumulated weight going negative (`addLoopWeight`), and a positive approach cost masks it.

The numbers, from the node coordinates in the generated `.osm` rather than from OSRM: `a` is 50 m from `e`, and `m` is 111.8 m from `a` straight across the plaza, so the walk is 161.8 m. Round by `d` would be 270.7 m.

| | table says | correct |
|---|---|---|
| today | 161.7 one way, 61.8 the other | 161.7 both |
| offering both shapes | 61.8 both ways | 161.7 both |

`161.74 - 61.78` is `99.96`, exactly twice the 49.98 m `e -> a` segment: the source seed subtracts its own segment and nothing adds it back.

Offering both shapes is the obvious fix and I tried it. It makes the matrix symmetric, which is the right shape for a walking cost function and worth having, but both cells then come out 100 m short instead of one being exact, so it is not an improvement on its own. It needs `addLoopWeight` to fire on the graph part of the weight rather than on the total, and then both shapes becomes the right default. That is its own piece of work; #7683 carries the diagnosis.

Worth noting for whoever picks it up: the asymmetry is the tell. A foot profile should never produce an asymmetric matrix, so the current output announces the bug on its own.

Verified with `ENABLE_ASSERTIONS=1`: all five unit suites, and the full cucumber matrix over `ch`/`mld` and `mmap`/`directly`/`datastore`, 1471 scenarios each.

Written with AI assistance: Claude Code, Claude Opus 5 🤖