### PR TITLE
fix(engine): a table cell with one end inside an open area came out short

### DIFF
--- a/features/foot/area_table_trip.feature
+++ b/features/foot/area_table_trip.feature
@@ -103,3 +103,39 @@ Feature: Foot - Tables and trips across a pedestrian area
         When I plan a trip I should get
             | waypoints | trips | distance |
             | p,q,s     | psq   | 647m +-6 |
+
+    # A pair with one end off the plaza.  Walking is symmetric, so the matrix has to be:
+    # an asymmetric cell for a foot profile is the bug announcing itself.  Both cells are
+    # 161.7 m, which is 50 m along way A and then 111.8 m straight across the plaza, and
+    # is what /route reports in both directions.
+    Scenario: Foot - A pair with only one end on the plaza
+        Given the node map
+            """
+            e-a-------b-f
+              |       |
+              | m     |
+            h-d-------c-g
+            """
+
+        And the ways
+            | nodes | highway    | area | name  |
+            | abcda | pedestrian | yes  | Plaza |
+            | ea    | pedestrian |      | A     |
+            | bf    | pedestrian |      | B     |
+            | hd    | pedestrian |      | C     |
+            | cg    | pedestrian |      | D     |
+
+        When I route I should get
+            | from | to | distance | time   |
+            | m    | e  | 161.7m   | 115.8s |
+            | e    | m  | 161.7m   | 115.8s |
+
+        When I request a travel distance matrix I should get
+            |   | m     | e     |
+            | m | 0     | 161.7 |
+            | e | 161.7 | 0     |
+
+        When I request a travel time matrix I should get
+            |   | m     | e     |
+            | m | 0     | 115.8 |
+            | e | 115.8 | 0     |

--- a/include/engine/routing_algorithms/many_to_many.hpp
+++ b/include/engine/routing_algorithms/many_to_many.hpp
@@ -22,6 +22,9 @@ struct NodeBucket
     EdgeWeight weight;
     EdgeDuration duration;
     EdgeDistance distance;
+    //! How much of @c weight is the walk into an open area rather than travel through the
+    //! graph; see ManyToManyHeapData::approach, which this is copied from.
+    EdgeWeight approach;
 
     NodeBucket(NodeID middle_node,
                NodeID parent_node,
@@ -29,9 +32,11 @@ struct NodeBucket
                unsigned column_index,
                EdgeWeight weight,
                EdgeDuration duration,
-               EdgeDistance distance)
+               EdgeDistance distance,
+               EdgeWeight approach = EdgeWeight{0})
         : middle_node(middle_node), parent_node(parent_node), column_index(column_index),
-          from_clique_arc(from_clique_arc), weight(weight), duration(duration), distance(distance)
+          from_clique_arc(from_clique_arc), weight(weight), duration(duration), distance(distance),
+          approach(approach)
     {
     }
 
@@ -40,9 +45,11 @@ struct NodeBucket
                unsigned column_index,
                EdgeWeight weight,
                EdgeDuration duration,
-               EdgeDistance distance)
+               EdgeDistance distance,
+               EdgeWeight approach = EdgeWeight{0})
         : middle_node(middle_node), parent_node(parent_node), column_index(column_index),
-          from_clique_arc(false), weight(weight), duration(duration), distance(distance)
+          from_clique_arc(false), weight(weight), duration(duration), distance(distance),
+          approach(approach)
     {
     }
 

--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -124,7 +124,8 @@ void insertSourceInHeap(ManyToManyQueryHeap &heap, const PhantomNodeCandidates &
                         phantom_node.GetForwardWeightAsSource(),
                         {phantom_node.forward_segment_id.id,
                          phantom_node.GetForwardDurationAsSource(),
-                         phantom_node.GetForwardDistanceAsSource()});
+                         phantom_node.GetForwardDistanceAsSource(),
+                         phantom_node.approach_weight});
         }
         if (phantom_node.IsValidReverseSource())
         {
@@ -132,7 +133,8 @@ void insertSourceInHeap(ManyToManyQueryHeap &heap, const PhantomNodeCandidates &
                         phantom_node.GetReverseWeightAsSource(),
                         {phantom_node.reverse_segment_id.id,
                          phantom_node.GetReverseDurationAsSource(),
-                         phantom_node.GetReverseDistanceAsSource()});
+                         phantom_node.GetReverseDistanceAsSource(),
+                         phantom_node.approach_weight});
         }
     }
 }
