### PR TITLE
feat(area): simplify plaza outlines at extraction, by Visvalingam-Whyatt

### DIFF
--- a/include/extractor/area/area_mesher.hpp
+++ b/include/extractor/area/area_mesher.hpp
@@ -63,6 +63,14 @@ class AreaMesher
     /** Speed in m/s for crossing an area, taken from the profile. */
     double area_walking_speed{1.4};
     /**
+     * Effective area, in square metres, below which a vertex is simplified away.
+     *
+     * An OSM plaza is drawn to be looked at: its outline follows kerbstones at a
+     * resolution nothing downstream can use, and every vertex is paid for again on each
+     * query that snaps into the area.  Zero switches it off.  See area/simplify.hpp.
+     */
+    double area_simplify_threshold{0.0};
+    /**
      * Emit the area's whole visibility graph rather than the pruned mesh.
      *
      * run_dijkstra() keeps the shortest-path tree rooted at each entry point, which holds

--- a/include/extractor/area/simplify.hpp
+++ b/include/extractor/area/simplify.hpp
@@ -1,0 +1,60 @@
+#ifndef OSRM_EXTRACTOR_AREA_SIMPLIFY_HPP
+#define OSRM_EXTRACTOR_AREA_SIMPLIFY_HPP
+
+#include "extractor/area/typedefs.hpp"
+
+namespace osrm::extractor::area
+{
+
+/**
+ * @brief Drop the vertices of an area that carry no shape, by Visvalingam-Whyatt.
+ *
+ * An OSM plaza is drawn to be looked at, not to be routed across.  Its outline follows
+ * kerbstones and planting beds at a resolution nothing downstream can use: Ile-de-France
+ * has a pedestrian area with 2739 nodes around 228 by 209 metres, one every 30 cm.  Three
+ * separate costs are paid per vertex, and all of them are paid per query rather than once:
+ *
+ *  * `SnapInsideOpenArea` asks the r-tree for the phantoms standing on each vertex the
+ *    coordinate can see, one nearest-neighbour traversal each;
+ *  * the engine's visibility graph is cubic in the vertex count, which is why
+ *    `GEODESIC_MAX_VERTICES` has to stop at 256;
+ *  * the mesher declines an area over `AreaMesher::max_vertices` obstacle vertices
+ *    outright, and 153 of Ile-de-France's 1234 areas hit that.
+ *
+ * Visvalingam-Whyatt is the right shape of algorithm here because it ranks a vertex by the
+ * *area* of the triangle it makes with its neighbours, so it removes what does not change
+ * the polygon rather than what is merely close to a line.  Douglas-Peucker, which the
+ * repository already has for route geometry, answers a different question -- how far a
+ * point strays from a chord -- and on a closed ring it will happily shave a whole shallow
+ * bay that a traveller has to walk round.
+ *
+ * The threshold is an area in square metres, so it says directly how much of the plaza a
+ * dropped vertex is allowed to add or remove.  A vertex is dropped when its triangle is
+ * smaller than that.
+ *
+ * @param poly       the polygon, outer ring first
+ * @param threshold  effective area, in square metres, below which a vertex is dropped;
+ *                   zero or less returns @p poly unchanged
+ * @param keep       vertices that must survive whatever their effective area.  Entry
+ *                   points go here: an entrance that is simplified away leaves the area
+ *                   unreachable from the way that met it, which is not a loss of detail
+ *                   but a loss of the graph.
+ *
+ * A ring is never reduced below three vertices, and a ring that would collapse is left as
+ * it is.  Nothing here can turn a valid polygon into one with fewer rings.
+ */
+OsmiumPolygon simplify(const OsmiumPolygon &poly, double threshold, const NodeRefSet &keep);
+
+/**
+ * @brief The effective area of one vertex, in square metres.
+ *
+ * The triangle @p before, @p at, @p after, measured on an equirectangular projection about
+ * the triangle's own latitude.  Exposed for testing.
+ */
+double effective_area(const osmium::NodeRef &before,
+                      const osmium::NodeRef &at,
+                      const osmium::NodeRef &after);
+
+} // namespace osrm::extractor::area
+
+#endif // OSRM_EXTRACTOR_AREA_SIMPLIFY_HPP

