### PR TITLE
fix(build): include <ostream> in io_config.hpp

### DIFF
--- a/include/storage/io_config.hpp
+++ b/include/storage/io_config.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <filesystem>
+#include <ostream>
 #include <set>
 #include <string>
 #include <vector>


### PR DESCRIPTION
# Issue

There is no separate issue: `include/storage/io_config.hpp` fails to compile against libc++ 23, which no longer provides the transitive includes the header relies on.

`IOConfig::ListInputFiles` writes into a `std::ostream`, but the header includes only `<array>`, `<filesystem>`, `<set>`, `<string>` and `<vector>`. Up to libc++ 22 one of those pulled in `<ostream>`; libc++ 23 removed the transitive includes, so the `operator<<(std::ostream&, const char*)` overload is no longer declared:

```
include/storage/io_config.hpp:53:21: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'const char[10]')
   53 |                 out << "required " << file.string() << "\n";
      |                 ~~~ ^  ~~~~~~~~~~~
```

This showed up when building v26.9.0 with Homebrew's clang/libc++ 23 on macOS; the same header in v26.8.0 has the problem too, it just did not surface with libc++ 22.

The fix is to include `<ostream>` directly.

## Tasklist

 - [x] self-review code for correctness and following the coding guidelines
 - [ ] add tests (not applicable: missing-include fix, covered by compiling the existing sources)
 - [ ] update relevant wiki pages (not applicable)
 - [ ] review
 - [ ] adjust for comments

## Verification

Built v26.9.0 with the patch using clang/libc++ 23 (arm64 macOS): all targets compile and all eight `osrm-*` binaries link. Without the patch the same build fails with the error above.

## AI disclosure

An AI tool (Claude Code) was used to diagnose the failure and prepare this one-line change; the diagnosis and the resulting build were verified locally before submitting.
