### PR TITLE
fix(engine): the visibility graph dropped every edge running along a wall

### DIFF
--- a/src/engine/area_visibility.cpp
+++ b/src/engine/area_visibility.cpp
@@ -2,6 +2,9 @@
 
 #include "extractor/area/util.hpp"
 
+#include <algorithm>
+#include <cmath>
+
 namespace osrm::engine::area
 {
 
@@ -12,6 +15,39 @@ template <typename Fun> void for_each_edge(Ring ring, Fun function)
 {
     for (std::size_t i = 0; i < ring.size(); ++i)
         function(ring[i], ring[(i + 1) % ring.size()]);
+}
+
+/** The squared distance from `point` to the segment a..b. */
+double distance_squared_to_segment(const Point &point, const Point &a, const Point &b)
+{
+    const auto dx = b.x - a.x, dy = b.y - a.y;
+    const auto length_squared = dx * dx + dy * dy;
+    auto t = 0.0;
+    if (length_squared > 0.0)
+    {
+        t = std::clamp(((point.x - a.x) * dx + (point.y - a.y) * dy) / length_squared, 0.0, 1.0);
+    }
+    const auto ex = point.x - (a.x + t * dx), ey = point.y - (a.y + t * dy);
+    return ex * ex + ey * ey;
+}
+
+/** Whether `point` lies on the boundary of any ring, to within `tolerance`. */
+bool on_any_ring(const Point &point, std::span<const Ring> rings, const double tolerance)
+{
+    const auto limit = tolerance * tolerance;
+    for (const Ring &ring : rings)
+    {
+        bool found = false;
+        for_each_edge(ring,
+                      [&](const Point &a, const Point &b)
+                      {
+                          if (!found && distance_squared_to_segment(point, a, b) <= limit)
+                              found = true;
+                      });
+        if (found)
+            return true;
+    }
+    return false;
 }
 } // namespace
 
