### PR TITLE
fix(build): export dynamic symbols from the Lua hosting binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,16 @@ target_link_libraries(osrm-customize osrm_customize ${Boost_PROGRAM_OPTIONS_LIBR
 target_link_libraries(osrm-contract osrm_contract ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(osrm-routed osrm ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OPTIONAL_SOCKET_LIBS} ${ZLIB_LIBRARY})
 
+# Lua C modules pulled in by a profile's require() are dlopen'ed at runtime and
+# resolve their lua_* symbols against the hosting executable. vcpkg links Lua
+# statically, which leaves those symbols out of the dynamic symbol table and
+# makes the load fail with "undefined symbol: lua_gettop". ENABLE_EXPORTS puts
+# them back (-rdynamic on ELF toolchains). Only these two binaries embed Lua.
+# See https://github.com/Project-OSRM/osrm-backend/issues/7700
+if(NOT MSVC)
+  set_target_properties(osrm-extract osrm-contract PROPERTIES ENABLE_EXPORTS ON)
+endif()
+
 set(EXTRACTOR_LIBRARIES
     ${BZIP2_LIBRARIES}
     ${BOOST_BASE_LIBRARIES}


### PR DESCRIPTION
Fixes the first half of #7700.

## Problem

Lua C modules pulled in by a profile's `require()` are `dlopen`'ed at runtime and resolve their `lua_*` symbols against the hosting executable. Since the vcpkg migration in #7487 Lua comes from vcpkg and the `x64-linux` triplet links it statically, so those symbols never reach the dynamic symbol table:

```
terminate called after throwing an instance of 'sol::error'
  what():  lua: error: error loading module 'socket.core' from file
  '/usr/lib/x86_64-linux-gnu/lua/5.5/socket/core.so':
  /usr/lib/x86_64-linux-gnu/lua/5.5/socket/core.so: undefined symbol: lua_gettop
```

Before #7487 `ENABLE_CONAN` defaulted to OFF and the build used the system Lua, a shared `liblua`, so a `dlopen`'ed module resolved these symbols from the already loaded `.so`. This is a regression.

## Fix

CMake historically added `-rdynamic` to every executable on ELF platforms. Under CMP0065, NEW here because of `cmake_minimum_required(VERSION 3.18)`, it does so only for targets with `ENABLE_EXPORTS`:

> CMake 3.4 and above prefer to do this only for executables that are explicitly marked with the `ENABLE_EXPORTS` target property.

So the property is set on `osrm-extract` and `osrm-contract`, the only two binaries linking `${LUA_LIBRARIES}`. This is the documented mechanism for executables that load plugins via `dlopen`, and replaces the reporter's `-DCMAKE_EXE_LINKER_FLAGS="-rdynamic"` workaround.

Guarded with `NOT MSVC`, where `ENABLE_EXPORTS` instead produces an import library and is not needed.

## Verification

No Linux machine was available here, so the policy behaviour was confirmed directly with a minimal project pinned to the same `cmake_minimum_required(VERSION 3.18)`, using a sentinel in place of the platform export flag, which is empty on Apple:

| target | export flag in link line |
| --- | --- |
| `ENABLE_EXPORTS ON` | present |
| default | absent |

Locally `osrm-extract` and `osrm-contract` configure, link, and run. Worth a check on Linux against the reporter's `lua-redis` case before merging.

## Not covered

The second half of #7700, system Lua module paths, is unaddressed. vcpkg builds Lua with upstream's `LUA_ROOT` of `/usr/local/`, so Debian's `/usr/share/lua/5.5` is never searched. Separately, `luaAddScriptFolderToLoadPath` (`include/util/lua_util.hpp:25`) extends `package.path` but never `package.cpath`, so profile local C modules cannot be loaded on any platform. Both need a portability decision and are left for a follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
