### PR TITLE
ci: fail the monthly release fast on a bad release token

### DIFF
--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -42,6 +42,41 @@ jobs:
             echo "nameserver 1.1.1.1"
             echo "nameserver 8.8.8.8"
           } | sudo tee /etc/resolv.conf > /dev/null
+      - name: Verify release token
+        env:
+          RELEASE_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "::error title=Release token missing::BACKEND_RELEASE_TOKEN is not available to this workflow. Store a token with contents:write and workflow permissions on $GITHUB_REPOSITORY as an organization or repository secret."
+            exit 1
+          fi
+
+          HEADERS="$(mktemp)"
+          STATUS="$(curl -sS --retry 3 --retry-connrefused -o /dev/null -D "$HEADERS" -w '%{http_code}' \
+            -H "Authorization: Bearer $RELEASE_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY" || echo "000")"
+
+          if [ "$STATUS" != "200" ]; then
+            echo "::error title=Release token rejected::BACKEND_RELEASE_TOKEN was rejected by the GitHub API (HTTP $STATUS); it has most likely expired or been revoked. Rotate the secret with a token that has contents:write and workflow permissions on $GITHUB_REPOSITORY, then re-run this workflow."
+            exit 1
+          fi
+
+          EXPIRY="$(tr -d '\r' < "$HEADERS" | tr 'A-Z' 'a-z' | sed -n 's/^github-authentication-token-expiration: *//p')"
+          if [ -z "$EXPIRY" ]; then
+            echo "BACKEND_RELEASE_TOKEN is valid and does not expire."
+            exit 0
+          fi
+
+          echo "BACKEND_RELEASE_TOKEN is valid until $EXPIRY."
+          EXPIRY_EPOCH="$(date -u -d "$EXPIRY" +%s 2>/dev/null || true)"
+          if [ -n "$EXPIRY_EPOCH" ]; then
+            DAYS_LEFT=$(( (EXPIRY_EPOCH - $(date -u +%s)) / 86400 ))
+            if [ "$DAYS_LEFT" -lt 45 ]; then
+              echo "::warning title=Release token expiring::BACKEND_RELEASE_TOKEN expires in $DAYS_LEFT day(s), on $EXPIRY. Rotate it before the next monthly release."
+            fi
+          fi
+
       - uses: actions/checkout@v7
         with:
           token: ${{ secrets.BACKEND_RELEASE_TOKEN }}

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -46,8 +46,10 @@ jobs:
         env:
           RELEASE_TOKEN: ${{ secrets.BACKEND_RELEASE_TOKEN }}
         run: |
+          PERMS="Contents: read and write plus Actions: read on $GITHUB_REPOSITORY (a classic PAT needs the repo scope)"
+
           if [ -z "$RELEASE_TOKEN" ]; then
-            echo "::error title=Release token missing::BACKEND_RELEASE_TOKEN is not available to this workflow. Store a token with contents:write and workflow permissions on $GITHUB_REPOSITORY as an organization or repository secret."
+            echo "::error title=Release token missing::BACKEND_RELEASE_TOKEN is not available to this workflow. Store a token with $PERMS as an organization or repository secret."
             exit 1
           fi
 
@@ -57,12 +59,28 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY" || echo "000")"
 
