### PR TITLE
fix(extract): remove stale open-area files when the profile meshed nothing

### DIFF
--- a/docs/areas.md
+++ b/docs/areas.md
@@ -41,9 +41,11 @@ flag turned on:
 osrm-extract -p profiles/foot_area.lua your-data.osm.pbf
 ```
 
-When meshing is off the extractor writes no `.osrm.openareas` files and the profile
-behaves exactly as it did before the feature existed. The rest of this section is for
-adding meshing to a profile of your own.
+When meshing is off the extractor writes no `.osrm.openareas` files, and removes any
+left behind by an earlier extraction under the same name, so that a dataset built with one
+profile cannot carry the areas of another. The profile then behaves exactly as it did
+before the feature existed. The rest of this section is for adding meshing to a profile of
+your own.
 
 ### Adding it to your own profile
 

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -53,6 +53,7 @@
 #include <osmium/visitor.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <memory>
 #include <thread>
 #include <tuple>
@@ -880,6 +881,18 @@ void Extractor::WriteOpenAreas(const std::vector<area::PolygonRecord> &polygons)
 {
     if (polygons.empty())
     {
+        // Nothing to write, and nothing must be left over either.  The engine loads
+        // .osrm.openareas whenever the file exists, so one left behind by an earlier
+        // extraction with a different profile would be attached to this graph as if it
+        // belonged to it, with edge-based node ids that mean something else entirely.
+        // Every other output of an extraction is overwritten; these have to be removed.
+        for (const auto &suffix :
+             {".osrm.openareas", ".osrm.openareas.ramIndex", ".osrm.openareas.fileIndex"})
+        {
+            // A leftover that cannot be removed is a failure of this extraction: the
+            // engine would load it as this dataset's, so the throw is the right answer.
+            std::filesystem::remove(config.GetPath(suffix));
+        }
         return;
     }
 

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -23,10 +23,13 @@ clean:
 
 ch/$(DATA_NAME).osrm: $(DATA_NAME).osrm
 	mkdir -p ch
+	# a fresh copy: a file the extraction no longer produces must not survive from an older one
+	rm -f ch/$(DATA_NAME).osrm.*
 	cp $(DATA_NAME).osrm.* ch/
 
 mld/$(DATA_NAME).osrm: $(DATA_NAME).osrm
 	mkdir -p mld
+	rm -f mld/$(DATA_NAME).osrm.*
 	cp $(DATA_NAME).osrm.* mld/
 
 $(DATA_NAME).osrm: $(DATA_NAME).osm.pbf $(DATA_NAME).poly $(PROFILE) $(OSRM_EXTRACT)


### PR DESCRIPTION
# Issue

Refs #7683.

## Problem

`WriteOpenAreas()` returned early when the profile meshed nothing and left any `.osrm.openareas`, `.ramIndex` and `.fileIndex` from an earlier extraction where they were. The engine loads `.osrm.openareas` whenever the file exists, so a dataset extracted with `car.lua` after one with `foot_area.lua` carried the old plaza data, naming edge-based nodes by ids that now meant something else.

The fixture Makefile had the same shape one level up: `cp` never removes what the extraction no longer produces, which is how the monaco fixture came to hold an `.osrm.openareas` from a different extraction than its `.osrm.ebg_nodes`.

## Fix

When there is nothing to write, the three files are removed, as every other output of an extraction is overwritten. The fixture copy rules clear their target first.

## Verification

Planting the three files and re-extracting with `car.lua` showed they survived before and are gone after. Area scenarios on CH and MLD.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Claude Code, Claude Fable 5.1
