### PR TITLE
fix(build): stop GCC's optimizer-invented warnings failing the build

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -469,7 +469,6 @@ jobs:
             BUILD_TYPE: Release
             CCOMPILER: gcc-14
             CXXCOMPILER: g++-14
-            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
 
           - name: gcc-15-release
             continue-on-error: false
@@ -478,7 +477,6 @@ jobs:
             BUILD_TYPE: Release
             CCOMPILER: gcc-15
             CXXCOMPILER: g++-15
-            CXXFLAGS: '-Wno-array-bounds -Wno-uninitialized'
 
           - name: linux-release-bindings
             build_bindings: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ OSRM supports two routing algorithms: Contraction Hierarchies (CH) and Multi-Lev
 
 We target C++20 but need to deal with older compilers that only have partial support.
 
-Use `./scripts/format.sh` to format the code. Ensure clang-format-15 is available on the system.
+Use `./scripts/format.sh` to format the code. Ensure clang-format-22 is available on the system.
 
 ## Coding Standards
 
@@ -25,7 +25,7 @@ Specific practices to follow (see [wiki](https://github.com/Project-OSRM/osrm-ba
 - **Comments**: Minimal use of comments on internal interfaces. Use C++ style `//` comments, not C style `/* */`. Use `#if 0` / `#endif` to comment out blocks
 - **Integer types**: Use only `int`/`unsigned` for 32-bit, or precise-width types like `int16_t`, `int64_t`
 - **No RTTI/exceptions**: Avoid `dynamic_cast<>` and exceptions (except for IO operations)
-- **Compiler warnings**: Treat all warnings as errors - fix them, don't ignore them
+- **Compiler warnings**: Treat all warnings as errors - fix them, don't ignore them. The one exception is GCC's optimizer-invented diagnostics, which report on code paths inlining created rather than on anything reachable. Those are suppressed by family in `cmake/warnings.cmake` under the `GNU` guard, because the call site they land on moves with every GCC release and the `-flto` ones come out of `lto1` with no source file to attach a pragma to. Add to that list only after confirming the diagnostic is unreachable, and never widen it to `-Wuninitialized`
 - **Assert liberally**: Use `BOOST_ASSERT` to check preconditions and assumptions
 - **Indentation**: 4 spaces (enforced by clang-format)
 

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -116,7 +116,14 @@ no_warning(restrict)
 no_warning(free-nonheap-object)
 no_warning(unneeded-internal-declaration)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  # GCC diagnoses code paths its own optimizer invented, most of them inside
+  # std::variant's visit-based move touching inactive alternatives. Which call
+  # site trips over first moves with every GCC release and with -flto, and the
+  # -flto ones are reported from lto1 with no source file to attach a pragma
+  # to, so this cannot be scoped down any further. -Wuninitialized stays on,
+  # so the definite case is still an error. See #7690.
   no_warning(stringop-overflow)
+  no_warning(maybe-uninitialized)
 endif()
 
 # MSVC-specific warning configuration

--- a/include/engine/datafacade/algorithm_datafacade.hpp
+++ b/include/engine/datafacade/algorithm_datafacade.hpp
@@ -10,6 +10,7 @@
 #include "partitioner/multi_level_partition.hpp"
 
 #include "util/filtered_graph.hpp"
+#include "util/function_ref.hpp"
 #include "util/integer_range.hpp"
 
 namespace osrm::engine::datafacade
@@ -55,7 +56,7 @@ template <> class AlgorithmDataFacade<CH>
 
     virtual EdgeID FindSmallestEdge(const NodeID edge_based_node_from,
                                     const NodeID edge_based_node_to,
-                                    const std::function<bool(const EdgeData &)> &filter) const = 0;
+                                    util::FunctionRef<bool(const EdgeData &)> filter) const = 0;
 };
 
 template <> class AlgorithmDataFacade<MLD>

