### PR TITLE
ci(cucumber): do not publish reports to reports.cucumber.io

### DIFF
--- a/cucumber.mjs
+++ b/cucumber.mjs
@@ -61,7 +61,10 @@ export default function() {
         './features/lib/github_summary_formatter.js',
         ['html', htmlReportFilename]
       ],
-      publish: true
+      // The HTML report is uploaded as a workflow artifact; publishing it to
+      // reports.cucumber.io as well made the job fail after every scenario had
+      // passed whenever a runner could not reach that host.
+      publish: false
     },
 
     // patches to base configs


### PR DESCRIPTION
# Issue

Two pull requests this morning failed `macos-26-x64-release` after all 1,482 cucumber scenarios had passed: the `github` profile in `cucumber.mjs` publishes the run's report to reports.cucumber.io, and the runner could not reach the host.

```
1482 scenarios (5 skipped, 1477 passed)
[TypeError: fetch failed] {
  [cause]: ConnectTimeoutError: Connect Timeout Error (attempted addresses: 104.21.11.61:443, 172.67.165.78:443, timeout: 10000ms)
##[error]Process completed with exit code 1.
```

## Fix

`publish: false`. The HTML report is written to `test/logs/` and uploaded as a workflow artifact either way, and nothing reads the published copy.

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.

🤖 Claude Code, Claude Fable 5.1
