### PR TITLE
fix(area): try every area holding a coordinate, not just the first

### DIFF
--- a/include/engine/area_snapping.hpp
+++ b/include/engine/area_snapping.hpp
@@ -44,8 +44,13 @@ enum class ApproachRole
  * have given if the coordinate had been part of it when it was built.  See
  * plans/open-area-snapping.md, sections R11 and R12.
  *
- * @return the candidates, or nothing if the coordinate is not inside any open area, or
- *         is inside one whose vertices are all unreachable.
+ * Areas overlap, and one holding the coordinate may have nothing to offer -- the extractor
+ * records a polygon before it applies AreaMesher::max_vertices, so a plaza too large to
+ * mesh is stored with no way on any of its vertices.  Every area holding the coordinate is
+ * tried before giving up.
+ *
+ * @return the candidates, or nothing if the coordinate is inside no open area, or inside
+ *         only areas whose vertices are all unreachable.
  */
 std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDataFacade &facade,
                                                         const util::Coordinate coordinate,

--- a/src/engine/area_geodesic.cpp
+++ b/src/engine/area_geodesic.cpp
@@ -101,11 +101,9 @@ Point projected_vertex(const SolvedArea &area, std::size_t index)
     return Point{};
 }
 
-SolvedArea solve(const std::vector<std::span<const util::Coordinate>> &rings)
+/** The mutually visible pairs, which is the expensive half and the reason to cache. */
+void build_adjacency(SolvedArea &area)
 {
-    SolvedArea area;
-    flatten(rings, area);
-
     area.adjacency.resize(area.size());
     for (std::size_t u = 0; u < area.size(); ++u)
     {
@@ -122,7 +120,6 @@ SolvedArea solve(const std::vector<std::span<const util::Coordinate>> &rings)
             }
         }
     }
