### PR TITLE
fix(engine): force the loop and match candidates by role in every search

### DIFF
--- a/include/engine/routing_algorithms/routing_base.hpp
+++ b/include/engine/routing_algorithms/routing_base.hpp
@@ -74,6 +74,17 @@ std::vector<NodeID> getForwardForceNodes(const PhantomCandidatesToTarget &candid
 std::vector<NodeID> getBackwardForceNodes(const PhantomEndpointCandidates &candidates);
 std::vector<NodeID> getBackwardForceNodes(const PhantomCandidatesToTarget &candidates);
 
+// Both lists at once, for a search that seeds both directions of every target into one
+// heap.  A source and a target on one edge-based node with the source the further along
+// need a loop, and the direct and alternative searches told them apart at the seed by the
+// sign of the weight alone: the graph part of a source's key is negative, a target's
+// positive, and their sum is negative exactly when the target sits before the source.
+// That holds only while a phantom's weight is nothing but its share of the node; a
+// phantom carrying a cost of its own at either end, as one snapped into an open area
+// is about to, lifts the sum above zero and the seed is taken for a path.  Naming the
+// nodes is what the via search has always done, and costs nothing.
+std::vector<NodeID> getForceStepNodes(const PhantomEndpointCandidates &candidates);
+
 // Find the specific phantom node endpoints for a given path from a list of candidates.
 PhantomEndpoints endpointsFromCandidates(const PhantomEndpointCandidates &candidates,
                                          const std::vector<NodeID> &path);

--- a/include/engine/routing_algorithms/shortest_path_impl.hpp
+++ b/include/engine/routing_algorithms/shortest_path_impl.hpp
@@ -247,7 +247,12 @@ constructRouteResult(const DataFacade<Algorithm> &facade,
                          source_candidates.end(),
                          [&start_node](const auto &source_phantom)
                          {
-                             return (start_node == source_phantom.forward_segment_id.id ||
+                             // per role, as endpointsFromCandidates: a candidate
+                             // may share its ids with another that serves the
+                             // other role
+                             return (source_phantom.IsValidForwardSource() &&
+                                     start_node == source_phantom.forward_segment_id.id) ||
+                                    (source_phantom.IsValidReverseSource() &&
                                      start_node == source_phantom.reverse_segment_id.id);
                          });
         BOOST_ASSERT(source_it != source_candidates.end());
@@ -257,7 +262,9 @@ constructRouteResult(const DataFacade<Algorithm> &facade,
                          target_candidates.end(),
                          [&end_node](const auto &target_phantom)
                          {
-                             return (end_node == target_phantom.forward_segment_id.id ||
+                             return (target_phantom.IsValidForwardTarget() &&
+                                     end_node == target_phantom.forward_segment_id.id) ||
+                                    (target_phantom.IsValidReverseTarget() &&
                                      end_node == target_phantom.reverse_segment_id.id);
                          });
         BOOST_ASSERT(target_it != target_candidates.end());

--- a/src/engine/routing_algorithms/alternative_path_mld.cpp
+++ b/src/engine/routing_algorithms/alternative_path_mld.cpp
@@ -690,6 +690,7 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
 
     EdgeWeight forward_heap_min = forward_heap.MinKey();
     EdgeWeight reverse_heap_min = reverse_heap.MinKey();
+    const auto force_step_nodes = getForceStepNodes(endpoint_candidates);
 
     while (forward_heap.Size() + reverse_heap.Size() > 0)
     {
@@ -714,7 +715,7 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
                                            reverse_heap,
                                            overlap_via,
                                            overlap_weight,
-                                           {},
+                                           force_step_nodes,
                                            endpoint_candidates);
 
             if (!forward_heap.Empty())
@@ -739,7 +740,7 @@ makeCandidateVias(SearchEngineData<Algorithm> &search_engine_data,
                                            forward_heap,
                                            overlap_via,
                                            overlap_weight,
-                                           {},
+                                           force_step_nodes,
                                            endpoint_candidates);
 
             if (!reverse_heap.Empty())

--- a/src/engine/routing_algorithms/direct_shortest_path.cpp
+++ b/src/engine/routing_algorithms/direct_shortest_path.cpp
@@ -33,7 +33,7 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<ch::Algorithm> &en
            reverse_heap,
            weight,
            packed_leg,
-           {},
+           getForceStepNodes(endpoint_candidates),
            endpoint_candidates);
 
     std::vector<NodeID> unpacked_nodes;
@@ -76,7 +76,7 @@ InternalRouteResult directShortestPathSearch(SearchEngineData<mld::Algorithm> &e
                                      facade,
                                      forward_heap,
                                      reverse_heap,
-                                     {},
+                                     getForceStepNodes(endpoint_candidates),
                                      INVALID_EDGE_WEIGHT,
                                      endpoint_candidates);
 

--- a/src/engine/routing_algorithms/routing_base.cpp
+++ b/src/engine/routing_algorithms/routing_base.cpp
@@ -74,6 +74,14 @@ std::vector<NodeID> getBackwardForceNodes(const PhantomEndpointCandidates &endpo
     return res;
 }
 
+std::vector<NodeID> getForceStepNodes(const PhantomEndpointCandidates &endpoint_candidates)
+{
+    auto nodes = getForwardForceNodes(endpoint_candidates);
+    const auto backward = getBackwardForceNodes(endpoint_candidates);
+    nodes.insert(nodes.end(), backward.begin(), backward.end());
+    return nodes;
+}
+
 std::vector<NodeID> getBackwardForceNodes(const PhantomCandidatesToTarget &endpoint_candidates)
 {
     std::vector<NodeID> res;

--- a/src/engine/routing_algorithms/routing_base.cpp
+++ b/src/engine/routing_algorithms/routing_base.cpp
@@ -103,15 +103,16 @@ PhantomEndpoints endpointsFromCandidates(const PhantomEndpointCandidates &candid
                      candidates.source_phantoms.end(),
                      [&path](const auto &source_phantom)
                      {
-                         // A disabled direction is not a direction the search
-                         // could have set off in, so its id says nothing about
-                         // which candidate this path came from.  Area snapping
-                         // relies on that: it offers one candidate per way
-                         // leaving a vertex, and the two ends of one way carry
-                         // the same pair of ids.
-                         return (source_phantom.forward_segment_id.enabled &&
+                         // A direction the search could not have set off in says
+                         // nothing about which candidate this path came from, and
+                         // that is per role: area snapping offers one candidate
+                         // per way leaving a vertex, and the two ends of one way
+                         // carry the same pair of ids; two candidates on one pair
+                         // may also differ only in the role they serve, one valid
+                         // as a source and the other as a target.
+                         return (source_phantom.IsValidForwardSource() &&
                                  path.front() == source_phantom.forward_segment_id.id) ||
-                                (source_phantom.reverse_segment_id.enabled &&
+                                (source_phantom.IsValidReverseSource() &&
                                  path.front() == source_phantom.reverse_segment_id.id);
                      });
     BOOST_ASSERT(source_it != candidates.source_phantoms.end());
@@ -121,9 +122,9 @@ PhantomEndpoints endpointsFromCandidates(const PhantomEndpointCandidates &candid
                      candidates.target_phantoms.end(),
                      [&path](const auto &target_phantom)
                      {
-                         return (target_phantom.forward_segment_id.enabled &&
+                         return (target_phantom.IsValidForwardTarget() &&
                                  path.back() == target_phantom.forward_segment_id.id) ||
-                                (target_phantom.reverse_segment_id.enabled &&
+                                (target_phantom.IsValidReverseTarget() &&
                                  path.back() == target_phantom.reverse_segment_id.id);
                      });
     BOOST_ASSERT(target_it != candidates.target_phantoms.end());


### PR DESCRIPTION
# Issue

Preparatory to the open-area snapping work tracked in #7683: two places where the search assumed more about a candidate than it will be able to.

## Problem

Two assumptions in the routing core hold for phantoms the r-tree produces and stop holding once a coordinate carries candidates with a cost of their own, or several candidates on one edge-based node that differ only in the role they serve.

- **The seed.** The direct and alternative searches tell a source after a target on the same edge-based node apart at the seed by the sign of the weight alone: the graph part of a source's key is negative, a target's positive, and their sum is negative exactly when the target sits before the source. A phantom whose weight is more than its share of the node lifts that sum above zero, and the seed is accepted as a path. The via search has always named the nodes to force instead (`getForwardForceNodes`, `getBackwardForceNodes`).
- **The match.** `endpointsFromCandidates` and the via search's `constructRouteResult` take the first candidate carrying the path's end node in either enabled direction. Two candidates may share a node with one valid as a source and the other as a target, and the wrong one is then reported.

## Fix

- `getForceStepNodes()` hands both lists to the direct and alternative searches, as the via search already does. No behaviour change for today's phantoms; the loop is forced only where the weights already said so.
- The match is made per role, with `IsValidForwardSource()` and friends rather than the direction being enabled.

## Verification

Engine unit tests, and the via, snap, basic, table and area snapping scenarios on CH and MLD.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

Refs #7683. No other PR is needed first.

🤖 Claude Code, Claude Fable 5.1