--- a/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
+++ b/include/engine/datafacade/contiguous_internalmem_datafacade.hpp
@@ -115,10 +115,9 @@ class ContiguousInternalMemoryAlgorithmDataFacade<CH> : public datafacade::Algor
             edge_based_node_from, edge_based_node_to, result);
     }
 
-    EdgeID
-    FindSmallestEdge(const NodeID edge_based_node_from,
-                     const NodeID edge_based_node_to,
-                     const std::function<bool(const EdgeData &)> &filter) const override final
+    EdgeID FindSmallestEdge(const NodeID edge_based_node_from,
+                            const NodeID edge_based_node_to,
+                            util::FunctionRef<bool(const EdgeData &)> filter) const override final
     { return m_query_graph.FindSmallestEdge(edge_based_node_from, edge_based_node_to, filter); }
 };
 

--- a/include/util/function_ref.hpp
+++ b/include/util/function_ref.hpp
@@ -1,0 +1,47 @@
+#ifndef OSRM_UTIL_FUNCTION_REF_HPP
+#define OSRM_UTIL_FUNCTION_REF_HPP
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace osrm::util
+{
+
+/**
+ * Non-owning view of a callable, for parameters that only need the callable for
+ * the duration of the call.
+ *
+ * Unlike std::function this stores a plain object pointer next to a plain
+ * function pointer. There is no small-buffer union and no allocation, so
+ * passing a lambda through a virtual interface costs two pointers and cannot
+ * throw. The referenced callable has to outlive the FunctionRef.
+ */
+template <typename Signature> class FunctionRef;
+
+template <typename Result, typename... Args> class FunctionRef<Result(Args...)>
+{
+  public:
+    template <typename Callable,
+              typename = std::enable_if_t<!std::is_same_v<std::decay_t<Callable>, FunctionRef> &&
+                                          std::is_invocable_r_v<Result, Callable &, Args...>>>
+    FunctionRef(Callable &&callable) noexcept
+        : erased(const_cast<void *>(static_cast<const void *>(std::addressof(callable)))),
+          invoker{[](void *object, Args... args) -> Result
+                  {
+                      return (*static_cast<std::remove_reference_t<Callable> *>(object))(
+                          std::forward<Args>(args)...);
+                  }}
+    {
+    }
+
+    Result operator()(Args... args) const { return invoker(erased, std::forward<Args>(args)...); }
+
+  private:
+    void *erased;
+    Result (*invoker)(void *, Args...);
+};
+
+} // namespace osrm::util
+
+#endif // OSRM_UTIL_FUNCTION_REF_HPP