@@ -148,7 +150,8 @@ void insertTargetInHeap(ManyToManyQueryHeap &heap, const PhantomNodeCandidates &
                         phantom_node.GetForwardWeightAsTarget(),
                         {phantom_node.forward_segment_id.id,
                          phantom_node.GetForwardDurationAsTarget(),
-                         phantom_node.GetForwardDistanceAsTarget()});
+                         phantom_node.GetForwardDistanceAsTarget(),
+                         phantom_node.approach_weight});
         }
         if (phantom_node.IsValidReverseTarget())
         {
@@ -156,7 +159,8 @@ void insertTargetInHeap(ManyToManyQueryHeap &heap, const PhantomNodeCandidates &
                         phantom_node.GetReverseWeightAsTarget(),
                         {phantom_node.reverse_segment_id.id,
                          phantom_node.GetReverseDurationAsTarget(),
-                         phantom_node.GetReverseDistanceAsTarget()});
+                         phantom_node.GetReverseDistanceAsTarget(),
+                         phantom_node.approach_weight});
         }
     }
 }

--- a/include/engine/search_engine_data.hpp
+++ b/include/engine/search_engine_data.hpp
@@ -33,8 +33,21 @@ struct ManyToManyHeapData : HeapData
 {
     EdgeDuration duration;
     EdgeDistance distance;
-    ManyToManyHeapData(NodeID p, EdgeDuration duration, EdgeDistance distance)
-        : HeapData(p), duration(duration), distance(distance)
+    // How much of the weight is the walk into an open area rather than travel through the
+    // graph (PhantomNode::approach_weight). Set by the seed and carried unchanged as the
+    // search relaxes, because a walk to where the graph starts is not made up by
+    // travelling along it.
+    //
+    // It has to be separable. A source and a target on one edge-based node with the target
+    // the earlier of the two need a loop, and the graph part of the weight going negative
+    // is what says so. A walk charged at both ends lifts the sum back above zero and hides
+    // it, and the cell then comes out short by the stretch in between.
+    EdgeWeight approach;
+    ManyToManyHeapData(NodeID p,
+                       EdgeDuration duration,
+                       EdgeDistance distance,
+                       EdgeWeight approach = EdgeWeight{0})
+        : HeapData(p), duration(duration), distance(distance), approach(approach)
     {
     }
 };
@@ -100,15 +113,22 @@ struct ManyToManyMultiLayerDijkstraHeapData : MultiLayerDijkstraHeapData
 {
     EdgeDuration duration;
     EdgeDistance distance;
-    ManyToManyMultiLayerDijkstraHeapData(NodeID p, EdgeDuration duration, EdgeDistance distance)
-        : MultiLayerDijkstraHeapData(p), duration(duration), distance(distance)
+    //! See ManyToManyHeapData::approach.
+    EdgeWeight approach;
+    ManyToManyMultiLayerDijkstraHeapData(NodeID p,
+                                         EdgeDuration duration,
+                                         EdgeDistance distance,
+                                         EdgeWeight approach = EdgeWeight{0})
+        : MultiLayerDijkstraHeapData(p), duration(duration), distance(distance), approach(approach)
     {
     }
     ManyToManyMultiLayerDijkstraHeapData(NodeID p,
                                          bool from,
                                          EdgeDuration duration,
-                                         EdgeDistance distance)
-        : MultiLayerDijkstraHeapData(p, from), duration(duration), distance(distance)
+                                         EdgeDistance distance,
+                                         EdgeWeight approach = EdgeWeight{0})
+        : MultiLayerDijkstraHeapData(p, from), duration(duration), distance(distance),
+          approach(approach)
     {
     }
 };

--- a/src/engine/area_snapping.cpp
+++ b/src/engine/area_snapping.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <span>
 #include <vector>
 
 namespace osrm::engine::area
@@ -163,6 +164,7 @@ std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDa
         }
 
         PhantomNodeCandidates candidates;