@@ -65,8 +101,22 @@ std::vector<std::size_t> visible_vertices(const Point &point, std::span<const Ri
     {
         for (const Point &vertex : ring)
         {
+            // Does the segment run through the interior, or outside it?  One interior
+            // sample answers that once crossings are ruled out below, because a segment
+            // cannot leave the area and come back without crossing an edge.
+            //
+            // The sample has to tolerate the boundary.  inside_area is strict, and ray
+            // casting on a point lying exactly on an edge answers arbitrarily, so a
+            // midpoint that lands on a ring was read as outside.  That is not a rare case,
+            // it is the commonest one there is: the midpoint of two adjacent vertices is
+            // always on the ring between them.  The effect was to drop the walls from the
+            // visibility graph, and a planner with no edge along a wall cannot route past
+            // an obstacle, only around it.
             const Point midpoint{(point.x + vertex.x) / 2, (point.y + vertex.y) / 2};
-            bool blocked = !inside_area(midpoint, rings);
+            const auto tolerance =
+                std::hypot(vertex.x - point.x, vertex.y - point.y) * 1e-9 + 1e-12;
+            bool blocked =
+                !inside_area(midpoint, rings) && !on_any_ring(midpoint, rings, tolerance);
             for (const Ring &other : rings)
             {
                 if (blocked)

--- a/unit_tests/engine/area_geodesic.cpp
+++ b/unit_tests/engine/area_geodesic.cpp
@@ -189,8 +189,31 @@ BOOST_AUTO_TEST_CASE(geodesic_threads_a_one_metre_gap)
     const auto found = geodesic_between(1, fresh_key(), rings, from, to);
 
     BOOST_REQUIRE(found);
-    // straight across would be 600 m; round the end of the wall is half as long again
-    BOOST_CHECK_GT(found->length, 1.5 * straight(from, to));
+
+    // It threads the gap by hugging the western face of the wall: it turns at that face's
+    // two corners and runs along it in between, which is the shortest way past and the
+    // reason the gap is passable at all.
+    //
+    // This assertion used to be that the path was at least half as long again as the 600 m
+    // straight line, which is what the solver produced when the visibility graph was
+    // missing every edge that runs along a wall. Without the wall's western face the path
+    // could not turn at its two corners in succession and had to leave by a longer route,
+    // 894 m against the 630 m it takes now. The number was measured from the behaviour
+    // rather than derived, so it pinned the defect in place. Naming the corners says what
+    // the path has to do instead of how far it may go.
+    const auto turns_at = [&](const util::Coordinate corner)
+    {
+        return std::any_of(found->bends.begin(),
+                           found->bends.end(),
+                           [&](const auto bend) { return straight(bend, corner) < 1.0; });
+    };
+    BOOST_CHECK(turns_at(at(1, 480)));
+    BOOST_CHECK(turns_at(at(1, 520)));
+
+    // Longer than the straight line, which runs into the wall, but only by the width of
+    // the detour to reach the gap and back.
+    BOOST_CHECK_GT(found->length, straight(from, to));
+    BOOST_CHECK_LT(found->length, 1.1 * straight(from, to));
     BOOST_REQUIRE_GE(found->bends.size(), 1u);
     // and it turns only at real corners -- of the wall, or of the plaza
     for (const auto bend : found->bends)

--- a/unit_tests/engine/area_visibility.cpp
+++ b/unit_tests/engine/area_visibility.cpp
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <span>
 #include <vector>
 
@@ -100,6 +101,143 @@ BOOST_AUTO_TEST_CASE(area_visibility_target_vertex_is_not_hidden_by_its_own_edge
     Fixture f{true};
     // sitting right next to a corner of the obstacle
     BOOST_CHECK(sees(f, Point{2.5, 2.5}, 4)); // (3,3)
+}
+
+// Standing on a wall, the next vertex along that wall is visible.
+//
+// Every test above asks from a point in the interior. This one asks from a vertex, which
+// is where the callers ask from: a portal sits on the boundary, and so does every vertex
+// the planner expands. It is also the case a midpoint test gets wrong, because the
+// midpoint of two adjacent vertices lies exactly on the ring between them and a strict
+// containment test answers arbitrarily there.
+BOOST_AUTO_TEST_CASE(area_visibility_a_wall_is_visible_along_its_length)
+{
+    Fixture f{true};
+
+    // The outer ring, in both directions, from a corner.
+    BOOST_CHECK(sees(f, f.outer[0], 1)); // (0,0) -> (10,0), along the bottom wall
+    BOOST_CHECK(sees(f, f.outer[0], 3)); // (0,0) -> (0,10), along the left wall
+    BOOST_CHECK(sees(f, f.outer[2], 1)); // (10,10) -> (10,0), along the right wall
+    BOOST_CHECK(sees(f, f.outer[2], 3)); // (10,10) -> (0,10), along the top wall
+
+    // And an obstacle's own wall, which is how a path gets round it. Indices 4..7.
+    BOOST_CHECK(sees(f, f.obstacle[0], 5)); // (3,3) -> (7,3)
+    BOOST_CHECK(sees(f, f.obstacle[0], 7)); // (3,3) -> (3,7)
+}
+
+// A diagonal of the square is not blocked by the walls it ends on.
+BOOST_AUTO_TEST_CASE(area_visibility_a_diagonal_from_a_corner_is_not_blocked)
+{
+    Fixture f{false};
+
+    BOOST_CHECK(sees(f, f.outer[0], 2)); // (0,0) -> (10,10)
+    BOOST_CHECK(sees(f, f.outer[1], 3)); // (10,0) -> (0,10)
+}
+
+// Every line that stays inside is reported, over every pair of vertices of several shapes.
+//
+// The converse of the tests above it, and the one that was missing. Checking only that no
+// reported line crosses an obstacle bounds the graph from one side: an oracle that reports
+// nothing at all passes every such test. The defect that costs a path its shape is the
+// opposite one, a pair that can see each other and is not reported, which deletes a
+// shortcut from the graph and sends the planner the long way round.
+//
+// The oracle here shares no code with visible_vertices(): a ring edge blocks only if it
+// properly crosses, meaning each segment strictly separates the other's endpoints, so
+// shared endpoints and grazes come out as not blocking. Touching a corner in passing is
+// allowed, cutting it is not.
+BOOST_AUTO_TEST_CASE(area_visibility_reports_every_line_that_stays_inside)
+{
+    const auto side = [](const Point &a, const Point &b, const Point &c)
+    {
+        const auto cross = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+        return cross > 0.0 ? 1 : (cross < 0.0 ? -1 : 0);
+    };
+
+    // A square, a square with a block, an L with a reflex corner, and two blocks.
+    std::vector<std::vector<std::vector<Point>>> shapes{
+        {{{0, 0}, {10, 0}, {10, 10}, {0, 10}}},
+        {{{0, 0}, {10, 0}, {10, 10}, {0, 10}}, {{3, 3}, {7, 3}, {7, 7}, {3, 7}}},
+        {{{0, 0}, {10, 0}, {10, 4}, {4, 4}, {4, 10}, {0, 10}}},
+        {{{0, 0}, {12, 0}, {12, 12}, {0, 12}},
+         {{2, 2}, {5, 2}, {5, 5}, {2, 5}},
+         {{7, 7}, {10, 7}, {10, 10}, {7, 10}}}};
+
+    std::size_t checked = 0;
+    for (const auto &shape : shapes)
+    {
+        std::vector<Ring> rings;
+        std::vector<Point> vertices;
+        for (const auto &ring : shape)
+        {
+            rings.emplace_back(ring);
+            vertices.insert(vertices.end(), ring.begin(), ring.end());
+        }
+
+        for (std::size_t v = 0; v < vertices.size(); ++v)
+        {
+            const auto reported = visible_vertices(vertices[v], rings);
+            for (std::size_t w = 0; w < vertices.size(); ++w)
+            {
+                if (w == v)
+                    continue;
+                const auto &from = vertices[v];
+                const auto &to = vertices[w];
+
+                auto blocked = false;
+                for (const auto &ring : rings)
+                {
+                    for (std::size_t i = 0; i < ring.size() && !blocked; ++i)
+                    {
+                        const auto &a = ring[i];
+                        const auto &b = ring[(i + 1) % ring.size()];
+                        blocked = side(from, to, a) * side(from, to, b) < 0 &&
+                                  side(a, b, from) * side(a, b, to) < 0;
+                    }
+                }
+                if (blocked)
+                    continue;
+
+                // Not blocked by a crossing, but it may still run outside the area, for
+                // instance across the notch of the L. Sample the interior to rule it out.
+                auto leaves = false;
+                for (int k = 1; k < 16 && !leaves; ++k)
+                {
+                    const auto t = static_cast<double>(k) / 16.0;
+                    const Point at{from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t};
+                    // A sample on the boundary has not left: a segment running along a
+                    // wall is inside the area for every purpose visibility cares about.
+                    auto on_a_ring = false;
+                    for (const auto &ring : rings)
+                    {
+                        for (std::size_t i = 0; i < ring.size() && !on_a_ring; ++i)
+                        {
+                            const auto &a = ring[i];
+                            const auto &b = ring[(i + 1) % ring.size()];
+                            const auto dx = b.x - a.x, dy = b.y - a.y;
+                            const auto len = dx * dx + dy * dy;
+                            auto u = 0.0;
+                            if (len > 0.0)
+                                u = std::clamp(
+                                    ((at.x - a.x) * dx + (at.y - a.y) * dy) / len, 0.0, 1.0);
+                            const auto ex = at.x - (a.x + u * dx), ey = at.y - (a.y + u * dy);
+                            on_a_ring = ex * ex + ey * ey < 1e-18;
+                        }
+                    }
+                    leaves = !inside_area(at, rings) && !on_a_ring;
+                }
+                if (leaves)
+                    continue;
+
+                ++checked;
+                BOOST_CHECK_MESSAGE(std::find(reported.begin(), reported.end(), w) !=
+                                        reported.end(),
+                                    "vertex " << v << " should see vertex " << w);
+            }
+        }
+    }
+
+    BOOST_CHECK_GT(checked, 100u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/engine/area_visibility.cpp
+++ b/unit_tests/engine/area_visibility.cpp
@@ -3,7 +3,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
-#include <cmath>
 #include <span>
 #include <vector>
 


### PR DESCRIPTION
## The defect

`visible_vertices()` decides whether a candidate segment runs through the interior by
testing its midpoint with `inside_area()`, which is strict about the boundary. Ray casting
on a point lying exactly on an edge answers arbitrarily, and the midpoint of two adjacent
ring vertices is always on the ring between them, so the commonest pair there is was read
as leaving the area.

The walls were therefore missing from the graph, and a planner with no edge along a wall
cannot route past an obstacle, only around it.

## What it cost

Measured over a random corpus of plazas:

* 1096 of 9114 clear vertex pairs were absent from the graph.
* One portal to portal path came out 2.65 times the straight line, bending at two plaza
  corners, where the correct path is 1.28 times and hugs the obstacle.

This affects the geodesic and area snapping at query time.

## The extractor is not affected

`VisibilityGraph::visible_vertices` in the extractor is a rotational sweep, a different
algorithm with no midpoint test. It omits ring edges deliberately and `AreaMesher` puts
them back with `with_ring_edges()`, so the stored mesh has its walls.

## Tests

Every existing test in `area_visibility.cpp` asks from a point in the interior. The callers
ask from vertices, which is where the defect lives, so two new tests ask along a wall.

The third is the property the suite was missing. The existing tests say that no reported
line crosses an obstacle, which bounds the graph from one side only and is satisfied by an
oracle that reports nothing at all. The converse, that every clear line is reported, is what
finds a missing edge. Its clearance oracle uses orientation predicates that share no code
with `intersect()`, because an oracle built on the code under test agrees with it whatever
it says.

All three fail on master and pass here.

## Cost

The geodesic gets slower, by about 24% on `area-geodesic-bench`: at 104 vertices, 6485 us
to 8043 us for graph plus Dijkstra, and 40 vertices goes from 567 us to 700 us, still
inside the roughly 1 ms budget. `GEODESIC_MAX_VERTICES` is unchanged.

That is the cost of doing work that was being skipped rather than an inefficiency in the
fix. Wall-adjacent pairs used to be rejected by the midpoint test before the crossing test
ran on them at all, and there are now 12% more edges for the search to relax.

## One existing assertion changed

`geodesic_threads_a_one_metre_gap` required the path to be at least half as long again as
the 600 m straight line. That was the length the solver produced when it could not turn at
the two corners of the wall's western face in succession and had to leave by a longer
route: 894 m, where the true geodesic is 630 m. The number was measured from the behaviour
rather than derived, so it held the defect in place.

It now names the two corners the path has to turn at, which is what threading the gap
means.

🤖 Claude Code, Claude Opus 5
