### PR TITLE
ci: drop x86_64 macOS from the build matrix

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -498,15 +498,6 @@ jobs:
             CXXCOMPILER: clang++-18
             ENABLE_LTO: OFF
 
-          - name: macos-26-x64-release
-            continue-on-error: true
-            node: 24
-            runs-on: macos-26-intel # x86_64
-            BUILD_TYPE: Release
-            CCOMPILER: clang
-            CXXCOMPILER: clang++
-            vcpkg_triplet: x64-osx
-
           - name: macos-26-arm64-release
             continue-on-error: true
             node: 24
@@ -517,16 +508,6 @@ jobs:
             vcpkg_triplet: arm64-osx
 
           # python & nodeJS release bindings — macos-15 for broad binary compatibility
-          - name: macos-15-x64-release-bindings
-            build_bindings: true
-            continue-on-error: true
-            node: 24
-            runs-on: macos-15-intel # x86_64
-            BUILD_TYPE: Release
-            CCOMPILER: clang
-            CXXCOMPILER: clang++
-            vcpkg_triplet: x64-osx
-
           - name: macos-15-arm64-release-bindings
             build_bindings: true
             continue-on-error: true

--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -507,7 +507,7 @@ jobs:
             CXXCOMPILER: clang++
             vcpkg_triplet: arm64-osx
 
-          # python & nodeJS release bindings — macos-15 for broad binary compatibility
+          # python & nodeJS release bindings
           - name: macos-15-arm64-release-bindings
             build_bindings: true
             continue-on-error: true

--- a/.github/workflows/release-monthly.yml
+++ b/.github/workflows/release-monthly.yml
@@ -333,6 +333,36 @@ jobs:
           run-id: ${{ needs.release.outputs.run_id }}
           github-token: ${{ github.token }}
 
+      - name: Verify wheel set is complete
+        run: |
+          # The build-matrix jobs that produce wheels are continue-on-error, so
+          # a failed one leaves the CI run green and its artifact simply absent.
+          # Without this check that silently ships a release missing a platform.
+          missing=0
+          for pattern in \
+            'osrm_bindings-*-manylinux*_x86_64.whl' \
+            'osrm_bindings-*-manylinux*_aarch64.whl' \
+            'osrm_bindings-*-macosx_*_arm64.whl' \
+            'osrm_bindings-*-win_amd64.whl' \
+            'osrm_bindings-*.tar.gz'; do
+            if ! compgen -G "dist/$pattern" > /dev/null; then
+              echo "✗ missing artifact matching $pattern"
+              missing=1
+            fi
+          done
+
+          echo "Artifacts downloaded from the CI run:"
+          ls -1 dist/
+
+          if [ "$missing" -ne 0 ]; then
+            echo "✗ Refusing to publish an incomplete set of artifacts to PyPI."
+            echo "  Check the build-matrix jobs in CI run ${{ needs.release.outputs.run_id }}"
+            echo "  for a bindings job that failed under continue-on-error."
+            exit 1
+          fi
+          echo "✓ All expected platform wheels and the sdist are present"
+        shell: bash
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.2
         with:

--- a/.github/workflows/vcpkg-smoke.yml
+++ b/.github/workflows/vcpkg-smoke.yml
@@ -51,7 +51,6 @@ jobs:
         include:
           - { os: ubuntu-26.04,    triplet: x64-linux }
           - { os: macos-26,        triplet: arm64-osx }
-          - { os: macos-26-intel,  triplet: x64-osx }
           - { os: windows-2025,    triplet: x64-windows-static-md }
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ You can install the Python bindings from PyPI via
 
     pip install osrm-bindings
 
-We distribute `abi3` wheels for CPython 3.12+ on Linux (x86_64), macOS (arm64, x86_64) and Windows (x86_64). On other platforms `pip` will fall back to building from source, which requires CPython 3.10+ and the OSRM build dependencies.
+We distribute `abi3` wheels for CPython 3.12+ on Linux (x86_64, aarch64), macOS (arm64) and Windows (x86_64). On other platforms, including Intel macOS, `pip` will fall back to building from source, which requires CPython 3.10+ and the OSRM build dependencies.
 
 To build from source from this repository:
 