+
         std::vector<NodeID> claimed_nodes;
         const auto claim = [&claimed_nodes](const NodeID node)
         {
@@ -202,24 +204,38 @@ std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDa
                 // source that is further along the same node, and the journey between
                 // them comes out short by the stretch in between.
                 const bool arriving = role == ApproachRole::Arrival;
-                const auto forward_usable =
-                    arriving ? phantom.IsValidForwardTarget() : phantom.IsValidForwardSource();
-                const auto reverse_usable =
-                    arriving ? phantom.IsValidReverseTarget() : phantom.IsValidReverseSource();
-                const auto forward_at_the_vertex =
-                    (arriving ? phantom.reverse_weight : phantom.forward_weight) == EdgeWeight{0};
-                const auto reverse_at_the_vertex =
-                    (arriving ? phantom.forward_weight : phantom.reverse_weight) == EdgeWeight{0};
+                {
+                    const auto forward_usable =
+                        arriving ? phantom.IsValidForwardTarget() : phantom.IsValidForwardSource();
+                    const auto reverse_usable =
+                        arriving ? phantom.IsValidReverseTarget() : phantom.IsValidReverseSource();
+                    const auto forward_at_the_vertex =
+                        (arriving ? phantom.reverse_weight : phantom.forward_weight) ==
+                        EdgeWeight{0};
+                    const auto reverse_at_the_vertex =
+                        (arriving ? phantom.forward_weight : phantom.reverse_weight) ==
+                        EdgeWeight{0};
 
-                if (forward_usable && forward_at_the_vertex && claim(phantom.forward_segment_id.id))
-                {
-                    candidates.push_back(at_vertex(
-                        phantom, true, coordinate, vertex, area.walking_speed, weight_multiplier));
-                }
-                if (reverse_usable && reverse_at_the_vertex && claim(phantom.reverse_segment_id.id))
-                {
-                    candidates.push_back(at_vertex(
-                        phantom, false, coordinate, vertex, area.walking_speed, weight_multiplier));
+                    if (forward_usable && forward_at_the_vertex &&
+                        claim(phantom.forward_segment_id.id))
+                    {
+                        candidates.push_back(at_vertex(phantom,
+                                                       true,
+                                                       coordinate,
+                                                       vertex,
+                                                       area.walking_speed,
+                                                       weight_multiplier));
+                    }
+                    if (reverse_usable && reverse_at_the_vertex &&
+                        claim(phantom.reverse_segment_id.id))
+                    {
+                        candidates.push_back(at_vertex(phantom,
+                                                       false,
+                                                       coordinate,
+                                                       vertex,
+                                                       area.walking_speed,
+                                                       weight_multiplier));
+                    }
                 }
             }
         }