-          if [ "$STATUS" != "200" ]; then
-            echo "::error title=Release token rejected::BACKEND_RELEASE_TOKEN was rejected by the GitHub API (HTTP $STATUS); it has most likely expired or been revoked. Rotate the secret with a token that has contents:write and workflow permissions on $GITHUB_REPOSITORY, then re-run this workflow."
-            exit 1
-          fi
+          case "$STATUS" in
+            200)
+              ;;
+            000)
+              echo "::error title=Token check failed::Could not reach the GitHub API to validate BACKEND_RELEASE_TOKEN. That is a connectivity failure on the runner, not evidence that the token is bad."
+              exit 1
+              ;;
+            401)
+              echo "::error title=Release token rejected::BACKEND_RELEASE_TOKEN was rejected with HTTP 401, so the value is not a credential GitHub recognizes: it has expired, been revoked, or been stored with stray whitespace. Regenerate it, update the secret, and re-run this workflow."
+              exit 1
+              ;;
+            403)
+              echo "::error title=Release token not authorized::BACKEND_RELEASE_TOKEN authenticated but was refused with HTTP 403, so the token is valid and its grant is not. It needs $PERMS."
+              exit 1
+              ;;
+            *)
+              echo "::error title=Release token check failed::Validating BACKEND_RELEASE_TOKEN against the GitHub API returned an unexpected HTTP $STATUS."
+              exit 1
+              ;;
+          esac
 
-          EXPIRY="$(tr -d '\r' < "$HEADERS" | tr 'A-Z' 'a-z' | sed -n 's/^github-authentication-token-expiration: *//p')"
+          EXPIRY="$(tr -d '\r' < "$HEADERS" | awk 'tolower($1) == "github-authentication-token-expiration:" { $1 = ""; sub(/^[[:space:]]+/, ""); print }')"
           if [ -z "$EXPIRY" ]; then
             echo "BACKEND_RELEASE_TOKEN is valid and does not expire."
             exit 0
@@ -70,11 +88,14 @@ jobs:
 
           echo "BACKEND_RELEASE_TOKEN is valid until $EXPIRY."
           EXPIRY_EPOCH="$(date -u -d "$EXPIRY" +%s 2>/dev/null || true)"
-          if [ -n "$EXPIRY_EPOCH" ]; then
-            DAYS_LEFT=$(( (EXPIRY_EPOCH - $(date -u +%s)) / 86400 ))
-            if [ "$DAYS_LEFT" -lt 45 ]; then
-              echo "::warning title=Release token expiring::BACKEND_RELEASE_TOKEN expires in $DAYS_LEFT day(s), on $EXPIRY. Rotate it before the next monthly release."
-            fi
+          if [ -z "$EXPIRY_EPOCH" ]; then
+            echo "::warning title=Release token expiry unreadable::Could not parse the token expiry '$EXPIRY', so the expiry warning is inactive for this run."
+            exit 0
+          fi
+
+          DAYS_LEFT=$(( (EXPIRY_EPOCH - $(date -u +%s)) / 86400 ))
+          if [ "$DAYS_LEFT" -lt 45 ]; then
+            echo "::warning title=Release token expiring::BACKEND_RELEASE_TOKEN expires in $DAYS_LEFT day(s), on $EXPIRY. Rotate it before the next monthly release."
           fi
 
       - uses: actions/checkout@v7

--- a/docs/python/development.md
+++ b/docs/python/development.md
@@ -287,15 +287,23 @@ one shot.
 The workflow pushes the version bump, the tag, and the GitHub Release with the
 `BACKEND_RELEASE_TOKEN` secret rather than the default `GITHUB_TOKEN`, because a
 tag pushed with `GITHUB_TOKEN` does not trigger the `osrm-backend.yml` run that
-builds the release artifacts. The token needs `contents:write` and `workflow`
-permissions on the repository.
+builds the release artifacts. The token needs Contents: read and write, to push
+the version bump and the tag, and Actions: read, so the job can poll the CI run
+it waits on. A classic PAT covers both with the `repo` scope.
 
 The first step of the release job checks that token against the GitHub API