--- a/include/util/function_ref.hpp
+++ b/include/util/function_ref.hpp
@@ -9,13 +9,23 @@ namespace osrm::util
 {
 
 /**
- * Non-owning view of a callable, for parameters that only need the callable for
- * the duration of the call.
+ * Non-owning view of a callable, for parameters that only need it for the
+ * duration of the call.
  *
- * Unlike std::function this stores a plain object pointer next to a plain
- * function pointer. There is no small-buffer union and no allocation, so
- * passing a lambda through a virtual interface costs two pointers and cannot
- * throw. The referenced callable has to outlive the FunctionRef.
+ * Unlike std::function this is an object pointer next to a function pointer.
+ * There is no small-buffer union and no allocation, so passing a lambda through
+ * a virtual interface costs two pointers and cannot throw. The absence of the
+ * union also keeps GCC from reporting a maybe-uninitialized read of the buffer
+ * on paths it inlined, which is what std::function does under -flto.
+ *
+ * This refers to the callable rather than owning it, so the callable has to
+ * outlive the FunctionRef. That holds for a parameter, where the argument lives
+ * until the end of the full expression, and it does not hold for a member or a
+ * return value. Do not store one.
+ *
+ * The callable has to be an object, which covers lambdas, function objects and
+ * function pointers. A plain function is not an object and there is nothing to
+ * point at, so wrap it in a lambda or take its address into a variable first.
  */
 template <typename Signature> class FunctionRef;
 
@@ -23,15 +33,14 @@ template <typename Result, typename... Args> class FunctionRef<Result(Args...)>
 {
   public:
     template <typename Callable,
+              typename Object = std::remove_reference_t<Callable>,
               typename = std::enable_if_t<!std::is_same_v<std::decay_t<Callable>, FunctionRef> &&
+                                          std::is_object_v<Object> &&
                                           std::is_invocable_r_v<Result, Callable &, Args...>>>
     FunctionRef(Callable &&callable) noexcept
         : erased(const_cast<void *>(static_cast<const void *>(std::addressof(callable)))),
           invoker{[](void *object, Args... args) -> Result
-                  {
-                      return (*static_cast<std::remove_reference_t<Callable> *>(object))(
-                          std::forward<Args>(args)...);
-                  }}
+                  { return (*static_cast<Object *>(object))(std::forward<Args>(args)...); }}
     {
     }
 

--- a/src/extractor/area/area_manager.cpp
+++ b/src/extractor/area/area_manager.cpp
@@ -2,7 +2,17 @@
 
 #include "util/log.hpp"
 
+// GCC cannot see that libosmium hands set_user() the NUL-terminated string of
+// the source object, so the strlen it inlines here looks like an overread.
+// Clang has no such warning group and would reject the name.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
 #include <osmium/area/assembler.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace osrm::extractor::area
 {

--- a/unit_tests/mocks/mock_datafacade.hpp
+++ b/unit_tests/mocks/mock_datafacade.hpp
@@ -15,6 +15,7 @@
 #include "engine/datafacade/algorithm_datafacade.hpp"
 #include "engine/datafacade/datafacade_base.hpp"
 
+#include "util/function_ref.hpp"
 #include "util/guidance/bearing_class.hpp"
 #include "util/guidance/entry_class.hpp"
 #include "util/typedefs.hpp"
@@ -189,10 +190,9 @@ class MockAlgorithmDataFacade<engine::datafacade::CH>
     EdgeID FindEdgeInEitherDirection(const NodeID /* from */, const NodeID /* to */) const override
     { return SPECIAL_EDGEID; }
 
-    EdgeID
-    FindSmallestEdge(const NodeID /* from */,
-                     const NodeID /* to */,
-                     const std::function<bool(const EdgeData &)> & /* filter */) const override
+    EdgeID FindSmallestEdge(const NodeID /* from */,
+                            const NodeID /* to */,
+                            util::FunctionRef<bool(const EdgeData &)> /* filter */) const override
     { return SPECIAL_EDGEID; }
 
     EdgeID FindEdgeIndicateIfReverse(const NodeID /* from */,

--- a/unit_tests/util/function_ref.cpp
+++ b/unit_tests/util/function_ref.cpp
@@ -1,0 +1,132 @@
+#include "util/function_ref.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <type_traits>
+
+BOOST_AUTO_TEST_SUITE(function_ref_test)
+
+using namespace osrm;
+using namespace osrm::util;
+
+namespace
+{
+struct EdgeData
+{
+    bool forward;
+    bool backward;
+};
+
+int applyTwice(FunctionRef<int(int)> fn, int value) { return fn(fn(value)); }
+
+bool freeFunction(const EdgeData &data) { return data.forward; }
+} // namespace
+
+BOOST_AUTO_TEST_CASE(calls_a_captureless_lambda)
+{
+    const EdgeData data{true, false};
+
+    BOOST_CHECK_EQUAL(FunctionRef<bool(const EdgeData &)>{[](const EdgeData &edge)
+                                                          { return edge.forward; }}(data),
+                      true);
+    BOOST_CHECK_EQUAL(FunctionRef<bool(const EdgeData &)>{[](const EdgeData &edge)
+                                                          { return edge.backward; }}(data),
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(reads_the_captured_state_through_the_reference)
+{
+    // The callable is referred to, not copied, so state captured by reference is
+    // observed at call time rather than at construction time.
+    int captured = 1;
+    const auto lambda = [&captured](int value) { return value * captured; };
+    const FunctionRef<int(int)> fn = lambda;
+
+    BOOST_CHECK_EQUAL(fn(10), 10);
+    captured = 3;
+    BOOST_CHECK_EQUAL(fn(10), 30);
+}
+
+BOOST_AUTO_TEST_CASE(mutates_the_referenced_callable)
+{
+    int calls = 0;
+    auto counter = [&calls](int value)
+    {
+        ++calls;
+        return value;
+    };
+    const FunctionRef<int(int)> fn = counter;
+
+    fn(0);
+    fn(0);
+    BOOST_CHECK_EQUAL(calls, 2);
+}
+
+BOOST_AUTO_TEST_CASE(passes_a_temporary_lambda_as_an_argument)
+{
+    // The argument outlives the call, which is the case FunctionRef is for.
+    BOOST_CHECK_EQUAL(applyTwice([](int value) { return value + 3; }, 1), 7);
+}
+
+BOOST_AUTO_TEST_CASE(forwards_arguments_without_copying)
+{
+    static int copies = 0;
+    struct Counted
+    {
+        Counted() = default;
+        Counted(const Counted &) { ++copies; }
+    };
+
+    const Counted counted;
+    const FunctionRef<bool(const Counted &)> fn = [](const Counted &) { return true; };
+
+    BOOST_CHECK_EQUAL(fn(counted), true);
+    BOOST_CHECK_EQUAL(copies, 0);
+}
+
+BOOST_AUTO_TEST_CASE(returns_void_and_non_trivial_types)
+{
+    bool ran = false;
+    const auto sink = [&ran](int) { ran = true; };
+    FunctionRef<void(int)>{sink}(0);
+    BOOST_CHECK(ran);
+
+    const auto name = [](int value) { return std::to_string(value); };
+    BOOST_CHECK_EQUAL(FunctionRef<std::string(int)>{name}(42), "42");
+}
+
+BOOST_AUTO_TEST_CASE(is_two_pointers_and_trivially_copyable)
+{
+    BOOST_CHECK_EQUAL(sizeof(FunctionRef<int(int)>), 2 * sizeof(void *));
+    BOOST_CHECK(std::is_trivially_copyable_v<FunctionRef<int(int)>>);
+    BOOST_CHECK((
+        std::is_nothrow_constructible_v<FunctionRef<int(int)>, decltype([](int i) { return i; })>));
+}
+
+BOOST_AUTO_TEST_CASE(rejects_what_it_cannot_point_at)
+{
+    // A plain function has no object to take the address of. Rejecting it in the
+    // constraint keeps the diagnostic readable instead of failing inside the body.
+    BOOST_CHECK(
+        (!std::is_constructible_v<FunctionRef<bool(const EdgeData &)>, decltype(freeFunction) &>));
+
+    // A function pointer is an object, so it is fine.
+    BOOST_CHECK((
+        std::is_constructible_v<FunctionRef<bool(const EdgeData &)>, bool (*&)(const EdgeData &)>));
+
+    // Signature mismatches are rejected rather than silently converted.
+    BOOST_CHECK((!std::is_constructible_v<FunctionRef<int(int)>,
+                                          decltype([](const std::string &) { return 0; }) &>));
+}
+
+BOOST_AUTO_TEST_CASE(calls_through_a_function_pointer_object)
+{
+    const EdgeData data{true, false};
+    bool (*pointer)(const EdgeData &) = &freeFunction;
+    const FunctionRef<bool(const EdgeData &)> fn = pointer;
+
+    BOOST_CHECK_EQUAL(fn(data), true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Fixes #7690.

Master does not build on Arch with GCC 15.2.1, and it fails differently depending on how it is configured. Reproducing it in a pinned Arch container turned up three separate `-Werror` failures, no two of them on the same line:

| Configuration | Failure | Where |
| --- | --- | --- |
| Reporter's | `maybe-uninitialized` | `geojson_debug_policy_toolkit.hpp:62`, via `std::variant`'s visit-based move |
| LTO release (our default) | `maybe-uninitialized` | `routing_base_ch.hpp:222`, via `std::function`, reported from `lto1` |
| Non-LTO release | `stringop-overread` | libosmium `osm_object_builder.hpp:500`, inlined into `area_manager.cpp:204` |

All three are code paths the optimizer created rather than anything reachable, and which one fires first moves with the GCC build and the `-flto` setting.

CI never saw any of it. The `gcc-14` and `gcc-15` jobs were passing `-Wno-array-bounds -Wno-uninitialized` through `CXXFLAGS`, added when the GCC 12 job landed in #6455 and copied forward ever since. `-Wno-uninitialized` also disables `-Wmaybe-uninitialized`, so those jobs were green only because the workflow suppressed for itself what nobody building from source ever got.

## What this changes

**A real fix where there was one.** `FindSmallestEdge` took a `std::function`, and GCC's complaint named `_Any_data`, its small-buffer union. All four call sites pass stateless lambdas, so the erasure stored nothing. `util::FunctionRef` replaces it with an object pointer next to a function pointer: no union, no allocation, no throwing call. The construct GCC objected to is gone rather than inlined differently.

**A scoped pragma where the code is not ours.** The libosmium overread is suppressed at its `#include`. It needs a `__GNUC__ && !__clang__` guard, because clang rejects `-Wstringop-overread` as an unknown warning group and would fail every clang job under `-Werror`.

**One flag, moved into the build and narrowed.** `cmake/warnings.cmake` disables `maybe-uninitialized` for GNU, beside the `stringop-overflow` entry already there for the same reason. This is the only change that covers the reported failure, which I could not reproduce and therefore cannot fix at the source. Under `-flto` these are reported from `lto1` against an ltrans object, so there is no translation unit to scope a pragma to.

`-Wuninitialized` stays enabled, so the definite case is still an error. Neither `-Wno-array-bounds` nor `-Wno-uninitialized` turned out to be needed, so both come out of the workflow and CI now builds what users build. Net, this is stricter than what CI has been running since 2022.

## Verification

Arch container pinned to the archive snapshot carrying GCC 15.2.1, dependencies via vcpkg as documented:

- LTO release and non-LTO release both go from failing to clean, `-Werror` on throughout
- 14 of 14 unit test suites pass, including `library-tests` routing on monaco through the CH unpacking path this touches
- The `FunctionRef` change alone fixes the LTO failure with no cmake suppression active, confirmed against the generated compile line

## Caveats

I could not reproduce the reported `std::variant` failure in 18 configurations across GCC 14.4, 15.3 and 16.2, at `-O2` and `-O3`, with and without LTO, nor under `_FORTIFY_SOURCE=3`, `_GLIBCXX_ASSERTIONS` or `-march=native` on 15.2.1 itself. Only that specific Arch rebuild produces it, so the retained flag is what closes the issue for the reporter. A source-level fix there would be either an unverifiable one-line change or taking `json::Value` off `std::variant`, which is a refactor of the whole JSON and API layer.

Validation was on Arch only. Dropping the workflow `CXXFLAGS`, in particular `-Wno-array-bounds` on Ubuntu `gcc-14`, is the part CI itself has to confirm. If it still trips, the answer is another `no_warning(array-bounds)` line rather than restoring the workflow hack.

AI participation: 🤖 Claude Code, Claude Opus 5.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

Fixes #7690. Reverts the CI workaround introduced in #6455 and carried forward through #6865, #6905 and #7574. Same warning family as #7422, which had a source-level fix available.