--- a/src/engine/routing_algorithms/many_to_many_ch.cpp
+++ b/src/engine/routing_algorithms/many_to_many_ch.cpp
@@ -12,19 +12,27 @@ namespace osrm::engine::routing_algorithms
 namespace ch
 {
 
+// The test is on weight minus approach, not on weight. A source and a target on one
+// edge-based node with the target the earlier of the two need a loop to get from one to
+// the other, and the graph part of the weight going negative is what says so. The walk
+// into an open area is charged at both ends and is not travel, so it lifts the sum back
+// above zero and hides the case. The cell then comes out short by the stretch between
+// them. weight is the whole weight, walk included, which is what the cell reports;
+// approach is how much of it is the walk.
 inline bool addLoopWeight(const DataFacade<ch::Algorithm> &facade,
                           const NodeID node,
                           EdgeWeight &weight,
+                          const EdgeWeight approach,
                           EdgeDuration &duration,
                           EdgeDistance &distance)
 { // Special case for CH when contractor creates a loop edge node->node
-    BOOST_ASSERT(weight < EdgeWeight{0});
+    BOOST_ASSERT(weight - approach < EdgeWeight{0});
 
     const auto loop_weight = ch::getLoopMetric<EdgeWeight>(facade, node);
     if (std::get<0>(loop_weight) != INVALID_EDGE_WEIGHT)
     {
         const auto new_weight_with_loop = weight + std::get<0>(loop_weight);
-        if (new_weight_with_loop >= EdgeWeight{0})
+        if (new_weight_with_loop - approach >= EdgeWeight{0})
         {
             weight = new_weight_with_loop;
             auto result = ch::getLoopMetric<EdgeDuration>(facade, node);
@@ -70,13 +78,17 @@ void relaxOutgoingEdges(
             // New Node discovered -> Add to Heap + Node Info Storage
             if (!toHeapNode)
             {
-                query_heap.Insert(to, to_weight, {heapNode.node, to_duration, to_distance});
+                query_heap.Insert(
+                    to,
+                    to_weight,
+                    {heapNode.node, to_duration, to_distance, heapNode.data.approach});
             }
             // Found a shorter Path -> Update weight and set new parent
             else if (std::tie(to_weight, to_duration) <
                      std::tie(toHeapNode->weight, toHeapNode->data.duration))
             {
-                toHeapNode->data = {heapNode.node, to_duration, to_distance};
+                toHeapNode->data = {
+                    heapNode.node, to_duration, to_distance, heapNode.data.approach};
                 toHeapNode->weight = to_weight;
                 query_heap.DecreaseKey(*toHeapNode);
             }
@@ -126,9 +138,12 @@ void forwardRoutingStep(const DataFacade<Algorithm> &facade,
         auto new_duration = heapNode.data.duration + target_duration;
         auto new_distance = heapNode.data.distance + target_distance;
 
-        if (new_weight < EdgeWeight{0})
+        const auto approach = heapNode.data.approach + current_bucket.approach;
+
+        if (new_weight - approach < EdgeWeight{0})
         {
-            if (addLoopWeight(facade, heapNode.node, new_weight, new_duration, new_distance))
+            if (addLoopWeight(
+                    facade, heapNode.node, new_weight, approach, new_duration, new_distance))
             {
                 current_weight = std::min(current_weight, new_weight);
                 current_duration = std::min(current_duration, new_duration);
@@ -164,7 +179,8 @@ void backwardRoutingStep(const DataFacade<Algorithm> &facade,
                                            column_index,
                                            heapNode.weight,
                                            heapNode.data.duration,
-                                           heapNode.data.distance);
+                                           heapNode.data.distance,
+                                           heapNode.data.approach);
 
     relaxOutgoingEdges<REVERSE_DIRECTION>(facade, heapNode, query_heap, candidates);
 }

--- a/src/engine/routing_algorithms/many_to_many_mld.cpp
+++ b/src/engine/routing_algorithms/many_to_many_mld.cpp
@@ -36,7 +36,8 @@ void relaxBorderEdges(const DataFacade<mld::Algorithm> &facade,
                       const EdgeDuration duration,
                       const EdgeDistance distance,
                       SearchEngineData<mld::Algorithm>::ManyToManyQueryHeap &query_heap,
-                      LevelID level)
+                      LevelID level,
+                      const EdgeWeight approach = EdgeWeight{0})
 {
     for (const auto edge : facade.GetBorderEdgeRange(level, node))
     {
@@ -70,7 +71,7 @@ void relaxBorderEdges(const DataFacade<mld::Algorithm> &facade,
             const auto toHeapNode = query_heap.GetHeapNodeIfWasInserted(to);
             if (!toHeapNode)
             {
-                query_heap.Insert(to, to_weight, {node, false, to_duration, to_distance});
+                query_heap.Insert(to, to_weight, {node, false, to_duration, to_distance, approach});
             }
             // Found a shorter Path -> Update weight and set new parent
             else if (std::tie(to_weight, to_duration, to_distance, node) <
@@ -79,7 +80,7 @@ void relaxBorderEdges(const DataFacade<mld::Algorithm> &facade,
                               toHeapNode->data.distance,
                               toHeapNode->data.parent))
             {
-                toHeapNode->data = {node, false, to_duration, to_distance};
+                toHeapNode->data = {node, false, to_duration, to_distance, approach};
                 toHeapNode->weight = to_weight;
                 query_heap.DecreaseKey(*toHeapNode);
             }
@@ -130,8 +131,13 @@ void relaxOutgoingEdges(
                     const auto toHeapNode = query_heap.GetHeapNodeIfWasInserted(to);
                     if (!toHeapNode)
                     {
-                        query_heap.Insert(
-                            to, to_weight, {heapNode.node, true, to_duration, to_distance});
+                        query_heap.Insert(to,
+                                          to_weight,
+                                          {heapNode.node,
+                                           true,
+                                           to_duration,
+                                           to_distance,
+                                           heapNode.data.approach});
                     }
                     else if (std::tie(to_weight, to_duration, to_distance, heapNode.node) <
                              std::tie(toHeapNode->weight,
@@ -139,7 +145,8 @@ void relaxOutgoingEdges(
                                       toHeapNode->data.distance,
                                       toHeapNode->data.parent))
                     {
-                        toHeapNode->data = {heapNode.node, true, to_duration, to_distance};
+                        toHeapNode->data = {
+                            heapNode.node, true, to_duration, to_distance, heapNode.data.approach};
                         toHeapNode->weight = to_weight;
                         query_heap.DecreaseKey(*toHeapNode);
                     }
@@ -171,8 +178,13 @@ void relaxOutgoingEdges(
                     const auto toHeapNode = query_heap.GetHeapNodeIfWasInserted(to);
                     if (!toHeapNode)
                     {
-                        query_heap.Insert(
-                            to, to_weight, {heapNode.node, true, to_duration, to_distance});
+                        query_heap.Insert(to,
+                                          to_weight,
+                                          {heapNode.node,
+                                           true,
+                                           to_duration,
+                                           to_distance,
+                                           heapNode.data.approach});
                     }
                     else if (std::tie(to_weight, to_duration, to_distance, heapNode.node) <
                              std::tie(toHeapNode->weight,
@@ -180,7 +192,8 @@ void relaxOutgoingEdges(
                                       toHeapNode->data.distance,
                                       toHeapNode->data.parent))
                     {
-                        toHeapNode->data = {heapNode.node, true, to_duration, to_distance};
+                        toHeapNode->data = {
+                            heapNode.node, true, to_duration, to_distance, heapNode.data.approach};
                         toHeapNode->weight = to_weight;
                         query_heap.DecreaseKey(*toHeapNode);
                     }
@@ -200,7 +213,8 @@ void relaxOutgoingEdges(
                                 heapNode.data.duration,
                                 heapNode.data.distance,
                                 query_heap,
-                                level);
+                                level,
+                                heapNode.data.approach);
 }
 
 //
@@ -221,7 +235,9 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                                               MAXIMAL_EDGE_DISTANCE);
 
     // Collect destination (source) nodes into a map
-    std::unordered_multimap<NodeID, std::tuple<std::size_t, EdgeWeight, EdgeDuration, EdgeDistance>>
+    std::unordered_multimap<
+        NodeID,
+        std::tuple<std::size_t, EdgeWeight, EdgeDuration, EdgeDistance, EdgeWeight>>
         target_nodes_index;
     target_nodes_index.reserve(target_indices.size());
     for (std::size_t index = 0; index < target_indices.size(); ++index)
@@ -238,7 +254,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                          std::make_tuple(index,
                                          phantom_node.GetForwardWeightAsTarget(),
                                          phantom_node.GetForwardDurationAsTarget(),
-                                         phantom_node.GetForwardDistanceAsTarget())});
+                                         phantom_node.GetForwardDistanceAsTarget(),
+                                         phantom_node.approach_weight)});
 
                 if (phantom_node.IsValidReverseTarget())
                     target_nodes_index.insert(
@@ -246,7 +263,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                          std::make_tuple(index,
                                          phantom_node.GetReverseWeightAsTarget(),
                                          phantom_node.GetReverseDurationAsTarget(),
-                                         phantom_node.GetReverseDistanceAsTarget())});
+                                         phantom_node.GetReverseDistanceAsTarget(),
+                                         phantom_node.approach_weight)});
             }
             else if (DIRECTION == REVERSE_DIRECTION)
             {
@@ -256,7 +274,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                          std::make_tuple(index,
                                          phantom_node.GetForwardWeightAsSource(),
                                          phantom_node.GetForwardDurationAsSource(),
-                                         phantom_node.GetForwardDistanceAsSource())});
+                                         phantom_node.GetForwardDistanceAsSource(),
+                                         phantom_node.approach_weight)});
 
                 if (phantom_node.IsValidReverseSource())
                     target_nodes_index.insert(
@@ -264,7 +283,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                          std::make_tuple(index,
                                          phantom_node.GetReverseWeightAsSource(),
                                          phantom_node.GetReverseDurationAsSource(),
-                                         phantom_node.GetReverseDistanceAsSource())});
+                                         phantom_node.GetReverseDistanceAsSource(),
+                                         phantom_node.approach_weight)});
             }
         }
     }
