### PR TITLE
perf(util): stop a suppressed log message taking the global lock twice

### DIFF
--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -69,8 +69,27 @@ Log::Log(LogLevel level_, std::ostream &ostream) : level(level_), stream(ostream
 
 Log::Log(LogLevel level_) : level(level_), buffer{}, stream{buffer} { Init(); }
 
+namespace
+{
+//! Whether anything written to a Log at this level will be printed at all.
+bool wanted(const LogLevel level)
+{
+    const auto &policy = LogPolicy::GetInstance();
+    return !policy.IsMute() && level <= policy.GetLevel();
+}
+} // namespace
+
 void Log::Init()
 {
+    // Asked before the lock is taken.  A Log that will not be printed is built and
+    // destroyed on every call of every statement that is switched off, and taking a
+    // process-wide mutex twice to decide to print nothing serialises every thread in the
+    // program on the ones in a hot loop.  operator<< already skips the formatting.
+    if (!wanted(level))
+    {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(get_mutex());
     if (!LogPolicy::GetInstance().IsMute() && level <= LogPolicy::GetInstance().GetLevel())
     {
@@ -121,6 +140,12 @@ std::mutex &Log::get_mutex()
  */
 Log::~Log()
 {
+    // As in Init(): decided before the lock, because there is nothing to flush.
+    if (!wanted(level))
+    {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(get_mutex());
     if (!LogPolicy::GetInstance().IsMute() && level <= LogPolicy::GetInstance().GetLevel())
     {


### PR DESCRIPTION
# Issue

No issue. Found while profiling an `osrm-extract` run that appeared to hang.

# The problem

`Log::Init()` and `Log::~Log()` each take a process-wide mutex *before* asking whether the
message will be printed:

```cpp
void Log::Init()
{
    std::lock_guard<std::mutex> lock(get_mutex());
    if (!LogPolicy::GetInstance().IsMute() && level <= LogPolicy::GetInstance().GetLevel())
    ...
```

So every switched-off statement, which at default verbosity means every `util::Log(logDEBUG)`
in the codebase, pays two round trips through one global lock to decide to print nothing.
`operator<<` already skips the formatting, so the lock is the whole cost, and it is the kind
that gets worse with more cores rather than better: one thread in a loop with a debug
statement in it serialises every other thread in the program.

I ran into this the hard way. Profiling an extract that would not finish, the entire sample
was `Log::~Log` into `pthread_mutex_unlock`, which told me nothing about the loop that was
actually running. Fixing this did not make the extract finish, but it made the real defect
visible (that one is #7695).

# The change

Ask before locking. The body of both functions was already wrapped in exactly this
condition, so this is the same test taken sooner and there is no behaviour change: a message
that was printed before is printed now, with the same prefix, on the same stream.

The remaining cost of a suppressed message is constructing and destroying an empty
`std::ostringstream`. Removing that too would mean changing how call sites are written, which
is a much larger change and not one to smuggle in here.

# Testing

All fourteen unit suites pass. Full cucumber: 1478 scenarios, 1463 passed, 15 skipped, 0
failed, unchanged. `--verbosity DEBUG` still prints what it printed before.

Was this change primarily generated using an AI tool? Yes.

🤖 Claude Code, Claude Opus 5

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [ ] add tests
 - [ ] update relevant wiki pages
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

Independent of #7695, though that is where it came from. No test here: the defect is a
performance property of a mutex under contention, and I could not write an assertion for it
that would not be flaky on CI.