-before anything else runs, so an expired or revoked token fails the job in
-seconds with an explicit message instead of a `could not read Username for
-'https://github.com'` error out of `actions/checkout`. When the token is within
-45 days of expiring the step emits a warning on the run, which is the cue to
-rotate the secret before the next monthly release.
+before anything else runs, so a bad token fails the job in seconds with an
+explicit message instead of a `could not read Username for 'https://github.com'`
+error out of `actions/checkout`. It separates the three cases that look alike
+from the outside: an unreachable API (a runner network fault, not a token
+fault), HTTP 401 (the value is not a credential GitHub recognizes, so it has
+expired, been revoked, or picked up stray whitespace on the way into the
+secret), and HTTP 403 (the token is real but its grant is too narrow).
+
+When the token is within 45 days of expiring the step emits a warning on the
+run, which is the cue to rotate the secret before the next monthly release.
+Expiry comes from the `github-authentication-token-expiration` response header,
+which is absent for tokens that never expire.
 
 ### Scheduled monthly release
 

--- a/docs/python/development.md
+++ b/docs/python/development.md
@@ -282,6 +282,21 @@ not by pushing a tag by hand. The workflow bumps the version, creates the tag,
 drives CI, downloads the built wheels, and publishes to both PyPI and npm in
 one shot.
 
+### Release credentials
+
+The workflow pushes the version bump, the tag, and the GitHub Release with the
+`BACKEND_RELEASE_TOKEN` secret rather than the default `GITHUB_TOKEN`, because a
+tag pushed with `GITHUB_TOKEN` does not trigger the `osrm-backend.yml` run that
+builds the release artifacts. The token needs `contents:write` and `workflow`
+permissions on the repository.
+
+The first step of the release job checks that token against the GitHub API
+before anything else runs, so an expired or revoked token fails the job in
+seconds with an explicit message instead of a `could not read Username for
+'https://github.com'` error out of `actions/checkout`. When the token is within
+45 days of expiring the step emits a warning on the run, which is the cue to
+rotate the secret before the next monthly release.
+
 ### Scheduled monthly release
 
 A cron on the 1st of each month at 08:00 UTC runs the workflow against
@@ -290,9 +305,9 @@ A cron on the 1st of each month at 08:00 UTC runs the workflow against
 1. Compute the next version as `(YYYY-2000).M.patchlevel` (e.g. `26.4.0`).
 2. Bump `package.json` + `package-lock.json`, commit, create annotated tag
    `v<version>`, push branch and tag.
-3. Dispatch `osrm-backend.yml` on the tag. That run builds wheels + sdist
+3. The tag push triggers `osrm-backend.yml`. That run builds wheels + sdist
    via `cibuildwheel` and uploads them as `wheels-*` artifacts.
-4. Wait for the dispatched CI run to finish with conclusion `success`.
+4. Wait for the CI run on the tag's commit to finish with conclusion `success`.
 5. Run the `publish` job: download every `wheels-*` artifact into `dist/`,
    publish to PyPI via trusted publisher (OIDC), then `npm publish`.
 


### PR DESCRIPTION
# Issue

No separate issue. The September release run failed on this: https://github.com/Project-OSRM/osrm-backend/actions/runs/33485931388

`BACKEND_RELEASE_TOKEN` had expired, and the first step that touched it was `actions/checkout`, which surfaced the 401 as

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

after three retries. That message names neither the token nor the expiry, so it reads like a checkout or a network problem. Working out that it was the token, and that the replacement had also been stored wrong, took several attempts against a 40 second feedback loop.

This adds a `Verify release token` step ahead of the checkout. It calls the GitHub API with the token and reports what actually went wrong:

* secret missing or empty, named explicitly
* secret rejected, with the HTTP status, which separates an invalid token (401) from an under-scoped one (403)

It also reads `github-authentication-token-expiration` off the response and raises a run warning when the token is within 45 days of expiring, so the rotation happens before a release fails rather than after.

Since the token is a hand-rotated PAT, this will recur. A GitHub App installation token via `actions/create-github-app-token` would remove the expiry entirely. Out of scope here.

Verified the step locally against a missing token, an invalid token, and a valid one, and checked the expiry parsing and the day arithmetic against a synthetic header.

Was this change primarily generated using an AI tool?
Claude Code, Claude Opus 5 🤖

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.