-    return area;
 }
 
 /**
@@ -324,12 +321,22 @@ geodesic_between(std::uint32_t dataset,
     }
     if (area == nullptr)
     {
-        // build it before deciding the points are inside, so that a run of queries
-        // against one area pays for the graph once whatever the answers turn out to be
-        area = &cache().put(key, solve(rings));
+        // Containment is decided before the graph is built, not after.  Projecting the
+        // rings is linear and building the visibility graph is cubic, and a coordinate
+        // arrives here once for every area whose *bounding box* claimed it, most of
+        // which do not hold it at all.  Building first would charge every one of those
+        // near misses the full price of an answer that is about to be thrown away.
+        SolvedArea candidate;
+        flatten(rings, candidate);
+        if (!inside_area(projected_from, candidate.rings) ||
+            !inside_area(projected_to, candidate.rings))
+        {
+            return std::nullopt;
+        }
+        build_adjacency(candidate);
+        area = &cache().put(key, std::move(candidate));
     }
-
-    if (!inside_area(projected_from, area->rings) || !inside_area(projected_to, area->rings))
+    else if (!inside_area(projected_from, area->rings) || !inside_area(projected_to, area->rings))
     {
         return std::nullopt;
     }

--- a/src/engine/area_route.cpp
+++ b/src/engine/area_route.cpp
@@ -26,20 +26,20 @@ constexpr double DEFAULT_WALKING_SPEED = 1.4;
 double metres(const util::Coordinate a, const util::Coordinate b)
 { return util::coordinate_calculation::greatCircleDistance(a, b); }
 
-/** The one area holding both coordinates, if there is one. */
-std::optional<extractor::AreaPolygonSegment> commonArea(const datafacade::BaseDataFacade &facade,
-                                                        const util::Coordinate from,
-                                                        const util::Coordinate to)
+/** Every area holding both coordinates, in an order that is a property of the data. */
+std::vector<extractor::AreaPolygonSegment> commonAreas(const datafacade::BaseDataFacade &facade,
+                                                       const util::Coordinate from,
+                                                       const util::Coordinate to)
 {
     auto here = facade.GetOpenAreasAt(from);
     if (here.empty())
     {
-        return std::nullopt;
+        return {};
     }
     const auto there = facade.GetOpenAreasAt(to);
     if (there.empty())
     {
-        return std::nullopt;
+        return {};
     }
 
     // the r-tree hands them back in packing order, which is not a property of the input
@@ -48,18 +48,46 @@ std::optional<extractor::AreaPolygonSegment> commonArea(const datafacade::BaseDa
               [](const auto &lhs, const auto &rhs)
               { return lhs.vertices_offset < rhs.vertices_offset; });
 
+    std::vector<extractor::AreaPolygonSegment> shared;
     for (const auto &area : here)
     {
-        const auto shared = std::any_of(there.begin(),
-                                        there.end(),
-                                        [&](const auto &other)
-                                        { return other.vertices_offset == area.vertices_offset; });
-        if (!shared)
+        if (std::any_of(there.begin(),
+                        there.end(),
+                        [&](const auto &other)
+                        { return other.vertices_offset == area.vertices_offset; }))
         {
-            continue;
+            // a bounding box is not the area; geodesic_between checks containment properly
+            shared.push_back(area);
         }
-        // a bounding box is not the area; geodesic_between checks containment properly
-        return area;
+    }
+    return shared;
+}
+
+/**
+ * @brief The geodesic between two coordinates, across whichever shared area holds them.
+ *
+ * The r-tree answers with bounding boxes, and a bounding box is not the area, so a
+ * coordinate can be filed under an area it is not inside.  geodesic_between settles that
+ * properly and declines when it does not hold.  Taking only the first shared area
+ * therefore threw the journey away whenever the first one was a near miss, even though a
+ * later one answered it perfectly well.
+ *
+ * The area is returned with the geodesic because the caller needs its walking speed.
+ */
+std::optional<std::pair<extractor::AreaPolygonSegment, Geodesic>>
+geodesicAcross(const datafacade::BaseDataFacade &facade,
+               const util::Coordinate from,
+               const util::Coordinate to)
+{
+    for (const auto &area : commonAreas(facade, from, to))
+    {
+        const auto rings = facade.GetOpenAreaRings(area);
+        auto geodesic =
+            geodesic_between(facade.GetCheckSum(), area.vertices_offset, rings, from, to);
+        if (geodesic)
+        {
+            return std::pair{area, std::move(*geodesic)};
+        }
     }
     return std::nullopt;
 }
@@ -133,19 +161,13 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
         {
             continue;
         }
-        const auto area = commonArea(facade, from, to);
-        if (!area)
+        const auto answer = geodesicAcross(facade, from, to);
+        if (!answer)
         {
             continue;
         }
-
-        const auto rings = facade.GetOpenAreaRings(*area);
-        const auto geodesic =
-            geodesic_between(facade.GetCheckSum(), area->vertices_offset, rings, from, to);
-        if (!geodesic)
-        {
-            continue;
-        }
+        const auto &area = answer->first;
+        const auto &geodesic = answer->second;
 
         // No comparison against the routed leg: there is nothing to compare with.  The
         // leg runs between the two *snapped* points and leaves the walks to them out of
@@ -154,15 +176,15 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
         // path between the two coordinates through the area, and a route that leaves the
         // area to come back could only beat it on ways faster than the area itself,
         // which for a profile that meshes plazas is not a case that arises.
-        if (geodesic->length < WORTH_REPLACING_METRES)
+        if (geodesic.length < WORTH_REPLACING_METRES)
         {
             continue;
         }
 
         // Every bend has to resolve to a node, or the geometry cannot be written down.
         std::vector<NodeID> bends;
-        bends.reserve(geodesic->bends.size());
-        for (const auto bend : geodesic->bends)
+        bends.reserve(geodesic.bends.size());
+        for (const auto bend : geodesic.bends)
         {
             const auto node = nodeAt(facade, bend);
             if (!node)
@@ -171,7 +193,7 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
             }
             bends.push_back(*node);
         }
-        if (bends.size() != geodesic->bends.size())
+        if (bends.size() != geodesic.bends.size())
         {
             continue;
         }