@@ -275,8 +295,11 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
     auto &query_heap = *(engine_working_data.many_to_many_heap);
 
     // Check if node is in the destinations list and update weights/durations
-    auto update_values =
-        [&](NodeID node, EdgeWeight weight, EdgeDuration duration, EdgeDistance distance)
+    auto update_values = [&](NodeID node,
+                             EdgeWeight weight,
+                             EdgeDuration duration,
+                             EdgeDistance distance,
+                             EdgeWeight approach)
     {
         auto candidates = target_nodes_index.equal_range(node);
         for (auto it = candidates.first; it != candidates.second;)
@@ -285,10 +308,16 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
             EdgeWeight target_weight;
             EdgeDuration target_duration;
             EdgeDistance target_distance;
-            std::tie(index, target_weight, target_duration, target_distance) = it->second;
+            EdgeWeight target_approach;
+            std::tie(index, target_weight, target_duration, target_distance, target_approach) =
+                it->second;
 
             const auto path_weight = weight + target_weight;
-            if (path_weight >= EdgeWeight{0})
+            // The walk into an open area is charged at both ends and is not travel, so it
+            // cannot make a target that sits before the source reachable.  Test the graph
+            // part, or a degenerate pairing is accepted and the cell comes out short by
+            // the stretch between them.  See ManyToManyHeapData::approach.
+            if (path_weight - (approach + target_approach) >= EdgeWeight{0})
             {
                 const auto path_duration = duration + target_duration;
                 const auto path_distance = distance + target_distance;
@@ -318,7 +347,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
     auto insert_node = [&](NodeID node,
                            EdgeWeight initial_weight,
                            EdgeDuration initial_duration,
-                           EdgeDistance initial_distance)
+                           EdgeDistance initial_distance,
+                           EdgeWeight approach)
     {
         if (target_nodes_index.contains(node))
         {
@@ -326,13 +356,20 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
             // the node (e.g destination is before source on oneway segment) we want to allow
             // node to be visited later in the search along a reachable path.
             // Therefore, we manually run first step of search without marking node as visited.
-            update_values(node, initial_weight, initial_duration, initial_distance);
-            relaxBorderEdges<DIRECTION>(
-                facade, node, initial_weight, initial_duration, initial_distance, query_heap, 0);
+            update_values(node, initial_weight, initial_duration, initial_distance, approach);
+            relaxBorderEdges<DIRECTION>(facade,
+                                        node,
+                                        initial_weight,
+                                        initial_duration,
+                                        initial_distance,
+                                        query_heap,
+                                        0,
+                                        approach);
         }
         else
         {
-            query_heap.Insert(node, initial_weight, {node, initial_duration, initial_distance});
+            query_heap.Insert(
+                node, initial_weight, {node, initial_duration, initial_distance, approach});
         }
     };
 
@@ -348,7 +385,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     insert_node(phantom_node.forward_segment_id.id,
                                 phantom_node.GetForwardWeightAsSource(),
                                 phantom_node.GetForwardDurationAsSource(),
-                                phantom_node.GetForwardDistanceAsSource());
+                                phantom_node.GetForwardDistanceAsSource(),
+                                phantom_node.approach_weight);
                 }
 
                 if (phantom_node.IsValidReverseSource())
