### PR TITLE
fix(profiles): apply turn restrictions to bicycle routing

### DIFF
--- a/features/bicycle/restrictions.feature
+++ b/features/bicycle/restrictions.feature
@@ -1,7 +1,8 @@
 @routing @bicycle @restrictions
 Feature: Bike - Turn restrictions
-# Ignore turn restrictions on bicycle, since you always become a temporary pedestrian.
-# Note that if u-turns are allowed, turn restrictions can lead to suprising, but correct, routes.
+# Turn restrictions apply to bicycles unless the relation says otherwise with
+# except=bicycle or restriction:bicycle. Note that if u-turns are allowed, turn
+# restrictions can lead to surprising, but correct, routes.
 
     Background:
         Given the profile "bicycle"
@@ -31,7 +32,7 @@ Feature: Bike - Turn restrictions
 
         When I route I should get
             | from | to | route    |
-            | s    | w  | sj,wj,wj |
+            | s    | w  |          |
             | s    | n  | sj,nj,nj |
             | s    | e  | sj,ej,ej |
 
@@ -64,8 +65,8 @@ Feature: Bike - Turn restrictions
         When I route I should get
             | from | to | route    |
             | s    | a  | sj,aj,aj |
-            | s    | b  | sj,bj,bj |
-            | s    | c  | sj,cj,cj |
+            | s    | b  |          |
+            | s    | c  |          |
             | s    | d  | sj,dj,dj |
 
     @except
@@ -92,6 +93,9 @@ Feature: Bike - Turn restrictions
             | s    | a  | sj,aj,aj |
             | s    | b  | sj,bj,bj |
 
+    # Only a semicolon separates values, and the parser does not trim spaces, so
+    # `bus; bicycle` and the comma separated forms below do not except anything.
+    # These are not forms that appear in OSM data, where `bicycle;bus` is the norm.
     @except
     Scenario: Bike - Multiple except tag values
         Given the node map
@@ -125,9 +129,9 @@ Feature: Bike - Turn restrictions
 
         When I route I should get
             | from | to | route    |
-            | s    | a  | sj,ja,ja |
+            | s    | a  |          |
             | s    | b  | sj,jb,jb |
-            | s    | c  | sj,jc,jc |
+            | s    | c  |          |
             | s    | d  | sj,jd,jd |
-            | s    | e  | sj,je,je |
-            | s    | f  | sj,jf,jf |
+            | s    | e  |          |
+            | s    | f  |          |

--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -24,7 +24,7 @@ function setup()
       weight_name                   = 'duration',
       process_call_tagless_node     = false,
       max_speed_for_map_matching    = 40/3.6, -- kmph -> m/s (reduced from 110 to realistic bicycle speed)
-      use_turn_restrictions         = false,
+      use_turn_restrictions         = true,
       continue_straight_at_waypoint = false,
       mode_change_penalty           = 30,
     },


### PR DESCRIPTION
# Issue

Fixes #7703.

The bicycle profile ignored every turn restriction. `profiles/bicycle.lua` set `use_turn_restrictions = false`, and `RestrictionParser::TryParse` returns an empty result for every relation when that flag is off, so `no_left_turn`, `no_straight_on` and the rest never reached the graph at all.

The two locations in the report check out against current OSM data:

| Location | Relation | Restriction | `except` |
| --- | --- | --- | --- |
| 47.2100, 9.4999 | 20632877, 20632878 | `no_straight_on` | none |
| 46.7961, 7.1300 | 18851498 | `no_left_turn` | none |

Neither carries an `except` tag, so both do apply to bicycles.

## Why it was off

This goes back to 313b93169 in February 2013. The commit message says nothing, but the reason was left in the feature file:

```
# Ignore turn restrictions on bicycle, since you always become a temporary pedestrian.
```

That argument has not aged well. OSM has `except=bicycle` for restrictions that genuinely do not bind cyclists, and it is widely used: `bicycle` is the single most common value of the `except` key, at 6458 uses. Switching restrictions off wholesale also cannot express a restriction that is physical rather than legal, which is what the reported `no_straight_on` looks like.

## The change

One flag. `bicycle.lua` already declared `restrictions = Set { 'bicycle' }`, which is exactly what makes `except=bicycle` and `restriction:bicycle` work, so the profile was already set up for this and the two settings contradicted each other.

Three scenarios in `features/bicycle/restrictions.feature` encoded the old policy and now assert the new one. Restrictions carrying `except=bicycle` still allow the turn; those without it now block. That is what the feature exists to check, and with restrictions off it was checking nothing.

## A note on the multi value scenario

`Bike - Multiple except tag values` now documents that only a semicolon separates values and that spaces are not trimmed, so `bus; bicycle` excepts nothing. This is pre-existing behaviour in `RestrictionParser::ShouldIgnoreRestriction` and applies to car as well, so this PR does not change it.

It is not a form that occurs in practice. The top 25 values of the `except` key are all semicolon separated with no spaces, `bicycle;bus` and `bus;bicycle` among them. Worth having pinned down now that the bicycle profile actually reads these tags. Happy to fix the trimming separately if you would rather.

## Verification

- `features/bicycle/restrictions.feature`: 4 scenarios, all passing
- `features/bicycle/`: 106 scenarios, 554 steps, all passing

Confirmed the flag is the only lever before making the change: flipping it alone made 3 of the 4 restriction scenarios fail, which is exactly the set that asserted restrictions were ignored.

## Expect route changes

This changes bicycle routes wherever a turn restriction exists without `except=bicycle`. That is the point of the fix, but it is a visible behaviour change for every bicycle user and probably deserves a mention in the release notes.

`foot.lua` carries the same setting and is left alone. Ignoring turn restrictions for pedestrians is much easier to defend.

AI participation: 🤖 Claude Code, Claude Opus 5.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (existing restriction scenarios rewritten to assert the new behaviour)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

Fixes #7703.
