### PR TITLE
fix(guidance): osrm-routed aborted on a plaza vertex with more than 32 ways

### DIFF
--- a/src/util/guidance/entry_class.cpp
+++ b/src/util/guidance/entry_class.cpp
@@ -18,7 +18,21 @@ bool EntryClass::activate(std::uint32_t index)
 
 bool EntryClass::allowsEntry(std::uint32_t index) const
 {
-    BOOST_ASSERT(index < CHAR_BIT * sizeof(FlagBaseType));
+    // Answered rather than asserted, because the caller cannot avoid asking.
+    //
+    // A road beyond the ones this class can hold was never stored: activate() refuses it
+    // and the extractor logs that it did.  The engine, though, walks the bearings, and
+    // there can be more of those than there are bits here.  An ordinary junction never
+    // gets near the limit, but a meshed pedestrian area does: every line of sight from a
+    // plaza vertex is a way, and a vertex on a busy plaza has been seen with 96 of them.
+    //
+    // Shifting by the width of the type is undefined, so with asserts on this aborted the
+    // server and with them off it read whatever the shift happened to produce.  Neither
+    // is an answer.  A road that could not be recorded reports no entry, which is what
+    // the stored data says about it.
+    if (index >= CHAR_BIT * sizeof(FlagBaseType))
+        return false;
+
     return 0 != (enabled_entries_flags & (FlagBaseType{1} << index));
 }
 

--- a/unit_tests/util/entry_class.cpp
+++ b/unit_tests/util/entry_class.cpp
@@ -1,0 +1,63 @@
+#include "util/guidance/entry_class.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <climits>
+#include <cstdint>
+#include <limits>
+
+BOOST_AUTO_TEST_SUITE(entry_class)
+
+using osrm::util::guidance::EntryClass;
+
+// How many roads the class can hold, which is how wide its flags are.
+constexpr std::uint32_t CAPACITY = 32;
+
+BOOST_AUTO_TEST_CASE(entry_class_records_what_it_is_given)
+{
+    EntryClass entries;
+    BOOST_CHECK(entries.activate(0));
+    BOOST_CHECK(entries.activate(CAPACITY - 1));
+
+    BOOST_CHECK(entries.allowsEntry(0));
+    BOOST_CHECK(entries.allowsEntry(CAPACITY - 1));
+    BOOST_CHECK(!entries.allowsEntry(1));
+}
+
+// Asking about a road the class cannot hold answers, rather than aborting or shifting off
+// the end of the type.
+//
+// The engine walks the bearings of an intersection and asks about each one, and there can
+// be more bearings than there are bits here.  An ordinary junction never comes close, but
+// a meshed pedestrian area does: every line of sight from a plaza vertex becomes a way,
+// and a single vertex has been seen with 96 of them in Ile-de-France.
+//
+// Before this the shift was by the width of the type, which is undefined behaviour: with
+// asserts on it aborted osrm-routed on any route reported with steps, and with them off it
+// returned whatever the shift produced.
+BOOST_AUTO_TEST_CASE(entry_class_answers_for_a_road_it_could_not_record)
+{
+    EntryClass entries;
+    for (std::uint32_t i = 0; i < CAPACITY; ++i)
+    {
+        BOOST_REQUIRE(entries.activate(i));
+    }
+
+    // Storing one beyond capacity already reports that it did not happen.
+    BOOST_CHECK(!entries.activate(CAPACITY));
+    BOOST_CHECK(!entries.activate(95));
+
+    // So reading it back says the same thing, for every index the engine might reach.
+    BOOST_CHECK(!entries.allowsEntry(CAPACITY));
+    BOOST_CHECK(!entries.allowsEntry(95));
+    BOOST_CHECK(!entries.allowsEntry(CHAR_BIT * sizeof(std::uint64_t)));
+    BOOST_CHECK(!entries.allowsEntry(std::numeric_limits<std::uint32_t>::max()));
+
+    // And the ones it could record are untouched.
+    for (std::uint32_t i = 0; i < CAPACITY; ++i)
+    {
+        BOOST_CHECK_MESSAGE(entries.allowsEntry(i), "road " << i << " should still allow entry");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

No issue. Hit while driving a running `osrm-routed` from the standard debug frontend against
an Ile-de-France extract built with `profiles/foot_area.lua`.

# The symptom

```
[assert] src/util/guidance/entry_class.cpp:21
in: bool osrm::util::guidance::EntryClass::allowsEntry(std::uint32_t) const:
    index < CHAR_BIT * sizeof(FlagBaseType)
libc++abi: terminating
```

The server dies. Not an error response, not a 500: the process aborts and every subsequent
request gets connection refused. With asserts compiled out it does not abort, it shifts by
the width of the type, which is undefined, and returns whatever that produced.

# The defect

`EntryClass` holds 32 roads in a `std::uint32_t`. `activate()` already refuses an index it
cannot store and returns false. `allowsEntry()` asserted instead, then shifted:

```cpp
BOOST_ASSERT(index < CHAR_BIT * sizeof(FlagBaseType));
return 0 != (enabled_entries_flags & (FlagBaseType{1} << index));
```

The caller cannot avoid asking. `assembleSteps` walks the bearings of an intersection and
asks about each one, and nothing keeps the number of bearings inside the number of bits:
`classifyIntersection` warns when `activate()` refuses a road but still adds its bearing to
the `BearingClass`. So the two go out of step by design, and the read side was not ready for it.

# Why this only shows up now

An ordinary road junction never has 32 roads, so on a normal extract the gap never opens.

A meshed pedestrian area is a different shape entirely: every line of sight from a plaza
vertex becomes a way. Extracting Ile-de-France with `foot_area.lua` logs **92,399** roads
that could not be recorded, reaching **road 95** at one vertex on Place de la Sorbonne, three
times what the class can hold.

That makes this reachable from any route reported with steps that turns at such a vertex,
which is every request the debug frontend makes (`steps=true`). My own probing missed it
entirely because I had been asking for `steps=false`.

# The fix

Answer instead of asserting, mirroring `activate()`. A road that could not be recorded
reports no entry, which is exactly what the stored data says about it. `bearings` and `entry`
stay the same length, so the API contract between those two arrays is unchanged.

# What this deliberately does not fix

A vertex with 96 ways still has 64 of them reported as not enterable. That is wrong, but it
is the same limit the extractor already warns about 92,399 times, and it is not a crash.

Fixing it properly means one of: widening `EntryClass`, which changes the on-disk format;
or not presenting a meshed plaza vertex as a 96-branch intersection in the first place, which
is a guidance design question for areas. Both want their own decision rather than being
smuggled into a crash fix.

# Testing

`unit_tests/util/entry_class.cpp`, two cases. The second reproduces the abort above exactly,
same assertion and same line, and checks every index the engine might reach, including the
96-road case seen in the wild. It also checks the 32 roads that *were* recorded still read
back correctly, so the fix cannot be "make it always say false".

All fourteen unit suites pass. Verified live: with this, all 21 plaza crossings over seven
Paris plazas answer with `steps=true` and the server stays up, including the two URLs from
the frontend that killed it.

Was this change primarily generated using an AI tool? Yes.

🤖 Claude Code, Claude Opus 5

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [x] add tests
 - [ ] update relevant wiki pages
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

Independent of #7695, but you need both to use a meshing profile on a real extract: #7695
so extraction finishes at all, this one so the server survives being asked for steps.