@@ -356,7 +394,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     insert_node(phantom_node.reverse_segment_id.id,
                                 phantom_node.GetReverseWeightAsSource(),
                                 phantom_node.GetReverseDurationAsSource(),
-                                phantom_node.GetReverseDistanceAsSource());
+                                phantom_node.GetReverseDistanceAsSource(),
+                                phantom_node.approach_weight);
                 }
             }
             else if (DIRECTION == REVERSE_DIRECTION)
@@ -366,7 +405,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     insert_node(phantom_node.forward_segment_id.id,
                                 phantom_node.GetForwardWeightAsTarget(),
                                 phantom_node.GetForwardDurationAsTarget(),
-                                phantom_node.GetForwardDistanceAsTarget());
+                                phantom_node.GetForwardDistanceAsTarget(),
+                                phantom_node.approach_weight);
                 }
 
                 if (phantom_node.IsValidReverseTarget())
@@ -374,7 +414,8 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
                     insert_node(phantom_node.reverse_segment_id.id,
                                 phantom_node.GetReverseWeightAsTarget(),
                                 phantom_node.GetReverseDurationAsTarget(),
-                                phantom_node.GetReverseDistanceAsTarget());
+                                phantom_node.GetReverseDistanceAsTarget(),
+                                phantom_node.approach_weight);
                 }
             }
         }