@@ -186,7 +208,7 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
 
         const auto cost = [&](double length)
         {
-            const auto stretch = length / area->walking_speed;
+            const auto stretch = length / area.walking_speed;
             return std::pair{to_alias<EdgeWeight>(std::lround(stretch * multiplier)),
                              to_alias<EdgeDuration>(std::lround(stretch * 10.))};
         };
@@ -203,10 +225,10 @@ void useGeodesicWhereShorter(const datafacade::BaseDataFacade &facade,
         auto previous = from;
         for (std::size_t i = 0; i < bends.size(); ++i)
         {
-            const auto [step_weight, step_duration] = cost(metres(previous, geodesic->bends[i]));
+            const auto [step_weight, step_duration] = cost(metres(previous, geodesic.bends[i]));
             path.push_back(
                 PathData{named, bends[i], step_weight, {0}, step_duration, {0}, 0, std::nullopt});
-            previous = geodesic->bends[i];
+            previous = geodesic.bends[i];
         }
 
         // assembleLeg adds the target phantom's own weight on top of the path, and
@@ -357,25 +379,20 @@ void useGeodesicInTable(const datafacade::BaseDataFacade &facade,
         for (std::size_t column = 0; column < columns; ++column)
         {
             const auto to = coordinates[destinations.empty() ? column : destinations[column]];
-            const auto area = commonArea(facade, from, to);
-            if (!area)
+            const auto answer = geodesicAcross(facade, from, to);
+            if (!answer)
             {
                 continue;
             }
-            const auto rings = facade.GetOpenAreaRings(*area);
-            const auto geodesic =
-                geodesic_between(facade.GetCheckSum(), area->vertices_offset, rings, from, to);
-            if (!geodesic)
-            {
-                continue;
-            }
+            const auto &area = answer->first;
+            const auto &geodesic = answer->second;
 
             const auto cell = row * columns + column;
             durations[cell] =
-                to_alias<EdgeDuration>(std::lround(geodesic->length / area->walking_speed * 10.));
+                to_alias<EdgeDuration>(std::lround(geodesic.length / area.walking_speed * 10.));
             if (!distances.empty())
             {
-                distances[cell] = to_alias<EdgeDistance>(geodesic->length);
+                distances[cell] = to_alias<EdgeDistance>(geodesic.length);
             }
         }
     }

--- a/src/engine/area_snapping.cpp
+++ b/src/engine/area_snapping.cpp
@@ -242,7 +242,17 @@ std::optional<PhantomNodeCandidates> SnapInsideOpenArea(const datafacade::BaseDa
 
         if (candidates.empty())
         {
-            return std::nullopt;
+            // Nothing here to set off from, which does not mean there is nowhere.  An
+            // area the mesher declined -- AreaMesher::max_vertices -- is recorded all the
+            // same, and no vertex of it carries a way, so it yields nothing however long
+            // it is walked over.  Areas overlap, so another one may hold this coordinate
+            // and be meshed.
+            //
+            // Returning here instead of looking sent the request back to ordinary
+            // snapping, which projects onto the nearest edge of the perimeter, and the
+            // route then leaves the plaza by a corner and comes back.  The `return` after
+            // the loop is what answers "none of them had anything".
+            continue;
         }
         return candidates;
     }

--- a/src/engine/area_visibility.cpp
+++ b/src/engine/area_visibility.cpp
@@ -37,15 +37,14 @@ bool on_any_ring(const Point &point, std::span<const Ring> rings, const double t
     const auto limit = tolerance * tolerance;
     for (const Ring &ring : rings)
     {
-        bool found = false;
-        for_each_edge(ring,
-                      [&](const Point &a, const Point &b)
-                      {
-                          if (!found && distance_squared_to_segment(point, a, b) <= limit)
-                              found = true;
-                      });
-        if (found)
-            return true;
+        // A plain loop rather than for_each_edge, which cannot stop early.  This runs
+        // once per vertex from visible_vertices, so scanning a whole ring after the
+        // answer is known costs the snapping path a factor of the ring's length.
+        for (std::size_t i = 0; i < ring.size(); ++i)
+        {
+            if (distance_squared_to_segment(point, ring[i], ring[(i + 1) % ring.size()]) <= limit)
+                return true;
+        }
     }
     return false;
 }
@@ -53,20 +52,22 @@ bool on_any_ring(const Point &point, std::span<const Ring> rings, const double t
 
 bool crosses_ring(const Point &from, const Point &to, Ring ring)
 {
-    bool crosses = false;
-    for_each_edge(ring,
-                  [&](const Point &a, const Point &b)
-                  {
-                      // an edge sharing an endpoint with from..to meets it only there,
-                      // and cannot obstruct it -- the same reasoning as in the sweep
-                      const auto same = [](const Point &p, const Point &q)
-                      { return p.x == q.x && p.y == q.y; };
-                      if (same(a, from) || same(a, to) || same(b, from) || same(b, to))
-                          return;
-                      if (extractor::area::intersect(&from, &to, &a, &b))
-                          crosses = true;
-                  });
-    return crosses;
+    const auto same = [](const Point &p, const Point &q) { return p.x == q.x && p.y == q.y; };
+    // A plain loop rather than for_each_edge, which cannot stop early.  visible_vertices
+    // calls this once per vertex per ring, so a whole-ring scan after the first crossing
+    // is found is a factor of the ring's length on the snapping path.
+    for (std::size_t i = 0; i < ring.size(); ++i)
+    {
+        const Point &a = ring[i];
+        const Point &b = ring[(i + 1) % ring.size()];
+        // an edge sharing an endpoint with from..to meets it only there, and cannot
+        // obstruct it -- the same reasoning as in the sweep
+        if (same(a, from) || same(a, to) || same(b, from) || same(b, to))
+            continue;
+        if (extractor::area::intersect(&from, &to, &a, &b))
+            return true;
+    }
+    return false;
 }
 
 bool inside_ring(const Point &point, Ring ring)

--- a/unit_tests/engine/area_geodesic.cpp
+++ b/unit_tests/engine/area_geodesic.cpp
@@ -311,6 +311,31 @@ BOOST_AUTO_TEST_CASE(geodesic_caches_the_graph_per_area_and_dataset)
     BOOST_CHECK_EQUAL(cached_geodesic_count(), 0u);
 }
 
+/**
+ * A near miss costs nothing but the containment test.
+ *
+ * The r-tree answers with bounding boxes, so this is asked about every area whose box
+ * claims a coordinate, and most of them do not hold it. Building the visibility graph is
+ * cubic in the vertex count and deciding containment is linear, so the order matters:
+ * building first charged every near miss the full price of an answer already lost.
+ */
+BOOST_AUTO_TEST_CASE(geodesic_does_not_build_a_graph_for_a_point_it_does_not_hold)
+{
+    forget_cached_geodesics();
+
+    // a right triangle sharing its bounding box with the 1000 m square
+    const std::vector<util::Coordinate> corners{at(0, 0), at(1000, 0), at(0, 1000)};
+    const Rings rings{corners};
+
+    // x + y > 1000, so both are in the bounding box and outside the triangle
+    BOOST_CHECK(!geodesic_between(1, fresh_key(), rings, at(600, 600), at(700, 700)));
+    BOOST_CHECK_EQUAL(cached_geodesic_count(), 0u);
+
+    // and a pair it does hold still builds and is kept
+    BOOST_REQUIRE(geodesic_between(1, fresh_key(), rings, at(100, 100), at(200, 200)));
+    BOOST_CHECK_EQUAL(cached_geodesic_count(), 1u);
+}
+
 // The cache is bounded, and evicting does not change any answer.
 BOOST_AUTO_TEST_CASE(geodesic_cache_is_bounded_and_eviction_is_invisible)
 {

--- a/unit_tests/engine/area_route.cpp
+++ b/unit_tests/engine/area_route.cpp
@@ -1,0 +1,106 @@
+#include "engine/area_route.hpp"
+
+#include "mocks/mock_area_facade.hpp"
+#include "engine/area_geodesic.hpp"
+
+#include "util/coordinate_calculation.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(area_route_test)
+
+using namespace osrm;
+using namespace osrm::engine;
+using namespace osrm::engine::area;
+using osrm::test::at;
+using osrm::test::mock_square;
+using osrm::test::mock_triangle;
+using osrm::test::MockAreaFacade;
+
+namespace
+{
+
+// Both call sites go through the same helper, and a table is the one that can be driven
+// with plain vectors, so it is what these exercise.
+
+constexpr EdgeDuration UNTOUCHED{99999};
+
+/** A one-cell table between two coordinates, returning what the cell became. */
+EdgeDuration
+cell_between(const MockAreaFacade &facade, const util::Coordinate from, const util::Coordinate to)
+{
+    // the cache is keyed on (checksum, area offset), and every fixture here has checksum
+    // zero, so one test could otherwise be answered from another's graph
+    forget_cached_geodesics();
+
+    const std::vector<util::Coordinate> coordinates{from, to};
+    const std::vector<std::size_t> sources{0}, destinations{1};
+    std::vector<EdgeDuration> durations{UNTOUCHED};
+    std::vector<EdgeDistance> distances;
+
+    useGeodesicInTable(facade, coordinates, sources, destinations, durations, distances);
+    return durations.front();
+}
+
+/** What the cell should hold: the straight line at the area's walking speed. */
+EdgeDuration straight_line(const util::Coordinate from, const util::Coordinate to, double speed)
+{
+    const auto metres = util::coordinate_calculation::greatCircleDistance(from, to);
+    return to_alias<EdgeDuration>(std::lround(metres / speed * 10.));
+}
+
+} // namespace
+
+// The ordinary case, so the fixture is known to be capable of answering at all.
+BOOST_AUTO_TEST_CASE(rewrites_a_cell_with_both_ends_on_one_plaza)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_square(0, 1000, 0));
+
+    const auto from = at(300, 300), to = at(700, 700);
+    BOOST_CHECK_EQUAL(cell_between(facade, from, to), straight_line(from, to, 1.4));
+}
+
+// Two coordinates with no area between them are left to the search.
+BOOST_AUTO_TEST_CASE(leaves_a_cell_that_touches_no_area)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_square(0, 1000, 0));
+
+    BOOST_CHECK_EQUAL(cell_between(facade, at(2000, 2000), at(2100, 2100)), UNTOUCHED);
+}
+
+/**
+ * The regression this file was written for.
+ *
+ * The r-tree answers with bounding boxes, so a coordinate is filed under areas it is not
+ * inside; geodesic_between settles containment properly and declines. Taking only the
+ * first shared area threw the journey away whenever that one was a near miss, and the leg
+ * stayed as the search left it: out to a corner of the plaza and back.
+ *
+ * The triangle sorts first here, shares its bounding box with the square, and holds
+ * neither coordinate.
+ */
+BOOST_AUTO_TEST_CASE(looks_past_an_area_that_only_the_bounding_box_claimed)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_triangle(0, 1000, 0)); // bounding box only
+    facade.areas.push_back(mock_square(200, 800, 3));  // genuinely holds both
+
+    // x + y > 1000, so both are outside the triangle and inside the square
+    const auto from = at(600, 600), to = at(700, 700);
+    BOOST_CHECK_EQUAL(cell_between(facade, from, to), straight_line(from, to, 1.4));
+}
+
+// And when the only candidate really is a near miss, there is nothing to rewrite.
+BOOST_AUTO_TEST_CASE(leaves_a_cell_whose_only_area_does_not_hold_it)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_triangle(0, 1000, 0));
+
+    BOOST_CHECK_EQUAL(cell_between(facade, at(600, 600), at(700, 700)), UNTOUCHED);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/engine/area_snapping.cpp
+++ b/unit_tests/engine/area_snapping.cpp
@@ -1,0 +1,79 @@
+#include "engine/area_snapping.hpp"
+
+#include "mocks/mock_area_facade.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(area_snapping_test)
+
+using namespace osrm;
+using namespace osrm::engine;
+using namespace osrm::engine::area;
+using osrm::test::at;
+using osrm::test::mock_square;
+using osrm::test::MockAreaFacade;
+
+namespace
+{
+std::optional<PhantomNodeCandidates> departing_from(const MockAreaFacade &facade,
+                                                    const util::Coordinate coordinate)
+{ return SnapInsideOpenArea(facade, coordinate, Approach::UNRESTRICTED, ApproachRole::Departure); }
+} // namespace
+
+// The ordinary case, so the fixture is known to be capable of answering at all.
+BOOST_AUTO_TEST_CASE(snaps_to_the_vertices_of_a_meshed_area)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_square(0, 1000, 0));
+
+    const auto candidates = departing_from(facade, at(500, 500));
+
+    BOOST_REQUIRE(candidates);
+    // every corner of an empty square is visible from the middle
+    BOOST_CHECK_EQUAL(candidates->size(), 4u);
+}
+
+// A coordinate outside every area is not this function's business.
+BOOST_AUTO_TEST_CASE(declines_a_coordinate_that_is_in_no_area)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_square(0, 1000, 0));
+
+    BOOST_CHECK(!departing_from(facade, at(2000, 2000)));
+}
+
+/**
+ * The regression this file was written for.
+ *
+ * Areas overlap, and one holding the coordinate can have nothing on it: the extractor
+ * records a polygon before it applies AreaMesher::max_vertices, so a plaza too large to
+ * mesh is stored with no way on any of its vertices.  Snapping returned on the first area
+ * that held the coordinate, so an unmeshed one sorting first swallowed the request and
+ * the route fell back to ordinary snapping -- onto the perimeter, out by a corner and
+ * back again.
+ *
+ * The unmeshed area sorts first here because snapping orders by `vertices_offset`.
+ */
+BOOST_AUTO_TEST_CASE(looks_past_an_area_that_has_nothing_to_offer)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_square(0, 1000, 0, false)); // recorded, never meshed
+    facade.areas.push_back(mock_square(200, 800, 4, true)); // the plaza with the ways on it
+
+    const auto candidates = departing_from(facade, at(500, 500));
+
+    BOOST_REQUIRE(candidates);
+    BOOST_CHECK_EQUAL(candidates->size(), 4u);
+}
+
+// And when none of them has anything, there is genuinely nothing to offer.
+BOOST_AUTO_TEST_CASE(declines_when_no_area_has_a_reachable_vertex)
+{
+    MockAreaFacade facade;
+    facade.areas.push_back(mock_square(0, 1000, 0, false));
+    facade.areas.push_back(mock_square(200, 800, 4, false));
+
+    BOOST_CHECK(!departing_from(facade, at(500, 500)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/mocks/mock_area_facade.hpp
+++ b/unit_tests/mocks/mock_area_facade.hpp
@@ -1,0 +1,194 @@
+#ifndef MOCK_AREA_FACADE_HPP
+#define MOCK_AREA_FACADE_HPP
+
+// A facade carrying a handful of open areas, for the snapping and geodesic code.  The
+// real one answers from an r-tree over bounding boxes and a flat vertex array; this
+// answers the same three questions from a vector of polygons.
+
+#include "mocks/mock_datafacade.hpp"
+
+#include "extractor/area_routing_data.hpp"
+#include "engine/phantom_node.hpp"
+#include "util/coordinate_calculation.hpp"
+
+#include <algorithm>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace osrm::test
+{
+
+// A degree of longitude at the equator, near enough for a fixture: the numbers are laid
+// out in metres and converted, the same convention as unit_tests/engine/area_geodesic.cpp.
+constexpr double AREA_METRE = 1.0 / 111319.49;
+
+inline util::Coordinate at(double x, double y)
+{ return {util::FloatLongitude{x * AREA_METRE}, util::FloatLatitude{y * AREA_METRE}}; }
+
+/**
+ * One area, remembered with whether the mesher gave its vertices a way.
+ *
+ * An area with no reachable vertex is not a contrivance.  The mesher declines anything
+ * over AreaMesher::max_vertices, and the record into `.osrm.openareas` happens before that
+ * test, so a large plaza is stored with no mesh behind it.  Every vertex of it then fails
+ * the "is there a phantom standing here" question, which is what `reachable` false stands
+ * for.
+ */
+struct MockArea
+{
+    std::vector<util::Coordinate> outer;
+    extractor::AreaPolygonSegment segment;
+    bool reachable = true;
+};
+
+// MockDataFacade is final, and the area code only ever takes a BaseDataFacade, so the
+// base half of the mock is all this needs.
+class MockAreaFacade final : public MockBaseDataFacade
+{
+  public:
+    std::vector<MockArea> areas;
+
+    /** Bounding boxes, as the r-tree gives them: a hit here is not containment. */
+    std::vector<extractor::AreaPolygonSegment>
+    GetOpenAreasAt(const util::Coordinate coordinate) const override
+    {
+        std::vector<extractor::AreaPolygonSegment> found;
+        for (const auto &area : areas)
+        {
+            if (within_bounding_box(area, coordinate))
+            {
+                found.push_back(area.segment);
+            }
+        }
+        return found;
+    }
+
+    std::vector<std::span<const util::Coordinate>>
+    GetOpenAreaRings(const extractor::AreaPolygonSegment &segment) const override
+    {
+        for (const auto &area : areas)
+        {
+            if (area.segment.vertices_offset == segment.vertices_offset)
+            {
+                return {std::span<const util::Coordinate>{area.outer}};
+            }
+        }
+        return {};
+    }
+
+    /**
+     * A phantom stands on a vertex exactly when the mesher gave that vertex a way.  The
+     * segment ids have to be distinct per vertex, because snapping claims each one once.
+     */
+    std::vector<engine::PhantomNodeWithDistance>
+    NearestPhantomNodes(const util::Coordinate coordinate,
+                        const size_t /*max_results*/,
+                        const std::optional<double> /*max_distance*/,
+                        const std::optional<engine::Bearing> /*bearing*/,
+                        const engine::Approach /*approach*/) const override
+    {
+        std::vector<engine::PhantomNodeWithDistance> found;
+        NodeID id = 1;
+        for (const auto &area : areas)
+        {
+            for (const auto vertex : area.outer)
+            {
+                if (area.reachable &&
+                    util::coordinate_calculation::greatCircleDistance(vertex, coordinate) < 0.5)
+                {
+                    found.push_back({standing_at(vertex, id), 0.0});
+                }
+                id += 2;
+            }
+        }
+        return found;
+    }
+
+  private:
+    static bool within_bounding_box(const MockArea &area, const util::Coordinate coordinate)
+    {
+        auto low = area.outer.front(), high = area.outer.front();
+        for (const auto vertex : area.outer)
+        {
+            low.lon = std::min(low.lon, vertex.lon);
+            low.lat = std::min(low.lat, vertex.lat);
+            high.lon = std::max(high.lon, vertex.lon);
+            high.lat = std::max(high.lat, vertex.lat);
+        }
+        return coordinate.lon >= low.lon && coordinate.lon <= high.lon &&
+               coordinate.lat >= low.lat && coordinate.lat <= high.lat;
+    }
+
+    /**
+     * A phantom sitting on a segment's first node: no weight forwards, the whole segment
+     * in reverse.  That is the shape snapping looks for when a traveller departs.
+     */
+    static engine::PhantomNode standing_at(const util::Coordinate vertex, const NodeID id)
+    {
+        // the constructor is the only way in: is_valid_* are private bitfields
+        struct Segment
+        {
+            SegmentID forward_segment_id;
+            SegmentID reverse_segment_id;
+            unsigned short fwd_segment_position;
+        } segment{{id, true}, {id + 1, true}, 0};
+
+        return engine::PhantomNode{segment,
+                                   ComponentID{0, 0},
+                                   EdgeWeight{0},
+                                   EdgeWeight{100},
+                                   EdgeWeight{0},
+                                   EdgeWeight{0},
+                                   EdgeDistance{0},
+                                   EdgeDistance{100},
+                                   EdgeDistance{0},
+                                   EdgeDistance{0},
+                                   EdgeDuration{0},
+                                   EdgeDuration{100},
+                                   EdgeDuration{0},
+                                   EdgeDuration{0},
+                                   true,
+                                   true,
+                                   true,
+                                   true,
+                                   vertex,
+                                   vertex,
+                                   0};
+    }
+};
+
+/** A square with its low corner at (lo, lo) and its high corner at (hi, hi). */
+inline MockArea mock_square(double lo, double hi, std::uint32_t offset, bool reachable = true)
+{
+    MockArea area;
+    area.outer = {at(lo, lo), at(hi, lo), at(hi, hi), at(lo, hi)};
+    area.segment.vertices_offset = offset;
+    area.segment.num_vertices = 4;
+    area.segment.num_rings = 1;
+    area.segment.walking_speed = 1.4;
+    area.reachable = reachable;
+    return area;
+}
+
+/**
+ * A right triangle on the same bounding box as `mock_square(lo, hi, ...)`.
+ *
+ * Its bounding box therefore claims coordinates it does not contain, which is the case
+ * that separates "the r-tree filed it here" from "it is inside".
+ */
+inline MockArea mock_triangle(double lo, double hi, std::uint32_t offset, bool reachable = true)
+{
+    MockArea area;
+    area.outer = {at(lo, lo), at(hi, lo), at(lo, hi)};
+    area.segment.vertices_offset = offset;
+    area.segment.num_vertices = 3;
+    area.segment.num_rings = 1;
+    area.segment.walking_speed = 1.4;
+    area.reachable = reachable;
+    return area;
+}
+
+} // namespace osrm::test
+
+#endif // MOCK_AREA_FACADE_HPP


### PR DESCRIPTION
# Issue

Refs #7683, the first of its known defects.

## Problem

A plaza route could leave by a corner and come back, and a plaza request cost about 288 ms against 0.8 ms for a comparable route touching no area. Those are one defect seen from two sides: the engine gave up on an area rather than trying the next, and did so only after paying the full price of deciding it could not use that one.

Areas overlap, and one holding a coordinate can have nothing to offer. The extractor records a polygon into `.osrm.openareas` before the `AreaMesher::max_vertices` valve decides whether to mesh it, so a plaza too large to mesh is stored with no way on any of its vertices. The r-tree also answers with bounding boxes, so a coordinate is filed under areas it is not inside at all. Three places then gave up on the first candidate:

- `SnapInsideOpenArea` returned inside its loop over the areas, so only the first one containing the coordinate was considered; the request fell back to ordinary snapping onto the perimeter, which is the route that goes out and comes back.
- `commonArea` returned the first shared area, and the geodesic replacement moved on when `geodesic_between` declined it.
- `geodesic_between` built the visibility graph before testing containment, so every bounding-box near miss was charged the cubic price of an answer already lost.

`crosses_ring` and `on_any_ring` also scanned a whole ring after the answer was known, once per vertex per ring on the snapping path.

## Fix

Every area holding the coordinate is tried before giving up, `commonAreas` and `geodesicAcross` try each shared area in turn, containment is tested before the graph is built, and the ring scans stop early.

## Verification

Neither `area_snapping.cpp` nor `area_route.cpp` had a test. Both have one now, sharing a facade mock that carries polygons: an area whose vertices carry no way, standing for one the mesher declined, and a triangle whose bounding box claims coordinates it does not hold. Reverting the three source files fails exactly the three new cases. Area scenarios pass on CH and MLD.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Claude Code, Claude Fable 5.1