--- a/include/extractor/profile_properties.hpp
+++ b/include/extractor/profile_properties.hpp
@@ -141,6 +141,11 @@ struct ProfileProperties
     //! Deliberately not called walking_speed: the profiles already use that name for a
     //! speed in km/h, and mixing the two units would be silent.
     double area_walking_speed = 1.4;
+    //! effective area, in square metres, below which a vertex of an open area is
+    //! simplified away at extraction (Visvalingam-Whyatt).  An OSM plaza is drawn to be
+    //! looked at, and its kerbstone detail is paid for again on every query that snaps
+    //! into it.  Zero switches it off.  See extractor/area/simplify.hpp.
+    double area_simplify_threshold = 0.0;
 };
 } // namespace osrm::extractor
 

--- a/profiles/foot.lua
+++ b/profiles/foot.lua
@@ -14,6 +14,14 @@ find_access_tag = require("lib/access").find_access_tag
 -- See docs/areas.md.
 local enable_area_meshing = enable_area_meshing or false
 
+-- How much of a plaza's outline is shape and how much is drawing. A vertex whose
+-- triangle with its two neighbours covers less than this many square metres is
+-- dropped at extraction, by Visvalingam-Whyatt. An OSM plaza is drawn to be looked
+-- at -- Ile-de-France has one with a node every 30 cm -- and every vertex is paid
+-- for again on each query that snaps into the area. Entry points are never dropped.
+-- Set to 0 to keep the outline exactly as drawn. See docs/areas.md.
+local area_simplify_threshold = area_simplify_threshold or 1.0
+
 function setup()
   local walking_speed = 5
 
@@ -32,6 +40,7 @@ function setup()
       use_turn_restrictions         = false,
       -- preserve short road crossings for pedestrian safety analysis
       max_collapse_distance         = 10,
+      area_simplify_threshold       = enable_area_meshing and area_simplify_threshold or 0,
     },
 
     default_mode            = mode.walking,

--- a/src/extractor/area/area_mesher.cpp
+++ b/src/extractor/area/area_mesher.cpp
@@ -4,6 +4,7 @@
 #include "extractor/area/area_mesher.hpp"
 
 #include "extractor/area/dijkstra.hpp"
+#include "extractor/area/simplify.hpp"
 #include "extractor/area/typedefs.hpp"
 #include "extractor/area/util.hpp"
 #include "extractor/area/visibility_graph.hpp"
@@ -361,15 +362,29 @@ void AreaMesher::mesh_area(const osmium::Area &area,
     };
 #endif
 