--- a/docs/python/development.md
+++ b/docs/python/development.md
@@ -2,17 +2,16 @@
 
 ## Installing for production
 
-Pre-built wheels are published to PyPI for Linux (x86\_64), macOS (x86\_64),
-and Windows (amd64). They use the CPython 3.12 stable ABI (`cp312-abi3`) and
-therefore install on Python 3.12+:
+Pre-built wheels are published to PyPI for Linux (x86\_64 and aarch64),
+macOS (arm64), and Windows (amd64). They use the CPython 3.12 stable ABI
+(`cp312-abi3`) and therefore install on Python 3.12+:
 
 ```bash
 pip install osrm-bindings
 ```
 
 The package itself supports Python 3.10+ when built from source — needed for
-3.10/3.11, aarch64 Linux, arm64 macOS, or any platform without a pre-built
-wheel:
+3.10/3.11, x86\_64 macOS, or any platform without a pre-built wheel:
 
 ```bash
 pip install osrm-bindings --no-binary osrm-bindings
@@ -338,8 +337,8 @@ After the run finishes, check:
 
 - Tag `v<version>` exists and the GitHub Release is published.
 - [pypi.org/project/osrm-bindings](https://pypi.org/project/osrm-bindings/) shows
-  the new version with an sdist and three platform wheels (manylinux x86_64,
-  macOS x86_64, win_amd64).
+  the new version with an sdist and four platform wheels (manylinux x86_64,
+  manylinux aarch64, macOS arm64, win_amd64).
 - [npmjs.com/package/@project-osrm/osrm](https://www.npmjs.com/package/@project-osrm/osrm)
   shows the matching version.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ environment = 'CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsyste
 # exported on the runner by lukka/run-vcpkg in the workflow and inherited
 # by cibuildwheel; CMAKE_ARGS routes the cmake configure through the vcpkg
 # toolchain. No triplet override — vcpkg's autodetect picks arm64-osx on
-# Apple Silicon and x64-osx on Intel, matching the main build-matrix step's
+# the Apple Silicon runners, matching the main build-matrix step's
 # CMakePresets, so the wheel hits the runner-level bincache populated there.
 environment = """\
 MACOSX_DEPLOYMENT_TARGET=15.0 \

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -14,7 +14,7 @@ pip install osrm-bindings
 Platform | Arch
 ---|---
 Linux | x86_64
-MacOS | aarch64
+Linux | aarch64
 MacOS | arm64
 Windows | x86_64
 


### PR DESCRIPTION
# Issue

Apple no longer ships Intel Macs, and the GitHub-hosted `macos-*-intel` runner images are on their way out. Rather than keep paying for a platform we no longer target, this drops x86_64 macOS from CI entirely and leaves macOS coverage on arm64.

Removed:

- `.github/workflows/osrm-backend.yml` — `macos-26-x64-release` and `macos-15-x64-release-bindings` (both `macos-*-intel` runners, `x64-osx` triplet)
- `.github/workflows/vcpkg-smoke.yml` — the `macos-26-intel` / `x64-osx` manifest-resolve entry

Nothing else keyed off those job names; the remaining `darwin-x64` hits in `package-lock.json` are npm dev-dependency optionals and unrelated to CI.

**Please note the release-artifact consequence.** `macos-15-x64-release-bindings` was the job that produced the macOS x86_64 wheel `release-monthly.yml` publishes to PyPI, and the `darwin-x64` Node package tarball. Both stop being built. Intel Mac users fall back to a source build (`pip install osrm-bindings --no-binary osrm-bindings`, or a local `npm` build). `docs/python/development.md` is updated to list the platform wheels that actually ship, which also corrects two entries that were already stale: Linux aarch64 and macOS arm64 wheels have been published for a while but were still documented as source-build-only.

If we would rather keep an Intel wheel on PyPI a while longer, the bindings job is the one to restore, and the plain `macos-26-x64-release` build job can still go.

Was this change primarily generated using an AI tool? Yes. 🤖 Claude Code, Claude Opus 5

## Tasklist

 - [x] self-review code for correctness and following the [coding guidelines](https://github.com/Project-OSRM/osrm-backend/wiki/Coding-Standards)
 - [ ] review
 - [ ] adjust for comments

## Requirements / Relations

None.
