### PR TITLE
fix(guidance): widen EntryClass so a plaza vertex can report its roads

### DIFF
--- a/include/util/guidance/entry_class.hpp
+++ b/include/util/guidance/entry_class.hpp
@@ -1,9 +1,11 @@
 #ifndef OSRM_UTIL_GUIDANCE_ENTRY_CLASS_HPP_
 #define OSRM_UTIL_GUIDANCE_ENTRY_CLASS_HPP_
 
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <type_traits>
 
 namespace osrm::util::guidance
 {
@@ -25,9 +27,26 @@ namespace util::guidance
 
 class EntryClass
 {
-    using FlagBaseType = std::uint32_t;
+    using FlagBaseType = std::uint64_t;
 
   public:
+    /**
+     * How many roads of one intersection this can hold an answer for.
+     *
+     * Sixty-four rather than thirty-two because a meshed pedestrian area produces
+     * intersections far larger than a junction ever is: every line of sight from a plaza
+     * vertex is a way. Over Ile-de-France 276 vertices had more roads than thirty-two
+     * bits could describe, with a median of 38 and a worst of 151; sixty-four covers all
+     * but eight of them. A road beyond this reports no entry -- see allowsEntry -- which
+     * is the one answer the stored data supports.
+     *
+     * Widening again is cheap in space, since only the *distinct* classes are stored and
+     * EntryClassID caps those at 65536, but it changes the layout of .osrm.icd and so
+     * costs a re-extraction.
+     */
+    static constexpr std::uint32_t CAPACITY =
+        static_cast<std::uint32_t>(CHAR_BIT * sizeof(FlagBaseType));
+
     constexpr EntryClass() : enabled_entries_flags(0) {}
 
     // we are hiding the access to the flags behind a protection wall, to make sure the bit logic

--- a/src/guidance/turn_classification.cpp
+++ b/src/guidance/turn_classification.cpp
@@ -2,6 +2,8 @@
 
 #include "util/to_osm_link.hpp"
 
+#include <boost/assert.hpp>
+
 #include <algorithm>
 #include <cstddef>
 
@@ -43,6 +45,13 @@ classifyIntersection(Intersection intersection, const osrm::util::Coordinate &lo
 
     // finally transfer data to the entry/bearing classes
     std::size_t number = 0;
+    // Only an intersection that cannot be discretized can carry more roads than the
+    // entry class holds: a meshed plaza vertex, where every line of sight is a way.
+    // Counted rather than reported one road at a time, since such a vertex is
+    // classified once per edge arriving at it, which made this the loudest thing in an
+    // extraction log by two orders of magnitude -- 157 094 lines over Ile-de-France,
+    // from 276 vertices.
+    std::size_t unrecorded = 0;
     if (canBeDiscretized)
     {
         if (util::guidance::BearingClass::getDiscreteBearing(
@@ -57,11 +66,11 @@ classifyIntersection(Intersection intersection, const osrm::util::Coordinate &lo
         {
             if (road.entry_allowed)
             {
-                if (!entry_class.activate(number))
-                {
-                    util::Log(logWARNING) << "Road " << number << " was not activated at "
-                                          << util::toOSMLink(location);
-                }
+                // a discretizable intersection has a road per bearing bucket at most,
+                // 24, which is within the capacity
+                const bool recorded = entry_class.activate(number);
+                BOOST_ASSERT(recorded);
+                (void)recorded;
             }
 
             auto discrete_bearing_class = util::guidance::BearingClass::getDiscreteBearing(
@@ -79,13 +88,19 @@ classifyIntersection(Intersection intersection, const osrm::util::Coordinate &lo
             {
                 if (!entry_class.activate(number))
                 {
-                    util::Log(logWARNING) << "Road " << number << " was not activated at "
-                                          << util::toOSMLink(location);
+                    ++unrecorded;
                 }
             }
             bearing_class.add(std::round(road.perceived_bearing));
             ++number;
         }
+    }
+    if (unrecorded > 0)
+    {
+        util::Log(logWARNING) << unrecorded << " roads allowing entry could not be recorded at "
+                              << "an intersection of " << number << " roads (capacity "
+                              << util::guidance::EntryClass::CAPACITY << ") at "
+                              << util::toOSMLink(location);
     }
     return std::make_pair(entry_class, bearing_class);
 }

--- a/src/util/guidance/entry_class.cpp
+++ b/src/util/guidance/entry_class.cpp
@@ -9,7 +9,7 @@ namespace osrm::util::guidance
 
 bool EntryClass::activate(std::uint32_t index)
 {
-    if (index >= CHAR_BIT * sizeof(FlagBaseType))
+    if (index >= CAPACITY)
         return false;
 
     enabled_entries_flags |= (FlagBaseType{1} << index);
@@ -24,13 +24,13 @@ bool EntryClass::allowsEntry(std::uint32_t index) const
     // and the extractor logs that it did.  The engine, though, walks the bearings, and
     // there can be more of those than there are bits here.  An ordinary junction never
     // gets near the limit, but a meshed pedestrian area does: every line of sight from a
-    // plaza vertex is a way, and a vertex on a busy plaza has been seen with 96 of them.
+    // plaza vertex is a way, and a vertex on a busy plaza has been seen with 151 of them.
     //
     // Shifting by the width of the type is undefined, so with asserts on this aborted the
     // server and with them off it read whatever the shift happened to produce.  Neither
     // is an answer.  A road that could not be recorded reports no entry, which is what
     // the stored data says about it.
-    if (index >= CHAR_BIT * sizeof(FlagBaseType))
+    if (index >= CAPACITY)
         return false;
 
     return 0 != (enabled_entries_flags & (FlagBaseType{1} << index));

--- a/unit_tests/extractor/turn_classification.cpp
+++ b/unit_tests/extractor/turn_classification.cpp
@@ -1,0 +1,47 @@
+#include "guidance/turn_classification.hpp"
+
+#include "guidance/intersection.hpp"
+#include "guidance/turn_instruction.hpp"
+#include "util/guidance/entry_class.hpp"
+#include "util/typedefs.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+
+BOOST_AUTO_TEST_SUITE(turn_classification)
+
+using namespace osrm;
+using namespace osrm::guidance;
+
+/**
+ * An intersection with more roads than EntryClass can hold: a vertex of a meshed
+ * plaza, where every line of sight is a way and the bearings are too close to be
+ * discretized.  The roads within the capacity are recorded and answer entry, the rest
+ * answer none, and the classification carries on.
+ */
+BOOST_AUTO_TEST_CASE(records_the_roads_within_capacity_and_no_more)
+{
+    const std::size_t capacity = util::guidance::EntryClass::CAPACITY;
+    const std::size_t roads = capacity + 8;
+
+    Intersection intersection;
+    for (std::size_t i = 0; i < roads; ++i)
+    {
+        const double bearing = 360.0 * static_cast<double>(i) / static_cast<double>(roads);
+        const extractor::intersection::IntersectionEdgeGeometry geometry{
+            static_cast<EdgeID>(i), bearing, bearing, 10.0};
+        const extractor::intersection::IntersectionViewData view{geometry, true, bearing};
+        intersection.push_back(
+            ConnectedRoad{view, TurnInstruction::NO_TURN(), INVALID_LANE_DATAID});
+    }
+
+    const auto entry_class = classifyIntersection(intersection, util::Coordinate{}).first;
+
+    for (std::size_t i = 0; i < roads; ++i)
+    {
+        BOOST_CHECK_EQUAL(entry_class.allowsEntry(static_cast<std::uint32_t>(i)), i < capacity);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/util/entry_class.cpp
+++ b/unit_tests/util/entry_class.cpp
@@ -10,8 +10,10 @@ BOOST_AUTO_TEST_SUITE(entry_class)
 
 using osrm::util::guidance::EntryClass;
 
-// How many roads the class can hold, which is how wide its flags are.
-constexpr std::uint32_t CAPACITY = 32;
+// How many roads the class can hold, which is how wide its flags are.  Taken from the
+// class so that widening it cannot leave the test asserting the old capacity.
+constexpr std::uint32_t CAPACITY = EntryClass::CAPACITY;
+static_assert(CAPACITY == 64, "EntryClass capacity changed, and so did the .osrm.icd layout");
 
 BOOST_AUTO_TEST_CASE(entry_class_records_what_it_is_given)
 {
@@ -30,7 +32,7 @@ BOOST_AUTO_TEST_CASE(entry_class_records_what_it_is_given)
 // The engine walks the bearings of an intersection and asks about each one, and there can
 // be more bearings than there are bits here.  An ordinary junction never comes close, but
 // a meshed pedestrian area does: every line of sight from a plaza vertex becomes a way,
-// and a single vertex has been seen with 96 of them in Ile-de-France.
+// and a single vertex has been seen with 151 of them in Ile-de-France.
 //
 // Before this the shift was by the width of the type, which is undefined behaviour: with
 // asserts on it aborted osrm-routed on any route reported with steps, and with them off it
@@ -45,11 +47,11 @@ BOOST_AUTO_TEST_CASE(entry_class_answers_for_a_road_it_could_not_record)
 
     // Storing one beyond capacity already reports that it did not happen.
     BOOST_CHECK(!entries.activate(CAPACITY));
-    BOOST_CHECK(!entries.activate(95));
+    BOOST_CHECK(!entries.activate(151));
 
     // So reading it back says the same thing, for every index the engine might reach.
     BOOST_CHECK(!entries.allowsEntry(CAPACITY));
-    BOOST_CHECK(!entries.allowsEntry(95));
+    BOOST_CHECK(!entries.allowsEntry(151));
     BOOST_CHECK(!entries.allowsEntry(CHAR_BIT * sizeof(std::uint64_t)));
     BOOST_CHECK(!entries.allowsEntry(std::numeric_limits<std::uint32_t>::max()));
 


### PR DESCRIPTION
# Issue

Refs #7683.

## Problem

`EntryClass` holds one bit per road of an intersection in a `uint32_t`, so a road beyond the thirty-second is never recorded and the API reports it as `entry: false`. An ordinary junction never comes close, a discretizable intersection has at most 24 roads, but a meshed pedestrian area is not discretizable: every line of sight from a plaza vertex is a way, and many share a bearing bucket. Over Ile-de-France 276 vertices had more roads than 32 bits describe, median 38, worst 151.

The warning for it was emitted per road, and a plaza vertex is classified once per edge arriving at it, which made this the loudest thing in an extraction log by two orders of magnitude: 157,094 lines over Ile-de-France.

## Fix

The flags widen to 64 bits, which recovers all but eight of the 276; the remaining eight still answer `entry: false` beyond 64, which is what the stored data supports and what `allowsEntry` documents. Widening further is cheap in space, since only distinct classes are stored and `EntryClassID` caps those at 65,536, but costs another re-extraction, so it waits until something needs it. The warning is counted per intersection: 763 lines instead of 157,094.

This changes the layout of `.osrm.icd`, which every profile writes, so data has to be re-extracted whether or not it meshes areas.

## Verification

The entry class unit test covers the wider range; guidance scenarios pass on both algorithms.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Claude Code, Claude Fable 5.1