-    for (const OsmiumPolygon &poly : area_builder(area))
+    for (const OsmiumPolygon &drawn : area_builder(area))
     {
-        NodeRefSet entry_points = get_entry_points(poly);
+        NodeRefSet entry_points = get_entry_points(drawn);
         if (entry_points.size() < 2)
         {
-            util::Log(logDEBUG) << "  Poly outer size: " << poly.outer().size();
-            util::Log(logDEBUG) << "  Poly inner rings: " << poly.inners().size();
+            util::Log(logDEBUG) << "  Poly outer size: " << drawn.outer().size();
+            util::Log(logDEBUG) << "  Poly inner rings: " << drawn.inners().size();
             util::Log(logDEBUG) << "  Not enough entry points: " << entry_points.size();
             continue;
+        }
+
+        // Drop the vertices that carry no shape, before anything else looks at the
+        // polygon, so that the mesher, the stored rings and everything the engine does
+        // with them are all talking about one geometry.  The entry points are pinned:
+        // they were found on the polygon as drawn, and an entrance simplified away leaves
+        // the area unreachable from the way that met it.
+        const OsmiumPolygon simplified = simplify(drawn, area_simplify_threshold, entry_points);
+        const OsmiumPolygon &poly = simplified;
+
+        if (poly.outer().size() != drawn.outer().size())
+        {
+            util::Log(logDEBUG) << "  Simplified outer ring " << drawn.outer().size() << " -> "
+                                << poly.outer().size() << " vertices";
         }
 
         // Hand the engine what it needs to snap a coordinate lying inside this area

--- a/src/extractor/area/simplify.cpp
+++ b/src/extractor/area/simplify.cpp
@@ -1,0 +1,206 @@
+#include "extractor/area/simplify.hpp"
+
+#include "extractor/area/util.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <numbers>
+#include <vector>
+
+namespace osrm::extractor::area
+{
+
+namespace
+{
+
+//! A ring below this many vertices is not a ring any more.
+constexpr std::size_t SMALLEST_RING = 3;
+
+//! Metres per degree of latitude.  Longitude is this scaled by cos(latitude).
+constexpr double METRES_PER_DEGREE = 111319.49079327358;
+
+/**
+ * @brief One ring, thinned.
+ *
+ * Straight Visvalingam-Whyatt: find the vertex whose triangle with its two neighbours is
+ * smallest, drop it, and repeat.  Dropping a vertex changes what its neighbours' triangles
+ * are, so their areas are recomputed, which is what makes this different from ranking every
+ * vertex once against the original shape.
+ *
+ * The search for the smallest is a scan rather than a heap.  This runs once per area at
+ * extraction, over rings of at most a few thousand vertices, so the quadratic term costs
+ * a few million operations on the largest area in a region -- against a heap that would
+ * need lazy deletion, and with it a tie-break that no longer depends only on the data.
+ * Determinism is worth more here than the exponent: two runs over one input have to
+ * produce the same file, or every downstream comparison stops meaning anything.
+ *
+ * Ties are broken by node id for the same reason.  Two vertices can easily have the same
+ * effective area -- a rectangular kerb has four of them -- and "whichever the scan reached
+ * first" is a property of the ring's rotation, not of the input.
+ */
+std::vector<osmium::NodeRef>
+thin(const std::vector<osmium::NodeRef> &ring, const double threshold, const NodeRefSet &keep)
+{
+    if (ring.size() <= SMALLEST_RING)
+    {
+        return ring;
+    }
+
+    // `alive` indexes into `ring`; removing from the middle of a vector is cheaper than
+    // the bookkeeping a linked list would need at these sizes
+    std::vector<std::size_t> alive(ring.size());
+    for (std::size_t i = 0; i < ring.size(); ++i)
+    {
+        alive[i] = i;
+    }
+
+    const auto pinned = [&keep, &ring](std::size_t index) { return keep.contains(ring[index]); };
+
+    while (alive.size() > SMALLEST_RING)
+    {
+        auto smallest = std::numeric_limits<double>::infinity();
+        std::size_t victim = alive.size();
+
+        for (std::size_t i = 0; i < alive.size(); ++i)
+        {
+            if (pinned(alive[i]))
+            {
+                continue;
+            }
+            // the ring is closed, so the first and last vertices have neighbours too
+            const auto &before = ring[alive[(i + alive.size() - 1) % alive.size()]];
+            const auto &at = ring[alive[i]];
+            const auto &after = ring[alive[(i + 1) % alive.size()]];
+
+            const auto area = effective_area(before, at, after);
+            if (area < smallest ||
+                (area == smallest && victim < alive.size() && at.ref() < ring[alive[victim]].ref()))
+            {
+                smallest = area;
+                victim = i;
+            }
+        }
+
+        if (victim == alive.size() || smallest >= threshold)
+        {
+            // everything left either carries shape or has to be kept
+            break;
+        }
+        alive.erase(alive.begin() + static_cast<std::ptrdiff_t>(victim));
+    }
+
+    std::vector<osmium::NodeRef> thinned;
+    thinned.reserve(alive.size());
+    for (const auto index : alive)
+    {
+        thinned.push_back(ring[index]);
+    }
+    return thinned;
+}
+
+/**
+ * @brief Does the ring cross itself?
+ *
+ * Every pair of edges that do not share a vertex, tested with the area code's own
+ * predicate rather than a new one: it is already careful about shared endpoints and about
+ * behaving the same on x86_64 and ARM64, and a second opinion about what "crossing" means
+ * is the last thing this needs.
+ *
+ * Quadratic, over a ring that has just been thinned, once per area at extraction.
+ */
+bool is_simple(const std::vector<osmium::NodeRef> &ring)
+{
+    const auto count = ring.size();
+    for (std::size_t i = 0; i < count; ++i)
+    {
+        for (std::size_t j = i + 1; j < count; ++j)
+        {
+            // edges sharing a vertex meet there by construction
+            if ((j + 1) % count == i || (i + 1) % count == j)
+            {
+                continue;
+            }
+            if (intersect(&ring[i], &ring[(i + 1) % count], &ring[j], &ring[(j + 1) % count]))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+double effective_area(const osmium::NodeRef &before,
+                      const osmium::NodeRef &at,
+                      const osmium::NodeRef &after)
+{
+    // Equirectangular about the middle vertex.  Over a triangle whose sides are metres
+    // this is exact enough that the error is far below the grid the coordinates are
+    // stored on, and unlike a spherical formula it cannot lose precision on a sliver.
+    const auto scale = std::cos(at.location().lat_without_check() * std::numbers::pi / 180.0);
+    const auto x = [scale](const osmium::NodeRef &node)
+    { return node.location().lon_without_check() * scale * METRES_PER_DEGREE; };
+    const auto y = [](const osmium::NodeRef &node)
+    { return node.location().lat_without_check() * METRES_PER_DEGREE; };
+
+    return std::fabs((x(at) - x(before)) * (y(after) - y(before)) -
+                     (x(after) - x(before)) * (y(at) - y(before))) /
+           2.0;
+}
+
+OsmiumPolygon simplify(const OsmiumPolygon &poly, const double threshold, const NodeRefSet &keep)
+{
+    if (!(threshold > 0.0))
+    {
+        return poly;
+    }
+
+    OsmiumPolygon simplified;
+
+    const std::vector<osmium::NodeRef> outer(poly.outer().begin(), poly.outer().end());
+    const auto thinned_outer = thin(outer, threshold, keep);
+    for (const auto &vertex : thinned_outer)
+    {
+        simplified.outer().push_back(vertex);
+    }
+
+    for (const auto &inner : poly.inners())
+    {
+        const std::vector<osmium::NodeRef> ring(inner.begin(), inner.end());
+        auto thinned = thin(ring, threshold, keep);
+        if (thinned.size() < SMALLEST_RING)
+        {
+            // an obstacle that thinned away is still an obstacle; keep it as drawn
+            thinned = ring;
+        }
+        simplified.inners().emplace_back();
+        for (const auto &vertex : thinned)
+        {
+            simplified.inners().back().push_back(vertex);
+        }
+    }
+
+    // Visvalingam-Whyatt makes no promise about simplicity.  Dropping a vertex from a
+    // narrow neck can walk one side of the ring through the other, and a plaza whose
+    // outline crosses itself answers point-in-polygon and visibility in ways that are not
+    // wrong so much as meaningless.  It is rare, it is cheap to detect on a ring that has
+    // just been made smaller, and the polygon as drawn is always an acceptable answer, so
+    // check and fall back rather than reason about when it cannot happen.
+    if (!is_simple(thinned_outer))
+    {
+        return poly;
+    }
+    for (const auto &inner : simplified.inners())
+    {
+        if (!is_simple(std::vector<osmium::NodeRef>(inner.begin(), inner.end())))
+        {
+            return poly;
+        }
+    }
+
+    return simplified;
+}
+
+} // namespace osrm::extractor::area

--- a/src/extractor/extractor.cpp
+++ b/src/extractor/extractor.cpp
@@ -656,6 +656,7 @@ Extractor::ParsedOSMData Extractor::ParseOSMData(ScriptingEnvironment &scripting
         const auto &area_properties = scripting_environment.GetProfileProperties();
         mesher.area_walking_speed = area_properties.area_walking_speed;
         mesher.emit_visibility_graph = area_properties.area_emit_visibility_graph;
+        mesher.area_simplify_threshold = area_properties.area_simplify_threshold;
         mesher.init(area_manager, extraction_containers);
 
         tbb::filter<OsmiumBuffer, OsmiumBuffer> mesh_areas_filter(

--- a/src/extractor/scripting_environment_lua.cpp
+++ b/src/extractor/scripting_environment_lua.cpp
@@ -235,6 +235,8 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
         &ProfileProperties::area_walking_speed,
         "area_emit_visibility_graph",
         &ProfileProperties::area_emit_visibility_graph,
+        "area_simplify_threshold",
+        &ProfileProperties::area_simplify_threshold,
         "weight_name",
         sol::property(&ProfileProperties::GetWeightName, &ProfileProperties::SetWeightName),
         "max_turn_weight",
@@ -787,6 +789,10 @@ void Sol2ScriptingEnvironment::InitContext(LuaScriptingContext &context)
                 properties["area_emit_visibility_graph"];
             if (area_emit_visibility_graph != sol::nullopt)
                 context.properties.area_emit_visibility_graph = area_emit_visibility_graph.value();
+
+            sol::optional<double> area_simplify_threshold = properties["area_simplify_threshold"];
+            if (area_simplify_threshold != sol::nullopt)
+                context.properties.area_simplify_threshold = area_simplify_threshold.value();
         }
     };
 

--- a/unit_tests/extractor/area_simplify.cpp
+++ b/unit_tests/extractor/area_simplify.cpp
@@ -1,0 +1,193 @@
+#include "extractor/area/simplify.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(area_simplify_test)
+
+using namespace osrm;
+using namespace osrm::extractor::area;
+
+namespace
+{
+
+// A degree of longitude at the equator, so the fixtures can be written in metres.
+constexpr double METRE = 1.0 / 111319.49079327358;
+
+osmium::NodeRef at(osmium::object_id_type id, double x, double y)
+{ return osmium::NodeRef{id, osmium::Location{x * METRE, y * METRE}}; }
+
+OsmiumPolygon square_with(const std::vector<osmium::NodeRef> &outer)
+{
+    OsmiumPolygon poly;
+    for (const auto &vertex : outer)
+    {
+        poly.outer().push_back(vertex);
+    }
+    return poly;
+}
+
+std::vector<osmium::object_id_type> ids(const OsmiumPolygon &poly)
+{
+    std::vector<osmium::object_id_type> result;
+    for (const auto &vertex : poly.outer())
+    {
+        result.push_back(vertex.ref());
+    }
+    return result;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(effective_area_of_a_right_triangle)
+{
+    // legs of 100 m and 200 m, so the triangle is 10000 square metres
+    BOOST_CHECK_CLOSE(effective_area(at(1, 0, 0), at(2, 100, 0), at(3, 100, 200)), 10000.0, 0.5);
+    // three points on a line enclose nothing
+    BOOST_CHECK_SMALL(effective_area(at(1, 0, 0), at(2, 50, 0), at(3, 100, 0)), 1e-6);
+}
+
+// A vertex sitting on the straight run between its neighbours carries no shape.
+BOOST_AUTO_TEST_CASE(drops_a_collinear_vertex)
+{
+    const auto poly = square_with({at(1, 0, 0),
+                                   at(2, 50, 0), // on the line from 1 to 3
+                                   at(3, 100, 0),
+                                   at(4, 100, 100),
+                                   at(5, 0, 100)});
+
+    const auto simplified = simplify(poly, 1.0, {});
+    BOOST_CHECK_EQUAL(simplified.outer().size(), 4u);
+    const std::vector<osmium::object_id_type> expected{1, 3, 4, 5};
+    BOOST_CHECK(ids(simplified) == expected);
+}
+
+// The corners of a square are the whole of its shape and none of them may go.
+BOOST_AUTO_TEST_CASE(keeps_every_corner_of_a_square)
+{
+    const auto poly = square_with({at(1, 0, 0), at(2, 100, 0), at(3, 100, 100), at(4, 0, 100)});
+
+    BOOST_CHECK_EQUAL(simplify(poly, 1.0, {}).outer().size(), 4u);
+    // even a threshold far larger than the square itself cannot take it below three
+    BOOST_CHECK_EQUAL(simplify(poly, 1e9, {}).outer().size(), 3u);
+}
+
+// A threshold of zero means the caller did not ask for this.
+BOOST_AUTO_TEST_CASE(does_nothing_when_switched_off)
+{
+    const auto poly =
+        square_with({at(1, 0, 0), at(2, 50, 0), at(3, 100, 0), at(4, 100, 100), at(5, 0, 100)});
+
+    BOOST_CHECK_EQUAL(simplify(poly, 0.0, {}).outer().size(), 5u);
+    BOOST_CHECK_EQUAL(simplify(poly, -1.0, {}).outer().size(), 5u);
+}
+
+/**
+ * An entry point may not be simplified away.
+ *
+ * It is where a routable way meets the perimeter. Losing it does not cost detail, it
+ * costs the connection: the area stops being reachable from that way.
+ */
+BOOST_AUTO_TEST_CASE(never_drops_a_pinned_vertex)
+{
+    const auto entrance = at(2, 50, 0);
+    const auto poly =
+        square_with({at(1, 0, 0), entrance, at(3, 100, 0), at(4, 100, 100), at(5, 0, 100)});
+
+    const NodeRefSet keep{entrance};
+    const auto simplified = simplify(poly, 1.0, keep);
+
+    BOOST_CHECK_EQUAL(simplified.outer().size(), 5u);
+    const std::vector<osmium::object_id_type> expected{1, 2, 3, 4, 5};
+    BOOST_CHECK(ids(simplified) == expected);
+}
+
+// A bump larger than the threshold is shape, not noise.
+BOOST_AUTO_TEST_CASE(keeps_a_vertex_that_carries_shape)
+{
+    // the bump encloses 0.5 * 100 * 20 = 1000 square metres against its neighbours
+    const auto poly =
+        square_with({at(1, 0, 0), at(2, 50, 20), at(3, 100, 0), at(4, 100, 100), at(5, 0, 100)});
+
+    BOOST_CHECK_EQUAL(simplify(poly, 100.0, {}).outer().size(), 5u);
+    BOOST_CHECK_EQUAL(simplify(poly, 2000.0, {}).outer().size(), 4u);
+}
+
+// Obstacles are simplified too, and an obstacle that would vanish is left as drawn.
+BOOST_AUTO_TEST_CASE(simplifies_obstacle_rings)
+{
+    OsmiumPolygon poly =
+        square_with({at(1, 0, 0), at(2, 1000, 0), at(3, 1000, 1000), at(4, 0, 1000)});
+    poly.inners().emplace_back();
+    for (const auto &vertex : {at(10, 400, 400),
+                               at(11, 500, 400), // collinear with 10 and 12
+                               at(12, 600, 400),
+                               at(13, 600, 600),
+                               at(14, 400, 600)})
+    {
+        poly.inners().back().push_back(vertex);
+    }
+
+    const auto simplified = simplify(poly, 1.0, {});
+    BOOST_REQUIRE_EQUAL(simplified.inners().size(), 1u);
+    BOOST_CHECK_EQUAL(simplified.inners()[0].size(), 4u);
+    // the outer ring is untouched, having no vertex to spare
+    BOOST_CHECK_EQUAL(simplified.outer().size(), 4u);
+}
+
+// Two runs over one input have to agree, or the extracted file stops being reproducible.
+BOOST_AUTO_TEST_CASE(is_deterministic_over_tied_vertices)
+{
+    // every vertex of a regular polygon has the same effective area, so every removal is
+    // a tie and the order has to come from the data rather than from the traversal
+    OsmiumPolygon poly;
+    for (int i = 0; i < 24; ++i)
+    {
+        const auto angle = 2 * std::numbers::pi * i / 24;
+        poly.outer().push_back(
+            at(100 + i, 500 + 100 * std::cos(angle), 500 + 100 * std::sin(angle)));
+    }
+
+    const auto once = simplify(poly, 200.0, {});
+    const auto twice = simplify(poly, 200.0, {});
+    BOOST_CHECK(ids(once) == ids(twice));
+    BOOST_CHECK_LT(once.outer().size(), 24u);
+}
+
+/**
+ * Visvalingam-Whyatt makes no promise about simplicity.  A rectangle with a shallow dent
+ * in its bottom edge and a slit from the top that reaches down into that dent: the dent
+ * vertex carries the least area, and the chord that replaces it runs straight through the
+ * slit.  The thinned ring crosses itself, so the polygon is kept as drawn.
+ */
+BOOST_AUTO_TEST_CASE(keeps_the_polygon_as_drawn_when_thinning_makes_it_cross_itself)
+{
+    const auto with_slit_into_the_dent = square_with({at(1, 0, 0),
+                                                      at(2, 100, -3), // the dent, 300 m2
+                                                      at(3, 200, 0),
+                                                      at(4, 200, 100),
+                                                      at(5, 105, 100),
+                                                      at(6, 105, -1), // the slit reaches below y=0
+                                                      at(7, 95, -1),
+                                                      at(8, 95, 100),
+                                                      at(9, 0, 100)});
+    // the dent is under the threshold, the slit's corners are not
+    BOOST_CHECK_EQUAL(simplify(with_slit_into_the_dent, 400.0, {}).outer().size(), 9u);
+
+    // the same shape with the slit ending above the chord thins as expected
+    const auto with_slit_above = square_with({at(1, 0, 0),
+                                              at(2, 100, -3),
+                                              at(3, 200, 0),
+                                              at(4, 200, 100),
+                                              at(5, 105, 100),
+                                              at(6, 105, 1),
+                                              at(7, 95, 1),
+                                              at(8, 95, 100),
+                                              at(9, 0, 100)});
+    BOOST_CHECK_EQUAL(simplify(with_slit_above, 400.0, {}).outer().size(), 8u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

Refs #7683.

## Problem

An OSM plaza is drawn to be looked at, not routed across. Ile-de-France has a pedestrian multipolygon of 2,739 nodes around 228 by 209 metres, a node every 30 cm. Three costs are paid per vertex and none of them once: snapping asks the r-tree for the phantoms on each visible vertex, 4.8 ms per coordinate inside an area; the engine's visibility graph is cubic in the vertex count, which pins `GEODESIC_MAX_VERTICES` at 256; and the mesher declines an area over `AreaMesher::max_vertices` outright, 153 of Ile-de-France's 1,234 areas.

## Fix

The vertices are thinned once, at extraction, before anything else looks at the polygon, so one geometry serves the mesher, the stored rings, snapping and the geodesic.

Visvalingam-Whyatt rather than the Douglas-Peucker the repository already has for route geometry: VW ranks a vertex by the area of the triangle it makes with its neighbours and drops what does not change the polygon, where DP asks how far a point strays from a chord and on a closed ring shaves off a whole shallow bay a traveller has to walk round. The threshold is therefore an area in square metres. Entry points are pinned: one simplified away is not lost detail but lost graph. Simplicity is checked rather than assumed, and the polygon as drawn is used if a thinned ring self-intersects. The search for the smallest triangle is a scan with ties to the lower node id, so two runs over one input produce the same file.

The threshold is the profile property `area_simplify_threshold`, 1 m² in `foot.lua` when meshing is on, 0 keeps the outline as drawn. `ProfileProperties` grows, so `.osrm` data has to be re-extracted.

## Verification

Measured on Ile-de-France at 1 m² against the same extract unsimplified:

| | before | after |
|---|---|---|
| areas declined by the mesher | 153 | 78 |
| `.osrm.openareas` | 1,814,016 bytes | 1,287,168 bytes |
| plaza route, both ends inside | 9.97 ms | 8.80 ms |
| République, worst detour ratio over 797 interior pairs | 1.00 | 1.00 |
| République, p95 latency | 83.2 ms | 52.9 ms |

Unit tests for the simplifier, including pinned entry points and the self-intersection fallback; area scenarios on both algorithms.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [x] add tests (see [testing](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] update relevant [wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Claude Code, Claude Fable 5.1