@@ -387,8 +428,11 @@ oneToManySearch(SearchEngineData<Algorithm> &engine_working_data,
         const auto heapNode = query_heap.DeleteMinGetHeapNode();
 
         // Update values
-        update_values(
-            heapNode.node, heapNode.weight, heapNode.data.duration, heapNode.data.distance);
+        update_values(heapNode.node,
+                      heapNode.weight,
+                      heapNode.data.duration,
+                      heapNode.data.distance,
+                      heapNode.data.approach);
 
         // Relax outgoing edges
         relaxOutgoingEdges<DIRECTION>(
@@ -448,7 +492,14 @@ void forwardRoutingStep(const DataFacade<Algorithm> &facade,
         auto new_duration = heapNode.data.duration + target_duration;
         auto new_distance = heapNode.data.distance + target_distance;
 
-        if (new_weight >= EdgeWeight{0} &&
+        // The graph part of the weight, not the whole of it.  A target that sits before
+        // the source on one edge-based node is unreachable this way, and that is what a
+        // negative weight says; the walk into an open area is charged at both ends and is
+        // not travel, so it can lift the sum above zero and hide it.  See
+        // ManyToManyHeapData::approach.
+        const auto approach = heapNode.data.approach + current_bucket.approach;
+
+        if (new_weight - approach >= EdgeWeight{0} &&
             std::tie(new_weight, new_duration, new_distance) <
                 std::tie(current_weight, current_duration, current_distance))
         {
@@ -480,7 +531,8 @@ void backwardRoutingStep(const DataFacade<Algorithm> &facade,
                                            column_idx,
                                            heapNode.weight,
                                            heapNode.data.duration,
-                                           heapNode.data.distance);
+                                           heapNode.data.distance,
+                                           heapNode.data.approach);
 
     const auto &partition = facade.GetMultiLevelPartition();
     const auto maximal_level = partition.GetNumberOfLevels() - 1;


### PR DESCRIPTION
Closes the last of the sign problems in #7683, and the one that survived #7688 because it was never about the sign.

## What was wrong

A candidate departed from stands at an edge-based node's start; one arrived at stands at its end. Snapping into an open area chose the shape from the coordinate's position in the request, which works for a route and not for a table, where every coordinate is a source and a destination at once.

Used in the role it was not shaped for, the candidate sits *before* the source on the same node, and the cell comes out short by the stretch between them. On a plaza with `m` inside it and `e` outside:

| | before | after | correct |
|---|---|---|---|
| `m -> e` | 161.7 m | 161.7 m | 161.7 m |
| `e -> m` | **61.8 m** | 161.7 m | 161.7 m |

161.7 m is 50 m along the footway and then 111.8 m straight across the plaza, computed from the node coordinates rather than from OSRM. The asymmetry is the tell: a walking profile should never produce one.

## The fix

A target that sits before the source on one edge-based node is unreachable that way and needs a loop to get to. The weight going negative is what says so. The walk into an open area is charged at both ends and is not travel, so it lifts the sum back above zero and the degenerate pairing is accepted:

```
CELL r=1 c=0 heap_d=-49.98 bucket_d=111.76 new_d=61.78
```

Both many-to-many implementations now carry how much of the weight is that walk, from the seed through the relaxation into the buckets, and test the graph part rather than the whole.

The two hide the same case in different places. CH hides it in `addLoopWeight` behind `new_weight < 0`. MLD hides it in the acceptance test `new_weight >= 0` that otherwise keeps a target in the search to be found later by a real path. Fixing either alone leaves the scenario failing on the other algorithm.

## Verification

The new scenario asserts both cells of the matrix and both directions of `/route`, so it fails on either algorithm if either half of the change is removed. Also all four unit suites and the full cucumber matrix, `ch` and `mld` across `mmap`, `directly` and `datastore`, 1478 scenarios each, with `ENABLE_ASSERTIONS=1`.

Written with AI assistance: Claude Code, Claude Opus 5 🤖


